### PR TITLE
[SPARK-37383][SQL]Print the parsing time for each phase of a SQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/QueryPlanningTracker.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.internal.Logging
-
 import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.Logging
 import org.apache.spark.util.BoundedPriorityQueue
 
 
@@ -134,9 +134,9 @@ class QueryPlanningTracker extends Logging {
       totalTimeSpent += duration
     }
     logInfo(
-      s"""
-				 |Query planning time spent:\n ${timeSpentSummary.toString}
-         |Total time spent: $totalTimeSpent""".stripMargin)
+      s"""Query planning time spent:\n ${timeSpentSummary.toString}
+         |Total time spent: $totalTimeSpent
+       """.stripMargin)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -164,11 +164,13 @@ class QueryExecution(
     // We need to materialize the optimizedPlan here, before tracking the planning phase, to ensure
     // that the optimization time is not counted as part of the planning phase.
     assertOptimized()
-    executePhase(QueryPlanningTracker.PLANNING) {
+    val plan = executePhase(QueryPlanningTracker.PLANNING) {
       // clone the plan to avoid sharing the plan instance between different stages like analyzing,
       // optimizing and planning.
       QueryExecution.prepareForExecution(preparations, sparkPlan.clone())
     }
+    tracker.logTimeSpent()
+    plan
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -164,13 +164,13 @@ class QueryExecution(
     // We need to materialize the optimizedPlan here, before tracking the planning phase, to ensure
     // that the optimization time is not counted as part of the planning phase.
     assertOptimized()
-    val plan = executePhase(QueryPlanningTracker.PLANNING) {
+    val executedPlan = executePhase(QueryPlanningTracker.PLANNING) {
       // clone the plan to avoid sharing the plan instance between different stages like analyzing,
       // optimizing and planning.
       QueryExecution.prepareForExecution(preparations, sparkPlan.clone())
     }
     tracker.logTimeSpent()
-    plan
+    executedPlan
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -118,7 +118,7 @@ case class AdaptiveSparkPlanExec(
       ensureRequirements,
       RemoveRedundantSorts,
       DisableUnnecessaryBucketedScan,
-      OptimizeSkewedJoin(ensureRequirements, costEvaluator)
+      OptimizeSkewedJoin(ensureRequirements)
     ) ++ context.session.sessionState.queryStagePrepRules
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR is proposed to:
print out the timeSpent for each phase of a SQL and the total timeSpent of the SQL for parsing

### Why are the changes needed?
the time spent for each parsing phase of a SQL is counted and recorded in QueryPlanningTracker ,  but it is not yet shown anywhere.
when SQL parsing is suspected to be slow, we cannot confirm which phase is slow，therefore, it is necessary to print out the SQL parsing time.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.
