### PR TITLE
[SPARK-37394][CORE] Skip registering with external shuffle server if a customized shuffle manager is configured

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -91,6 +91,15 @@ private[spark] trait ShuffleManager {
    */
   def shuffleBlockResolver: ShuffleBlockResolver
 
+  /**
+   * The flag to indicate if the shuffle manager needs to work with a local shuffle service,
+   * by default it returns true; if the shuffle manager works with a remote shuffle service,
+   * this function needs to be overridden and return false instead.
+   * @return true if this shuffle manager needs to work with a local external shuffle service,
+   *         otherwise false.
+   */
+  def supportExternalShuffleService: Boolean = true
+
   /** Shut down this ShuffleManager. */
   def stop(): Unit
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleManager.scala
@@ -92,9 +92,9 @@ private[spark] trait ShuffleManager {
   def shuffleBlockResolver: ShuffleBlockResolver
 
   /**
-   * The flag to indicate if the shuffle manager needs to work with a local shuffle service,
-   * by default it returns true; if the shuffle manager works with a remote shuffle service,
-   * this function needs to be overridden and return false instead.
+   * The flag to indicate if the shuffle manager needs to work with a local external
+   * shuffle service, by default it returns true; if it doesn't work with a local external
+   * shuffle service, this function needs to be overridden and return false instead.
    * @return true if this shuffle manager needs to work with a local external shuffle service,
    *         otherwise false.
    */

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -529,7 +529,8 @@ private[spark] class BlockManager(
     }
 
     // Register Executors' configuration with the local shuffle service, if one should exist.
-    if (externalShuffleServiceEnabled && !blockManagerId.isDriver) {
+    if (externalShuffleServiceEnabled && !blockManagerId.isDriver
+      && shuffleManager.supportExternalShuffleService) {
       registerWithExternalShuffleServer()
     }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -560,22 +560,13 @@ private[spark] class BlockManager(
   }
 
   private def registerWithExternalShuffleServer(): Unit = {
-    val shuffleManagerName = shuffleManager.getClass.getName
-    if (shuffleManagerName != classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName) {
-      // there is no need to register with the default external shuffle server
-      // when a customized shuffle manager is configured
-      logInfo(s"Customized shuffle manager ${shuffleManagerName} configured, " +
-        s"skip registering with the default external shuffle service")
-      return
-    }
-
     logInfo("Registering executor with local external shuffle service.")
     val shuffleManagerMeta =
       if (Utils.isPushBasedShuffleEnabled(conf, isDriver = isDriver, checkSerializer = false)) {
-        s"${shuffleManagerName}:" +
+        s"${shuffleManager.getClass.getName}:" +
           s"${diskBlockManager.getMergeDirectoryAndAttemptIDJsonString()}}}"
       } else {
-        shuffleManagerName
+        shuffleManager.getClass.getName
       }
     val shuffleConfig = new ExecutorShuffleInfo(
       diskBlockManager.localDirsString,

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -560,13 +560,22 @@ private[spark] class BlockManager(
   }
 
   private def registerWithExternalShuffleServer(): Unit = {
+    val shuffleManagerName = shuffleManager.getClass.getName
+    if (shuffleManagerName != classOf[org.apache.spark.shuffle.sort.SortShuffleManager].getName) {
+      // there is no need to register with the default external shuffle server
+      // when a customized shuffle manager is configured
+      logInfo(s"Customized shuffle manager ${shuffleManagerName} configured, " +
+        s"skip registering with the default external shuffle service")
+      return
+    }
+
     logInfo("Registering executor with local external shuffle service.")
     val shuffleManagerMeta =
       if (Utils.isPushBasedShuffleEnabled(conf, isDriver = isDriver, checkSerializer = false)) {
-        s"${shuffleManager.getClass.getName}:" +
+        s"${shuffleManagerName}:" +
           s"${diskBlockManager.getMergeDirectoryAndAttemptIDJsonString()}}}"
       } else {
-        shuffleManager.getClass.getName
+        shuffleManagerName
       }
     val shuffleConfig = new ExecutorShuffleInfo(
       diskBlockManager.localDirsString,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Propose to skip registering with ESS if a customized shuffle manager (Remote Shuffle Service) is configured. Otherwise, when the dynamic allocation is enabled without an external shuffle service in place, the Spark executor still tries to connect to the external shuffle service which gets to a connection refused exception.


### Why are the changes needed?
To get dynamic allocation works with a 3rd party remote shuffle service.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test locally on K8s with docker-desktop, DA enabled, no external shuffle service, running Uber's RSS locally.

With the default setting, when I run spark job and it will fail with the following error:

> 21/11/30 07:35:24 INFO BlockManager: Registering executor with local external shuffle service.                                                                                              
21/11/30 07:35:24 ERROR BlockManager: Failed to connect to external shuffle server, will retry 2 more times after waiting 5 seconds...
java.io.IOException: Failed to connect to /10.1.2.201:7337

Then apply this patch to Spark, rebuild Spark, and make the changes like the following in the ShuffleManager implementation, i.e `RssShuffleManager.scala`

```
diff --git a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
index 4b6e825..aeffd7d 100644
--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -442,5 +442,8 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
       }
     new ServerConnectionCacheUpdateRefresher(serverConnectionResolver, MultiServerHeartbeatClient.getServerCache)
   }
+
+  override def supportExternalShuffleService: Boolean = false
+
```
restart RSS, and rerun the Spark job, the same job can be successfully completed.
