### PR TITLE
[SPARK-37510][PYTHON] Support basic operations of timedelta Series/Index

### DIFF
--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -143,7 +143,7 @@ class DatetimeOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
         elif isinstance(spark_type, BooleanType):
-            raise TypeError("cannot astype a datetimelike from [datetime64[ns]] to [bool]")
+            raise TypeError("cannot astype a datetimelike from [%s] to [bool]" % dtype)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:

--- a/python/pyspark/pandas/data_type_ops/datetime_ops.py
+++ b/python/pyspark/pandas/data_type_ops/datetime_ops.py
@@ -143,7 +143,7 @@ class DatetimeOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
         elif isinstance(spark_type, BooleanType):
-            raise TypeError("cannot astype a datetimelike from [%s] to [bool]" % dtype)
+            raise TypeError("cannot astype a %s to [bool]" % self.pretty_name)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -15,21 +15,26 @@
 # limitations under the License.
 #
 
-from typing import Union
+from datetime import timedelta
+from typing import Any, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
+from pyspark.sql.column import Column
 from pyspark.sql.types import (
     BooleanType,
+    DayTimeIntervalType,
     StringType,
 )
-from pyspark.pandas._typing import Dtype, IndexOpsLike
+from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
+from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.data_type_ops.base import (
     DataTypeOps,
     _as_categorical_type,
     _as_other_type,
     _as_string_type,
+    _sanitize_list_like,
 )
 from pyspark.pandas.typedef import pandas_on_spark_type
 
@@ -58,3 +63,51 @@ class TimedeltaOps(DataTypeOps):
     def prepare(self, col: pd.Series) -> pd.Series:
         """Prepare column when from_pandas."""
         return col
+
+    def sub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        _sanitize_list_like(right)
+
+        if (
+            isinstance(right, IndexOpsMixin)
+            and isinstance(right.spark.data_type, DayTimeIntervalType)
+            or isinstance(right, timedelta)
+        ):
+            return column_op(Column.__sub__)(left, right)
+        else:
+            raise TypeError("Timedelta subtraction can only be applied to timedelta series.")
+
+    def rsub(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        _sanitize_list_like(right)
+
+        if isinstance(right, timedelta):
+            return column_op(Column.__rsub__)(left, right)
+        else:
+            raise TypeError("Timedelta subtraction can only be applied to timedelta series.")
+
+    def lt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        _sanitize_list_like(right)
+        return column_op(Column.__lt__)(left, right)
+
+    def le(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        _sanitize_list_like(right)
+        return column_op(Column.__le__)(left, right)
+
+    def ge(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        _sanitize_list_like(right)
+        return column_op(Column.__ge__)(left, right)
+
+    def gt(self, left: IndexOpsLike, right: Any) -> SeriesOrIndex:
+        from pyspark.pandas.base import column_op
+
+        _sanitize_list_like(right)
+        return column_op(Column.__gt__)(left, right)

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -54,7 +54,7 @@ class TimedeltaOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
         elif isinstance(spark_type, BooleanType):
-            raise TypeError("cannot astype a datetimelike from [timedelta64[ns]] to [bool]")
+            raise TypeError("cannot astype a timedelta from [%s] to [bool]" % dtype)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:

--- a/python/pyspark/pandas/data_type_ops/timedelta_ops.py
+++ b/python/pyspark/pandas/data_type_ops/timedelta_ops.py
@@ -54,7 +54,7 @@ class TimedeltaOps(DataTypeOps):
         if isinstance(dtype, CategoricalDtype):
             return _as_categorical_type(index_ops, dtype, spark_type)
         elif isinstance(spark_type, BooleanType):
-            raise TypeError("cannot astype a timedelta from [%s] to [bool]" % dtype)
+            raise TypeError("cannot astype a %s to [bool]" % self.pretty_name)
         elif isinstance(spark_type, StringType):
             return _as_string_type(index_ops, dtype, null_str=str(pd.NaT))
         else:

--- a/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
+++ b/python/pyspark/pandas/tests/data_type_ops/testing_utils.py
@@ -91,6 +91,9 @@ class TestCasesUtils(object):
                 [datetime.date(1994, 1, 1), datetime.date(1994, 1, 2), datetime.date(1994, 1, 3)]
             ),
             "datetime": pd.to_datetime(pd.Series([1, 2, 3])),
+            "timedelta": pd.Series(
+                [datetime.timedelta(1), datetime.timedelta(hours=2), datetime.timedelta(weeks=3)]
+            ),
             "categorical": pd.Series(["a", "b", "a"], dtype="category"),
         }
         return pd.concat(psers, axis=1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support basic operations of timedelta Series/Index

### Why are the changes needed?
To be consistent with pandas

### Does this PR introduce _any_ user-facing change?
Yes.
```py
>>> psdf = ps.DataFrame(
... {'this': [timedelta(1), timedelta(microseconds=2), timedelta(weeks=3)],
...  'that': [timedelta(0), timedelta(microseconds=1), timedelta(seconds=2)]}
... )
>>> psdf
                    this                   that
0        1 days 00:00:00        0 days 00:00:00
1 0 days 00:00:00.000002 0 days 00:00:00.000001
2       21 days 00:00:00        0 days 00:00:02

# __sub__
>>> psdf.this - psdf.that
0          1 days 00:00:00
1   0 days 00:00:00.000001
2         20 days 23:59:58
dtype: timedelta64[ns]
>>> psdf.this - timedelta(1)
0            0 days 00:00:00
1   -1 days +00:00:00.000002
2           20 days 00:00:00
Name: this, dtype: timedelta64[ns]

#  __rsub__
>>> timedelta(1) - psdf.this
0          0 days 00:00:00
1   0 days 23:59:59.999998
2       -20 days +00:00:00
Name: this, dtype: timedelta64[ns]
```

### How was this patch tested?
Unit tests.
