### PR TITLE
[SPARK-37502][SQL] Support cast aware output partitioning and required if it can up cast

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/PartitioningSemanticEquals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/PartitioningSemanticEquals.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.physical
+
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression}
+import org.apache.spark.sql.catalyst.trees.TreePattern
+
+/**
+ * A help trait that provide semantic equal for output partitioning.
+ * For example, we treat the cast expression is semantic equal with its child if it can up cast.
+ */
+trait PartitioningSemanticEquals {
+  private def canonicalize(expr: Expression): Expression = {
+    expr.canonicalized.transformWithPruning(_.containsPattern(TreePattern.CAST)) {
+      case Cast(child, dataType, _, _) if Cast.canUpCast(child.dataType, dataType) =>
+        child
+    }
+  }
+
+  def partitioningSemanticsEquals(left: Expression, right: Expression): Boolean = {
+    left.deterministic && right.deterministic &&
+      canonicalize(left) == canonicalize(right)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Enhance semantic equals at `Partitioning` to support cast aware output partitioning and required if it can up cast.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If a `Cast` is up cast then it should be without any truncating or precision lose or possible runtime failures. So the output partitioning should be same with/without `Cast` if the `Cast` is up cast.

Let's say we have a query:
```sql
-- v1: c1 int
-- v2: c2 long

SELECT * FROM v2 JOIN (SELECT c1, count(*) FROM v1 GROUP BY c1) v1 ON v1.c1 = v2.c2
```

The executed plan contains three shuffle nodes which looks like:
```sql
SortMergeJoin
  Exchange(cast(c1 as bigint))
    HashAggregate
      Exchange(c1)
        Scan v1
  Exchange(c2)
    Scan v2
```

We can simplify the plan using two shuffle nodes:
```sql
SortMergeJoin
  HashAggregate
    Exchange(c1)
      Scan v1
  Exchange(c2)
    Scan v2
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, the plan may be changed

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add test in:
- org.apache.spark.sql.catalyst.DistributionSuite
- org.apache.spark.sql.SQLQuerySuite