### PR TITLE
[SPARK-36346][SQL][FOLLOWUP] Rename `withAllOrcReaders` to `withAllNativeOrcReaders`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -776,7 +776,7 @@ abstract class OrcQuerySuite extends OrcQueryTest with SharedSparkSession {
     } :+ (null, null)
 
     withOrcFile(data) { file =>
-      withAllOrcReaders {
+      withAllNativeOrcReaders {
         checkAnswer(spark.read.orc(file), data.toDF().collect())
       }
     }
@@ -799,7 +799,7 @@ abstract class OrcQuerySuite extends OrcQueryTest with SharedSparkSession {
     withTempPath { file =>
       val df = spark.createDataFrame(sparkContext.parallelize(data), actualSchema)
       df.write.orc(file.getCanonicalPath)
-      withAllOrcReaders {
+      withAllNativeOrcReaders {
         val msg = intercept[SparkException] {
           spark.read.schema(providedSchema).orc(file.getCanonicalPath).collect()
         }.getMessage
@@ -825,7 +825,7 @@ abstract class OrcQuerySuite extends OrcQueryTest with SharedSparkSession {
     withTempPath { file =>
       val df = spark.createDataFrame(sparkContext.parallelize(data), actualSchema)
       df.write.orc(file.getCanonicalPath)
-      withAllOrcReaders {
+      withAllNativeOrcReaders {
         checkAnswer(spark.read.schema(providedSchema).orc(file.getCanonicalPath), answer)
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -143,7 +143,7 @@ abstract class OrcTest extends QueryTest with FileBasedDataSourceTest with Befor
     spark.read.orc(file.getAbsolutePath)
   }
 
-  def withAllOrcReaders(code: => Unit): Unit = {
+  def withAllNativeOrcReaders(code: => Unit): Unit = {
     // test the row-based reader
     withSQLConf(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false")(code)
     // test the vectorized reader


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename `withAllOrcReaders` to `withAllNativeOrcReaders`.

### Why are the changes needed?

Apache Spark have non-native ORC reader too. In `SQL` module, we only test native readers.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.