### PR TITLE
[SPARK-37649][PYTHON] Switch default index to distributed-sequence by default in pandas API on Spark

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/best_practices.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/best_practices.rst
@@ -235,7 +235,7 @@ Use ``distributed`` or ``distributed-sequence`` default index
 One common issue when pandas-on-Spark users face is the slow performance by default index. Pandas API on Spark attaches
 a default index when the index is unknown, for example, Spark DataFrame is directly converted to pandas-on-Spark DataFrame.
 
-This default index is ``sequence`` which requires the computation on single partition which is discouraged. If you plan
+Note that ``sequence`` requires the computation on single partition which is discouraged. If you plan
 to handle large data in production, make it distributed by configuring the default index to ``distributed`` or
 ``distributed-sequence`` .
 

--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -245,65 +245,65 @@ This is conceptually equivalent to the PySpark example as below:
 Available options
 -----------------
 
-=============================== ============== =====================================================
-Option                          Default        Description
-=============================== ============== =====================================================
-display.max_rows                1000           This sets the maximum number of rows pandas-on-Spark
-                                               should output when printing out various output. For
-                                               example, this value determines the number of rows to
-                                               be shown at the repr() in a dataframe. Set `None` to
-                                               unlimit the input length. Default is 1000.
-compute.max_rows                1000           'compute.max_rows' sets the limit of the current
-                                               pandas-on-Spark DataFrame. Set `None` to unlimit the
-                                               input length. When the limit is set, it is executed
-                                               by the shortcut by collecting the data into the
-                                               driver, and then using the pandas API. If the limit
-                                               is unset, the operation is executed by PySpark.
-                                               Default is 1000.
-compute.shortcut_limit          1000           'compute.shortcut_limit' sets the limit for a
-                                               shortcut. It computes specified number of rows and
-                                               use its schema. When the dataframe length is larger
-                                               than this limit, pandas-on-Spark uses PySpark to
-                                               compute.
-compute.ops_on_diff_frames      False          This determines whether or not to operate between two
-                                               different dataframes. For example, 'combine_frames'
-                                               function internally performs a join operation which
-                                               can be expensive in general. So, if
-                                               `compute.ops_on_diff_frames` variable is not True,
-                                               that method throws an exception.
-compute.default_index_type      'sequence'     This sets the default index type: sequence,
-                                               distributed and distributed-sequence.
-compute.ordered_head            False          'compute.ordered_head' sets whether or not to operate
-                                               head with natural ordering. pandas-on-Spark does not
-                                               guarantee the row ordering so `head` could return
-                                               some rows from distributed partitions. If
-                                               'compute.ordered_head' is set to True, pandas-on-
-                                               Spark performs natural ordering beforehand, but it
-                                               will cause a performance overhead.
-compute.eager_check             True           'compute.eager_check' sets whether or not to launch
-                                               some Spark jobs just for the sake of validation. If
-                                               'compute.eager_check' is set to True, pandas-on-Spark
-                                               performs the validation beforehand, but it will cause
-                                               a performance overhead. Otherwise, pandas-on-Spark
-                                               skip the validation and will be slightly different
-                                               from pandas. Affected APIs: `Series.dot`,
-                                               `Series.asof`, `Series.compare`,
-                                               `FractionalExtensionOps.astype`,
-                                               `IntegralExtensionOps.astype`,
-                                               `FractionalOps.astype`, `DecimalOps.astype`.
-compute.isin_limit              80             'compute.isin_limit' sets the limit for filtering by
-                                               'Column.isin(list)'. If the length of the ‘list’ is
-                                               above the limit, broadcast join is used instead for
-                                               better performance.
-plotting.max_rows               1000           'plotting.max_rows' sets the visual limit on top-n-
-                                               based plots such as `plot.bar` and `plot.pie`. If it
-                                               is set to 1000, the first 1000 data points will be
-                                               used for plotting. Default is 1000.
-plotting.sample_ratio           None           'plotting.sample_ratio' sets the proportion of data
-                                               that will be plotted for sample-based plots such as
-                                               `plot.line` and `plot.area`. This option defaults to
-                                               'plotting.max_rows' option.
-plotting.backend                'plotly'       Backend to use for plotting. Default is plotly.
-                                               Supports any package that has a top-level `.plot`
-                                               method. Known options are: [matplotlib, plotly].
-=============================== ============== =====================================================
+=============================== ======================= =====================================================
+Option                          Default                 Description
+=============================== ======================= =====================================================
+display.max_rows                1000                    This sets the maximum number of rows pandas-on-Spark
+                                                        should output when printing out various output. For
+                                                        example, this value determines the number of rows to
+                                                        be shown at the repr() in a dataframe. Set `None` to
+                                                        unlimit the input length. Default is 1000.
+compute.max_rows                1000                    'compute.max_rows' sets the limit of the current
+                                                        pandas-on-Spark DataFrame. Set `None` to unlimit the
+                                                        input length. When the limit is set, it is executed
+                                                        by the shortcut by collecting the data into the
+                                                        driver, and then using the pandas API. If the limit
+                                                        is unset, the operation is executed by PySpark.
+                                                        Default is 1000.
+compute.shortcut_limit          1000                    'compute.shortcut_limit' sets the limit for a
+                                                        shortcut. It computes specified number of rows and
+                                                        use its schema. When the dataframe length is larger
+                                                        than this limit, pandas-on-Spark uses PySpark to
+                                                        compute.
+compute.ops_on_diff_frames      False                   This determines whether or not to operate between two
+                                                        different dataframes. For example, 'combine_frames'
+                                                        function internally performs a join operation which
+                                                        can be expensive in general. So, if
+                                                        `compute.ops_on_diff_frames` variable is not True,
+                                                        that method throws an exception.
+compute.default_index_type      'distributed-sequence'  This sets the default index type: sequence,
+                                                        distributed and distributed-sequence.
+compute.ordered_head            False                   'compute.ordered_head' sets whether or not to operate
+                                                        head with natural ordering. pandas-on-Spark does not
+                                                        guarantee the row ordering so `head` could return
+                                                        some rows from distributed partitions. If
+                                                        'compute.ordered_head' is set to True, pandas-on-
+                                                        Spark performs natural ordering beforehand, but it
+                                                        will cause a performance overhead.
+compute.eager_check             True                    'compute.eager_check' sets whether or not to launch
+                                                        some Spark jobs just for the sake of validation. If
+                                                        'compute.eager_check' is set to True, pandas-on-Spark
+                                                        performs the validation beforehand, but it will cause
+                                                        a performance overhead. Otherwise, pandas-on-Spark
+                                                        skip the validation and will be slightly different
+                                                        from pandas. Affected APIs: `Series.dot`,
+                                                        `Series.asof`, `Series.compare`,
+                                                        `FractionalExtensionOps.astype`,
+                                                        `IntegralExtensionOps.astype`,
+                                                        `FractionalOps.astype`, `DecimalOps.astype`.
+compute.isin_limit              80                      'compute.isin_limit' sets the limit for filtering by
+                                                        'Column.isin(list)'. If the length of the ‘list’ is
+                                                        above the limit, broadcast join is used instead for
+                                                        better performance.
+plotting.max_rows               1000                    'plotting.max_rows' sets the visual limit on top-n-
+                                                        based plots such as `plot.bar` and `plot.pie`. If it
+                                                        is set to 1000, the first 1000 data points will be
+                                                        used for plotting. Default is 1000.
+plotting.sample_ratio           None                    'plotting.sample_ratio' sets the proportion of data
+                                                        that will be plotted for sample-based plots such as
+                                                        `plot.line` and `plot.area`. This option defaults to
+                                                        'plotting.max_rows' option.
+plotting.backend                'plotly'                Backend to use for plotting. Default is plotly.
+                                                        Supports any package that has a top-level `.plot`
+                                                        method. Known options are: [matplotlib, plotly].
+=============================== ======================= =====================================================

--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -160,7 +160,7 @@ There are several types of the default index that can be configured by `compute.
 
 **sequence**: It implements a sequence that increases one by one, by PySpark's Window function without
 specifying partition. Therefore, it can end up with whole partition in single node.
-This index type should be avoided when the data is large. This is default. See the example below:
+This index type should be avoided when the data is large. See the example below:
 
 .. code-block:: python
 
@@ -183,7 +183,7 @@ This is conceptually equivalent to the PySpark example as below:
     >>> spark_df.select(sequential_index).rdd.map(lambda r: r[0]).collect()
     [0, 1, 2]
 
-**distributed-sequence**: It implements a sequence that increases one by one, by group-by and
+**distributed-sequence** (default): It implements a sequence that increases one by one, by group-by and
 group-map approach in a distributed manner. It still generates the sequential index globally.
 If the default index must be the sequence in a large dataset, this
 index has to be used.

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -112,7 +112,8 @@ class Option:
 # Available options.
 #
 # NOTE: if you are fixing or adding an option here, make sure you execute `show_options()` and
-#     copy & paste the results into show_options 'docs/source/user_guide/options.rst' as well.
+#     copy & paste the results into show_options
+#     'docs/source/user_guide/pandas_on_spark/options.rst' as well.
 #     See the examples below:
 #     >>> from pyspark.pandas.config import show_options
 #     >>> show_options()
@@ -175,7 +176,7 @@ _options: List[Option] = [
     Option(
         key="compute.default_index_type",
         doc=("This sets the default index type: sequence, distributed and distributed-sequence."),
-        default="sequence",
+        default="distributed-sequence",
         types=str,
         check_func=(
             lambda v: v in ("sequence", "distributed", "distributed-sequence"),
@@ -290,18 +291,18 @@ def show_options() -> None:
     import textwrap
 
     header = ["Option", "Default", "Description"]
-    row_format = "{:<31} {:<14} {:<53}"
+    row_format = "{:<31} {:<23} {:<53}"
 
-    print(row_format.format("=" * 31, "=" * 14, "=" * 53))
+    print(row_format.format("=" * 31, "=" * 23, "=" * 53))
     print(row_format.format(*header))
-    print(row_format.format("=" * 31, "=" * 14, "=" * 53))
+    print(row_format.format("=" * 31, "=" * 23, "=" * 53))
 
     for option in _options:
         doc = textwrap.fill(option.doc, 53)
-        formatted = "".join([line + "\n" + (" " * 47) for line in doc.split("\n")]).rstrip()
+        formatted = "".join([line + "\n" + (" " * 56) for line in doc.split("\n")]).rstrip()
         print(row_format.format(option.key, repr(option.default), formatted))
 
-    print(row_format.format("=" * 31, "=" * 14, "=" * 53))
+    print(row_format.format("=" * 31, "=" * 23, "=" * 53))
 
 
 def get_option(key: str, default: Union[Any, _NoValueType] = _NoValue) -> Any:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to switch default index to `distributed-sequence` by default.

### Why are the changes needed?

`sequence` type relies on sending all data to one executor that easily causes OOM and make the computation slow
We should better switch to `distributed-sequence` type that truly distributes the data.

In my own internal benchmark, it boosts the performance around 2 ~ 3 times faster on average.

### Does this PR introduce _any_ user-facing change?

Ideally no. Order might be affected but that's not already guaranteed. 

### How was this patch tested?

Existing CI should test it out.