### PR TITLE
[SPARK-37488][CORE] When `TaskLocation` is `HDFSCacheTaskLocation` or `HostTaskLocation`, check if executor is alive on the host

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -291,7 +291,8 @@ class TaskSetManagerSuite
     assert(manager.resourceOffer("execA", "host1", ANY)._1.get.index === 0)
   }
 
-  test("skip unsatisfiable locality levels (the case TaskLocation is HostTaskLocation)") {
+  test("SPARK-37488 skip unsatisfiable locality levels " +
+    "(the case TaskLocation is HostTaskLocation)") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc, ("execA", "host1"))
     val taskSet = FakeTask.createTaskSet(2, Seq(TaskLocation("host1")), Seq(TaskLocation("host2")))


### PR DESCRIPTION
```java
// The online environment is actually hive partition data imported to tidb, the code logic can be simplified as follows
SparkSession testApp = SparkSession.builder()
    .master("local[*]")
    .appName("test app")
    .enableHiveSupport()
    .getOrCreate();
Dataset<Row> dataset = testApp.sql("select * from default.test where dt = '20211129'");
dataset.persist(StorageLevel.MEMORY_AND_DISK());
dataset.count();
```
I have observed that tasks are permanently pending and reruns can always be reproduced.
Since it is only reproducible online, I use the arthas runtime to see the status of the function entries and returns within the `TaskSetManager`.
I replaced the real host to avoid revealing company information
https://gist.github.com/guiyanakuang/431584f191645513552a937d16ae8fbd

`NODE_LOCAL` level, because the persist function is called, the pendingTasks.forHost has a collection of pending tasks, but it points to the machine where the block of partitioned data is located, and since the only resource spark gets is the driver. 

Here is the forHost information I got through the arthas hook
```
    forHost=@HashMap[
        serialVersionUID=@Long[1],
        _loadFactor=@Integer[750],
        table=@HashEntry[][
            @DefaultEntry[(kv: hdfs-loc-1, ArrayBuffer(2, 1))],
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            @DefaultEntry[(kv: driver-host, ArrayBuffer())],
            null,
            null,
            null,
            null,
            @DefaultEntry[(kv: hdfs-loc-2, ArrayBuffer(2, 1))],
            @DefaultEntry[(kv: hdfs-loc-3, ArrayBuffer(2, 1))],
        ],
```
When we can only provide driver resources, getAllowedLocalityLevel limits the attempt level to NODE_LOCAL. But in reality, the task cannot run at this level, and the attempt level cannot reach ANY

### What changes were proposed in this pull request?
To solve the above mentioned problem, this pr modifies the initialization logic of `forHost`. 
When `TaskLocation` is `HDFSCacheTaskLocation` or `HostTaskLocation`, check if executor is alive on the host.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In my online environment it may cause the task to pending permanently, this pr aims to fix this issue.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add unit test