### PR TITLE
[SPARK-37569][SQL] Don't mark nested view fields as nullable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3543,7 +3543,7 @@ class Analyzer(override val catalogManager: CatalogManager)
         case u @ UpCast(child, _, walkedTypePath) if !Cast.canUpCast(child.dataType, u.dataType) =>
           fail(child, u.dataType, walkedTypePath)
 
-        case u @ UpCast(child, _, _) => Cast(child, u.dataType.asNullable)
+        case u @ UpCast(child, _, _) => Cast(child, u.dataType)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -393,6 +393,18 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
       assert(e2.message.contains("Cannot time travel views"))
     }
   }
+
+  test("SPARK-37569: view should report correct nullability information for nested fields") {
+    withView("v") {
+      val sql = "SELECT id, named_struct('a', id) AS nested FROM RANGE(10)"
+      val df = spark.sql(sql)
+
+      spark.sql(s"CREATE VIEW v AS $sql")
+      val dfFromView = spark.table("v")
+
+      assert(df.schema == dfFromView.schema)
+    }
+  }
 }
 
 abstract class TempViewTestSuite extends SQLViewTestSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -395,13 +395,11 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-37569: view should report correct nullability information for nested fields") {
-    withView("v") {
-      val sql = "SELECT id, named_struct('a', id) AS nested FROM RANGE(10)"
+    val sql = "SELECT id, named_struct('a', id) AS nested FROM RANGE(10)"
+    val viewName = createView("testView", sql)
+    withView(viewName) {
       val df = spark.sql(sql)
-
-      spark.sql(s"CREATE VIEW v AS $sql")
-      val dfFromView = spark.table("v")
-
+      val dfFromView = spark.table(viewName)
       assert(df.schema == dfFromView.schema)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

When analyzing a view, we should not unnecessarily mark nested fields as nullable. If the columns projected by the view define themselves as non-nullable, their nullability should be preserved.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

Consider a view as follows with all fields non-nullable (required)
```
spark.sql("""
    CREATE OR REPLACE VIEW v AS 
    SELECT id, named_struct('a', id) AS nested
    FROM RANGE(10)
""")
```

When trying to read this view, it incorrectly marks nested column a as nullable
```
scala> spark.table("v2").printSchema
root
 |-- id: long (nullable = false)
 |-- nested: struct (nullable = false)
 |    |-- a: long (nullable = true)
```

However, we can see that the view schema has been correctly stored as non-nullable
```
scala> System.out.println(spark.sessionState.catalog.externalCatalog.getTable("default", "v2"))
CatalogTable(
Database: default
Table: v2
.
.
.
Schema: root
 |-- id: long (nullable = false)
 |-- nested: struct (nullable = false)
 |    |-- a: long (nullable = false)
)
```

This is caused by [this line](https://github.com/apache/spark/blob/fb40c0e19f84f2de9a3d69d809e9e4031f76ef90/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala#L3546) in Analyzer.scala. Going through the history of changes for this block of code, it seems like `asNullable` is a remnant of a time before we added [checks](https://github.com/apache/spark/blob/fb40c0e19f84f2de9a3d69d809e9e4031f76ef90/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala#L3543) to ensure that the from and to types of the cast were compatible. As nullability is already checked, it should be safe to add a cast without converting the target datatype to nullable.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. View analysis will preserve nullability of nested fields instead of marking all nested fields as nullable.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added unit test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
