### PR TITLE
[SPARK-37615][BUILD][FOLLOWUP] Upgrade SBT to 1.5.6 in AppVeyor

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -97,7 +97,7 @@ if (!(Test-Path $tools)) {
 # ========================== SBT
 Push-Location $tools
 
-$sbtVer = "1.5.5"
+$sbtVer = "1.5.6"
 Start-FileDownload "https://github.com/sbt/sbt/releases/download/v$sbtVer/sbt-$sbtVer.zip" "sbt.zip"
 
 # extract


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #34869 . This PR aims to update SBT version in `AppVeyor` CI.

Please note that SPARK-37615 is backported to branch-3.2, but this PR is only for `master` branch because we changed `AppVeyor` in Apache Spark 3.3 only via `[SPARK-37103][INFRA] Switch from Maven to SBT to build Spark on AppVeyor` .

### Why are the changes needed?

For consistency.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass AppVeyor.