### PR TITLE
[SPARK-37650][PYTHON] Tell spark-env.sh the python interpreter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3030,8 +3030,8 @@ Certain Spark settings can be configured through environment variables, which ar
 `conf/spark-env.sh` script in the directory where Spark is installed (or `conf/spark-env.cmd` on
 Windows). In Standalone and Mesos modes, this file can give machine specific information such as
 hostnames. It is also sourced when running local Spark applications or submission scripts. For
-pyspark applications, the environment variable `_PYSPARK_DRIVER_SYS_EXECUTABLE` will be set to
-the python interpreter's `sys.executable`, which will allow further customization based on the
+PySpark applications, the environment variable `_PYSPARK_DRIVER_SYS_EXECUTABLE` will be set to
+the Python interpreter's `sys.executable`, which will allow further customization based on the
 user's virtual environment.
 
 Note that `conf/spark-env.sh` does not exist by default when Spark is installed. However, you can

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3029,7 +3029,10 @@ can be found on the pages for each mode:
 Certain Spark settings can be configured through environment variables, which are read from the
 `conf/spark-env.sh` script in the directory where Spark is installed (or `conf/spark-env.cmd` on
 Windows). In Standalone and Mesos modes, this file can give machine specific information such as
-hostnames. It is also sourced when running local Spark applications or submission scripts.
+hostnames. It is also sourced when running local Spark applications or submission scripts. For
+pyspark applications, the environment variable `_PYSPARK_DRIVER_SYS_EXECUTABLE` will be set to
+the python interpreter's `sys.executable`, which will allow further customization based on the
+user's virtual environment.
 
 Note that `conf/spark-env.sh` does not exist by default when Spark is installed. However, you can
 copy `conf/spark-env.sh.template` to create it. Make sure you make the copy executable.

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -21,6 +21,7 @@ import signal
 import shlex
 import shutil
 import socket
+import sys
 import platform
 import tempfile
 import time
@@ -80,6 +81,7 @@ def launch_gateway(conf=None, popen_kwargs=None):
 
             env = dict(os.environ)
             env["_PYSPARK_DRIVER_CONN_INFO_PATH"] = conn_info_file
+            env["_PYSPARK_DRIVER_SYS_EXECUTABLE"] = sys.executable
 
             # Launch the Java gateway.
             popen_kwargs = {} if popen_kwargs is None else popen_kwargs


### PR DESCRIPTION
When loading config defaults via spark-env.sh, it can be useful to know
the current pyspark python interpreter to allow the configuration to set
values properly. Pass this value in the environment as
_PYSPARK_DRIVER_SYS_EXECUTABLE to the environment script.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It's currently possible to set sensible site-wide spark configuration defaults by using `$SPARK_CONF_DIR/spark-env.sh`. In the case where a user is using pyspark, however, there are a number of things that aren't discoverable by that script, due to the way that it's called. There is a chain of calls (java_gateway.py -> shell script -> java -> shell script) that ends up obliterating any bit of the python context.

This change proposes to add en environment variable `_PYSPARK_DRIVER_SYS_EXECUTABLE` which points to the filename of the top-level python executable within pyspark's `java_gateway.py` bootstrapping process. With that, spark-env.sh will be able to infer enough information about the python environment to set the appropriate configuration variables.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Right now, there a number of config options useful to pyspark that can't be reliably set by `spark-env.sh` because it is unaware of the python context that spawning the executor. To give the most trivial example, it is currently possible to set `spark.kubernetes.container.image` or `spark.driver.host` based on information readily available from the environment (e.g. the k8s downward API). However, `spark.pyspark.python` and family cannot be set because when `spark-env.sh` executes it's lost all of the python context. We can instruct users to add the appropriate config variables, but this form of cargo-culting is error-prone and not scalable. It would be much better to expose important python variables so that pyspark can not be a second-class citizen.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. With this change, if python spawns the JVM, `spark-env.sh` will receive an environment variable `_PYSPARK_DRIVER_SYS_EXECUTABLE` pointing to the python executor.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
To be perfectly honest, I don't know where this fits into the testing infrastructure. I monkey-patched a binary 3.2.0 install to add the lines to java_gateway.py and that works, but in terms of adding this to the CI ... I'm at a loss. I'm more than willing to add the additional info, if needed.
