### PR TITLE
[SPARK-37522][PYTHON][TESTS] Fix MultilayerPerceptronClassifierTest.test_raw_and_probability_prediction

### DIFF
--- a/python/pyspark/ml/tests/test_algorithms.py
+++ b/python/pyspark/ml/tests/test_algorithms.py
@@ -101,7 +101,7 @@ class MultilayerPerceptronClassifierTest(SparkSessionTestCase):
         expected_rawPrediction = [-11.6081922998, -8.15827998691, 22.17757045]
         self.assertTrue(result.prediction, expected_prediction)
         self.assertTrue(np.allclose(result.probability, expected_probability, atol=1e-4))
-        self.assertTrue(np.allclose(result.rawPrediction, expected_rawPrediction, rtol=0.1))
+        self.assertTrue(np.allclose(result.rawPrediction, expected_rawPrediction, rtol=0.11))
 
 
 class OneVsRestTests(SparkSessionTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update a PySpark unit test case by increasing the tolerance by `10%` from `0.1` to `0.11`.

### Why are the changes needed?

```
$ java -version
openjdk version "17.0.1" 2021-10-19 LTS
OpenJDK Runtime Environment Zulu17.30+15-CA (build 17.0.1+12-LTS)
OpenJDK 64-Bit Server VM Zulu17.30+15-CA (build 17.0.1+12-LTS, mixed mode, sharing)

$ build/sbt test:package

$ python/run-tests --testname 'pyspark.ml.tests.test_algorithms MultilayerPerceptronClassifierTest.test_raw_and_probability_prediction' --python-executables=python3
...
======================================================================
FAIL: test_raw_and_probability_prediction (pyspark.ml.tests.test_algorithms.MultilayerPerceptronClassifierTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dongjoon/APACHE/spark-merge/python/pyspark/ml/tests/test_algorithms.py", line 104, in test_raw_and_probability_prediction
    self.assertTrue(np.allclose(result.rawPrediction, expected_rawPrediction, rtol=0.102))
AssertionError: False is not true

----------------------------------------------------------------------
Ran 1 test in 7.385s

FAILED (failures=1)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually on native AppleSilicon Java 17.