### PR TITLE
[WIP][SPARK-37259] Add option to unwrap query to support CTE for MSSQL JDBC driver

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -258,6 +258,7 @@ object JDBCOptions {
   val JDBC_URL = newOption("url")
   val JDBC_TABLE_NAME = newOption("dbtable")
   val JDBC_QUERY_STRING = newOption("query")
+  val JDBC_USE_RAW_QUERY = newOption("useRawQuery")
   val JDBC_DRIVER_CLASS = newOption("driver")
   val JDBC_PARTITION_COLUMN = newOption("partitionColumn")
   val JDBC_LOWER_BOUND = newOption("lowerBound")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -25,9 +25,11 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.analysis._
+import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.catalyst.util.{DateFormatter, DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{getZoneId, stringToDate, stringToTimestamp}
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.{JDBC_CUSTOM_DATAFRAME_COLUMN_TYPES, JDBC_USE_RAW_QUERY}
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.JdbcDialects
@@ -237,11 +239,24 @@ private[sql] object JDBCRelation extends Logging {
    * @return resolved Catalyst schema of a JDBC table
    */
   def getSchema(resolver: Resolver, jdbcOptions: JDBCOptions): StructType = {
-    val tableSchema = JDBCRDD.resolveTable(jdbcOptions)
-    jdbcOptions.customSchema match {
-      case Some(customSchema) => JdbcUtils.getCustomSchema(
-        tableSchema, customSchema, resolver)
-      case None => tableSchema
+    val runQueryAsIs = jdbcOptions.parameters.getOrElse(JDBC_USE_RAW_QUERY, "false").toBoolean
+    if (runQueryAsIs) {
+      val customSchema = jdbcOptions.parameters.get(JDBC_CUSTOM_DATAFRAME_COLUMN_TYPES)
+      val newSchema = jdbcOptions.customSchema match {
+        case Some(customSchema) => CatalystSqlParser.parseTableSchema(customSchema)
+        case None => throw new IllegalArgumentException(
+          s"Field $JDBC_CUSTOM_DATAFRAME_COLUMN_TYPES is mandatory when using $JDBC_USE_RAW_QUERY")
+      }
+      logInfo(s"Option $JDBC_USE_RAW_QUERY is enabled, parsed $newSchema " +
+        s"from the option $JDBC_CUSTOM_DATAFRAME_COLUMN_TYPES with value $customSchema")
+      newSchema
+    } else {
+      val tableSchema = JDBCRDD.resolveTable(jdbcOptions)
+      jdbcOptions.customSchema match {
+        case Some(customSchema) => JdbcUtils.getCustomSchema(
+          tableSchema, customSchema, resolver)
+        case None => tableSchema
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds the boolean option 'useRawQuery' to unwrap the query from 'select' statement, used to get schema, as it causes problems with CTE when using MSSQL JDBC driver. When set to 'true', the user has to also provide a schema of result in 'customSchema' option. The obvious downside of this approach is that the user is obligated to fetch schema beforehand when running the query. The advantage is that we are avoiding running query twice just to get schema, and users can run query without modification, unlike the solution described in https://github.com/apache/spark/pull/34693


### Why are the changes needed?
These changes are needed to support of CTE while using MSSQL JDBC


### Does this PR introduce _any_ user-facing change?
Added optiont 'useRawQuery' to JDBC options. Example:
```
JdbcMsSqlDF = (
    spark.read.format("jdbc")
    .option("url", f"jdbc:sqlserver://{server}:{port};databaseName={database};")
    .option("user", user)
    .option("password", password)
    .option("useRawQuery", "true")  //<----------- Do not wrap the query
    .option("customSchema", schema)
    .option("driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver")
    .option("query", query)
    .load()
)
```


### How was this patch tested?
The patch was tested manually, unit tests  are pending, it's still WIP.
