### PR TITLE
[SPARK-37436][PYTHON] Uses Python's standard string formatter for SQL API in pandas API on Spark

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -604,6 +604,7 @@ pyspark_pandas = Module(
         "pyspark.pandas.mlflow",
         "pyspark.pandas.namespace",
         "pyspark.pandas.numpy_compat",
+        "pyspark.pandas.sql_processor",
         "pyspark.pandas.sql_formatter",
         "pyspark.pandas.strings",
         "pyspark.pandas.utils",

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -604,7 +604,7 @@ pyspark_pandas = Module(
         "pyspark.pandas.mlflow",
         "pyspark.pandas.namespace",
         "pyspark.pandas.numpy_compat",
-        "pyspark.pandas.sql_processor",
+        "pyspark.pandas.sql_formatter",
         "pyspark.pandas.strings",
         "pyspark.pandas.utils",
         "pyspark.pandas.window",

--- a/python/docs/source/migration_guide/pyspark_3.2_to_3.3.rst
+++ b/python/docs/source/migration_guide/pyspark_3.2_to_3.3.rst
@@ -20,4 +20,5 @@
 Upgrading from PySpark 3.2 to 3.3
 =================================
 
+* In Spark 3.3, the ``pyspark.pandas.sql`` method follows [the standard Python string formatter](https://docs.python.org/3/library/string.html#format-string-syntax). To restore the previous behavior, set ``PYSPARK_PANDAS_SQL_LEGACY`` environment variable to ``1``.
 * In Spark 3.3, the ``drop`` method of pandas API on Spark DataFrame supports dropping rows by ``index``, and sets dropping by index instead of column by default.

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -144,4 +144,4 @@ _auto_patch_pandas()
 # Import after the usage logger is attached.
 from pyspark.pandas.config import get_option, options, option_context, reset_option, set_option
 from pyspark.pandas.namespace import *  # F405
-from pyspark.pandas.sql_processor import sql
+from pyspark.pandas.sql_formatter import sql

--- a/python/pyspark/pandas/sql_formatter.py
+++ b/python/pyspark/pandas/sql_formatter.py
@@ -152,7 +152,7 @@ def sql(
     1  2
     2  3
     """
-    if "PYSPARK_PANDAS_SQL_LEGACY" in os.environ:
+    if os.environ.get("PYSPARK_PANDAS_SQL_LEGACY") == "1":
         from pyspark.pandas import sql_processor
 
         warnings.warn(

--- a/python/pyspark/pandas/sql_formatter.py
+++ b/python/pyspark/pandas/sql_formatter.py
@@ -1,0 +1,273 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import string
+from typing import Any, Optional, Union, List, Sequence, Mapping, Tuple
+import uuid
+import warnings
+
+import pandas as pd
+
+from pyspark.pandas.internal import InternalFrame
+from pyspark.pandas.namespace import _get_index_map
+from pyspark.sql.functions import lit
+from pyspark import pandas as ps
+from pyspark.sql import SparkSession
+from pyspark.pandas.utils import default_session
+from pyspark.pandas.frame import DataFrame
+from pyspark.pandas.series import Series
+
+
+__all__ = ["sql"]
+
+
+# This is not used in this file. It's for legacy sql_processor.
+_CAPTURE_SCOPES = 3
+
+
+def sql(
+    query: str,
+    index_col: Optional[Union[str, List[str]]] = None,
+    **kwargs: Any,
+) -> DataFrame:
+    """
+    Execute a SQL query and return the result as a pandas-on-Spark DataFrame.
+
+    This function acts as a standard Python string formatter with understanding
+    the following variable types:
+
+        * pandas-on-Spark DataFrame
+        * pandas-on-Spark Series
+        * pandas DataFrame
+        * pandas Series
+        * string
+
+    Parameters
+    ----------
+    query : str
+        the SQL query
+    index_col : str or list of str, optional
+        Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+        in pandas-on-Spark is ignored. By default, the index is always lost.
+
+        .. note:: If you want to preserve the index, explicitly use :func:`DataFrame.reset_index`,
+            and pass it to the sql statement with `index_col` parameter.
+
+            For example,
+
+            >>> psdf = ps.DataFrame({"A": [1, 2, 3], "B":[4, 5, 6]}, index=['a', 'b', 'c'])
+            >>> new_psdf = psdf.reset_index()
+            >>> ps.sql("SELECT * FROM {new_psdf}", index_col="index", new_psdf=new_psdf)
+            ... # doctest: +NORMALIZE_WHITESPACE
+                   A  B
+            index
+            a      1  4
+            b      2  5
+            c      3  6
+
+            For MultiIndex,
+
+            >>> psdf = ps.DataFrame(
+            ...     {"A": [1, 2, 3], "B": [4, 5, 6]},
+            ...     index=pd.MultiIndex.from_tuples(
+            ...         [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
+            ...     ),
+            ... )
+            >>> new_psdf = psdf.reset_index()
+            >>> ps.sql("SELECT * FROM {new_psdf}", index_col=["index1", "index2"], new_psdf=new_psdf)
+            ... # doctest: +NORMALIZE_WHITESPACE
+                           A  B
+            index1 index2
+            a      b       1  4
+            c      d       2  5
+            e      f       3  6
+
+            Also note that the index name(s) should be matched to the existing name.
+    kwargs
+        other variables that the user want to set that can be referenced in the query
+
+    Returns
+    -------
+    pandas-on-Spark DataFrame
+
+    Examples
+    --------
+
+    Calling a built-in SQL function.
+
+    >>> ps.sql("SELECT * FROM range(10) where id > 7")
+       id
+    0   8
+    1   9
+
+    >>> ps.sql("SELECT * FROM range(10) WHERE id > {bound1} AND id < {bound2}", bound1=7, bound2=9)
+       id
+    0   8
+
+    >>> mydf = ps.range(10)
+    >>> x = tuple(range(4))
+    >>> ps.sql("SELECT {ser} FROM {mydf} WHERE id IN {x}", ser=mydf.id, mydf=mydf, x=x)
+       id
+    0   0
+    1   1
+    2   2
+    3   3
+
+    Mixing pandas-on-Spark and pandas DataFrames in a join operation. Note that the index is
+    dropped.
+
+    >>> ps.sql('''
+    ...   SELECT m1.a, m2.b
+    ...   FROM {table1} m1 INNER JOIN {table2} m2
+    ...   ON m1.key = m2.key
+    ...   ORDER BY m1.a, m2.b''',
+    ...   table1=ps.DataFrame({"a": [1,2], "key": ["a", "b"]}),
+    ...   table2=pd.DataFrame({"b": [3,4,5], "key": ["a", "b", "b"]}))
+       a  b
+    0  1  3
+    1  2  4
+    2  2  5
+
+    Also, it is possible to query using Series.
+
+    >>> psdf = ps.DataFrame({"A": [1, 2, 3], "B":[4, 5, 6]}, index=['a', 'b', 'c'])
+    >>> ps.sql("SELECT {mydf.A} FROM {mydf}", mydf=psdf)
+       A
+    0  1
+    1  2
+    2  3
+    """
+    if "PYSPARK_PANDAS_SQL_LEGACY" in os.environ:
+        from pyspark.pandas import sql_processor
+
+        warnings.warn(
+            "Deprecated in 3.3.0, and the legacy behavior "
+            "will be removed in the future releases.",
+            FutureWarning,
+        )
+        return sql_processor.sql(query, index_col=index_col, **kwargs)
+
+    session = default_session()
+    formatter = SQLStringFormatter(session)
+    try:
+        sdf = session.sql(formatter.format(query, **kwargs))
+    finally:
+        formatter.clear()
+
+    index_spark_columns, index_names = _get_index_map(sdf, index_col)
+
+    return DataFrame(
+        InternalFrame(
+            spark_frame=sdf, index_spark_columns=index_spark_columns, index_names=index_names
+        )
+    )
+
+
+class SQLStringFormatter(string.Formatter):
+    """
+    A standard ``string.Formatter`` in Python that can understand pandas-on-Spark instances
+    with basic Python objects. This object has to be clear after the use for single SQL
+    query; cannot be reused across multiple SQL queries without cleaning.
+    """
+
+    def __init__(self, session: SparkSession) -> None:
+        self._session: SparkSession = session
+        self._temp_views: List[Tuple[DataFrame, str]] = []
+        self._ref_sers: List[Tuple[Series, str]] = []
+
+    def vformat(self, format_string: str, args: Sequence[Any], kwargs: Mapping[str, Any]) -> str:
+        ret = super(SQLStringFormatter, self).vformat(format_string, args, kwargs)
+
+        for ref, n in self._ref_sers:
+            if not any((ref is v for v in df._pssers.values()) for df, _ in self._temp_views):
+                # If referred DataFrame does not hold the given Series, raise an error.
+                raise ValueError("The series in {%s} does not refer any dataframe specified." % n)
+        return ret
+
+    def get_field(self, field_name: str, args: Sequence[Any], kwargs: Mapping[str, Any]) -> Any:
+        obj, first = super(SQLStringFormatter, self).get_field(field_name, args, kwargs)
+        return self._convert_value(obj, field_name), first
+
+    def _convert_value(self, val: Any, name: str) -> Optional[str]:
+        """
+        Converts the given value into a SQL string.
+        """
+        if isinstance(val, pd.Series):
+            # Return the column name from pandas Series directly.
+            return ps.from_pandas(val).to_frame()._to_spark().columns[0]
+        elif isinstance(val, Series):
+            # Return the column name of pandas-on-Spark Series iff its DataFrame was
+            # referred. The check will be done in `vformat` after we parse all.
+            self._ref_sers.append((val, name))
+            return val.to_frame()._to_spark().columns[0]
+        elif isinstance(val, (DataFrame, pd.DataFrame)):
+            df_name = "_pandas_api_%s" % str(uuid.uuid4()).replace("-", "")
+
+            if isinstance(val, pd.DataFrame):
+                # Don't store temp view for plain pandas instances
+                # because it is unable to know which pandas DataFrame
+                # holds which Series.
+                val = ps.from_pandas(val)
+            else:
+                for df, n in self._temp_views:
+                    if df is val:
+                        return n
+                self._temp_views.append((val, df_name))
+
+            val._to_spark().createOrReplaceTempView(df_name)
+            return df_name
+        elif isinstance(val, str):
+            return lit(val)._jc.expr().sql()  # for escaped characters.
+        else:
+            return val
+
+    def clear(self) -> None:
+        for _, n in self._temp_views:
+            self._session.catalog.dropTempView(n)
+        self._temp_views = []
+        self._ref_sers = []
+
+
+def _test() -> None:
+    import os
+    import doctest
+    import sys
+    from pyspark.sql import SparkSession
+    import pyspark.pandas.sql_formatter
+
+    os.chdir(os.environ["SPARK_HOME"])
+
+    globs = pyspark.pandas.sql_formatter.__dict__.copy()
+    globs["ps"] = pyspark.pandas
+    spark = (
+        SparkSession.builder.master("local[4]")
+        .appName("pyspark.pandas.sql_processor tests")
+        .getOrCreate()
+    )
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.pandas.sql_formatter,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+    )
+    spark.stop()
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -77,9 +77,13 @@ def sql(
 
             For example,
 
+            >>> from pyspark.pandas import sql_processor
+            >>> # we will call 'sql_processor' directly in doctests so decrease one level.
+            >>> sql_processor._CAPTURE_SCOPES = 2
+            >>> sql = sql_processor.sql
             >>> psdf = ps.DataFrame({"A": [1, 2, 3], "B":[4, 5, 6]}, index=['a', 'b', 'c'])
             >>> psdf_reset_index = psdf.reset_index()
-            >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col="index")
+            >>> sql("SELECT * FROM {psdf_reset_index}", index_col="index")
             ... # doctest: +NORMALIZE_WHITESPACE
                    A  B
             index
@@ -96,7 +100,7 @@ def sql(
             ...     ),
             ... )
             >>> psdf_reset_index = psdf.reset_index()
-            >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col=["index1", "index2"])
+            >>> sql("SELECT * FROM {psdf_reset_index}", index_col=["index1", "index2"])
             ... # doctest: +NORMALIZE_WHITESPACE
                            A  B
             index1 index2
@@ -122,7 +126,7 @@ def sql(
 
     Calling a built-in SQL function.
 
-    >>> ps.sql("select * from range(10) where id > 7")
+    >>> sql("select * from range(10) where id > 7")
        id
     0   8
     1   9
@@ -130,7 +134,7 @@ def sql(
     A query can also reference a local variable or parameter by wrapping them in curly braces:
 
     >>> bound1 = 7
-    >>> ps.sql("select * from range(10) where id > {bound1} and id < {bound2}", bound2=9)
+    >>> sql("select * from range(10) where id > {bound1} and id < {bound2}", bound2=9)
        id
     0   8
 
@@ -139,7 +143,7 @@ def sql(
 
     >>> mydf = ps.range(10)
     >>> x = range(4)
-    >>> ps.sql("SELECT * from {mydf} WHERE id IN {x}")
+    >>> sql("SELECT * from {mydf} WHERE id IN {x}")
        id
     0   0
     1   1
@@ -150,7 +154,7 @@ def sql(
 
     >>> def statement():
     ...     mydf2 = ps.DataFrame({"x": range(2)})
-    ...     return ps.sql("SELECT * from {mydf2}")
+    ...     return sql("SELECT * from {mydf2}")
     >>> statement()
        x
     0  0
@@ -159,7 +163,7 @@ def sql(
     Mixing pandas-on-Spark and pandas DataFrames in a join operation. Note that the index is
     dropped.
 
-    >>> ps.sql('''
+    >>> sql('''
     ...   SELECT m1.a, m2.b
     ...   FROM {table1} m1 INNER JOIN {table2} m2
     ...   ON m1.key = m2.key
@@ -174,12 +178,11 @@ def sql(
     Also, it is possible to query using Series.
 
     >>> myser = ps.Series({'a': [1.0, 2.0, 3.0], 'b': [15.0, 30.0, 45.0]})
-    >>> ps.sql("SELECT * from {myser}")
+    >>> sql("SELECT * from {myser}")
                         0
     0     [1.0, 2.0, 3.0]
     1  [15.0, 30.0, 45.0]
     """
-
     if globals is None:
         globals = _get_ipython_scope()
     _globals = builtin_globals() if globals is None else dict(globals)
@@ -273,19 +276,23 @@ class SQLProcessor(object):
         Returns a DataFrame for which the SQL statement has been executed by
         the underlying SQL engine.
 
+        >>> from pyspark.pandas import sql_processor
+        >>> # we will call 'sql_processor' directly in doctests so decrease one level.
+        >>> sql_processor._CAPTURE_SCOPES = 2
+        >>> sql = sql_processor.sql
         >>> str0 = 'abc'
-        >>> ps.sql("select {str0}")
+        >>> sql("select {str0}")
            abc
         0  abc
 
         >>> str1 = 'abc"abc'
         >>> str2 = "abc'abc"
-        >>> ps.sql("select {str0}, {str1}, {str2}")
+        >>> sql("select {str0}, {str1}, {str2}")
            abc  abc"abc  abc'abc
         0  abc  abc"abc  abc'abc
 
         >>> strs = ['a', 'b']
-        >>> ps.sql("select 'a' in {strs} as cond1, 'c' in {strs} as cond2")
+        >>> sql("select 'a' in {strs} as cond1, 'c' in {strs} as cond2")
            cond1  cond2
         0   True  False
         """

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -43,142 +43,6 @@ def sql(
     locals: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
 ) -> DataFrame:
-    """
-    Execute a SQL query and return the result as a pandas-on-Spark DataFrame.
-
-    This function also supports embedding Python variables (locals, globals, and parameters)
-    in the SQL statement by wrapping them in curly braces. See examples section for details.
-
-    In addition to the locals, globals and parameters, the function will also attempt
-    to determine if the program currently runs in an IPython (or Jupyter) environment
-    and to import the variables from this environment. The variables have the same
-    precedence as globals.
-
-    The following variable types are supported:
-
-        * string
-        * int
-        * float
-        * list, tuple, range of above types
-        * pandas-on-Spark DataFrame
-        * pandas-on-Spark Series
-        * pandas DataFrame
-
-    Parameters
-    ----------
-    query : str
-        the SQL query
-    index_col : str or list of str, optional
-        Column names to be used in Spark to represent pandas-on-Spark's index. The index name
-        in pandas-on-Spark is ignored. By default, the index is always lost.
-
-        .. note:: If you want to preserve the index, explicitly use :func:`DataFrame.reset_index`,
-            and pass it to the sql statement with `index_col` parameter.
-
-            For example,
-
-            >>> psdf = ps.DataFrame({"A": [1, 2, 3], "B":[4, 5, 6]}, index=['a', 'b', 'c'])
-            >>> psdf_reset_index = psdf.reset_index()
-            >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col="index")
-            ... # doctest: +NORMALIZE_WHITESPACE
-                   A  B
-            index
-            a      1  4
-            b      2  5
-            c      3  6
-
-            For MultiIndex,
-
-            >>> psdf = ps.DataFrame(
-            ...     {"A": [1, 2, 3], "B": [4, 5, 6]},
-            ...     index=pd.MultiIndex.from_tuples(
-            ...         [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
-            ...     ),
-            ... )
-            >>> psdf_reset_index = psdf.reset_index()
-            >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col=["index1", "index2"])
-            ... # doctest: +NORMALIZE_WHITESPACE
-                           A  B
-            index1 index2
-            a      b       1  4
-            c      d       2  5
-            e      f       3  6
-
-            Also note that the index name(s) should be matched to the existing name.
-
-    globals : dict, optional
-        the dictionary of global variables, if explicitly set by the user
-    locals : dict, optional
-        the dictionary of local variables, if explicitly set by the user
-    kwargs
-        other variables that the user may want to set manually that can be referenced in the query
-
-    Returns
-    -------
-    pandas-on-Spark DataFrame
-
-    Examples
-    --------
-
-    Calling a built-in SQL function.
-
-    >>> ps.sql("select * from range(10) where id > 7")
-       id
-    0   8
-    1   9
-
-    A query can also reference a local variable or parameter by wrapping them in curly braces:
-
-    >>> bound1 = 7
-    >>> ps.sql("select * from range(10) where id > {bound1} and id < {bound2}", bound2=9)
-       id
-    0   8
-
-    You can also wrap a DataFrame with curly braces to query it directly. Note that when you do
-    that, the indexes, if any, automatically become top level columns.
-
-    >>> mydf = ps.range(10)
-    >>> x = range(4)
-    >>> ps.sql("SELECT * from {mydf} WHERE id IN {x}")
-       id
-    0   0
-    1   1
-    2   2
-    3   3
-
-    Queries can also be arbitrarily nested in functions:
-
-    >>> def statement():
-    ...     mydf2 = ps.DataFrame({"x": range(2)})
-    ...     return ps.sql("SELECT * from {mydf2}")
-    >>> statement()
-       x
-    0  0
-    1  1
-
-    Mixing pandas-on-Spark and pandas DataFrames in a join operation. Note that the index is
-    dropped.
-
-    >>> ps.sql('''
-    ...   SELECT m1.a, m2.b
-    ...   FROM {table1} m1 INNER JOIN {table2} m2
-    ...   ON m1.key = m2.key
-    ...   ORDER BY m1.a, m2.b''',
-    ...   table1=ps.DataFrame({"a": [1,2], "key": ["a", "b"]}),
-    ...   table2=pd.DataFrame({"b": [3,4,5], "key": ["a", "b", "b"]}))
-       a  b
-    0  1  3
-    1  2  4
-    2  2  5
-
-    Also, it is possible to query using Series.
-
-    >>> myser = ps.Series({'a': [1.0, 2.0, 3.0], 'b': [15.0, 30.0, 45.0]})
-    >>> ps.sql("SELECT * from {myser}")
-                        0
-    0     [1.0, 2.0, 3.0]
-    1  [15.0, 30.0, 45.0]
-    """
     if globals is None:
         globals = _get_ipython_scope()
     _globals = builtin_globals() if globals is None else dict(globals)
@@ -195,7 +59,7 @@ def sql(
     return SQLProcessor(_dict, query, default_session()).execute(index_col)
 
 
-_CAPTURE_SCOPES = 2
+_CAPTURE_SCOPES = 3
 
 
 def _get_local_scope() -> Dict[str, Any]:
@@ -268,26 +132,6 @@ class SQLProcessor(object):
         self._session = session
 
     def execute(self, index_col: Optional[Union[str, List[str]]]) -> DataFrame:
-        """
-        Returns a DataFrame for which the SQL statement has been executed by
-        the underlying SQL engine.
-
-        >>> str0 = 'abc'
-        >>> ps.sql("select {str0}")
-           abc
-        0  abc
-
-        >>> str1 = 'abc"abc'
-        >>> str2 = "abc'abc"
-        >>> ps.sql("select {str0}, {str1}, {str2}")
-           abc  abc"abc  abc'abc
-        0  abc  abc"abc  abc'abc
-
-        >>> strs = ['a', 'b']
-        >>> ps.sql("select 'a' in {strs} as cond1, 'c' in {strs} as cond2")
-           cond1  cond2
-        0   True  False
-        """
         blocks = _string.formatter_parser(self._statement)
         # TODO: use a string builder
         res = ""
@@ -354,33 +198,3 @@ class SQLProcessor(object):
         if isinstance(var, (tuple, range)):
             return self._convert_var(list(var))
         raise ValueError("Unsupported variable type {}: {}".format(type(var).__name__, str(var)))
-
-
-def _test() -> None:
-    import os
-    import doctest
-    import sys
-    from pyspark.sql import SparkSession
-    import pyspark.pandas.sql_processor
-
-    os.chdir(os.environ["SPARK_HOME"])
-
-    globs = pyspark.pandas.sql_processor.__dict__.copy()
-    globs["ps"] = pyspark.pandas
-    spark = (
-        SparkSession.builder.master("local[4]")
-        .appName("pyspark.pandas.sql_processor tests")
-        .getOrCreate()
-    )
-    (failure_count, test_count) = doctest.testmod(
-        pyspark.pandas.sql_processor,
-        globs=globs,
-        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
-    )
-    spark.stop()
-    if failure_count:
-        sys.exit(-1)
-
-
-if __name__ == "__main__":
-    _test()

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -43,6 +43,143 @@ def sql(
     locals: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
 ) -> DataFrame:
+    """
+    Execute a SQL query and return the result as a pandas-on-Spark DataFrame.
+
+    This function also supports embedding Python variables (locals, globals, and parameters)
+    in the SQL statement by wrapping them in curly braces. See examples section for details.
+
+    In addition to the locals, globals and parameters, the function will also attempt
+    to determine if the program currently runs in an IPython (or Jupyter) environment
+    and to import the variables from this environment. The variables have the same
+    precedence as globals.
+
+    The following variable types are supported:
+
+        * string
+        * int
+        * float
+        * list, tuple, range of above types
+        * pandas-on-Spark DataFrame
+        * pandas-on-Spark Series
+        * pandas DataFrame
+
+    Parameters
+    ----------
+    query : str
+        the SQL query
+    index_col : str or list of str, optional
+        Column names to be used in Spark to represent pandas-on-Spark's index. The index name
+        in pandas-on-Spark is ignored. By default, the index is always lost.
+
+        .. note:: If you want to preserve the index, explicitly use :func:`DataFrame.reset_index`,
+            and pass it to the sql statement with `index_col` parameter.
+
+            For example,
+
+            >>> psdf = ps.DataFrame({"A": [1, 2, 3], "B":[4, 5, 6]}, index=['a', 'b', 'c'])
+            >>> psdf_reset_index = psdf.reset_index()
+            >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col="index")
+            ... # doctest: +NORMALIZE_WHITESPACE
+                   A  B
+            index
+            a      1  4
+            b      2  5
+            c      3  6
+
+            For MultiIndex,
+
+            >>> psdf = ps.DataFrame(
+            ...     {"A": [1, 2, 3], "B": [4, 5, 6]},
+            ...     index=pd.MultiIndex.from_tuples(
+            ...         [("a", "b"), ("c", "d"), ("e", "f")], names=["index1", "index2"]
+            ...     ),
+            ... )
+            >>> psdf_reset_index = psdf.reset_index()
+            >>> ps.sql("SELECT * FROM {psdf_reset_index}", index_col=["index1", "index2"])
+            ... # doctest: +NORMALIZE_WHITESPACE
+                           A  B
+            index1 index2
+            a      b       1  4
+            c      d       2  5
+            e      f       3  6
+
+            Also note that the index name(s) should be matched to the existing name.
+
+    globals : dict, optional
+        the dictionary of global variables, if explicitly set by the user
+    locals : dict, optional
+        the dictionary of local variables, if explicitly set by the user
+    kwargs
+        other variables that the user may want to set manually that can be referenced in the query
+
+    Returns
+    -------
+    pandas-on-Spark DataFrame
+
+    Examples
+    --------
+
+    Calling a built-in SQL function.
+
+    >>> ps.sql("select * from range(10) where id > 7")
+       id
+    0   8
+    1   9
+
+    A query can also reference a local variable or parameter by wrapping them in curly braces:
+
+    >>> bound1 = 7
+    >>> ps.sql("select * from range(10) where id > {bound1} and id < {bound2}", bound2=9)
+       id
+    0   8
+
+    You can also wrap a DataFrame with curly braces to query it directly. Note that when you do
+    that, the indexes, if any, automatically become top level columns.
+
+    >>> mydf = ps.range(10)
+    >>> x = range(4)
+    >>> ps.sql("SELECT * from {mydf} WHERE id IN {x}")
+       id
+    0   0
+    1   1
+    2   2
+    3   3
+
+    Queries can also be arbitrarily nested in functions:
+
+    >>> def statement():
+    ...     mydf2 = ps.DataFrame({"x": range(2)})
+    ...     return ps.sql("SELECT * from {mydf2}")
+    >>> statement()
+       x
+    0  0
+    1  1
+
+    Mixing pandas-on-Spark and pandas DataFrames in a join operation. Note that the index is
+    dropped.
+
+    >>> ps.sql('''
+    ...   SELECT m1.a, m2.b
+    ...   FROM {table1} m1 INNER JOIN {table2} m2
+    ...   ON m1.key = m2.key
+    ...   ORDER BY m1.a, m2.b''',
+    ...   table1=ps.DataFrame({"a": [1,2], "key": ["a", "b"]}),
+    ...   table2=pd.DataFrame({"b": [3,4,5], "key": ["a", "b", "b"]}))
+       a  b
+    0  1  3
+    1  2  4
+    2  2  5
+
+    Also, it is possible to query using Series.
+
+    >>> myser = ps.Series({'a': [1.0, 2.0, 3.0], 'b': [15.0, 30.0, 45.0]})
+    >>> ps.sql("SELECT * from {myser}")
+                        0
+    0     [1.0, 2.0, 3.0]
+    1  [15.0, 30.0, 45.0]
+    """
+
     if globals is None:
         globals = _get_ipython_scope()
     _globals = builtin_globals() if globals is None else dict(globals)
@@ -132,6 +269,26 @@ class SQLProcessor(object):
         self._session = session
 
     def execute(self, index_col: Optional[Union[str, List[str]]]) -> DataFrame:
+        """
+        Returns a DataFrame for which the SQL statement has been executed by
+        the underlying SQL engine.
+
+        >>> str0 = 'abc'
+        >>> ps.sql("select {str0}")
+           abc
+        0  abc
+
+        >>> str1 = 'abc"abc'
+        >>> str2 = "abc'abc"
+        >>> ps.sql("select {str0}, {str1}, {str2}")
+           abc  abc"abc  abc'abc
+        0  abc  abc"abc  abc'abc
+
+        >>> strs = ['a', 'b']
+        >>> ps.sql("select 'a' in {strs} as cond1, 'c' in {strs} as cond2")
+           cond1  cond2
+        0   True  False
+        """
         blocks = _string.formatter_parser(self._statement)
         # TODO: use a string builder
         res = ""
@@ -198,3 +355,33 @@ class SQLProcessor(object):
         if isinstance(var, (tuple, range)):
             return self._convert_var(list(var))
         raise ValueError("Unsupported variable type {}: {}".format(type(var).__name__, str(var)))
+
+
+def _test() -> None:
+    import os
+    import doctest
+    import sys
+    from pyspark.sql import SparkSession
+    import pyspark.pandas.sql_processor
+
+    os.chdir(os.environ["SPARK_HOME"])
+
+    globs = pyspark.pandas.sql_processor.__dict__.copy()
+    globs["ps"] = pyspark.pandas
+    spark = (
+        SparkSession.builder.master("local[4]")
+        .appName("pyspark.pandas.sql_processor tests")
+        .getOrCreate()
+    )
+    (failure_count, test_count) = doctest.testmod(
+        pyspark.pandas.sql_processor,
+        globs=globs,
+        optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE,
+    )
+    spark.stop()
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -25,7 +25,7 @@ from typing import Union
 
 import pandas as pd
 
-from pyspark.pandas import config, namespace, sql_processor
+from pyspark.pandas import config, namespace, sql_formatter
 from pyspark.pandas.accessors import PandasOnSparkFrameMethods
 from pyspark.pandas.frame import DataFrame
 from pyspark.pandas.datetimes import DatetimeMethods
@@ -113,8 +113,8 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
     except ImportError:
         pass
 
-    sql_processor._CAPTURE_SCOPES = 3
-    modules.append(sql_processor)
+    sql_formatter._CAPTURE_SCOPES = 4
+    modules.append(sql_formatter)
 
     # Modules
     for target_module in modules:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use [Python's standard string formatter](https://docs.python.org/3/library/string.html#custom-string-formatting) instead of hacky custom SQL parser for SQL API in pandas API on Spark

### Why are the changes needed?

Current implementation of parsing is very hacky, and does not work. It is [dependent on Python's internal module](https://github.com/apache/spark/blob/master/python/pyspark/pandas/sql_processor.py#L291), and [Series is being treated as a table](https://github.com/apache/spark/blob/master/python/pyspark/pandas/sql_processor.py#L339-L340), etc.

We should have the Python standard string formatter with the standard interface and the standard support.

### Does this PR introduce _any_ user-facing change?

Yes.

**Disallowed:**

1. `Series` as a table

    ```python
    myser = ps.Series({'a': [1.0, 2.0, 3.0], 'b': [15.0, 30.0, 45.0]})
    ps.sql("SELECT * from {myser}", myser=myser)
    ```

2. `list` and `range`

    ```python
    strs = ['a', 'b']
    ps.sql("SELECT 'a' IN {strs}", strs=strs)
    ```

3. Automatic local/global variable detection:

    ```python
    strs = ['a', 'b']
    ps.sql("SELECT 'a' IN {strs}")
    ```

**Allowed:**

1. `Series` as a column

    ```python
    mydf = ps.range(10)
    ps.sql("SELECT {ser} FROM {mydf}", ser=mydf.id, mydf=mydf)
    ```

2. Reference checking (between `Series` and `DataFrame`)

    ```python
    mydf = ps.range(10)
    ps.sql("SELECT {ser} FROM tblA", ser=mydf.id)
    ```

    ```
    ValueError: The series in {ser} does not refer any dataframe specified.
    ```

3. Attribute supports from frame (standard Python support):

    ```python
    mydf = ps.range(10)
    ps.sql("SELECT {tbl.id} FROM {tbl}", tbl=mydf)
    ```

### How was this patch tested?

Doctests were added.