### PR TITLE
[SPARK-37434][BUILD] Add a new profile to auto disable unsupported UTs on MacOs using Apple Silicon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3583,7 +3583,7 @@
     <profile>
       <id>mac-on-apple-silicon</id>
       <properties>
-        <test.exclude.tags>org.apache.spark.tags.ExtendedLevelDBTest,org.apache.spark.tags.ExtendedRocksDBTest</test.exclude.tags>
+        <test.default.exclude.tags>org.apache.spark.tags.ChromeUITest,org.apache.spark.tags.ExtendedLevelDBTest,org.apache.spark.tags.ExtendedRocksDBTest</test.default.exclude.tags>
       </properties>
       <activation>
         <os>

--- a/pom.xml
+++ b/pom.xml
@@ -3581,6 +3581,18 @@
       </activation>
     </profile>
     <profile>
+      <id>mac-on-apple-silicon</id>
+      <properties>
+        <test.exclude.tags>org.apache.spark.tags.ExtendedLevelDBTest,org.apache.spark.tags.ExtendedRocksDBTest</test.exclude.tags>
+      </properties>
+      <activation>
+        <os>
+          <family>macos</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+    </profile>
+    <profile>
       <id>jdwp-test-debug</id>
       <properties>
         <jdwp.arg.line>-agentlib:jdwp=transport=dt_socket,suspend=${test.jdwp.suspend},server=${test.jdwp.server},address=${test.jdwp.address}</jdwp.arg.line>

--- a/pom.xml
+++ b/pom.xml
@@ -3583,7 +3583,8 @@
     <profile>
       <id>mac-on-apple-silicon</id>
       <properties>
-        <test.default.exclude.tags>org.apache.spark.tags.ChromeUITest,org.apache.spark.tags.ExtendedLevelDBTest,org.apache.spark.tags.ExtendedRocksDBTest</test.default.exclude.tags>
+        <test.applesilicon.exclude.tags>org.apache.spark.tags.ExtendedLevelDBTest,org.apache.spark.tags.ExtendedRocksDBTest</test.applesilicon.exclude.tags>
+        <test.default.exclude.tags>org.apache.spark.tags.ChromeUITest,${test.applesilicon.exclude.tags}</test.default.exclude.tags>
       </properties>
       <activation>
         <os>

--- a/pom.xml
+++ b/pom.xml
@@ -3587,7 +3587,7 @@
       </properties>
       <activation>
         <os>
-          <family>macos</family>
+          <family>mac</family>
           <arch>aarch64</arch>
         </os>
       </activation>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1106,13 +1106,12 @@ object TestSettings {
   import BuildCommons._
   private val isMacOnAppleSilicon = System.getProperty("os.name").startsWith("Mac OS X") &&
     System.getProperty("os.arch").equals("aarch64")
-  private val defaultExcludedTags = if (isMacOnAppleSilicon) {
-    Seq("org.apache.spark.tags.ChromeUITest",
-      "org.apache.spark.tags.ExtendedLevelDBTest",
-      "org.apache.spark.tags.ExtendedRocksDBTest")
-  } else {
-    Seq("org.apache.spark.tags.ChromeUITest")
-  }
+  private val defaultExcludedTags = Seq("org.apache.spark.tags.ChromeUITest") ++
+    if (isMacOnAppleSilicon) {
+      Seq("org.apache.spark.tags.ExtendedLevelDBTest", "org.apache.spark.tags.ExtendedRocksDBTest")
+    } else {
+      Seq.empty
+    }
 
   lazy val settings = Seq (
     // Fork new JVMs for tests and set Java options for those

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1104,14 +1104,16 @@ object CopyDependencies {
 
 object TestSettings {
   import BuildCommons._
-  private val isMacOnAppleSilicon = System.getProperty("os.name").startsWith("Mac OS X") &&
-    System.getProperty("os.arch").equals("aarch64")
-  private val defaultExcludedTags = Seq("org.apache.spark.tags.ChromeUITest") ++
+  private val extraDefaultExcludedTags = {
+    val isMacOnAppleSilicon = System.getProperty("os.name").startsWith("Mac OS X") &&
+      System.getProperty("os.arch").equals("aarch64")
     if (isMacOnAppleSilicon) {
       Seq("org.apache.spark.tags.ExtendedLevelDBTest", "org.apache.spark.tags.ExtendedRocksDBTest")
     } else {
       Seq.empty
     }
+  }
+  private val defaultExcludedTags = Seq("org.apache.spark.tags.ChromeUITest") ++ extraDefaultExcludedTags
 
   lazy val settings = Seq (
     // Fork new JVMs for tests and set Java options for those

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1104,7 +1104,15 @@ object CopyDependencies {
 
 object TestSettings {
   import BuildCommons._
-  private val defaultExcludedTags = Seq("org.apache.spark.tags.ChromeUITest")
+  private val isMacOnAppleSilicon = System.getProperty("os.name").startsWith("Mac OS X") &&
+    System.getProperty("os.arch").equals("aarch64")
+  private val defaultExcludedTags = if (isMacOnAppleSilicon) {
+    Seq("org.apache.spark.tags.ChromeUITest",
+      "org.apache.spark.tags.ExtendedLevelDBTest",
+      "org.apache.spark.tags.ExtendedRocksDBTest")
+  } else {
+    Seq("org.apache.spark.tags.ChromeUITest")
+  }
 
   lazy val settings = Seq (
     // Fork new JVMs for tests and set Java options for those


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-37272  and SPARK-37282,  we can manually add

```
-Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest,org.apache.spark.tags.ExtendedRocksDBTest 
```
when run `mvn test` or `sbt test` to disable unsupported UTs on MacOs using Apple Silicon.

This pr add a new profile to re-write `test.default.exclude.tags` property and  activate it automatically when build on MacOs using Apple Silicon to simplify execution commands.


### Why are the changes needed?
Simplify test commands on MacOs using Apple Silicon.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

- Pass the Jenkins or GitHub Action

- Run the tests on M1, there are 3 modules with `Extended{LevelDB,RocksDB}Test` annotation: `core`,`sql`, `yarn`
 1. For maven, we can use follow commands to test the effectiveness of the current pr:
```
mvn clean install -DskipTest -pl ${moduleName} [-Pyarn]
mvn test -pl ${moduleName} [-Pyarn]
```
 2. For sbt, we can use follow commands to test the effectiveness of the current pr:
```
build/sbt "${moduleName}/test" [-Pyarn]
```

Using the this PR, when testing with MacOs using Apple Silicon , Maven and SBT can automatically skip the UTs with `Extended{LevelDB,RocksDB}Test` annotation.



