### PR TITLE
[SPARK-37548][INFRA][R][TESTS] Add Java17 SparkR daily test coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -354,7 +354,9 @@ jobs:
 
   sparkr:
     needs: configure-jobs
-    if: needs.configure-jobs.outputs.type == 'regular'
+    if: >-
+      needs.configure-jobs.outputs.type == 'regular'
+      || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -401,7 +401,7 @@ jobs:
         key: sparkr-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           sparkr-coursier-
-    - name: Install Java ${{ needs.configure-jobs.outputs.java }}
+    - name: Install Java
        uses: actions/setup-java@v1
        with:
          java-version: ${{ needs.configure-jobs.outputs.java }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -401,10 +401,10 @@ jobs:
         key: sparkr-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           sparkr-coursier-
-    - name: Install Java
-       uses: actions/setup-java@v1
-       with:
-         java-version: ${{ needs.configure-jobs.outputs.java }}
+    - name: Install Java ${{ needs.configure-jobs.outputs.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ needs.configure-jobs.outputs.java }}
     - name: Run tests
       run: |
         # The followings are also used by `r-lib/actions/setup-r` to avoid

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -401,6 +401,10 @@ jobs:
         key: sparkr-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
         restore-keys: |
           sparkr-coursier-
+    - name: Install Java ${{ needs.configure-jobs.outputs.java }}
+       uses: actions/setup-java@v1
+       with:
+         java-version: ${{ needs.configure-jobs.outputs.java }}
     - name: Run tests
       run: |
         # The followings are also used by `r-lib/actions/setup-r` to avoid


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Java 17` SparkR daily test coverage.

### Why are the changes needed?

To support `Java 17` for SparkR in Apache Spark 3.3.0.

I manually tested SparkR UT on `Java 17` on `MacBook Pro (16-inch, 2021) Apple Silicon M1 Max`.
```
$ java -version
openjdk version "17.0.1" 2021-10-19 LTS
OpenJDK Runtime Environment Zulu17.30+15-CA (build 17.0.1+12-LTS)
OpenJDK 64-Bit Server VM Zulu17.30+15-CA (build 17.0.1+12-LTS, mixed mode, sharing)

$ build/sbt -Phive -Psparkr test:package

$ R/install-dev.sh

$ env SPARK_HOME=$PWD R/run-tests.sh
...
══ Skipped ═════════════════════════════════════════════════════════════════════
1. sparkJars tag in SparkContext (test_Windows.R:22:5) - Reason: This test is only for Windows, skipped

══ DONE ════════════════════════════════════════════════════════════════════════
...
+ popd
Tests passed.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually review. This should be tested after merging.