### PR TITLE
[SPARK-37598][PYTHON] Adding support for ShortWriables to pyspark's newAPIHadoopRDD method

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -76,6 +76,7 @@ private[python] class WritableToJavaConverter(
       case fw: FloatWritable => fw.get()
       case t: Text => t.toString
       case bw: BooleanWritable => bw.get()
+      case byw: ByteWritable => byw.get()
       case byw: BytesWritable =>
         val bytes = new Array[Byte](byw.getLength)
         System.arraycopy(byw.getBytes(), 0, bytes, 0, byw.getLength)
@@ -124,9 +125,11 @@ private[python] class JavaToWritableConverter extends Converter[Any, Writable] {
       case i: java.lang.Integer => new IntWritable(i)
       case d: java.lang.Double => new DoubleWritable(d)
       case l: java.lang.Long => new LongWritable(l)
+      case s: java.lang.Short => new ShortWritable(s)
       case f: java.lang.Float => new FloatWritable(f)
       case s: java.lang.String => new Text(s)
       case b: java.lang.Boolean => new BooleanWritable(b)
+      case b: java.lang.Byte => new ByteWritable(b)
       case aob: Array[Byte] => new BytesWritable(aob)
       case null => NullWritable.get()
       case map: java.util.Map[_, _] =>

--- a/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonHadoopUtil.scala
@@ -72,6 +72,7 @@ private[python] class WritableToJavaConverter(
       case iw: IntWritable => iw.get()
       case dw: DoubleWritable => dw.get()
       case lw: LongWritable => lw.get()
+      case sw: ShortWritable => sw.get()
       case fw: FloatWritable => fw.get()
       case t: Text => t.toString
       case bw: BooleanWritable => bw.get()

--- a/core/src/test/scala/org/apache/spark/api/python/PythonHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonHadoopUtilSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.python
+
+import java.util.HashMap
+
+import org.apache.hadoop.io.{MapWritable, ShortWritable, Text}
+import org.junit.Assert
+import org.mockito.Mockito.mock
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.util.SerializableConfiguration
+
+class PythonHadoopUtilSuite extends SparkFunSuite {
+  test("Testing that ShortWritables convert to Shorts") {
+    val broadcast = mock(classOf[Broadcast[SerializableConfiguration]])
+    val writableToJavaConverter = new WritableToJavaConverter(broadcast)
+    val shortWritable = new ShortWritable(5)
+    val result = writableToJavaConverter.convert(shortWritable)
+    val expected = 5.asInstanceOf[Short]
+    Assert.assertEquals(expected, result)
+  }
+
+  test("Testing that ShortWritables in MapWritables convert to Shorts") {
+    val broadcast = mock(classOf[Broadcast[SerializableConfiguration]])
+    val writableToJavaConverter = new WritableToJavaConverter(broadcast)
+    val keyString = "key"
+    val key = new Text(keyString)
+    val shortWritable = new ShortWritable(5)
+    val mapWritable = new MapWritable()
+    mapWritable.put(key, shortWritable)
+    val result = writableToJavaConverter.convert(mapWritable)
+    val expected = new HashMap[String, Short]()
+    expected.put(keyString, 5.asInstanceOf[Short])
+    Assert.assertEquals(expected, result)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/api/python/PythonHadoopUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonHadoopUtilSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.api.python
 
 import java.util.HashMap
 
-import org.apache.hadoop.io.{MapWritable, ShortWritable, Text}
+import org.apache.hadoop.io.{BooleanWritable, BytesWritable, ByteWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable,
+  MapWritable, NullWritable, ShortWritable, Text, Writable}
 import org.junit.Assert
 import org.mockito.Mockito.mock
 
@@ -28,26 +29,52 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.util.SerializableConfiguration
 
 class PythonHadoopUtilSuite extends SparkFunSuite {
-  test("Testing that ShortWritables convert to Shorts") {
+  def checkConversion(input: Writable, expected: Any): Unit = {
     val broadcast = mock(classOf[Broadcast[SerializableConfiguration]])
     val writableToJavaConverter = new WritableToJavaConverter(broadcast)
-    val shortWritable = new ShortWritable(5)
-    val result = writableToJavaConverter.convert(shortWritable)
-    val expected = 5.asInstanceOf[Short]
-    Assert.assertEquals(expected, result)
+    val result = writableToJavaConverter.convert(input)
+    expected match {
+      case _: Array[Byte] => Assert.assertArrayEquals(
+        expected.asInstanceOf[Array[Byte]], result.asInstanceOf[Array[Byte]])
+      case _ => Assert.assertEquals(expected, result)
+    }
+    val javaToWritableConverter = new JavaToWritableConverter()
+    val reConverted = javaToWritableConverter.convert(result)
+    Assert.assertEquals("Round trip conversion failed", input, reConverted)
   }
 
-  test("Testing that ShortWritables in MapWritables convert to Shorts") {
-    val broadcast = mock(classOf[Broadcast[SerializableConfiguration]])
-    val writableToJavaConverter = new WritableToJavaConverter(broadcast)
-    val keyString = "key"
-    val key = new Text(keyString)
+  test("Testing roundtrip conversion of various types") {
+    checkConversion(new IntWritable(5), 5.asInstanceOf[Int])
+    checkConversion(new DoubleWritable(5.2), 5.2.asInstanceOf[Double])
+    checkConversion(new LongWritable(Long.MaxValue), Long.MaxValue.asInstanceOf[Long])
+    checkConversion(new ShortWritable(5), 5.asInstanceOf[Short])
+    checkConversion(new FloatWritable(5.2f), 5.2.asInstanceOf[Float])
+    checkConversion(new Text("This is some text"), "This is some text")
+    checkConversion(new BooleanWritable(true), true)
+    checkConversion(new BooleanWritable(false), false)
+    checkConversion(new ByteWritable(5), 5.asInstanceOf[Byte])
+    checkConversion(NullWritable.get(), null)
+  }
+
+  test("Testing that BytesWritables convert to arrays of bytes and back") {
+    val byteArray = Array.fill[Byte](5)(1)
+    val bytesWritable = new BytesWritable(byteArray)
+    checkConversion(bytesWritable, byteArray)
+  }
+
+  test("Testing that MapWritables convert to Maps and back") {
+    val key1String = "key1"
+    val key1 = new Text(key1String)
+    val key2String = "key2"
+    val key2 = new Text(key2String)
     val shortWritable = new ShortWritable(5)
+    val longWritable = new LongWritable(55)
     val mapWritable = new MapWritable()
-    mapWritable.put(key, shortWritable)
-    val result = writableToJavaConverter.convert(mapWritable)
-    val expected = new HashMap[String, Short]()
-    expected.put(keyString, 5.asInstanceOf[Short])
-    Assert.assertEquals(expected, result)
+    mapWritable.put(key1, shortWritable)
+    mapWritable.put(key2, longWritable)
+    val expected = new HashMap[String, Any]()
+    expected.put(key1String, 5.asInstanceOf[Short])
+    expected.put(key2String, 55.asInstanceOf[Long])
+    checkConversion(mapWritable, expected)
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
This commit adds support for RDDs containing ShortWritables to pyspark. Right now if a user calls sc.newAPIHadoopRDD() with an InputFormat that provides ShortWritables, the call will fail with an error like the one below because ShortWritable is not explicitly handled by PythonHadoopUtil.
```
>>> rdd = sc.newAPIHadoopRDD(inputFormatClass="org.elasticsearch.hadoop.mr.EsInputFormat",
...                          keyClass="org.apache.hadoop.io.NullWritable",
...                          valueClass="org.elasticsearch.hadoop.mr.LinkedMapWritable",
...                          conf=conf)
2021-12-08 14:38:40,439 ERROR scheduler.TaskSetManager: task 0.0 in stage 15.0 (TID 31) had a not serializable result: org.apache.hadoop.io.ShortWritable
Serialization stack:
	- object not serializable (class: org.apache.hadoop.io.ShortWritable, value: 1)
	- writeObject data (class: java.util.HashMap)
	- object (class java.util.HashMap, {price=1})
	- field (class: scala.Tuple2, name: _2, type: class java.lang.Object)
	- object (class scala.Tuple2, (1,{price=1}))
	- element of array (index: 0)
	- array (class [Lscala.Tuple2;, size 1); not retrying
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/home/hduser/spark-3.1.2-bin-hadoop3.2/python/pyspark/context.py", line 853, in newAPIHadoopRDD
    jconf, batchSize)
  File "/home/hduser/spark-3.1.2-bin-hadoop3.2/python/lib/py4j-0.10.9-src.zip/py4j/java_gateway.py", line 1305, in __call__
  File "/home/hduser/spark-3.1.2-bin-hadoop3.2/python/pyspark/sql/utils.py", line 111, in deco
    return f(*a, **kw)
  File "/home/hduser/spark-3.1.2-bin-hadoop3.2/python/lib/py4j-0.10.9-src.zip/py4j/protocol.py", line 328, in get_return_value
py4j.protocol.Py4JJavaError: An error occurred while calling z:org.apache.spark.api.python.PythonRDD.newAPIHadoopRDD.
: org.apache.spark.SparkException: Job aborted due to stage failure: task 0.0 in stage 15.0 (TID 31) had a not serializable result: org.apache.hadoop.io.ShortWritable
Serialization stack:
	- object not serializable (class: org.apache.hadoop.io.ShortWritable, value: 1)
	- writeObject data (class: java.util.HashMap)
	- object (class java.util.HashMap, {price=1})
	- field (class: scala.Tuple2, name: _2, type: class java.lang.Object)
	- object (class scala.Tuple2, (1,{price=1}))
	- element of array (index: 0)
	- array (class [Lscala.Tuple2;, size 1)
	at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:2258)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:2207)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:2206)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:2206)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:1079)
	at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:1079)
	at scala.Option.foreach(Option.scala:407)
	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:1079)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2445)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2387)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2376)
	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:868)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2196)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2217)
	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2236)
	at org.apache.spark.rdd.RDD.$anonfun$take$1(RDD.scala:1449)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
	at org.apache.spark.rdd.RDD.withScope(RDD.scala:414)
	at org.apache.spark.rdd.RDD.take(RDD.scala:1422)
	at org.apache.spark.api.python.SerDeUtil$.pairRDDToPython(SerDeUtil.scala:173)
	at org.apache.spark.api.python.PythonRDD$.newAPIHadoopRDD(PythonRDD.scala:385)
	at org.apache.spark.api.python.PythonRDD.newAPIHadoopRDD(PythonRDD.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:282)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748)
```

### Why are the changes needed?
Without these changes, ShortWritables coming from a Hadoop InputFormat will not be converted to Shorts. Instead they will remain ShortWritables. ShortWritables are not Serializable, so spark will fail with a serialization error.

### Does this PR introduce _any_ user-facing change?
Users will be able to use InputFormats that use ShortWritables, which was previously not possible.

### How was this patch tested?
I have adde unit tests in org.apache.spark.api.python.PythonHadoopUtilSuite. Without the code change these tests fail. I have also manually tested this in the situation where this originally came up -- if an Elasticsearch mapping has a short field and you read the data out using es-hadoop's pyspark integration's newAPIHadoopRDD method then it was previously failing but succeeds now.