### PR TITLE
[SPARK-37615][BUILD] Upgrade SBT to 1.5.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 # Please update the version in appveyor-install-dependencies.ps1 together.
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade SBT to 1.5.6.

### Why are the changes needed?

- https://github.com/sbt/sbt/releases/tag/v1.5.6
SBT 1.5.6 updates log4j 2 to 2.15.0, which fixes remote code execution vulnerability (CVE-2021-44228)

### Does this PR introduce _any_ user-facing change?

No. This only affects build servers.

### How was this patch tested?

Pass the CIs.