### PR TITLE
[SPARK-37446][SQL] Use reflection for getWithoutRegisterFns to allow different Hive versions for building

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -207,7 +207,7 @@ private[hive] class HiveClientImpl(
     } catch {
       // SPARK-37069: not all Hive versions have the above method (e.g., Hive 2.3.9 has it but
       // 2.3.8 don't), therefore here we fallback when encountering the exception.
-      case _: NoSuchMethodError =>
+      case _: NoSuchMethodException =>
         Hive.get(conf)
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -202,7 +202,8 @@ private[hive] class HiveClientImpl(
 
   private def getHive(conf: HiveConf): Hive = {
     try {
-      Hive.getWithoutRegisterFns(conf)
+      classOf[Hive].getMethod("getWithoutRegisterFns", classOf[HiveConf])
+        .invoke(null, conf).asInstanceOf[Hive]
     } catch {
       // SPARK-37069: not all Hive versions have the above method (e.g., Hive 2.3.9 has it but
       // 2.3.8 don't), therefore here we fallback when encountering the exception.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Since Hive 2.3.9  start have function `getWithoutRegisterFns`, but user may use hive 2.3.8 or lower version.
Here we should use reflection to let user build with hive 2.3.8 or lower version


### Why are the changes needed?
Support build with hive version lower than 2.3.9 since many user will build spark with it 's own hive code and their own jar (they may do some optimize or. other thing in their own code). This pr make it easier to integrate and won't hurt current logic.


### Does this PR introduce _any_ user-facing change?
User can build spark with hive version lower than 2.3.9


### How was this patch tested?

build with command 
```
./dev/make-distribution.sh --tgz -Pyarn -Phive -Phive-thriftserver -Dhive.version=2.3.8
```

Jars under dist
![image](https://user-images.githubusercontent.com/46485123/143162194-d505b151-f23d-4268-af19-6dfeccea4a74.png)
