### PR TITLE
[SPARK-37592][SQL] Improve performance of `JoinSelection`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -62,6 +62,8 @@ case class ResolvedHint(child: LogicalPlan, hints: HintInfo = HintInfo())
  */
 case class JoinHint(leftHint: Option[HintInfo], rightHint: Option[HintInfo]) {
 
+  def isEmpty: Boolean = leftHint.isEmpty && rightHint.isEmpty
+
   override def toString: String = {
     Seq(
       leftHint.map("leftHint=" + _),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -548,11 +548,9 @@ case class ApplyColumnarRulesAndInsertTransitions(
 
   def apply(plan: SparkPlan): SparkPlan = {
     var preInsertPlan: SparkPlan = plan
-    columnarRules.foreach((r : ColumnarRule) =>
-      preInsertPlan = r.preColumnarTransitions(preInsertPlan))
+    columnarRules.foreach( r => preInsertPlan = r.preColumnarTransitions(preInsertPlan))
     var postInsertPlan = insertTransitions(preInsertPlan, outputsColumnar)
-    columnarRules.reverse.foreach((r : ColumnarRule) =>
-      postInsertPlan = r.postColumnarTransitions(postInsertPlan))
+    columnarRules.reverse.foreach( r => postInsertPlan = r.postColumnarTransitions(postInsertPlan))
     postInsertPlan
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -550,7 +550,7 @@ case class ApplyColumnarRulesAndInsertTransitions(
     var preInsertPlan: SparkPlan = plan
     columnarRules.foreach(r => preInsertPlan = r.preColumnarTransitions(preInsertPlan))
     var postInsertPlan = insertTransitions(preInsertPlan, outputsColumnar)
-    columnarRules.reverse.foreach( r => postInsertPlan = r.postColumnarTransitions(postInsertPlan))
+    columnarRules.reverse.foreach(r => postInsertPlan = r.postColumnarTransitions(postInsertPlan))
     postInsertPlan
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/Columnar.scala
@@ -548,7 +548,7 @@ case class ApplyColumnarRulesAndInsertTransitions(
 
   def apply(plan: SparkPlan): SparkPlan = {
     var preInsertPlan: SparkPlan = plan
-    columnarRules.foreach( r => preInsertPlan = r.preColumnarTransitions(preInsertPlan))
+    columnarRules.foreach(r => preInsertPlan = r.preColumnarTransitions(preInsertPlan))
     var postInsertPlan = insertTransitions(preInsertPlan, outputsColumnar)
     columnarRules.reverse.foreach( r => postInsertPlan = r.postColumnarTransitions(postInsertPlan))
     postInsertPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -343,10 +343,13 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             }
         }
 
-        createBroadcastNLJoin(hintToBroadcastLeft(hint), hintToBroadcastRight(hint))
-          .orElse { if (hintToShuffleReplicateNL(hint)) createCartesianProduct() else None }
-          .getOrElse(createJoinWithoutHint())
-
+        if (hint.isEmpty) {
+          createJoinWithoutHint()
+        } else {
+          createBroadcastNLJoin(hintToBroadcastLeft(hint), hintToBroadcastRight(hint))
+            .orElse { if (hintToShuffleReplicateNL(hint)) createCartesianProduct() else None }
+            .getOrElse(createJoinWithoutHint())
+        }
 
       // --- Cases where this strategy does not apply ---------------------------------------------
       case _ => Nil


### PR DESCRIPTION
### What changes were proposed in this pull request?
When I reading the implement of AQE, I find the process select join with hint exists a lot cumbersome code.

The join hint has a relatively high learning curve for users, so the SQL not  contains join hint in more cases. 

### Why are the changes needed?
Improve performance of `JoinSelection`


### Does this PR introduce _any_ user-facing change?
'No'.
Just change the inner implement.


### How was this patch tested?
Jenkins test.
