### PR TITLE
[MINOR][DOCS] Fix scaladoc for skewed partitions optimization

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
@@ -41,7 +41,7 @@ object OptimizeSkewInRebalancePartitions extends AQEShuffleReadRule {
 
   /**
    * Splits the skewed partition based on the map size and the target partition size
-   * after split. Create a list of `PartialMapperPartitionSpec` for skewed partition and
+   * after split. Create a list of `PartialReducerPartitionSpec` for skewed partition and
    * create `CoalescedPartition` for normal partition.
    */
   private def optimizeSkewedPartitions(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -371,7 +371,7 @@ object ShufflePartitionsUtil extends Logging {
 
   /**
    * Splits the skewed partition based on the map size and the target partition size
-   * after split, and create a list of `PartialMapperPartitionSpec`. Returns None if can't split.
+   * after split, and create a list of `PartialReducerPartitionSpec`. Returns None if can't split.
    */
   def createSkewPartitionSpecs(
       shuffleId: Int,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replaces the incorrect reference of `PartialMapperPartitionSpec` with `PartialReducerPartitionSpec` for the comments of skew partitions methods.

## Why are the changes needed?
Fix scaladoc.

## Does this PR introduce any user-facing change?
No.

## How was this patch tested?
Existing tests.

