### PR TITLE
[SPARK-31785][SQL][FOLLOWUP] Rename `withAllParquetReaders` to `withAllNativeParquetReaders`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -80,7 +80,7 @@ abstract class ParquetFileFormatSuite
           withTempPath { file =>
             val df = spark.createDataFrame(sparkContext.parallelize(data), schema)
             df.write.parquet(file.getCanonicalPath)
-            withAllParquetReaders {
+            withAllNativeParquetReaders {
               val df2 = spark.read.parquet(file.getCanonicalPath)
               checkAnswer(df2, df.collect().toSeq)
             }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -890,7 +890,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
 
   test("Filter applied on merged Parquet schema with new column should work") {
     import testImplicits._
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       withSQLConf(SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> "true",
         SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true") {
         withTempPath { dir =>
@@ -1326,7 +1326,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
   }
 
   test("SPARK-17213: Broken Parquet filter push-down for string columns") {
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       withTempPath { dir =>
         import testImplicits._
 
@@ -1349,7 +1349,7 @@ abstract class ParquetFilterSuite extends QueryTest with ParquetTest with Shared
   test("SPARK-31026: Parquet predicate pushdown for fields having dots in the names") {
     import testImplicits._
 
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       withSQLConf(
           SQLConf.PARQUET_FILTER_PUSHDOWN_ENABLED.key -> true.toString,
           SQLConf.SUPPORT_QUOTED_REGEX_COLUMN_NAME.key -> "false") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -122,7 +122,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   test("SPARK-36182: TimestampNTZ") {
     val data = Seq("2021-01-01T00:00:00", "1970-07-15T01:02:03.456789")
       .map(ts => Tuple1(LocalDateTime.parse(ts)))
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       checkParquetFile(data)
     }
   }
@@ -155,7 +155,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
         }
         writer.close
 
-        withAllParquetReaders {
+        withAllNativeParquetReaders {
           val df = spark.read.parquet(tablePath.toString)
           assertResult(df.schema) {
             StructType(
@@ -859,7 +859,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   }
 
   test("read dictionary encoded decimals written as INT32") {
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       checkAnswer(
         // Decimal column in this file is encoded using plain dictionary
         readResourceParquetFile("test-data/dec-in-i32.parquet"),
@@ -868,7 +868,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   }
 
   test("read dictionary encoded decimals written as INT64") {
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       checkAnswer(
         // Decimal column in this file is encoded using plain dictionary
         readResourceParquetFile("test-data/dec-in-i64.parquet"),
@@ -877,7 +877,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   }
 
   test("read dictionary encoded decimals written as FIXED_LEN_BYTE_ARRAY") {
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       checkAnswer(
         // Decimal column in this file is encoded using plain dictionary
         readResourceParquetFile("test-data/dec-in-fixed-len.parquet"),
@@ -886,7 +886,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
   }
 
   test("read dictionary and plain encoded timestamp_millis written as INT64") {
-    withAllParquetReaders {
+    withAllNativeParquetReaders {
       checkAnswer(
         // timestamp column in this file is encoded using combination of plain
         // and dictionary encodings.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetInteroperabilitySuite.scala
@@ -135,7 +135,7 @@ class ParquetInteroperabilitySuite extends ParquetCompatibilityTest with SharedS
 
           // Reading of data should succeed and should not fail with
           // java.lang.ClassCastException: optional int32 col-0 is not a group
-          withAllParquetReaders {
+          withAllNativeParquetReaders {
             checkAnswer(
               spark.read.schema(schema2).parquet(tableDir.getAbsolutePath),
               Seq(
@@ -176,7 +176,7 @@ class ParquetInteroperabilitySuite extends ParquetCompatibilityTest with SharedS
       FileUtils.copyFile(new File(impalaPath), new File(tableDir, "part-00001.parq"))
 
       Seq(false, true).foreach { int96TimestampConversion =>
-        withAllParquetReaders {
+        withAllNativeParquetReaders {
           withSQLConf(
               (SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
                 SQLConf.ParquetOutputTimestampType.INT96.toString),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRebaseDatetimeSuite.scala
@@ -171,7 +171,7 @@ abstract class ParquetRebaseDatetimeSuite
       // contain Spark version.
       "2_4_5" -> failInRead _,
       "2_4_6" -> successInRead _).foreach { case (version, checkDefaultRead) =>
-      withAllParquetReaders {
+      withAllNativeParquetReaders {
         checkReadMixedFiles(
           s"before_1582_date_v$version.snappy.parquet",
           "date",
@@ -196,7 +196,7 @@ abstract class ParquetRebaseDatetimeSuite
     Seq(
       "2_4_5" -> failInRead _,
       "2_4_6" -> successInRead _).foreach { case (version, checkDefaultRead) =>
-      withAllParquetReaders {
+      withAllNativeParquetReaders {
         Seq("plain", "dict").foreach { enc =>
           checkReadMixedFiles(
             s"before_1582_timestamp_int96_${enc}_v$version.snappy.parquet",
@@ -249,7 +249,7 @@ abstract class ParquetRebaseDatetimeSuite
                   .parquet(path)
               }
 
-              withAllParquetReaders {
+              withAllNativeParquetReaders {
                 // The file metadata indicates if it needs rebase or not, so we can always get the
                 // correct result regardless of the "rebase mode" config.
                 runInMode(inReadConf, Seq(LEGACY, CORRECTED, EXCEPTION)) { options =>
@@ -287,7 +287,7 @@ abstract class ParquetRebaseDatetimeSuite
             .parquet(path)
         }
 
-        withAllParquetReaders {
+        withAllNativeParquetReaders {
           // The file metadata indicates if it needs rebase or not, so we can always get the
           // correct result regardless of the "rebase mode" config.
           runInMode(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -161,7 +161,7 @@ private[sql] trait ParquetTest extends FileBasedDataSourceTest {
     Thread.currentThread().getContextClassLoader.getResource(name).toString
   }
 
-  def withAllParquetReaders(code: => Unit): Unit = {
+  def withAllNativeParquetReaders(code: => Unit): Unit = {
     // test the row-based reader
     withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false")(code)
     // test the vectorized reader

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveParquetSourceSuite.scala
@@ -390,7 +390,7 @@ class HiveParquetSourceSuite extends ParquetPartitioningTest with ParquetTest {
       val (ym, dt) = (java.time.Period.ofMonths(10), java.time.Duration.ofDays(1))
       val df = Seq((ym, dt)).toDF("ym", "dt")
       df.write.mode(SaveMode.Overwrite).format("parquet").saveAsTable(tableName)
-      withAllParquetReaders {
+      withAllNativeParquetReaders {
         checkAnswer(sql(s"select * from $tableName"), Row(ym, dt))
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to rename `withAllParquetReaders` to `withAllNativeParquetReaders`


### Why are the changes needed?
Apache Spark have non-native Parquet reader too. In SQL module, we only test native readers.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Exists test.
