### PR TITLE
[SPARK-37390][PYTHON][DOCS] Add default value to getattr(app, add_javascript)

### DIFF
--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -398,7 +398,7 @@ epub_exclude_files = ['search.html']
 #epub_use_index = True
 def setup(app):
     # The app.add_javascript() is deprecated.
-    getattr(app, "add_js_file", getattr(app, "add_javascript"))('copybutton.js')
+    getattr(app, "add_js_file", getattr(app, "add_javascript", None))('copybutton.js')
 
 # Skip sample endpoint link (not expected to resolve)
 linkcheck_ignore = [r'https://kinesis.us-east-1.amazonaws.com']


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


This PR adds `default` (`None`) value to `getattr(app, add_javascript)`. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Current logic fails on `getattr(app, "add_javascript")` when executed with Sphinx 4.x. The problem can be illustrated with a simple snippet.

```python
>>> class Sphinx:
...     def add_js_file(self, filename: str, priority: int = 500, **kwargs: Any) -> None: ...
... 
>>> app = Sphinx()
>>> getattr(app, "add_js_file", getattr(app, "add_javascript"))
Traceback (most recent call last):
  File "<ipython-input-11-442ab6dfc933>", line 1, in <module>
    getattr(app, "add_js_file", getattr(app, "add_javascript"))
AttributeError: 'Sphinx' object has no attribute 'add_javascript'
```
After this PR is merged we'll fallback to `getattr(app, "add_js_file")`:

```python
>>> getattr(app, "add_js_file", getattr(app, "add_javascript", None))
<bound method Sphinx.add_js_file of <__main__.Sphinx object at 0x7f444456abe0>>
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manual docs build.
