### PR TITLE
[SPARK-37568][SQL] Support 2-arguments by the convert_timezone() function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3007,7 +3007,7 @@ object SubtractDates {
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_([sourceTz,] targetTz, sourceTs) - Converts the timestamp without time zone `sourceTs` from the `sourceTz` time zone to `targetTz`. ",
+  usage = "_FUNC_(sourceTz, targetTz, sourceTs) - Converts the timestamp without time zone `sourceTs` from the `sourceTz` time zone to `targetTz`. ",
   arguments = """
     Arguments:
       * sourceTz - the time zone for the input timestamp

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3011,8 +3011,8 @@ object SubtractDates {
   arguments = """
     Arguments:
       * sourceTz - the time zone for the input timestamp
-        - if not specified, SESSION_LOCAL_TIMEZONE is used when sourceTs is timestamp_ntz,
-          or timezone of sourceTs is used when sourceTs is timestamp_ltz
+          - if not specified, SESSION_LOCAL_TIMEZONE is used when sourceTs is timestamp_ntz,
+            or timezone of sourceTs is used when sourceTs is timestamp_ltz
       * targetTz - the time zone to which the input timestamp should be converted
       * sourceTs - a timestamp
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3022,8 +3022,6 @@ object SubtractDates {
        2021-12-05 15:00:00
       > SELECT _FUNC_('America/Los_Angeles', timestamp'2021-12-06 00:00:00 Europe/Amsterdam');
        2021-12-05 15:00:00
-      > SELECT _FUNC_('America/Los_Angeles', timestamp_ntz'2021-12-06 00:00:00');
-       2021-12-05 07:00:00 (when SESSION_LOCAL_TIMEZONE is Asia/Tokyo)
   """,
   group = "datetime_funcs",
   since = "3.3.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -3028,6 +3028,17 @@ case class ConvertTimezone(
     sourceTs: Expression)
   extends TernaryExpression with ImplicitCastInputTypes with NullIntolerant {
 
+  def this(targetTz: Expression, sourceTs: Expression) = {
+    this(
+      if (sourceTs.dataType == TimestampNTZType) Literal(SQLConf.get.sessionLocalTimeZone)
+      else DateFormatClass(sourceTs, Literal("VV")),
+      // else Literal(SQLConf.get.sessionLocalTimeZone),
+      targetTz,
+      if (sourceTs.dataType == TimestampNTZType) sourceTs
+      else ParseToTimestampNTZ(sourceTs, None, Cast(sourceTs, TimestampNTZType))
+    )
+  }
+
   override def first: Expression = sourceTz
   override def second: Expression = targetTz
   override def third: Expression = sourceTs


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Support 2-arguments  by the convert_timezone() function.
If users omit sourceTz, spark takes it from sourceTimestamp or SESSION_LOCAL_TIMEZONE.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Users can call this API with fewer arguments. The same function in Snowflake supports 2 arguments.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users can call this function with 2 arguments.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
unit tests