### PR TITLE
[SPARK-37450][SQL] Prune unnecessary fields from Generate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2170,7 +2170,7 @@ object RemoveLiteralFromGroupExpressions extends Rule[LogicalPlan] {
 object GenerateOptimization extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformDownWithPruning(
       _.containsAllPatterns(PROJECT, GENERATE), ruleId) {
-      case p @ Project(_, g: Generate) if p.references.intersect(g.outputSet).isEmpty
+      case p @ Project(_, g: Generate) if p.references.isEmpty
           && g.generator.isInstanceOf[ExplodeBase] =>
         g.generator.children.head.dataType match {
           case ArrayType(StructType(fields), _) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2198,10 +2198,10 @@ object CountAggregateOptimization extends Rule[LogicalPlan] {
             val extractor = if (atomicFields.size > 0) {
               // Pick an arbitrary atomic field, if any
               ExtractValue(g.generator.children.head,
-                Literal(atomicFields(0).name), SQLConf.get.resolver)
+                Literal(atomicFields(0).name), conf.resolver)
             } else {
               ExtractValue(g.generator.children.head,
-                Literal(fields(0).name), SQLConf.get.resolver)
+                Literal(fields(0).name), conf.resolver)
             }
             val rewrittenG = g.transformExpressions {
               case e: ExplodeBase =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2173,7 +2173,7 @@ object GenerateOptimization extends Rule[LogicalPlan] {
       case p @ Project(_, g: Generate) if p.references.isEmpty
           && g.generator.isInstanceOf[ExplodeBase] =>
         g.generator.children.head.dataType match {
-          case ArrayType(StructType(fields), containsNull) =>
+          case ArrayType(StructType(fields), containsNull) if fields.length > 1 =>
             // Try to pick up smallest field
             val sortedFields = fields.zipWithIndex.sortBy(f => f._1.dataType.defaultSize)
             val extractor = GetArrayStructFields(g.generator.children.head, sortedFields(0)._1,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -134,6 +134,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.ReassignLambdaVariableID" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveDispensableExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions" ::
+      "org.apache.spark.sql.catalyst.optimizer.CountAggregateOptimization" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveNoopOperators" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveRedundantAggregates" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveRepetitionFromGroupExpressions" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -134,7 +134,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.ReassignLambdaVariableID" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveDispensableExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions" ::
-      "org.apache.spark.sql.catalyst.optimizer.CountAggregateOptimization" ::
+      "org.apache.spark.sql.catalyst.optimizer.GenerateOptimization" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveNoopOperators" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveRedundantAggregates" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveRepetitionFromGroupExpressions" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CountAggregateOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CountAggregateOptimizationSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.Explode
+import org.apache.spark.sql.catalyst.optimizer.NestedColumnAliasingSuite.collectGeneratedAliases
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.types.StructType
+
+class CountAggregateOptimizationSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("CountAggregateOptimization", FixedPoint(100),
+      ColumnPruning,
+      CollapseProject,
+      CountAggregateOptimization) :: Nil
+  }
+
+  private val item = StructType.fromDDL("item_id int, item_data string, item_price int")
+  private val relation = LocalRelation('items.array(item))
+
+  test("Prune unnecessary field on Explode from count-only aggregate") {
+    val query = relation
+      .generate(Explode('items), outputNames = Seq("explode"))
+      .select('explode)
+      .groupBy()(count(1))
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val aliases = collectGeneratedAliases(optimized)
+
+    val expected = relation
+      .select(
+        'items.getField("item_id").as(aliases(0)))
+      .generate(Explode($"${aliases(0)}"),
+        unrequiredChildIndex = Seq(0),
+        outputNames = Seq("explode"))
+      .select()
+      .groupBy()(count(1))
+      .analyze
+    comparePlans(optimized, expected)
+  }
+
+  test("Do not prune field from Explode if the struct is needed") {
+    val query = relation
+      .generate(Explode('items), outputNames = Seq("explode"))
+      .select('explode)
+      .groupBy()(count(1), collectList('explode))
+      .analyze
+
+    val optimized = Optimize.execute(query)
+
+    val expected = relation
+      .generate(Explode('items), unrequiredChildIndex = Seq(0), outputNames = Seq("explode"))
+      .select('explode)
+      .groupBy()(count(1), collectList('explode))
+      .analyze
+
+    comparePlans(optimized, expected)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/GenerateOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/GenerateOptimizationSuite.scala
@@ -26,13 +26,13 @@ import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types.StructType
 
-class CountAggregateOptimizationSuite extends PlanTest {
+class GenerateOptimizationSuite extends PlanTest {
 
   object Optimize extends RuleExecutor[LogicalPlan] {
-    val batches = Batch("CountAggregateOptimization", FixedPoint(100),
+    val batches = Batch("GenerateOptimization", FixedPoint(100),
       ColumnPruning,
       CollapseProject,
-      CountAggregateOptimization) :: Nil
+      GenerateOptimization) :: Nil
   }
 
   private val item = StructType.fromDDL("item_id int, item_data string, item_price int")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -891,15 +891,17 @@ abstract class SchemaPruningSuite
         val path = dir.getCanonicalPath
 
         val jsonStr =
-          """{
-        "items": [
-          {"itemId": 1, "itemData": "a"},
-          {"itemId": 2, "itemData": "b"}
-        ]}""".stripMargin
+          """
+            |{
+            |  "items": [
+            |  {"itemId": 1, "itemData": "a"},
+            |  {"itemId": 2, "itemData": "b"}
+            |]}
+            |""".stripMargin
         val df = spark.read.json(Seq(jsonStr).toDS)
-        makeDataSourceFile(df, new File(path + "/table"))
+        makeDataSourceFile(df, new File(path))
 
-        spark.read.format(dataSourceName).load(path + "/table")
+        spark.read.format(dataSourceName).load(path)
           .createOrReplaceTempView("table")
 
         val read = spark.table("table")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -905,7 +905,7 @@ abstract class SchemaPruningSuite
         val read = spark.table("table")
         val query = read.select(explode($"items").as('item)).select(count($"*"))
 
-        checkScan(query, "struct<items:array<struct<itemData:string>>>")
+        checkScan(query, "struct<items:array<struct<itemId:long>>>")
         checkAnswer(query, Row(2) :: Nil)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SchemaPruningSuite.scala
@@ -882,4 +882,32 @@ abstract class SchemaPruningSuite
           Nil)
     }
   }
+
+  test("SPARK-37450: Prunes unnecessary fields from Explode for count aggregation") {
+    import testImplicits._
+
+    withTempView("table") {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
+
+        val jsonStr =
+          """{
+        "items": [
+          {"itemId": 1, "itemData": "a"},
+          {"itemId": 2, "itemData": "b"}
+        ]}""".stripMargin
+        val df = spark.read.json(Seq(jsonStr).toDS)
+        makeDataSourceFile(df, new File(path + "/table"))
+
+        spark.read.format(dataSourceName).load(path + "/table")
+          .createOrReplaceTempView("table")
+
+        val read = spark.table("table")
+        val query = read.select(explode($"items").as('item)).select(count($"*"))
+
+        checkScan(query, "struct<items:array<struct<itemData:string>>>")
+        checkAnswer(query, Row(2) :: Nil)
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes an optimization rule to prune unnecessary fields from `Generate` for some cases, e.g. under count-only `Aggregate`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As shown in the JIRA, if a query counts nested elements (structs) on an array by exploding the array in `Generate`, because there is no particular nested field is specified, Spark currently reads the full nested struct without any pruning, e.g.,

```
== Optimized Logical Plan ==
Aggregate [count(1) AS count(true)#20299L]
+- Project
   +- Generate explode(items#20293), [0], false, [item#20296]
      +- Filter ((size(items#20293, true) > 0) AND isnotnull(items#20293))
         +- Relation default.table[items#20293] parquet
```

An optimization can be made to pick up arbitrary nested field from the struct. So we can prune unnecessary field access and still count the number of array elements.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added test.