### PR TITLE
[SPARK-37259][SQL] Support CTE and TempTable queries with MSSQL JDBC

### DIFF
--- a/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/external/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -358,7 +358,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
         0, 0, 0, 1, 0, 0, 0, 3))
   }
 
-  test("withClause and query  JDBC options") {
+  test("withClause and query JDBC options") {
     val expectedResult = Set(
       (42, "fred"),
       (17, "dave")
@@ -392,6 +392,24 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
       .option("url", jdbcUrl)
       .option("withClause", withClause)
       .option("dbtable", dbtable)
+      .load()
+    assert(df.collect.toSet === expectedResult)
+  }
+
+  test("temp table withClause and query JDBC options") {
+    val expectedResult = Set(
+      (42, "fred"),
+      (17, "dave")
+    ).map { case (x, y) =>
+      Row(Integer.valueOf(x), String.valueOf(y))
+    }
+
+    val withClause = "(SELECT * INTO #TempTable FROM (SELECT * FROM tbl) t)"
+    val query = "SELECT * FROM #TempTable"
+    val df = spark.read.format("jdbc")
+      .option("url", jdbcUrl)
+      .option("withClause", withClause)
+      .option("query", query)
       .load()
     assert(df.collect.toSet === expectedResult)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -222,6 +222,8 @@ class JDBCOptions(
 
   // User specified JDBC connection provider name
   val connectionProviderName = parameters.get(JDBC_CONNECTION_PROVIDER)
+
+  val withClause = parameters.get(JDBC_WITH_CLAUSE).map(_ + " ").getOrElse("")
 }
 
 class JdbcOptionsInWrite(
@@ -282,4 +284,5 @@ object JDBCOptions {
   val JDBC_TABLE_COMMENT = newOption("tableComment")
   val JDBC_REFRESH_KRB5_CONFIG = newOption("refreshKrb5Config")
   val JDBC_CONNECTION_PROVIDER = newOption("connectionProvider")
+  val JDBC_WITH_CLAUSE = newOption("withClause")
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -53,9 +53,10 @@ object JDBCRDD extends Logging {
    */
   def resolveTable(options: JDBCOptions): StructType = {
     val url = options.url
+    val withClause = options.withClause
     val table = options.tableOrQuery
     val dialect = JdbcDialects.get(url)
-    getQueryOutputSchema(dialect.getSchemaQuery(table), options, dialect)
+    getQueryOutputSchema(withClause + dialect.getSchemaQuery(table), options, dialect)
   }
 
   def getQueryOutputSchema(
@@ -367,7 +368,8 @@ private[jdbc] class JDBCRDD(
 
     val myLimitClause: String = dialect.getLimitClause(limit)
 
-    val sqlText = s"SELECT $columnList FROM ${options.tableOrQuery} $myTableSampleClause" +
+    val sqlText = options.withClause +
+      s"SELECT $columnList FROM ${options.tableOrQuery} $myTableSampleClause" +
       s" $myWhereClause $getGroupByClause $myLimitClause"
     stmt = conn.prepareStatement(sqlText,
         ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -325,6 +325,6 @@ private[sql] case class JDBCRelation(
   override def toString: String = {
     val partitioningInfo = if (parts.nonEmpty) s" [numPartitions=${parts.length}]" else ""
     // credentials should not be included in the plan output, table information is sufficient.
-    s"JDBCRelation(${jdbcOptions.withClause}${jdbcOptions.tableOrQuery})" + partitioningInfo
+    s"JDBCRelation(${jdbcOptions.withClause}${jdbcOptions.tableOrQuery})$partitioningInfo"
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -325,6 +325,6 @@ private[sql] case class JDBCRelation(
   override def toString: String = {
     val partitioningInfo = if (parts.nonEmpty) s" [numPartitions=${parts.length}]" else ""
     // credentials should not be included in the plan output, table information is sufficient.
-    s"JDBCRelation(${jdbcOptions.tableOrQuery})" + partitioningInfo
+    s"JDBCRelation(${jdbcOptions.withClause}${jdbcOptions.tableOrQuery})" + partitioningInfo
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -256,7 +256,8 @@ object JdbcUtils extends Logging with SQLConfHelper {
     val dialect = JdbcDialects.get(options.url)
 
     try {
-      val statement = conn.prepareStatement(dialect.getSchemaQuery(options.tableOrQuery))
+      val statement =
+        conn.prepareStatement(options.withClause + dialect.getSchemaQuery(options.tableOrQuery))
       try {
         statement.setQueryTimeout(options.queryTimeout)
         Some(getSchema(statement.executeQuery(), dialect))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -91,7 +91,8 @@ case class JDBCScanBuilder(
       "GROUP BY " + groupByCols.mkString(",")
     }
 
-    val aggQuery = s"SELECT ${selectList.mkString(",")} FROM ${jdbcOptions.tableOrQuery} " +
+    val aggQuery = jdbcOptions.withClause +
+      s"SELECT ${selectList.mkString(",")} FROM ${jdbcOptions.tableOrQuery} " +
       s"WHERE 1=0 $groupByClause"
     try {
       finalSchema = JDBCRDD.getQueryOutputSchema(aggQuery, jdbcOptions, dialect)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently CTE queries from Spark are not supported with MSSQL server via JDBC. This is because MSSQL server doesn't support the nested CTE syntax (`SELECT * FROM (WITH t AS (...) SELECT ... FROM t) WHERE 1=0`) that Spark builds from the original query (`options.tableOrQuery`) in `JDBCRDD.resolveTable()`  and in `JDBCRDD.compute()`.
Unfortunately, it is non-trivial to split an arbitrary query it into "with" and "regular" clauses in `MsSqlServerDialect`. So instead, I'm proposing a new general JDBC option "withClause" that users can use if they have complex queries with CTE:
```
val withClause = "WITH t AS (SELECT x, y FROM tbl)"
val query = "SELECT * FROM t WHERE x > 10"
val df = spark.read.format("jdbc")
  .option("url", jdbcUrl)
  .option("withClause", withClause)
  .option("query", query)
  .load()
```
This change also works with MSSQL's temp table syntax:
```
val withClause = "(SELECT * INTO #TempTable FROM (SELECT * FROM tbl WHERE x > 10) t)"
val query = "SELECT * FROM #TempTable"
val df = spark.read.format("jdbc")
  .option("url", jdbcUrl)
  .option("withClause", withClause)
  .option("query", query)
  .load()
```

### Why are the changes needed?
To support CTE queries with MSSQL.

### Does this PR introduce _any_ user-facing change?
Yes, CTE queries are supported form now.

### How was this patch tested?
Added new integration UTs.
