### PR TITLE
[SPARK-37622][K8S] Support K8s executor rolling policy

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.deploy.k8s
 
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.deploy.k8s.Constants._
@@ -144,6 +145,20 @@ private[spark] object Config extends Logging {
       .timeConf(TimeUnit.SECONDS)
       .checkValue(_ >= 0, "Interval should be non-negative")
       .createWithDefault(0)
+
+  object ExecutorRollPolicy extends Enumeration {
+    val ID, ADD_TIME, TOTAL_GC_TIME, TOTAL_DURATION = Value
+  }
+
+  val EXECUTOR_ROLL_POLICY =
+    ConfigBuilder("spark.kubernetes.executor.rollPolicy")
+      .doc("Executor roll policy: Valid values are ID, ADD_TIME, TOTAL_GC_TIME (default), " +
+        "and TOTAL_DURATION")
+      .version("3.3.0")
+      .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValues(ExecutorRollPolicy.values.map(_.toString))
+      .createWithDefault(ExecutorRollPolicy.TOTAL_GC_TIME.toString)
 
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -153,7 +153,12 @@ private[spark] object Config extends Logging {
   val EXECUTOR_ROLL_POLICY =
     ConfigBuilder("spark.kubernetes.executor.rollPolicy")
       .doc("Executor roll policy: Valid values are ID, ADD_TIME, TOTAL_GC_TIME (default), " +
-        "and TOTAL_DURATION")
+        "and TOTAL_DURATION. When executor roll happens, Spark uses this policy to choose " +
+        "an executor and decomission it. The built-in policies are based on executor summary." +
+        "ID policy chooses an executor with the smallest executor ID. " +
+        "ADD_TIME policy chooses an executor with the smallest add-time. " +
+        "TOTAL_GC_TIME policy chooses an executor with the biggest total task GC time. " +
+        "TOTAL_DURATION policy chooses an executor with the biggest total task time. ")
       .version("3.3.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPlugin.scala
@@ -23,10 +23,11 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.SparkContext
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
-import org.apache.spark.deploy.k8s.Config.EXECUTOR_ROLL_INTERVAL
+import org.apache.spark.deploy.k8s.Config.{EXECUTOR_ROLL_INTERVAL, EXECUTOR_ROLL_POLICY, ExecutorRollPolicy}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.DECOMMISSION_ENABLED
 import org.apache.spark.scheduler.ExecutorDecommissionInfo
+import org.apache.spark.status.api.v1
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -37,63 +38,76 @@ import org.apache.spark.util.ThreadUtils
  * To use this plugin, we assume that a user has the required maximum number of executors + 1
  * in both static and dynamic allocation configurations.
  */
-class ExecutorRollPlugin extends SparkPlugin with Logging {
-  override def driverPlugin(): DriverPlugin = {
-    new DriverPlugin() {
-      private var sparkContext: SparkContext = _
-
-      private val periodicService: ScheduledExecutorService =
-        ThreadUtils.newDaemonSingleThreadScheduledExecutor("executor-roller")
-
-      override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
-        val interval = sc.conf.get(EXECUTOR_ROLL_INTERVAL)
-        if (interval <= 0) {
-          logWarning(s"Disabled due to invalid interval value, '$interval'")
-        } else if (!sc.conf.get(DECOMMISSION_ENABLED)) {
-          logWarning(s"Disabled because ${DECOMMISSION_ENABLED.key} is false.")
-        } else {
-          // Scheduler is not created yet
-          sparkContext = sc
-
-          periodicService.scheduleAtFixedRate(() => {
-            try {
-              sparkContext.schedulerBackend match {
-                case scheduler: KubernetesClusterSchedulerBackend =>
-                  // Roughly assume that the smallest ID executor is the most long-lived one.
-                  val smallestID = scheduler
-                    .getExecutorIds()
-                    .filterNot(_.equals(SparkContext.DRIVER_IDENTIFIER))
-                    .map(_.toInt)
-                    .sorted
-                    .headOption
-                  smallestID match {
-                    case Some(id) =>
-                      // Use decommission to be safe.
-                      logInfo(s"Ask to decommission executor $id")
-                      val now = System.currentTimeMillis()
-                      scheduler.decommissionExecutor(
-                        id.toString,
-                        ExecutorDecommissionInfo(s"Rolling at $now"),
-                        adjustTargetNumExecutors = false)
-                    case _ =>
-                      logInfo("There is nothing to roll.")
-                  }
-                case _ =>
-                  logWarning("This plugin expects " +
-                    s"${classOf[KubernetesClusterSchedulerBackend].getSimpleName}.")
-              }
-            } catch {
-              case e: Throwable => logError("Error in rolling thread", e)
-            }
-          }, interval, interval, TimeUnit.SECONDS)
-        }
-        Map.empty[String, String].asJava
-      }
-
-      override def shutdown(): Unit = periodicService.shutdown()
-    }
-  }
+class ExecutorRollPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new ExecutorRollDriverPlugin()
 
   // No-op
   override def executorPlugin(): ExecutorPlugin = null
+}
+
+class ExecutorRollDriverPlugin extends DriverPlugin with Logging {
+  private var sparkContext: SparkContext = _
+
+  private val periodicService: ScheduledExecutorService =
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("executor-roller")
+
+  override def init(sc: SparkContext, ctx: PluginContext): JMap[String, String] = {
+    val interval = sc.conf.get(EXECUTOR_ROLL_INTERVAL)
+    if (interval <= 0) {
+      logWarning(s"Disabled due to invalid interval value, '$interval'")
+    } else if (!sc.conf.get(DECOMMISSION_ENABLED)) {
+      logWarning(s"Disabled because ${DECOMMISSION_ENABLED.key} is false.")
+    } else {
+      // Scheduler is not created yet
+      sparkContext = sc
+
+      val policy = ExecutorRollPolicy.withName(sc.conf.get(EXECUTOR_ROLL_POLICY))
+      periodicService.scheduleAtFixedRate(() => {
+        try {
+          sparkContext.schedulerBackend match {
+            case scheduler: KubernetesClusterSchedulerBackend =>
+              val executorSummaryList = sparkContext
+                .statusStore
+                .executorList(true)
+              choose(executorSummaryList, policy) match {
+                case Some(id) =>
+                  // Use decommission to be safe.
+                  logInfo(s"Ask to decommission executor $id")
+                  val now = System.currentTimeMillis()
+                  scheduler.decommissionExecutor(
+                    id,
+                    ExecutorDecommissionInfo(s"Rolling via $policy at $now"),
+                    adjustTargetNumExecutors = false)
+                case _ =>
+                  logInfo("There is nothing to roll.")
+              }
+            case _ =>
+              logWarning("This plugin expects " +
+                s"${classOf[KubernetesClusterSchedulerBackend].getSimpleName}.")
+          }
+        } catch {
+          case e: Throwable => logError("Error in rolling thread", e)
+        }
+      }, interval, interval, TimeUnit.SECONDS)
+    }
+    Map.empty[String, String].asJava
+  }
+
+  override def shutdown(): Unit = periodicService.shutdown()
+
+  private def choose(list: Seq[v1.ExecutorSummary], policy: ExecutorRollPolicy.Value)
+      : Option[String] = {
+    val listWithoutDriver = list.filterNot(_.id.equals(SparkContext.DRIVER_IDENTIFIER))
+    val sortedList = policy match {
+      case ExecutorRollPolicy.ID =>
+        listWithoutDriver.sortBy(_.id)
+      case ExecutorRollPolicy.ADD_TIME =>
+        listWithoutDriver.sortBy(_.addTime)
+      case ExecutorRollPolicy.TOTAL_GC_TIME =>
+        listWithoutDriver.sortBy(_.totalGCTime).reverse
+      case ExecutorRollPolicy.TOTAL_DURATION =>
+        listWithoutDriver.sortBy(_.totalDuration).reverse
+    }
+    sortedList.headOption.map(_.id)
+  }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPluginSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.scheduler.cluster.k8s
+
+import java.util.Date
+
+import org.junit.Assert.assertEquals
+import org.scalatest.PrivateMethodTester
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.deploy.k8s.Config.ExecutorRollPolicy
+import org.apache.spark.status.api.v1.ExecutorSummary
+
+class ExecutorRollPluginSuite extends SparkFunSuite with PrivateMethodTester {
+
+  val plugin = new ExecutorRollPlugin().driverPlugin()
+
+  private val _choose = PrivateMethod[Option[String]](Symbol("choose"))
+
+  val driverSummary = new ExecutorSummary("driver", "host:port", true, 1,
+    10, 10, 1, 1, 1,
+    0, 0, 1, 100,
+    1, 100, 100,
+    10, false, 20, new Date(1639300000000L),
+    Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+    false, Set())
+
+  val execWithSmallestID = new ExecutorSummary("1", "host:port", true, 1,
+    10, 10, 1, 1, 1,
+    0, 0, 1, 100,
+    1, 100, 100,
+    10, false, 20, new Date(1639300001000L),
+    Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+    false, Set())
+
+  // The smallest addTime
+  val execWithSmallestAddTime = new ExecutorSummary("2", "host:port", true, 1,
+    10, 10, 1, 1, 1,
+    0, 0, 1, 100,
+    1, 100, 100,
+    10, false, 20, new Date(1639300000000L),
+    Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+    false, Set())
+
+  // The biggest totalGCTime
+  val execWithBiggestTotalGCTime = new ExecutorSummary("3", "host:port", true, 1,
+    10, 10, 1, 1, 1,
+    0, 0, 1, 100,
+    4, 100, 100,
+    10, false, 20, new Date(1639300002000L),
+    Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+    false, Set())
+
+  // The biggest totalDuration
+  val execWithBiggestTotalDuration = new ExecutorSummary("4", "host:port", true, 1,
+    10, 10, 1, 1, 1,
+    0, 0, 1, 400,
+    1, 100, 100,
+    10, false, 20, new Date(1639300003000L),
+    Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+    false, Set())
+
+  val list = Seq(driverSummary, execWithSmallestID, execWithSmallestAddTime,
+    execWithBiggestTotalGCTime, execWithBiggestTotalDuration)
+
+  test("Empty executor list") {
+    ExecutorRollPolicy.values.foreach { value =>
+      assertEquals(None, plugin.invokePrivate[Option[String]](_choose(Seq.empty, value)))
+    }
+  }
+
+  test("Driver summary should be ignored") {
+    ExecutorRollPolicy.values.foreach { value =>
+      assertEquals(plugin.invokePrivate(_choose(Seq(driverSummary), value)), None)
+    }
+  }
+
+  test("A one-item executor list") {
+    ExecutorRollPolicy.values.foreach { value =>
+      assertEquals(
+        Some(execWithSmallestID.id),
+        plugin.invokePrivate(_choose(Seq(execWithSmallestID), value)))
+    }
+  }
+
+  test("Policy: ID") {
+    assertEquals(Some("1"), plugin.invokePrivate(_choose(list, ExecutorRollPolicy.ID)))
+  }
+
+  test("Policy: ADD_TIME") {
+    assertEquals(Some("2"), plugin.invokePrivate(_choose(list, ExecutorRollPolicy.ADD_TIME)))
+  }
+
+  test("Policy: TOTAL_GC_TIME") {
+    assertEquals(Some("3"), plugin.invokePrivate(_choose(list, ExecutorRollPolicy.TOTAL_GC_TIME)))
+  }
+
+  test("Policy: TOTAL_DURATION") {
+    assertEquals(Some("4"), plugin.invokePrivate(_choose(list, ExecutorRollPolicy.TOTAL_DURATION)))
+  }
+}

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -184,6 +184,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
       .set(config.DECOMMISSION_ENABLED.key, "true")
       .set(PLUGINS.key, "org.apache.spark.scheduler.cluster.k8s.ExecutorRollPlugin")
       .set("spark.kubernetes.executor.rollInterval", "30s")
+      .set("spark.kubernetes.executor.rollPolicy", "ID")
 
     runSparkApplicationAndVerifyCompletion(
       appResource = PythonTestsSuite.PYSPARK_PI,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support K8s executor rolling policies via `spark.kubernetes.executor.rollPolicy`.

### Why are the changes needed?

Users can choose one of the following policy in order to decommission one executor at every `spark.kubernetes.executor.rollInterval`.
- ID: An executor with the smallest executor ID. This is most human-readable.
- ADD_TIME: An executor with the smallest add-time. This is the most long-live executor.
- TOTAL_GC_TIME: An executor with the biggest GC time. This could have GC issue for some reason.
- TOTAL_DURATION: An executor with the biggest total task time. This executor may have busy neighbor or CPU thresholding by K8s controller.

### Does this PR introduce _any_ user-facing change?

Yes, but this is a new feature.

### How was this patch tested?

Pass the CIs.