### PR TITLE
[SPARK-37633][SQL] Unwrap cast should skip if downcast failed with an…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -306,12 +306,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     // decimal type), or that the literal `value` is within range `(min, max)`. For these, we
     // optimize by moving the cast to the literal side.
 
-    val newValue = try {
-      Cast(Literal(value), fromType).eval()
-    } catch {
-      case _: ArithmeticException => null
-      case ex: Throwable => throw ex
-    }
+    val newValue = Cast(Literal(value), fromType, ansiEnabled = false).eval()
     if (newValue == null) {
       // This means the cast failed, for instance, due to the value is not representable in the
       // narrower type. In this case we simply return the original expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -306,7 +306,12 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
     // decimal type), or that the literal `value` is within range `(min, max)`. For these, we
     // optimize by moving the cast to the literal side.
 
-    val newValue = Cast(Literal(value), fromType).eval()
+    val newValue = try {
+      Cast(Literal(value), fromType).eval()
+    } catch {
+      case _: ArithmeticException => null
+      case ex: Throwable => throw ex
+    }
     if (newValue == null) {
       // This means the cast failed, for instance, due to the value is not representable in the
       // narrower type. In this case we simply return the original expression.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.optimizer.UnwrapCastInBinaryComparison._
 import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelper {
@@ -202,8 +203,12 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
   }
 
   test("unwrap casts should skip if downcast failed") {
-    val decimalValue = decimal2(123456.1234)
-    assertEquivalent(castDecimal2(f3) === decimalValue, castDecimal2(f3) === decimalValue)
+    Seq("true", "false").foreach { ansiEnabled =>
+      withSQLConf(SQLConf.ANSI_ENABLED.key -> ansiEnabled) {
+        val decimalValue = decimal2(123456.1234)
+        assertEquivalent(castDecimal2(f3) === decimalValue, castDecimal2(f3) === decimalValue)
+      }
+    }
   }
 
   test("unwrap cast should skip if cannot coerce type") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Use non-ANSI cast when applying `UnwrapCastInBinaryComparison` rule.

### Why are the changes needed?
Since `UnwrapCastInBinaryComparison` is an optimizer rule, it should not fail the application in cast.


### Does this PR introduce _any_ user-facing change?
With `spark.sql.ansi.enabled=true`, application won't fail if downcast fail when applying `UnwrapCastInBinaryComparison` rule.

### How was this patch tested?
Update UT.
