### PR TITLE
[SPARK-37531][INFRA][PYTHON][TESTS] Use PyArrow 6.0.0 in Python 3.9 tests at GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -254,7 +254,7 @@ jobs:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210930
+      image: dongjoon/apache-spark-github-action-image:20211116
     strategy:
       fail-fast: false
       matrix:
@@ -358,7 +358,7 @@ jobs:
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20210930
+      image: dongjoon/apache-spark-github-action-image:20211116
     env:
       HADOOP_PROFILE: ${{ needs.configure-jobs.outputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -425,7 +425,7 @@ jobs:
       PYSPARK_DRIVER_PYTHON: python3.9
       PYSPARK_PYTHON: python3.9
     container:
-      image: dongjoon/apache-spark-github-action-image:20210930
+      image: dongjoon/apache-spark-github-action-image:20211116
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `PyArrow 6.0.0` in `Python 3.9` unit tests at GitHub Action jobs.

Although the new change is removing `<5.0.0' limitation, there are other minor changes because it's built more recently, too.
- https://github.com/dongjoon-hyun/ApacheSparkGitHubActionImage/commit/4f7408f4a95ef9784fdaf490be56bcfd7ff309bb
```
- RUN python3.9 -m pip install numpy 'pyarrow<5.0.0' pandas scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0'
+ RUN python3.9 -m pip install numpy pyarrow pandas scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0'
```

```
$ docker run -it --rm dongjoon/apache-spark-github-action-image:20211116 pip3.9 list > 20211116
$ docker run -it --rm dongjoon/apache-spark-github-action-image:20210930 pip3.9 list > 20210930
$ diff 20210930 20211116
# The following is manually formatted for simplicity.
...
Jinja2                    3.0.1         3.0.3
mlflow                    1.20.2        1.21.0
numpy                     1.21.2        1.21.4
pandas                    1.3.3         1.3.4
plotly                    5.3.1         5.4.0
pyarrow                   4.0.1         6.0.0
scikit-learn              1.0           1.0.1
scipy                     1.7.1         1.7.2
```

### Why are the changes needed?

SPARK-37342 upgraded `Apache Arrow` to 6.0.0 in Java/Scala.
This is a corresponding upgrade in PySpark.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action.