### PR TITLE
[SPARK-36861][SQL] Use `yyyy-MM-dd` as the date pattern in partition discovery

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.ml.source.image
 
 import java.net.URI
 import java.nio.file.Paths
-import java.sql.Date
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.image.ImageSchema._
@@ -96,14 +95,14 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
       .collect()
 
     assert(Set(result: _*) === Set(
-      Row("29.5.a_b_EGDP022204.jpg", "kittens", Date.valueOf("2018-01-01")),
-      Row("54893.jpg", "kittens", Date.valueOf("2018-02-01")),
-      Row("DP153539.jpg", "kittens", Date.valueOf("2018-02-01")),
-      Row("DP802813.jpg", "kittens", Date.valueOf("2018-02-01")),
-      Row("BGRA.png", "multichannel", Date.valueOf("2018-01-01")),
-      Row("BGRA_alpha_60.png", "multichannel", Date.valueOf("2018-01-01")),
-      Row("chr30.4.184.jpg", "multichannel", Date.valueOf("2018-02-01")),
-      Row("grayscale.jpg", "multichannel", Date.valueOf("2018-02-01"))
+      Row("29.5.a_b_EGDP022204.jpg", "kittens", "2018-01"),
+      Row("54893.jpg", "kittens", "2018-02"),
+      Row("DP153539.jpg", "kittens", "2018-02"),
+      Row("DP802813.jpg", "kittens", "2018-02"),
+      Row("BGRA.png", "multichannel", "2018-01"),
+      Row("BGRA_alpha_60.png", "multichannel", "2018-01"),
+      Row("chr30.4.184.jpg", "multichannel", "2018-02"),
+      Row("grayscale.jpg", "multichannel", "2018-02")
     ))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -135,7 +135,7 @@ object PartitioningUtils extends SQLConfHelper{
       Map.empty[String, String]
     }
 
-    val dateFormatter = DateFormatter()
+    val dateFormatter = DateFormatter(DateFormatter.defaultPattern)
     val timestampFormatter = TimestampFormatter(
       timestampPartitionPattern,
       zoneId,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1065,14 +1065,15 @@ abstract class ParquetPartitionDiscoverySuite
     }
   }
 
-  test("SPARK-23436: invalid Dates should be inferred as String in partition inference") {
+  test(
+    "SPARK-23436, SPARK-36861: invalid Dates should be inferred as String in partition inference") {
     withTempPath { path =>
-      val data = Seq(("1", "2018-41", "2018-01-01-04", "test"))
-        .toDF("id", "date_month", "date_hour", "data")
+      val data = Seq(("1", "2018-41", "2018-01-01-04", "2021-01-01T00", "test"))
+        .toDF("id", "date_month", "date_hour", "date_t_hour", "data")
 
-      data.write.partitionBy("date_month", "date_hour").parquet(path.getAbsolutePath)
+      data.write.partitionBy("date_month", "date_hour", "date_t_hour").parquet(path.getAbsolutePath)
       val input = spark.read.parquet(path.getAbsolutePath).select("id",
-        "date_month", "date_hour", "data")
+        "date_month", "date_hour", "date_t_hour", "data")
 
       assert(input.schema.sameType(input.schema))
       checkAnswer(input, data)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to explicitly set the date pattern to `yyyy-MM-dd` while inferring types of partition values.

### Why are the changes needed?
The existing date partition parser is much more tolerant to its input, and can skip some parts of date strings. For example, see SPARK-36861. As a consequence, it can loose some user's info (pieces of partition values).

### Does this PR introduce _any_ user-facing change?
No. New behaviour introduced by https://github.com/apache/spark/pull/33709 hasn't released yet.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "test:testOnly *ParquetV2PartitionDiscoverySuite"
$ build/sbt "test:testOnly *ImageFileFormatSuite"
```