### PR TITLE
[SPARK-37606][SQL] ALTER NAMESPACE ... SET PROPERTIES v2 command should use existing properties in addition to new properties

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Util.scala
@@ -63,12 +63,10 @@ private[sql] object CatalogV2Util {
       SupportsNamespaces.PROP_OWNER)
 
   /**
-   * Apply properties changes to a map and return the result.
+   * Apply properties changes and return the result.
    */
-  def applyNamespaceChanges(
-      properties: Map[String, String],
-      changes: Seq[NamespaceChange]): Map[String, String] = {
-    applyNamespaceChanges(properties.asJava, changes).asScala.toMap
+  def applyNamespaceChanges(changes: Seq[NamespaceChange]): Map[String, String] = {
+    applyNamespaceChanges(Map[String, String]().asJava, changes).asScala.toMap
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
@@ -858,16 +858,16 @@ class CatalogSuite extends SparkFunSuite {
 
     catalog.alterNamespace(testNs, NamespaceChange.setProperty("property2", "value2"))
     assert(catalog.loadNamespaceMetadata(testNs).asScala === Map(
-      "property" -> "value", "property2" -> "value2"))
+      "property2" -> "value2"))
 
     catalog.alterNamespace(testNs,
       NamespaceChange.removeProperty("property2"),
       NamespaceChange.setProperty("property3", "value3"))
     assert(catalog.loadNamespaceMetadata(testNs).asScala === Map(
-      "property" -> "value", "property3" -> "value3"))
+      "property3" -> "value3"))
 
     catalog.alterNamespace(testNs, NamespaceChange.removeProperty("property3"))
-    assert(catalog.loadNamespaceMetadata(testNs).asScala === Map("property" -> "value"))
+    assert(catalog.loadNamespaceMetadata(testNs).asScala === Map())
   }
 
   test("alterNamespace: create metadata if missing and table exists") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -209,8 +209,7 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
   override def alterNamespace(
       namespace: Array[String],
       changes: NamespaceChange*): Unit = {
-    val metadata = loadNamespaceMetadata(namespace).asScala.toMap
-    namespaces.put(namespace.toList, CatalogV2Util.applyNamespaceChanges(metadata, changes))
+    namespaces.put(namespace.toList, CatalogV2Util.applyNamespaceChanges(changes))
   }
 
   override def dropNamespace(namespace: Array[String]): Boolean = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -209,7 +209,11 @@ class InMemoryTableCatalog extends BasicInMemoryTableCatalog with SupportsNamesp
   override def alterNamespace(
       namespace: Array[String],
       changes: NamespaceChange*): Unit = {
-    namespaces.put(namespace.toList, CatalogV2Util.applyNamespaceChanges(changes))
+    if (namespaceExists(namespace)) {
+      namespaces.put(namespace.toList, CatalogV2Util.applyNamespaceChanges(changes))
+    } else {
+      throw new NoSuchNamespaceException(namespace)
+    }
   }
 
   override def dropNamespace(namespace: Array[String]): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterNamespaceSetPropertiesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterNamespaceSetPropertiesExec.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.{NamespaceChange, SupportsNamespaces}
@@ -29,7 +31,8 @@ case class AlterNamespaceSetPropertiesExec(
     namespace: Seq[String],
     props: Map[String, String]) extends LeafV2CommandExec {
   override protected def run(): Seq[InternalRow] = {
-    val changes = props.map{ case (k, v) =>
+    val existingProps = catalog.loadNamespaceMetadata(namespace.toArray).asScala.toMap
+    val changes = (existingProps ++ props).map { case (k, v) =>
       NamespaceChange.setProperty(k, v)
     }.toSeq
     catalog.alterNamespace(namespace.toArray, changes: _*)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

For `ALTER NAMESPACE ... SET PROPERTIES`, v2 command uses only the properties specified in the command:
https://github.com/apache/spark/blob/5edd9592dda6a540b398e6f6a662ea603f0e8ce2/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterNamespaceSetPropertiesExec.scala#L31-L35, and the v2 catalog implementation is handles the existing properties. For example:
https://github.com/apache/spark/blob/5edd9592dda6a540b398e6f6a662ea603f0e8ce2/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala#L209-L214,

On the other hand, v1 command is responsible for adding the existing properties to the properties specified, not the catalog implementation:
https://github.com/apache/spark/blob/5edd9592dda6a540b398e6f6a662ea603f0e8ce2/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala#L132-L135

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make the v1 and v2 command consistent for `ALTER NAMESPACE ... SET PROPERTIES`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now `SupportsNamespaces.alterNamespace`'s `NamespaceChange... changes` gets existing properties as well.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests in `DataSourceV2SQLSuite` cover the changes.