### PR TITLE
[SPARK-37617][SQL][HIVE] In CTAS, Replace Parquet name columns that have not alias

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3502,6 +3502,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val REPLACE_SCHEMA_ALIAS_AS_COLUMN = buildConf("spark.sql.schema.replace.alias.asColumn")
+    .doc(s"""When true, Spark will replace invalid attribute charactor(s) among ",;{}()\\n\\t= "
+            |""".stripMargin)
+    .version("3.2.0")
+    .booleanConf
+    .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3626,6 +3633,8 @@ class SQLConf extends Serializable with Logging {
   @transient protected val reader = new ConfigReader(settings)
 
   /** ************************ Spark SQL Params/Hints ******************* */
+
+  def replaceSchemaAliasAsColumn: Boolean = getConf(REPLACE_SCHEMA_ALIAS_AS_COLUMN)
 
   def analyzerMaxIterations: Int = getConf(ANALYZER_MAX_ITERATIONS)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -96,6 +96,7 @@ class HiveSessionStateBuilder(
     override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
       DetectAmbiguousSelfJoin +:
         new DetermineTableStats(session) +:
+        ReplaceParquetSchema +:
         RelationConversions(catalog) +:
         PreprocessTableCreation(session) +:
         PreprocessTableInsertion +:

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
@@ -17,10 +17,18 @@
 
 package org.apache.spark.sql.hive
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{types, AnalysisException, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAlias, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Literal, NamedExpression, UnixTimestamp}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Max
+import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand
 import org.apache.spark.sql.hive.test.{TestHiveSingleton, TestHiveSparkSession}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 
 class TestHiveSuite extends TestHiveSingleton with SQLTestUtils {
@@ -45,5 +53,71 @@ class TestHiveSuite extends TestHiveSingleton with SQLTestUtils {
 
   test("SPARK-15887: hive-site.xml should be loaded") {
     assert(hiveClient.getConf("hive.in.test", "") == "true")
+  }
+
+  Seq(
+    "parquet" -> ((
+      "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+      "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+      "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    ))).foreach { case (provider, (inputFormat, outputFormat, serde)) =>
+
+    test("replace parquet schema using CTAS") {
+      withTable("alias", "alias_b") {
+        withSQLConf(SQLConf.REPLACE_SCHEMA_ALIAS_AS_COLUMN.key -> "true",
+          "hive.default.fileformat" -> "parquet") {
+          sql("CREATE TABLE `alias` (\n  `a` INT,\n  `b` STRING)\nUSING parquet")
+          val analyzed = sql(" create table  alias_b as select a, " +
+            "max(unix_timestamp(b)) from alias group by a")
+          import hiveContext._
+          val hiveTable =
+            sessionState.catalog.getTableMetadata(TableIdentifier("alias_b", Some("default")))
+          assert(hiveTable.storage.serde == Some(serde))
+          assert(hiveTable.storage.inputFormat == Some(inputFormat))
+          assert(hiveTable.storage.outputFormat == Some(outputFormat))
+          assert(hiveTable.provider == Some("hive"))
+          import org.apache.spark.sql.catalyst.dsl.expressions._
+
+          val originQuery = Aggregate(Seq('a.int),
+            Seq('a.int,
+              UnresolvedAlias(Max(UnixTimestamp('b.string, Literal("yyyy-MM-dd HH:mm:ss"))),
+                Option(x => "max_unix_timestamp_b__yyyy-MM-dd_HH:mm:ss__")))
+              .asInstanceOf[Seq[NamedExpression]],
+            UnresolvedRelation(Seq("alias"))
+          )
+          val query = Aggregate(Seq('a.int),
+            Seq('a.int,
+              UnresolvedAlias(Max(UnixTimestamp('b.string, Literal("yyyy-MM-dd HH:mm:ss"))),
+                Option(x => "max_unix_timestamp_b__yyyy-MM-dd_HH:mm:ss__")))
+              .asInstanceOf[Seq[NamedExpression]],
+            UnresolvedRelation(Seq("alias"))
+          )
+
+          val createTable = CreateHiveTableAsSelectCommand(
+            CatalogTable(TableIdentifier("alias_b", Some("defualt")),
+              CatalogTableType.MANAGED,
+              CatalogStorageFormat.empty,
+              provider = Some("hive"),
+              schema = StructType(Seq(types.StructField("a", IntegerType),
+                StructField("b", StringType)))),
+            query = query,
+            outputColumnNames = Seq("a", "max_unix_timestamp_b__yyyy-MM-dd_HH:mm:ss__"),
+            mode = SaveMode.ErrorIfExists
+          )
+
+          val testHiveSparkSession = spark.asInstanceOf[TestHiveSparkSession]
+          val analyer = testHiveSparkSession.sessionState.analyzer
+          val analysis = analyer.execute(createTable)
+
+          assert(analyer.execute(createTable.copy(query = originQuery))
+            .find(_.isInstanceOf[Aggregate]).
+            get.asInstanceOf[Aggregate].
+            aggregateExpressions.drop(1).head.asInstanceOf[Alias].name
+            == analysis.find(_.isInstanceOf[Aggregate]).
+            get.asInstanceOf[Aggregate].
+            aggregateExpressions.drop(1).head.asInstanceOf[Alias].name)
+        }
+      }
+    }
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/TestHiveSuite.scala
@@ -62,7 +62,7 @@ class TestHiveSuite extends TestHiveSingleton with SQLTestUtils {
       "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
     ))).foreach { case (provider, (inputFormat, outputFormat, serde)) =>
 
-    test("replace parquet schema using CTAS") {
+    test("SPARK-37617: replace parquet schema in CTAS") {
       withTable("alias", "alias_b") {
         withSQLConf(SQLConf.REPLACE_SCHEMA_ALIAS_AS_COLUMN.key -> "true",
           "hive.default.fileformat" -> "parquet") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In CTAS, Replace name columns that have not alias.Mostly, columns without alias
  always is operator such as sum, divide that will lead to schema check error. Also,  provide a config option, "spark.sql.schema.replace.alias.asColumn", default is false to choose if we should replace the alias  or not. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
if we do not replace the alias ,the error 'Column name "$name" contains invalid character(s).
         |Please use alias to rename it.' will appear

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, 
spark sql("CREATE TABLE `alias` (
  `a` INT,
  `b` STRING)
USING parquet")
spark.sql(" create table  alias_b as select a, " +
            "max(unix_timestamp(b)) from alias group by a")

Before this pr:
logical plan like this :
```
OptimizedCreateHiveTableAsSelectCommand [Database: default, TableName: alias_b, InsertIntoHadoopFsRelationCommand]
+- Aggregate [a#10], [a#10, max(unix_timestamp(b#11, yyyy-MM-dd HH:mm:ss, Some(America/Los_Angeles), false)) AS max(unix_timestamp(b, yyyy-MM-dd HH:mm:ss))#19L]
   +- SubqueryAlias spark_catalog.default.alias
      +- Relation default.alias[a#10,b#11] parquet

```
and error will throw:
```
Column name "max(unix_timestamp(b, yyyy-MM-dd HH:mm:ss))" contains invalid character(s). Please use alias to rename it.
```
After this pr and set spark.sql.schema.replace.alias.asColumn =true:
logical plan is :
```
== Analyzed Logical Plan ==
OptimizedCreateHiveTableAsSelectCommand [Database: default, TableName: alias_b, InsertIntoHadoopFsRelationCommand]
+- Aggregate [a#10], [a#10, max(unix_timestamp(b#11, yyyy-MM-dd HH:mm:ss, Some(America/Los_Angeles), false)) AS max_unix_timestamp_b__yyyy-MM-dd_HH:mm:ss__#14L]
   +- SubqueryAlias spark_catalog.default.alias
      +- Relation default.alias[a#10,b#11] parquet
```
and sql("desc table alias_b").show(false):
```
+-------------------------------------------+---------+-------+
|col_name                                   |data_type|comment|
+-------------------------------------------+---------+-------+
|a                                          |int      |null   |
|max_unix_timestamp_b__yyyy-MM-dd_HH:mm:ss__|bigint   |null   |
+-------------------------------------------+---------+-------+
```
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
unit test
