### PR TITLE
[SPARK-37624][PYTHON][DOCS] Suppress warnings for live pandas-on-Spark quickstart notebooks

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -37,7 +37,7 @@ pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
 # Set 'PYARROW_IGNORE_TIMEZONE' to surpress warnings from PyArrow.
 echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
 
-# Surpress warnings
+# Surpress warnings from Spark jobs, and UI progress bar.
 mkdir -p ~/.ipython/profile_default/startup
 echo """from pyspark.sql import SparkSession
 SparkSession.builder.config('spark.ui.showConsoleProgress', 'false').getOrCreate().sparkContext.setLogLevel('FATAL')

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -33,3 +33,12 @@ else
 fi
 
 pip install plotly "pyspark[sql,ml,mllib,pandas_on_spark]$SPECIFIER$VERSION"
+
+# Set 'PYARROW_IGNORE_TIMEZONE' to surpress warnings from PyArrow.
+echo "export PYARROW_IGNORE_TIMEZONE=1" >> ~/.profile
+
+# Surpress warnings
+mkdir -p ~/.ipython/profile_default/startup
+echo """from pyspark.sql import SparkSession
+SparkSession.builder.config('spark.ui.showConsoleProgress', 'false').getOrCreate().sparkContext.setLogLevel('FATAL')
+""" > ~/.ipython/profile_default/startup/00-init.py


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to suppress warnings, in live pandas-on-Spark quickstart notebooks, as below:

<img width="1109" alt="Screen Shot 2021-12-13 at 2 02 45 PM" src="https://user-images.githubusercontent.com/6477701/145756407-03b9d94e-a082-42a1-8052-d14b4989ae86.png">
<img width="1103" alt="Screen Shot 2021-12-13 at 2 02 25 PM" src="https://user-images.githubusercontent.com/6477701/145756419-b5dfa729-96fa-4646-bb26-40302d33632b.png">
<img width="1100" alt="Screen Shot 2021-12-13 at 2 02 20 PM" src="https://user-images.githubusercontent.com/6477701/145756420-b8e1b105-495b-4b1c-ab3c-4d47793ba80e.png">
<img width="1027" alt="Screen Shot 2021-12-13 at 1 32 05 PM" src="https://user-images.githubusercontent.com/6477701/145756424-bf93a4a1-2587-49fb-9abb-e2f6de032e48.png">

### Why are the changes needed?

This is a user-facing quickstart that is interactive shall, and showing a lot of warnings makes difficult to follow the output. Note that we also set a lower log4j level to interpreters. 

### Does this PR introduce _any_ user-facing change?

Users will see clean output in live quickstart notebook: https://mybinder.org/v2/gh/apache/spark/9e614e265f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb

### How was this patch tested?

I manually tested at https://mybinder.org/v2/gh/HyukjinKwon/spark/cleanup-ps-quickstart?labpath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb