### PR TITLE
[WIP][SPARK-37487][SQL][CORE] Avoid performing CollectMetrics twice if the operation is followed by global sort.

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2775,6 +2775,7 @@ object SparkContext extends Logging {
   private[spark] val SPARK_JOB_DESCRIPTION = "spark.job.description"
   private[spark] val SPARK_JOB_GROUP_ID = "spark.jobGroup.id"
   private[spark] val SPARK_JOB_INTERRUPT_ON_CANCEL = "spark.job.interruptOnCancel"
+  private[spark] val SPARK_JOB_IS_SAMPLING_JOB = "spark.job.isSamplingJob"
   private[spark] val SPARK_SCHEDULER_POOL = "spark.scheduler.pool"
   private[spark] val RDD_SCOPE_KEY = "spark.rdd.scope"
   private[spark] val RDD_SCOPE_NO_OVERRIDE_KEY = "spark.rdd.scope.noOverride"


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes an issue that `CollectMetrics` performs twice if it's followed by global sort like as follows.
```
val df = spark.range(100)
  .observe(
    name = "my_event",
    min($"id").as("min_val"),
    max($"id").as("max_val"),
    sum($"id"),
    count(when($"id" % 2 === 0, 1)).as("num_even"))
  .sort($"id".desc)
```

The expected statistics calculated by `CollectMetrics` is `[0,99,4950,50]` but the actual result is `[0,99,9900,100]`.
The reason is that jobs for sampling can run before the global sort, which performs extra `CollectMetrics`.
https://github.com/apache/spark/blob/e7fa28930dce468df02b5915e1792ada758a96e3/core/src/main/scala/org/apache/spark/Partitioner.scala#L171
https://github.com/apache/spark/blob/e7fa28930dce468df02b5915e1792ada758a96e3/core/src/main/scala/org/apache/spark/Partitioner.scala#L195

The solution this PR proposes to introduce a property `spark.job.isSamplingJob` which is intended to be get/set internally.
Before the sampling jobs run, Spark sets the property, and reset it after the jobs finish.
Then, `CollectMetrics` can judge a task is whether of a sampling job or not.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New test.