### PR TITLE
[SPARK-37511][DOCS][FOLLOW-UP] Fix documentation build warning from TimedeltaIndex

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/indexing.rst
+++ b/python/docs/source/reference/pyspark.pandas/indexing.rst
@@ -337,7 +337,7 @@ DatatimeIndex
    DatetimeIndex
 
 TimedeltaIndex
--------------
+--------------
 .. autosummary::
    :toctree: api/
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/34657 that adds underline to match with the title.

### Why are the changes needed?

To fix the PySpark documentation build warning:

```
/.../spark/python/docs/source/reference/pyspark.pandas/indexing.rst:340: WARNING: Title underline too short.

TimedeltaIndex
-------------
```

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manual build of the PySpark documentation.