### PR TITLE
[SPARK-37468][SQL] Support ANSI intervals and TimestampNTZ for UnionEstimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -53,12 +53,8 @@ object UnionEstimation {
     case TimestampNTZType => (a: Any, b: Any) =>
       TimestampNTZType.ordering.lt(a.asInstanceOf[TimestampNTZType.InternalType],
         b.asInstanceOf[TimestampNTZType.InternalType])
-    case y: YearMonthIntervalType => (a: Any, b: Any) =>
-      y.ordering.lt(a.asInstanceOf[y.InternalType],
-        b.asInstanceOf[y.InternalType])
-    case d: DayTimeIntervalType => (a: Any, b: Any) =>
-      d.ordering.lt(a.asInstanceOf[d.InternalType],
-        b.asInstanceOf[d.InternalType])
+    case i: AnsiIntervalType => (a: Any, b: Any) =>
+      i.ordering.lt(a.asInstanceOf[i.InternalType], b.asInstanceOf[i.InternalType])
     case _ =>
       throw new IllegalStateException(s"Unsupported data type: ${dt.catalogString}")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -62,7 +62,7 @@ object UnionEstimation {
   private def isTypeSupported(dt: DataType): Boolean = dt match {
     case ByteType | IntegerType | ShortType | FloatType | LongType |
          DoubleType | DateType | _: DecimalType | TimestampType | TimestampNTZType |
-         _: YearMonthIntervalType | _: DayTimeIntervalType => true
+         _: AnsiIntervalType => true
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/UnionEstimation.scala
@@ -50,13 +50,23 @@ object UnionEstimation {
     case TimestampType => (a: Any, b: Any) =>
       TimestampType.ordering.lt(a.asInstanceOf[TimestampType.InternalType],
         b.asInstanceOf[TimestampType.InternalType])
+    case TimestampNTZType => (a: Any, b: Any) =>
+      TimestampNTZType.ordering.lt(a.asInstanceOf[TimestampNTZType.InternalType],
+        b.asInstanceOf[TimestampNTZType.InternalType])
+    case y: YearMonthIntervalType => (a: Any, b: Any) =>
+      y.ordering.lt(a.asInstanceOf[y.InternalType],
+        b.asInstanceOf[y.InternalType])
+    case d: DayTimeIntervalType => (a: Any, b: Any) =>
+      d.ordering.lt(a.asInstanceOf[d.InternalType],
+        b.asInstanceOf[d.InternalType])
     case _ =>
       throw new IllegalStateException(s"Unsupported data type: ${dt.catalogString}")
   }
 
   private def isTypeSupported(dt: DataType): Boolean = dt match {
     case ByteType | IntegerType | ShortType | FloatType | LongType |
-         DoubleType | DateType | _: DecimalType | TimestampType => true
+         DoubleType | DateType | _: DecimalType | TimestampType | TimestampNTZType |
+         _: YearMonthIntervalType | _: DayTimeIntervalType => true
     case _ => false
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/UnionEstimationSuite.scala
@@ -57,6 +57,9 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
     val attrDecimal = AttributeReference("cdecimal", DecimalType(5, 4))()
     val attrDate = AttributeReference("cdate", DateType)()
     val attrTimestamp = AttributeReference("ctimestamp", TimestampType)()
+    val attrTimestampNTZ = AttributeReference("ctimestamp_ntz", TimestampNTZType)()
+    val attrYMInterval = AttributeReference("cyminterval", YearMonthIntervalType())()
+    val attrDTInterval = AttributeReference("cdtinterval", DayTimeIntervalType())()
 
     val s1 = 1.toShort
     val s2 = 4.toShort
@@ -84,7 +87,10 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
         attrFloat -> ColumnStat(min = Some(1.1f), max = Some(4.1f)),
         attrDecimal -> ColumnStat(min = Some(Decimal(13.5)), max = Some(Decimal(19.5))),
         attrDate -> ColumnStat(min = Some(1), max = Some(4)),
-        attrTimestamp -> ColumnStat(min = Some(1L), max = Some(4L))))
+        attrTimestamp -> ColumnStat(min = Some(1L), max = Some(4L)),
+        attrTimestampNTZ -> ColumnStat(min = Some(1L), max = Some(4L)),
+        attrYMInterval -> ColumnStat(min = Some(2), max = Some(5)),
+        attrDTInterval -> ColumnStat(min = Some(2L), max = Some(5L))))
 
     val s3 = 2.toShort
     val s4 = 6.toShort
@@ -118,7 +124,16 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
         AttributeReference("cdate1", DateType)() -> ColumnStat(min = Some(3), max = Some(6)),
         AttributeReference("ctimestamp1", TimestampType)() -> ColumnStat(
           min = Some(3L),
-          max = Some(6L))))
+          max = Some(6L)),
+        AttributeReference("ctimestamp_ntz1", TimestampNTZType)() -> ColumnStat(
+          min = Some(3L),
+          max = Some(6L)),
+        AttributeReference("cymtimestamp1", YearMonthIntervalType())() -> ColumnStat(
+          min = Some(4),
+          max = Some(8)),
+        AttributeReference("cdttimestamp1", DayTimeIntervalType())() -> ColumnStat(
+          min = Some(4L),
+          max = Some(8L))))
 
     val child1 = StatsTestPlan(
       outputList = columnInfo.keys.toSeq.sortWith(_.exprId.id < _.exprId.id),
@@ -147,7 +162,10 @@ class UnionEstimationSuite extends StatsEstimationTestBase {
           attrFloat -> ColumnStat(min = Some(1.1f), max = Some(6.1f)),
           attrDecimal -> ColumnStat(min = Some(Decimal(13.5)), max = Some(Decimal(19.9))),
           attrDate -> ColumnStat(min = Some(1), max = Some(6)),
-          attrTimestamp -> ColumnStat(min = Some(1L), max = Some(6L)))))
+          attrTimestamp -> ColumnStat(min = Some(1L), max = Some(6L)),
+          attrTimestampNTZ -> ColumnStat(min = Some(1L), max = Some(6L)),
+          attrYMInterval -> ColumnStat(min = Some(2), max = Some(8)),
+          attrDTInterval -> ColumnStat(min = Some(2L), max = Some(8L)))))
     assert(union.stats === expectedStats)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to support ANSI intervals and TimestampNTZ for `UnionEstimation`.
Currently, `UnionEstimation` doesn't support ANSI intervals and TimestampNTZ. But I think it can support those types because their underlying types are integer or long, which `UnionEstimation` can compute stats for.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make CBO better.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. Not interferes with the current behavior.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Modified `UnionEstimationSuite`.