### PR TITLE
[SPARK-37542][SQL] Optimize the dynamic partition pruning rule to avoid inserting unnecessary predicate to improve performance

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -109,7 +109,8 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
       canReuse: Boolean): LogicalPlan = {
     val index = joinKeys.indexOf(filteringKey)
     lazy val hasBenefit = pruningHasBenefit(pruningKey, partScan, filteringKey, filteringPlan)
-    if (canReuse || hasBenefit) {
+    // Avoid to insert an unnecessary dynamic partition pruning predicate
+    if (canReuse || (!conf.dynamicPartitionPruningReuseBroadcastOnly && hasBenefit)) {
       // insert a DynamicPruning wrapper to identify the subquery during query planning
       Filter(
         DynamicPruningSubquery(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Optimize the dynamic partitioning pruning rule to avoid inserting unnecessary predicates to improve performance.

### Why are the changes needed?
Currently, the dynamic partition pruning rule will insert a predicate on the filterable table using the filter from the other side of the join , and the predicate will be re-optimized by the AQE or non-AQE.

But, the predicate may be unnecessary if the join can NOT reuse broadcastExchange or it is not benefit, and it will be removed by the rules of the AQE or non-AQE, so we should  optimize the dynamic partition pruning rule to avoid inserting unnecessary predicate to improve performance.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?

A query example:

spark.sql.autoBroadcastJoinThreshold=10000
```sql
spark.range(1000).select(
  $"id",
  ($"id" + 1).cast("string").as("one"),
  ($"id" + 2).cast("string").as("two"),
  ($"id" + 3).cast("string").as("three"),
  (($"id" * 20) % 100).as("mod"),
  ($"id" % 10).cast("string").as("str"))
  .write.partitionBy("one", "two", "three")
  .format("parquet").mode("overwrite").saveAsTable("fact1")

spark.range(1000).select(
  $"id",
  ($"id" + 1).cast("string").as("one"),
  ($"id" + 2).cast("string").as("two"),
  ($"id" + 3).cast("string").as("three"),
  (($"id" * 20) % 100).as("mod"),
  ($"id" % 10).cast("string").as("str"))
  .write.partitionBy("one", "two", "three")
  .format("parquet").mode("overwrite").saveAsTable("fact2")

spark.range(10).select(
  $"id",
  ($"id" + 1).cast("string").as("one"),
  ($"id" + 2).cast("string").as("two"),
  ($"id" + 3).cast("string").as("three"),
  ($"id" * 10).as("prod"))
  .write.partitionBy("one", "two", "three", "prod")
  .format("parquet").mode("overwrite").saveAsTable("dim")

val df = sql(
  """
  |select f1.id, f1.one,f1.two,f1.three
  |FROM fact1 f1
  | JOIN dim d
  | ON f1.one = d.one and d.prod > 80
  |left join fact2 f2
  |ON f1.one = f2.one
""".stripMargin)
df.collect()
```

before this pr:

```log
== Physical Plan ==
AdaptiveSparkPlan (36)
+- == Final Plan ==
   * Project (22)
   +- * SortMergeJoin LeftOuter (21)
      :- * Sort (13)
      :  +- AQEShuffleRead (12)
      :     +- ShuffleQueryStage (11)
      :        +- Exchange (10)
      :           +- * Project (9)
      :              +- * BroadcastHashJoin Inner BuildRight (8)
      :                 :- * ColumnarToRow (2)
      :                 :  +- Scan parquet default.fact1 (1)
      :                 +- BroadcastQueryStage (7)
      :                    +- BroadcastExchange (6)
      :                       +- * Project (5)
      :                          +- * ColumnarToRow (4)
      :                             +- Scan parquet default.dim (3)
      +- * Sort (20)
         +- AQEShuffleRead (19)
            +- ShuffleQueryStage (18)
               +- Exchange (17)
                  +- * Project (16)
                     +- * ColumnarToRow (15)
                        +- Scan parquet default.fact2 (14)
+- == Initial Plan ==
   Project (35)
   +- SortMergeJoin LeftOuter (34)
      :- Sort (29)
      :  +- Exchange (28)
      :     +- Project (27)
      :        +- BroadcastHashJoin Inner BuildRight (26)
      :           :- Scan parquet default.fact1 (23)
      :           +- BroadcastExchange (25)
      :              +- Project (24)
      :                 +- Scan parquet default.dim (3)
      +- Sort (33)
         +- Exchange (32)
            +- Project (31)
               +- Scan parquet default.fact2 (30)


(1) Scan parquet default.fact1
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact1/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5368), dynamicpruningexpression(one#5368 IN dynamicpruning#5386)]
ReadSchema: struct<id:bigint>

(2) ColumnarToRow [codegen id : 3]
Input [4]: [id#5365L, one#5368, two#5369, three#5370]

(3) Scan parquet default.dim
Output [4]: [one#5372, two#5373, three#5374, prod#5375L]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/dim/one=10/two=11/three=12/prod=90]
PartitionFilters: [isnotnull(prod#5375L), (prod#5375L > 80), isnotnull(one#5372)]
ReadSchema: struct<>

(4) ColumnarToRow [codegen id : 1]
Input [4]: [one#5372, two#5373, three#5374, prod#5375L]

(5) Project [codegen id : 1]
Output [1]: [one#5372]
Input [4]: [one#5372, two#5373, three#5374, prod#5375L]

(6) BroadcastExchange
Input [1]: [one#5372]
Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#414]

(7) BroadcastQueryStage
Output [1]: [one#5372]
Arguments: 0

(8) BroadcastHashJoin [codegen id : 3]
Left keys [1]: [one#5368]
Right keys [1]: [one#5372]
Join condition: None

(9) Project [codegen id : 3]
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5372]

(10) Exchange
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: hashpartitioning(one#5368, 5), ENSURE_REQUIREMENTS, [id=#528]

(11) ShuffleQueryStage
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: 2

(12) AQEShuffleRead
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: coalesced

(13) Sort [codegen id : 4]
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: [one#5368 ASC NULLS FIRST], false, 0

(14) Scan parquet default.fact2
Output [3]: [one#5379, two#5380, three#5381]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact2/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5379), dynamicpruningexpression(true)]
ReadSchema: struct<>

(15) ColumnarToRow [codegen id : 2]
Input [3]: [one#5379, two#5380, three#5381]

(16) Project [codegen id : 2]
Output [1]: [one#5379]
Input [3]: [one#5379, two#5380, three#5381]

(17) Exchange
Input [1]: [one#5379]
Arguments: hashpartitioning(one#5379, 5), ENSURE_REQUIREMENTS, [id=#461]

(18) ShuffleQueryStage
Output [1]: [one#5379]
Arguments: 1

(19) AQEShuffleRead
Input [1]: [one#5379]
Arguments: coalesced

(20) Sort [codegen id : 5]
Input [1]: [one#5379]
Arguments: [one#5379 ASC NULLS FIRST], false, 0

(21) SortMergeJoin [codegen id : 6]
Left keys [1]: [one#5368]
Right keys [1]: [one#5379]
Join condition: None

(22) Project [codegen id : 6]
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5379]

(23) Scan parquet default.fact1
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact1/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5368), dynamicpruningexpression(one#5368 IN dynamicpruning#5386)]
ReadSchema: struct<id:bigint>

(24) Project
Output [1]: [one#5372]
Input [4]: [one#5372, two#5373, three#5374, prod#5375L]

(25) BroadcastExchange
Input [1]: [one#5372]
Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#381]

(26) BroadcastHashJoin
Left keys [1]: [one#5368]
Right keys [1]: [one#5372]
Join condition: None

(27) Project
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5372]

(28) Exchange
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: hashpartitioning(one#5368, 5), ENSURE_REQUIREMENTS, [id=#386]

(29) Sort
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: [one#5368 ASC NULLS FIRST], false, 0

(30) Scan parquet default.fact2
Output [3]: [one#5379, two#5380, three#5381]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact2/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5379), dynamicpruningexpression(one#5379 IN dynamicpruning#5387)]
ReadSchema: struct<>

(31) Project
Output [1]: [one#5379]
Input [3]: [one#5379, two#5380, three#5381]

(32) Exchange
Input [1]: [one#5379]
Arguments: hashpartitioning(one#5379, 5), ENSURE_REQUIREMENTS, [id=#387]

(33) Sort
Input [1]: [one#5379]
Arguments: [one#5379 ASC NULLS FIRST], false, 0

(34) SortMergeJoin
Left keys [1]: [one#5368]
Right keys [1]: [one#5379]
Join condition: None

(35) Project
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5379]

(36) AdaptiveSparkPlan
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: isFinalPlan=true

```

after this pr:

```log
== Physical Plan ==
AdaptiveSparkPlan (35)
+- == Final Plan ==
   * Project (22)
   +- * SortMergeJoin LeftOuter (21)
      :- * Sort (13)
      :  +- AQEShuffleRead (12)
      :     +- ShuffleQueryStage (11)
      :        +- Exchange (10)
      :           +- * Project (9)
      :              +- * BroadcastHashJoin Inner BuildRight (8)
      :                 :- * ColumnarToRow (2)
      :                 :  +- Scan parquet default.fact1 (1)
      :                 +- BroadcastQueryStage (7)
      :                    +- BroadcastExchange (6)
      :                       +- * Project (5)
      :                          +- * ColumnarToRow (4)
      :                             +- Scan parquet default.dim (3)
      +- * Sort (20)
         +- AQEShuffleRead (19)
            +- ShuffleQueryStage (18)
               +- Exchange (17)
                  +- * Project (16)
                     +- * ColumnarToRow (15)
                        +- Scan parquet default.fact2 (14)
+- == Initial Plan ==
   Project (34)
   +- SortMergeJoin LeftOuter (33)
      :- Sort (29)
      :  +- Exchange (28)
      :     +- Project (27)
      :        +- BroadcastHashJoin Inner BuildRight (26)
      :           :- Scan parquet default.fact1 (23)
      :           +- BroadcastExchange (25)
      :              +- Project (24)
      :                 +- Scan parquet default.dim (3)
      +- Sort (32)
         +- Exchange (31)
            +- Project (30)
               +- Scan parquet default.fact2 (14)


(1) Scan parquet default.fact1
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact1/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5368), dynamicpruningexpression(one#5368 IN dynamicpruning#5386)]
ReadSchema: struct<id:bigint>

(2) ColumnarToRow [codegen id : 3]
Input [4]: [id#5365L, one#5368, two#5369, three#5370]

(3) Scan parquet default.dim
Output [4]: [one#5372, two#5373, three#5374, prod#5375L]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/dim/one=10/two=11/three=12/prod=90]
PartitionFilters: [isnotnull(prod#5375L), (prod#5375L > 80), isnotnull(one#5372)]
ReadSchema: struct<>

(4) ColumnarToRow [codegen id : 1]
Input [4]: [one#5372, two#5373, three#5374, prod#5375L]

(5) Project [codegen id : 1]
Output [1]: [one#5372]
Input [4]: [one#5372, two#5373, three#5374, prod#5375L]

(6) BroadcastExchange
Input [1]: [one#5372]
Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#387]

(7) BroadcastQueryStage
Output [1]: [one#5372]
Arguments: 0

(8) BroadcastHashJoin [codegen id : 3]
Left keys [1]: [one#5368]
Right keys [1]: [one#5372]
Join condition: None

(9) Project [codegen id : 3]
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5372]

(10) Exchange
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: hashpartitioning(one#5368, 5), ENSURE_REQUIREMENTS, [id=#477]

(11) ShuffleQueryStage
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: 2

(12) AQEShuffleRead
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: coalesced

(13) Sort [codegen id : 4]
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: [one#5368 ASC NULLS FIRST], false, 0

(14) Scan parquet default.fact2
Output [3]: [one#5379, two#5380, three#5381]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact2/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5379)]
ReadSchema: struct<>

(15) ColumnarToRow [codegen id : 2]
Input [3]: [one#5379, two#5380, three#5381]

(16) Project [codegen id : 2]
Output [1]: [one#5379]
Input [3]: [one#5379, two#5380, three#5381]

(17) Exchange
Input [1]: [one#5379]
Arguments: hashpartitioning(one#5379, 5), ENSURE_REQUIREMENTS, [id=#411]

(18) ShuffleQueryStage
Output [1]: [one#5379]
Arguments: 1

(19) AQEShuffleRead
Input [1]: [one#5379]
Arguments: coalesced

(20) Sort [codegen id : 5]
Input [1]: [one#5379]
Arguments: [one#5379 ASC NULLS FIRST], false, 0

(21) SortMergeJoin [codegen id : 6]
Left keys [1]: [one#5368]
Right keys [1]: [one#5379]
Join condition: None

(22) Project [codegen id : 6]
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5379]

(23) Scan parquet default.fact1
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Batched: true
Location: InMemoryFileIndex [file:/Users/weixiuli/git/master/sql/catalyst/spark-warehouse/org.apache.spark.sql.DynamicPartitionPruningV1SuiteAEOn/fact1/one=533/two=534/three=535, ... 999 entries]
PartitionFilters: [isnotnull(one#5368), dynamicpruningexpression(one#5368 IN dynamicpruning#5386)]
ReadSchema: struct<id:bigint>

(24) Project
Output [1]: [one#5372]
Input [4]: [one#5372, two#5373, three#5374, prod#5375L]

(25) BroadcastExchange
Input [1]: [one#5372]
Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#354]

(26) BroadcastHashJoin
Left keys [1]: [one#5368]
Right keys [1]: [one#5372]
Join condition: None

(27) Project
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5372]

(28) Exchange
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: hashpartitioning(one#5368, 5), ENSURE_REQUIREMENTS, [id=#359]

(29) Sort
Input [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: [one#5368 ASC NULLS FIRST], false, 0

(30) Project
Output [1]: [one#5379]
Input [3]: [one#5379, two#5380, three#5381]

(31) Exchange
Input [1]: [one#5379]
Arguments: hashpartitioning(one#5379, 5), ENSURE_REQUIREMENTS, [id=#360]

(32) Sort
Input [1]: [one#5379]
Arguments: [one#5379 ASC NULLS FIRST], false, 0

(33) SortMergeJoin
Left keys [1]: [one#5368]
Right keys [1]: [one#5379]
Join condition: None

(34) Project
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Input [5]: [id#5365L, one#5368, two#5369, three#5370, one#5379]

(35) AdaptiveSparkPlan
Output [4]: [id#5365L, one#5368, two#5369, three#5370]
Arguments: isFinalPlan=true
```

Exist unittests.