### PR TITLE
[SPARK-37512][PYTHON] Support TimedeltaIndex creation (from Series/Index) and TimedeltaIndex.astype

### DIFF
--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -30,7 +30,6 @@ from pyspark.pandas.data_type_ops.base import (
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
-    _sanitize_list_like,
 )
 from pyspark.pandas.typedef import pandas_on_spark_type
 

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -55,3 +55,7 @@ class TimedeltaOps(DataTypeOps):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:
             return _as_other_type(index_ops, dtype, spark_type)
+
+    def prepare(self, col: pd.Series) -> pd.Series:
+        """Prepare column when from_pandas."""
+        return col

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -15,7 +15,24 @@
 # limitations under the License.
 #
 
-from pyspark.pandas.data_type_ops.base import DataTypeOps
+from typing import Union
+
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+from pyspark.sql.types import (
+    BooleanType,
+    StringType,
+)
+from pyspark.pandas._typing import Dtype, IndexOpsLike
+from pyspark.pandas.data_type_ops.base import (
+    DataTypeOps,
+    _as_categorical_type,
+    _as_other_type,
+    _as_string_type,
+    _sanitize_list_like,
+)
+from pyspark.pandas.typedef import pandas_on_spark_type
 
 
 class TimedeltaOps(DataTypeOps):
@@ -26,3 +43,15 @@ class TimedeltaOps(DataTypeOps):
     @property
     def pretty_name(self) -> str:
         return "timedelta"
+
+    def astype(self, index_ops: IndexOpsLike, dtype: Union[str, type, Dtype]) -> IndexOpsLike:
+        dtype, spark_type = pandas_on_spark_type(dtype)
+
+        if isinstance(dtype, CategoricalDtype):
+            return _as_categorical_type(index_ops, dtype, spark_type)
+        elif isinstance(spark_type, BooleanType):
+            raise TypeError("cannot astype a datetimelike from [timedelta64[ns]] to [bool]")
+        elif isinstance(spark_type, StringType):
+            return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
+        else:
+            return _as_other_type(index_ops, dtype, spark_type)

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -85,8 +85,9 @@ class TimedeltaIndex(Index):
             raise TypeError("Index.name must be a hashable type")
 
         if isinstance(data, (Series, Index)):
-            # TODO(SPARK-37512): Support TimedeltaIndex creation given a timedelta Series/Index
-            raise NotImplementedError("Create a TimedeltaIndex from Index/Series is not supported")
+            if dtype is None:
+                dtype = "timedelta64[ns]"
+            return cast(TimedeltaIndex, Index(data, dtype=dtype, copy=copy, name=name))
 
         kwargs = dict(
             data=data,

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -56,6 +56,18 @@ class TimedeltaIndex(Index):
     >>> from datetime import timedelta
     >>> ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)])
     TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
+
+    From an Series:
+
+    >>> s = ps.Series([timedelta(1), timedelta(microseconds=2)], index=[10, 20])
+    >>> ps.TimedeltaIndex(s)
+    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
+
+    From an Index:
+
+    >>> idx = ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)])
+    >>> ps.TimedeltaIndex(idx)
+    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
     """
 
     @no_type_check

--- a/python/pyspark/pandas/tests/data_type_ops/test_base.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_base.py
@@ -30,6 +30,7 @@ from pyspark.pandas.data_type_ops.datetime_ops import DatetimeOps, DatetimeNTZOp
 from pyspark.pandas.data_type_ops.null_ops import NullOps
 from pyspark.pandas.data_type_ops.num_ops import IntegralOps, FractionalOps, DecimalOps
 from pyspark.pandas.data_type_ops.string_ops import StringOps
+from pyspark.pandas.data_type_ops.timedelta_ops import TimedeltaOps
 from pyspark.pandas.data_type_ops.udt_ops import UDTOps
 from pyspark.sql.types import (
     ArrayType,
@@ -37,6 +38,7 @@ from pyspark.sql.types import (
     BooleanType,
     DataType,
     DateType,
+    DayTimeIntervalType,
     DecimalType,
     FractionalType,
     IntegralType,
@@ -64,6 +66,7 @@ class BaseTest(unittest.TestCase):
             (_mock_dtype, TimestampType(), DatetimeOps),
             (_mock_dtype, TimestampNTZType(), DatetimeNTZOps),
             (_mock_dtype, DateType(), DateOps),
+            (_mock_dtype, DayTimeIntervalType(), TimedeltaOps),
             (_mock_dtype, BinaryType(), BinaryOps),
             (_mock_dtype, ArrayType(StringType()), ArrayOps),
             (_mock_dtype, MapType(StringType(), IntegralType()), MapOps),

--- a/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_timedelta_ops.py
@@ -1,0 +1,197 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from datetime import timedelta
+
+import pandas as pd
+from pandas.api.types import CategoricalDtype
+
+import pyspark.pandas as ps
+from pyspark.pandas.tests.data_type_ops.testing_utils import TestCasesUtils
+from pyspark.testing.pandasutils import PandasOnSparkTestCase
+
+
+class TimedeltaOpsTest(PandasOnSparkTestCase, TestCasesUtils):
+    @property
+    def pser(self):
+        return pd.Series([timedelta(1), timedelta(microseconds=2)])
+
+    @property
+    def psser(self):
+        return ps.from_pandas(self.pser)
+
+    @property
+    def td_pdf(self):
+        psers = {
+            "this": self.pser,
+            "that": pd.Series([timedelta(weeks=1), timedelta(days=2)]),
+        }
+        return pd.concat(psers, axis=1)
+
+    @property
+    def td_psdf(self):
+        return ps.from_pandas(self.td_pdf)
+
+    def test_add(self):
+        self.assertRaises(TypeError, lambda: self.psser + "x")
+        self.assertRaises(TypeError, lambda: self.psser + 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser + psser)
+
+    def test_sub(self):
+        self.assertRaises(TypeError, lambda: self.psser - "x")
+        self.assertRaises(TypeError, lambda: self.psser - 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser - psser)
+
+    def test_mul(self):
+        self.assertRaises(TypeError, lambda: self.psser * "x")
+        self.assertRaises(TypeError, lambda: self.psser * 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser * psser)
+
+    def test_truediv(self):
+        self.assertRaises(TypeError, lambda: self.psser / "x")
+        self.assertRaises(TypeError, lambda: self.psser / 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser / psser)
+
+    def test_floordiv(self):
+        self.assertRaises(TypeError, lambda: self.psser // "x")
+        self.assertRaises(TypeError, lambda: self.psser // 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser // psser)
+
+    def test_mod(self):
+        self.assertRaises(TypeError, lambda: self.psser % "x")
+        self.assertRaises(TypeError, lambda: self.psser % 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser % psser)
+
+    def test_pow(self):
+        self.assertRaises(TypeError, lambda: self.psser ** "x")
+        self.assertRaises(TypeError, lambda: self.psser ** 1)
+
+        for psser in self.pssers:
+            self.assertRaises(TypeError, lambda: self.psser ** psser)
+
+    def test_radd(self):
+        self.assertRaises(TypeError, lambda: "x" + self.psser)
+        self.assertRaises(TypeError, lambda: 1 + self.psser)
+
+    def test_rsub(self):
+        self.assertRaises(TypeError, lambda: "x" - self.psser)
+        self.assertRaises(TypeError, lambda: 1 - self.psser)
+
+    def test_rmul(self):
+        self.assertRaises(TypeError, lambda: "x" * self.psser)
+        self.assertRaises(TypeError, lambda: 2 * self.psser)
+
+    def test_rtruediv(self):
+        self.assertRaises(TypeError, lambda: "x" / self.psser)
+        self.assertRaises(TypeError, lambda: 1 / self.psser)
+
+    def test_rfloordiv(self):
+        self.assertRaises(TypeError, lambda: "x" // self.psser)
+        self.assertRaises(TypeError, lambda: 1 // self.psser)
+
+    def test_rmod(self):
+        self.assertRaises(TypeError, lambda: 1 % self.psser)
+
+    def test_rpow(self):
+        self.assertRaises(TypeError, lambda: "x" ** self.psser)
+        self.assertRaises(TypeError, lambda: 1 ** self.psser)
+
+    def test_from_to_pandas(self):
+        data = [timedelta(1), timedelta(microseconds=2)]
+        pser = pd.Series(data)
+        psser = ps.Series(data)
+        self.assert_eq(pser, psser.to_pandas())
+        self.assert_eq(ps.from_pandas(pser), psser)
+
+    def test_isnull(self):
+        self.assert_eq(self.pser.isnull(), self.psser.isnull())
+
+    def test_astype(self):
+        pser = self.pser
+        psser = self.psser
+        target_psser = ps.Series(
+            ["INTERVAL '1 00:00:00' DAY TO SECOND", "INTERVAL '0 00:00:00.000002' DAY TO SECOND"]
+        )
+        self.assert_eq(target_psser, psser.astype(str))
+        self.assert_eq(pser.astype("category"), psser.astype("category"))
+        cat_type = CategoricalDtype(categories=["a", "b", "c"])
+        self.assert_eq(pser.astype(cat_type), psser.astype(cat_type))
+
+        self.assertRaises(TypeError, lambda: psser.astype(bool))
+
+    def test_neg(self):
+        self.assertRaises(TypeError, lambda: -self.psser)
+
+    def test_abs(self):
+        self.assertRaises(TypeError, lambda: abs(self.psser))
+
+    def test_invert(self):
+        self.assertRaises(TypeError, lambda: ~self.psser)
+
+    def test_eq(self):
+        pdf, psdf = self.td_pdf, self.td_psdf
+        self.assert_eq(pdf["this"] == pdf["this"], psdf["this"] == psdf["this"])
+        self.assert_eq(pdf["this"] == pdf["that"], psdf["this"] == psdf["that"])
+
+    def test_ne(self):
+        pdf, psdf = self.td_pdf, self.td_psdf
+        self.assert_eq(pdf["this"] != pdf["this"], psdf["this"] != psdf["this"])
+        self.assert_eq(pdf["this"] != pdf["that"], psdf["this"] != psdf["that"])
+
+    def test_lt(self):
+        self.assertRaisesRegex(
+            TypeError, "< can not be applied to", lambda: self.psser < self.psser
+        )
+
+    def test_le(self):
+        self.assertRaisesRegex(
+            TypeError, "<= can not be applied to", lambda: self.psser <= self.psser
+        )
+
+    def test_gt(self):
+        self.assertRaisesRegex(
+            TypeError, "> can not be applied to", lambda: self.psser > self.psser
+        )
+
+    def test_ge(self):
+        self.assertRaisesRegex(
+            TypeError, ">= can not be applied to", lambda: self.psser >= self.psser
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.data_type_ops.test_timedelta_ops import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support TimedeltaIndex creation given a timedelta Series/Index.

`astype` is also supported naturally in this PR.


### Why are the changes needed?
Follow panda's behavior.

### Does this PR introduce _any_ user-facing change?
Yes.

#### TimedeltaIndex creation (from Series/Index)
```py
>>> idx = ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)])
>>> s = ps.Series([timedelta(1), timedelta(microseconds=2)], index=[10, 20])

## FROM ## 
>>> ps.TimedeltaIndex(idx)
Traceback (most recent call last):
...
NotImplementedError: Create a TimedeltaIndex from Index/Series is not supported

>>> ps.TimedeltaIndex(s)
Traceback (most recent call last):
...
NotImplementedError: Create a TimedeltaIndex from Index/Series is not supported

## TO ##
>>> ps.TimedeltaIndex(idx)
TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)

>>> ps.TimedeltaIndex(s)
TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)

```
#### TimedeltaIndex.astype
```py
>>> psidx = ps.TimedeltaIndex([timedelta(1)])
>>> psidx.astype(str)
Index(['INTERVAL '1 00:00:00' DAY TO SECOND'], dtype='object')
>>> psidx.astype(int)
Int64Index([86400], dtype='int64')
>>> psidx.astype('category')
CategoricalIndex(['1 days'], categories=[1 days 00:00:00], ordered=False, dtype='category')
```

### How was this patch tested?
Unit tests.