### PR TITLE
[SPARK-33898][SQL][FOLLOWUP] Unify the v2 behavior with v1 for `SHOW CREATE TABLE` command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -109,7 +109,7 @@ case class ShowCreateTableExec(
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }
 
-      builder ++= "TBLPROPERTIES"
+      builder ++= "TBLPROPERTIES "
       builder ++= concatByMultiLines(props)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -843,16 +843,6 @@ class FileSourceCharVarcharTestSuite extends CharVarcharTestSuite with SharedSpa
     }
   }
 
-  // TODO(SPARK-33898): Move these tests to super after SHOW CREATE TABLE for v2 implemented
-  test("SPARK-33892: SHOW CREATE TABLE w/ char/varchar") {
-    withTable("t") {
-      sql(s"CREATE TABLE t(v VARCHAR(3), c CHAR(5)) USING $format")
-      val rest = sql("SHOW CREATE TABLE t").head().getString(0)
-      assert(rest.contains("VARCHAR(3)"))
-      assert(rest.contains("CHAR(5)"))
-    }
-  }
-
   test("SPARK-34114: should not trim right for read-side length check and char padding") {
     Seq("char", "varchar").foreach { typ =>
       withTempPath { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2031,7 +2031,7 @@ class DataSourceV2SQLSuite
         "PARTITIONED BY (a)",
         "COMMENT 'This is a comment'",
         "LOCATION 'file:/tmp'",
-        "TBLPROPERTIES(",
+        "TBLPROPERTIES (",
         "'prop1' = '1',",
         "'prop2' = '2',",
         "'prop3' = '3',",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CharVarcharDDLTestBase.scala
@@ -160,6 +160,15 @@ trait CharVarcharDDLTestBase extends QueryTest with SQLTestUtils {
         Row("char(5)"))
     }
   }
+
+  test("SPARK-33892: SHOW CREATE TABLE w/ char/varchar") {
+    withTable("t") {
+      sql(s"CREATE TABLE t(v VARCHAR(3), c CHAR(5)) USING $format")
+      val rest = sql("SHOW CREATE TABLE t").head().getString(0)
+      assert(rest.contains("VARCHAR(3)"))
+      assert(rest.contains("CHAR(5)"))
+    }
+  }
 }
 
 class FileSourceCharVarcharDDLTestSuite extends CharVarcharDDLTestBase with SharedSparkSession {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Move the `SHOW CREATE TABLE w/ char/varchar` to `CharVarcharDDLTestBase`
2. Fix the behavior different with v1 command that about the `TBLPROPERTIES`

### Why are the changes needed?
Before the [#PR](https://github.com/apache/spark/pull/34719) merge. We should handle some different behavior or bugs between v1 and v2 command.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existed test case.
