### PR TITLE
[SPARK-37526][INFRA][PYTHON][TESTS] Add Java17 PySpark daily test coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -248,6 +248,7 @@ jobs:
     # Run regular jobs for commit in both Apache Spark and fored repository
     if: >-
       (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled')
+      || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
       || needs.configure-jobs.outputs.type == 'regular'
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
@@ -256,6 +257,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java:
+          - ${{ needs.configure-jobs.outputs.java }}
         modules:
           - >-
             pyspark-sql, pyspark-mllib, pyspark-resource
@@ -308,6 +311,10 @@ jobs:
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           pyspark-coursier-
+    - name: Install Java ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
     - name: List Python packages (Python 3.9)
       run: |
         python3.9 -m pip list

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -245,7 +245,8 @@ jobs:
   pyspark:
     needs: configure-jobs
     # Run PySpark coverage scheduled jobs for Apache Spark only
-    # Run regular jobs for commit in both Apache Spark and fored repository
+    # Run scheduled jobs with JDK 17 in Apache Spark
+    # Run regular jobs for commit in both Apache Spark and forked repository
     if: >-
       (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled')
       || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Java 17 PySpark daily test coverage.

### Why are the changes needed?

To support Java 17 at Apache Spark 3.3.

After SPARK-37522, I verified the following with Python 3.9.7 on Linux. (not every Python libraries).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Pass the CIs to verify this doesn't break anything.
- After manually review, this should be verified after merging.