### PR TITLE
[SPARK-37540][SQL] Detect more unsupported time travel

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CTESubstitution.scala
@@ -178,7 +178,7 @@ object CTESubstitution extends Rule[LogicalPlan] {
       cteDefs: mutable.ArrayBuffer[CTERelationDef]): (LogicalPlan, Option[LogicalPlan]) = {
     var lastSubstituted: Option[LogicalPlan] = None
     val newPlan = plan.resolveOperatorsUpWithPruning(
-        _.containsAnyPattern(UNRESOLVED_RELATION, PLAN_EXPRESSION)) {
+        _.containsAnyPattern(UNRESOLVED_WITH, PLAN_EXPRESSION)) {
       case UnresolvedWith(child: LogicalPlan, relations) =>
         val resolvedCTERelations =
           resolveCTERelations(relations, isLegacy = false, isCommand, cteDefs)
@@ -226,7 +226,12 @@ object CTESubstitution extends Rule[LogicalPlan] {
       plan: LogicalPlan,
       alwaysInline: Boolean,
       cteRelations: Seq[(String, CTERelationDef)]): LogicalPlan =
-    plan.resolveOperatorsUpWithPruning(_.containsAnyPattern(UNRESOLVED_RELATION, PLAN_EXPRESSION)) {
+    plan.resolveOperatorsUpWithPruning(
+        _.containsAnyPattern(RELATION_TIME_TRAVEL, UNRESOLVED_RELATION, PLAN_EXPRESSION)) {
+      case RelationTimeTravel(UnresolvedRelation(Seq(table), _, _), _, _)
+        if cteRelations.exists(r => plan.conf.resolver(r._1, table)) =>
+        throw QueryCompilationErrors.timeTravelUnsupportedError("subqueries from WITH clause")
+
       case u @ UnresolvedRelation(Seq(table), _, _) =>
         cteRelations.find(r => plan.conf.resolver(r._1, table)).map { case (_, d) =>
           if (alwaysInline) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationTimeTravel.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/RelationTimeTravel.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{RELATION_TIME_TRAVEL, TreePattern}
 
 /**
  * A logical node used to time travel the child relation to the given `timestamp` or `version`.
@@ -31,4 +32,5 @@ case class RelationTimeTravel(
     version: Option[String]) extends LeafNode {
   override def output: Seq[Attribute] = Nil
   override lazy val resolved: Boolean = false
+  override val nodePatterns: Seq[TreePattern] = Seq(RELATION_TIME_TRAVEL)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -108,6 +108,7 @@ object TreePattern extends Enumeration  {
   val NATURAL_LIKE_JOIN: Value = Value
   val OUTER_JOIN: Value = Value
   val PROJECT: Value = Value
+  val RELATION_TIME_TRAVEL: Value = Value
   val REPARTITION_OPERATION: Value = Value
   val UNION: Value = Value
   val UNRESOLVED_RELATION: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2387,8 +2387,8 @@ object QueryCompilationErrors {
     new AnalysisException(s"${expr.sql} is not a valid timestamp expression for time travel.")
   }
 
-  def viewNotSupportTimeTravelError(viewName: Seq[String]): Throwable = {
-    new AnalysisException(viewName.quoted + " is a view which does not support time travel.")
+  def timeTravelUnsupportedError(target: String): Throwable = {
+    new AnalysisException(s"Cannot time travel $target.")
   }
 
   def tableNotSupportTimeTravelError(tableName: Identifier): UnsupportedOperationException = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala
@@ -83,8 +83,7 @@ class V2SessionCatalog(catalog: SessionCatalog)
     t match {
       case V1Table(catalogTable) =>
         if (catalogTable.tableType == CatalogTableType.VIEW) {
-          throw QueryCompilationErrors.viewNotSupportTimeTravelError(
-            ident.namespace() :+ ident.name())
+          throw QueryCompilationErrors.timeTravelUnsupportedError("views")
         } else {
           throw QueryCompilationErrors.tableNotSupportTimeTravelError(ident)
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3014,6 +3014,16 @@ class DataSourceV2SQLSuite
         sql("SELECT * FROM t TIMESTAMP AS OF abs(true)").collect()
       )
       assert(e5.message.contains("cannot resolve 'abs(true)' due to data type mismatch"))
+
+      val e6 = intercept[AnalysisException](
+        sql("SELECT * FROM parquet.`/the/path` VERSION AS OF 1")
+      )
+      assert(e6.message.contains("Cannot time travel path-based tables"))
+
+      val e7 = intercept[AnalysisException](
+        sql("WITH x AS (SELECT 1) SELECT * FROM x VERSION AS OF 1")
+      )
+      assert(e7.message.contains("Cannot time travel subqueries from WITH clause"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -385,12 +385,12 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       val e1 = intercept[AnalysisException](
         sql(s"SELECT * FROM $viewName VERSION AS OF 1").collect()
       )
-      assert(e1.message.contains(s"$viewName is a view which does not support time travel"))
+      assert(e1.message.contains("Cannot time travel views"))
 
       val e2 = intercept[AnalysisException](
         sql(s"SELECT * FROM $viewName TIMESTAMP AS OF '2000-10-10'").collect()
       )
-      assert(e2.message.contains(s"$viewName is a view which does not support time travel"))
+      assert(e2.message.contains("Cannot time travel views"))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR detects unsupported time travel in more places:
1. path-based tables (```parquet.`/path` VERSION AS OF ...```)
2. CTE subqueris (`WITH t ... FROM t VERSION AS OF`)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
better error message

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
This feature is not released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests