### PR TITLE
[SPARK-37601][PYTHON] sql.DataFrame.transform accept function parameters

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3058,7 +3058,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jdf = self._jdf.toDF(self._jseq(cols))
         return DataFrame(jdf, self.sql_ctx)
 
-    def transform(self, func: Callable[["DataFrame"], "DataFrame"]) -> "DataFrame":
+    def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
         """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
 
         .. versionadded:: 3.0.0
@@ -3067,6 +3067,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ----------
         func : function
             a function that takes and returns a :class:`DataFrame`.
+        args : Any
+            optional positional arguments for the func function
+        kwargs: Any
+            optional keyword arguments for the func function
 
         Examples
         --------
@@ -3083,8 +3087,17 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         |    1|  1|
         |    2|  2|
         +-----+---+
+        >>> def mul_by(input_df, m):
+        ...     return input_df.select([(col(col_name) * m).alias(col_name) for col_name in input_df.columns])
+        >>> df.transform(mul_by, 3).show()
+        +---+-----+
+        |int|float|
+        +---+-----+
+        |  3|  3.0|
+        |  6|  6.0|
+        +---+-----+
         """
-        result = func(self)
+        result = func(self, *args, **kwargs)
         assert isinstance(
             result, DataFrame
         ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)


### PR DESCRIPTION
### What changes were proposed in this pull request?
[SPARK-37601](https://issues.apache.org/jira/browse/SPARK-37601):

```python
def foo(df: DataFrame, p: int) -> DataFrame
  ...

# current:

from functools import partial
df.transform(partial(foo, p=3))

# or:

df.transform(lambda df: foo(df, p=3))

# vs this PR:

df.transform(foo, p=3)
```

### Does this PR introduce any user-facing change?
Yes, new feature.

### How was this patch tested?
Added Unit test.