### PR TITLE
[SPARK-37646][SQL]Avoid touching Scala reflection APIs in the lit function

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -117,7 +117,7 @@ object functions {
     case c: Column => c
     case s: Symbol => new ColumnName(s.name)
     case _ =>
-      // This is different from `typedLit`. `typedLit` calls `Literal.create` to use
+      // This is different from `typedlit`. `typedlit` calls `Literal.create` to use
       // `ScalaReflection` to get the type of `literal`. However, since we use `Any` in this method,
       // `typedLit[Any](literal)` will always fail and fallback to `Literal.apply`. Hence, we can
       // just manually call `Literal.apply` to skip the expensive `ScalaReflection` code. This is
@@ -144,7 +144,7 @@ object functions {
    * The difference between this function and [[lit]] is that this function
    * can handle parameterized scala types e.g.: List, Seq and Map.
    *
-   * Note: `typedLit` will call expensive Scala reflection APIs. `lit` is preferred if parameterized
+   * Note: `typedlit` will call expensive Scala reflection APIs. `lit` is preferred if parameterized
    * scala types are not used.
    *
    * @group normal_funcs

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -113,7 +113,17 @@ object functions {
    * @group normal_funcs
    * @since 1.3.0
    */
-  def lit(literal: Any): Column = typedLit(literal)
+  def lit(literal: Any): Column = literal match {
+    case c: Column => c
+    case s: Symbol => new ColumnName(s.name)
+    case _ =>
+      // This is different from `typedLit`. `typedLit` calls `Literal.create` to use
+      // `ScalaReflection` to get the type of `literal`. However, since we use `Any` in this method,
+      // `typedLit[Any](literal)` will always fail and fallback to `Literal.apply`. Hence, we can
+      // just manually call `Literal.apply` to skip the expensive `ScalaReflection` code. This is
+      // significantly better when there are many threads calling `lit` concurrently.
+      Column(Literal(literal))
+  }
 
   /**
    * Creates a [[Column]] of literal value.
@@ -133,6 +143,9 @@ object functions {
    * Otherwise, a new [[Column]] is created to represent the literal value.
    * The difference between this function and [[lit]] is that this function
    * can handle parameterized scala types e.g.: List, Seq and Map.
+   *
+   * Note: `typedLit` will call expensive Scala reflection APIs. `lit` is preferred if parameterized
+   * scala types are not used.
    *
    * @group normal_funcs
    * @since 3.2.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -144,8 +144,8 @@ object functions {
    * The difference between this function and [[lit]] is that this function
    * can handle parameterized scala types e.g.: List, Seq and Map.
    *
-   * Note: `typedlit` will call expensive Scala reflection APIs. `lit` is preferred if parameterized
-   * scala types are not used.
+   * @note `typedlit` will call expensive Scala reflection APIs. `lit` is preferred if parameterized
+   * Scala types are not used.
    *
    * @group normal_funcs
    * @since 3.2.0

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -932,7 +932,19 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       testData2.collect().toSeq.map(r => Row(r.getInt(0) ^ r.getInt(1) ^ 39)))
   }
 
+  test("SPARK-37646: lit") {
+    assert(lit($"foo") == $"foo")
+    assert(lit('foo) == $"foo")
+    assert(lit(1) == Column(Literal(1)))
+    assert(lit(null) == Column(Literal(null, NullType)))
+  }
+
   test("typedLit") {
+    assert(typedLit($"foo") == $"foo")
+    assert(typedLit('foo) == $"foo")
+    assert(typedLit(1) == Column(Literal(1)))
+    assert(typedLit[String](null) == Column(Literal(null, StringType)))
+
     val df = Seq(Tuple1(0)).toDF("a")
     // Only check the types `lit` cannot handle
     checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to avoid touching Scala reflection APIs in the lit function.

### Why are the changes needed?

Currently `lit` calls `typedlit[Any]` and touches Scala reflection APIs unnecessarily. As Scala reflection APIs touch multiple global locks and they are pretty slow when the parallelism is pretty high.

This PR inlines `typedlit` to `lit` and replaces `Literal.create` with `Literal.apply` to avoid touching Scala reflection APIs. There is no behavior change.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- New unit tests.
- Manually ran the test in https://issues.apache.org/jira/browse/SPARK-37646 and saw no difference between `new Column(Literal(0L))` and `lit(0L)`.