### PR TITLE
[SPARK-37596][SQL] Add the support for struct type column in the DropDuplicate

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -3042,10 +3042,10 @@ class DataFrameSuite extends QueryTest
     checkAnswer(df.dropDuplicates("b.c1"), Row("d1", Row(1, 2)))
 
     // Multiple column in dropDuplicates
-    checkAnswer(df.dropDuplicates(Seq("a","b.c1")), Row("d1", Row(1, 2)))
+    checkAnswer(df.dropDuplicates(Seq("a", "b.c1")), Row("d1", Row(1, 2)))
 
     // multiple struct column in dropDuplicates
-    checkAnswer(df.dropDuplicates(Seq("b.c1","b.c2")), Row("d1", Row(1, 2)))
+    checkAnswer(df.dropDuplicates(Seq("b.c1", "b.c2")), Row("d1", Row(1, 2)))
 
     // Error scenario where struct column does not
     // exist is passed in the dropDuplicate
@@ -3062,7 +3062,7 @@ class DataFrameSuite extends QueryTest
     checkAnswer(df.dropDuplicates(Seq("b.struct2.c1")), Row("d1", Row(Row(4, 3), 2)))
 
     // Nested Struct with multiple columns in dropDuplicate
-    checkAnswer(df.dropDuplicates(Seq("a","b.struct2.c1")), Row("d1", Row(Row(4, 3), 2)))
+    checkAnswer(df.dropDuplicates(Seq("a", "b.struct2.c1")), Row("d1", Row(Row(4, 3), 2)))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the support for struct type column in the DropDuplicate in spark.Currently on using the struct col in the DropDuplicate we will get the below exception
```
case class StructDropDup(c1: Int, c2: Int)
val df = Seq(("d1", StructDropDup(1, 2)),
      ("d1", StructDropDup(1, 2))).toDF("a", "b")
df.dropDuplicates("b.c1")

org.apache.spark.sql.AnalysisException: Cannot resolve column name "b.c1" among (a, b)
  at org.apache.spark.sql.Dataset.$anonfun$dropDuplicates$1(Dataset.scala:2576)
  at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:245)
  at scala.collection.Iterator.foreach(Iterator.scala:941)
  at scala.collection.Iterator.foreach$(Iterator.scala:941)
  at scala.collection.AbstractIterator.foreach(Iterator.scala:1429) 
```

As workAround in order to find the the duplicate using the struct column

df1.withColumn("b.c1", col("b.c1")).dropDuplicates("b.c1").drop("b.c1").collect
```
df.withColumn("b.c1", col("b.c1")).dropDuplicates("b.c1").drop("b.c1").collect
res25: Array[org.apache.spark.sql.Row] = Array([d1,[1,2]])
```
Used the similar approach from the workaround to provide the support for the struct column whenever struct col is present in the dropDuplicate

After fix

```
case class StructDropDup(c1: Int, c2: Int)
val df = Seq(("d1", StructDropDup(1, 2)),
      ("d1", StructDropDup(1, 2))).toDF("a", "b")
df.dropDuplicates("b.c1").show

+---+------+
|  a|     b|
+---+------+
| d1|{1, 2}|
+---+------+

scala>  df.dropDuplicates("b.c1").queryExecution
== Parsed Logical Plan ==
Project [a#7, b#8]
+- Deduplicate [b.c1#63]
   +- Project [a#7, b#8, b#8.c1 AS c1#62 AS b.c1#63]
      +- Project [_1#2 AS a#7, _2#3 AS b#8]
         +- LocalRelation [_1#2, _2#3]

== Analyzed Logical Plan ==
a: string, b: struct<c1:int,c2:int>
Project [a#7, b#8]
+- Deduplicate [b.c1#63]
   +- Project [a#7, b#8, b#8.c1 AS b.c1#63]
      +- Project [_1#2 AS a#7, _2#3 AS b#8]
         +- LocalRelation [_1#2, _2#3]

== Optimized Logical Plan ==
Aggregate [b.c1#63], [first(a#7, false) AS a#68, first(b#8, false) AS b#70]
+- LocalRelation [a#7, b#8, b.c1#63]

== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortAggregate(key=[b.c1#63], functions=[first(a#7, false), first(b#8, false)], output=[a#68, b#70])
   +- Sort [b.c1#63 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(b.c1#63, 200), ENSURE_REQUIREMENTS, [id=#74]
         +- SortAggregate(key=[b.c1#63], functions=[partial_first(a#7, false), partial_first(b#8, false)], output=[b.c1#63, first#75, valueSet#76, first#77, valueSet#78])
            +- Sort [b.c1#63 ASC NULLS FIRST], false, 0
               +- LocalTableScan [a#7, b#8, b.c1#63]

```

### Why are the changes needed?
There is need to provide the the way to use the dropDuplicate with struct Column. In existing code we are getting exception on using the struct Column in the dropDuplicates.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added the Unit test and also tested using the spark-shell
