### PR TITLE
[SPARK-37555][SQL] spark-sql should pass last unclosed comment to backend

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -613,7 +613,9 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
 
       isStatement = statementInProgress(index)
     }
-    ret.add(line.substring(beginIndex))
+    if (beginIndex < line.length()) {
+      ret.add(line.substring(beginIndex))
+    }
     ret
   }
 }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -613,9 +613,7 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
 
       isStatement = statementInProgress(index)
     }
-    if (isStatement) {
-      ret.add(line.substring(beginIndex))
-    }
+    ret.add(line.substring(beginIndex))
     ret
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -620,4 +620,22 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
         |""".stripMargin -> "SELECT 1"
     )
   }
+
+  test("SPARK-37555: spark-sql should pass last unclosed comment to backend") {
+    runCliWithin(2.minute)(
+      // Unclosed comment
+      """
+        |/* SELECT /*+ HINT() 4; */;
+        |""".stripMargin -> "Error in query",
+      // Unclosed comment with query.
+      """
+        |/* SELECT /*+ HINT() 4; */
+        |SELECT 1;
+        |""".stripMargin -> "1",
+      // Whole comment.
+      """
+        |/* SELECT /*+ HINT() */ 4; */;
+        |""".stripMargin -> ""
+    )
+  }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -623,19 +623,14 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("SPARK-37555: spark-sql should pass last unclosed comment to backend") {
     runCliWithin(2.minute)(
-      // Unclosed comment
-      """
-        |/* SELECT /*+ HINT() 4; */;
-        |""".stripMargin -> "Error in query",
+      // Only unclosed comment.
+      "/* SELECT /*+ HINT() 4; */;".stripMargin -> "Error in query",
+      // Unclosed nested bracketed comment.
+      "/* SELECT /*+ HINT() 4; */ SELECT 1;".stripMargin -> "1",
       // Unclosed comment with query.
-      """
-        |/* SELECT /*+ HINT() 4; */
-        |SELECT 1;
-        |""".stripMargin -> "1",
+      "/* Here is a unclosed bracketed comment SELECT 1;"-> "Unclosed bracketed comment",
       // Whole comment.
-      """
-        |/* SELECT /*+ HINT() */ 4; */;
-        |""".stripMargin -> ""
+      "/* SELECT /*+ HINT() */ 4; */;".stripMargin -> ""
     )
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -624,7 +624,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   test("SPARK-37555: spark-sql should pass last unclosed comment to backend") {
     runCliWithin(2.minute)(
       // Only unclosed comment.
-      "/* SELECT /*+ HINT() 4; */;".stripMargin -> "Error in query",
+      "/* SELECT /*+ HINT() 4; */;".stripMargin -> "mismatched input ';'",
       // Unclosed nested bracketed comment.
       "/* SELECT /*+ HINT() 4; */ SELECT 1;".stripMargin -> "1",
       // Unclosed comment with query.


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current spark-sql cli interface, if the end SQL is  not a close comment, the SQL won't be passed to backend engine and just ignored. This caused a problem that if user write a SQL with wrong comment. It's just ignored and won't throw exception.
For example:
```
spark-sql> /* This is a comment without end symbol SELECT 1;
spark-sql>
```

After this pr:
```
spark-sql> /* This is a comment without end symbol SELECT 1;
Error in query:
Unclosed bracketed comment(line 1, pos 0)

 == SQL ==
 /* This is a comment without end symbol SELECT 1;
 ^^^
```

In SPARK-33100 add this change https://github.com/apache/spark/pull/29982

Hive related code
https://github.com/apache/hive/blob/1090c93b1a02d480bdee2af2cecf503f8a54efc6/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java#L488-L490



### Why are the changes needed?
Exact exceptions are thrown for wrong statements, which is convenient for users to troubleshoot.



### Does this PR introduce _any_ user-facing change?
Yes, if user write a wrong comment in sql/sql file or query in the end. 
Before it's just ignored since it's not a statement. Now it will be passed to backend engine and if the statement is not correct, it will throw SQL exception.


### How was this patch tested?
added UT and  test by handle.

```
spark-sql> /* SELECT /*+ HINT() 4; */;
Error in query:
mismatched input ';' expecting {'(', 'ADD', 'ALTER', 'ANALYZE', 'CACHE', 'CLEAR', 'COMMENT', 'COMMIT', 'CREATE', 'DELETE', 'DESC', 'DESCRIBE', 'DFS', 'DROP', 'EXPLAIN', 'EXPORT', 'FROM', 'GRANT', 'IMPORT', 'INSERT', 'LIST', 'LOAD', 'LOCK', 'MAP', 'MERGE', 'MSCK', 'REDUCE', 'REFRESH', 'REPLACE', 'RESET', 'REVOKE', 'ROLLBACK', 'SELECT', 'SET', 'SHOW', 'START', 'TABLE', 'TRUNCATE', 'UNCACHE', 'UNLOCK', 'UPDATE', 'USE', 'VALUES', 'WITH'}(line 1, pos 26)

== SQL ==
/* SELECT /*+ HINT() 4; */;
--------------------------^^^

spark-sql> /* SELECT /*+ HINT() 4; */
         >         SELECT 1;
1
Time taken: 3.16 seconds, Fetched 1 row(s)
spark-sql> /* SELECT /*+ HINT() */ 4; */;
spark-sql>
         > ;
spark-sql>
         > /* SELECT /*+ HINT() 4\\;
         >         SELECT 1;
Error in query:
Unclosed bracketed comment(line 1, pos 0)

== SQL ==
/* SELECT /*+ HINT() 4\\;
^^^
        SELECT 1;

spark-sql>
```
