### PR TITLE
[SPARK-37597][WIP] Deduplicate the right side of left-semi join and left-anti join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -2155,7 +2155,7 @@ object RewriteIntersectAll extends Rule[LogicalPlan] {
 object DeduplicateLeftSemiLeftAntiRightSide extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
     _.containsPattern(LEFT_SEMI_OR_ANTI_JOIN), ruleId) {
-    case join @ Join(_, right, LeftSemiOrAnti(joinType), _, _) if !right.isInstanceOf[Aggregate] =>
+    case join @ Join(_, right, LeftSemiOrAnti(_), _, _) if !right.isInstanceOf[Aggregate] =>
       join.copy(right = Aggregate(right.output, right.output, right))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -108,6 +108,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.ConvertToLocalRelation" ::
       "org.apache.spark.sql.catalyst.optimizer.CostBasedJoinReorder" ::
       "org.apache.spark.sql.catalyst.optimizer.DecimalAggregates" ::
+      "org.apache.spark.sql.catalyst.optimizer.DeduplicateLeftSemiLeftAntiRightSide" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateAggregateFilter" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateLimits" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateMapObjects" ::


### PR DESCRIPTION
### What changes were proposed in this pull request?

Deduplicate the right side of left-semi join and left-anti join


### Why are the changes needed?

1, reduce the shuffle amount in the right side;
2, improve the chance to broadcast the right side;
3, reslove skewed keys in the right side;


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
added testsuits
