### PR TITLE
[SPARK-37486][SQL][HIVE]  set the ContextClassLoader before using the `addJars` in `HiveClient` 

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -139,8 +139,8 @@ class HiveSessionResourceLoader(
   override def addJar(path: String): Unit = {
     val uri = Utils.resolveURI(path)
     resolveJars(uri).foreach { p =>
-      client.addJar(p)
       super.addJar(p)
+      client.addJar(p)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `HiveSessionResourceLoader`,  call the  function `addJars` of its supper class firstly and set the contextClassLoader in current thread, and then  use the `addJars` in `HiveClient`. to avoid that different class loaders load the same class. 

### Why are the changes needed?

when using livy to execute sql statements that will use the udf jars located in lakefs, a inner filesystem in Tencent Cloud DLC. it will threw the following exceptions:

`java.lang.LinkageError: loader constraint violation: loader (instance of sun/misc/Launcher$AppClassLoader) previously initiated loading for a different type with name`     

Maybe it happens  in some other filesystem.

This PR fix the bug  by  setting the setContextClassLoader before using the addJars in HiveClient

### Why are the changes needed?

fix  the bug that different class loaders  load the same class. 

### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?

existing testsuites