### PR TITLE
[SPARK-37501][SQL] CREATE/REPLACE TABLE should qualify location for v2 command

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -259,7 +259,7 @@ object CatalogUtils {
     new Path(str).toUri
   }
 
-  def makeQualifiedNamespacePath(
+  def makeQualifiedDBObjectPath(
       locationUri: URI,
       warehousePath: String,
       hadoopConf: Configuration): URI = {
@@ -269,6 +269,14 @@ object CatalogUtils {
       val fullPath = new Path(warehousePath, CatalogUtils.URIToString(locationUri))
       makeQualifiedPath(fullPath.toUri, hadoopConf)
     }
+  }
+
+  def makeQualifiedDBObjectPath(
+      warehouse: String,
+      location: String,
+      hadoopConf: Configuration): String = {
+    val nsPath = makeQualifiedDBObjectPath(stringToURI(location), warehouse, hadoopConf)
+    URIToString(nsPath)
   }
 
   def makeQualifiedPath(path: URI, hadoopConf: Configuration): URI = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -252,7 +252,7 @@ class SessionCatalog(
   }
 
   private def makeQualifiedDBPath(locationUri: URI): URI = {
-    CatalogUtils.makeQualifiedNamespacePath(locationUri, conf.warehousePath, hadoopConf)
+    CatalogUtils.makeQualifiedDBObjectPath(locationUri, conf.warehousePath, hadoopConf)
   }
 
   def dropDatabase(db: String, ignoreIfNotExists: Boolean, cascade: Boolean): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -126,7 +126,7 @@ class DataSourceV2SQLSuite
       " PARTITIONED BY (id)" +
       " TBLPROPERTIES ('bar'='baz')" +
       " COMMENT 'this is a test table'" +
-      " LOCATION '/tmp/testcat/table_name'")
+      " LOCATION 'file:/tmp/testcat/table_name'")
     val descriptionDf = spark.sql("DESCRIBE TABLE EXTENDED testcat.table_name")
     assert(descriptionDf.schema.map(field => (field.name, field.dataType))
       === Seq(
@@ -149,7 +149,7 @@ class DataSourceV2SQLSuite
       Array("# Detailed Table Information", "", ""),
       Array("Name", "testcat.table_name", ""),
       Array("Comment", "this is a test table", ""),
-      Array("Location", "/tmp/testcat/table_name", ""),
+      Array("Location", "file:/tmp/testcat/table_name", ""),
       Array("Provider", "foo", ""),
       Array(TableCatalog.PROP_OWNER.capitalize, defaultUser, ""),
       Array("Table Properties", "[bar=baz]", "")))
@@ -1179,8 +1179,9 @@ class DataSourceV2SQLSuite
               s" ('path'='bar', 'Path'='noop')")
             val tableCatalog = catalog("testcat").asTableCatalog
             val identifier = Identifier.of(Array(), "reservedTest")
-            assert(tableCatalog.loadTable(identifier).properties()
-              .get(TableCatalog.PROP_LOCATION) == "foo",
+            val location = tableCatalog.loadTable(identifier).properties()
+              .get(TableCatalog.PROP_LOCATION)
+            assert(location.startsWith("file:") && location.endsWith("foo"),
               "path as a table property should not have side effects")
             assert(tableCatalog.loadTable(identifier).properties().get("path") == "bar",
               "path as a table property should not have side effects")
@@ -2012,7 +2013,7 @@ class DataSourceV2SQLSuite
            |COMMENT 'This is a comment'
            |TBLPROPERTIES ('prop1' = '1', 'prop2' = '2', 'prop3' = 3, 'prop4' = 4)
            |PARTITIONED BY (a)
-           |LOCATION '/tmp'
+           |LOCATION 'file:/tmp'
         """.stripMargin)
       val showDDL = getShowCreateDDL(s"SHOW CREATE TABLE $t")
       assert(showDDL === Array(
@@ -2029,7 +2030,7 @@ class DataSourceV2SQLSuite
         "'via' = '2')",
         "PARTITIONED BY (a)",
         "COMMENT 'This is a comment'",
-        "LOCATION '/tmp'",
+        "LOCATION 'file:/tmp'",
         "TBLPROPERTIES(",
         "'prop1' = '1',",
         "'prop2' = '2',",


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Rename method name `makeQualifiedNamespacePath` -> `makeQualifiedLocationPath` in `CatalogUtils`, so it not only for db/namespace, also for table.
2. Override the method `makeQualifiedLocationPath` to take more types of parameters
3. In `CreateTableExec` add handle the `location` properties convert.
4. Add handle for `Replace table` command.


### Why are the changes needed?
keep consistent for v1 and v2, and disscuss at [#comments](https://github.com/apache/spark/pull/34719#discussion_r758156938)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existed test case.
