### PR TITLE
[SPARK-37619][BUILD][test-maven] Upgrade Maven to 3.8.4

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -81,7 +81,7 @@ if (!(Test-Path $tools)) {
 # ========================== Maven
 # Push-Location $tools
 #
-# $mavenVer = "3.6.3"
+# $mavenVer = "3.8.4"
 # Start-FileDownload "https://archive.apache.org/dist/maven/maven-3/$mavenVer/binaries/apache-maven-$mavenVer-bin.zip" "maven.zip"
 #
 # # extract

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -27,7 +27,7 @@ license: |
 ## Apache Maven
 
 The Maven-based build is the build of reference for Apache Spark.
-Building Spark using Maven requires Maven 3.6.3 and Java 8.
+Building Spark using Maven requires Maven 3.8.4 and Java 8.
 Spark requires Scala 2.12/2.13; support for Scala 2.11 was removed in Spark 3.0.0.
 
 ### Setting up Maven's Memory Usage

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <maven.version>3.6.3</maven.version>
+    <maven.version>3.8.4</maven.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Maven to 3.8.4 from 3.6.3.

### Why are the changes needed?

https://maven.apache.org/docs/3.8.4/release-notes.html
```
Upgrade to Jansi 2.4.0 which supports macOS on ARM natively
```

Note that MNG-6843 `Parallel build fails due to missing JAR artifacts in compilePath` exists in both 3.6.3 and 3.8.4 because MNG-6843 was merged at 3.8.2 and reverted at 3.8.4.

https://issues.apache.org/jira/browse/MNG-6843

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the Jenkins with Maven. The current Jenkins run is triggered via `Maven 3.8.4`

```
========================================================================
Building Spark
========================================================================
[info] Building Spark using Maven with these arguments:  -Phadoop-3 -Pmesos -Phadoop-cloud -Pdocker-integration-tests -Phive-thriftserver -Phive -Pkubernetes -Pyarn -Pspark-ganglia-lgpl -Pkinesis-asl clean package -DskipTests
exec: curl --silent --show-error -L https://downloads.lightbend.com/scala/2.12.15/scala-2.12.15.tgz
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz?action=download
exec: curl --silent --show-error -L https://archive.apache.org/dist/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz.sha512
```