### PR TITLE
[SPARK-37454][SQL] Support expressions in time travel timestamp

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -616,7 +616,7 @@ fromClause
 
 temporalClause
     : FOR? (SYSTEM_VERSION | VERSION) AS OF version=(INTEGER_VALUE | STRING)
-    | FOR? (SYSTEM_TIME | TIMESTAMP) AS OF timestamp=STRING
+    | FOR? (SYSTEM_TIME | TIMESTAMP) AS OF timestamp=valueExpression
     ;
 
 aggregationClause
@@ -731,7 +731,8 @@ identifierComment
     ;
 
 relationPrimary
-    : multipartIdentifier temporalClause? sample? tableAlias  #tableName
+    : multipartIdentifier temporalClause?
+      sample? tableAlias                      #tableName
     | '(' query ')' sample? tableAlias        #aliasedQuery
     | '(' relation ')' sample? tableAlias     #aliasedRelation
     | inlineTable                             #inlineTableDefault2

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCatalog.java
@@ -22,6 +22,7 @@ import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.errors.QueryCompilationErrors;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.Map;
@@ -106,7 +107,7 @@ public interface TableCatalog extends CatalogPlugin {
    * @throws NoSuchTableException If the table doesn't exist or is a view
    */
   default Table loadTable(Identifier ident, String version) throws NoSuchTableException {
-    throw new UnsupportedOperationException("Load table with version is not supported.");
+    throw QueryCompilationErrors.tableNotSupportTimeTravelError(ident);
   }
 
   /**
@@ -121,7 +122,7 @@ public interface TableCatalog extends CatalogPlugin {
    * @throws NoSuchTableException If the table doesn't exist or is a view
    */
   default Table loadTable(Identifier ident, long timestamp) throws NoSuchTableException {
-    throw new UnsupportedOperationException("Load table with timestamp is not supported.");
+    throw QueryCompilationErrors.tableNotSupportTimeTravelError(ident);
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
@@ -227,7 +227,7 @@ object CTESubstitution extends Rule[LogicalPlan] {
       alwaysInline: Boolean,
       cteRelations: Seq[(String, CTERelationDef)]): LogicalPlan =
     plan.resolveOperatorsUpWithPruning(_.containsAnyPattern(UNRESOLVED_RELATION, PLAN_EXPRESSION)) {
-      case u @ UnresolvedRelation(Seq(table), _, _, _) =>
+      case u @ UnresolvedRelation(Seq(table), _, _) =>
         cteRelations.find(r => plan.conf.resolver(r._1, table)).map { case (_, d) =>
           if (alwaysInline) {
             d.child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationTimeTravel.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationTimeTravel.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
+
+/**
+ * A logical node used to time travel the child relation to the given `timestamp` or `version`.
+ * The `child` must support time travel, e.g. a v2 source, and cannot be a view, subquery or stream.
+ * The timestamp expression cannot refer to any columns and cannot contain subqueries.
+ */
+case class RelationTimeTravel(
+    relation: LogicalPlan,
+    timestamp: Option[Expression],
+    version: Option[String]) extends LeafNode {
+  override def output: Seq[Attribute] = Nil
+  override lazy val resolved: Boolean = false
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveHints.scala
@@ -106,7 +106,7 @@ object ResolveHints {
 
       val newNode = CurrentOrigin.withOrigin(plan.origin) {
         plan match {
-          case ResolvedHint(u @ UnresolvedRelation(ident, _, _, _), hint)
+          case ResolvedHint(u @ UnresolvedRelation(ident, _, _), hint)
               if matchedIdentifierInHint(ident) =>
             ResolvedHint(u, createHintInfo(hintName).merge(hint, hintErrorHandler))
 
@@ -114,7 +114,7 @@ object ResolveHints {
               if matchedIdentifierInHint(extractIdentifier(r)) =>
             ResolvedHint(r, createHintInfo(hintName).merge(hint, hintErrorHandler))
 
-          case UnresolvedRelation(ident, _, _, _) if matchedIdentifierInHint(ident) =>
+          case UnresolvedRelation(ident, _, _) if matchedIdentifierInHint(ident) =>
             ResolvedHint(plan, createHintInfo(hintName))
 
           case r: SubqueryAlias if matchedIdentifierInHint(extractIdentifier(r)) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeTravelSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TimeTravelSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions.{AnsiCast, Cast, Expression, SubqueryExpression}
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.TimestampType
+
+sealed trait TimeTravelSpec
+
+case class AsOfTimestamp(timestamp: Long) extends TimeTravelSpec
+case class AsOfVersion(version: String) extends TimeTravelSpec
+
+object TimeTravelSpec {
+  def create(
+      timestamp: Option[Expression],
+      version: Option[String],
+      conf: SQLConf) : Option[TimeTravelSpec] = {
+    if (timestamp.nonEmpty && version.nonEmpty) {
+      throw QueryCompilationErrors.invalidTimeTravelSpecError()
+    } else if (timestamp.nonEmpty) {
+      val ts = timestamp.get
+      assert(ts.resolved && ts.references.isEmpty && !SubqueryExpression.hasSubquery(ts))
+      if (!AnsiCast.canCast(ts.dataType, TimestampType)) {
+        throw QueryCompilationErrors.invalidTimestampExprForTimeTravel(ts)
+      }
+      val tz = Some(conf.sessionLocalTimeZone)
+      // Set `ansiEnabled` to false, so that it can return null for invalid input and we can provide
+      // better error message.
+      val value = Cast(ts, TimestampType, tz, ansiEnabled = false).eval()
+      if (value == null) {
+        throw QueryCompilationErrors.invalidTimestampExprForTimeTravel(ts)
+      }
+      Some(AsOfTimestamp(value.asInstanceOf[Long]))
+    } else if (version.nonEmpty) {
+      Some(AsOfVersion(version.get))
+    } else {
+      None
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, UnaryNode}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.connector.expressions.TimeTravelSpec
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.types.{DataType, Metadata, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -46,8 +45,7 @@ class UnresolvedException(function: String)
 case class UnresolvedRelation(
     multipartIdentifier: Seq[String],
     options: CaseInsensitiveStringMap = CaseInsensitiveStringMap.empty(),
-    override val isStreaming: Boolean = false,
-    timeTravelSpec: Option[TimeTravelSpec] = None)
+    override val isStreaming: Boolean = false)
   extends LeafNode with NamedRelation {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 
@@ -67,13 +65,9 @@ object UnresolvedRelation {
   def apply(
       tableIdentifier: TableIdentifier,
       extraOptions: CaseInsensitiveStringMap,
-      isStreaming: Boolean,
-      timeTravelSpec: Option[TimeTravelSpec]): UnresolvedRelation = {
+      isStreaming: Boolean): UnresolvedRelation = {
     UnresolvedRelation(
-      tableIdentifier.database.toSeq :+ tableIdentifier.table,
-      extraOptions,
-      isStreaming,
-      timeTravelSpec)
+      tableIdentifier.database.toSeq :+ tableIdentifier.table, extraOptions, isStreaming)
   }
 
   def apply(tableIdentifier: TableIdentifier): UnresolvedRelation =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils, Inte
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, getZoneId, stringToDate, stringToTimestamp, stringToTimestampWithoutTimeZone}
 import org.apache.spark.sql.connector.catalog.{SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
-import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, TimeTravelSpec, Transform, YearsTransform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.errors.QueryParsingErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -1257,18 +1257,30 @@ class AstBuilder extends SqlBaseBaseVisitor[AnyRef] with SQLConfHelper with Logg
    */
   override def visitTableName(ctx: TableNameContext): LogicalPlan = withOrigin(ctx) {
     val tableId = visitMultipartIdentifier(ctx.multipartIdentifier)
-    val timeTravel = if (ctx.temporalClause != null) {
-      val v = ctx.temporalClause.version
-      val version =
-        if (ctx.temporalClause.INTEGER_VALUE != null) Some(v.getText) else Option(v).map(string)
-      TimeTravelSpec.create(Option(ctx.temporalClause.timestamp).map(string), version)
-    } else {
-      None
-    }
-
-    val table = mayApplyAliasPlan(ctx.tableAlias,
-      UnresolvedRelation(tableId, timeTravelSpec = timeTravel))
+    val relation = UnresolvedRelation(tableId)
+    val table = mayApplyAliasPlan(
+      ctx.tableAlias, relation.optionalMap(ctx.temporalClause)(withTimeTravel))
     table.optionalMap(ctx.sample)(withSample)
+  }
+
+  private def withTimeTravel(
+      ctx: TemporalClauseContext, plan: LogicalPlan): LogicalPlan = withOrigin(ctx) {
+    val v = ctx.version
+    val version = if (ctx.INTEGER_VALUE != null) {
+      Some(v.getText)
+    } else {
+      Option(v).map(string)
+    }
+    val timestamp = Option(ctx.timestamp).map(expression)
+    if (timestamp.exists(_.references.nonEmpty)) {
+      throw QueryParsingErrors.invalidTimeTravelSpec(
+        "timestamp expression cannot refer to any columns", ctx.timestamp)
+    }
+    if (timestamp.exists(e => SubqueryExpression.hasSubquery(e))) {
+      throw QueryParsingErrors.invalidTimeTravelSpec(
+        "timestamp expression cannot contain subqueries", ctx.timestamp)
+    }
+    RelationTimeTravel(plan, timestamp, version)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -22,10 +22,9 @@ import java.util.Collections
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.catalyst.analysis.{NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException}
+import org.apache.spark.sql.catalyst.analysis.{AsOfTimestamp, AsOfVersion, NamedRelation, NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, TimeTravelSpec}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelectStatement, CreateTableStatement, ReplaceTableAsSelectStatement, ReplaceTableStatement, SerdeInfo}
 import org.apache.spark.sql.connector.catalog.TableChange._
-import org.apache.spark.sql.connector.expressions.{AsOfTimestamp, AsOfVersion, TimeTravelSpec}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/expressions/expressions.scala
@@ -19,11 +19,7 @@ package org.apache.spark.sql.connector.expressions
 
 import org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, IntegerType, StringType}
-import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Helper methods for working with the logical expressions API.
@@ -359,27 +355,5 @@ private[sql] object SortValue {
       Some((sort.expression, sort.direction, sort.nullOrdering))
     case _ =>
       None
-  }
-}
-
-private[sql] sealed trait TimeTravelSpec
-
-private[sql] case class AsOfTimestamp(timestamp: Long) extends TimeTravelSpec
-private[sql] case class AsOfVersion(version: String) extends TimeTravelSpec
-
-private[sql] object TimeTravelSpec {
-  def create(timestamp: Option[String], version: Option[String]) : Option[TimeTravelSpec] = {
-    if (timestamp.nonEmpty && version.nonEmpty) {
-      throw QueryCompilationErrors.invalidTimeTravelSpecError()
-    } else if (timestamp.nonEmpty) {
-      val ts = DateTimeUtils.stringToTimestampAnsi(
-        UTF8String.fromString(timestamp.get),
-        DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
-      Some(AsOfTimestamp(ts))
-    } else if (version.nonEmpty) {
-      Some(AsOfVersion(version.get))
-    } else {
-      None
-    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2379,6 +2379,19 @@ object QueryCompilationErrors {
   }
 
   def invalidTimeTravelSpecError(): Throwable = {
-    new AnalysisException("Cannot specify both version and timestamp when scanning the table.")
+    new AnalysisException(
+      "Cannot specify both version and timestamp when time travelling the table.")
+  }
+
+  def invalidTimestampExprForTimeTravel(expr: Expression): Throwable = {
+    new AnalysisException(s"${expr.sql} is not a valid timestamp expression for time travel.")
+  }
+
+  def viewNotSupportTimeTravelError(viewName: Seq[String]): Throwable = {
+    new AnalysisException(viewName.quoted + " is a view which does not support time travel.")
+  }
+
+  def tableNotSupportTimeTravelError(tableName: Identifier): UnsupportedOperationException = {
+    new UnsupportedOperationException(s"Table $tableName does not support time travel.")
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -429,4 +429,8 @@ object QueryParsingErrors {
   def unclosedBracketedCommentError(command: String, position: Origin): Throwable = {
     new ParseException(Some(command), "Unclosed bracketed comment", position, position)
   }
+
+  def invalidTimeTravelSpec(reason: String, ctx: ParserRuleContext): Throwable = {
+    new ParseException(s"Invalid time travel spec: $reason.", ctx)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.catalyst.parser
 
-import java.time.DateTimeException
-import java.util
 import java.util.Locale
 
 import org.apache.spark.sql.AnalysisException
@@ -27,10 +25,9 @@ import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, Hex, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition.{after, first}
-import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, TimeTravelSpec, Transform, YearsTransform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructType, TimestampType}
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 class DDLParserSuite extends AnalysisTest {
@@ -2427,118 +2424,5 @@ class DDLParserSuite extends AnalysisTest {
       insertPartitionPlan("INTERVAL '1 02:03:04.128462' DAY TO SECOND"))
     comparePlans(parsePlan(timestampTypeSql), insertPartitionPlan(timestamp))
     comparePlans(parsePlan(binaryTypeSql), insertPartitionPlan(binaryStr))
-  }
-
-  test("as of syntax") {
-    val properties = new util.HashMap[String, String]
-    var timeTravel = TimeTravelSpec.create(None, Some("Snapshot123456789"))
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c VERSION AS OF 'Snapshot123456789'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c FOR VERSION AS OF 'Snapshot123456789'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    timeTravel = TimeTravelSpec.create(None, Some("123456789"))
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c FOR SYSTEM_VERSION AS OF 123456789"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c SYSTEM_VERSION AS OF 123456789"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    timeTravel = TimeTravelSpec.create(Some("2019-01-29 00:37:58"), None)
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c TIMESTAMP AS OF '2019-01-29 00:37:58'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c FOR TIMESTAMP AS OF '2019-01-29 00:37:58'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c FOR SYSTEM_TIME AS OF '2019-01-29 00:37:58'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c SYSTEM_TIME AS OF '2019-01-29 00:37:58'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    timeTravel = TimeTravelSpec.create(Some("2019-01-29"), None)
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c TIMESTAMP AS OF '2019-01-29'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c FOR TIMESTAMP AS OF '2019-01-29'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c FOR SYSTEM_TIME AS OF '2019-01-29'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    comparePlans(
-      parsePlan("SELECT * FROM a.b.c SYSTEM_TIME AS OF '2019-01-29'"),
-      Project(Seq(UnresolvedStar(None)),
-        UnresolvedRelation(
-          Seq("a", "b", "c"),
-          new CaseInsensitiveStringMap(properties),
-          timeTravelSpec = timeTravel)))
-
-    val e1 = intercept[DateTimeException] {
-      parsePlan("SELECT * FROM a.b.c TIMESTAMP AS OF '2019-01-11111'")
-    }.getMessage
-    assert(e1.contains("Cannot cast 2019-01-11111 to TimestampType."))
-
-    val e2 = intercept[AnalysisException] {
-      timeTravel = TimeTravelSpec.create(Some("2019-01-29 00:37:58"), Some("123456789"))
-    }.getMessage
-    assert(e2.contains("Cannot specify both version and timestamp when scanning the table."))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Utils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Utils.scala
@@ -25,10 +25,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.catalyst.analysis.TimeTravelSpec
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SessionConfigSupport, SupportsCatalogOptions, SupportsRead, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability.BATCH_READ
-import org.apache.spark.sql.connector.expressions.TimeTravelSpec
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
@@ -100,8 +101,8 @@ private[sql] object DataSourceV2Utils extends Logging {
       source: String,
       paths: String*): Option[DataFrame] = {
     val catalogManager = sparkSession.sessionState.catalogManager
-    val sessionOptions = DataSourceV2Utils.extractSessionConfigs(
-      source = provider, conf = sparkSession.sessionState.conf)
+    val conf = sparkSession.sessionState.conf
+    val sessionOptions = DataSourceV2Utils.extractSessionConfigs(provider, conf)
 
     val optionsWithPath = getOptionsWithPaths(extraOptions, paths: _*)
 
@@ -123,8 +124,8 @@ private[sql] object DataSourceV2Utils extends Logging {
         val timestamp = hasCatalog.extractTimeTravelTimestamp(dsOptions)
 
         val timeTravelVersion = if (version.isPresent) Some(version.get) else None
-        val timeTravelTimestamp = if (timestamp.isPresent) Some(timestamp.get) else None
-        val timeTravel = TimeTravelSpec.create(timeTravelTimestamp, timeTravelVersion)
+        val timeTravelTimestamp = if (timestamp.isPresent) Some(Literal(timestamp.get)) else None
+        val timeTravel = TimeTravelSpec.create(timeTravelTimestamp, timeTravelVersion, conf)
         (CatalogV2Util.loadTable(catalog, ident, timeTravel).get, Some(catalog), Some(ident))
       case _ =>
         // TODO: Non-catalog paths for DSV2 are currently not well defined.

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/SupportsCatalogOptionsSuite.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAM
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StructType}
@@ -276,7 +275,9 @@ class SupportsCatalogOptionsSuite extends QueryTest with SharedSparkSession with
     }
   }
 
-  test("mock time travel test") {
+  test("time travel") {
+    // The testing in-memory table simply append the version/timestamp to the table name when
+    // looking up tables.
     val t1 = s"$catalogName.tSnapshot123456789"
     val t2 = s"$catalogName.t2345678910"
     withTable(t1, t2) {
@@ -298,10 +299,10 @@ class SupportsCatalogOptionsSuite extends QueryTest with SharedSparkSession with
 
     val ts1 = DateTimeUtils.stringToTimestampAnsi(
       UTF8String.fromString("2019-01-29 00:37:58"),
-      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+      DateTimeUtils.getZoneId(conf.sessionLocalTimeZone))
     val ts2 = DateTimeUtils.stringToTimestampAnsi(
       UTF8String.fromString("2021-01-29 00:37:58"),
-      DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone))
+      DateTimeUtils.getZoneId(conf.sessionLocalTimeZone))
     val t3 = s"$catalogName.t$ts1"
     val t4 = s"$catalogName.t$ts2"
     withTable(t3, t4) {
@@ -328,7 +329,7 @@ class SupportsCatalogOptionsSuite extends QueryTest with SharedSparkSession with
         timestamp = Some("2019-01-29 00:37:58"))
     }
     assert(e.getMessage
-      .contains("Cannot specify both version and timestamp when scanning the table."))
+      .contains("Cannot specify both version and timestamp when time travelling the table."))
   }
 
   private def checkV2Identifiers(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution
 import org.apache.spark.SparkException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
@@ -217,12 +216,6 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
         sql(s"ANALYZE TABLE $viewName COMPUTE STATISTICS FOR COLUMNS id")
       }.getMessage
       assert(e5.contains(s"Temporary view `$viewName` is not cached for analyzing columns."))
-    }
-  }
-
-  private def assertNoSuchTable(query: String): Unit = {
-    intercept[NoSuchTableException] {
-      sql(query)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -378,6 +378,21 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-37219: time travel is unsupported") {
+    val viewName = createView("testView", "SELECT 1 col")
+    withView(viewName) {
+      val e1 = intercept[AnalysisException](
+        sql(s"SELECT * FROM $viewName VERSION AS OF 1").collect()
+      )
+      assert(e1.message.contains(s"$viewName is a view which does not support time travel"))
+
+      val e2 = intercept[AnalysisException](
+        sql(s"SELECT * FROM $viewName TIMESTAMP AS OF '2000-10-10'").collect()
+      )
+      assert(e2.message.contains(s"$viewName is a view which does not support time travel"))
+    }
+  }
 }
 
 abstract class TempViewTestSuite extends SQLViewTestSuite {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -599,7 +599,7 @@ private[hive] class TestHiveQueryExecution(
   override lazy val analyzed: LogicalPlan = sparkSession.withActive {
     // Make sure any test tables referenced are loaded.
     val referencedTables = logical.collect {
-      case UnresolvedRelation(ident, _, _, _) =>
+      case UnresolvedRelation(ident, _, _) =>
         if (ident.length > 1 && ident.head.equalsIgnoreCase(CatalogManager.SESSION_CATALOG_NAME)) {
           ident.tail.asTableIdentifier
         } else ident.asTableIdentifier


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Allow expressions to be the timestamp of time travel spec, with 3 limitations:
1. the expression must be foldable (can't refer to columns)
2. can not contain subqueries
3. can be casted to timestamp

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's convenient to support expressions as timestamp in time travel, e.g. we can query the table in yesterday by `FROM t TIMESTAMP AS OF current_date() - INTERVAL 1 DAY`, or `FROM t TIMESTAMP AS OF TIMESTAMP'yesterday'`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, a new feature

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests