### PR TITLE
[SPARK-37629][SQL] Speed up Expression.canonicalized

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -641,7 +641,7 @@ case object UnresolvedSeed extends LeafExpression with Unevaluable {
  */
 case class TempResolvedColumn(child: Expression, nameParts: Seq[String]) extends UnaryExpression
   with Unevaluable {
-  override lazy val canonicalized = child.canonicalized
+  override lazy val preCanonicalized = child.preCanonicalized
   override def dataType: DataType = child.dataType
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Canonicalize.scala
@@ -18,48 +18,17 @@
 package org.apache.spark.sql.catalyst.expressions
 
 /**
- * Rewrites an expression using rules that are guaranteed preserve the result while attempting
- * to remove cosmetic variations. Deterministic expressions that are `equal` after canonicalization
- * will always return the same answer given the same input (i.e. false positives should not be
- * possible). However, it is possible that two canonical expressions that are not equal will in fact
- * return the same answer given any input (i.e. false negatives are possible).
- *
- * The following rules are applied:
- *  - Names and nullability hints for [[org.apache.spark.sql.types.DataType]]s are stripped.
- *  - Names for [[GetStructField]] are stripped.
- *  - TimeZoneId for [[Cast]] and [[AnsiCast]] are stripped if `needsTimeZone` is false.
- *  - Commutative and associative operations ([[Add]] and [[Multiply]]) have their children ordered
- *    by `hashCode`.
- *  - [[EqualTo]] and [[EqualNullSafe]] are reordered by `hashCode`.
- *  - Other comparisons ([[GreaterThan]], [[LessThan]]) are reversed by `hashCode`.
- *  - Elements in [[In]] are reordered by `hashCode`.
+ * Reorders adjacent commutative operators such as [[And]] in the expression tree, according to
+ * the `hashCode` of non-commutative nodes, to remove cosmetic variations. Caller side should only
+ * call it on the root node of an expression tree that needs to be canonicalized.
  */
 object Canonicalize {
-  def execute(e: Expression): Expression = {
-    expressionReorder(ignoreTimeZone(ignoreNamesTypes(e)))
-  }
-
-  /** Remove names and nullability from types, and names from `GetStructField`. */
-  private[expressions] def ignoreNamesTypes(e: Expression): Expression = e match {
-    case a: AttributeReference =>
-      AttributeReference("none", a.dataType.asNullable)(exprId = a.exprId)
-    case GetStructField(child, ordinal, Some(_)) => GetStructField(child, ordinal, None)
-    case _ => e
-  }
-
-  /** Remove TimeZoneId for Cast if needsTimeZone return false. */
-  private[expressions] def ignoreTimeZone(e: Expression): Expression = e match {
-    case c: CastBase if c.timeZoneId.nonEmpty && !c.needsTimeZone =>
-      c.withTimeZone(null)
-    case _ => e
-  }
-
   /** Collects adjacent commutative operations. */
   private def gatherCommutative(
       e: Expression,
       f: PartialFunction[Expression, Seq[Expression]]): Seq[Expression] = e match {
     case c if f.isDefinedAt(c) => f(c).flatMap(gatherCommutative(_, f))
-    case other => other :: Nil
+    case other => reorderCommutativeOperators(other) :: Nil
   }
 
   /** Orders a set of commutative operations by their hash code. */
@@ -68,18 +37,17 @@ object Canonicalize {
       f: PartialFunction[Expression, Seq[Expression]]): Seq[Expression] =
     gatherCommutative(e, f).sortBy(_.hashCode())
 
-  /** Rearrange expressions that are commutative or associative. */
-  private def expressionReorder(e: Expression): Expression = e match {
+  def reorderCommutativeOperators(e: Expression): Expression = e match {
     // TODO: do not reorder consecutive `Add`s or `Multiply`s with different `failOnError` flags
     case a @ Add(_, _, f) =>
       orderCommutative(a, { case Add(l, r, _) => Seq(l, r) }).reduce(Add(_, _, f))
     case m @ Multiply(_, _, f) =>
       orderCommutative(m, { case Multiply(l, r, _) => Seq(l, r) }).reduce(Multiply(_, _, f))
 
-    case o: Or =>
+    case o @ Or(l, r) if l.deterministic && r.deterministic =>
       orderCommutative(o, { case Or(l, r) if l.deterministic && r.deterministic => Seq(l, r) })
         .reduce(Or)
-    case a: And =>
+    case a @ And(l, r) if l.deterministic && r.deterministic =>
       orderCommutative(a, { case And(l, r) if l.deterministic && r.deterministic => Seq(l, r)})
         .reduce(And)
 
@@ -90,25 +58,6 @@ object Canonicalize {
     case x: BitwiseXor =>
       orderCommutative(x, { case BitwiseXor(l, r) => Seq(l, r) }).reduce(BitwiseXor)
 
-    case EqualTo(l, r) if l.hashCode() > r.hashCode() => EqualTo(r, l)
-    case EqualNullSafe(l, r) if l.hashCode() > r.hashCode() => EqualNullSafe(r, l)
-
-    case GreaterThan(l, r) if l.hashCode() > r.hashCode() => LessThan(r, l)
-    case LessThan(l, r) if l.hashCode() > r.hashCode() => GreaterThan(r, l)
-
-    case GreaterThanOrEqual(l, r) if l.hashCode() > r.hashCode() => LessThanOrEqual(r, l)
-    case LessThanOrEqual(l, r) if l.hashCode() > r.hashCode() => GreaterThanOrEqual(r, l)
-
-    // Note in the following `NOT` cases, `l.hashCode() <= r.hashCode()` holds. The reason is that
-    // canonicalization is conducted bottom-up -- see [[Expression.canonicalized]].
-    case Not(GreaterThan(l, r)) => LessThanOrEqual(l, r)
-    case Not(LessThan(l, r)) => GreaterThanOrEqual(l, r)
-    case Not(GreaterThanOrEqual(l, r)) => LessThan(l, r)
-    case Not(LessThanOrEqual(l, r)) => GreaterThan(l, r)
-
-    // order the list in the In operator
-    case In(value, list) if list.length > 1 => In(value, list.sortBy(_.hashCode()))
-
     case g: Greatest =>
       val newChildren = orderCommutative(g, { case Greatest(children) => children })
       Greatest(newChildren)
@@ -116,6 +65,6 @@ object Canonicalize {
       val newChildren = orderCommutative(l, { case Least(children) => children })
       Least(newChildren)
 
-    case _ => e
+    case _ => e.withNewChildren(e.children.map(reorderCommutativeOperators))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -316,6 +316,15 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   override lazy val resolved: Boolean =
     childrenResolved && checkInputDataTypes().isSuccess && (!needsTimeZone || timeZoneId.isDefined)
 
+  override lazy val preCanonicalized: Expression = {
+    val basic = withNewChildren(Seq(child.preCanonicalized)).asInstanceOf[CastBase]
+    if (timeZoneId.isDefined && !needsTimeZone) {
+      basic.withTimeZone(null)
+    } else {
+      basic
+    }
+  }
+
   def needsTimeZone: Boolean = Cast.needsTimeZone(child.dataType, dataType)
 
   // [[func]] assumes the input is no longer null because eval already does the null check.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruning.scala
@@ -74,11 +74,11 @@ case class DynamicPruningSubquery(
 
   override def toString: String = s"dynamicpruning#${exprId.id} $conditionString"
 
-  override lazy val canonicalized: DynamicPruning = {
+  override lazy val preCanonicalized: DynamicPruning = {
     copy(
-      pruningKey = pruningKey.canonicalized,
+      pruningKey = pruningKey.preCanonicalized,
       buildQuery = buildQuery.canonicalized,
-      buildKeys = buildKeys.map(_.canonicalized),
+      buildKeys = buildKeys.map(_.preCanonicalized),
       exprId = ExprId(0))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -71,8 +71,8 @@ case class PythonUDF(
 
   override def nullable: Boolean = true
 
-  override lazy val canonicalized: Expression = {
-    val canonicalizedChildren = children.map(_.canonicalized)
+  override lazy val preCanonicalized: Expression = {
+    val canonicalizedChildren = children.map(_.preCanonicalized)
     // `resultId` can be seen as cosmetic variation in PythonUDF, as it doesn't affect the result.
     this.copy(resultId = ExprId(-1)).withNewChildren(canonicalizedChildren)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -64,10 +64,10 @@ case class ScalaUDF(
 
   override def name: String = udfName.getOrElse("UDF")
 
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     // SPARK-32307: `ExpressionEncoder` can't be canonicalized, and technically we don't
     // need it to identify a `ScalaUDF`.
-    Canonicalize.execute(copy(children = children.map(_.canonicalized), inputEncoders = Nil))
+    copy(children = children.map(_.preCanonicalized), inputEncoders = Nil)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/interfaces.scala
@@ -123,7 +123,7 @@ case class AggregateExpression(
   def filterAttributes: AttributeSet = filter.map(_.references).getOrElse(AttributeSet.empty)
 
   // We compute the same thing regardless of our final result.
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     val normalizedAggFunc = mode match {
       // For PartialMerge or Final mode, the input to the `aggregateFunction` is aggregate buffers,
       // and the actual children of `aggregateFunction` is not used, here we normalize the expr id.
@@ -134,10 +134,10 @@ case class AggregateExpression(
     }
 
     AggregateExpression(
-      normalizedAggFunc.canonicalized.asInstanceOf[AggregateFunction],
+      normalizedAggFunc.preCanonicalized.asInstanceOf[AggregateFunction],
       mode,
       isDistinct,
-      filter.map(_.canonicalized),
+      filter.map(_.preCanonicalized),
       ExprId(0))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -106,6 +106,10 @@ case class GetStructField(child: Expression, ordinal: Int, name: Option[String] 
 
   lazy val childSchema = child.dataType.asInstanceOf[StructType]
 
+  override lazy val preCanonicalized: Expression = {
+    copy(child = child.preCanonicalized, name = None)
+  }
+
   override def dataType: DataType = childSchema(ordinal).dataType
   override def nullable: Boolean = child.nullable || childSchema(ordinal).nullable
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -114,7 +114,7 @@ case class PromotePrecision(child: Expression) extends UnaryExpression {
     child.genCode(ctx)
   override def prettyName: String = "promote_precision"
   override def sql: String = child.sql
-  override lazy val canonicalized: Expression = child.canonicalized
+  override lazy val preCanonicalized: Expression = child.preCanonicalized
 
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -208,7 +208,7 @@ trait HigherOrderFunction extends Expression with ExpectsInputTypes {
       }
   }
 
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     var currExprId = -1
     val argumentMap = functions.flatMap(_.collect {
       case l: NamedLambdaVariable =>
@@ -221,8 +221,8 @@ trait HigherOrderFunction extends Expression with ExpectsInputTypes {
         val newExprId = argumentMap(l.exprId)
         NamedLambdaVariable("none", l.dataType, l.nullable, exprId = ExprId(newExprId), null)
     }
-    val canonicalizedChildren = cleaned.children.map(_.canonicalized)
-    Canonicalize.execute(withNewChildren(canonicalizedChildren))
+    val canonicalizedChildren = cleaned.children.map(_.preCanonicalized)
+    withNewChildren(canonicalizedChildren)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala
@@ -293,6 +293,10 @@ case class AttributeReference(
     h
   }
 
+  override lazy val preCanonicalized: Expression = {
+    AttributeReference("none", dataType.asNullable)(exprId)
+  }
+
   override def newInstance(): AttributeReference =
     AttributeReference(name, dataType, nullable, metadata)(qualifier = qualifier)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/subquery.scala
@@ -263,12 +263,12 @@ case class ScalarSubquery(
   override def nullable: Boolean = true
   override def withNewPlan(plan: LogicalPlan): ScalarSubquery = copy(plan = plan)
   override def toString: String = s"scalar-subquery#${exprId.id} $conditionString"
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     ScalarSubquery(
       plan.canonicalized,
-      outerAttrs.map(_.canonicalized),
+      outerAttrs.map(_.preCanonicalized),
       ExprId(0),
-      joinCond.map(_.canonicalized))
+      joinCond.map(_.preCanonicalized))
   }
 
   override protected def withNewChildrenInternal(
@@ -305,12 +305,12 @@ case class LateralSubquery(
   override def nullable: Boolean = true
   override def withNewPlan(plan: LogicalPlan): LateralSubquery = copy(plan = plan)
   override def toString: String = s"lateral-subquery#${exprId.id} $conditionString"
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     LateralSubquery(
       plan.canonicalized,
-      outerAttrs.map(_.canonicalized),
+      outerAttrs.map(_.preCanonicalized),
       ExprId(0),
-      joinCond.map(_.canonicalized))
+      joinCond.map(_.preCanonicalized))
   }
 
   override protected def withNewChildrenInternal(
@@ -350,13 +350,13 @@ case class ListQuery(
   override def nullable: Boolean = false
   override def withNewPlan(plan: LogicalPlan): ListQuery = copy(plan = plan)
   override def toString: String = s"list#${exprId.id} $conditionString"
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     ListQuery(
       plan.canonicalized,
-      outerAttrs.map(_.canonicalized),
+      outerAttrs.map(_.preCanonicalized),
       ExprId(0),
-      childOutputs.map(_.canonicalized.asInstanceOf[Attribute]),
-      joinCond.map(_.canonicalized))
+      childOutputs.map(_.preCanonicalized.asInstanceOf[Attribute]),
+      joinCond.map(_.preCanonicalized))
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): ListQuery =
@@ -402,12 +402,12 @@ case class Exists(
   override def nullable: Boolean = false
   override def withNewPlan(plan: LogicalPlan): Exists = copy(plan = plan)
   override def toString: String = s"exists#${exprId.id} $conditionString"
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     Exists(
       plan.canonicalized,
-      outerAttrs.map(_.canonicalized),
+      outerAttrs.map(_.preCanonicalized),
       ExprId(0),
-      joinCond.map(_.canonicalized))
+      joinCond.map(_.preCanonicalized))
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Exists =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ExpressionSetSuite.scala
@@ -34,34 +34,26 @@ class ExpressionSetSuite extends SparkFunSuite {
 
   // An [AttributeReference] with almost the maximum hashcode, to make testing canonicalize rules
   // like `case GreaterThan(l, r) if l.hashcode > r.hashcode => GreaterThan(r, l)` easier
-  val maxHash =
-    Canonicalize.ignoreNamesTypes(
-      AttributeReference("maxHash", IntegerType)(exprId =
-        new ExprId(4, NamedExpression.jvmId) {
-          // maxHash's hashcode is calculated based on this exprId's hashcode, so we set this
-          // exprId's hashCode to this specific value to make sure maxHash's hashcode is
-          // `Int.MaxValue`
-          override def hashCode: Int = 1394598635
-          // We are implementing this equals() only because the style-checking rule "you should
-          // implement equals and hashCode together" requires us to
-          override def equals(obj: Any): Boolean = super.equals(obj)
-        })).asInstanceOf[AttributeReference]
+  val maxHash = AttributeReference("none", IntegerType)(exprId =
+    new ExprId(4, NamedExpression.jvmId) {
+      // This `hashCode` is carefully picked to make `maxHash.hashCode` becomes `Int.MaxValue`.
+      override def hashCode: Int = 1394598635
+      // We are implementing this equals() only because the style-checking rule "you should
+      // implement equals and hashCode together" requires us to
+      override def equals(obj: Any): Boolean = super.equals(obj)
+    })
   assert(maxHash.hashCode() == Int.MaxValue)
 
   // An [AttributeReference] with almost the minimum hashcode, to make testing canonicalize rules
   // like `case GreaterThan(l, r) if l.hashcode > r.hashcode => GreaterThan(r, l)` easier
-  val minHash =
-    Canonicalize.ignoreNamesTypes(
-      AttributeReference("minHash", IntegerType)(exprId =
-        new ExprId(5, NamedExpression.jvmId) {
-          // minHash's hashcode is calculated based on this exprId's hashcode, so we set this
-          // exprId's hashCode to this specific value to make sure minHash's hashcode is
-          // `Int.MinValue`
-          override def hashCode: Int = -462684520
-          // We are implementing this equals() only because the style-checking rule "you should
-          // implement equals and hashCode together" requires us to
-          override def equals(obj: Any): Boolean = super.equals(obj)
-        })).asInstanceOf[AttributeReference]
+  val minHash = AttributeReference("none", IntegerType)(exprId =
+    new ExprId(5, NamedExpression.jvmId) {
+      // This `hashCode` is carefully picked to make `minHash.hashCode` becomes `Int.MinValue`.
+      override def hashCode: Int = -462684520
+      // We are implementing this equals() only because the style-checking rule "you should
+      // implement equals and hashCode together" requires us to
+      override def equals(obj: Any): Boolean = super.equals(obj)
+    })
   assert(minHash.hashCode() == Int.MinValue)
 
   def setTest(size: Int, exprs: Expression*): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/subquery.scala
@@ -68,7 +68,7 @@ case class ScalarSubquery(
   override def toString: String = plan.simpleString(SQLConf.get.maxToStringFields)
   override def withNewPlan(query: BaseSubqueryExec): ScalarSubquery = copy(plan = query)
 
-  override lazy val canonicalized: Expression = {
+  override lazy val preCanonicalized: Expression = {
     ScalarSubquery(plan.canonicalized.asInstanceOf[BaseSubqueryExec], ExprId(0))
   }
 
@@ -156,9 +156,9 @@ case class InSubqueryExec(
     inSet.doGenCode(ctx, ev)
   }
 
-  override lazy val canonicalized: InSubqueryExec = {
+  override lazy val preCanonicalized: InSubqueryExec = {
     copy(
-      child = child.canonicalized,
+      child = child.preCanonicalized,
       plan = plan.canonicalized.asInstanceOf[BaseSubqueryExec],
       exprId = ExprId(0),
       resultBroadcast = null,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`Expression.canonicalized` is very slow with a large expression tree, because its time complexity is O(n^2). To understand this performance issue, let's take a closer look at the related source code. First of all, `Expression.canonicalized` is recursive, as its default implementation is
```
lazy val canonicalized: Expression = {
  val canonicalizedChildren = children.map(_.canonicalized)
  Canonicalize.execute(withNewChildren(canonicalizedChildren))
}
```

However,  `Canonicalize.execute` is also recursive when dealing with commutative operators, as it needs to collect all the commutative operators in the expression tree, and reorder them.

Let's say that we have a deep expression tree with 1000 `And`: `And(c1, And(c2, And(c3, ...)))`. If we call its `canonicalized` method, we first reorder 2 `And`s in a small subtree, then reorder 3 `And`s in a larger subtree, ... and finally reorder 1000 `And`s in the complete tree. This is O(n^2).

To make it O(n), this PR makes the following changes:
1. Introduce `Expression.roughlyCanonicalized`, which recursively canonicalize each expression node in the tree, without changing the tree structure (thus no commutative operators reordering).
2. `Expression.canonicalized` just reorders the commutative operators in `roughlyCanonicalized`.
3. `Canonicalize` only reorders commutative operators now. Other logics are moved to the corresponding expressions' `roughlyCanonicalized` override.

After this PR, when we canonicalize a deep expression tree with 1000 `And`, we first traverse the expression tree once, to make it roughly canonicailized (name, nullability, etc. are normalized). Then we call `Canonicalize` once to reorder `And`s, which also traverse the tree only once.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix a performance issue when `Expression.canonicalized` can be very slow.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
pass the existing tests and run a benchmark manually
```
test("benchmark") {
  val col = Literal(true)
  var and = And(col, col)
  var i = 0
  while (i < 2000) {
    and = And(and, col)
    i += 1
  }
  and.canonicalized
}
```
Before this PR, it takes 10 seconds, now it takes 200 ms.