### PR TITLE
[SPARK-37553][PYTHON] Fix underscore (`_`) bug in pyspark.pandas.frames.DataFrame.pivot_table

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -57,6 +57,8 @@ from pandas.tseries.frequencies import DateOffset, to_offset
 if TYPE_CHECKING:
     from pandas.io.formats.style import Styler
 
+import itertools
+
 from pandas.core.dtypes.common import infer_dtype_from_object
 from pandas.core.accessor import CachedAccessor
 from pandas.core.dtypes.inference import is_sequence
@@ -6061,10 +6063,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     column_name_to_index = dict(
                         zip(self._internal.data_spark_column_names, self._internal.column_labels)
                     )
-                    column_labels = [
-                        tuple(list(column_name_to_index[name.split("_")[1]]) + [name.split("_")[0]])
-                        for name in data_columns
-                    ]
+                    _columns = set(self[columns].tolist())
+                    _values = itertools.chain.from_iterable(values)
+                    column_labels = [i for i in itertools.product(_values, _columns)]
                     column_label_names = (
                         [cast(Optional[Name], None)] * column_labels_level(values)
                     ) + [columns]

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6056,18 +6056,21 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     # E.g. if column is b and values is ['b','e'],
                     # then ['2_b', '2_e', '3_b', '3_e'].
 
-                    # We sort the columns of Spark DataFrame by values.
-                    data_columns.sort(key=lambda x: x.split("_", 1)[1])
-                    sdf = sdf.select(index_columns + data_columns)
-
-                    column_name_to_index = dict(
-                        zip(self._internal.data_spark_column_names, self._internal.column_labels)
-                    )
                     _columns = [str(i) for i in self[columns].unique().tolist()]
                     column_labels = [
                         tuple(list(i[0]) + [i[1]]) for i in itertools.product(values, _columns)
                     ]
                     column_labels.sort()
+                    # We sort the columns of Spark DataFrame by values.
+                    if len(values[0]) > 1:
+                        data_columns = [
+                            "_".join([i[-1], str(i[:-1]).replace("'", "")]) for i in column_labels
+                        ]
+                    else:
+                        data_columns = [
+                            "_".join([i[-1], str(i[0]).replace("'", "")]) for i in column_labels
+                        ]
+                    sdf = sdf.select(index_columns + data_columns)
                     column_label_names = (
                         [cast(Optional[Name], None)] * column_labels_level(values)
                     ) + [columns]

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6063,9 +6063,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     column_name_to_index = dict(
                         zip(self._internal.data_spark_column_names, self._internal.column_labels)
                     )
-                    _columns = set(self[columns].tolist())
-                    _values = itertools.chain.from_iterable(values)
-                    column_labels = [i for i in itertools.product(_values, _columns)]
+                    _columns = [str(i) for i in self[columns].unique().tolist()]
+                    column_labels = [tuple(list(i[0]) + [i[1]]) for i in itertools.product(values, _columns)]
+                    column_labels.sort()
                     column_label_names = (
                         [cast(Optional[Name], None)] * column_labels_level(values)
                     ) + [columns]

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6064,7 +6064,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                         zip(self._internal.data_spark_column_names, self._internal.column_labels)
                     )
                     _columns = [str(i) for i in self[columns].unique().tolist()]
-                    column_labels = [tuple(list(i[0]) + [i[1]]) for i in itertools.product(values, _columns)]
+                    column_labels = [
+                        tuple(list(i[0]) + [i[1]]) for i in itertools.product(values, _columns)
+                    ]
                     column_labels.sort()
                     column_label_names = (
                         [cast(Optional[Name], None)] * column_labels_level(values)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6081,9 +6081,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                             "_".join([i[-1], f"({', '.join(i[:-1])})"]) for i in column_labels
                         ]
                     else:
-                        data_columns = [
-                            "_".join([i[-1], str(i[0])]) for i in column_labels
-                        ]
+                        data_columns = ["_".join([i[-1], str(i[0])]) for i in column_labels]
                     sdf = sdf.select(index_columns + data_columns)
                     column_label_names = (
                         [cast(Optional[Name], None)] * column_labels_level(values)

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3054,7 +3054,6 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             almost=True,
         )
 
-
     def test_pivot_table_underscore_in_values(self):
         pdf = pd.DataFrame(
             {
@@ -3074,6 +3073,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             pdf.pivot_table(index=["c"], columns="a", values=["b_b", "d_d"]).sort_index(),
             almost=True,
         )
+
     def test_pivot_table_and_index(self):
         # https://github.com/databricks/koalas/issues/805
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3054,6 +3054,26 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             almost=True,
         )
 
+
+    def test_pivot_table_underscore_in_values(self):
+        pdf = pd.DataFrame(
+            {
+                "a": [4, 2, 3, 4, 8, 6],
+                "b_b": [1, 2, 2, 4, 2, 4],
+                "e": [10, 20, 20, 40, 20, 40],
+                "c": [1, 2, 9, 4, 7, 4],
+                "d_d": [-1, -2, -3, -4, -5, -6],
+            },
+            index=np.random.rand(6),
+        )
+        psdf = ps.from_pandas(pdf)
+
+        # Checking if both DataFrames have the same results
+        self.assert_eq(
+            psdf.pivot_table(index=["c"], columns="a", values=["b_b", "d_d"]).sort_index(),
+            pdf.pivot_table(index=["c"], columns="a", values=["b_b", "d_d"]).sort_index(),
+            almost=True,
+        )
     def test_pivot_table_and_index(self):
         # https://github.com/databricks/koalas/issues/805
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3034,6 +3034,26 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             almost=True,
         )
 
+    def test_pivot_table_underscore_in_columns(self):
+        pdf = pd.DataFrame(
+            {
+                "a_a": [4, 2, 3, 4, 8, 6],
+                "b": [1, 2, 2, 4, 2, 4],
+                "e": [10, 20, 20, 40, 20, 40],
+                "c": [1, 2, 9, 4, 7, 4],
+                "d": [-1, -2, -3, -4, -5, -6],
+            },
+            index=np.random.rand(6),
+        )
+        psdf = ps.from_pandas(pdf)
+
+        # Checking if both DataFrames have the same results
+        self.assert_eq(
+            psdf.pivot_table(columns="a_a", values="b").sort_index(),
+            pdf.pivot_table(columns="a_a", values="b").sort_index(),
+            almost=True,
+        )
+
     def test_pivot_table_and_index(self):
         # https://github.com/databricks/koalas/issues/805
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3034,10 +3034,10 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
             almost=True,
         )
 
-    def test_pivot_table_underscore_in_columns(self):
+    def test_pivot_table_underscore_in_column_elements(self):
         pdf = pd.DataFrame(
             {
-                "a_a": [4, 2, 3, 4, 8, 6],
+                "a": ["4_4", "2_2", "3_3", "4_4", "8_8", "6_6"],
                 "b": [1, 2, 2, 4, 2, 4],
                 "e": [10, 20, 20, 40, 20, 40],
                 "c": [1, 2, 9, 4, 7, 4],
@@ -3049,8 +3049,8 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # Checking if both DataFrames have the same results
         self.assert_eq(
-            psdf.pivot_table(columns="a_a", values="b").sort_index(),
-            pdf.pivot_table(columns="a_a", values="b").sort_index(),
+            psdf.pivot_table(index=["c"], columns="a", values=["b", "d"]).sort_index(),
+            pdf.pivot_table(index=["c"], columns="a", values=["b", "d"]).sort_index(),
             almost=True,
         )
 

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3035,6 +3035,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         )
 
     def test_pivot_table_underscore_in_column_elements(self):
+        # SPARK-37553: Fix bug with underscore in column name and values
         pdf = pd.DataFrame(
             {
                 "a": ["4_4", "2_2", "3_3", "4_4", "8_8", "6_6"],
@@ -3071,6 +3072,7 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(repr(ktable.index), repr(ptable.index))
 
     def test_pivot_table_underscore_in_values_column_name(self):
+        # SPARK-37553: Fix bug with underscore in column name and values
         pdf = pd.DataFrame(
             {
                 "a": [4, 2, 3, 4, 8, 6],

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -3048,31 +3048,63 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         psdf = ps.from_pandas(pdf)
 
         # Checking if both DataFrames have the same results
-        self.assert_eq(
-            psdf.pivot_table(index=["c"], columns="a", values=["b", "d"]).sort_index(),
-            pdf.pivot_table(index=["c"], columns="a", values=["b", "d"]).sort_index(),
-            almost=True,
-        )
+        ktable = psdf.pivot_table(index=["c"], columns="a", values=["b", "d"]).sort_index()
+        ptable = pdf.pivot_table(index=["c"], columns="a", values=["b", "d"]).sort_index()
+        self.assert_eq(ktable, ptable)
+        self.assert_eq(ktable.index, ptable.index)
+        self.assert_eq(repr(ktable.index), repr(ptable.index))
 
-    def test_pivot_table_underscore_in_values(self):
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples(
+            [("x", "a"), ("x", "b"), ("y", "e"), ("z", "c"), ("w", "d")]
+        )
+        pdf.columns = columns
+        psdf.columns = columns
+        ktable = psdf.pivot_table(
+            index=[("z", "c")], columns=("x", "a"), values=[("x", "b"), ("w", "d")]
+        ).sort_index()
+        ptable = pdf.pivot_table(
+            index=[("z", "c")], columns=[("x", "a")], values=[("x", "b"), ("w", "d")]
+        ).sort_index()
+        self.assert_eq(ktable, ptable)
+        self.assert_eq(ktable.index, ptable.index)
+        self.assert_eq(repr(ktable.index), repr(ptable.index))
+
+    def test_pivot_table_underscore_in_values_column_name(self):
         pdf = pd.DataFrame(
             {
                 "a": [4, 2, 3, 4, 8, 6],
                 "b_b": [1, 2, 2, 4, 2, 4],
                 "e": [10, 20, 20, 40, 20, 40],
                 "c": [1, 2, 9, 4, 7, 4],
-                "d_d": [-1, -2, -3, -4, -5, -6],
+                "d": [-1, -2, -3, -4, -5, -6],
             },
             index=np.random.rand(6),
         )
         psdf = ps.from_pandas(pdf)
 
         # Checking if both DataFrames have the same results
-        self.assert_eq(
-            psdf.pivot_table(index=["c"], columns="a", values=["b_b", "d_d"]).sort_index(),
-            pdf.pivot_table(index=["c"], columns="a", values=["b_b", "d_d"]).sort_index(),
-            almost=True,
+        ktable = psdf.pivot_table(index=["c"], columns="a", values=["b_b", "d"]).sort_index()
+        ptable = pdf.pivot_table(index=["c"], columns="a", values=["b_b", "d"]).sort_index()
+        self.assert_eq(ktable, ptable)
+        self.assert_eq(ktable.index, ptable.index)
+        self.assert_eq(repr(ktable.index), repr(ptable.index))
+
+        # multi-index columns
+        columns = pd.MultiIndex.from_tuples(
+            [("x", "a"), ("x", "b_b"), ("y", "e"), ("z", "c"), ("w", "d")]
         )
+        pdf.columns = columns
+        psdf.columns = columns
+        ktable = psdf.pivot_table(
+            index=[("z", "c")], columns=("x", "a"), values=[("x", "b_b"), ("w", "d")]
+        ).sort_index()
+        ptable = pdf.pivot_table(
+            index=[("z", "c")], columns=[("x", "a")], values=[("x", "b_b"), ("w", "d")]
+        ).sort_index()
+        self.assert_eq(ktable, ptable)
+        self.assert_eq(ktable.index, ptable.index)
+        self.assert_eq(repr(ktable.index), repr(ptable.index))
 
     def test_pivot_table_and_index(self):
         # https://github.com/databricks/koalas/issues/805


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Adds example code changes to allow for underscores in (1) the elements for the `columns` arg and (2) for the column names used for the `values` arg when `len(values) > 1`. 


### Why are the changes needed?
Fixes a bug with the method `pyspark.pandas.frames.DataFrame.pivot_table` that causes a `KeyError` when an underscore is present (more details in [SPARK-37553](https://issues.apache.org/jira/browse/SPARK-37553)).
```python
>>> import numpy as np
>>> import pandas as pd
>>> from pyspark import pandas as ps
>>> pdf = pd.DataFrame(
        {
            "a": [4, 2, 3, 4, 8, 6],
            "b_b": [1, 2, 2, 4, 2, 4],
            "e": [10, 20, 20, 40, 20, 40],
            "c": [1, 2, 9, 4, 7, 4],
            "d": [-1, -2, -3, -4, -5, -6],
        },
        index=np.random.rand(6),
    )
>>> psdf = ps.from_pandas(pdf)
>>> psdf.pivot_table(index=["c"], columns="a", values=["b_b", "e"])

---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-8-32d5bb0e1166> in <module>
----> 1 psdf.pivot_table(index=["c"], columns="a", values=["b_b", "e"])

~/.pyenv/versions/3.7.9/envs/venv37/lib/python3.7/site-packages/pyspark/pandas/frame.py in pivot_table(self, values, index, columns, aggfunc, fill_value)
   6053                     column_labels = [
   6054                         tuple(list(column_name_to_index[name.split("_")[1]]) + [name.split("_")[0]])
-> 6055                         for name in data_columns
   6056                     ]
   6057                     column_label_names = (

~/.pyenv/versions/3.7.9/envs/venv37/lib/python3.7/site-packages/pyspark/pandas/frame.py in <listcomp>(.0)
   6053                     column_labels = [
   6054                         tuple(list(column_name_to_index[name.split("_")[1]]) + [name.split("_")[0]])
-> 6055                         for name in data_columns
   6056                     ]
   6057                     column_label_names = (

KeyError: 'b'
```


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- [x] Add unit tests for code changes
- [] Build package via Github Actions 
