### PR TITLE
[SPARK-33875][SQL][FOLLOWUP] Handle the char/varchar column for `Describe column` command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeColumnExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeColumnExec.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 
 case class DescribeColumnExec(
     override val output: Seq[Attribute],
@@ -37,7 +38,8 @@ case class DescribeColumnExec(
     }
 
     rows += toCatalystRow("col_name", column.name)
-    rows += toCatalystRow("data_type", column.dataType.catalogString)
+    rows += toCatalystRow("data_type",
+      CharVarcharUtils.getRawType(column.metadata).getOrElse(column.dataType).catalogString)
     rows += toCatalystRow("comment", comment)
 
     // TODO: The extended description (isExtended = true) can be added here.

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -843,17 +843,6 @@ class FileSourceCharVarcharTestSuite extends CharVarcharTestSuite with SharedSpa
     }
   }
 
-  // TODO(SPARK-33875): Move these tests to super after DESCRIBE COLUMN v2 implemented
-  test("SPARK-33892: DESCRIBE COLUMN w/ char/varchar") {
-    withTable("t") {
-      sql(s"CREATE TABLE t(v VARCHAR(3), c CHAR(5)) USING $format")
-      checkAnswer(sql("desc t v").selectExpr("info_value").where("info_value like '%char%'"),
-        Row("varchar(3)"))
-      checkAnswer(sql("desc t c").selectExpr("info_value").where("info_value like '%char%'"),
-        Row("char(5)"))
-    }
-  }
-
   // TODO(SPARK-33898): Move these tests to super after SHOW CREATE TABLE for v2 implemented
   test("SPARK-33892: SHOW CREATE TABLE w/ char/varchar") {
     withTable("t") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala
@@ -150,6 +150,16 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-33892: DESCRIBE COLUMN w/ char/varchar") {
+    withTable("t") {
+      sql(s"CREATE TABLE t(v VARCHAR(3), c CHAR(5)) USING $format")
+      checkAnswer(sql("desc t v").selectExpr("info_value").where("info_value like '%char%'"),
+        Row("varchar(3)"))
+      checkAnswer(sql("desc t c").selectExpr("info_value").where("info_value like '%char%'"),
+        Row("char(5)"))
+    }
+  }
 }
 
 class FileSourceCharVarcharDDLTestSuite extends CharVarcharDDLTestBase with SharedSparkSession {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add handle column with char/varchar datatype for `DESCRIBE tableName columnName` command.

### Why are the changes needed?
when create table with char/varchar column. we should show char/varchar instead of `string` for `Describe table column` command.

### Does this PR introduce _any_ user-facing change?
```scala
CREATE TABLE catlog.table (id char(10), name varchar(20)) USING foo
DESCRIBE catlog.table id
DESCRIBE catlog.table name
```
Before the PR
The result is
```scala
+---------+----------+
|info_name|info_value|
+---------+----------+
| col_name|        id|
|data_type|    string|
|  comment|      NULL|
+---------+----------+

+---------+----------+
|info_name|info_value|
+---------+----------+
| col_name|      name|
|data_type|    string|
|  comment|      NULL|
+---------+----------+
```
After the PR
The result is
```scala
+---------+----------+
|info_name|info_value|
+---------+----------+
| col_name|        id|
|data_type|  char(10)|
|  comment|      NULL|
+---------+----------+

+---------+-----------+
|info_name| info_value|
+---------+-----------+
| col_name|       name|
|data_type|varchar(20)|
|  comment|       NULL|
+---------+-----------+
```

### How was this patch tested?
extend testcase.
