### PR TITLE
[MINOR][R][DOCS] Rewrite \url to \href, if name is provided

### DIFF
--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -890,7 +890,7 @@ setMethod("toJSON",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the JSON-specific options for writing JSON files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
@@ -925,7 +925,7 @@ setMethod("write.json",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the ORC-specific options for writing ORC files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
@@ -960,7 +960,7 @@ setMethod("write.orc",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the Parquet-specific options for writing Parquet files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option
 #'            }{Data Source Option} in the version you use.
 #'
@@ -996,7 +996,7 @@ setMethod("write.parquet",
 #'             save mode (it is 'error' by default)
 #' @param ... additional argument(s) passed to the method.
 #'            You can find the text-specific options for writing text files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #'
@@ -3748,7 +3748,7 @@ setMethod("histogram",
 #' Save the content of the SparkDataFrame to an external database table via JDBC. Additional JDBC
 #' database connection properties can be set (...)
 #' You can find the JDBC-specific option and parameter documentation for writing tables via JDBC in
-#' \url{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
 #' Data Source Option} in the version you use.
 #'
 #' Also, mode is used to specify the behavior of the save operation when

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -382,7 +382,7 @@ setMethod("toDF", signature(x = "RDD"),
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
 #'            You can find the JSON-specific options for reading JSON files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-json.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -414,7 +414,7 @@ read.json <- function(path, ...) {
 #' @param path Path of file to read.
 #' @param ... additional external data source specific named properties.
 #'            You can find the ORC-specific options for reading ORC files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-orc.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -439,7 +439,7 @@ read.orc <- function(path, ...) {
 #' @param path path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional data source specific named properties.
 #'            You can find the Parquet-specific options for reading Parquet files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-parquet.html#data-source-option
 #'            }{Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -468,7 +468,7 @@ read.parquet <- function(path, ...) {
 #' @param path Path of file to read. A vector of multiple paths is allowed.
 #' @param ... additional external data source specific named properties.
 #'            You can find the text-specific options for reading text files in
-#'            \url{
+#'            \href{
 #'            https://spark.apache.org/docs/latest/sql-data-sources-text.html#data-source-option}{
 #'            Data Source Option} in the version you use.
 #' @return SparkDataFrame
@@ -619,7 +619,7 @@ loadDF <- function(path = NULL, source = NULL, schema = NULL, ...) {
 #'
 #' Additional JDBC database connection properties can be set (...)
 #' You can find the JDBC-specific option and parameter documentation for reading tables via JDBC in
-#' \url{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
+#' \href{https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option}{
 #' Data Source Option} in the version you use.
 #'
 #' Only one of partitionColumn or predicates should be set. Partitions of the table will be


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR replaces `\url` commands with `\href`, when alias is provided.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`\url` is applicable only to links which have no aliases ‒ https://roxygen2.r-lib.org/articles/rd-formatting.html#links-1

As a result, some the links are not rendered as expected

![before-change](https://user-images.githubusercontent.com/1554276/143506659-d1438a50-e23e-4ad4-add0-38d2c682e839.png)

After this PR is merged, will get expected results, with `href` applied to provided text

![after-change](https://user-images.githubusercontent.com/1554276/143506733-8e21b955-b537-4c65-be2c-f74127e6916d.png)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Docs only, as described above.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Docs build and manual inspection of the results.
