### PR TITLE
[SPARK-37620][PYTHON] Use more precise types for SparkContext Optional fields (i.e. _gateway, _jvm)

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -152,10 +152,10 @@ class SparkContext(object):
     """
 
     # set assignment ignore temporarily to prevent errors from other files
-    _gateway: ClassVar[JavaGateway] = None  # type: ignore[assignment]
-    _jvm: ClassVar[JVMView] = None  # type: ignore[assignment]
+    _gateway: ClassVar[Optional[JavaGateway]] = None
+    _jvm: ClassVar[Optional[JVMView]] = None
     _next_accum_id = 0
-    _active_spark_context: ClassVar["SparkContext"] = None  # type: ignore[assignment]
+    _active_spark_context: ClassVar[Optional["SparkContext"]] = None
     _lock = RLock()
     _python_includes: Optional[
         List[str]
@@ -288,9 +288,11 @@ class SparkContext(object):
 
         # Create a single Accumulator in Java that we'll send all our updates through;
         # they will be passed back to us through a TCP server
+        assert self._gateway is not None
         auth_token = self._gateway.gateway_parameters.auth_token
         self._accumulatorServer = accumulators._start_update_server(auth_token)  # type: ignore[attr-defined]
         (host, port) = self._accumulatorServer.server_address
+        assert self._jvm is not None
         self._javaAccumulator = self._jvm.PythonAccumulatorV2(host, port, auth_token)
         self._jsc.sc().register(self._javaAccumulator)
 
@@ -349,6 +351,7 @@ class SparkContext(object):
                     )
 
         # Create a temporary directory inside spark.local.dir:
+        assert self._jvm is not None
         local_dir = self._jvm.org.apache.spark.util.Utils.getLocalDir(self._jsc.sc().conf())
         self._temp_dir = self._jvm.org.apache.spark.util.Utils.createTempDir(
             local_dir, "pyspark"
@@ -400,6 +403,7 @@ class SparkContext(object):
         """
         Initialize SparkContext in function to allow subclass specific initialization
         """
+        assert self._jvm is not None
         return self._jvm.JavaSparkContext(jconf)
 
     @classmethod
@@ -499,6 +503,7 @@ class SparkContext(object):
         must be invoked before instantiating SparkContext.
         """
         SparkContext._ensure_initialized()
+        assert SparkContext._jvm is not None
         SparkContext._jvm.java.lang.System.setProperty(key, value)
 
     @property
@@ -662,9 +667,11 @@ class SparkContext(object):
         serializer = BatchedSerializer(self._unbatched_serializer, batchSize)
 
         def reader_func(temp_filename: str) -> JavaObject:
+            assert self._jvm is not None
             return self._jvm.PythonRDD.readRDDFromFile(self._jsc, temp_filename, numSlices)
 
         def createRDDServer() -> JavaObject:
+            assert self._jvm is not None
             return self._jvm.PythonParallelizeServer(self._jsc.sc(), numSlices)
 
         jrdd = self._serialize_to_jvm(c, serializer, reader_func, createRDDServer)
@@ -852,6 +859,7 @@ class SparkContext(object):
         return RDD(self._jsc.binaryRecords(path, recordLength), self, NoOpSerializer())
 
     def _dictToJavaMap(self, d: Optional[Dict[str, str]]) -> JavaMap:
+        assert self._jvm is not None
         jm = self._jvm.java.util.HashMap()
         if not d:
             d = {}
@@ -900,6 +908,7 @@ class SparkContext(object):
             Java object. (default 0, choose batchSize automatically)
         """
         minSplits = minSplits or min(self.defaultParallelism, 2)
+        assert self._jvm is not None
         jrdd = self._jvm.PythonRDD.sequenceFile(
             self._jsc,
             path,
@@ -958,6 +967,7 @@ class SparkContext(object):
             Java object. (default 0, choose batchSize automatically)
         """
         jconf = self._dictToJavaMap(conf)
+        assert self._jvm is not None
         jrdd = self._jvm.PythonRDD.newAPIHadoopFile(
             self._jsc,
             path,
@@ -1010,6 +1020,7 @@ class SparkContext(object):
             Java object. (default 0, choose batchSize automatically)
         """
         jconf = self._dictToJavaMap(conf)
+        assert self._jvm is not None
         jrdd = self._jvm.PythonRDD.newAPIHadoopRDD(
             self._jsc,
             inputFormatClass,
@@ -1064,6 +1075,7 @@ class SparkContext(object):
             Java object. (default 0, choose batchSize automatically)
         """
         jconf = self._dictToJavaMap(conf)
+        assert self._jvm is not None
         jrdd = self._jvm.PythonRDD.hadoopFile(
             self._jsc,
             path,
@@ -1116,6 +1128,7 @@ class SparkContext(object):
             Java object. (default 0, choose batchSize automatically)
         """
         jconf = self._dictToJavaMap(conf)
+        assert self._jvm is not None
         jrdd = self._jvm.PythonRDD.hadoopRDD(
             self._jsc,
             inputFormatClass,
@@ -1156,7 +1169,9 @@ class SparkContext(object):
         if any(x._jrdd_deserializer != first_jrdd_deserializer for x in rdds):  # type: ignore[attr-defined]
             rdds = [x._reserialize() for x in rdds]  # type: ignore[attr-defined]
         gw = SparkContext._gateway
+        assert gw is not None
         jvm = SparkContext._jvm
+        assert jvm is not None
         jrdd_cls = jvm.org.apache.spark.api.java.JavaRDD
         jpair_rdd_cls = jvm.org.apache.spark.api.java.JavaPairRDD
         jdouble_rdd_cls = jvm.org.apache.spark.api.java.JavaDoubleRDD
@@ -1281,7 +1296,7 @@ class SparkContext(object):
         """
         if not isinstance(storageLevel, StorageLevel):
             raise TypeError("storageLevel must be of type pyspark.StorageLevel")
-
+        assert self._jvm is not None
         newStorageLevel = self._jvm.org.apache.spark.storage.StorageLevel
         return newStorageLevel(
             storageLevel.useDisk,
@@ -1428,6 +1443,7 @@ class SparkContext(object):
         # by runJob() in order to avoid having to pass a Python lambda into
         # SparkContext#runJob.
         mappedRDD = rdd.mapPartitions(partitionFunc)
+        assert self._jvm is not None
         sock_info = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, partitions)  # type: ignore[attr-defined]
         return list(_load_from_socket(sock_info, mappedRDD._jrdd_deserializer))  # type: ignore[attr-defined]
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -151,7 +151,6 @@ class SparkContext(object):
     ValueError: ...
     """
 
-    # set assignment ignore temporarily to prevent errors from other files
     _gateway: ClassVar[Optional[JavaGateway]] = None
     _jvm: ClassVar[Optional[JVMView]] = None
     _next_accum_id = 0

--- a/python/pyspark/files.py
+++ b/python/pyspark/files.py
@@ -60,6 +60,6 @@ class SparkFiles(object):
             return cast(str, cls._root_directory)
         else:
             # This will have to change if we support multiple SparkContexts:
-            return cast(
-                "SparkContext", cls._sc
-            )._jvm.org.apache.spark.SparkFiles.getRootDirectory()  # type: ignore[attr-defined]
+            assert cls._sc is not None
+            assert cls._sc._jvm is not None
+            return cls._sc._jvm.org.apache.spark.SparkFiles.getRootDirectory()  # type: ignore[attr-defined]

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -66,6 +66,7 @@ def _to_java_object_rdd(rdd: RDD) -> JavaObject:
     RDD is serialized in batch or not.
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(CPickleSerializer()))  # type: ignore[attr-defined]
+    assert rdd.ctx._jvm is not None
     return rdd.ctx._jvm.org.apache.spark.ml.python.MLSerDe.pythonToJava(rdd._jrdd, True)  # type: ignore[attr-defined]
 
 
@@ -85,6 +86,7 @@ def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
         pass
     else:
         data = bytearray(CPickleSerializer().dumps(obj))
+        assert sc._jvm is not None
         obj = sc._jvm.org.apache.spark.ml.python.MLSerDe.loads(data)  # type: ignore[attr-defined]
     return obj
 
@@ -96,6 +98,8 @@ def _java2py(sc: SparkContext, r: "JavaObjectOrPickleDump", encoding: str = "byt
         if clsName != "JavaRDD" and clsName.endswith("RDD"):
             r = r.toJavaRDD()
             clsName = "JavaRDD"
+
+        assert sc._jvm is not None
 
         if clsName == "JavaRDD":
             jrdd = sc._jvm.org.apache.spark.ml.python.MLSerDe.javaToPython(r)  # type: ignore[attr-defined]

--- a/python/pyspark/mllib/common.py
+++ b/python/pyspark/mllib/common.py
@@ -68,6 +68,7 @@ def _to_java_object_rdd(rdd: RDD) -> JavaObject:
     RDD is serialized in batch or not.
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(CPickleSerializer()))  # type: ignore[attr-defined]
+    assert rdd.ctx._jvm is not None
     return rdd.ctx._jvm.org.apache.spark.mllib.api.python.SerDe.pythonToJava(rdd._jrdd, True)  # type: ignore[attr-defined]
 
 
@@ -87,6 +88,7 @@ def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
         pass
     else:
         data = bytearray(CPickleSerializer().dumps(obj))
+        assert sc._jvm is not None
         obj = sc._jvm.org.apache.spark.mllib.api.python.SerDe.loads(data)  # type: ignore[attr-defined]
     return obj
 
@@ -98,6 +100,8 @@ def _java2py(sc: SparkContext, r: "JavaObjectOrPickleDump", encoding: str = "byt
         if clsName != "JavaRDD" and clsName.endswith("RDD"):
             r = r.toJavaRDD()
             clsName = "JavaRDD"
+
+        assert sc._jvm is not None
 
         if clsName == "JavaRDD":
             jrdd = sc._jvm.org.apache.spark.mllib.api.python.SerDe.javaToPython(r)  # type: ignore[attr-defined]
@@ -130,7 +134,8 @@ def callJavaFunc(
 def callMLlibFunc(name: str, *args: Any) -> "JavaObjectOrPickleDump":
     """Call API in PythonMLLibAPI"""
     sc = SparkContext.getOrCreate()
-    api = getattr(sc._jvm.PythonMLLibAPI(), name)  # type: ignore[attr-defined]
+    assert sc._jvm is not None
+    api = getattr(sc._jvm.PythonMLLibAPI(), name)
     return callJavaFunc(sc, api, *args)
 
 
@@ -144,7 +149,8 @@ class JavaModelWrapper(object):
         self._java_model = java_model
 
     def __del__(self) -> None:
-        self._sc._gateway.detach(self._java_model)  # type: ignore[attr-defined]
+        assert self._sc._gateway is not None
+        self._sc._gateway.detach(self._java_model)
 
     def call(self, name: str, *a: Any) -> "JavaObjectOrPickleDump":
         """Call method of java_model"""

--- a/python/pyspark/resource/requests.py
+++ b/python/pyspark/resource/requests.py
@@ -304,6 +304,7 @@ class TaskResourceRequests(object):
 
         _jvm = _jvm or SparkContext._jvm  # type: ignore[attr-defined]
         if _jvm is not None:
+            assert SparkContext._jvm is not None
             self._java_task_resource_requests: Optional[
                 JavaObject
             ] = (

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -73,7 +73,9 @@ def from_avro(
     [Row(value=Row(avro=Row(age=2, name='Alice')))]
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     try:
         jc = sc._jvm.org.apache.spark.sql.avro.functions.from_avro(
             _to_java_column(data), jsonFormatSchema, options or {}
@@ -118,7 +120,9 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     [Row(suite=bytearray(b'\\x02\\x00'))]
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     try:
         if jsonFormatSchema == "":
             jc = sc._jvm.org.apache.spark.sql.avro.functions.to_avro(_to_java_column(data))

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -74,8 +74,7 @@ def from_avro(
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     try:
         jc = sc._jvm.org.apache.spark.sql.avro.functions.from_avro(
             _to_java_column(data), jsonFormatSchema, options or {}
@@ -121,8 +120,7 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     try:
         if jsonFormatSchema == "":
             jc = sc._jvm.org.apache.spark.sql.avro.functions.to_avro(_to_java_column(data))

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -46,15 +46,13 @@ __all__ = ["Column"]
 
 def _create_column_from_literal(literal: Union["LiteralType", "DecimalLiteral"]) -> "Column":
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return sc._jvm.functions.lit(literal)
 
 
 def _create_column_from_name(name: str) -> "Column":
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return sc._jvm.functions.col(name)
 
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -122,8 +122,7 @@ def _unary_op(
 def _func_op(name: str, doc: str = "") -> Callable[["Column"], "Column"]:
     def _(self: "Column") -> "Column":
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         jc = getattr(sc._jvm.functions, name)(self._jc)
         return Column(jc)
 
@@ -138,8 +137,7 @@ def _bin_func_op(
 ) -> Callable[["Column", Union["Column", "LiteralType", "DecimalLiteral"]], "Column"]:
     def _(self: "Column", other: Union["Column", "LiteralType", "DecimalLiteral"]) -> "Column":
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         fn = getattr(sc._jvm.functions, name)
         jc = other._jc if isinstance(other, Column) else _create_column_from_literal(other)
         njc = fn(self._jc, jc) if not reverse else fn(jc, self._jc)

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -45,12 +45,16 @@ __all__ = ["Column"]
 
 
 def _create_column_from_literal(literal: Union["LiteralType", "DecimalLiteral"]) -> "Column":
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return sc._jvm.functions.lit(literal)
 
 
 def _create_column_from_name(name: str) -> "Column":
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return sc._jvm.functions.col(name)
 
 
@@ -82,6 +86,7 @@ def _to_seq(
     """
     if converter:
         cols = [converter(c) for c in cols]
+    assert sc._jvm is not None
     return sc._jvm.PythonUtils.toSeq(cols)  # type: ignore[attr-defined]
 
 
@@ -98,7 +103,8 @@ def _to_list(
     """
     if converter:
         cols = [converter(c) for c in cols]
-    return sc._jvm.PythonUtils.toList(cols)  # type: ignore[attr-defined]
+    assert sc._jvm is not None
+    return sc._jvm.PythonUtils.toList(cols)
 
 
 def _unary_op(
@@ -117,7 +123,9 @@ def _unary_op(
 
 def _func_op(name: str, doc: str = "") -> Callable[["Column"], "Column"]:
     def _(self: "Column") -> "Column":
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         jc = getattr(sc._jvm.functions, name)(self._jc)
         return Column(jc)
 
@@ -131,7 +139,9 @@ def _bin_func_op(
     doc: str = "binary function",
 ) -> Callable[["Column", Union["Column", "LiteralType", "DecimalLiteral"]], "Column"]:
     def _(self: "Column", other: Union["Column", "LiteralType", "DecimalLiteral"]) -> "Column":
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         fn = getattr(sc._jvm.functions, name)
         jc = other._jc if isinstance(other, Column) else _create_column_from_literal(other)
         njc = fn(self._jc, jc) if not reverse else fn(jc, self._jc)
@@ -542,8 +552,8 @@ class Column(object):
         +--------------+
 
         """
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
-
+        sc = SparkContext._active_spark_context
+        assert sc is not None
         jc = self._jc.dropFields(_to_seq(sc, fieldNames))
         return Column(jc)
 
@@ -728,7 +738,8 @@ class Column(object):
             Tuple,
             [c._jc if isinstance(c, Column) else _create_column_from_literal(c) for c in cols],
         )
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
         jc = getattr(self._jc, "isin")(_to_seq(sc, cols))
         return Column(jc)
 
@@ -875,9 +886,11 @@ class Column(object):
         metadata = kwargs.pop("metadata", None)
         assert not kwargs, "Unexpected kwargs where passed: %s" % kwargs
 
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
         if len(alias) == 1:
             if metadata:
+                assert sc._jvm is not None
                 jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(json.dumps(metadata))
                 return Column(getattr(self._jc, "as")(alias[0], jmeta))
             else:

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -168,6 +168,7 @@ class SQLContext(object):
             cls._instantiatedContext is None
             or SQLContext._instantiatedContext._sc._jsc is None  # type: ignore[union-attr]
         ):
+            assert sc._jvm is not None
             jsqlContext = (
                 sc._jvm.SparkSession.builder()  # type: ignore[attr-defined]
                 .sparkContext(sc._jsc.sc())  # type: ignore[attr-defined]
@@ -733,6 +734,7 @@ class HiveContext(SQLContext):
         confusing error messages.
         """
         jsc = sparkContext._jsc.sc()  # type: ignore[attr-defined]
+        assert sparkContext._jvm is not None
         jtestHive = sparkContext._jvm.org.apache.spark.sql.hive.test.TestHiveContext(  # type: ignore[attr-defined]
             jsc, False
         )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -426,9 +426,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             explain_mode = cast(str, mode)
         elif is_extended_as_mode:
             explain_mode = cast(str, extended)
-
+        assert self._sc._jvm is not None
         print(
-            self._sc._jvm.PythonSQLUtils.explainString(  # type: ignore[attr-defined]
+            self._sc._jvm.PythonSQLUtils.explainString(
                 self._jdf.queryExecution(), explain_mode
             )
         )
@@ -2986,7 +2986,9 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         if not isinstance(metadata, dict):
             raise TypeError("metadata should be a dict")
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(json.dumps(metadata))
         return DataFrame(self._jdf.withMetadata(columnName, jmeta), self.sql_ctx)
 
@@ -3278,7 +3280,8 @@ def _to_scala_map(sc: SparkContext, jm: Dict) -> JavaObject:
     """
     Convert a dict into a JVM Map.
     """
-    return sc._jvm.PythonUtils.toScalaMap(jm)  # type: ignore[attr-defined]
+    assert sc._jvm is not None
+    return sc._jvm.PythonUtils.toScalaMap(jm)
 
 
 class DataFrameNaFunctions(object):

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2983,8 +2983,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         if not isinstance(metadata, dict):
             raise TypeError("metadata should be a dict")
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         jmeta = sc._jvm.org.apache.spark.sql.types.Metadata.fromJson(json.dumps(metadata))
         return DataFrame(self._jdf.withMetadata(columnName, jmeta), self.sql_ctx)
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -427,11 +427,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         elif is_extended_as_mode:
             explain_mode = cast(str, extended)
         assert self._sc._jvm is not None
-        print(
-            self._sc._jvm.PythonSQLUtils.explainString(
-                self._jdf.queryExecution(), explain_mode
-            )
-        )
+        print(self._sc._jvm.PythonSQLUtils.explainString(self._jdf.queryExecution(), explain_mode))
 
     def exceptAll(self, other: "DataFrame") -> "DataFrame":
         """Return a new :class:`DataFrame` containing rows in this :class:`DataFrame` but

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1082,8 +1082,7 @@ def approx_count_distinct(col: "ColumnOrName", rsd: Optional[float] = None) -> C
     [Row(distinct_ages=2)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if rsd is None:
         jc = sc._jvm.functions.approx_count_distinct(_to_java_column(col))
     else:
@@ -1096,8 +1095,7 @@ def broadcast(df: DataFrame) -> DataFrame:
     """Marks a DataFrame as small enough for use in broadcast joins."""
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return DataFrame(sc._jvm.functions.broadcast(df._jdf), df.sql_ctx)
 
 
@@ -1137,8 +1135,7 @@ def coalesce(*cols: "ColumnOrName") -> Column:
     +----+----+----------------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.coalesce(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -1158,8 +1155,7 @@ def corr(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(c=1.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1178,8 +1174,7 @@ def covar_pop(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(c=0.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1198,8 +1193,7 @@ def covar_samp(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(c=0.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1228,8 +1222,7 @@ def count_distinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
     [Row(c=2)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.count_distinct(_to_java_column(col), _to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -1248,8 +1241,7 @@ def first(col: "ColumnOrName", ignorenulls: bool = False) -> Column:
     rows which may be non-deterministic after a shuffle.
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.first(_to_java_column(col), ignorenulls)
     return Column(jc)
 
@@ -1273,8 +1265,7 @@ def grouping(col: "ColumnOrName") -> Column:
     +-----+--------------+--------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.grouping(_to_java_column(col))
     return Column(jc)
 
@@ -1304,8 +1295,7 @@ def grouping_id(*cols: "ColumnOrName") -> Column:
     +-----+-------------+--------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.grouping_id(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -1314,8 +1304,7 @@ def grouping_id(*cols: "ColumnOrName") -> Column:
 def input_file_name() -> Column:
     """Creates a string column for the file name of the current Spark task."""
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.input_file_name())
 
 
@@ -1331,8 +1320,7 @@ def isnan(col: "ColumnOrName") -> Column:
     [Row(r1=False, r2=False), Row(r1=True, r2=True)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.isnan(_to_java_column(col)))
 
 
@@ -1348,8 +1336,7 @@ def isnull(col: "ColumnOrName") -> Column:
     [Row(r1=False, r2=False), Row(r1=True, r2=True)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.isnull(_to_java_column(col)))
 
 
@@ -1367,8 +1354,7 @@ def last(col: "ColumnOrName", ignorenulls: bool = False) -> Column:
     rows which may be non-deterministic after a shuffle.
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.last(_to_java_column(col), ignorenulls)
     return Column(jc)
 
@@ -1396,8 +1382,7 @@ def monotonically_increasing_id() -> Column:
     [Row(id=0), Row(id=1), Row(id=2), Row(id=8589934592), Row(id=8589934593), Row(id=8589934594)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.monotonically_increasing_id())
 
 
@@ -1415,8 +1400,7 @@ def nanvl(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(r1=1.0, r2=1.0), Row(r1=2.0, r2=2.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.nanvl(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1461,8 +1445,7 @@ def percentile_approx(
      |-- median: double (nullable = true)
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
 
     if isinstance(percentage, (list, tuple)):
         # A local list
@@ -1502,8 +1485,7 @@ def rand(seed: Optional[int] = None) -> Column:
      Row(age=5, name='Bob', rand=2.3913904055683974)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if seed is not None:
         jc = sc._jvm.functions.rand(seed)
     else:
@@ -1528,8 +1510,7 @@ def randn(seed: Optional[int] = None) -> Column:
     Row(age=5, name='Bob', randn=0.7400395449950132)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if seed is not None:
         jc = sc._jvm.functions.randn(seed)
     else:
@@ -1550,8 +1531,7 @@ def round(col: "ColumnOrName", scale: int = 0) -> Column:
     [Row(r=3.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.round(_to_java_column(col), scale))
 
 
@@ -1568,8 +1548,7 @@ def bround(col: "ColumnOrName", scale: int = 0) -> Column:
     [Row(r=2.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.bround(_to_java_column(col), scale))
 
 
@@ -1596,8 +1575,7 @@ def shiftleft(col: "ColumnOrName", numBits: int) -> Column:
     [Row(r=42)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.shiftleft(_to_java_column(col), numBits))
 
 
@@ -1624,8 +1602,7 @@ def shiftright(col: "ColumnOrName", numBits: int) -> Column:
     [Row(r=21)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.shiftRight(_to_java_column(col), numBits)
     return Column(jc)
 
@@ -1654,8 +1631,7 @@ def shiftrightunsigned(col: "ColumnOrName", numBits: int) -> Column:
     [Row(r=9223372036854775787)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.shiftRightUnsigned(_to_java_column(col), numBits)
     return Column(jc)
 
@@ -1675,8 +1651,7 @@ def spark_partition_id() -> Column:
     [Row(pid=0), Row(pid=0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.spark_partition_id())
 
 
@@ -1691,8 +1666,7 @@ def expr(str: str) -> Column:
     [Row(length(name)=5), Row(length(name)=3)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.expr(str))
 
 
@@ -1714,8 +1688,7 @@ def struct(*cols: "ColumnOrName") -> Column:
     [Row(struct=Row(age=2, name='Alice')), Row(struct=Row(age=5, name='Bob'))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.struct(_to_seq(sc, cols, _to_java_column))
@@ -1738,8 +1711,7 @@ def greatest(*cols: "ColumnOrName") -> Column:
     if len(cols) < 2:
         raise ValueError("greatest should take at least two columns")
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.greatest(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -1759,8 +1731,7 @@ def least(*cols: Column) -> Column:
     if len(cols) < 2:
         raise ValueError("least should take at least two columns")
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.least(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -1785,8 +1756,7 @@ def when(condition: Column, value: Any) -> Column:
     [Row(age=3), Row(age=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if not isinstance(condition, Column):
         raise TypeError("condition should be a Column")
     v = value._jc if isinstance(value, Column) else value
@@ -1820,8 +1790,7 @@ def log(arg1: Union["ColumnOrName", float], arg2: Optional["ColumnOrName"] = Non
     ['0.69314', '1.60943']
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if arg2 is None:
         jc = sc._jvm.functions.log(_to_java_column(cast("ColumnOrName", arg1)))
     else:
@@ -1840,8 +1809,7 @@ def log2(col: "ColumnOrName") -> Column:
     [Row(log2=2.0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.log2(_to_java_column(col)))
 
 
@@ -1858,8 +1826,7 @@ def conv(col: "ColumnOrName", fromBase: int, toBase: int) -> Column:
     [Row(hex='15')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.conv(_to_java_column(col), fromBase, toBase))
 
 
@@ -1876,8 +1843,7 @@ def factorial(col: "ColumnOrName") -> Column:
     [Row(f=120)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.factorial(_to_java_column(col)))
 
 
@@ -1904,8 +1870,7 @@ def lag(col: "ColumnOrName", offset: int = 1, default: Optional[Any] = None) -> 
         default value
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.lag(_to_java_column(col), offset, default))
 
 
@@ -1929,8 +1894,7 @@ def lead(col: "ColumnOrName", offset: int = 1, default: Optional[Any] = None) ->
         default value
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.lead(_to_java_column(col), offset, default))
 
 
@@ -1957,8 +1921,7 @@ def nth_value(col: "ColumnOrName", offset: int, ignoreNulls: Optional[bool] = Fa
         determination of which row to use
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.nth_value(_to_java_column(col), offset, ignoreNulls))
 
 
@@ -1979,8 +1942,7 @@ def ntile(n: int) -> Column:
         an integer
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.ntile(int(n)))
 
 
@@ -1994,8 +1956,7 @@ def current_date() -> Column:
     All calls of current_date within the same query return the same value.
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.current_date())
 
 
@@ -2005,8 +1966,7 @@ def current_timestamp() -> Column:
     column. All calls of current_timestamp within the same query return the same value.
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.current_timestamp())
 
 
@@ -2033,8 +1993,7 @@ def date_format(date: "ColumnOrName", format: str) -> Column:
     [Row(date='04/08/2015')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.date_format(_to_java_column(date), format))
 
 
@@ -2051,8 +2010,7 @@ def year(col: "ColumnOrName") -> Column:
     [Row(year=2015)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.year(_to_java_column(col)))
 
 
@@ -2069,8 +2027,7 @@ def quarter(col: "ColumnOrName") -> Column:
     [Row(quarter=2)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.quarter(_to_java_column(col)))
 
 
@@ -2087,8 +2044,7 @@ def month(col: "ColumnOrName") -> Column:
     [Row(month=4)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.month(_to_java_column(col)))
 
 
@@ -2106,8 +2062,7 @@ def dayofweek(col: "ColumnOrName") -> Column:
     [Row(day=4)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.dayofweek(_to_java_column(col)))
 
 
@@ -2124,8 +2079,7 @@ def dayofmonth(col: "ColumnOrName") -> Column:
     [Row(day=8)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.dayofmonth(_to_java_column(col)))
 
 
@@ -2142,8 +2096,7 @@ def dayofyear(col: "ColumnOrName") -> Column:
     [Row(day=98)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.dayofyear(_to_java_column(col)))
 
 
@@ -2160,8 +2113,7 @@ def hour(col: "ColumnOrName") -> Column:
     [Row(hour=13)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.hour(_to_java_column(col)))
 
 
@@ -2178,8 +2130,7 @@ def minute(col: "ColumnOrName") -> Column:
     [Row(minute=8)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.minute(_to_java_column(col)))
 
 
@@ -2196,8 +2147,7 @@ def second(col: "ColumnOrName") -> Column:
     [Row(second=15)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.second(_to_java_column(col)))
 
 
@@ -2216,8 +2166,7 @@ def weekofyear(col: "ColumnOrName") -> Column:
     [Row(week=15)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.weekofyear(_to_java_column(col)))
 
 
@@ -2243,8 +2192,7 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     [Row(datefield=datetime.date(2020, 6, 26))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     year_col = _to_java_column(year)
     month_col = _to_java_column(month)
     day_col = _to_java_column(day)
@@ -2265,8 +2213,7 @@ def date_add(start: "ColumnOrName", days: int) -> Column:
     [Row(next_date=datetime.date(2015, 4, 9))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.date_add(_to_java_column(start), days))
 
 
@@ -2283,8 +2230,7 @@ def date_sub(start: "ColumnOrName", days: int) -> Column:
     [Row(prev_date=datetime.date(2015, 4, 7))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.date_sub(_to_java_column(start), days))
 
 
@@ -2301,8 +2247,7 @@ def datediff(end: "ColumnOrName", start: "ColumnOrName") -> Column:
     [Row(diff=32)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.datediff(_to_java_column(end), _to_java_column(start)))
 
 
@@ -2319,8 +2264,7 @@ def add_months(start: "ColumnOrName", months: int) -> Column:
     [Row(next_month=datetime.date(2015, 5, 8))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.add_months(_to_java_column(start), months))
 
 
@@ -2343,8 +2287,7 @@ def months_between(date1: "ColumnOrName", date2: "ColumnOrName", roundOff: bool 
     [Row(months=3.9495967741935485)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(
         sc._jvm.functions.months_between(_to_java_column(date1), _to_java_column(date2), roundOff)
     )
@@ -2371,8 +2314,7 @@ def to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     [Row(date=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if format is None:
         jc = sc._jvm.functions.to_date(_to_java_column(col))
     else:
@@ -2411,8 +2353,7 @@ def to_timestamp(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if format is None:
         jc = sc._jvm.functions.to_timestamp(_to_java_column(col))
     else:
@@ -2443,8 +2384,7 @@ def trunc(date: "ColumnOrName", format: str) -> Column:
     [Row(month=datetime.date(1997, 2, 1))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.trunc(_to_java_column(date), format))
 
 
@@ -2473,8 +2413,7 @@ def date_trunc(format: str, timestamp: "ColumnOrName") -> Column:
     [Row(month=datetime.datetime(1997, 2, 1, 0, 0))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.date_trunc(format, _to_java_column(timestamp)))
 
 
@@ -2494,8 +2433,7 @@ def next_day(date: "ColumnOrName", dayOfWeek: str) -> Column:
     [Row(date=datetime.date(2015, 8, 2))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.next_day(_to_java_column(date), dayOfWeek))
 
 
@@ -2512,8 +2450,7 @@ def last_day(date: "ColumnOrName") -> Column:
     [Row(date=datetime.date(1997, 2, 28))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.last_day(_to_java_column(date)))
 
 
@@ -2534,8 +2471,7 @@ def from_unixtime(timestamp: "ColumnOrName", format: str = "yyyy-MM-dd HH:mm:ss"
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.from_unixtime(_to_java_column(timestamp), format))
 
 
@@ -2560,8 +2496,7 @@ def unix_timestamp(
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if timestamp is None:
         return Column(sc._jvm.functions.unix_timestamp())
     return Column(sc._jvm.functions.unix_timestamp(_to_java_column(timestamp), format))
@@ -2608,8 +2543,7 @@ def from_utc_timestamp(timestamp: "ColumnOrName", tz: "ColumnOrName") -> Column:
     [Row(local_time=datetime.datetime(1997, 2, 28, 19, 30))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if isinstance(tz, Column):
         tz = _to_java_column(tz)
     return Column(sc._jvm.functions.from_utc_timestamp(_to_java_column(timestamp), tz))
@@ -2656,8 +2590,7 @@ def to_utc_timestamp(timestamp: "ColumnOrName", tz: "ColumnOrName") -> Column:
     [Row(utc_time=datetime.datetime(1997, 2, 28, 1, 30))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if isinstance(tz, Column):
         tz = _to_java_column(tz)
     return Column(sc._jvm.functions.to_utc_timestamp(_to_java_column(timestamp), tz))
@@ -2682,8 +2615,7 @@ def timestamp_seconds(col: "ColumnOrName") -> Column:
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.timestamp_seconds(_to_java_column(col)))
 
 
@@ -2750,8 +2682,7 @@ def window(
             raise TypeError("%s should be provided as a string" % fieldName)
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     time_col = _to_java_column(timeColumn)
     check_string_field(windowDuration, "windowDuration")
     if slideDuration and startTime:
@@ -2817,8 +2748,7 @@ def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) 
             raise TypeError("%s should be provided as a string or Column" % fieldName)
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     time_col = _to_java_column(timeColumn)
     check_field(gapDuration, "gapDuration")
     gap_duration = gapDuration if isinstance(gapDuration, str) else _to_java_column(gapDuration)
@@ -2842,8 +2772,7 @@ def crc32(col: "ColumnOrName") -> Column:
     [Row(crc32=2743272264)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.crc32(_to_java_column(col)))
 
 
@@ -2858,8 +2787,7 @@ def md5(col: "ColumnOrName") -> Column:
     [Row(hash='902fbdd2b1df0c4f70b4a5d23525e932')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.md5(_to_java_column(col))
     return Column(jc)
 
@@ -2875,8 +2803,7 @@ def sha1(col: "ColumnOrName") -> Column:
     [Row(hash='3c01bdbb26f358bab27f267924aa2c9a03fcfdb8')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.sha1(_to_java_column(col))
     return Column(jc)
 
@@ -2897,8 +2824,7 @@ def sha2(col: "ColumnOrName", numBits: int) -> Column:
     Row(s='cd9fb1e148ccd8442e5aa74904cc73bf6fb54d1d54d333bd596aa9bb4bb4e961')
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.sha2(_to_java_column(col), numBits)
     return Column(jc)
 
@@ -2914,8 +2840,7 @@ def hash(*cols: "ColumnOrName") -> Column:
     [Row(hash=-757602832)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.hash(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -2932,8 +2857,7 @@ def xxhash64(*cols: "ColumnOrName") -> Column:
     [Row(hash=4105715581806190027)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.xxhash64(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -2958,8 +2882,7 @@ def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None
     [Row(r=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if errMsg is None:
         return Column(sc._jvm.functions.assert_true(_to_java_column(col)))
     if not isinstance(errMsg, (str, Column)):
@@ -2980,8 +2903,7 @@ def raise_error(errMsg: Union[Column, str]) -> Column:
         raise TypeError("errMsg should be a Column or a str, got {}".format(type(errMsg)))
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     errMsg = (
         _create_column_from_literal(errMsg) if isinstance(errMsg, str) else _to_java_column(errMsg)
     )
@@ -3069,8 +2991,7 @@ def concat_ws(sep: str, *cols: "ColumnOrName") -> Column:
     [Row(s='abcd-123')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.concat_ws(sep, _to_seq(sc, cols, _to_java_column)))
 
 
@@ -3081,8 +3002,7 @@ def decode(col: "ColumnOrName", charset: str) -> Column:
     (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.decode(_to_java_column(col), charset))
 
 
@@ -3093,8 +3013,7 @@ def encode(col: "ColumnOrName", charset: str) -> Column:
     (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.encode(_to_java_column(col), charset))
 
 
@@ -3116,8 +3035,7 @@ def format_number(col: "ColumnOrName", d: int) -> Column:
     [Row(v='5.0000')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.format_number(_to_java_column(col), d))
 
 
@@ -3141,8 +3059,7 @@ def format_string(format: str, *cols: "ColumnOrName") -> Column:
     [Row(v='5 hello')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.format_string(format, _to_seq(sc, cols, _to_java_column)))
 
 
@@ -3163,8 +3080,7 @@ def instr(str: "ColumnOrName", substr: str) -> Column:
     [Row(s=2)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.instr(_to_java_column(str), substr))
 
 
@@ -3203,8 +3119,7 @@ def overlay(
     len = _create_column_from_literal(len) if isinstance(len, int) else _to_java_column(len)
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
 
     return Column(
         sc._jvm.functions.overlay(_to_java_column(src), _to_java_column(replace), pos, len)
@@ -3247,8 +3162,7 @@ def sentences(
         country = lit("")
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(
         sc._jvm.functions.sentences(
             _to_java_column(string), _to_java_column(language), _to_java_column(country)
@@ -3275,8 +3189,7 @@ def substring(str: "ColumnOrName", pos: int, len: int) -> Column:
     [Row(s='ab')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.substring(_to_java_column(str), pos, len))
 
 
@@ -3298,8 +3211,7 @@ def substring_index(str: "ColumnOrName", delim: str, count: int) -> Column:
     [Row(s='b.c.d')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.substring_index(_to_java_column(str), delim, count))
 
 
@@ -3315,8 +3227,7 @@ def levenshtein(left: "ColumnOrName", right: "ColumnOrName") -> Column:
     [Row(d=3)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.levenshtein(_to_java_column(left), _to_java_column(right))
     return Column(jc)
 
@@ -3348,8 +3259,7 @@ def locate(substr: str, str: "ColumnOrName", pos: int = 1) -> Column:
     [Row(s=2)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.locate(substr, _to_java_column(str), pos))
 
 
@@ -3366,8 +3276,7 @@ def lpad(col: "ColumnOrName", len: int, pad: str) -> Column:
     [Row(s='##abcd')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.lpad(_to_java_column(col), len, pad))
 
 
@@ -3384,8 +3293,7 @@ def rpad(col: "ColumnOrName", len: int, pad: str) -> Column:
     [Row(s='abcd##')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.rpad(_to_java_column(col), len, pad))
 
 
@@ -3402,8 +3310,7 @@ def repeat(col: "ColumnOrName", n: int) -> Column:
     [Row(s='ababab')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.repeat(_to_java_column(col), n))
 
 
@@ -3441,8 +3348,7 @@ def split(str: "ColumnOrName", pattern: str, limit: int = -1) -> Column:
     [Row(s=['one', 'two', 'three', ''])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.split(_to_java_column(str), pattern, limit))
 
 
@@ -3465,8 +3371,7 @@ def regexp_extract(str: "ColumnOrName", pattern: str, idx: int) -> Column:
     [Row(d='')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.regexp_extract(_to_java_column(str), pattern, idx)
     return Column(jc)
 
@@ -3483,8 +3388,7 @@ def regexp_replace(str: "ColumnOrName", pattern: str, replacement: str) -> Colum
     [Row(d='-----')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.regexp_replace(_to_java_column(str), pattern, replacement)
     return Column(jc)
 
@@ -3500,8 +3404,7 @@ def initcap(col: "ColumnOrName") -> Column:
     [Row(v='Ab Cd')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.initcap(_to_java_column(col)))
 
 
@@ -3518,8 +3421,7 @@ def soundex(col: "ColumnOrName") -> Column:
     [Row(soundex='P362'), Row(soundex='U612')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.soundex(_to_java_column(col)))
 
 
@@ -3534,8 +3436,7 @@ def bin(col: "ColumnOrName") -> Column:
     [Row(c='10'), Row(c='101')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.bin(_to_java_column(col))
     return Column(jc)
 
@@ -3553,8 +3454,7 @@ def hex(col: "ColumnOrName") -> Column:
     [Row(hex(a)='414243', hex(b)='3')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.hex(_to_java_column(col))
     return Column(jc)
 
@@ -3571,8 +3471,7 @@ def unhex(col: "ColumnOrName") -> Column:
     [Row(unhex(a)=bytearray(b'ABC'))]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.unhex(_to_java_column(col)))
 
 
@@ -3589,8 +3488,7 @@ def length(col: "ColumnOrName") -> Column:
     [Row(length=4)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.length(_to_java_column(col)))
 
 
@@ -3661,8 +3559,7 @@ def translate(srcCol: "ColumnOrName", matching: str, replace: str) -> Column:
     [Row(r='1a2s3ae')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.translate(_to_java_column(srcCol), matching, replace))
 
 
@@ -3688,8 +3585,7 @@ def create_map(*cols: "ColumnOrName") -> Column:
     [Row(map={'Alice': 2}), Row(map={'Bob': 5})]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.map(_to_seq(sc, cols, _to_java_column))
@@ -3719,8 +3615,7 @@ def map_from_arrays(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     +----------------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.map_from_arrays(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -3743,8 +3638,7 @@ def array(*cols: "ColumnOrName") -> Column:
     [Row(arr=[2, 2]), Row(arr=[5, 5])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.array(_to_seq(sc, cols, _to_java_column))
@@ -3774,8 +3668,7 @@ def array_contains(col: "ColumnOrName", value: Any) -> Column:
     [Row(array_contains(data, a)=True), Row(array_contains(data, a)=False)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     value = value._jc if isinstance(value, Column) else value
     return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))
 
@@ -3795,8 +3688,7 @@ def arrays_overlap(a1: "ColumnOrName", a2: "ColumnOrName") -> Column:
     [Row(overlap=True), Row(overlap=False)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.arrays_overlap(_to_java_column(a1), _to_java_column(a2)))
 
 
@@ -3823,8 +3715,7 @@ def slice(x: "ColumnOrName", start: Union[Column, int], length: Union[Column, in
     [Row(sliced=[2, 3]), Row(sliced=[5])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(
         sc._jvm.functions.slice(
             _to_java_column(x),
@@ -3852,8 +3743,7 @@ def array_join(
     [Row(joined='a,b,c'), Row(joined='a,NULL')]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if null_replacement is None:
         return Column(sc._jvm.functions.array_join(_to_java_column(col), delimiter))
     else:
@@ -3880,8 +3770,7 @@ def concat(*cols: "ColumnOrName") -> Column:
     [Row(arr=[1, 2, 3, 4, 5]), Row(arr=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.concat(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -3904,8 +3793,7 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
     [Row(array_position(data, a)=3), Row(array_position(data, a)=0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_position(_to_java_column(col), value))
 
 
@@ -3938,8 +3826,7 @@ def element_at(col: "ColumnOrName", extraction: Any) -> Column:
     [Row(element_at(data, a)=1.0), Row(element_at(data, a)=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.element_at(_to_java_column(col), lit(extraction)._jc))
 
 
@@ -3963,8 +3850,7 @@ def array_remove(col: "ColumnOrName", element: Any) -> Column:
     [Row(array_remove(data, 1)=[2, 3]), Row(array_remove(data, 1)=[])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_remove(_to_java_column(col), element))
 
 
@@ -3986,8 +3872,7 @@ def array_distinct(col: "ColumnOrName") -> Column:
     [Row(array_distinct(data)=[1, 2, 3]), Row(array_distinct(data)=[4, 5])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_distinct(_to_java_column(col)))
 
 
@@ -4013,8 +3898,7 @@ def array_intersect(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(array_intersect(c1, c2)=['a', 'c'])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_intersect(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -4040,8 +3924,7 @@ def array_union(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(array_union(c1, c2)=['b', 'a', 'c', 'd', 'f'])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_union(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -4067,8 +3950,7 @@ def array_except(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     [Row(array_except(c1, c2)=['b'])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_except(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -4095,8 +3977,7 @@ def explode(col: "ColumnOrName") -> Column:
     +---+-----+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.explode(_to_java_column(col))
     return Column(jc)
 
@@ -4124,8 +4005,7 @@ def posexplode(col: "ColumnOrName") -> Column:
     +---+---+-----+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.posexplode(_to_java_column(col))
     return Column(jc)
 
@@ -4165,8 +4045,7 @@ def explode_outer(col: "ColumnOrName") -> Column:
     +---+----------+----+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.explode_outer(_to_java_column(col))
     return Column(jc)
 
@@ -4205,8 +4084,7 @@ def posexplode_outer(col: "ColumnOrName") -> Column:
     +---+----------+----+----+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.posexplode_outer(_to_java_column(col))
     return Column(jc)
 
@@ -4234,8 +4112,7 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.get_json_object(_to_java_column(col), path)
     return Column(jc)
 
@@ -4260,8 +4137,7 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.json_tuple(_to_java_column(col), _to_seq(sc, fields))
     return Column(jc)
 
@@ -4322,8 +4198,7 @@ def from_json(
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if isinstance(schema, DataType):
         schema = schema.json()
     elif isinstance(schema, Column):
@@ -4379,8 +4254,7 @@ def to_json(col: "ColumnOrName", options: Optional[Dict[str, str]] = None) -> Co
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.to_json(_to_java_column(col), _options_to_str(options))
     return Column(jc)
 
@@ -4422,8 +4296,7 @@ def schema_of_json(json: "ColumnOrName", options: Optional[Dict[str, str]] = Non
         raise TypeError("schema argument should be a column or string")
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.schema_of_json(col, _options_to_str(options))
     return Column(jc)
 
@@ -4461,8 +4334,7 @@ def schema_of_csv(csv: "ColumnOrName", options: Optional[Dict[str, str]] = None)
         raise TypeError("schema argument should be a column or string")
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.schema_of_csv(col, _options_to_str(options))
     return Column(jc)
 
@@ -4495,8 +4367,7 @@ def to_csv(col: "ColumnOrName", options: Optional[Dict[str, str]] = None) -> Col
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     jc = sc._jvm.functions.to_csv(_to_java_column(col), _options_to_str(options))
     return Column(jc)
 
@@ -4519,8 +4390,7 @@ def size(col: "ColumnOrName") -> Column:
     [Row(size(data)=3), Row(size(data)=1), Row(size(data)=0)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.size(_to_java_column(col)))
 
 
@@ -4542,8 +4412,7 @@ def array_min(col: "ColumnOrName") -> Column:
     [Row(min=1), Row(min=-1)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_min(_to_java_column(col)))
 
 
@@ -4565,8 +4434,7 @@ def array_max(col: "ColumnOrName") -> Column:
     [Row(max=3), Row(max=10)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_max(_to_java_column(col)))
 
 
@@ -4594,8 +4462,7 @@ def sort_array(col: "ColumnOrName", asc: bool = True) -> Column:
     [Row(r=[3, 2, 1, None]), Row(r=[1]), Row(r=[])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.sort_array(_to_java_column(col), asc))
 
 
@@ -4618,8 +4485,7 @@ def array_sort(col: "ColumnOrName") -> Column:
     [Row(r=[1, 2, 3, None]), Row(r=[1]), Row(r=[])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.array_sort(_to_java_column(col)))
 
 
@@ -4645,8 +4511,7 @@ def shuffle(col: "ColumnOrName") -> Column:
     [Row(s=[3, 1, 5, 20]), Row(s=[20, None, 3, 1])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.shuffle(_to_java_column(col)))
 
 
@@ -4671,8 +4536,7 @@ def reverse(col: "ColumnOrName") -> Column:
     [Row(r=[3, 1, 2]), Row(r=[1]), Row(r=[])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.reverse(_to_java_column(col)))
 
 
@@ -4696,8 +4560,7 @@ def flatten(col: "ColumnOrName") -> Column:
     [Row(r=[1, 2, 3, 4, 5, 6]), Row(r=None)]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.flatten(_to_java_column(col)))
 
 
@@ -4724,8 +4587,7 @@ def map_keys(col: "ColumnOrName") -> Column:
     +------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.map_keys(_to_java_column(col)))
 
 
@@ -4752,8 +4614,7 @@ def map_values(col: "ColumnOrName") -> Column:
     +------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.map_values(_to_java_column(col)))
 
 
@@ -4780,8 +4641,7 @@ def map_entries(col: "ColumnOrName") -> Column:
     +----------------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.map_entries(_to_java_column(col)))
 
 
@@ -4808,8 +4668,7 @@ def map_from_entries(col: "ColumnOrName") -> Column:
     +----------------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.map_from_entries(_to_java_column(col)))
 
 
@@ -4826,8 +4685,7 @@ def array_repeat(col: "ColumnOrName", count: Union[Column, int]) -> Column:
     [Row(r=['ab', 'ab', 'ab'])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(
         sc._jvm.functions.array_repeat(
             _to_java_column(col), _to_java_column(count) if isinstance(count, Column) else count
@@ -4855,8 +4713,7 @@ def arrays_zip(*cols: "ColumnOrName") -> Column:
     [Row(zipped=[Row(vals1=1, vals2=2), Row(vals1=2, vals2=3), Row(vals1=3, vals2=4)])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.arrays_zip(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -4882,8 +4739,7 @@ def map_concat(*cols: "ColumnOrName") -> Column:
     +------------------------+
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.map_concat(_to_seq(sc, cols, _to_java_column))
@@ -4910,8 +4766,7 @@ def sequence(
     [Row(r=[4, 2, 0, -2, -4])]
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if step is None:
         return Column(sc._jvm.functions.sequence(_to_java_column(start), _to_java_column(stop)))
     else:
@@ -4963,8 +4818,7 @@ def from_csv(
     """
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     if isinstance(schema, str):
         schema = _create_column_from_literal(schema)
     elif isinstance(schema, Column):
@@ -4986,8 +4840,7 @@ def _unresolved_named_lambda_variable(*name_parts: Any) -> Column:
     name_parts : str
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     name_parts_seq = _to_seq(sc, name_parts)
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
     return Column(sc._jvm.Column(expressions.UnresolvedNamedLambdaVariable(name_parts_seq)))
@@ -5034,8 +4887,7 @@ def _create_lambda(f: Callable) -> Callable:
     parameters = _get_lambda_parameters(f)
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
 
     argnames = ["x", "y", "z"]
@@ -5074,8 +4926,7 @@ def _invoke_higher_order_function(
     :return: a Column
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
     expr = getattr(expressions, name)
 
@@ -5577,8 +5428,7 @@ def years(col: "ColumnOrName") -> Column:
 
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.years(_to_java_column(col)))
 
 
@@ -5603,8 +5453,7 @@ def months(col: "ColumnOrName") -> Column:
 
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.months(_to_java_column(col)))
 
 
@@ -5629,8 +5478,7 @@ def days(col: "ColumnOrName") -> Column:
 
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.days(_to_java_column(col)))
 
 
@@ -5655,8 +5503,7 @@ def hours(col: "ColumnOrName") -> Column:
 
     """
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.functions.hours(_to_java_column(col)))
 
 
@@ -5684,8 +5531,7 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
         raise TypeError("numBuckets should be a Column or an int, got {}".format(type(numBuckets)))
 
     sc = SparkContext._active_spark_context
-    assert sc is not None
-    assert sc._jvm is not None
+    assert sc is not None and sc._jvm is not None
     numBuckets = (
         _create_column_from_literal(numBuckets)
         if isinstance(numBuckets, int)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -79,9 +79,7 @@ def _invoke_function(name: str, *args: Any) -> Column:
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
     assert SparkContext._active_spark_context is not None
-    jf = _get_get_jvm_function(
-        name, SparkContext._active_spark_context
-    )
+    jf = _get_get_jvm_function(name, SparkContext._active_spark_context)
     return Column(jf(*args))
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -69,7 +69,8 @@ def _get_get_jvm_function(name: str, sc: SparkContext) -> Callable:
     Retrieves JVM function identified by name from
     Java gateway associated with sc.
     """
-    return getattr(sc._jvm.functions, name)  # type: ignore[attr-defined]
+    assert sc._jvm is not None
+    return getattr(sc._jvm.functions, name)
 
 
 def _invoke_function(name: str, *args: Any) -> Column:
@@ -77,8 +78,9 @@ def _invoke_function(name: str, *args: Any) -> Column:
     Invokes JVM function identified by name with args
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
+    assert SparkContext._active_spark_context is not None
     jf = _get_get_jvm_function(
-        name, SparkContext._active_spark_context  # type: ignore[attr-defined]
+        name, SparkContext._active_spark_context
     )
     return Column(jf(*args))
 
@@ -1081,7 +1083,9 @@ def approx_count_distinct(col: "ColumnOrName", rsd: Optional[float] = None) -> C
     >>> df.agg(approx_count_distinct(df.age).alias('distinct_ages')).collect()
     [Row(distinct_ages=2)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if rsd is None:
         jc = sc._jvm.functions.approx_count_distinct(_to_java_column(col))
     else:
@@ -1093,7 +1097,9 @@ def approx_count_distinct(col: "ColumnOrName", rsd: Optional[float] = None) -> C
 def broadcast(df: DataFrame) -> DataFrame:
     """Marks a DataFrame as small enough for use in broadcast joins."""
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return DataFrame(sc._jvm.functions.broadcast(df._jdf), df.sql_ctx)
 
 
@@ -1132,7 +1138,9 @@ def coalesce(*cols: "ColumnOrName") -> Column:
     |null|   2|             0.0|
     +----+----+----------------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.coalesce(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -1151,7 +1159,9 @@ def corr(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.agg(corr("a", "b").alias('c')).collect()
     [Row(c=1.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.corr(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1169,7 +1179,9 @@ def covar_pop(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.agg(covar_pop("a", "b").alias('c')).collect()
     [Row(c=0.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.covar_pop(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1187,7 +1199,9 @@ def covar_samp(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.agg(covar_samp("a", "b").alias('c')).collect()
     [Row(c=0.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.covar_samp(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1215,7 +1229,9 @@ def count_distinct(col: "ColumnOrName", *cols: "ColumnOrName") -> Column:
     >>> df.agg(count_distinct("age", "name").alias('c')).collect()
     [Row(c=2)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.count_distinct(_to_java_column(col), _to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -1233,7 +1249,9 @@ def first(col: "ColumnOrName", ignorenulls: bool = False) -> Column:
     The function is non-deterministic because its results depends on the order of the
     rows which may be non-deterministic after a shuffle.
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.first(_to_java_column(col), ignorenulls)
     return Column(jc)
 
@@ -1256,7 +1274,9 @@ def grouping(col: "ColumnOrName") -> Column:
     |  Bob|             0|       5|
     +-----+--------------+--------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.grouping(_to_java_column(col))
     return Column(jc)
 
@@ -1285,7 +1305,9 @@ def grouping_id(*cols: "ColumnOrName") -> Column:
     |  Bob|            0|       5|
     +-----+-------------+--------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.grouping_id(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -1293,7 +1315,9 @@ def grouping_id(*cols: "ColumnOrName") -> Column:
 @since(1.6)
 def input_file_name() -> Column:
     """Creates a string column for the file name of the current Spark task."""
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.input_file_name())
 
 
@@ -1308,7 +1332,9 @@ def isnan(col: "ColumnOrName") -> Column:
     >>> df.select(isnan("a").alias("r1"), isnan(df.a).alias("r2")).collect()
     [Row(r1=False, r2=False), Row(r1=True, r2=True)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.isnan(_to_java_column(col)))
 
 
@@ -1323,7 +1349,9 @@ def isnull(col: "ColumnOrName") -> Column:
     >>> df.select(isnull("a").alias("r1"), isnull(df.a).alias("r2")).collect()
     [Row(r1=False, r2=False), Row(r1=True, r2=True)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.isnull(_to_java_column(col)))
 
 
@@ -1340,7 +1368,9 @@ def last(col: "ColumnOrName", ignorenulls: bool = False) -> Column:
     The function is non-deterministic because its results depends on the order of the
     rows which may be non-deterministic after a shuffle.
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.last(_to_java_column(col), ignorenulls)
     return Column(jc)
 
@@ -1367,7 +1397,9 @@ def monotonically_increasing_id() -> Column:
     >>> df0.select(monotonically_increasing_id().alias('id')).collect()
     [Row(id=0), Row(id=1), Row(id=2), Row(id=8589934592), Row(id=8589934593), Row(id=8589934594)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.monotonically_increasing_id())
 
 
@@ -1384,7 +1416,9 @@ def nanvl(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.select(nanvl("a", "b").alias("r1"), nanvl(df.a, df.b).alias("r2")).collect()
     [Row(r1=1.0, r2=1.0), Row(r1=2.0, r2=2.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.nanvl(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -1428,7 +1462,9 @@ def percentile_approx(
      |-- key: long (nullable = true)
      |-- median: double (nullable = true)
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
 
     if isinstance(percentage, (list, tuple)):
         # A local list
@@ -1467,7 +1503,9 @@ def rand(seed: Optional[int] = None) -> Column:
     [Row(age=2, name='Alice', rand=2.4052597283576684),
      Row(age=5, name='Bob', rand=2.3913904055683974)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if seed is not None:
         jc = sc._jvm.functions.rand(seed)
     else:
@@ -1491,7 +1529,9 @@ def randn(seed: Optional[int] = None) -> Column:
     [Row(age=2, name='Alice', randn=1.1027054481455365),
     Row(age=5, name='Bob', randn=0.7400395449950132)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if seed is not None:
         jc = sc._jvm.functions.randn(seed)
     else:
@@ -1511,7 +1551,9 @@ def round(col: "ColumnOrName", scale: int = 0) -> Column:
     >>> spark.createDataFrame([(2.5,)], ['a']).select(round('a', 0).alias('r')).collect()
     [Row(r=3.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.round(_to_java_column(col), scale))
 
 
@@ -1527,7 +1569,9 @@ def bround(col: "ColumnOrName", scale: int = 0) -> Column:
     >>> spark.createDataFrame([(2.5,)], ['a']).select(bround('a', 0).alias('r')).collect()
     [Row(r=2.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.bround(_to_java_column(col), scale))
 
 
@@ -1553,7 +1597,9 @@ def shiftleft(col: "ColumnOrName", numBits: int) -> Column:
     >>> spark.createDataFrame([(21,)], ['a']).select(shiftleft('a', 1).alias('r')).collect()
     [Row(r=42)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.shiftleft(_to_java_column(col), numBits))
 
 
@@ -1579,7 +1625,9 @@ def shiftright(col: "ColumnOrName", numBits: int) -> Column:
     >>> spark.createDataFrame([(42,)], ['a']).select(shiftright('a', 1).alias('r')).collect()
     [Row(r=21)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.shiftRight(_to_java_column(col), numBits)
     return Column(jc)
 
@@ -1607,7 +1655,9 @@ def shiftrightunsigned(col: "ColumnOrName", numBits: int) -> Column:
     >>> df.select(shiftrightunsigned('a', 1).alias('r')).collect()
     [Row(r=9223372036854775787)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.shiftRightUnsigned(_to_java_column(col), numBits)
     return Column(jc)
 
@@ -1626,7 +1676,9 @@ def spark_partition_id() -> Column:
     >>> df.repartition(1).select(spark_partition_id().alias("pid")).collect()
     [Row(pid=0), Row(pid=0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.spark_partition_id())
 
 
@@ -1640,7 +1692,9 @@ def expr(str: str) -> Column:
     >>> df.select(expr("length(name)")).collect()
     [Row(length(name)=5), Row(length(name)=3)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.expr(str))
 
 
@@ -1661,7 +1715,9 @@ def struct(*cols: "ColumnOrName") -> Column:
     >>> df.select(struct([df.age, df.name]).alias("struct")).collect()
     [Row(struct=Row(age=2, name='Alice')), Row(struct=Row(age=5, name='Bob'))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.struct(_to_seq(sc, cols, _to_java_column))
@@ -1683,7 +1739,9 @@ def greatest(*cols: "ColumnOrName") -> Column:
     """
     if len(cols) < 2:
         raise ValueError("greatest should take at least two columns")
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.greatest(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -1702,7 +1760,9 @@ def least(*cols: Column) -> Column:
     """
     if len(cols) < 2:
         raise ValueError("least should take at least two columns")
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.least(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -1726,7 +1786,9 @@ def when(condition: Column, value: Any) -> Column:
     >>> df.select(when(df.age == 2, df.age + 1).alias("age")).collect()
     [Row(age=3), Row(age=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if not isinstance(condition, Column):
         raise TypeError("condition should be a Column")
     v = value._jc if isinstance(value, Column) else value
@@ -1759,7 +1821,9 @@ def log(arg1: Union["ColumnOrName", float], arg2: Optional["ColumnOrName"] = Non
     >>> df.select(log(df.age).alias('e')).rdd.map(lambda l: str(l.e)[:7]).collect()
     ['0.69314', '1.60943']
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if arg2 is None:
         jc = sc._jvm.functions.log(_to_java_column(cast("ColumnOrName", arg1)))
     else:
@@ -1777,7 +1841,9 @@ def log2(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([(4,)], ['a']).select(log2('a').alias('log2')).collect()
     [Row(log2=2.0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.log2(_to_java_column(col)))
 
 
@@ -1793,7 +1859,9 @@ def conv(col: "ColumnOrName", fromBase: int, toBase: int) -> Column:
     >>> df.select(conv(df.n, 2, 16).alias('hex')).collect()
     [Row(hex='15')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.conv(_to_java_column(col), fromBase, toBase))
 
 
@@ -1809,7 +1877,9 @@ def factorial(col: "ColumnOrName") -> Column:
     >>> df.select(factorial(df.n).alias('f')).collect()
     [Row(f=120)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.factorial(_to_java_column(col)))
 
 
@@ -1835,7 +1905,9 @@ def lag(col: "ColumnOrName", offset: int = 1, default: Optional[Any] = None) -> 
     default : optional
         default value
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.lag(_to_java_column(col), offset, default))
 
 
@@ -1858,7 +1930,9 @@ def lead(col: "ColumnOrName", offset: int = 1, default: Optional[Any] = None) ->
     default : optional
         default value
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.lead(_to_java_column(col), offset, default))
 
 
@@ -1884,7 +1958,9 @@ def nth_value(col: "ColumnOrName", offset: int, ignoreNulls: Optional[bool] = Fa
         indicates the Nth value should skip null in the
         determination of which row to use
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.nth_value(_to_java_column(col), offset, ignoreNulls))
 
 
@@ -1904,7 +1980,9 @@ def ntile(n: int) -> Column:
     n : int
         an integer
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.ntile(int(n)))
 
 
@@ -1917,7 +1995,9 @@ def current_date() -> Column:
     Returns the current date at the start of query evaluation as a :class:`DateType` column.
     All calls of current_date within the same query return the same value.
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.current_date())
 
 
@@ -1926,7 +2006,9 @@ def current_timestamp() -> Column:
     Returns the current timestamp at the start of query evaluation as a :class:`TimestampType`
     column. All calls of current_timestamp within the same query return the same value.
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.current_timestamp())
 
 
@@ -1952,7 +2034,9 @@ def date_format(date: "ColumnOrName", format: str) -> Column:
     >>> df.select(date_format('dt', 'MM/dd/yyy').alias('date')).collect()
     [Row(date='04/08/2015')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.date_format(_to_java_column(date), format))
 
 
@@ -1968,7 +2052,9 @@ def year(col: "ColumnOrName") -> Column:
     >>> df.select(year('dt').alias('year')).collect()
     [Row(year=2015)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.year(_to_java_column(col)))
 
 
@@ -1984,7 +2070,9 @@ def quarter(col: "ColumnOrName") -> Column:
     >>> df.select(quarter('dt').alias('quarter')).collect()
     [Row(quarter=2)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.quarter(_to_java_column(col)))
 
 
@@ -2000,7 +2088,9 @@ def month(col: "ColumnOrName") -> Column:
     >>> df.select(month('dt').alias('month')).collect()
     [Row(month=4)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.month(_to_java_column(col)))
 
 
@@ -2017,7 +2107,9 @@ def dayofweek(col: "ColumnOrName") -> Column:
     >>> df.select(dayofweek('dt').alias('day')).collect()
     [Row(day=4)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.dayofweek(_to_java_column(col)))
 
 
@@ -2033,7 +2125,9 @@ def dayofmonth(col: "ColumnOrName") -> Column:
     >>> df.select(dayofmonth('dt').alias('day')).collect()
     [Row(day=8)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.dayofmonth(_to_java_column(col)))
 
 
@@ -2049,7 +2143,9 @@ def dayofyear(col: "ColumnOrName") -> Column:
     >>> df.select(dayofyear('dt').alias('day')).collect()
     [Row(day=98)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.dayofyear(_to_java_column(col)))
 
 
@@ -2065,7 +2161,9 @@ def hour(col: "ColumnOrName") -> Column:
     >>> df.select(hour('ts').alias('hour')).collect()
     [Row(hour=13)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.hour(_to_java_column(col)))
 
 
@@ -2081,7 +2179,9 @@ def minute(col: "ColumnOrName") -> Column:
     >>> df.select(minute('ts').alias('minute')).collect()
     [Row(minute=8)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.minute(_to_java_column(col)))
 
 
@@ -2097,7 +2197,9 @@ def second(col: "ColumnOrName") -> Column:
     >>> df.select(second('ts').alias('second')).collect()
     [Row(second=15)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.second(_to_java_column(col)))
 
 
@@ -2115,7 +2217,9 @@ def weekofyear(col: "ColumnOrName") -> Column:
     >>> df.select(weekofyear(df.dt).alias('week')).collect()
     [Row(week=15)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.weekofyear(_to_java_column(col)))
 
 
@@ -2140,7 +2244,9 @@ def make_date(year: "ColumnOrName", month: "ColumnOrName", day: "ColumnOrName") 
     >>> df.select(make_date(df.Y, df.M, df.D).alias("datefield")).collect()
     [Row(datefield=datetime.date(2020, 6, 26))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     year_col = _to_java_column(year)
     month_col = _to_java_column(month)
     day_col = _to_java_column(day)
@@ -2160,7 +2266,9 @@ def date_add(start: "ColumnOrName", days: int) -> Column:
     >>> df.select(date_add(df.dt, 1).alias('next_date')).collect()
     [Row(next_date=datetime.date(2015, 4, 9))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.date_add(_to_java_column(start), days))
 
 
@@ -2176,7 +2284,9 @@ def date_sub(start: "ColumnOrName", days: int) -> Column:
     >>> df.select(date_sub(df.dt, 1).alias('prev_date')).collect()
     [Row(prev_date=datetime.date(2015, 4, 7))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.date_sub(_to_java_column(start), days))
 
 
@@ -2192,7 +2302,9 @@ def datediff(end: "ColumnOrName", start: "ColumnOrName") -> Column:
     >>> df.select(datediff(df.d2, df.d1).alias('diff')).collect()
     [Row(diff=32)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.datediff(_to_java_column(end), _to_java_column(start)))
 
 
@@ -2208,7 +2320,9 @@ def add_months(start: "ColumnOrName", months: int) -> Column:
     >>> df.select(add_months(df.dt, 1).alias('next_month')).collect()
     [Row(next_month=datetime.date(2015, 5, 8))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.add_months(_to_java_column(start), months))
 
 
@@ -2230,7 +2344,9 @@ def months_between(date1: "ColumnOrName", date2: "ColumnOrName", roundOff: bool 
     >>> df.select(months_between(df.date1, df.date2, False).alias('months')).collect()
     [Row(months=3.9495967741935485)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(
         sc._jvm.functions.months_between(_to_java_column(date1), _to_java_column(date2), roundOff)
     )
@@ -2256,7 +2372,9 @@ def to_date(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     >>> df.select(to_date(df.t, 'yyyy-MM-dd HH:mm:ss').alias('date')).collect()
     [Row(date=datetime.date(1997, 2, 28))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if format is None:
         jc = sc._jvm.functions.to_date(_to_java_column(col))
     else:
@@ -2294,7 +2412,9 @@ def to_timestamp(col: "ColumnOrName", format: Optional[str] = None) -> Column:
     >>> df.select(to_timestamp(df.t, 'yyyy-MM-dd HH:mm:ss').alias('dt')).collect()
     [Row(dt=datetime.datetime(1997, 2, 28, 10, 30))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if format is None:
         jc = sc._jvm.functions.to_timestamp(_to_java_column(col))
     else:
@@ -2324,7 +2444,9 @@ def trunc(date: "ColumnOrName", format: str) -> Column:
     >>> df.select(trunc(df.d, 'mon').alias('month')).collect()
     [Row(month=datetime.date(1997, 2, 1))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.trunc(_to_java_column(date), format))
 
 
@@ -2352,7 +2474,9 @@ def date_trunc(format: str, timestamp: "ColumnOrName") -> Column:
     >>> df.select(date_trunc('mon', df.t).alias('month')).collect()
     [Row(month=datetime.datetime(1997, 2, 1, 0, 0))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.date_trunc(format, _to_java_column(timestamp)))
 
 
@@ -2371,7 +2495,9 @@ def next_day(date: "ColumnOrName", dayOfWeek: str) -> Column:
     >>> df.select(next_day(df.d, 'Sun').alias('date')).collect()
     [Row(date=datetime.date(2015, 8, 2))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.next_day(_to_java_column(date), dayOfWeek))
 
 
@@ -2387,7 +2513,9 @@ def last_day(date: "ColumnOrName") -> Column:
     >>> df.select(last_day(df.d).alias('date')).collect()
     [Row(date=datetime.date(1997, 2, 28))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.last_day(_to_java_column(date)))
 
 
@@ -2407,7 +2535,9 @@ def from_unixtime(timestamp: "ColumnOrName", format: str = "yyyy-MM-dd HH:mm:ss"
     [Row(ts='2015-04-08 00:00:00')]
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.from_unixtime(_to_java_column(timestamp), format))
 
 
@@ -2431,7 +2561,9 @@ def unix_timestamp(
     [Row(unix_time=1428476400)]
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if timestamp is None:
         return Column(sc._jvm.functions.unix_timestamp())
     return Column(sc._jvm.functions.unix_timestamp(_to_java_column(timestamp), format))
@@ -2477,7 +2609,9 @@ def from_utc_timestamp(timestamp: "ColumnOrName", tz: "ColumnOrName") -> Column:
     >>> df.select(from_utc_timestamp(df.ts, df.tz).alias('local_time')).collect()
     [Row(local_time=datetime.datetime(1997, 2, 28, 19, 30))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if isinstance(tz, Column):
         tz = _to_java_column(tz)
     return Column(sc._jvm.functions.from_utc_timestamp(_to_java_column(timestamp), tz))
@@ -2523,7 +2657,9 @@ def to_utc_timestamp(timestamp: "ColumnOrName", tz: "ColumnOrName") -> Column:
     >>> df.select(to_utc_timestamp(df.ts, df.tz).alias('utc_time')).collect()
     [Row(utc_time=datetime.datetime(1997, 2, 28, 1, 30))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if isinstance(tz, Column):
         tz = _to_java_column(tz)
     return Column(sc._jvm.functions.to_utc_timestamp(_to_java_column(timestamp), tz))
@@ -2547,7 +2683,9 @@ def timestamp_seconds(col: "ColumnOrName") -> Column:
     >>> spark.conf.unset("spark.sql.session.timeZone")
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.timestamp_seconds(_to_java_column(col)))
 
 
@@ -2613,7 +2751,9 @@ def window(
         if not field or type(field) is not str:
             raise TypeError("%s should be provided as a string" % fieldName)
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     time_col = _to_java_column(timeColumn)
     check_string_field(windowDuration, "windowDuration")
     if slideDuration and startTime:
@@ -2678,7 +2818,9 @@ def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) 
         if field is None or not isinstance(field, (str, Column)):
             raise TypeError("%s should be provided as a string or Column" % fieldName)
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     time_col = _to_java_column(timeColumn)
     check_field(gapDuration, "gapDuration")
     gap_duration = gapDuration if isinstance(gapDuration, str) else _to_java_column(gapDuration)
@@ -2701,7 +2843,9 @@ def crc32(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC',)], ['a']).select(crc32('a').alias('crc32')).collect()
     [Row(crc32=2743272264)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.crc32(_to_java_column(col)))
 
 
@@ -2715,7 +2859,9 @@ def md5(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC',)], ['a']).select(md5('a').alias('hash')).collect()
     [Row(hash='902fbdd2b1df0c4f70b4a5d23525e932')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.md5(_to_java_column(col))
     return Column(jc)
 
@@ -2730,7 +2876,9 @@ def sha1(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC',)], ['a']).select(sha1('a').alias('hash')).collect()
     [Row(hash='3c01bdbb26f358bab27f267924aa2c9a03fcfdb8')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.sha1(_to_java_column(col))
     return Column(jc)
 
@@ -2750,7 +2898,9 @@ def sha2(col: "ColumnOrName", numBits: int) -> Column:
     >>> digests[1]
     Row(s='cd9fb1e148ccd8442e5aa74904cc73bf6fb54d1d54d333bd596aa9bb4bb4e961')
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.sha2(_to_java_column(col), numBits)
     return Column(jc)
 
@@ -2765,7 +2915,9 @@ def hash(*cols: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC',)], ['a']).select(hash('a').alias('hash')).collect()
     [Row(hash=-757602832)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.hash(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -2781,7 +2933,9 @@ def xxhash64(*cols: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC',)], ['a']).select(xxhash64('a').alias('hash')).collect()
     [Row(hash=4105715581806190027)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.xxhash64(_to_seq(sc, cols, _to_java_column))
     return Column(jc)
 
@@ -2805,7 +2959,9 @@ def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None
     >>> df.select(assert_true(df.a < df.b, 'error').alias('r')).collect()
     [Row(r=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if errMsg is None:
         return Column(sc._jvm.functions.assert_true(_to_java_column(col)))
     if not isinstance(errMsg, (str, Column)):
@@ -2825,7 +2981,9 @@ def raise_error(errMsg: Union[Column, str]) -> Column:
     if not isinstance(errMsg, (str, Column)):
         raise TypeError("errMsg should be a Column or a str, got {}".format(type(errMsg)))
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     errMsg = (
         _create_column_from_literal(errMsg) if isinstance(errMsg, str) else _to_java_column(errMsg)
     )
@@ -2912,7 +3070,9 @@ def concat_ws(sep: str, *cols: "ColumnOrName") -> Column:
     >>> df.select(concat_ws('-', df.s, df.d).alias('s')).collect()
     [Row(s='abcd-123')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.concat_ws(sep, _to_seq(sc, cols, _to_java_column)))
 
 
@@ -2922,7 +3082,9 @@ def decode(col: "ColumnOrName", charset: str) -> Column:
     Computes the first argument into a string from a binary using the provided character set
     (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.decode(_to_java_column(col), charset))
 
 
@@ -2932,7 +3094,9 @@ def encode(col: "ColumnOrName", charset: str) -> Column:
     Computes the first argument into a binary from a string using the provided character set
     (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.encode(_to_java_column(col), charset))
 
 
@@ -2953,7 +3117,9 @@ def format_number(col: "ColumnOrName", d: int) -> Column:
     >>> spark.createDataFrame([(5,)], ['a']).select(format_number('a', 4).alias('v')).collect()
     [Row(v='5.0000')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.format_number(_to_java_column(col), d))
 
 
@@ -2976,7 +3142,9 @@ def format_string(format: str, *cols: "ColumnOrName") -> Column:
     >>> df.select(format_string('%d %s', df.a, df.b).alias('v')).collect()
     [Row(v='5 hello')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.format_string(format, _to_seq(sc, cols, _to_java_column)))
 
 
@@ -2996,7 +3164,9 @@ def instr(str: "ColumnOrName", substr: str) -> Column:
     >>> df.select(instr(df.s, 'b').alias('s')).collect()
     [Row(s=2)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.instr(_to_java_column(str), substr))
 
 
@@ -3034,7 +3204,9 @@ def overlay(
     pos = _create_column_from_literal(pos) if isinstance(pos, int) else _to_java_column(pos)
     len = _create_column_from_literal(len) if isinstance(len, int) else _to_java_column(len)
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
 
     return Column(
         sc._jvm.functions.overlay(_to_java_column(src), _to_java_column(replace), pos, len)
@@ -3076,7 +3248,9 @@ def sentences(
     if country is None:
         country = lit("")
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(
         sc._jvm.functions.sentences(
             _to_java_column(string), _to_java_column(language), _to_java_column(country)
@@ -3102,7 +3276,9 @@ def substring(str: "ColumnOrName", pos: int, len: int) -> Column:
     >>> df.select(substring(df.s, 1, 2).alias('s')).collect()
     [Row(s='ab')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.substring(_to_java_column(str), pos, len))
 
 
@@ -3123,7 +3299,9 @@ def substring_index(str: "ColumnOrName", delim: str, count: int) -> Column:
     >>> df.select(substring_index(df.s, '.', -3).alias('s')).collect()
     [Row(s='b.c.d')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.substring_index(_to_java_column(str), delim, count))
 
 
@@ -3138,7 +3316,9 @@ def levenshtein(left: "ColumnOrName", right: "ColumnOrName") -> Column:
     >>> df0.select(levenshtein('l', 'r').alias('d')).collect()
     [Row(d=3)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.levenshtein(_to_java_column(left), _to_java_column(right))
     return Column(jc)
 
@@ -3169,7 +3349,9 @@ def locate(substr: str, str: "ColumnOrName", pos: int = 1) -> Column:
     >>> df.select(locate('b', df.s, 1).alias('s')).collect()
     [Row(s=2)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.locate(substr, _to_java_column(str), pos))
 
 
@@ -3185,7 +3367,9 @@ def lpad(col: "ColumnOrName", len: int, pad: str) -> Column:
     >>> df.select(lpad(df.s, 6, '#').alias('s')).collect()
     [Row(s='##abcd')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.lpad(_to_java_column(col), len, pad))
 
 
@@ -3201,7 +3385,9 @@ def rpad(col: "ColumnOrName", len: int, pad: str) -> Column:
     >>> df.select(rpad(df.s, 6, '#').alias('s')).collect()
     [Row(s='abcd##')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.rpad(_to_java_column(col), len, pad))
 
 
@@ -3217,7 +3403,9 @@ def repeat(col: "ColumnOrName", n: int) -> Column:
     >>> df.select(repeat(df.s, 3).alias('s')).collect()
     [Row(s='ababab')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.repeat(_to_java_column(col), n))
 
 
@@ -3254,7 +3442,9 @@ def split(str: "ColumnOrName", pattern: str, limit: int = -1) -> Column:
     >>> df.select(split(df.s, '[ABC]', -1).alias('s')).collect()
     [Row(s=['one', 'two', 'three', ''])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.split(_to_java_column(str), pattern, limit))
 
 
@@ -3276,7 +3466,9 @@ def regexp_extract(str: "ColumnOrName", pattern: str, idx: int) -> Column:
     >>> df.select(regexp_extract('str', '(a+)(b)?(c)', 2).alias('d')).collect()
     [Row(d='')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.regexp_extract(_to_java_column(str), pattern, idx)
     return Column(jc)
 
@@ -3292,7 +3484,9 @@ def regexp_replace(str: "ColumnOrName", pattern: str, replacement: str) -> Colum
     >>> df.select(regexp_replace('str', r'(\d+)', '--').alias('d')).collect()
     [Row(d='-----')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.regexp_replace(_to_java_column(str), pattern, replacement)
     return Column(jc)
 
@@ -3307,7 +3501,9 @@ def initcap(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ab cd',)], ['a']).select(initcap("a").alias('v')).collect()
     [Row(v='Ab Cd')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.initcap(_to_java_column(col)))
 
 
@@ -3323,7 +3519,9 @@ def soundex(col: "ColumnOrName") -> Column:
     >>> df.select(soundex(df.name).alias("soundex")).collect()
     [Row(soundex='P362'), Row(soundex='U612')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.soundex(_to_java_column(col)))
 
 
@@ -3337,7 +3535,9 @@ def bin(col: "ColumnOrName") -> Column:
     >>> df.select(bin(df.age).alias('c')).collect()
     [Row(c='10'), Row(c='101')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.bin(_to_java_column(col))
     return Column(jc)
 
@@ -3354,7 +3554,9 @@ def hex(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC', 3)], ['a', 'b']).select(hex('a'), hex('b')).collect()
     [Row(hex(a)='414243', hex(b)='3')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.hex(_to_java_column(col))
     return Column(jc)
 
@@ -3370,7 +3572,9 @@ def unhex(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('414243',)], ['a']).select(unhex('a')).collect()
     [Row(unhex(a)=bytearray(b'ABC'))]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.unhex(_to_java_column(col)))
 
 
@@ -3386,7 +3590,9 @@ def length(col: "ColumnOrName") -> Column:
     >>> spark.createDataFrame([('ABC ',)], ['a']).select(length('a').alias('length')).collect()
     [Row(length=4)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.length(_to_java_column(col)))
 
 
@@ -3456,7 +3662,9 @@ def translate(srcCol: "ColumnOrName", matching: str, replace: str) -> Column:
     ...     .alias('r')).collect()
     [Row(r='1a2s3ae')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.translate(_to_java_column(srcCol), matching, replace))
 
 
@@ -3481,7 +3689,9 @@ def create_map(*cols: "ColumnOrName") -> Column:
     >>> df.select(create_map([df.name, df.age]).alias("map")).collect()
     [Row(map={'Alice': 2}), Row(map={'Bob': 5})]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.map(_to_seq(sc, cols, _to_java_column))
@@ -3510,7 +3720,9 @@ def map_from_arrays(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     |{2 -> a, 5 -> b}|
     +----------------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.map_from_arrays(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -3532,7 +3744,9 @@ def array(*cols: "ColumnOrName") -> Column:
     >>> df.select(array([df.age, df.age]).alias("arr")).collect()
     [Row(arr=[2, 2]), Row(arr=[5, 5])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.array(_to_seq(sc, cols, _to_java_column))
@@ -3561,7 +3775,9 @@ def array_contains(col: "ColumnOrName", value: Any) -> Column:
     >>> df.select(array_contains(df.data, lit("a"))).collect()
     [Row(array_contains(data, a)=True), Row(array_contains(data, a)=False)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     value = value._jc if isinstance(value, Column) else value
     return Column(sc._jvm.functions.array_contains(_to_java_column(col), value))
 
@@ -3580,7 +3796,9 @@ def arrays_overlap(a1: "ColumnOrName", a2: "ColumnOrName") -> Column:
     >>> df.select(arrays_overlap(df.x, df.y).alias("overlap")).collect()
     [Row(overlap=True), Row(overlap=False)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.arrays_overlap(_to_java_column(a1), _to_java_column(a2)))
 
 
@@ -3606,7 +3824,9 @@ def slice(x: "ColumnOrName", start: Union[Column, int], length: Union[Column, in
     >>> df.select(slice(df.x, 2, 2).alias("sliced")).collect()
     [Row(sliced=[2, 3]), Row(sliced=[5])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(
         sc._jvm.functions.slice(
             _to_java_column(x),
@@ -3633,7 +3853,9 @@ def array_join(
     >>> df.select(array_join(df.data, ",", "NULL").alias("joined")).collect()
     [Row(joined='a,b,c'), Row(joined='a,NULL')]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if null_replacement is None:
         return Column(sc._jvm.functions.array_join(_to_java_column(col), delimiter))
     else:
@@ -3659,7 +3881,9 @@ def concat(*cols: "ColumnOrName") -> Column:
     >>> df.select(concat(df.a, df.b, df.c).alias("arr")).collect()
     [Row(arr=[1, 2, 3, 4, 5]), Row(arr=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.concat(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -3681,7 +3905,9 @@ def array_position(col: "ColumnOrName", value: Any) -> Column:
     >>> df.select(array_position(df.data, "a")).collect()
     [Row(array_position(data, a)=3), Row(array_position(data, a)=0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_position(_to_java_column(col), value))
 
 
@@ -3713,7 +3939,9 @@ def element_at(col: "ColumnOrName", extraction: Any) -> Column:
     >>> df.select(element_at(df.data, lit("a"))).collect()
     [Row(element_at(data, a)=1.0), Row(element_at(data, a)=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.element_at(_to_java_column(col), lit(extraction)._jc))
 
 
@@ -3736,7 +3964,9 @@ def array_remove(col: "ColumnOrName", element: Any) -> Column:
     >>> df.select(array_remove(df.data, 1)).collect()
     [Row(array_remove(data, 1)=[2, 3]), Row(array_remove(data, 1)=[])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_remove(_to_java_column(col), element))
 
 
@@ -3757,7 +3987,9 @@ def array_distinct(col: "ColumnOrName") -> Column:
     >>> df.select(array_distinct(df.data)).collect()
     [Row(array_distinct(data)=[1, 2, 3]), Row(array_distinct(data)=[4, 5])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_distinct(_to_java_column(col)))
 
 
@@ -3782,7 +4014,9 @@ def array_intersect(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.select(array_intersect(df.c1, df.c2)).collect()
     [Row(array_intersect(c1, c2)=['a', 'c'])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_intersect(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -3807,7 +4041,9 @@ def array_union(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.select(array_union(df.c1, df.c2)).collect()
     [Row(array_union(c1, c2)=['b', 'a', 'c', 'd', 'f'])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_union(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -3832,7 +4068,9 @@ def array_except(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
     >>> df.select(array_except(df.c1, df.c2)).collect()
     [Row(array_except(c1, c2)=['b'])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_except(_to_java_column(col1), _to_java_column(col2)))
 
 
@@ -3858,7 +4096,9 @@ def explode(col: "ColumnOrName") -> Column:
     |  a|    b|
     +---+-----+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.explode(_to_java_column(col))
     return Column(jc)
 
@@ -3885,7 +4125,9 @@ def posexplode(col: "ColumnOrName") -> Column:
     |  0|  a|    b|
     +---+---+-----+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.posexplode(_to_java_column(col))
     return Column(jc)
 
@@ -3924,7 +4166,9 @@ def explode_outer(col: "ColumnOrName") -> Column:
     |  3|      null|null|
     +---+----------+----+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.explode_outer(_to_java_column(col))
     return Column(jc)
 
@@ -3962,7 +4206,9 @@ def posexplode_outer(col: "ColumnOrName") -> Column:
     |  3|      null|null|null|
     +---+----------+----+----+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.posexplode_outer(_to_java_column(col))
     return Column(jc)
 
@@ -3989,7 +4235,9 @@ def get_json_object(col: "ColumnOrName", path: str) -> Column:
     ...                   get_json_object(df.jstring, '$.f2').alias("c1") ).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.get_json_object(_to_java_column(col), path)
     return Column(jc)
 
@@ -4013,7 +4261,9 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
     >>> df.select(df.key, json_tuple(df.jstring, 'f1', 'f2')).collect()
     [Row(key='1', c0='value1', c1='value2'), Row(key='2', c0='value12', c1=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.json_tuple(_to_java_column(col), _to_seq(sc, fields))
     return Column(jc)
 
@@ -4073,7 +4323,9 @@ def from_json(
     [Row(json=[1, 2, 3])]
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if isinstance(schema, DataType):
         schema = schema.json()
     elif isinstance(schema, Column):
@@ -4128,7 +4380,9 @@ def to_json(col: "ColumnOrName", options: Optional[Dict[str, str]] = None) -> Co
     [Row(json='["Alice","Bob"]')]
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.to_json(_to_java_column(col), _options_to_str(options))
     return Column(jc)
 
@@ -4169,7 +4423,9 @@ def schema_of_json(json: "ColumnOrName", options: Optional[Dict[str, str]] = Non
     else:
         raise TypeError("schema argument should be a column or string")
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.schema_of_json(col, _options_to_str(options))
     return Column(jc)
 
@@ -4206,7 +4462,9 @@ def schema_of_csv(csv: "ColumnOrName", options: Optional[Dict[str, str]] = None)
     else:
         raise TypeError("schema argument should be a column or string")
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.schema_of_csv(col, _options_to_str(options))
     return Column(jc)
 
@@ -4238,7 +4496,9 @@ def to_csv(col: "ColumnOrName", options: Optional[Dict[str, str]] = None) -> Col
     [Row(csv='2,Alice')]
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     jc = sc._jvm.functions.to_csv(_to_java_column(col), _options_to_str(options))
     return Column(jc)
 
@@ -4260,7 +4520,9 @@ def size(col: "ColumnOrName") -> Column:
     >>> df.select(size(df.data)).collect()
     [Row(size(data)=3), Row(size(data)=1), Row(size(data)=0)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.size(_to_java_column(col)))
 
 
@@ -4281,7 +4543,9 @@ def array_min(col: "ColumnOrName") -> Column:
     >>> df.select(array_min(df.data).alias('min')).collect()
     [Row(min=1), Row(min=-1)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_min(_to_java_column(col)))
 
 
@@ -4302,7 +4566,9 @@ def array_max(col: "ColumnOrName") -> Column:
     >>> df.select(array_max(df.data).alias('max')).collect()
     [Row(max=3), Row(max=10)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_max(_to_java_column(col)))
 
 
@@ -4329,7 +4595,9 @@ def sort_array(col: "ColumnOrName", asc: bool = True) -> Column:
     >>> df.select(sort_array(df.data, asc=False).alias('r')).collect()
     [Row(r=[3, 2, 1, None]), Row(r=[1]), Row(r=[])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.sort_array(_to_java_column(col), asc))
 
 
@@ -4351,7 +4619,9 @@ def array_sort(col: "ColumnOrName") -> Column:
     >>> df.select(array_sort(df.data).alias('r')).collect()
     [Row(r=[1, 2, 3, None]), Row(r=[1]), Row(r=[])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.array_sort(_to_java_column(col)))
 
 
@@ -4376,7 +4646,9 @@ def shuffle(col: "ColumnOrName") -> Column:
     >>> df.select(shuffle(df.data).alias('s')).collect()  # doctest: +SKIP
     [Row(s=[3, 1, 5, 20]), Row(s=[20, None, 3, 1])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.shuffle(_to_java_column(col)))
 
 
@@ -4400,7 +4672,9 @@ def reverse(col: "ColumnOrName") -> Column:
     >>> df.select(reverse(df.data).alias('r')).collect()
     [Row(r=[3, 1, 2]), Row(r=[1]), Row(r=[])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.reverse(_to_java_column(col)))
 
 
@@ -4423,7 +4697,9 @@ def flatten(col: "ColumnOrName") -> Column:
     >>> df.select(flatten(df.data).alias('r')).collect()
     [Row(r=[1, 2, 3, 4, 5, 6]), Row(r=None)]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.flatten(_to_java_column(col)))
 
 
@@ -4449,7 +4725,9 @@ def map_keys(col: "ColumnOrName") -> Column:
     |[1, 2]|
     +------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.map_keys(_to_java_column(col)))
 
 
@@ -4475,7 +4753,9 @@ def map_values(col: "ColumnOrName") -> Column:
     |[a, b]|
     +------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.map_values(_to_java_column(col)))
 
 
@@ -4501,7 +4781,9 @@ def map_entries(col: "ColumnOrName") -> Column:
     |[{1, a}, {2, b}]|
     +----------------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.map_entries(_to_java_column(col)))
 
 
@@ -4527,7 +4809,9 @@ def map_from_entries(col: "ColumnOrName") -> Column:
     |{1 -> a, 2 -> b}|
     +----------------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.map_from_entries(_to_java_column(col)))
 
 
@@ -4543,7 +4827,9 @@ def array_repeat(col: "ColumnOrName", count: Union[Column, int]) -> Column:
     >>> df.select(array_repeat(df.data, 3).alias('r')).collect()
     [Row(r=['ab', 'ab', 'ab'])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(
         sc._jvm.functions.array_repeat(
             _to_java_column(col), _to_java_column(count) if isinstance(count, Column) else count
@@ -4570,7 +4856,9 @@ def arrays_zip(*cols: "ColumnOrName") -> Column:
     >>> df.select(arrays_zip(df.vals1, df.vals2).alias('zipped')).collect()
     [Row(zipped=[Row(vals1=1, vals2=2), Row(vals1=2, vals2=3), Row(vals1=3, vals2=4)])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.arrays_zip(_to_seq(sc, cols, _to_java_column)))
 
 
@@ -4595,7 +4883,9 @@ def map_concat(*cols: "ColumnOrName") -> Column:
     |{1 -> a, 2 -> b, 3 -> c}|
     +------------------------+
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if len(cols) == 1 and isinstance(cols[0], (list, set)):
         cols = cols[0]
     jc = sc._jvm.functions.map_concat(_to_seq(sc, cols, _to_java_column))
@@ -4621,7 +4911,9 @@ def sequence(
     >>> df2.select(sequence('C1', 'C2', 'C3').alias('r')).collect()
     [Row(r=[4, 2, 0, -2, -4])]
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if step is None:
         return Column(sc._jvm.functions.sequence(_to_java_column(start), _to_java_column(stop)))
     else:
@@ -4672,7 +4964,9 @@ def from_csv(
     [Row(csv=Row(s='abc'))]
     """
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     if isinstance(schema, str):
         schema = _create_column_from_literal(schema)
     elif isinstance(schema, Column):
@@ -4693,7 +4987,9 @@ def _unresolved_named_lambda_variable(*name_parts: Any) -> Column:
     ----------
     name_parts : str
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     name_parts_seq = _to_seq(sc, name_parts)
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
     return Column(sc._jvm.Column(expressions.UnresolvedNamedLambdaVariable(name_parts_seq)))
@@ -4739,7 +5035,9 @@ def _create_lambda(f: Callable) -> Callable:
     """
     parameters = _get_lambda_parameters(f)
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
 
     argnames = ["x", "y", "z"]
@@ -4777,7 +5075,9 @@ def _invoke_higher_order_function(
 
     :return: a Column
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     expressions = sc._jvm.org.apache.spark.sql.catalyst.expressions
     expr = getattr(expressions, name)
 
@@ -5278,7 +5578,9 @@ def years(col: "ColumnOrName") -> Column:
     method of the `DataFrameWriterV2`.
 
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.years(_to_java_column(col)))
 
 
@@ -5302,7 +5604,9 @@ def months(col: "ColumnOrName") -> Column:
     method of the `DataFrameWriterV2`.
 
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.months(_to_java_column(col)))
 
 
@@ -5326,7 +5630,9 @@ def days(col: "ColumnOrName") -> Column:
     method of the `DataFrameWriterV2`.
 
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.days(_to_java_column(col)))
 
 
@@ -5350,7 +5656,9 @@ def hours(col: "ColumnOrName") -> Column:
     method of the `DataFrameWriterV2`.
 
     """
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     return Column(sc._jvm.functions.hours(_to_java_column(col)))
 
 
@@ -5377,7 +5685,9 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
     if not isinstance(numBuckets, (int, Column)):
         raise TypeError("numBuckets should be a Column or an int, got {}".format(type(numBuckets)))
 
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
+    assert sc is not None
+    assert sc._jvm is not None
     numBuckets = (
         _create_column_from_literal(numBuckets)
         if isinstance(numBuckets, int)

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -103,7 +103,8 @@ class Observation:
         assert self._jo is None, "an Observation can be used with a DataFrame only once"
 
         self._jvm = df._sc._jvm  # type: ignore[attr-defined]
-        cls = self._jvm.org.apache.spark.sql.Observation  # type: ignore[attr-defined]
+        assert self._jvm is not None
+        cls = self._jvm.org.apache.spark.sql.Observation
         self._jo = cls(self._name) if self._name is not None else cls()
         observed_df = self._jo.on(
             df._jdf, exprs[0]._jc, column._to_seq(df._sc, [c._jc for c in exprs[1:]])

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -617,7 +617,8 @@ class SparkConversionMixin(object):
         jrdd = self._sc._serialize_to_jvm(  # type: ignore[attr-defined]
             arrow_data, ser, reader_func, create_RDD_server
         )
-        jdf = self._jvm.PythonSQLUtils.toDataFrame(  # type: ignore[attr-defined]
+        assert self._jvm is not None
+        jdf = self._jvm.PythonSQLUtils.toDataFrame(
             jrdd, schema.json(), jsqlContext
         )
         df = DataFrame(jdf, self._wrapped)

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -618,9 +618,7 @@ class SparkConversionMixin(object):
             arrow_data, ser, reader_func, create_RDD_server
         )
         assert self._jvm is not None
-        jdf = self._jvm.PythonSQLUtils.toDataFrame(
-            jrdd, schema.json(), jsqlContext
-        )
+        jdf = self._jvm.PythonSQLUtils.toDataFrame(jrdd, schema.json(), jsqlContext)
         df = DataFrame(jdf, self._wrapped)
         df._schema = schema
         return df

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -180,6 +180,7 @@ class DataFrameReader(OptionUtils):
         elif path is not None:
             if type(path) != list:
                 path = [path]  # type: ignore[list-item]
+            assert self._spark._sc._jvm is not None
             return self._df(
                 self._jreader.load(
                     self._spark._sc._jvm.PythonUtils.toSeq(path)  # type: ignore[attr-defined]
@@ -285,6 +286,7 @@ class DataFrameReader(OptionUtils):
         if isinstance(path, str):
             path = [path]
         if type(path) == list:
+            assert self._spark._sc._jvm is not None
             return self._df(
                 self._jreader.json(
                     self._spark._sc._jvm.PythonUtils.toSeq(path)  # type: ignore[attr-defined]
@@ -302,6 +304,7 @@ class DataFrameReader(OptionUtils):
 
             keyed = path.mapPartitions(func)
             keyed._bypass_serializer = True  # type: ignore[attr-defined]
+            assert self._spark._jvm is not None
             jrdd = keyed._jrdd.map(self._spark._jvm.BytesToString())  # type: ignore[attr-defined]
             return self._df(self._jreader.json(jrdd))
         else:
@@ -424,6 +427,7 @@ class DataFrameReader(OptionUtils):
 
         if isinstance(paths, str):
             paths = [paths]
+        assert self._spark._sc._jvm is not None
         return self._df(
             self._jreader.text(
                 self._spark._sc._jvm.PythonUtils.toSeq(paths)  # type: ignore[attr-defined]
@@ -541,6 +545,7 @@ class DataFrameReader(OptionUtils):
         if isinstance(path, str):
             path = [path]
         if type(path) == list:
+            assert self._spark._sc._jvm is not None
             return self._df(
                 self._jreader.csv(
                     self._spark._sc._jvm.PythonUtils.toSeq(path)  # type: ignore[attr-defined]
@@ -703,9 +708,10 @@ class DataFrameReader(OptionUtils):
         """
         if properties is None:
             properties = dict()
+        assert self._spark._sc._gateway is not None
         jprop = JavaClass(
             "java.util.Properties",
-            self._spark._sc._gateway._gateway_client,  # type: ignore[attr-defined]
+            self._spark._sc._gateway._gateway_client,
         )()
         for k in properties:
             jprop.setProperty(k, properties[k])
@@ -721,7 +727,8 @@ class DataFrameReader(OptionUtils):
                 )
             )
         if predicates is not None:
-            gateway = self._spark._sc._gateway  # type: ignore[attr-defined]
+            gateway = self._spark._sc._gateway
+            assert gateway is not None
             jpredicates = utils.toJArray(gateway, gateway.jvm.java.lang.String, predicates)
             return self._df(self._jreader.jdbc(url, table, jpredicates, jprop))
         return self._df(self._jreader.jdbc(url, table, jprop))
@@ -1340,9 +1347,11 @@ class DataFrameWriter(OptionUtils):
         """
         if properties is None:
             properties = dict()
+
+        assert self._spark._sc._gateway is not None
         jprop = JavaClass(
             "java.util.Properties",
-            self._spark._sc._gateway._gateway_client,  # type: ignore[attr-defined]
+            self._spark._sc._gateway._gateway_client,
         )()
         for k in properties:
             jprop.setProperty(k, properties[k])

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -299,8 +299,11 @@ class SparkSession(SparkConversionMixin):
         from pyspark.sql.context import SQLContext
 
         self._sc = sparkContext
-        self._jsc = self._sc._jsc  # type: ignore[attr-defined]
-        self._jvm = self._sc._jvm  # type: ignore[attr-defined]
+        self._jsc = self._sc._jsc
+        self._jvm = self._sc._jvm
+
+        assert self._jvm is not None
+
         if jsparkSession is None:
             if (
                 self._jvm.SparkSession.getDefaultSession().isDefined()
@@ -330,6 +333,7 @@ class SparkSession(SparkConversionMixin):
         ):
             SparkSession._instantiatedSession = self
             SparkSession._activeSession = self
+            assert self._jvm is not None
             self._jvm.SparkSession.setDefaultSession(self._jsparkSession)
             self._jvm.SparkSession.setActiveSession(self._jsparkSession)
 
@@ -376,10 +380,11 @@ class SparkSession(SparkConversionMixin):
         """
         from pyspark import SparkContext
 
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
         if sc is None:
             return None
         else:
+            assert sc._jvm is not None
             if sc._jvm.SparkSession.getActiveSession().isDefined():
                 SparkSession(sc, sc._jvm.SparkSession.getActiveSession().get())
                 return SparkSession._activeSession
@@ -663,6 +668,7 @@ class SparkSession(SparkConversionMixin):
         try:
             # Try to access HiveConf, it will raise exception if Hive is not added
             conf = SparkConf()
+            assert SparkContext._jvm is not None
             if cast(str, conf.get("spark.sql.catalogImplementation", "hive")).lower() == "hive":
                 (
                     SparkContext._jvm.org.apache.hadoop.hive.conf.HiveConf()  # type: ignore[attr-defined]
@@ -855,6 +861,7 @@ class SparkSession(SparkConversionMixin):
         Py4JJavaError: ...
         """
         SparkSession._activeSession = self
+        assert self._jvm is not None
         self._jvm.SparkSession.setActiveSession(self._jsparkSession)
         if isinstance(data, DataFrame):
             raise TypeError("data is already a DataFrame")
@@ -917,6 +924,7 @@ class SparkSession(SparkConversionMixin):
             rdd, struct = self._createFromRDD(data.map(prepare), schema, samplingRatio)
         else:
             rdd, struct = self._createFromLocal(map(prepare, data), schema)
+        assert self._jvm is not None
         jrdd = self._jvm.SerDeUtil.toJavaArray(
             rdd._to_java_object_rdd()  # type: ignore[attr-defined]
         )
@@ -1096,6 +1104,7 @@ class SparkSession(SparkConversionMixin):
 
         self._sc.stop()
         # We should clean the default session up. See SPARK-23228.
+        assert self._jvm is not None
         self._jvm.SparkSession.clearDefaultSession()
         self._jvm.SparkSession.clearActiveSession()
         SparkSession._instantiatedSession = None

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -1062,6 +1062,7 @@ class DataStreamWriter(object):
             raise ValueError("Multiple triggers not allowed.")
 
         jTrigger = None
+        assert self._spark._sc._jvm is not None
         if processingTime is not None:
             if type(processingTime) != str or len(processingTime.strip()) == 0:
                 raise ValueError(
@@ -1270,6 +1271,7 @@ class DataStreamWriter(object):
 
         serializer = AutoBatchedSerializer(CPickleSerializer())
         wrapped_func = _wrap_function(self._spark._sc, func, serializer, serializer)
+        assert self._spark._sc._jvm is not None
         jForeachWriter = self._spark._sc._jvm.org.apache.spark.sql.execution.python.PythonForeachWriter(  # type: ignore[attr-defined]
             wrapped_func, self._df._jdf.schema()
         )
@@ -1303,7 +1305,8 @@ class DataStreamWriter(object):
 
         from pyspark.java_gateway import ensure_callback_server_started
 
-        gw = self._spark._sc._gateway  # type: ignore[attr-defined]
+        gw = self._spark._sc._gateway
+        assert gw is not None
         java_import(gw.jvm, "org.apache.spark.sql.execution.streaming.sources.*")
 
         wrapped_func = ForeachBatchFunction(self._spark, func)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1012,13 +1012,18 @@ def _parse_datatype_string(s: str) -> DataType:
     from pyspark import SparkContext
 
     sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    assert sc is not None
 
     def from_ddl_schema(type_str: str) -> DataType:
+        assert sc is not None
+        assert sc._jvm is not None
         return _parse_datatype_json_string(
             sc._jvm.org.apache.spark.sql.types.StructType.fromDDL(type_str).json()
         )
 
     def from_ddl_datatype(type_str: str) -> DataType:
+        assert sc is not None
+        assert sc._jvm is not None
         return _parse_datatype_json_string(
             sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseDataType(type_str).json()
         )
@@ -1947,7 +1952,8 @@ class DatetimeNTZConverter(object):
         from pyspark import SparkContext
 
         seconds = calendar.timegm(obj.utctimetuple())
-        jvm = SparkContext._jvm  # type: ignore[attr-defined]
+        jvm = SparkContext._jvm
+        assert jvm is not None
         return jvm.org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToLocalDateTime(
             int(seconds) * 1000000 + obj.microsecond
         )
@@ -1960,7 +1966,8 @@ class DayTimeIntervalTypeConverter(object):
     def convert(self, obj: datetime.timedelta, gateway_client: JavaGateway) -> JavaObject:
         from pyspark import SparkContext
 
-        jvm = SparkContext._jvm  # type: ignore[attr-defined]
+        jvm = SparkContext._jvm
+        assert jvm is not None
         return jvm.org.apache.spark.sql.catalyst.util.IntervalUtils.microsToDuration(
             (math.floor(obj.total_seconds()) * 1000000) + obj.microseconds
         )

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1015,15 +1015,13 @@ def _parse_datatype_string(s: str) -> DataType:
     assert sc is not None
 
     def from_ddl_schema(type_str: str) -> DataType:
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         return _parse_datatype_json_string(
             sc._jvm.org.apache.spark.sql.types.StructType.fromDDL(type_str).json()
         )
 
     def from_ddl_datatype(type_str: str) -> DataType:
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         return _parse_datatype_json_string(
             sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseDataType(type_str).json()
         )

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -48,7 +48,8 @@ def _wrap_function(
 ) -> JavaObject:
     command = (func, returnType)
     pickled_command, broadcast_vars, env, includes = _prepare_for_python_RDD(sc, command)
-    return sc._jvm.PythonFunction(  # type: ignore[attr-defined]
+    assert sc._jvm is not None
+    return sc._jvm.PythonFunction(
         bytearray(pickled_command),
         env,
         includes,
@@ -222,14 +223,15 @@ class UserDefinedFunction(object):
 
         wrapped_func = _wrap_function(sc, func, self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())
-        judf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonFunction(  # type: ignore[attr-defined]
+        assert sc._jvm is not None
+        judf = sc._jvm.org.apache.spark.sql.execution.python.UserDefinedPythonFunction(
             self._name, wrapped_func, jdt, self.evalType, self.deterministic
         )
         return judf
 
     def __call__(self, *cols: "ColumnOrName") -> Column:
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
-
+        sc = SparkContext._active_spark_context
+        assert sc is not None
         profiler: Optional[Profiler] = None
         if sc.profiler_collector:
             f = self.func

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -48,6 +48,7 @@ class CapturedException(Exception):
         )
 
         self.desc = desc if desc is not None else cast(Py4JJavaError, origin).getMessage()
+        assert SparkContext._jvm is not None
         self.stackTrace = (
             stackTrace
             if stackTrace is not None

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -76,8 +76,7 @@ class Window(object):
         Creates a :class:`WindowSpec` with the partitioning defined.
         """
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.partitionBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
@@ -88,8 +87,7 @@ class Window(object):
         Creates a :class:`WindowSpec` with the ordering defined.
         """
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.orderBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
@@ -154,8 +152,7 @@ class Window(object):
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rowsBetween(start, end)
         return WindowSpec(jspec)
 
@@ -223,8 +220,7 @@ class Window(object):
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
         sc = SparkContext._active_spark_context
-        assert sc is not None
-        assert sc._jvm is not None
+        assert sc is not None and sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rangeBetween(start, end)
         return WindowSpec(jspec)
 

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -30,9 +30,10 @@ __all__ = ["Window", "WindowSpec"]
 
 
 def _to_java_cols(cols: Tuple[Union["ColumnOrName", List["ColumnOrName"]], ...]) -> int:
-    sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+    sc = SparkContext._active_spark_context
     if len(cols) == 1 and isinstance(cols[0], list):
         cols = cols[0]  # type: ignore[assignment]
+    assert sc is not None
     return _to_seq(sc, cast(Iterable["ColumnOrName"], cols), _to_java_column)
 
 
@@ -74,7 +75,9 @@ class Window(object):
         """
         Creates a :class:`WindowSpec` with the partitioning defined.
         """
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.partitionBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
@@ -84,7 +87,9 @@ class Window(object):
         """
         Creates a :class:`WindowSpec` with the ordering defined.
         """
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.orderBy(_to_java_cols(cols))
         return WindowSpec(jspec)
 
@@ -148,7 +153,9 @@ class Window(object):
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rowsBetween(start, end)
         return WindowSpec(jspec)
 
@@ -215,7 +222,9 @@ class Window(object):
             start = Window.unboundedPreceding
         if end >= Window._FOLLOWING_THRESHOLD:
             end = Window.unboundedFollowing
-        sc = SparkContext._active_spark_context  # type: ignore[attr-defined]
+        sc = SparkContext._active_spark_context
+        assert sc is not None
+        assert sc._jvm is not None
         jspec = sc._jvm.org.apache.spark.sql.expressions.Window.rangeBetween(start, end)
         return WindowSpec(jspec)
 

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -327,11 +327,7 @@ def inheritable_thread_target(f: Callable) -> Callable:
         # copies local properties when the thread starts but `inheritable_thread_target`
         # copies when the function is wrapped.
         assert SparkContext._active_spark_context is not None
-        properties = (
-            SparkContext._active_spark_context._jsc.sc()
-            .getLocalProperties()
-            .clone()
-        )
+        properties = SparkContext._active_spark_context._jsc.sc().getLocalProperties().clone()
 
         @functools.wraps(f)
         def wrapped(*args: Any, **kwargs: Any) -> Any:
@@ -406,11 +402,7 @@ class InheritableThread(threading.Thread):
 
             # Local property copy should happen in Thread.start to mimic JVM's behavior.
             assert SparkContext._active_spark_context is not None
-            self._props = (
-                SparkContext._active_spark_context._jsc.sc()
-                .getLocalProperties()
-                .clone()
-            )
+            self._props = SparkContext._active_spark_context._jsc.sc().getLocalProperties().clone()
         return super(InheritableThread, self).start()
 
     @staticmethod

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -409,7 +409,7 @@ class InheritableThread(threading.Thread):
     def _clean_py4j_conn_for_current_thread() -> None:
         from pyspark import SparkContext
 
-        jvm = SparkContext._jvm  # type: ignore[attr-defined]
+        jvm = SparkContext._jvm
         assert jvm is not None
         thread_connection = jvm._gateway_client.get_thread_connection()
         if thread_connection is not None:

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -326,8 +326,9 @@ def inheritable_thread_target(f: Callable) -> Callable:
         # NOTICE the internal difference vs `InheritableThread`. `InheritableThread`
         # copies local properties when the thread starts but `inheritable_thread_target`
         # copies when the function is wrapped.
+        assert SparkContext._active_spark_context is not None
         properties = (
-            SparkContext._active_spark_context._jsc.sc()  # type: ignore[attr-defined]
+            SparkContext._active_spark_context._jsc.sc()
             .getLocalProperties()
             .clone()
         )
@@ -336,6 +337,7 @@ def inheritable_thread_target(f: Callable) -> Callable:
         def wrapped(*args: Any, **kwargs: Any) -> Any:
             try:
                 # Set local properties in child thread.
+                assert SparkContext._active_spark_context is not None
                 SparkContext._active_spark_context._jsc.sc().setLocalProperties(  # type: ignore[attr-defined]
                     properties
                 )
@@ -379,6 +381,7 @@ class InheritableThread(threading.Thread):
             def copy_local_properties(*a: Any, **k: Any) -> Any:
                 # self._props is set before starting the thread to match the behavior with JVM.
                 assert hasattr(self, "_props")
+                assert SparkContext._active_spark_context is not None
                 SparkContext._active_spark_context._jsc.sc().setLocalProperties(  # type: ignore[attr-defined]
                     self._props
                 )
@@ -402,8 +405,9 @@ class InheritableThread(threading.Thread):
             # Here's when the pinned-thread mode (PYSPARK_PIN_THREAD) is on.
 
             # Local property copy should happen in Thread.start to mimic JVM's behavior.
+            assert SparkContext._active_spark_context is not None
             self._props = (
-                SparkContext._active_spark_context._jsc.sc()  # type: ignore[attr-defined]
+                SparkContext._active_spark_context._jsc.sc()
                 .getLocalProperties()
                 .clone()
             )
@@ -414,6 +418,7 @@ class InheritableThread(threading.Thread):
         from pyspark import SparkContext
 
         jvm = SparkContext._jvm  # type: ignore[attr-defined]
+        assert jvm is not None
         thread_connection = jvm._gateway_client.get_thread_connection()
         if thread_connection is not None:
             try:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In SPARK-37152, we agreed to temporarily hide numerous errors by a quick fix. However, we should use a more precise type (optional) to describe sparkcontext's internal field, including _gateway, _jvm, and _active_spark_context.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Use the precise type for sparkcontext's field

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
regular test