### PR TITLE
[SPARK-37549][SQL] Support set parallel through data source properties

### DIFF
--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -159,8 +159,9 @@ To load files with paths matching a given modified time range, you can use:
 
 ### Scan parallelism
 
-`parallel` is used to set the parallelism when reading data files.
-We will fall back to using `spark.sql.files.maxPartitionBytes` to determine the parallelism if it is not set.
+`parallel` is used to set the expected parallelism while reading data from files. We will fall back to 
+using `spark.sql.files.maxPartitionBytes` to determine the parallelism if it is not set.
+Please note that Spark can not guarantee the parallelism exactly is `parallel`. 
 
 To set the parallelism when reading data files, you can use:
 

--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -188,7 +188,7 @@ CREATE TEMPORARY VIEW parquetTable
 USING org.apache.spark.sql.parquet
 OPTIONS (
   path "examples/src/main/resources/people.parquet",
-  parallel "12000"
+  parallel "100"
 )
 
 SELECT * FROM parquetTable

--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -156,3 +156,43 @@ To load files with paths matching a given modified time range, you can use:
 {% include_example load_with_modified_time_filter  r/RSparkSQLExample.R %}
 </div>
 </div>
+
+### Scan parallelism
+
+`parallel` is used to set the parallelism when reading data files.
+We will fall back to using `spark.sql.files.maxPartitionBytes` to determine the parallelism if it is not set.
+
+To set the parallelism when reading data files, you can use:
+
+<div class="codetabs">
+<div data-lang="scala"  markdown="1">
+{% include_example load_with_parallel scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% include_example load_with_parallel java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java %}
+</div>
+
+<div data-lang="python"  markdown="1">
+{% include_example load_with_parallel python/sql/datasource.py %}
+</div>
+
+<div data-lang="r"  markdown="1">
+{% include_example load_with_parallel r/RSparkSQLExample.R %}
+</div>
+
+<div data-lang="SQL"  markdown="1">
+{% highlight sql %}
+
+CREATE TEMPORARY VIEW parquetTable
+USING org.apache.spark.sql.parquet
+OPTIONS (
+  path "examples/src/main/resources/people.parquet",
+  parallel "12000"
+)
+
+SELECT * FROM parquetTable
+
+{% endhighlight %}
+</div>
+</div>

--- a/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/sql/JavaSQLDataSourceExample.java
@@ -169,6 +169,17 @@ public class JavaSQLDataSourceExample {
     // |file1.parquet|
     // +-------------+
     // $example off:load_with_modified_time_filter$
+    // $example on:load_with_parallel$
+    Dataset<Row> testParallelDF = spark.read().format("parquet")
+        .option("parallel", "100")
+        .load("examples/src/main/resources/dir1/dir2");
+    testParallelDF.show();
+    // +-------------+
+    // |         file|
+    // +-------------+
+    // |file2.parquet|
+    // +-------------+
+    // $example off:load_with_parallel$
   }
 
   private static void runBasicDataSourceExample(SparkSession spark) {

--- a/examples/src/main/python/sql/datasource.py
+++ b/examples/src/main/python/sql/datasource.py
@@ -87,6 +87,17 @@ def generic_file_source_options_example(spark):
     # +-------------+
     # $example off:load_with_modified_time_filter$
 
+    # $example on:load_with_parallel$
+    df = spark.read.load("examples/src/main/resources/dir1/dir2",
+                         format="parquet", parallel="100")
+    df.show()
+    # +-------------+
+    # |         file|
+    # +-------------+
+    # |file2.parquet|
+    # +-------------+
+    # $example off:load_with_parallel$
+
 
 def basic_datasource_example(spark):
     # $example on:generic_load_save_functions$

--- a/examples/src/main/r/RSparkSQLExample.R
+++ b/examples/src/main/r/RSparkSQLExample.R
@@ -152,6 +152,12 @@ afterDF <- read.df("examples/src/main/resources/dir1", "parquet", modifiedAfter 
 #            file
 # $example off:load_with_modified_time_filter$
 
+# $example on:load_with_parallel$
+beforeDF <- read.df("examples/src/main/resources/dir1/dir2", "parquet", parallel= "100")
+#            file
+# 1 file2.parquet
+# $example off:load_with_parallel$
+
 # $example on:manual_save_options_orc$
 df <- read.df("examples/src/main/resources/users.orc", "orc")
 write.orc(df, "users_with_options.orc", orc.bloom.filter.columns = "favorite_color", orc.dictionary.key.threshold = 1.0, orc.column.encoding.direct = "name")

--- a/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/SQLDataSourceExample.scala
@@ -104,6 +104,17 @@ object SQLDataSourceExample {
     // +-------------+
     // +-------------+
     // $example off:load_with_modified_time_filter$
+    // $example on:load_with_parallel$
+    val testParallelDF = spark.read.format("parquet")
+      .option("parallel", "100")
+      .load("examples/src/main/resources/dir1/dir2")
+    testParallelDF.show()
+    // +-------------+
+    // |         file|
+    // +-------------+
+    // |file2.parquet|
+    // +-------------+
+    // $example off:load_with_parallel$
   }
 
   private def runBasicDataSourceExample(spark: SparkSession): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -608,7 +608,8 @@ case class FileSourceScanExec(
       fsRelation: HadoopFsRelation): RDD[InternalRow] = {
     val openCostInBytes = fsRelation.sparkSession.sessionState.conf.filesOpenCostInBytes
     val maxSplitBytes =
-      FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions)
+      FilePartition.maxSplitBytes(fsRelation.sparkSession, selectedPartitions,
+        new SourceOptions(fsRelation.options).parallel)
     logInfo(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
       s"open cost is considered as scanning $openCostInBytes bytes.")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -85,7 +85,8 @@ object FilePartition extends Logging {
 
   def maxSplitBytes(
       sparkSession: SparkSession,
-      selectedPartitions: Seq[PartitionDirectory]): Long = {
+      selectedPartitions: Seq[PartitionDirectory],
+      parallel: Option[Int] = None): Long = {
     val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
     val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
     val minPartitionNum = sparkSession.sessionState.conf.filesMinPartitionNum
@@ -93,6 +94,7 @@ object FilePartition extends Logging {
     val totalBytes = selectedPartitions.flatMap(_.files.map(_.getLen + openCostInBytes)).sum
     val bytesPerCore = totalBytes / minPartitionNum
 
-    Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+    parallel.map(totalBytes / _)
+      .getOrElse(Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore)))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SourceOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SourceOptions.scala
@@ -36,6 +36,9 @@ class SourceOptions(
   // A flag to always respect the Spark schema restored from the table properties
   val respectSparkSchema: Boolean = parameters
     .get(RESPECT_SPARK_SCHEMA).map(_.toBoolean).getOrElse(DEFAULT_RESPECT_SPARK_SCHEMA)
+
+  // Expected parallelism from the data source properties.
+  val parallel: Option[Int] = parameters.get(PARALLEL).map(_.toInt)
 }
 
 
@@ -46,5 +49,7 @@ object SourceOptions {
 
   val RESPECT_SPARK_SCHEMA = "respectSparkSchema"
   val DEFAULT_RESPECT_SPARK_SCHEMA = false
+
+  val PARALLEL = "parallel"
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceParallelSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceParallelSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 class FileSourceParallelSuite extends QueryTest with SharedSparkSession {
 
-  test("Specify parallel with read option") {
+  test("SPARK-37549 Specify parallel with read option") {
     withSQLConf(SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "10") {
       withTempPath { path =>
         spark.range(1, 1000, 1, 1)
@@ -44,7 +44,7 @@ class FileSourceParallelSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("Specify parallel with table option") {
+  test("SPARK-37549: Specify parallel with table option") {
     withSQLConf(SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "10") {
       withTable("t1") {
         spark.range(1, 1000, 1, 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceParallelSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceParallelSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class FileSourceParallelSuite extends QueryTest with SharedSparkSession {
+
+  test("Specify parallel with read option") {
+    withSQLConf(SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "10") {
+      withTempPath { path =>
+        spark.range(1, 1000, 1, 1)
+          .selectExpr("id as key", "id * 3 as s1", "id * 5 as s2")
+          .write.format("parquet").save(path.getAbsolutePath)
+
+        Seq(3, 7, 10).foreach { parallelism =>
+          val plan = spark.read.option("Parallel", parallelism)
+            .parquet(path.getAbsolutePath)
+            .queryExecution
+            .sparkPlan
+          val scan = plan.collect { case scan: FileSourceScanExec => scan }
+          assert(scan.size === 1)
+          assert(scan.head.inputRDD.partitions.length === parallelism)
+        }
+      }
+    }
+  }
+
+  test("Specify parallel with table option") {
+    withSQLConf(SQLConf.FILES_OPEN_COST_IN_BYTES.key -> "10") {
+      withTable("t1") {
+        spark.range(1, 1000, 1, 1)
+          .selectExpr("id as key", "id * 3 as s1", "id * 5 as s2")
+          .write.format("parquet").option("Parallel", 5).saveAsTable("t1")
+
+        val plan = spark.table("t1").queryExecution.sparkPlan
+        val scan = plan.collect { case scan: FileSourceScanExec => scan }
+        assert(scan.size === 1)
+        assert(scan.head.inputRDD.partitions.length === 5)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add support set parallel through data source properties when reading data. For example:
```scala
spark.read.option("Parallel", 1000).parquet("path/to/parquet")
```
```sql
CREATE TABLE very_large_partitioned_bucketed_table (
  id STRING,
  foo STRING,
  bar STRING,
  other STRING,
  dt STRING,
  type STRING)
USING parquet
OPTIONS (
  compression 'gzip',
  PARALLEL '12000'
)
PARTITIONED BY (dt, type)
CLUSTERED BY (id)
INTO 6000 BUCKETS
```

Oracle has similar feature:
https://docs.oracle.com/cd/B19306_01/server.102/b14200/clauses006.htm
https://docs.oracle.com/cd/E11882_01/server.112/e25523/parallel002.htm#BEIDFDEH

How to alter table parallelism:
```sql
ALTER TABLE table_name SET TBLPROPERTIES ('parallel' = 'parallel number');
```

### Why are the changes needed?

1. To decrease the degree of parallelism if it is very large partitioned and bucketed table as it is not always use bucket scan since [SPARK-32859](https://issues.apache.org/jira/browse/SPARK-32859).
2. To increase the degree of parallelism on the stream side if it is `BroadcastNestedLoopJoinExec`.
3. To support setting parallel through hint in the future(Oracle has similar feature: https://docs.oracle.com/cd/E11882_01/server.112/e41573/hintsref.htm#CHDJIGDG).

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
