### PR TITLE
[SPARK-37465][Python][WIP] Raise minimum supported Pandas version to 1.0.0

### DIFF
--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -19,7 +19,7 @@
 def require_minimum_pandas_version() -> None:
     """Raise ImportError if minimum version of Pandas is not installed"""
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.
-    minimum_pandas_version = "0.23.2"
+    minimum_pandas_version = "1.0.0"
 
     from distutils.version import LooseVersion
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -111,7 +111,7 @@ if (in_spark):
 # For Arrow, you should also check ./pom.xml and ensure there are no breaking changes in the
 # binary format protocol with the Java version, see ARROW_HOME/format/* for specifications.
 # Also don't forget to update python/docs/source/getting_started/install.rst.
-_minimum_pandas_version = "0.23.2"
+_minimum_pandas_version = "1.0.0"
 _minimum_pyarrow_version = "1.0.0"
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This raises Spark's minimum supported Pandas version to 1.0.0. If the installed version is below, Spark fails with: _"Pandas >= 1.0.0 must be installed; however, your version was ..."_

### Why are the changes needed?
Some of the Pandas-on-Spark tests do not pass with Pandas < 1.0, see SPARK-37465.

### Does this PR introduce _any_ user-facing change?
Yes, users with installed Pandas versions below 1.0 will see failures. Also Pandas 1.0 introduces breaks [(listed here)](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html#backwards-incompatible-api-changes) which should not affect Spark's interaction with Pandas, but it might introduce breaks to user environments that get their Pandas version transitively through PySpark.

### How was this patch tested?
Existing tests. The Pandas version used in Github actions is 1.3.3. I'll verify tests also pass with 1.0.0.
