### PR TITLE
[SPARK-37602][CORE] Add config property to set default Spark listeners

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1310,7 +1310,10 @@ package object config {
       .toSequence
       .createWithDefault(Nil)
 
+  private[spark] val DEFAULT_LISTENERS = "spark.defaultListeners"
+
   private[spark] val EXTRA_LISTENERS = ConfigBuilder("spark.extraListeners")
+    .withPrepended(DEFAULT_LISTENERS, separator = ",")
     .doc("Class names of listeners to add to SparkContext during initialization.")
     .version("1.3.0")
     .stringConf

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -448,13 +448,14 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
     assert(jobCounter2.count === 5)
   }
 
-  test("registering listeners via spark.extraListeners") {
-    val listeners = Seq(
-      classOf[ListenerThatAcceptsSparkConf],
+  test("registering listeners via spark.extraListeners and spark.defaultListeners") {
+    val defaultListener = classOf[ListenerThatAcceptsSparkConf]
+    val extraListeners = Seq(
       classOf[FirehoseListenerThatAcceptsSparkConf],
       classOf[BasicJobCounter])
     val conf = new SparkConf().setMaster("local").setAppName("test")
-      .set(EXTRA_LISTENERS, listeners.map(_.getName))
+      .set(DEFAULT_LISTENERS, defaultListener.getName)
+      .set(EXTRA_LISTENERS, extraListeners.map(_.getName))
     sc = new SparkContext(conf)
     sc.listenerBus.listeners.asScala.count(_.isInstanceOf[BasicJobCounter]) should be (1)
     sc.listenerBus.listeners.asScala

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,6 +332,17 @@ of the most common options to set are:
   <td>1.3.0</td>
 </tr>
 <tr>
+  <td><code>spark.defaultListeners</code></td>
+  <td>(none)</td>
+  <td>
+    A comma-separated list of classes to prepend to <code>spark.extraListeners</code>.
+    This is intended to be set by administrators. This exists so that it is possible for the default
+    listeners to be placed in the Spark default config file, allowing users to easily add other
+    listeners from the command line without overwriting the config file's list.
+  </td>
+  <td>3.3.0</td>
+</tr>
+<tr>
   <td><code>spark.local.dir</code></td>
   <td>/tmp</td>
   <td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adds a new config property `spark.defaultListeners` which is intended to be set by administrators to signify the "default" set of Spark listeners to be used in the job. This list will be combined with `spark.extraListeners` at runtime. This is similar in spirit to `spark.driver.defaultJavaOptions` and `spark.plugins.defaultList`.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
`spark.extraListeners` allows users to custom Spark Listeners. Spark platform administrators would want to set their own set of "default" listeners for all jobs on the platform, however using `spark.extraListeners` makes it easy for end users to unknowingly override the default listeners.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, adds new a config property.


### How was this patch tested?
Modified existing UT to test new config property
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
