### PR TITLE
[SPARK-37638][PYTHON] Use existing active Spark session instead of SparkSession.getOrCreate in pandas API on Spark

### DIFF
--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -464,24 +464,12 @@ def is_testing() -> bool:
     return "SPARK_TESTING" in os.environ
 
 
-def default_session(conf: Optional[Dict[str, Any]] = None) -> SparkSession:
-    if conf is None:
-        conf = dict()
-
+def default_session() -> SparkSession:
     spark = SparkSession.getActiveSession()
     if spark is not None:
         return spark
 
     builder = SparkSession.builder.appName("pandas-on-Spark")
-    for key, value in conf.items():
-        builder = builder.config(key, value)
-    # Currently, pandas-on-Spark is dependent on such join due to 'compute.ops_on_diff_frames'
-    # configuration. This is needed with Spark 3.0+.
-    builder.config("spark.sql.analyzer.failAmbiguousSelfJoin", False)
-
-    if is_testing():
-        builder.config("spark.executor.allowSparkContext", False)
-
     return builder.getOrCreate()
 
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -468,6 +468,10 @@ def default_session(conf: Optional[Dict[str, Any]] = None) -> SparkSession:
     if conf is None:
         conf = dict()
 
+    spark = SparkSession.getActiveSession()
+    if spark is not None:
+        return spark
+
     builder = SparkSession.builder.appName("pandas-on-Spark")
     for key, value in conf.items():
         builder = builder.config(key, value)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use an existing active Spark session instead of `SparkSession.getOrCreate` in pandas API on Spark.

### Why are the changes needed?

Because it shows warnings for configurations not taking effect as below:

Otherwise, it attempts to create a new session, and shows warnings as below:

```python
>>> ps.range(10)
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; the static sql configurations will not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; some spark core configurations may not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; the static sql configurations will not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; some spark core configurations may not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; the static sql configurations will not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; some spark core configurations may not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; the static sql configurations will not take effect.
21/12/14 16:12:58 WARN SparkSession: Using an existing SparkSession; some spark core configurations may not take effect.
...
   id
0   0
1   1
2   2
3   3
4   4
5   5
6   6
7   7
8   8
```

### Does this PR introduce _any_ user-facing change?

Yes, after this PR, it will explicitly uses active Spark session, and does not show such warnings:

```python
>>> import pyspark.pandas as ps
>>> ps.range(10)
...
   id
0   0
1   1
2   2
3   3
```

### How was this patch tested?

Manually tested as below:

```python
import pyspark.pandas as ps
ps.range(10)
```