### PR TITLE
[SPARK-37484][CORE][SQL] Replace `get` and `getOrElse` with `getOrElse`

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -463,14 +463,14 @@ object ResourceProfile extends Logging {
           case ResourceProfile.CORES =>
             cores = execReq.amount.toInt
           case rName =>
-            val nameToUse = resourceMappings.get(rName).getOrElse(rName)
+            val nameToUse = resourceMappings.getOrElse(rName, rName)
             customResources(nameToUse) = execReq
         }
       }
       customResources.toMap
     } else {
       defaultResources.customResources.map { case (rName, execReq) =>
-        val nameToUse = resourceMappings.get(rName).getOrElse(rName)
+        val nameToUse = resourceMappings.getOrElse(rName, rName)
         (nameToUse, execReq)
       }
     }

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -104,7 +104,8 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
     readLock.lock()
     try {
       resourceProfileIdToResourceProfile.getOrElse(rpId,
-        throw new SparkException(s"ResourceProfileId $rpId not found!"))
+        throw new SparkException(s"ResourceProfileId $rpId not found!")
+      )
     } finally {
       readLock.unlock()
     }

--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfileManager.scala
@@ -103,9 +103,8 @@ private[spark] class ResourceProfileManager(sparkConf: SparkConf,
   def resourceProfileFromId(rpId: Int): ResourceProfile = {
     readLock.lock()
     try {
-      resourceProfileIdToResourceProfile.get(rpId).getOrElse(
-        throw new SparkException(s"ResourceProfileId $rpId not found!")
-      )
+      resourceProfileIdToResourceProfile.getOrElse(rpId,
+        throw new SparkException(s"ResourceProfileId $rpId not found!"))
     } finally {
       readLock.unlock()
     }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -387,11 +387,10 @@ private[kafka010] class KafkaOffsetReaderAdmin(
 
     // Calculate offset ranges
     val offsetRangesBase = untilPartitionOffsets.keySet.map { tp =>
-      val fromOffset = fromPartitionOffsets.get(tp).getOrElse {
+      val fromOffset = fromPartitionOffsets.getOrElse(tp,
         // This should not happen since topicPartitions contains all partitions not in
         // fromPartitionOffsets
-        throw new IllegalStateException(s"$tp doesn't have a from offset")
-      }
+        throw new IllegalStateException(s"$tp doesn't have a from offset"))
       val untilOffset = untilPartitionOffsets(tp)
       KafkaOffsetRange(tp, fromOffset, untilOffset, None)
     }.toSeq

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderAdmin.scala
@@ -390,7 +390,8 @@ private[kafka010] class KafkaOffsetReaderAdmin(
       val fromOffset = fromPartitionOffsets.getOrElse(tp,
         // This should not happen since topicPartitions contains all partitions not in
         // fromPartitionOffsets
-        throw new IllegalStateException(s"$tp doesn't have a from offset"))
+        throw new IllegalStateException(s"$tp doesn't have a from offset")
+      )
       val untilOffset = untilPartitionOffsets(tp)
       KafkaOffsetRange(tp, fromOffset, untilOffset, None)
     }.toSeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -136,10 +136,9 @@ trait FileScan extends Scan
     val partitionAttributes = fileIndex.partitionSchema.toAttributes
     val attributeMap = partitionAttributes.map(a => normalizeName(a.name) -> a).toMap
     val readPartitionAttributes = readPartitionSchema.map { readField =>
-      attributeMap.get(normalizeName(readField.name)).getOrElse {
+      attributeMap.getOrElse(normalizeName(readField.name),
         throw QueryCompilationErrors.cannotFindPartitionColumnInPartitionSchemaError(
-          readField, fileIndex.partitionSchema)
-      }
+          readField, fileIndex.partitionSchema))
     }
     lazy val partitionValueProject =
       GenerateUnsafeProjection.generate(readPartitionAttributes, partitionAttributes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -138,7 +138,8 @@ trait FileScan extends Scan
     val readPartitionAttributes = readPartitionSchema.map { readField =>
       attributeMap.getOrElse(normalizeName(readField.name),
         throw QueryCompilationErrors.cannotFindPartitionColumnInPartitionSchemaError(
-          readField, fileIndex.partitionSchema))
+          readField, fileIndex.partitionSchema)
+      )
     }
     lazy val partitionValueProject =
       GenerateUnsafeProjection.generate(readPartitionAttributes, partitionAttributes)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -116,7 +116,7 @@ private[sql] class RocksDBStateStoreProvider
         rocksDBMetrics.nativeOpsHistograms.get(typ).map(_.count).getOrElse(0)
       }
       def nativeOpsMetrics(typ: String): Long = {
-        rocksDBMetrics.nativeOpsMetrics.get(typ).getOrElse(0)
+        rocksDBMetrics.nativeOpsMetrics.getOrElse(typ, 0)
       }
 
       val stateStoreCustomMetrics = Map[StateStoreCustomMetric, Long](


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are some combined calls of `get` and `getOrElse` in Spark code, we can call `getOrElse` directly in this scene.

**Before**

```
val map = Map(1 -> 42)
map.get(key).getOrElse(defValue)
```

**After**

```
val map = Map(1 -> 42)
map.getOrElse(key, defValue)
```


### Why are the changes needed?
Code simplification


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

- Pass the Jenkins or GitHub Action
