### PR TITLE
[SPARK-37580][CORE] Reset numFailures when one of task attempts succeeds

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -971,8 +971,14 @@ private[spark] class TaskSetManager(
     }
 
     if (successful(index)) {
-      logInfo(s"${taskName(info.taskId)} failed, but the task will not" +
-        " be re-executed (either because the task failed with a shuffle data fetch failure," +
+      val message = if (numFailures(index) >= maxTaskFailures) {
+        s"Task %d in stage %s failed %d times (current failed task %s (TID %s))".format(
+          index, taskSet.id, maxTaskFailures, info.id, info.taskId)
+      } else {
+        s"${taskName(info.taskId)} failed"
+      }
+      logInfo(s"$message, but the task will not be re-executed" +
+        " (either because the task failed with a shuffle data fetch failure," +
         " so the previous stage needs to be re-run, or because a different copy of the task" +
         " has already succeeded).")
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -964,7 +964,7 @@ private[spark] class TaskSetManager(
         info.host, info.executorId, index, failureReason))
       if (!successful(index)) {
         numFailures(index) += 1
-        if (numFailures(index) >= maxTaskFailures && !successful(index)) {
+        if (numFailures(index) >= maxTaskFailures) {
           logError("Task %d in stage %s failed %d times; aborting job".format(
             index, taskSet.id, maxTaskFailures))
           abort("Task %d in stage %s failed %d times, most recent failure: %s\nDriver stacktrace:"
@@ -975,8 +975,8 @@ private[spark] class TaskSetManager(
     }
 
     if (successful(index)) {
-      logInfo(s"${taskName(info.taskId)} failed, but the task will not be re-executed" +
-        " (either because the task failed with a shuffle data fetch failure," +
+      logInfo(s"${taskName(info.taskId)} failed, but the task will not" +
+        " be re-executed (either because the task failed with a shuffle data fetch failure," +
         " so the previous stage needs to be re-run, or because a different copy of the task" +
         " has already succeeded).")
     } else {

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -960,13 +960,15 @@ private[spark] class TaskSetManager(
       assert (null != failureReason)
       taskSetExcludelistHelperOpt.foreach(_.updateExcludedForFailedTask(
         info.host, info.executorId, index, failureReason))
-      numFailures(index) += 1
-      if (numFailures(index) >= maxTaskFailures && !successful(index)) {
-        logError("Task %d in stage %s failed %d times; aborting job".format(
-          index, taskSet.id, maxTaskFailures))
-        abort("Task %d in stage %s failed %d times, most recent failure: %s\nDriver stacktrace:"
-          .format(index, taskSet.id, maxTaskFailures, failureReason), failureException)
-        return
+      if (!successful(index)) {
+        numFailures(index) += 1
+        if (numFailures(index) >= maxTaskFailures && !successful(index)) {
+          logError("Task %d in stage %s failed %d times; aborting job".format(
+            index, taskSet.id, maxTaskFailures))
+          abort("Task %d in stage %s failed %d times, most recent failure: %s\nDriver stacktrace:"
+            .format(index, taskSet.id, maxTaskFailures, failureReason), failureException)
+          return
+        }
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -961,7 +961,7 @@ private[spark] class TaskSetManager(
       taskSetExcludelistHelperOpt.foreach(_.updateExcludedForFailedTask(
         info.host, info.executorId, index, failureReason))
       numFailures(index) += 1
-      if (numFailures(index) >= maxTaskFailures) {
+      if (numFailures(index) >= maxTaskFailures && !successful(index)) {
         logError("Task %d in stage %s failed %d times; aborting job".format(
           index, taskSet.id, maxTaskFailures))
         abort("Task %d in stage %s failed %d times, most recent failure: %s\nDriver stacktrace:"

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -959,7 +959,7 @@ private[spark] class TaskSetManager(
     sched.dagScheduler.taskEnded(tasks(index), reason, null, accumUpdates, metricPeaks, info)
 
     if (!isZombie && reason.countTowardsTaskFailures) {
-      assert(null != failureReason)
+      assert (null != failureReason)
       taskSetExcludelistHelperOpt.foreach(_.updateExcludedForFailedTask(
         info.host, info.executorId, index, failureReason))
       numFailures(index) += 1

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -820,6 +820,7 @@ private[spark] class TaskSetManager(
         s"on ${info.host} (executor ${info.executorId}) ($tasksSuccessful/$numTasks)")
       // Mark successful and stop if all the tasks have succeeded.
       successful(index) = true
+      numFailures(index) = 0
       if (tasksSuccessful == numTasks) {
         isZombie = true
       }
@@ -843,6 +844,7 @@ private[spark] class TaskSetManager(
       if (!successful(index)) {
         tasksSuccessful += 1
         successful(index) = true
+        numFailures(index) = 0
         if (tasksSuccessful == numTasks) {
           isZombie = true
         }
@@ -973,13 +975,7 @@ private[spark] class TaskSetManager(
     }
 
     if (successful(index)) {
-      val message = if (numFailures(index) >= maxTaskFailures) {
-        s"Task %d in stage %s failed %d times (current failed task %s (TID %s))".format(
-          index, taskSet.id, maxTaskFailures, info.id, info.taskId)
-      } else {
-        s"${taskName(info.taskId)} failed"
-      }
-      logInfo(s"$message, but the task will not be re-executed" +
+      logInfo(s"${taskName(info.taskId)} failed, but the task will not be re-executed" +
         " (either because the task failed with a shuffle data fetch failure," +
         " so the previous stage needs to be re-run, or because a different copy of the task" +
         " has already succeeded).")

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -959,18 +959,16 @@ private[spark] class TaskSetManager(
     sched.dagScheduler.taskEnded(tasks(index), reason, null, accumUpdates, metricPeaks, info)
 
     if (!isZombie && reason.countTowardsTaskFailures) {
-      assert (null != failureReason)
+      assert(null != failureReason)
       taskSetExcludelistHelperOpt.foreach(_.updateExcludedForFailedTask(
         info.host, info.executorId, index, failureReason))
-      if (!successful(index)) {
-        numFailures(index) += 1
-        if (numFailures(index) >= maxTaskFailures) {
-          logError("Task %d in stage %s failed %d times; aborting job".format(
-            index, taskSet.id, maxTaskFailures))
-          abort("Task %d in stage %s failed %d times, most recent failure: %s\nDriver stacktrace:"
-            .format(index, taskSet.id, maxTaskFailures, failureReason), failureException)
-          return
-        }
+      numFailures(index) += 1
+      if (numFailures(index) >= maxTaskFailures) {
+        logError("Task %d in stage %s failed %d times; aborting job".format(
+          index, taskSet.id, maxTaskFailures))
+        abort("Task %d in stage %s failed %d times, most recent failure: %s\nDriver stacktrace:"
+          .format(index, taskSet.id, maxTaskFailures, failureReason), failureException)
+        return
       }
     }
 

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2306,6 +2306,11 @@ class TaskSetManagerSuite
     val speculativeTask = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(speculativeTask.isDefined)
     manager.handleSuccessfulTask(speculativeTask.get.taskId, createTaskResult(1))
+    // if task success, numFailures will be reset to 0
+    val numFailuresField = classOf[TaskSetManager].getDeclaredField("numFailures")
+    numFailuresField.setAccessible(true)
+    val numFailures = numFailuresField.get(manager).asInstanceOf[Array[Int]]
+    assert(numFailures(1) == 0)
 
     // failed the originalTask(index 1) and check if the task manager is zombie
     val failedReason = ExceptionFailure("a", "b", Array(), "c", None)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2244,6 +2244,75 @@ class TaskSetManagerSuite
     // After 3s have elapsed now the task is marked as speculative task
     assert(sched.speculativeTasks.size == 1)
   }
+
+  test("task failed reach max failure threshold should check if another task " +
+    "succeed before abort job") {
+    sc = new SparkContext("local", "test")
+    // Set the speculation multiplier to be 0 so speculative tasks are launched immediately
+    sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
+    sc.conf.set(config.SPECULATION_QUANTILE, 0.6)
+    sc.conf.set(config.SPECULATION_ENABLED, true)
+
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"), ("exec2", "host2"), ("exec3", "host3"))
+    sched.backend = mock(classOf[SchedulerBackend])
+    val taskSet = FakeTask.createTaskSet(3)
+    val clock = new ManualClock()
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES, clock = clock)
+
+    // Offer resources for 3 task to start
+    val tasks = new ArrayBuffer[TaskDescription]()
+    for ((k, v) <- List("exec1" -> "host1", "exec2" -> "host2", "exec3" -> "host3")) {
+      val taskOption = manager.resourceOffer(k, v, NO_PREF)._1
+      assert(taskOption.isDefined)
+      val task = taskOption.get
+      assert(task.executorId === k)
+      tasks += task
+    }
+    assert(sched.startedTasks.toSet === (0 until 3).toSet)
+
+    def runningTaskForIndex(index: Int): TaskDescription = {
+      tasks.find { task =>
+        task.index == index && !sched.endedTasks.contains(task.taskId)
+      }.getOrElse {
+        throw new RuntimeException(s"couldn't find index $index in " +
+          s"tasks: ${tasks.map { t => t.index -> t.taskId }} with endedTasks:" +
+          s" ${sched.endedTasks.keys}")
+      }
+    }
+    clock.advance(1)
+
+    // running task with taskId 1 fail 3 times (not enough to abort the stage)
+    (0 until 3).foreach { attempt =>
+      val task = runningTaskForIndex(1)
+      logInfo(s"failing task $task")
+      val endReason = ExceptionFailure("a", "b", Array(), "c", None)
+      manager.handleFailedTask(task.taskId, TaskState.FAILED, endReason)
+      sched.endedTasks(task.taskId) = endReason
+      assert(!manager.isZombie)
+      val nextTask = manager.resourceOffer(s"exec2", s"host2", NO_PREF)._1
+      assert(nextTask.isDefined, s"no offer for attempt $attempt of 1")
+      tasks += nextTask.get
+    }
+
+    // make task(TID 2) success to speculative other tasks
+    manager.handleSuccessfulTask(2, createTaskResult(2))
+
+    val originalTask = runningTaskForIndex(1)
+    clock.advance(1)
+    assert(manager.checkSpeculatableTasks(0))
+    assert(sched.speculativeTasks.toSet === Set(0, 1))
+
+    // make the speculative task(TID 1) success
+    val speculativeTask = manager.resourceOffer("exec1", "host1", NO_PREF)._1
+    assert(speculativeTask.isDefined)
+    manager.handleSuccessfulTask(1, createTaskResult(1))
+
+    // failed the task(TID 1) and check if the task manager is zombie
+    val failedReason = ExceptionFailure("a", "b", Array(), "c", None)
+    manager.handleFailedTask(originalTask.taskId, TaskState.FAILED, failedReason)
+    assert(!manager.isZombie)
+  }
+
 }
 
 class FakeLongTasks(stageId: Int, partitionId: Int) extends FakeTask(stageId, partitionId) {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2245,8 +2245,7 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.size == 1)
   }
 
-  test("SPARK-37580: task failed reach max failure threshold should check if another attempt " +
-    "succeeded before abort the stage") {
+  test("SPARK-37580: Reset numFailures when one of task attempts succeeds") {
     sc = new SparkContext("local", "test")
     // Set the speculation multiplier to be 0 so speculative tasks are launched immediately
     sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2245,8 +2245,8 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.size == 1)
   }
 
-  test("task failed reach max failure threshold should check if another task " +
-    "succeed before abort job") {
+  test("task failed reach max failure threshold should check if another attempt " +
+    "succeeded before abort the stage") {
     sc = new SparkContext("local", "test")
     // Set the speculation multiplier to be 0 so speculative tasks are launched immediately
     sc.conf.set(config.SPECULATION_MULTIPLIER, 0.0)
@@ -2281,7 +2281,7 @@ class TaskSetManagerSuite
     }
     clock.advance(1)
 
-    // running task with taskId 1 fail 3 times (not enough to abort the stage)
+    // running task with taskId(TID 1) fail 3 times (not enough to abort the stage)
     (0 until 3).foreach { attempt =>
       val task = runningTaskForIndex(1)
       logInfo(s"failing task $task")

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2245,7 +2245,7 @@ class TaskSetManagerSuite
     assert(sched.speculativeTasks.size == 1)
   }
 
-  test("task failed reach max failure threshold should check if another attempt " +
+  test("SPARK-37580 task failed reach max failure threshold should check if another attempt " +
     "succeeded before abort the stage") {
     sc = new SparkContext("local", "test")
     // Set the speculation multiplier to be 0 so speculative tasks are launched immediately

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2281,7 +2281,7 @@ class TaskSetManagerSuite
     }
     clock.advance(1)
 
-    // running task with taskId(TID 1) fail 3 times (not enough to abort the stage)
+    // running task with taskId(index 1) fail 3 times (not enough to abort the stage)
     (0 until 3).foreach { attempt =>
       val task = runningTaskForIndex(1)
       logInfo(s"failing task $task")
@@ -2302,12 +2302,12 @@ class TaskSetManagerSuite
     assert(manager.checkSpeculatableTasks(0))
     assert(sched.speculativeTasks.toSet === Set(0, 1))
 
-    // make the speculative task(TID 1) success
+    // make the speculative task(index 1) success
     val speculativeTask = manager.resourceOffer("exec1", "host1", NO_PREF)._1
     assert(speculativeTask.isDefined)
-    manager.handleSuccessfulTask(1, createTaskResult(1))
+    manager.handleSuccessfulTask(speculativeTask.get.taskId, createTaskResult(1))
 
-    // failed the task(TID 1) and check if the task manager is zombie
+    // failed the originalTask(index 1) and check if the task manager is zombie
     val failedReason = ExceptionFailure("a", "b", Array(), "c", None)
     manager.handleFailedTask(originalTask.taskId, TaskState.FAILED, failedReason)
     assert(!manager.isZombie)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2461,9 +2461,10 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.task.maxFailures</code></td>
   <td>4</td>
   <td>
-    Number of failures of any particular task before giving up on the job.
+    Number of continuous failures of any particular task before giving up on the job.
     The total number of failures spread across different tasks will not cause the job
-    to fail; a particular task has to fail this number of attempts.
+    to fail; a particular task has to fail this number of attempts continuously.
+    Be aware that if one of attempts succeed, current count of task failures will be reset.
     Should be greater than or equal to 1. Number of allowed retries = this value - 1.
   </td>
   <td>0.8.0</td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2464,7 +2464,7 @@ Apart from these, the following properties are also available, and may be useful
     Number of continuous failures of any particular task before giving up on the job.
     The total number of failures spread across different tasks will not cause the job
     to fail; a particular task has to fail this number of attempts continuously.
-    Be aware that if one of attempts succeed, current count of task failures will be reset.
+    If any attempt succeeds, the failure count for the task will be reset.
     Should be greater than or equal to 1. Number of allowed retries = this value - 1.
   </td>
   <td>0.8.0</td>

--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -163,7 +163,7 @@ The master URL passed to Spark can be in one of the following formats:
 <tr><th>Master URL</th><th>Meaning</th></tr>
 <tr><td> <code>local</code> </td><td> Run Spark locally with one worker thread (i.e. no parallelism at all). </td></tr>
 <tr><td> <code>local[K]</code> </td><td> Run Spark locally with K worker threads (ideally, set this to the number of cores on your machine). </td></tr>
-<tr><td> <code>local[K,F]</code> </td><td> Run Spark locally with K worker threads and F continuous maxFailures (see <a href="configuration.html#scheduling">spark.task.maxFailures</a> for an explanation of this variable). </td></tr>
+<tr><td> <code>local[K,F]</code> </td><td> Run Spark locally with K worker threads and F maxFailures (see <a href="configuration.html#scheduling">spark.task.maxFailures</a> for an explanation of this variable). </td></tr>
 <tr><td> <code>local[*]</code> </td><td> Run Spark locally with as many worker threads as logical cores on your machine.</td></tr>
 <tr><td> <code>local[*,F]</code> </td><td> Run Spark locally with as many worker threads as logical cores on your machine and F maxFailures.</td></tr>
 <tr><td> <code>local-cluster[N,C,M]</code> </td><td> Local-cluster mode is only for unit tests. It emulates a distributed cluster in a single JVM with N number of workers, C cores per worker and M MiB of memory per worker.</td></tr>

--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -163,7 +163,7 @@ The master URL passed to Spark can be in one of the following formats:
 <tr><th>Master URL</th><th>Meaning</th></tr>
 <tr><td> <code>local</code> </td><td> Run Spark locally with one worker thread (i.e. no parallelism at all). </td></tr>
 <tr><td> <code>local[K]</code> </td><td> Run Spark locally with K worker threads (ideally, set this to the number of cores on your machine). </td></tr>
-<tr><td> <code>local[K,F]</code> </td><td> Run Spark locally with K worker threads and F maxFailures (see <a href="configuration.html#scheduling">spark.task.maxFailures</a> for an explanation of this variable). </td></tr>
+<tr><td> <code>local[K,F]</code> </td><td> Run Spark locally with K worker threads and F continuous maxFailures (see <a href="configuration.html#scheduling">spark.task.maxFailures</a> for an explanation of this variable). </td></tr>
 <tr><td> <code>local[*]</code> </td><td> Run Spark locally with as many worker threads as logical cores on your machine.</td></tr>
 <tr><td> <code>local[*,F]</code> </td><td> Run Spark locally with as many worker threads as logical cores on your machine and F maxFailures.</td></tr>
 <tr><td> <code>local-cluster[N,C,M]</code> </td><td> Local-cluster mode is only for unit tests. It emulates a distributed cluster in a single JVM with N number of workers, C cores per worker and M MiB of memory per worker.</td></tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reset `numFailures` whenever a task attempt succeeds.


### Why are the changes needed?
In extreme situation, if  one task has failed 3 times(max failed threshold is 4 in default), and there is a retry task and speculative task both in running state, then one of these 2 task attempts succeed and to cancel another. But executor which task need to be cancelled lost(oom in our situcation), this task marked as failed, and TaskSetManager handle this failed task attempt, it has failed 4 times so abort this stage and cause job failed.


### Does this PR introduce _any_ user-facing change?
Yes, the meaning of `spark.task.maxFailures` has changed, from total count to continuous count of one particular task 


### How was this patch tested?
Unit test.
