### PR TITLE
[SPARK-37482][PYTHON] Skip check monotonic increasing for Series.asof with 'compute.eager_check'

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -286,7 +286,8 @@ compute.eager_check             True           'compute.eager_check' sets whethe
                                                performs the validation beforehand, but it will cause
                                                a performance overhead. Otherwise, pandas-on-Spark
                                                skip the validation and will be slightly different
-                                               from pandas. Affected APIs: `Series.dot`.
+                                               from pandas. Affected APIs: `Series.dot`,
+                                               `Series.asof`.
 compute.isin_limit              80             'compute.isin_limit' sets the limit for filtering by
                                                'Column.isin(list)'. If the length of the ‘list’ is
                                                above the limit, broadcast join is used instead for

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -201,7 +201,7 @@ _options: List[Option] = [
             "of validation. If 'compute.eager_check' is set to True, pandas-on-Spark performs the "
             "validation beforehand, but it will cause a performance overhead. Otherwise, "
             "pandas-on-Spark skip the validation and will be slightly different from pandas. "
-            "Affected APIs: `Series.dot`."
+            "Affected APIs: `Series.dot`, `Series.asof`."
         ),
         default=True,
         types=bool,

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2121,16 +2121,12 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
         with ps.option_context("compute.eager_check", False):
             self.assert_eq(psser.asof(20), 1.0)
-        with ps.option_context("compute.eager_check", True):
-            self.assertRaises(ValueError, lambda: psser.asof(20))
 
         pser = pd.Series([1, 2, np.nan, 4], index=[40, 30, 20, 10])
         psser = ps.from_pandas(pser)
 
         with ps.option_context("compute.eager_check", False):
             self.assert_eq(psser.asof(20), 4.0)
-        with ps.option_context("compute.eager_check", True):
-            self.assertRaises(ValueError, lambda: psser.asof(20))
 
     def test_squeeze(self):
         # Single value


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip check monotonic increasing for Series.asof with 'compute.eager_check'

### Why are the changes needed?
monotonic increasing checking is expensive, so we should use config 'compute.eager_check' to skip this one

### Does this PR introduce _any_ user-facing change?
Yes

Before this PR
```python
>>> s = ps.Series([1, 2, np.nan, 4], index=[10, 30, 20, 40])
>>> with ps.option_context("compute.eager_check", False):
...     s.asof(20)
... 
21/11/29 17:09:39 WARN WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
21/11/29 17:09:40 WARN WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
21/11/29 17:09:40 WARN WindowExec: No Partition Defined for Window operation! Moving all data to a single partition, this can cause serious performance degradation.
Traceback (most recent call last):                                              
  File "<stdin>", line 2, in <module>
  File "/u02/spark/python/pyspark/pandas/series.py", line 5220, in asof
    raise ValueError("asof requires a sorted index")
ValueError: asof requires a sorted index


```
After this PR, when config 'compute.eager_check' is False, pandas-on-Spark just proceeds and performs by ignoring the indeces's order
```python
>>> s = ps.Series([1, 2, np.nan, 4], index=[10, 30, 20, 40])
>>> with ps.option_context("compute.eager_check", False):
...     s.asof(20)
... 
1.0 
```
### How was this patch tested?
Unit tests
