### PR TITLE
[SPARK-37508][SQL][DOCS][FOLLOW-UP] Update expression desc of `CONTAINS()` string function 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -467,7 +467,7 @@ abstract class StringPredicate extends BinaryExpression
  */
 @ExpressionDescription(
   usage = """
-    _FUNC_(expr1, expr2) - Returns a BOOLEAN. The value is True if right is found inside left.
+    _FUNC_(left, right) - Returns a boolean. The value is True if right is found inside left.
     Returns NULL if either input expression is NULL. Otherwise, returns False.
   """,
   examples = """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -467,8 +467,8 @@ abstract class StringPredicate extends BinaryExpression
  */
 @ExpressionDescription(
   usage = """
-    _FUNC_(expr1, expr2) - Returns a boolean value if expr2 is found inside expr1.
-    Returns NULL if either input expression is NULL.
+    _FUNC_(expr1, expr2) - Returns a BOOLEAN. The value is True if right is found inside left.
+    Returns NULL if either input expression is NULL. Otherwise, returns False.
   """,
   examples = """
     Examples:


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Update usage doc of `CONTAINS()` string function to 
```
_FUNC_(left, right) - Returns a boolean. The value is True if right is found inside left.
    Returns NULL if either input expression is NULL. Otherwise, returns False.
```
To clarify that when left and right expression both not `NULL` and if right is not found inside left, returns `False`

### Why are the changes needed?
Make function description more clear

### Does this PR introduce _any_ user-facing change?
`DESCRIBE FUNCTION EXTENDED contains`'s usage now return:

```
contains(left, right) - Returns a boolean. The value is True if right is found inside left.
    Returns NULL if either input expression is NULL. Otherwise, returns False.
```

### How was this patch tested?
 Verified it after documentation build or SQL command such s DESCRIBE FUNCTION EXTENDED contains.
