### PR TITLE
[SPARK-30471][SQL]Fix issue when comparing String and IntegerType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -652,7 +652,13 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
       buildCast[UTF8String](_, UTF8StringUtils.toIntExact)
     case StringType =>
       val result = new IntWrapper()
-      buildCast[UTF8String](_, s => if (s.toInt(result)) result.value else null)
+      buildCast[UTF8String](_, s => {
+        if (s.toInt(result)) {
+          result.value}
+        else {
+          throw new ArithmeticException(s"Casting $s to int causes overflow")
+        }
+      })
     case BooleanType =>
       buildCast[Boolean](_, b => if (b) 1 else 0)
     case DateType =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -80,6 +80,14 @@ class CastSuite extends CastSuiteBase {
     checkEvaluation(Cast(Literal("2015-031-8"), DateType), null)
   }
 
+
+  test("cast from string to int overflow"){
+    val s = "11111111111111111111"
+    checkExceptionInExpression[ArithmeticException](
+      cast(s,IntegerType),expectedErrMsg = s"Casting $s to int causes overflow")
+    checkEvaluation(cast("11111111", IntegerType), 11111111.toInt)
+  }
+
   test("casting to fixed-precision decimals") {
     assert(cast(123, DecimalType.USER_DEFAULT).nullable === false)
     assert(cast(10.03f, DecimalType.SYSTEM_DEFAULT).nullable)


### PR DESCRIPTION
### What changes were proposed in this pull request?
For  comparing StringType and IntegerType, the value of string exceed Int.MaxValue, then should thrown exception.
Other wise, the result is null.
For example:
SQL "select cast('2147483648' as int);",which return is null.

### Why are the changes needed?
User needs to know when an exception occurs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added Unit test.