### PR TITLE
[SPARK-36231][PYTHON] Support arithmetic operations of decimal(nan) series

### DIFF
--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -172,29 +172,19 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:
             pser, psser = pdf[col], psdf[col]
-            if col == "float":
-                self.assert_eq(pser ** pser, psser ** psser)
-                self.assert_eq(pser ** pser.astype(bool), psser ** psser.astype(bool))
-                self.assert_eq(pser ** True, psser ** True)
-                self.assert_eq(pser ** False, psser ** False)
-
-            for n_col in self.non_numeric_df_cols:
-                if n_col == "bool":
-                    self.assert_eq(pdf["float"] ** pdf[n_col], psdf["float"] ** psdf[n_col])
-                else:
-                    self.assertRaises(TypeError, lambda: psser ** psdf[n_col])
-
-    # TODO(SPARK-36031): Merge test_pow_with_nan into test_pow
-    def test_pow_with_float_nan(self):
-        for col in self.numeric_w_nan_df_cols:
-            if col == "float_w_nan":
-                pser, psser = self.numeric_w_nan_pdf[col], self.numeric_w_nan_psdf[col]
+            if col in ["float", "float_w_nan"]:
                 self.assert_eq(pser ** pser, psser ** psser)
                 self.assert_eq(pser ** pser.astype(bool), psser ** psser.astype(bool))
                 self.assert_eq(pser ** True, psser ** True)
                 self.assert_eq(pser ** False, psser ** False)
                 self.assert_eq(pser ** 1, psser ** 1)
                 self.assert_eq(pser ** 0, psser ** 0)
+
+            for n_col in self.non_numeric_df_cols:
+                if n_col == "bool":
+                    self.assert_eq(pdf["float"] ** pdf[n_col], psdf["float"] ** psdf[n_col])
+                else:
+                    self.assertRaises(TypeError, lambda: psser ** psdf[n_col])
 
     def test_radd(self):
         pdf, psdf = self.pdf, self.psdf
@@ -344,40 +334,36 @@ class NumOpsTest(PandasOnSparkTestCase, TestCasesUtils):
             self.assert_eq(ps.from_pandas(pser), psser)
 
     def test_isnull(self):
-        pdf, psdf = self.numeric_w_nan_pdf, self.numeric_w_nan_psdf
-        for col in self.numeric_w_nan_df_cols:
+        pdf, psdf = self.pdf, self.psdf
+        for col in self.numeric_df_cols:
             self.assert_eq(pdf[col].isnull(), psdf[col].isnull())
 
     def test_astype(self):
         pdf, psdf = self.pdf, self.psdf
         for col in self.numeric_df_cols:
             pser, psser = pdf[col], psdf[col]
-            self.assert_eq(pser.astype(int), psser.astype(int))
+
+            for int_type in [int, np.int32, np.int16, np.int8]:
+                if not pser.hasnans:
+                    self.assert_eq(pser.astype(int_type), psser.astype(int_type))
+                else:
+                    self.assertRaisesRegex(
+                        ValueError,
+                        "Cannot convert %s with missing "
+                        "values to integer" % psser._dtype_op.pretty_name,
+                        lambda: psser.astype(int_type),
+                    )
+
+            # TODO(SPARK-37039): the np.nan series.astype(bool) should be True
+            if not pser.hasnans:
+                self.assert_eq(pser.astype(bool), psser.astype(bool))
+
             self.assert_eq(pser.astype(float), psser.astype(float))
             self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
-            self.assert_eq(pser.astype(np.int32), psser.astype(np.int32))
-            self.assert_eq(pser.astype(np.int16), psser.astype(np.int16))
-            self.assert_eq(pser.astype(np.int8), psser.astype(np.int8))
             self.assert_eq(pser.astype(str), psser.astype(str))
-            self.assert_eq(pser.astype(bool), psser.astype(bool))
             self.assert_eq(pser.astype("category"), psser.astype("category"))
             cat_type = CategoricalDtype(categories=[2, 1, 3])
             self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
-        self.assertRaisesRegex(
-            ValueError,
-            "Cannot convert fractions with missing values to integer",
-            lambda: self.float_withnan_psser.astype(int),
-        )
-        self.assertRaisesRegex(
-            ValueError,
-            "Cannot convert fractions with missing values to integer",
-            lambda: self.float_withnan_psser.astype(np.int32),
-        )
-        self.assert_eq(self.float_withnan_psser.astype(str), self.float_withnan_psser.astype(str))
-        self.assert_eq(self.float_withnan_psser.astype(bool), self.float_withnan_psser.astype(bool))
-        self.assert_eq(
-            self.float_withnan_psser.astype("category"), self.float_withnan_psser.astype("category")
-        )
         if extension_object_dtypes_available and extension_float_dtypes_available:
             pser = pd.Series(pd.Categorical([1.0, 2.0, 3.0]), dtype=pd.Float64Dtype())
             psser = ps.from_pandas(pser)

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -49,8 +49,14 @@ class TestCasesUtils(object):
         dtypes = [np.int32, int, np.float32, float]
         sers = [pd.Series([1, 2, 3], dtype=dtype) for dtype in dtypes]
         sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(3)]))
+        sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)]))
+        sers.append(pd.Series([1, 2, np.nan], dtype=float))
         pdf = pd.concat(sers, axis=1)
-        pdf.columns = [dtype.__name__ for dtype in dtypes] + ["decimal"]
+        pdf.columns = [dtype.__name__ for dtype in dtypes] + [
+            "decimal",
+            "decimal_nan",
+            "float_nan",
+        ]
         return pdf
 
     @property
@@ -68,25 +74,6 @@ class TestCasesUtils(object):
     @property
     def integral_psdf(self):
         return ps.from_pandas(self.integral_pdf)
-
-    # TODO(SPARK-36031): Merge self.numeric_w_nan_p(s)df into self.numeric_p(s)df
-    @property
-    def numeric_w_nan_pdf(self):
-        psers = {
-            "float_w_nan": pd.Series([1, 2, np.nan]),
-            "decimal_w_nan": pd.Series(
-                [decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)]
-            ),
-        }
-        return pd.concat(psers, axis=1)
-
-    @property
-    def numeric_w_nan_psdf(self):
-        return ps.from_pandas(self.numeric_w_nan_pdf)
-
-    @property
-    def numeric_w_nan_df_cols(self):
-        return self.numeric_w_nan_pdf.columns
 
     @property
     def non_numeric_pdf(self):
@@ -133,31 +120,8 @@ class TestCasesUtils(object):
         return [ps.from_pandas(pser) for pser in self.numeric_psers]
 
     @property
-    def decimal_withnan_pser(self):
-        return pd.Series([decimal.Decimal(1.0), decimal.Decimal(2.0), decimal.Decimal(np.nan)])
-
-    @property
-    def decimal_withnan_psser(self):
-        return ps.from_pandas(self.decimal_withnan_pser)
-
-    @property
-    def float_withnan_pser(self):
-        return pd.Series([1, 2, np.nan])
-
-    @property
-    def float_withnan_psser(self):
-        return ps.from_pandas(self.float_withnan_pser)
-
-    @property
     def numeric_pser_psser_pairs(self):
         return zip(self.numeric_psers, self.numeric_pssers)
-
-    @property
-    def numeric_withnan_pser_psser_pairs(self):
-        return zip(
-            self.numeric_psers + [self.decimal_withnan_pser, self.float_withnan_pser],
-            self.numeric_pssers + [self.decimal_withnan_psser, self.float_withnan_psser],
-        )
 
     @property
     def non_numeric_psers(self):

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -49,14 +49,21 @@ class TestCasesUtils(object):
         dtypes = [np.int32, int, np.float32, float]
         sers = [pd.Series([1, 2, 3], dtype=dtype) for dtype in dtypes]
         sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(3)]))
-        sers.append(pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)]))
         sers.append(pd.Series([1, 2, np.nan], dtype=float))
+        # Skip decimal_nan test before v1.3.0, it not supported by pandas on spark yet.
+        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
+            sers.append(
+                pd.Series([decimal.Decimal(1), decimal.Decimal(2), decimal.Decimal(np.nan)])
+            )
         pdf = pd.concat(sers, axis=1)
-        pdf.columns = [dtype.__name__ for dtype in dtypes] + [
-            "decimal",
-            "decimal_nan",
-            "float_nan",
-        ]
+        if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
+            pdf.columns = [dtype.__name__ for dtype in dtypes] + [
+                "decimal",
+                "float_nan",
+                "decimal_nan",
+            ]
+        else:
+            pdf.columns = [dtype.__name__ for dtype in dtypes] + ["decimal", "float_nan"]
         return pdf
 
     @property


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch has changes as below to follow the pandas behavior:
- **Add nan value process in _non_fractional_astype**: Follow the pandas [to_string](https://github.com/pandas-dev/pandas/blob/0a9f9eed3e3eb7d5fa23cbc588e78b9bef915a89/pandas/core/series.py#L1486) covert method, it should be `"NaN"` rather than `str(np.nan)`(`"nan"`)， which is covered by `self.assert_eq(pser.astype(str), psser.astype(str))`.
- **Add null value process in rpow**, which is covered by `def test_rpow(self)`
- **Add index_ops.hasnans in `astype`**, which is covered by `test_astype`.

This patch also move `numeric_w_nan_pdf` into `numeric_pdf`, that means all float_nan/decimal_nan separated test case have been cleaned up and merged into numeric test.

### Why are the changes needed?
Follow the pandas behavior

### Does this PR introduce _any_ user-facing change?
Yes, correct the null value result to follow the pandas behavior


### How was this patch tested?
1. ut to cover all changes
2. Passed all python test case with pandas v1.1.x
3. Passed all python test case with pandas v1.2.x