### PR TITLE
[SPARK-37145][K8S] Add support for extending user feature steps with configuration

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -386,14 +386,23 @@ object KubernetesUtils extends Logging {
   @Since("3.3.0")
   def loadFeatureStep(conf: KubernetesConf, className: String): KubernetesFeatureConfigStep = {
     val constructors = Utils.classForName(className).getConstructors
+    // Try to find constructor with only type matched conf or only KubernetesConf conf
     val confConstructor = constructors.find { constructor =>
       constructor.getParameterCount == 1 &&
         (constructor.getParameterTypes()(0) == conf.getClass ||
           constructor.getParameterTypes()(0) == classOf[KubernetesConf])
     }
+    // Try to find no param constructor
     val noParamConstructor = constructors.find { constructor =>
       constructor.getParameterCount == 0
     }
+    // Throw SparkException if no expected constructor found
+    if (noParamConstructor.isEmpty && confConstructor.isEmpty) {
+      throw new SparkException(s"Failed to load feature step: $className, " +
+        s"the constructor of the feature step should be no param or with only " +
+        s"${conf.getClass.getSimpleName}/KubernetesConf param.")
+    }
+
     val constructor = confConstructor.map { confConstructor =>
       (conf: KubernetesConf) => confConstructor.newInstance(conf)
     }.getOrElse {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilder.scala
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.KubernetesClient
 
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.features._
-import org.apache.spark.util.Utils
 
 private[spark] class KubernetesDriverBuilder {
 
@@ -39,7 +38,7 @@ private[spark] class KubernetesDriverBuilder {
 
     val userFeatures = conf.get(Config.KUBERNETES_DRIVER_POD_FEATURE_STEPS)
       .map { className =>
-        Utils.classForName(className).newInstance().asInstanceOf[KubernetesFeatureConfigStep]
+        KubernetesUtils.loadFeatureStep(conf, className)
       }
 
     val features = Seq(

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilder.scala
@@ -22,7 +22,6 @@ import org.apache.spark.SecurityManager
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.features._
 import org.apache.spark.resource.ResourceProfile
-import org.apache.spark.util.Utils
 
 private[spark] class KubernetesExecutorBuilder {
 
@@ -43,7 +42,7 @@ private[spark] class KubernetesExecutorBuilder {
 
     val userFeatures = conf.get(Config.KUBERNETES_EXECUTOR_POD_FEATURE_STEPS)
       .map { className =>
-        Utils.classForName(className).newInstance().asInstanceOf[KubernetesFeatureConfigStep]
+        KubernetesUtils.loadFeatureStep(conf, className)
       }
 
     val features = Seq(

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodBuilderSuite.scala
@@ -66,7 +66,7 @@ abstract class PodBuilderSuite extends SparkFunSuite {
     assert(pod.container.getVolumeMounts.asScala.exists(_.getName == "so_long_two"))
   }
 
-  test("configure a custom test step with base config") {
+  test("SPARK-37145: configure a custom test step with base config") {
     val client = mockKubernetesClient()
     val sparkConf = baseConf.clone()
       .set(userFeatureStepsConf.key,
@@ -79,7 +79,7 @@ abstract class PodBuilderSuite extends SparkFunSuite {
     assert(metadata.getAnnotations.containsKey("test-user-feature-annotation"))
   }
 
-  test("configure a custom test step with driver or executor config") {
+  test("SPARK-37145: configure a custom test step with driver or executor config") {
     val client = mockKubernetesClient()
     val (featureSteps, annotationKey) = this.getClass.getSimpleName match {
       case "KubernetesDriverBuilderSuite" =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch adds the support for extending user feature steps with configuration.

Before this patch user can only add feature step like:
- `class TestStep extends KubernetesFeatureConfigStep`

After this patch user can add feature step with configuration like:
- `class TestStep extends KubernetesFeatureConfigStep`
- `class TestStepWithK8SConf(conf: KubernetesConf) extends KubernetesFeatureConfigStep`
- `class TestStepWithDriverConf(conf: KubernetesDriverConf) extends KubernetesFeatureConfigStep`
- `class TestStepWithExecConf(conf: KubernetesExecutorConf) extends KubernetesFeatureConfigStep`

### Why are the changes needed?
In https://github.com/apache/spark/pull/30206 , a developer API for custom feature steps has been added, but it didn't support initialize user feature step with kubernetes conf (like `KubernetesConf`/`KubernetesDriverConf`/`KubernetesExecutorConf`).

In most of scenarios, users want to make corresponding changes in their feature steps according to the configuration. Such as, the customized scheduler scenario, user wants to configure pod according to passed job configuration.

### Does this PR introduce _any_ user-facing change?
Improve the developer API for for custom feature steps.


### How was this patch tested?
- Added UT
- Runing k8s integration test manaully: `build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dtest.exclude.tags=minikube,r "kubernetes-integration-tests/test`
