### PR TITLE
[SPARK-37575][SQL] null values should be saved as nothing rather than quoted empty Strings "" by default settings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityGenerator.scala
@@ -95,7 +95,7 @@ class UnivocityGenerator(
       if (!row.isNullAt(i)) {
         values(i) = valueConverters(i).apply(row, i)
       } else {
-        values(i) = options.nullValue
+        values(i) = null
       }
       i += 1
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityGenerator.scala
@@ -94,8 +94,6 @@ class UnivocityGenerator(
     while (i < row.numFields) {
       if (!row.isNullAt(i)) {
         values(i) = valueConverters(i).apply(row, i)
-      } else {
-        values(i) = null
       }
       i += 1
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -805,19 +805,28 @@ abstract class CSVSuite
     }
   }
 
-  test("SPARK-37575: null values should not reflect to any characters by default") {
+  test("SPARK-37575: null values should be saved as nothing rather than " +
+    "quoted empty Strings \"\" with default settings") {
     val litNull: String = null
-    val data = Seq(("Tesla", litNull, ""))
+    val df = Seq(("Tesla", litNull, ""))
+      .toDF("make", "comment", "blank")
     withTempPath { path =>
-      val csvDir = new File(path, "csv")
-      val cars = data.toDF("make", "comment", "blank")
-      cars.coalesce(1).write.csv(csvDir.getCanonicalPath)
+      val csvDir = path.getCanonicalPath
+      df.write.csv(csvDir)
 
-      csvDir.listFiles().filter(_.getName.endsWith("csv")).foreach({ csvFile =>
-        val readBack = Files.readAllBytes(csvFile.toPath)
+      path.listFiles().filter(_.getName.endsWith("csv")).foreach({ csvFile =>
+        val csvData = Files.readAllBytes(csvFile.toPath)
         val expected = ("Tesla,,\"\"" + Properties.lineSeparator).getBytes()
-        assert(readBack === expected)
+        assert(csvData === expected)
       })
+
+      val results = spark.read
+        .format("csv")
+        .schema(df.schema)
+        .load(csvDir)
+        .collect()
+      val expected = Seq(Seq("Tesla", litNull, litNull))
+      assert(results.toSeq.map(_.toSeq) === expected)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -806,7 +806,8 @@ abstract class CSVSuite
   }
 
   test("SPARK-37575: null values should not reflect to any characters by default") {
-    val data = Seq(("Tesla", null.asInstanceOf[String], ""))
+    val litNull: String = null
+    val data = Seq(("Tesla", litNull, ""))
     withTempPath { path =>
       val csvDir = new File(path, "csv")
       val cars = data.toDF("make", "comment", "blank")
@@ -1784,7 +1785,7 @@ abstract class CSVSuite
         (1, "John Doe"),
         (2, "-"),
         (3, "-"),
-        (4, "-")
+        (4, null)
       ).toDF("id", "name")
 
       checkAnswer(computed, expected)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -808,7 +808,10 @@ abstract class CSVSuite
   test("SPARK-37575: null values should be saved as nothing rather than " +
     "quoted empty Strings \"\" with default settings") {
     withTempPath { path =>
-      Seq(("Tesla", null: String, "")).toDF("make", "comment", "blank").write.csv(path.getCanonicalPath)
+      Seq(("Tesla", null: String, ""))
+        .toDF("make", "comment", "blank")
+        .write
+        .csv(path.getCanonicalPath)
       checkAnswer(spark.read.text(path.getCanonicalPath), Row("Tesla,,\"\""))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the bug that null values are saved as quoted empty strings "" (as the same as empty strings) rather than nothing by default csv settings since Spark 2.4.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is an unexpected bug, if don't fix it,  we still can't distinguish null values and empty strings in saved csv files.

As mentioned in [spark sql migration guide](https://spark.apache.org/docs/latest/sql-migration-guide.html#upgrading-from-spark-sql-23-to-24)(2.3=>2.4), empty strings are saved as quoted empty string "", null values as saved as nothing since Spark 2.4.

> Since Spark 2.4, empty strings are saved as quoted empty strings "". In version 2.3 and earlier, empty strings are equal to null values and do not reflect to any characters in saved CSV files. For example, the row of "a", null, "", 1 was written as a,,,1. Since Spark 2.4, the same row is saved as a,,"",1. To restore the previous behavior, set the CSV option emptyValue to empty (not quoted) string.

But actually, we found that null values are also saved as quoted empty strings "" as the same as empty strings.

For codes follows:
```scala
Seq(("Tesla", null.asInstanceOf[String], ""))
  .toDF("make", "comment", "blank")
  .coalesce(1)
  .write.csv(path)
```

actual results:
>Tesla,"",""

expected results:
>Tesla,,""

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, if this bug has been fixed, the output of null values would been changed to nothing rather than quoted empty strings "".

But, users can set nullValue to "\\"\\""(same as emptyValueInWrite's default value) to restore the previous behavior since 2.4.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Adding a test case.