### PR TITLE
[SPARK-37504][PYTHON] Pyspark create SparkSession with existed session should not pass static conf

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,7 +278,9 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
                 for key, value in self._options.items():
-                    if not session._jvm.org.apache.spark.sql.internal.SQLConf.isStaticConfigKey(key):
+                    if not session._jvm.org.apache.spark.sql.internal.SQLConf.isStaticConfigKey(
+                        key
+                    ):
                         session._jsparkSession.sessionState().conf().setConfString(key, value)
                 return session
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,9 +278,9 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
                 else:
-                    getattr(getattr(session._jvm, "SparkSession$"), "MODULE$").applyModifiableSettings(
-                        session._jsparkSession, self._options
-                    )
+                    getattr(
+                        getattr(session._jvm, "SparkSession$"), "MODULE$"
+                    ).applyModifiableSettings(session._jsparkSession, self._options)
                 return session
 
     builder = Builder()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -289,7 +289,7 @@ class SparkSession(SparkConversionMixin):
     _instantiatedSession: ClassVar[Optional["SparkSession"]] = None
     _activeSession: ClassVar[Optional["SparkSession"]] = None
 
-    def applyModifiableSetting(self, session: JavaObject, options: Dict[str, Any]):
+    def applyModifiableSetting(self, session: JavaObject, options: Dict[str, Any]) -> None:
         log4jLogger = self._jvm.org.apache.log4j
         LOGGER = log4jLogger.LogManager.getLogger("SparkSession")
         staticConfs: Dict[str, Any] = {}
@@ -311,7 +311,6 @@ class SparkSession(SparkConversionMixin):
                 "Using an existing SparkSession; some spark core configurations may not take"
                 + " effect."
             )
-        return
 
     def __init__(
         self,

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,7 +278,8 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
                 for key, value in self._options.items():
-                    session._jsparkSession.sessionState().conf().setConfString(key, value)
+                    if not session._jvm.org.apache.spark.sql.internal.SQLConf.isStaticConfigKey(key):
+                        session._jsparkSession.sessionState().conf().setConfString(key, value)
                 return session
 
     builder = Builder()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,7 +278,9 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
                 else:
-                    session._jvm.SparkSession.applyModifiableSettings(session._jsparkSession, self._options)
+                    getattr(getattr(session._jvm, "SparkSession$"), "MODULE$").applyModifiableSettings(
+                        session._jsparkSession, self._options
+                    )
                 return session
 
     builder = Builder()
@@ -304,11 +306,15 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
-                self._jvm.SparkSession.applyModifiableSettings(jsparkSession, options)
+                getattr(getattr(self._jvm, "SparkSession$"), "MODULE$").applyModifiableSettings(
+                    jsparkSession, options
+                )
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc(), options)
         else:
-            self._jvm.SparkSession.applyModifiableSettings(jsparkSession, options)
+            getattr(getattr(self._jvm, "SparkSession$"), "MODULE$").applyModifiableSettings(
+                jsparkSession, options
+            )
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -291,7 +291,7 @@ class SparkSession(SparkConversionMixin):
         self,
         sparkContext: SparkContext,
         jsparkSession: Optional[JavaObject] = None,
-        options: Optional[Dict[str, Any]] = {},
+        options: Dict[str, Any] = {},
     ):
         from pyspark.sql.context import SQLContext
 
@@ -304,13 +304,11 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
-                if options is not None:
-                    self._jvm.SparkSession.applyModifiableSettings(jsparkSession, options)
+                self._jvm.SparkSession.applyModifiableSettings(jsparkSession, options)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc(), options)
         else:
-            if options is not None:
-                self._jvm.SparkSession.applyModifiableSettings(jsparkSession, options)
+            self._jvm.SparkSession.applyModifiableSettings(jsparkSession, options)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -278,7 +278,9 @@ class SparkSession(SparkConversionMixin):
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
                 else:
-                    SparkSession.applyModifiableSetting(session, session._jsparkSession, self._options)
+                    SparkSession.applyModifiableSetting(
+                        session, session._jsparkSession, self._options
+                    )
                 return session
 
     builder = Builder()
@@ -332,7 +334,7 @@ class SparkSession(SparkConversionMixin):
                     self.applyModifiableSetting(jsparkSession, options)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc(), options)
-        else :
+        else:
             if options is not None:
                 self.applyModifiableSetting(jsparkSession, options)
         self._jsparkSession = jsparkSession

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -277,25 +277,8 @@ class SparkSession(SparkConversionMixin):
                     # Do not update `SparkConf` for existing `SparkContext`, as it's shared
                     # by all sessions.
                     session = SparkSession(sc, options=self._options)
-                staticConfs: Dict[str, Any] = {}
-                otherConfs: Dict[str, Any] = {}
-                for key, value in self._options.items():
-                    if session._jvm.org.apache.spark.sql.internal.SQLConf.isStaticConfigKey(key):
-                        staticConfs[key] = value
-                    else:
-                        otherConfs[key] = value
-                for key, value in otherConfs.items():
-                    session._jsparkSession.sessionState().conf().setConfString(key, value)
-                if not staticConfs:
-                    session._jsparkSession.logWarning(
-                        "Using an existing SparkSession; the static sql configurations will not take"
-                        + " effect."
-                    )
-                if not otherConfs:
-                    session._jsparkSession.logWarning(
-                        "Using an existing SparkSession; some spark core configurations may not take"
-                        + " effect."
-                    )
+                else:
+                    SparkSession.applyModifiableSetting(session, session._jsparkSession, self._options)
                 return session
 
     builder = Builder()
@@ -303,6 +286,30 @@ class SparkSession(SparkConversionMixin):
 
     _instantiatedSession: ClassVar[Optional["SparkSession"]] = None
     _activeSession: ClassVar[Optional["SparkSession"]] = None
+
+    def applyModifiableSetting(self, session: JavaObject, options: Dict[str, Any]):
+        log4jLogger = self._jvm.org.apache.log4j
+        LOGGER = log4jLogger.LogManager.getLogger("SparkSession")
+        staticConfs: Dict[str, Any] = {}
+        otherConfs: Dict[str, Any] = {}
+        for key, value in options.items():
+            if self._jvm.org.apache.spark.sql.internal.SQLConf.isStaticConfigKey(key):
+                staticConfs[key] = value
+            else:
+                otherConfs[key] = value
+        for key, value in otherConfs.items():
+            session.sessionState().conf().setConfString(key, value)
+        if not staticConfs:
+            LOGGER.warn(
+                "Using an existing SparkSession; the static sql configurations will not take"
+                + " effect."
+            )
+        if not otherConfs:
+            LOGGER.warn(
+                "Using an existing SparkSession; some spark core configurations may not take"
+                + " effect."
+            )
+        return
 
     def __init__(
         self,
@@ -321,8 +328,13 @@ class SparkSession(SparkConversionMixin):
                 and not self._jvm.SparkSession.getDefaultSession().get().sparkContext().isStopped()
             ):
                 jsparkSession = self._jvm.SparkSession.getDefaultSession().get()
+                if options is not None:
+                    self.applyModifiableSetting(jsparkSession, options)
             else:
                 jsparkSession = self._jvm.SparkSession(self._jsc.sc(), options)
+        else :
+            if options is not None:
+                self.applyModifiableSetting(jsparkSession, options)
         self._jsparkSession = jsparkSession
         self._jwrapped = self._jsparkSession.sqlContext()
         self._wrapped = SQLContext(self._sc, self, self._jwrapped)

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -273,7 +273,9 @@ class SparkSessionBuilderTests(unittest.TestCase):
         session2 = None
         try:
             session1 = SparkSession.builder.config("key1", "value1").getOrCreate()
-            session2 = SparkSession.builder.config("spark.sql.codegen.comments", "true").getOrCreate()
+            session2 = SparkSession.builder.config(
+                "spark.sql.codegen.comments", "true"
+            ).getOrCreate()
 
             self.assertEqual(session1.conf.get("key1"), "value1")
             self.assertEqual(session2.conf.get("key1"), "value1")

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -273,12 +273,12 @@ class SparkSessionBuilderTests(unittest.TestCase):
         session2 = None
         try:
             session1 = SparkSession.builder.config("key1", "value1").getOrCreate()
-            session2 = SparkSession.builder.config("key2", "value2").getOrCreate()
+            session2 = SparkSession.builder.config("spark.sql.codegen.comments", "true").getOrCreate()
 
             self.assertEqual(session1.conf.get("key1"), "value1")
             self.assertEqual(session2.conf.get("key1"), "value1")
-            self.assertEqual(session1.conf.get("key2"), "value2")
-            self.assertEqual(session2.conf.get("key2"), "value2")
+            self.assertEqual(session1.conf.get("spark.sql.codegen.comments"), "false")
+            self.assertEqual(session2.conf.get("spark.sql.codegen.comments"), "false")
             self.assertEqual(session1.sparkContext, session2.sparkContext)
 
             self.assertEqual(session1.sparkContext.getConf().get("key1"), "value1")

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1062,7 +1062,7 @@ object SparkSession extends Logging {
    * Apply modifiable settings to an existing [[SparkSession]]. This method are used
    * both in Scala and Python, so put this under [[SparkSession]] object.
    */
-  def applyModifiableSettings(
+  private[sql] def applyModifiableSettings(
       session: SparkSession,
       options: java.util.HashMap[String, String]): Unit = {
     val (staticConfs, otherConfs) =

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1058,7 +1058,11 @@ object SparkSession extends Logging {
       throw new IllegalStateException("No active or default Spark session found")))
   }
 
-  def applyModifiableSettings(
+  /**
+   * Apply modifiable settings to an existed SparkSession. This method are used
+   * both in scala and pyspark, so put this under SparkSession object.
+   */
+  private[sql] def applyModifiableSettings(
       session: SparkSession,
       options: java.util.HashMap[String, String]): Unit = {
     val (staticConfs, otherConfs) =

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1060,7 +1060,7 @@ object SparkSession extends Logging {
 
   /**
    * Apply modifiable settings to an existed SparkSession. This method are used
-   * both in scala and pyspark, so put this under SparkSession object.
+   * both in scala and Pyspark, so put this under SparkSession object.
    */
   private[sql] def applyModifiableSettings(
       session: SparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1060,7 +1060,7 @@ object SparkSession extends Logging {
 
   /**
    * Apply modifiable settings to an existed SparkSession. This method are used
-   * both in scala and Pyspark, so put this under SparkSession object.
+   * both in Scala and Python, so put this under [[SparkSession]] object.
    */
   private[sql] def applyModifiableSettings(
       session: SparkSession,

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1062,7 +1062,7 @@ object SparkSession extends Logging {
    * Apply modifiable settings to an existing [[SparkSession]]. This method are used
    * both in Scala and Python, so put this under [[SparkSession]] object.
    */
-  private[sql] def applyModifiableSettings(
+  def applyModifiableSettings(
       session: SparkSession,
       options: java.util.HashMap[String, String]): Unit = {
     val (staticConfs, otherConfs) =

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1059,7 +1059,7 @@ object SparkSession extends Logging {
   }
 
   /**
-   * Apply modifiable settings to an existed SparkSession. This method are used
+   * Apply modifiable settings to an existing [[SparkSession]]. This method are used
    * both in Scala and Python, so put this under [[SparkSession]] object.
    */
   private[sql] def applyModifiableSettings(

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -930,7 +930,7 @@ object SparkSession extends Logging {
       // Get the session from current thread's active session.
       var session = activeThreadSession.get()
       if ((session ne null) && !session.sparkContext.isStopped) {
-        applyModifiableSettings(session)
+        applyModifiableSettings(session, new java.util.HashMap[String, String](options.asJava))
         return session
       }
 
@@ -939,7 +939,7 @@ object SparkSession extends Logging {
         // If the current thread does not have an active session, get it from the global session.
         session = defaultSession.get()
         if ((session ne null) && !session.sparkContext.isStopped) {
-          applyModifiableSettings(session)
+          applyModifiableSettings(session, new java.util.HashMap[String, String](options.asJava))
           return session
         }
 
@@ -966,22 +966,6 @@ object SparkSession extends Logging {
       }
 
       return session
-    }
-
-    private def applyModifiableSettings(session: SparkSession): Unit = {
-      val (staticConfs, otherConfs) =
-        options.partition(kv => SQLConf.isStaticConfigKey(kv._1))
-
-      otherConfs.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
-
-      if (staticConfs.nonEmpty) {
-        logWarning("Using an existing SparkSession; the static sql configurations will not take" +
-          " effect.")
-      }
-      if (otherConfs.nonEmpty) {
-        logWarning("Using an existing SparkSession; some spark core configurations may not take" +
-          " effect.")
-      }
     }
   }
 
@@ -1072,6 +1056,24 @@ object SparkSession extends Logging {
   def active: SparkSession = {
     getActiveSession.getOrElse(getDefaultSession.getOrElse(
       throw new IllegalStateException("No active or default Spark session found")))
+  }
+
+  def applyModifiableSettings(
+      session: SparkSession,
+      options: java.util.HashMap[String, String]): Unit = {
+    val (staticConfs, otherConfs) =
+      options.asScala.partition(kv => SQLConf.isStaticConfigKey(kv._1))
+
+    otherConfs.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
+
+    if (staticConfs.nonEmpty) {
+      logWarning("Using an existing SparkSession; the static sql configurations will not take" +
+        " effect.")
+    }
+    if (otherConfs.nonEmpty) {
+      logWarning("Using an existing SparkSession; some spark core configurations may not take" +
+        " effect.")
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current pyspark, we have code as below
```
for key, value in self._options.items():
      session._jsparkSession.sessionState().conf().setConfString(key, value)
return session
```

Here will pass all options to created/existed SparkSession, in Scala code path, spark only pass non-static sql conf.
```
    private def applyModifiableSettings(session: SparkSession): Unit = {
      val (staticConfs, otherConfs) =
        options.partition(kv => SQLConf.isStaticConfigKey(kv._1))

      otherConfs.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }

      if (staticConfs.nonEmpty) {
        logWarning("Using an existing SparkSession; the static sql configurations will not take" +
          " effect.")
      }
      if (otherConfs.nonEmpty) {
        logWarning("Using an existing SparkSession; some spark core configurations may not take" +
          " effect.")
      }
    }
```

In this pr, we keep this behavior consistent
 

### Why are the changes needed?
Keep consistent behavior between pyspark and Scala code. when initialize SparkSession, when their are existed Session, only overwrite non-static sql conf.


### Does this PR introduce _any_ user-facing change?
User can't overwrite static sql conf when use pyspark with existed SparkSession


### How was this patch tested?
Modefied UT
