### PR TITLE
[SPARK-37591][SQL] Support the GCM mode by `aes_encrypt()`/`aes_decrypt()`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -21,13 +21,20 @@ import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
 
 /**
  * An utility class for constructing expressions.
  */
 public class ExpressionImplUtils {
+  private static final SecureRandom secureRandom = new SecureRandom();
+  private static final int GCM_IV_LEN = 12;
+  private static final int GCM_TAG_LEN = 128;
+
   public static byte[] aesEncrypt(byte[] input, byte[] key, UTF8String mode, UTF8String padding) {
     return aesInternal(input, key, mode.toString(), padding.toString(), Cipher.ENCRYPT_MODE);
   }
@@ -42,28 +49,44 @@ public class ExpressionImplUtils {
       String mode,
       String padding,
       int opmode) {
-    int inputLength = input.length;
-    int keyLength = key.length;
     SecretKeySpec secretKey;
 
-    if (!mode.equalsIgnoreCase("ECB") || !padding.equalsIgnoreCase("PKCS")) {
-      throw QueryExecutionErrors.aesModeUnsupportedError(mode, padding);
-    }
-
-    switch (keyLength) {
+    switch (key.length) {
       case 16:
       case 24:
       case 32:
-        secretKey = new SecretKeySpec(key, 0, keyLength, "AES");
+        secretKey = new SecretKeySpec(key, 0, key.length, "AES");
         break;
       default:
-        throw QueryExecutionErrors.invalidAesKeyLengthError(keyLength);
+        throw QueryExecutionErrors.invalidAesKeyLengthError(key.length);
       }
 
     try {
-      Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-      cipher.init(opmode, secretKey);
-      return cipher.doFinal(input, 0, inputLength);
+      if (mode.equalsIgnoreCase("ECB") && padding.equalsIgnoreCase("PKCS")) {
+        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+        cipher.init(opmode, secretKey);
+        return cipher.doFinal(input, 0, input.length);
+      } else if (mode.equalsIgnoreCase("GCM") && padding.equalsIgnoreCase("NONE")) {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        if (opmode == Cipher.ENCRYPT_MODE) {
+          byte[] iv = new byte[GCM_IV_LEN];
+          secureRandom.nextBytes(iv);
+          GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LEN, iv);
+          cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
+          byte[] encrypted = cipher.doFinal(input, 0, input.length);
+          ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + encrypted.length);
+          byteBuffer.put(iv);
+          byteBuffer.put(encrypted);
+          return byteBuffer.array();
+        } else {
+          assert(opmode == Cipher.DECRYPT_MODE);
+          GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LEN, input, 0, GCM_IV_LEN);
+          cipher.init(Cipher.DECRYPT_MODE, secretKey, parameterSpec);
+          return cipher.doFinal(input, GCM_IV_LEN, input.length - GCM_IV_LEN);
+        }
+      } else {
+        throw QueryExecutionErrors.aesModeUnsupportedError(mode, padding);
+      }
     } catch (GeneralSecurityException e) {
         throw new RuntimeException(e);
     }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -62,11 +62,13 @@ public class ExpressionImplUtils {
       }
 
     try {
-      if (mode.equalsIgnoreCase("ECB") && padding.equalsIgnoreCase("PKCS")) {
+      if (mode.equalsIgnoreCase("ECB") &&
+          (padding.equalsIgnoreCase("PKCS") || padding.equalsIgnoreCase("DEFAULT"))) {
         Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
         cipher.init(opmode, secretKey);
         return cipher.doFinal(input, 0, input.length);
-      } else if (mode.equalsIgnoreCase("GCM") && padding.equalsIgnoreCase("NONE")) {
+      } else if (mode.equalsIgnoreCase("GCM") &&
+          (padding.equalsIgnoreCase("NONE") || padding.equalsIgnoreCase("DEFAULT"))) {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         if (opmode == Cipher.ENCRYPT_MODE) {
           byte[] iv = new byte[GCM_IV_LEN];

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -321,7 +321,7 @@ case class CurrentUser() extends LeafExpression with Unevaluable {
       * expr - The binary value to encrypt.
       * key - The passphrase to use to encrypt the data.
       * mode - Specifies which block cipher mode should be used to encrypt messages.
-               Supported modes: ECB, GCM.
+               Valid modes: ECB, GCM.
       * padding - Specifies how to pad messages whose length is not a multiple of the block size.
                   Valid values: PKCS, NONE.
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -314,16 +314,16 @@ case class CurrentUser() extends LeafExpression with Unevaluable {
 @ExpressionDescription(
   usage = """
     _FUNC_(expr, key[, mode[, padding]]) - Returns an encrypted value of `expr` using AES in given `mode` with the specified `padding`.
-      Key lengths of 16, 24 and 32 bits are supported.
+      Key lengths of 16, 24 and 32 bits are supported. Supported combinations of (`mode`, `padding`) are ('ECB', 'PKCS') and ('GCM', 'NONE').
   """,
   arguments = """
     Arguments:
       * expr - The binary value to encrypt.
       * key - The passphrase to use to encrypt the data.
       * mode - Specifies which block cipher mode should be used to encrypt messages.
-               Supported modes: ECB.
+               Supported modes: ECB, GCM.
       * padding - Specifies how to pad messages whose length is not a multiple of the block size.
-                  Valid values: PKCS.
+                  Valid values: PKCS, NONE.
   """,
   examples = """
     Examples:
@@ -375,22 +375,24 @@ case class AesEncrypt(
 @ExpressionDescription(
   usage = """
     _FUNC_(expr, key[, mode[, padding]]) - Returns a decrepted value of `expr` using AES in `mode` with `padding`.
-      Key lengths of 16, 24 and 32 bits are supported.
+      Key lengths of 16, 24 and 32 bits are supported. Supported combinations of (`mode`, `padding`) are ('ECB', 'PKCS') and ('GCM', 'NONE').
   """,
   arguments = """
     Arguments:
       * expr - The binary value to decrypt.
       * key - The passphrase to use to decrypt the data.
       * mode - Specifies which block cipher mode should be used to decrypt messages.
-               Valid modes: ECB.
+               Valid modes: ECB, GCM.
       * padding - Specifies how to pad messages whose length is not a multiple of the block size.
-                  Valid values: PKCS.
+                  Valid values: PKCS, NONE.
   """,
   examples = """
     Examples:
       > SELECT _FUNC_(unbase64('4Hv0UKCx6nfUeAoPZo1z+w=='), 'abcdefghijklmnop');
        Spark
       > SELECT _FUNC_(unbase64('3lmwu+Mw0H3fi5NDvcu9lg=='), '1234567890abcdef', 'ECB', 'PKCS');
+       Spark SQL
+      > SELECT _FUNC_(unbase64('2sXi+jZd/ws+qFC1Tnzvvde5lz+8Haryz9HHBiyrVohXUG7LHA=='), '1234567890abcdef', 'GCM', 'NONE');
        Spark SQL
   """,
   since = "3.3.0",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -315,6 +315,7 @@ case class CurrentUser() extends LeafExpression with Unevaluable {
   usage = """
     _FUNC_(expr, key[, mode[, padding]]) - Returns an encrypted value of `expr` using AES in given `mode` with the specified `padding`.
       Key lengths of 16, 24 and 32 bits are supported. Supported combinations of (`mode`, `padding`) are ('ECB', 'PKCS') and ('GCM', 'NONE').
+      The default mode is ECB.
   """,
   arguments = """
     Arguments:
@@ -323,7 +324,7 @@ case class CurrentUser() extends LeafExpression with Unevaluable {
       * mode - Specifies which block cipher mode should be used to encrypt messages.
                Valid modes: ECB, GCM.
       * padding - Specifies how to pad messages whose length is not a multiple of the block size.
-                  Valid values: PKCS, NONE.
+                  Valid values: PKCS, NONE, DEFAULT. The DEFAULT padding means PKCS for ECB and NONE for GCM.
   """,
   examples = """
     Examples:
@@ -356,7 +357,7 @@ case class AesEncrypt(
         Seq(BinaryType, BinaryType, StringType, StringType)))
   }
   def this(input: Expression, key: Expression, mode: Expression) =
-    this(input, key, mode, Literal("PKCS"))
+    this(input, key, mode, Literal("DEFAULT"))
   def this(input: Expression, key: Expression) =
     this(input, key, Literal("ECB"))
 
@@ -376,6 +377,7 @@ case class AesEncrypt(
   usage = """
     _FUNC_(expr, key[, mode[, padding]]) - Returns a decrepted value of `expr` using AES in `mode` with `padding`.
       Key lengths of 16, 24 and 32 bits are supported. Supported combinations of (`mode`, `padding`) are ('ECB', 'PKCS') and ('GCM', 'NONE').
+      The default mode is ECB.
   """,
   arguments = """
     Arguments:
@@ -384,7 +386,7 @@ case class AesEncrypt(
       * mode - Specifies which block cipher mode should be used to decrypt messages.
                Valid modes: ECB, GCM.
       * padding - Specifies how to pad messages whose length is not a multiple of the block size.
-                  Valid values: PKCS, NONE.
+                  Valid values: PKCS, NONE, DEFAULT. The DEFAULT padding means PKCS for ECB and NONE for GCM.
   """,
   examples = """
     Examples:
@@ -392,7 +394,7 @@ case class AesEncrypt(
        Spark
       > SELECT _FUNC_(unbase64('3lmwu+Mw0H3fi5NDvcu9lg=='), '1234567890abcdef', 'ECB', 'PKCS');
        Spark SQL
-      > SELECT _FUNC_(unbase64('2sXi+jZd/ws+qFC1Tnzvvde5lz+8Haryz9HHBiyrVohXUG7LHA=='), '1234567890abcdef', 'GCM', 'NONE');
+      > SELECT _FUNC_(unbase64('2sXi+jZd/ws+qFC1Tnzvvde5lz+8Haryz9HHBiyrVohXUG7LHA=='), '1234567890abcdef', 'GCM');
        Spark SQL
   """,
   since = "3.3.0",
@@ -419,7 +421,7 @@ case class AesDecrypt(
         Seq(BinaryType, BinaryType, StringType, StringType)))
   }
   def this(input: Expression, key: Expression, mode: Expression) =
-    this(input, key, mode, Literal("PKCS"))
+    this(input, key, mode, Literal("DEFAULT"))
   def this(input: Expression, key: Expression) =
     this(input, key, Literal("ECB"))
 

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -12,7 +12,7 @@
 | org.apache.spark.sql.catalyst.expressions.Add | + | SELECT 1 + 2 | struct<(1 + 2):int> |
 | org.apache.spark.sql.catalyst.expressions.AddMonths | add_months | SELECT add_months('2016-08-31', 1) | struct<add_months(2016-08-31, 1):date> |
 | org.apache.spark.sql.catalyst.expressions.AesDecrypt | aes_decrypt | SELECT aes_decrypt(unbase64('4Hv0UKCx6nfUeAoPZo1z+w=='), 'abcdefghijklmnop') | struct<aesdecrypt(unbase64(4Hv0UKCx6nfUeAoPZo1z+w==), abcdefghijklmnop):binary> |
-| org.apache.spark.sql.catalyst.expressions.AesEncrypt | aes_encrypt | SELECT base64(aes_encrypt('Spark', 'abcdefghijklmnop')) | struct<base64(aesencrypt(Spark, abcdefghijklmnop, ECB, PKCS)):string> |
+| org.apache.spark.sql.catalyst.expressions.AesEncrypt | aes_encrypt | SELECT base64(aes_encrypt('Spark', 'abcdefghijklmnop')) | struct<base64(aesencrypt(Spark, abcdefghijklmnop, ECB, DEFAULT)):string> |
 | org.apache.spark.sql.catalyst.expressions.And | and | SELECT true and true | struct<(true AND true):boolean> |
 | org.apache.spark.sql.catalyst.expressions.ArrayAggregate | aggregate | SELECT aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x) | struct<aggregate(array(1, 2, 3), 0, lambdafunction((namedlambdavariable() + namedlambdavariable()), namedlambdavariable(), namedlambdavariable()), lambdafunction(namedlambdavariable(), namedlambdavariable())):int> |
 | org.apache.spark.sql.catalyst.expressions.ArrayContains | array_contains | SELECT array_contains(array(1, 2, 3), 2) | struct<array_contains(array(1, 2, 3), 2):boolean> |

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -386,7 +386,8 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     }
 
     // Unsupported AES mode and padding in decrypt
-    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GSM', 'PKCS')"))
+    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GSM')"))
+    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GCM', 'PKCS')"))
     checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value32, '$key32', 'ECB', 'None')"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -386,7 +386,7 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     }
 
     // Unsupported AES mode and padding in decrypt
-    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GSM')"))
+    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GSM', 'PKCS')"))
     checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value32, '$key32', 'ECB', 'None')"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -71,7 +71,8 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
       assert(encrypted.filter($"enc" === $"input").isEmpty)
       val result = encrypted.selectExpr(
         "CAST(aes_decrypt(enc, key, 'GCM', 'NONE') AS STRING) AS res", "input")
-      assert(!result.filter($"res" === $"input").isEmpty)
+      assert(!result.filter($"res" === $"input").isEmpty &&
+        result.filter($"res" =!= $"input").isEmpty)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.BinaryType
 
 class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
@@ -54,6 +55,23 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
       checkAnswer(df, Row(spark.sparkContext.sparkUser))
       val e = intercept[ParseException](sql("select current_user()"))
       assert(e.getMessage.contains("current_user"))
+    }
+  }
+
+  test("SPARK-37591: AES functions - GCM mode") {
+    Seq(
+      ("abcdefghijklmnop", ""),
+      ("abcdefghijklmnop", "abcdefghijklmnop"),
+      ("abcdefghijklmnop12345678", "Spark"),
+      ("abcdefghijklmnop12345678ABCDEFGH", "GCM mode")
+    ).foreach { case (key, input) =>
+      val df = Seq((key, input)).toDF("key", "input")
+      val encrypted = df.selectExpr("aes_encrypt(input, key, 'GCM', 'NONE') AS enc", "input", "key")
+      assert(encrypted.schema("enc").dataType === BinaryType)
+      assert(encrypted.filter($"enc" === $"input").isEmpty)
+      val result = encrypted.selectExpr(
+        "CAST(aes_decrypt(enc, key, 'GCM', 'NONE') AS STRING) AS res", "input")
+      assert(!result.filter($"res" === $"input").isEmpty)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose new AES mode for the `aes_encrypt()`/`aes_decrypt()` functions - `GCM` ([Galois/Counter Mode](https://en.wikipedia.org/wiki/Galois/Counter_Mode)) w/o padding. The `aes_encrypt()` function returns a binary value which consists of the following fields:
1. An initialization vector (IV) generated per every `aes_encrypt()` call using `java.security.SecureRandom`. The length of IV is 12 bytes.
2. The encrypted input.
3. An authentication tag that can be used to verify the integrity of the data. The length of the tag is 16 bytes.

The `aes_decrypt()` functions assumes that its input has the fields as showed above.

For example:
```sql
spark-sql> SELECT base64(aes_encrypt('Apache Spark', '0000111122223333', 'GCM', 'NONE'));
ak3k4wV71YJAjg6d5sUTm15Ag9fyQP0UL/ComBkBxzVvft2NBOCF+g==
spark-sql> SELECT aes_decrypt(unbase64('ak3k4wV71YJAjg6d5sUTm15Ag9fyQP0UL/ComBkBxzVvft2NBOCF+g=='), '0000111122223333', 'GCM', 'NONE');
Apache Spark
```

### Why are the changes needed?
To achieve feature parity with other systems/frameworks, and make the migration process from them to Spark SQL easier. For example, the `GCM` mode is supported by:
- BigQuery: https://cloud.google.com/bigquery/docs/reference/standard-sql/aead-encryption-concepts#block_cipher_modes
- Snowflake: https://docs.snowflake.com/en/sql-reference/functions/encrypt.html

### Does this PR introduce _any_ user-facing change?
No. The AES functions haven't been released yet.

### How was this patch tested?
By running new checks:
```
$ build/sbt "test:testOnly org.apache.spark.sql.DataFrameFunctionsSuite"
$ build/sbt "sql/test:testOnly org.apache.spark.sql.expressions.ExpressionInfoSuite"
$ build/sbt "test:testOnly org.apache.spark.sql.MiscFunctionsSuite"
```