### PR TITLE
[SPARK-37653][BUILD] Upgrade RoaringBitmap to 0.9.23

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -1,7 +1,7 @@
 HikariCP/2.5.1//HikariCP-2.5.1.jar
 JLargeArrays/1.5//JLargeArrays-1.5.jar
 JTransforms/3.1//JTransforms-3.1.jar
-RoaringBitmap/0.9.22//RoaringBitmap-0.9.22.jar
+RoaringBitmap/0.9.23//RoaringBitmap-0.9.23.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.21//aircompressor-0.21.jar
@@ -226,7 +226,7 @@ scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
-shims/0.9.22//shims-0.9.22.jar
+shims/0.9.23//shims-0.9.23.jar
 slf4j-api/1.7.30//slf4j-api-1.7.30.jar
 slf4j-log4j12/1.7.30//slf4j-log4j12-1.7.30.jar
 snakeyaml/1.28//snakeyaml-1.28.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -1,7 +1,7 @@
 HikariCP/2.5.1//HikariCP-2.5.1.jar
 JLargeArrays/1.5//JLargeArrays-1.5.jar
 JTransforms/3.1//JTransforms-3.1.jar
-RoaringBitmap/0.9.22//RoaringBitmap-0.9.22.jar
+RoaringBitmap/0.9.23//RoaringBitmap-0.9.23.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.21//aircompressor-0.21.jar
@@ -213,7 +213,7 @@ scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.15//scala-reflect-2.12.15.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.3//shapeless_2.12-2.3.3.jar
-shims/0.9.22//shims-0.9.22.jar
+shims/0.9.23//shims-0.9.23.jar
 slf4j-api/1.7.30//slf4j-api-1.7.30.jar
 slf4j-log4j12/1.7.30//slf4j-log4j12-1.7.30.jar
 snakeyaml/1.28//snakeyaml-1.28.jar

--- a/pom.xml
+++ b/pom.xml
@@ -783,7 +783,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.22</version>
+        <version>0.9.23</version>
       </dependency>
       <dependency>
         <groupId>commons-net</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr upgrade `RoaringBitmap` from 0.9.22 to 0.9.23


### Why are the changes needed?
Bring some optimizations(like [RoaringBitmap#525](https://github.com/RoaringBitmap/RoaringBitmap/pull/525)) and bug fix([RoaringBitmap#537](like https://github.com/RoaringBitmap/RoaringBitmap/pull/538)), and this is the first `RoaringBitmap` version that supports Java 17 CI ([RoaringBitmap#533](https://github.com/RoaringBitmap/RoaringBitmap/pull/533)).



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass the Jenkins or GitHub Action

