### PR TITLE
[SPARK-37574][CORE][SHUFFLE] Simplify fetchBlocks w/o retry

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -132,14 +132,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
               logger.info("This clientFactory was closed. Skipping further block fetch retries.");
             }
           };
-
-      if (maxRetries > 0) {
-        // Note this Fetcher will correctly handle maxRetries == 0; we avoid it just in case there's
-        // a bug in this code. We should remove the if statement once we're sure of the stability.
-        new RetryingBlockTransferor(transportConf, blockFetchStarter, blockIds, listener).start();
-      } else {
-        blockFetchStarter.createAndStart(blockIds, listener);
-      }
+      new RetryingBlockTransferor(transportConf, blockFetchStarter, blockIds, listener).start();
     } catch (Exception e) {
       logger.error("Exception while beginning fetchBlocks", e);
       for (String blockId : blockIds) {

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -139,14 +139,7 @@ private[spark] class NettyBlockTransferService(
           }
         }
       }
-
-      if (maxRetries > 0) {
-        // Note this Fetcher will correctly handle maxRetries == 0; we avoid it just in case there's
-        // a bug in this code. We should remove the if statement once we're sure of the stability.
-        new RetryingBlockTransferor(transportConf, blockFetchStarter, blockIds, listener).start()
-      } else {
-        blockFetchStarter.createAndStart(blockIds, listener)
-      }
+      new RetryingBlockTransferor(transportConf, blockFetchStarter, blockIds, listener).start()
     } catch {
       case e: Exception =>
         logger.error("Exception while beginning fetchBlocks", e)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Simplify code of fetchBlocks w/o retry

### Why are the changes needed?

Simplify code.

The original code added in SPARK-4188, the `RetryingBlockTransferor` looks quite stable now.

#33340 renames `RetryingBlockFetcher` to `RetryingBlockTransferor`, the comment still calls it as `Fetcher`, it's a little misleading.

```
if (maxRetries > 0) {
  // Note this Fetcher will correctly handle maxRetries == 0; we avoid it just in case there's
  // a bug in this code. We should remove the if statement once we're sure of the stability.
  new RetryingBlockTransferor(transportConf, blockFetchStarter, blockIds, listener).start()
} else {
  blockFetchStarter.createAndStart(blockIds, listener)
}
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

Update RetryingBlockTransferorSuite
