### PR TITLE
[SPARK-37616][SQL] Support pushing down a dynamic partition pruning from one join to other joins.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -341,6 +341,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DYNAMIC_PARTITION_PRUNING_PUSH_DOWN_ENABLED =
+    buildConf("spark.sql.optimizer.dynamicPartitionPruning.pushdown")
+      .internal()
+      .doc("When true, push down a dynamic partition pruning from one join to other joins.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")
@@ -3653,6 +3661,9 @@ class SQLConf extends Serializable with Logging {
 
   def dynamicPartitionPruningReuseBroadcastOnly: Boolean =
     getConf(DYNAMIC_PARTITION_PRUNING_REUSE_BROADCAST_ONLY)
+
+  def dynamicPartitionPruningPushdownEnabled: Boolean =
+    getConf(DYNAMIC_PARTITION_PRUNING_PUSH_DOWN_ENABLED)
 
   def stateStoreProviderClass: String = getConf(STATE_STORE_PROVIDER_CLASS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.datasources.PruneFileSourcePartitions
 import org.apache.spark.sql.execution.datasources.SchemaPruning
 import org.apache.spark.sql.execution.datasources.v2.{V2ScanRelationPushDown, V2Writes}
-import org.apache.spark.sql.execution.dynamicpruning.{CleanupDynamicPruningFilters, PartitionPruning}
+import org.apache.spark.sql.execution.dynamicpruning.{CleanupDynamicPruningFilters, PartitionPruning, PushDownDynamicPartitionPruning}
 import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggregate, ExtractPythonUDFFromAggregate, ExtractPythonUDFs}
 
 class SparkOptimizer(
@@ -42,7 +42,8 @@ class SparkOptimizer(
   override def defaultBatches: Seq[Batch] = (preOptimizationBatches ++ super.defaultBatches :+
     Batch("Optimize Metadata Only Query", Once, OptimizeMetadataOnlyQuery(catalog)) :+
     Batch("PartitionPruning", Once,
-      PartitionPruning) :+
+      PartitionPruning,
+      PushDownDynamicPartitionPruning) :+
     Batch("Pushdown Filters from PartitionPruning", fixedPoint,
       PushDownPredicates) :+
     Batch("Cleanup filters that cannot be pushed down", Once,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/DynamicPruningHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/DynamicPruningHelper.scala
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.dynamicpruning
+
+import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, BinaryComparison, Expression, In, InSet, MultiLikeBase, Not, Or, PredicateHelper, StringPredicate, StringRegexExpression, V2ExpressionUtils}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.connector.read.SupportsRuntimeFiltering
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+trait DynamicPruningHelper extends PredicateHelper {
+
+  /**
+   * Searches for a table scan that can be filtered for a given column in a logical plan.
+   *
+   * This methods tries to find either a v1 or Hive serde partitioned scan for a given
+   * partition column or a v2 scan that support runtime filtering on a given attribute.
+   */
+  def getFilterableTableScan(a: Expression, plan: LogicalPlan): Option[LogicalPlan] = {
+    val srcInfo: Option[(Expression, LogicalPlan)] = findExpressionAndTrackLineageDown(a, plan)
+    srcInfo.flatMap {
+      case (resExp, l: LogicalRelation) =>
+        l.relation match {
+          case fs: HadoopFsRelation =>
+            val partitionColumns = AttributeSet(
+              l.resolve(fs.partitionSchema, fs.sparkSession.sessionState.analyzer.resolver))
+            if (resExp.references.subsetOf(partitionColumns)) {
+              return Some(l)
+            } else {
+              None
+            }
+          case _ => None
+        }
+      case (resExp, l: HiveTableRelation) =>
+        if (resExp.references.subsetOf(AttributeSet(l.partitionCols))) {
+          return Some(l)
+        } else {
+          None
+        }
+      case (resExp, r @ DataSourceV2ScanRelation(_, scan: SupportsRuntimeFiltering, _)) =>
+        val filterAttrs = V2ExpressionUtils.resolveRefs[Attribute](scan.filterAttributes, r)
+        if (resExp.references.subsetOf(AttributeSet(filterAttrs))) {
+          Some(r)
+        } else {
+          None
+        }
+      case _ => None
+    }
+  }
+
+  // checks if two expressions are on opposite sides of the join
+  def fromDifferentSides(
+    left: LogicalPlan,
+    right: LogicalPlan,
+    x: Expression,
+    y: Expression): Boolean = {
+    def fromLeftRight(x: Expression, y: Expression) =
+      !x.references.isEmpty && x.references.subsetOf(left.outputSet) &&
+        !y.references.isEmpty && y.references.subsetOf(right.outputSet)
+    fromLeftRight(x, y) || fromLeftRight(y, x)
+  }
+
+  /**
+   * Returns whether an expression is likely to be selective
+   */
+  private def isLikelySelective(e: Expression): Boolean = e match {
+    case Not(expr) => isLikelySelective(expr)
+    case And(l, r) => isLikelySelective(l) || isLikelySelective(r)
+    case Or(l, r) => isLikelySelective(l) && isLikelySelective(r)
+    case _: StringRegexExpression => true
+    case _: BinaryComparison => true
+    case _: In | _: InSet => true
+    case _: StringPredicate => true
+    case _: MultiLikeBase => true
+    case _ => false
+  }
+
+  /**
+   * Search a filtering predicate in a given logical plan
+   */
+  private def hasSelectivePredicate(plan: LogicalPlan): Boolean = {
+    plan.find {
+      case f: Filter => isLikelySelective(f.condition)
+      case _ => false
+    }.isDefined
+  }
+
+  /**
+   * To be able to prune partitions on a join key, the filtering side needs to
+   * meet the following requirements:
+   *   (1) it can not be a stream
+   *   (2) it needs to contain a selective predicate used for filtering
+   */
+  def hasPartitionPruningFilter(plan: LogicalPlan): Boolean = {
+    !plan.isStreaming && hasSelectivePredicate(plan)
+  }
+
+  def canPruneLeft(joinType: JoinType): Boolean = joinType match {
+    case Inner | LeftSemi | RightOuter => true
+    case _ => false
+  }
+
+  def canPruneRight(joinType: JoinType): Boolean = joinType match {
+    case Inner | LeftSemi | LeftOuter => true
+    case _ => false
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PushDownDynamicPartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PushDownDynamicPartitionPruning.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.dynamicpruning
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{DYNAMIC_PRUNING_SUBQUERY, JOIN}
+
+/**
+ * This rule can handle pushing down a dynamic partition pruning from a child join to
+ * its parent join, when the following conditions are met:
+ * (1) the pruning side of the parent join is a partition table
+ * (2) the table to prune is filterable by the JOIN key
+ * (3) the parent join operation is one of the following types: INNER, LEFT SEMI,
+ *  LEFT OUTER (partitioned on right), or RIGHT OUTER (partitioned on left)
+ *
+ * Use the dynamic partition pruning of the child join to create a new dynamic partition pruning for
+ * the parent join with the onlyInBroadcast is true, to make sure it will use the filter only if it
+ * can reuse the results of the broadcast through ReuseExchange.
+ */
+object PushDownDynamicPartitionPruning extends Rule[LogicalPlan] with DynamicPruningHelper {
+
+  /**
+   * Searches for the head dynamic partition pruning in children joins, and use it to create a new
+   * dynamic partition pruning for their parent join.
+   */
+  private def getDynamicPartitionPruning(
+    exp: Expression,
+    plan: LogicalPlan): Option[DynamicPruningSubquery] = plan match {
+    case p @ Project(_, child: Join) =>
+      if (canPushThrough(child.joinType)) {
+        getDynamicPartitionPruning(replaceAlias(exp, getAliasMap(p)), child)
+      } else {
+        None
+      }
+    // we can unwrap only if there are row projections, and no aggregation operation
+    case a @ Aggregate(_, _, child: Join) =>
+      if (canPushThrough(child.joinType)) {
+        getDynamicPartitionPruning(replaceAlias(exp, getAliasMap(a)), child)
+      } else {
+        None
+      }
+    case f @ Filter(d: DynamicPruningSubquery, l)
+        if exp.references.subsetOf(f.outputSet) && exp.references.subsetOf(l.outputSet) =>
+      Some(d)
+    case other =>
+      other.children.flatMap {
+        child => if (exp.references.subsetOf(child.outputSet)) {
+          getDynamicPartitionPruning(exp, child)
+        } else {
+          None
+        }
+      }.headOption
+  }
+
+  private def canPushThrough(joinType: JoinType): Boolean = joinType match {
+    case Inner | LeftSemi | RightOuter | LeftOuter => true
+    case _ => false
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!conf.dynamicPartitionPruningEnabled || !conf.dynamicPartitionPruningPushdownEnabled) {
+      plan
+    } else {
+      plan.transformWithPruning(
+        _.containsAllPatterns(DYNAMIC_PRUNING_SUBQUERY, JOIN)) {
+        // push down the dynamic partition pruning from the a join to its parent join when the
+        // exchange can reuse.
+        case Join(left, right, joinType, Some(condition), hint) if conf.exchangeReuseEnabled &&
+            canPushThrough(joinType) =>
+          var newLeft = left
+          var newRight = right
+          splitConjunctivePredicates(condition).foreach {
+            case EqualTo(a: Expression, b: Expression)
+                if fromDifferentSides(left, right, a, b) =>
+              val (l, r) = if (a.references.subsetOf(left.outputSet) &&
+                b.references.subsetOf(right.outputSet)) {
+                a -> b
+              } else {
+                b -> a
+              }
+              // currently only supports reusing the results of the broadcast from the child
+              // join through ReuseExchange.
+              var filterableScan = getFilterableTableScan(l, left)
+              if (filterableScan.isDefined && canPruneLeft(joinType) &&
+                hasPartitionPruningFilter(right)) {
+                val rightChildDpp = getDynamicPartitionPruning(r, right)
+                rightChildDpp.foreach {
+                  case d: DynamicPruningSubquery
+                      if l.dataType == d.buildKeys(d.broadcastKeyIndex).dataType =>
+                    newLeft = Filter(DynamicPruningSubquery(l, d.buildQuery, d.buildKeys,
+                      d.broadcastKeyIndex, true), newLeft)
+                  case _ =>
+                }
+              } else {
+                filterableScan = getFilterableTableScan(r, right)
+                if (filterableScan.isDefined && canPruneRight(joinType) &&
+                  hasPartitionPruningFilter(left)) {
+                  val leftChildDpp = getDynamicPartitionPruning(l, left)
+                  leftChildDpp.foreach {
+                    case d: DynamicPruningSubquery
+                        if r.dataType == d.buildKeys(d.broadcastKeyIndex).dataType =>
+                      newRight = Filter(DynamicPruningSubquery(r, d.buildQuery, d.buildKeys,
+                        d.broadcastKeyIndex, true), newRight)
+                    case _ =>
+                  }
+                }
+              }
+            case _ =>
+          }
+          Join(newLeft, newRight, joinType, Some(condition), hint)
+        case j => j
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Introduce a rule to handle pushing down a dynamic partition pruning from a child join to its parent join, when the following conditions are met:
 (1) the pruning side of the parent join is a partition table
 (2) the table to prune is filterable by the JOIN key
 (3) the parent join operation is one of the following types: INNER, LEFT SEMI,
  LEFT OUTER (partitioned on right), or RIGHT OUTER (partitioned on left)
 
A query example: 
```sql
SELECT f.store_id, k.units_sold
FROM fact_stats f
JOIN dim_stats d
    ON f.store_id = d.store_id
        AND d.country = 'NL'
LEFT JOIN fact_sk k
    ON f.store_id = k.store_id
```

Before the PR:

![image](https://user-images.githubusercontent.com/39684231/145710866-70b44119-12ba-4afc-8a02-385189712950.png)

After the PR:
![image](https://user-images.githubusercontent.com/39684231/145710859-93ed90ae-1b5b-4516-a780-dfb1c14e5e0d.png)

### Why are the changes needed?
Push down a dynamic partition pruning from one join to other joins to prune the table of other joins  to improve performance.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
Added unittests.
