### PR TITLE
[SPARK-37529][K8S][TESTS] Support K8s integration tests for Java 17

### DIFF
--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -43,6 +43,7 @@
     <spark.kubernetes.test.master></spark.kubernetes.test.master>
     <spark.kubernetes.test.namespace></spark.kubernetes.test.namespace>
     <spark.kubernetes.test.serviceAccountName></spark.kubernetes.test.serviceAccountName>
+    <spark.kubernetes.test.dockerFile>N/A</spark.kubernetes.test.dockerFile>
 
     <test.exclude.tags></test.exclude.tags>
     <test.include.tags></test.include.tags>
@@ -111,6 +112,9 @@
 
                 <argument>--spark-tgz</argument>
                 <argument>${spark.kubernetes.test.sparkTgz}</argument>
+
+                <argument>--docker-file</argument>
+                <argument>${spark.kubernetes.test.dockerFile}</argument>
 
                 <argument>--test-exclude-tags</argument>
                 <argument>"${test.exclude.tags}"</argument>

--- a/resource-managers/kubernetes/integration-tests/scripts/setup-integration-test-env.sh
+++ b/resource-managers/kubernetes/integration-tests/scripts/setup-integration-test-env.sh
@@ -26,6 +26,7 @@ IMAGE_TAG="N/A"
 JAVA_IMAGE_TAG="8-jre-slim"
 SPARK_TGZ="N/A"
 MVN="$TEST_ROOT_DIR/build/mvn"
+DOCKER_FILE="N/A"
 EXCLUDE_TAGS=""
 
 # Parse arguments
@@ -57,6 +58,10 @@ while (( "$#" )); do
       ;;
     --spark-tgz)
       SPARK_TGZ="$2"
+      shift
+      ;;
+    --docker-file)
+      DOCKER_FILE="$2"
       shift
       ;;
     --test-exclude-tags)
@@ -97,8 +102,12 @@ then
   IMAGE_TAG=${VERSION}_$(uuidgen)
   cd $SPARK_INPUT_DIR
 
-  # OpenJDK base-image tag (e.g. 8-jre-slim, 11-jre-slim)
-  JAVA_IMAGE_TAG_BUILD_ARG="-b java_image_tag=$JAVA_IMAGE_TAG"
+  if [[ $DOCKER_FILE == "N/A" ]]; then
+    # OpenJDK base-image tag (e.g. 8-jre-slim, 11-jre-slim)
+    JAVA_IMAGE_TAG_BUILD_ARG="-b java_image_tag=$JAVA_IMAGE_TAG"
+  else
+    JAVA_IMAGE_TAG_BUILD_ARG="-f $DOCKER_FILE"
+  fi
 
   # Build PySpark image
   LANGUAGE_BINDING_BUILD_ARGS="-p $DOCKER_FILE_BASE_PATH/bindings/python/Dockerfile"


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to support K8s integration tests for Java 17 using Maven and SBT.
The new system property `spark.kubernetes.test.dockerFile` is introduced to specify a Dockerfile.
By setting `Dockerfile.java17` to the property, the integration tests run with Java 17.

This PR also revised the change brought by SPARK-37354 (#34628) by changing `SparkBuild.scala` so that it can recognize the system property `spark.kubernetes.test.javaImageTag`, like the integration tests with Maven do.

If both `spark.kubernetes.test.dockerFile` and `spark.kubernetes.test.javaImageTag` are set, `spark.kubernetes.test.dockerFile` is preferred.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To ensure Spark works on K8s with Java 17.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Confirmed that the intended version of Java is used for each pattern.
* Neither `spark.kubernetes.test.javaImageTag` nor `spark.kubernetes.test.dockerFile` is set (SBT)
```
# Run the integration tests to create the container image
$ build/sbt -Pkubernetes  -Pkubernetes-integration-tests "kubernetes-integration-tests/test"

# Create and login the container.
docker run -it <hash> /bin/bash

185@b40ef8aaa56c:/opt/spark/work-dir$ java -version
openjdk version "1.8.0_312"
OpenJDK Runtime Environment (build 1.8.0_312-b07)
OpenJDK 64-Bit Server VM (build 25.312-b07, mixed mode)
```

* Neither `spark.kubernetes.test.javaImageTag` nor `spark.kubernetes.test.dockerFile` is set (Maven)
```
# Run the integration tests to create the container image
$ build/mvn -Pkubernetes -Pkubernetes-integration-tests -pl resource-managers/kubernetes/integration-tests integration-test

# Create and login the container.
docker run -it <hash> /bin/bash

185@36ae5c5c21f4:/opt/spark/work-dir$ java -version
openjdk version "1.8.0_312"
OpenJDK Runtime Environment (build 1.8.0_312-b07)
OpenJDK 64-Bit Server VM (build 25.312-b07, mixed mode)
```

* `spark.kubernetes.test.javaImageTag` is set (SBT):
```
# Run the integration tests to create the container image
$ build/sbt -Dspark.kubernetes.test.javaImageTag=11-jre-slim -Pkubernetes  -Pkubernetes-integration-tests "kubernetes-integration-tests/test"

# Create and login the container.
docker run -it <hash> /bin/bash

185@5b896d0e5dd8:/opt/spark/work-dir$ java -version
openjdk version "11.0.13" 2021-10-19
OpenJDK Runtime Environment 18.9 (build 11.0.13+8)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.13+8, mixed mode, sharing)
```

* `spark.kubernetes.test.javaImageTag` is set (Maven):
```
# Run the integration tests to create the container image
$ build/mvn -Dspark.kubernetes.test.javaImageTag=11-jre-slim -Pkubernetes -Pkubernetes-integration-tests -pl resource-managers/kubernetes/integration-tests integration-test

# Create and login the container.
docker run -it <hash> /bin/bash

185@5d3c228e7521:/opt/spark/work-dir$ java -version
openjdk version "11.0.13" 2021-10-19
OpenJDK Runtime Environment 18.9 (build 11.0.13+8)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.13+8, mixed mode, sharing)
```

* `spark.kubernetes.test.dockerFile` is set (SBT)
```
$ build/sbt -Dspark.kubernetes.test.dockerFile=resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.java17 -Pkubernetes  -Pkubernetes-integration-tests package "kubernetes-integration-tests/test"

# Create and login the container.
docker run -it <hash> /bin/bash

185@550515c76582:/opt/spark/work-dir$ java -version
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment (build 17.0.1+12-Debian-1deb11u2)
OpenJDK 64-Bit Server VM (build 17.0.1+12-Debian-1deb11u2, mixed mode, sharing)
```

* `spark.kubernetes.test.dockerFile` is set (Maven)
```
build/mvn -Dspark.kubernetes.test.dockerFile=resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.java17 -Pkubernetes -Pkubernetes-integration-tests -pl resource-managers/kubernetes/integration-tests integration-test

# Create and login the container.
docker run -it <hash> /bin/bash

185@be35bde0ebfa:/opt/spark/work-dir$ java -version
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment (build 17.0.1+12-Debian-1deb11u2)
OpenJDK 64-Bit Server VM (build 17.0.1+12-Debian-1deb11u2, mixed mode, sharing)
```

* Both `spark.kubernetes.test.javaImageTag` and `spark.kubernetes.test.dockerFile` are set (SBT)
```
$ build/sbt -Dspark.kubernetes.test.dockerFile=resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.java17 -Dspark.kubernetes.test.javaImageTag=11-jre-slim -Pkubernetes  -Pkubernetes-integration-tests package "kubernetes-integration-tests/test"

# Create and login the container.
docker run -it <hash> /bin/bash

185@7ed1891b2921:/opt/spark/work-dir$ java -version
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment (build 17.0.1+12-Debian-1deb11u2)
OpenJDK 64-Bit Server VM (build 17.0.1+12-Debian-1deb11u2, mixed mode, sharing)
```

* Both `spark.kubernetes.test.javaImageTag` and `spark.kubernetes.test.dockerFile` are set (Maven)
```
$ build/mvn -Dspark.kubernetes.test.dockerFile=resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.java17 -Dspark.kubernetes.test.javaImageTag=11-jre-slim -Pkubernetes -Pkubernetes-integration-tests -pl resource-managers/kubernetes/integration-tests integration-test

# Create and login the container.
docker run -it <hash> /bin/bash

185@84f3a8b7b4a6:/opt/spark/work-dir$ java -version
openjdk version "17.0.1" 2021-10-19
OpenJDK Runtime Environment (build 17.0.1+12-Debian-1deb11u2)
OpenJDK 64-Bit Server VM (build 17.0.1+12-Debian-1deb11u2, mixed mode, sharing)
```