### PR TITLE
[SPARK-37192][SQL] Migrate SHOW TBLPROPERTIES to use V2 command by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.plans.logical.{DescribeNamespace, LogicalPlan, ShowNamespaces, ShowTables}
+import org.apache.spark.sql.catalyst.plans.logical.{DescribeNamespace, LogicalPlan, ShowNamespaces, ShowTableProperties, ShowTables}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.internal.SQLConf
@@ -43,6 +43,8 @@ object KeepLegacyOutputs extends Rule[LogicalPlan] {
           assert(d.output.length == 2)
           d.copy(output = Seq(d.output.head.withName("database_description_item"),
             d.output.last.withName("database_description_value")))
+        case s: ShowTableProperties if s.propertyKey.isDefined =>
+           s.copy(output = Seq(s.output.last))
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -401,15 +401,13 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
           throw QueryCompilationErrors.externalCatalogNotSupportShowViewsError(resolved)
       }
 
-    case s @ ShowTableProperties(ResolvedV1TableOrViewIdentifier(ident), propertyKey, output) =>
-      val newOutput =
-        if (conf.getConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA) && propertyKey.isDefined) {
-          assert(output.length == 2)
-          output.tail
-        } else {
-          output
-        }
-      ShowTablePropertiesCommand(ident.asTableIdentifier, propertyKey, newOutput)
+    // If target is view, force use v1 command
+    case s @ ShowTableProperties(ResolvedViewIdentifier(ident), propertyKey, output) =>
+      ShowTablePropertiesCommand(ident.asTableIdentifier, propertyKey, output)
+
+    case s @ ShowTableProperties(ResolvedV1TableIdentifier(ident), propertyKey, output)
+        if conf.useV1Command =>
+      ShowTablePropertiesCommand(ident.asTableIdentifier, propertyKey, output)
 
     case DescribeFunction(ResolvedFunc(identifier), extended) =>
       DescribeFunctionCommand(identifier.asFunctionIdentifier, extended)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -896,7 +896,7 @@ case class ShowTablePropertiesCommand(
           }
         case None =>
           catalogTable.properties.filterKeys(!_.startsWith(CatalogTable.VIEW_PREFIX))
-            .map(p => Row(p._1, p._2)).toSeq
+            .toSeq.sortBy(_._1).map(p => Row(p._1, p._2)).toSeq
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablePropertiesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablePropertiesExec.scala
@@ -39,7 +39,11 @@ case class ShowTablePropertiesExec(
       case Some(p) =>
         val propValue = properties
           .getOrElse(p, s"Table ${catalogTable.name} does not have property: $p")
-        Seq(toCatalystRow(p, propValue))
+        if (output.length == 1) {
+          Seq(toCatalystRow(propValue))
+        } else {
+          Seq(toCatalystRow(p, propValue))
+        }
       case None =>
         properties.toSeq.sortBy(_._1).map(kv =>
           toCatalystRow(kv._1, kv._2)).toSeq

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTblPropertiesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTblPropertiesSuiteBase.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.command
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 
 /**
@@ -51,7 +52,7 @@ trait ShowTblPropertiesSuiteBase extends QueryTest with DDLCommandTestUtils {
         Row("user", user))
 
       assert(properties.schema === schema)
-      checkAnswer(properties.sort("key"), expected)
+      checkAnswer(properties, expected)
     }
   }
 
@@ -85,6 +86,27 @@ trait ShowTblPropertiesSuiteBase extends QueryTest with DDLCommandTestUtils {
       assert(res.length == 1)
       assert(res.head.getString(0) == nonExistingKey)
       assert(res.head.getString(1).contains(s"does not have property: $nonExistingKey"))
+    }
+  }
+
+  test("KEEP THE LEGACY OUTPUT SCHEMA") {
+    Seq(true, false).foreach { keepLegacySchema =>
+      withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> keepLegacySchema.toString) {
+        withNamespaceAndTable("ns1", "tbl") { tbl =>
+          spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing " +
+            "TBLPROPERTIES ('user'='spark', 'status'='new')")
+
+          val properties = sql(s"SHOW TBLPROPERTIES $tbl ('status')")
+          val schema = properties.schema.fieldNames.toSeq
+          if (keepLegacySchema) {
+            assert(schema === Seq("value"))
+            checkAnswer(properties, Seq(Row("new")))
+          } else {
+            assert(schema === Seq("key", "value"))
+            checkAnswer(properties, Seq(Row("status", "new")))
+          }
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTblPropertiesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTblPropertiesSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.command.v1
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.command
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * This base suite contains unified tests for the `SHOW TBLPROPERTIES` command that checks V1
@@ -33,17 +32,6 @@ import org.apache.spark.sql.internal.SQLConf
 trait ShowTblPropertiesSuiteBase extends command.ShowTblPropertiesSuiteBase
     with command.TestsV1AndV2Commands {
 
-  test("SHOW TBLPROPERTIES WITH LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA") {
-    withNamespaceAndTable("ns1", "tbl") { tbl =>
-      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing " +
-        s"TBLPROPERTIES ('user'='andrew', 'status'='new')")
-      withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> "true") {
-        checkAnswer(sql(s"SHOW TBLPROPERTIES $tbl('user')"), Row("andrew"))
-        checkAnswer(sql(s"SHOW TBLPROPERTIES $tbl('status')"), Row("new"))
-      }
-    }
-  }
-
   test("SHOW TBLPROPERTIES FOR VIEW") {
     val v = "testview"
     withView(v) {
@@ -56,7 +44,7 @@ trait ShowTblPropertiesSuiteBase extends command.ShowTblPropertiesSuiteBase
     }
   }
 
-  test("SHOW TBLPROPERTIES FOR TEMPORARY IEW") {
+  test("SHOW TBLPROPERTIES FOR TEMPORARY VIEW") {
     val v = "testview"
     withView(v) {
       spark.sql(s"CREATE TEMPORARY VIEW $v AS SELECT 1 AS c1;")


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Migrate `SHOW TBLPROPERTIES` to use V2 command by default
2. Sort the result of V1 command of `SHOW TBLPROPERTIES`
3. handle the `output == 1` case for V2 command to match V1 behavior

### Why are the changes needed?
It's been a while since we introduced the v2 commands, and it seems reasonable to use v2 commands by default even for the session catalog, with a legacy config to fall back to the v1 commands.


### Does this PR introduce _any_ user-facing change?
For use V2 command: 
if LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA == true
change output `Row("key", "value")` =>  `Row("value")`

### How was this patch tested?
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *ShowTblPropertiesSuite"
