### PR TITLE
[SPARK-37495][PYTHON] Skip identical index checking of Series.compare when config 'compute.eager_check' is disabled

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -287,9 +287,10 @@ compute.eager_check             True           'compute.eager_check' sets whethe
                                                a performance overhead. Otherwise, pandas-on-Spark
                                                skip the validation and will be slightly different
                                                from pandas. Affected APIs: `Series.dot`,
-                                               `Series.asof`, `FractionalExtensionOps.astype`,
-                                               `IntegralExtensionOps.astype`, `FractionalOps.astype`,
-                                               `DecimalOps.astype`.
+                                               `Series.asof`, `Series.compare`,
+                                               `FractionalExtensionOps.astype`,
+                                               `IntegralExtensionOps.astype`,
+                                               `FractionalOps.astype`, `DecimalOps.astype`.
 compute.isin_limit              80             'compute.isin_limit' sets the limit for filtering by
                                                'Column.isin(list)'. If the length of the ‘list’ is
                                                above the limit, broadcast join is used instead for

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -201,8 +201,9 @@ _options: List[Option] = [
             "of validation. If 'compute.eager_check' is set to True, pandas-on-Spark performs the "
             "validation beforehand, but it will cause a performance overhead. Otherwise, "
             "pandas-on-Spark skip the validation and will be slightly different from pandas. "
-            "Affected APIs: `Series.dot`, `Series.asof`, `FractionalExtensionOps.astype`, "
-            "`IntegralExtensionOps.astype`, `FractionalOps.astype`, `DecimalOps.astype`."
+            "Affected APIs: `Series.dot`, `Series.asof`, `Series.compare`, "
+            "`FractionalExtensionOps.astype`, `IntegralExtensionOps.astype`, "
+            "`FractionalOps.astype`, `DecimalOps.astype`."
         ),
         default=True,
         types=bool,

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5868,8 +5868,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             if get_option("compute.eager_check") and not self.index.equals(other.index):
                 raise ValueError("Can only compare identically-labeled Series objects")
-            elif len(self.index) != len(other.index):
-                raise ValueError("Can only compare identically-labeled Series objects")
 
             combined = combine_frames(self.to_frame(), other.to_frame())
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5781,6 +5781,25 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         Compare to another Series and show the differences.
 
+        .. note:: This API is slightly different from pandas when indexes from both Series
+            are not identical and config 'compute.eager_check' is False. pandas raises an exception;
+            however, pandas-on-Spark just proceeds and performs by ignoring mismatches.
+
+            >>> psser1 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 3, 4, 5]))
+            >>> psser2 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 4, 3, 6]))
+            >>> psser1.compare(psser2)  # doctest: +SKIP
+            ...
+            ValueError: Can only compare identically-labeled Series objects
+
+            >>> with ps.option_context("compute.eager_check", False):
+            ...     psser1.compare(psser2)  # doctest: +SKIP
+            ...
+               self  other
+            3   3.0    4.0
+            4   4.0    3.0
+            5   5.0    NaN
+            6   NaN    5.0
+
         Parameters
         ----------
         other : Series
@@ -5847,7 +5866,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 )
             )
         else:
-            if not self.index.equals(other.index):
+            if get_option("compute.eager_check") and not self.index.equals(other.index):
+                raise ValueError("Can only compare identically-labeled Series objects")
+            elif len(self.index) != len(other.index):
                 raise ValueError("Can only compare identically-labeled Series objects")
 
             combined = combine_frames(self.to_frame(), other.to_frame())

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -913,25 +913,14 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         # SPARK-37495: Skip identical index checking of Series.compare when config
         # 'compute.eager_check' is disabled
         psser1 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 3, 4, 5]))
-        psser2 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 4, 3, 6]))
+        psser2 = ps.Series([1, 2, 3, 4, 5, 6], index=pd.Index([1, 2, 4, 3, 6, 7]))
         expected = ps.DataFrame(
-            {"self": [3, 4, 5, np.nan], "other": [4, 3, np.nan, 5.0]}, index=[3, 4, 5, 6]
+            {"self": [3, 4, 5, np.nan, np.nan], "other": [4, 3, np.nan, 5.0, 6.0]},
+            index=[3, 4, 5, 6, 7],
         )
 
         with ps.option_context("compute.eager_check", False):
             self.assert_eq(expected, psser1.compare(psser2))
-
-        psser1 = ps.Series([1, 2, 3, 4, 5, 6], index=pd.Index([1, 2, 3, 4, 5, 6]))
-        psser2 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 4, 3, 5]))
-
-        with self.assertRaisesRegex(
-            ValueError, "Can only compare identically-labeled Series objects"
-        ):
-            psser1.compare(psser2)
-        with ps.option_context("compute.eager_check", False), self.assertRaisesRegex(
-            ValueError, "Can only compare identically-labeled Series objects"
-        ):
-            psser1.compare(psser2)
 
     def test_different_columns(self):
         psdf1 = self.psdf1

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -910,6 +910,28 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
                 ),
             )
             psser1.compare(psser2)
+        # SPARK-37495: Skip identical index checking of Series.compare when config
+        # 'compute.eager_check' is disabled
+        psser1 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 3, 4, 5]))
+        psser2 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 4, 3, 6]))
+        expected = ps.DataFrame(
+            {"self": [3, 4, 5, np.nan], "other": [4, 3, np.nan, 5.0]}, index=[3, 4, 5, 6]
+        )
+
+        with ps.option_context("compute.eager_check", False):
+            self.assert_eq(expected, psser1.compare(psser2))
+
+        psser1 = ps.Series([1, 2, 3, 4, 5, 6], index=pd.Index([1, 2, 3, 4, 5, 6]))
+        psser2 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 4, 3, 5]))
+
+        with self.assertRaisesRegex(
+            ValueError, "Can only compare identically-labeled Series objects"
+        ):
+            psser1.compare(psser2)
+        with ps.option_context("compute.eager_check", False), self.assertRaisesRegex(
+            ValueError, "Can only compare identically-labeled Series objects"
+        ):
+            psser1.compare(psser2)
 
     def test_different_columns(self):
         psdf1 = self.psdf1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip identical index checking of Series.compare when config 'compute.eager_check' is disabled

### Why are the changes needed?
Identical index checking is expensive, so we should use config 'compute.eager_check' to skip this one

### Does this PR introduce _any_ user-facing change?
Yes

Before this PR
```python
>>> psser1 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 3, 4, 5]))
>>> psser2 = ps.Series([1, 2, 3, 4, 5], index=pd.Index([1, 2, 4, 3, 6]))
>>> psser1.compare(psser2)
Traceback (most recent call last):                                              
  File "<stdin>", line 1, in <module>
  File "/u02/spark/python/pyspark/pandas/series.py", line 5851, in compare
    raise ValueError("Can only compare identically-labeled Series objects")
ValueError: Can only compare identically-labeled Series objects
```
After this PR, when config 'compute.eager_check' is False, pandas-on-Spark just proceeds and performs by ignoring the identical index checking.
```python
>>> with ps.option_context("compute.eager_check", False):
...     psser1.compare(psser2)
... 
   self  other
3   3.0    4.0
4   4.0    3.0
5   5.0    NaN
6   NaN    5.0
```
### How was this patch tested?
Unit tests

