### PR TITLE
[SPARK-37669][PYTHON] Remove unnecessary usages of OrderedDict

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -18,7 +18,7 @@
 """
 A wrapper class for Spark DataFrame to behave similar to pandas DataFrame.
 """
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from collections.abc import Mapping
 import re
 import warnings
@@ -6085,7 +6085,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 index_values = values[-1]
             else:
                 index_values = values
-            index_map: Dict[str, Optional[Label]] = OrderedDict()
+            index_map: Dict[str, Optional[Label]] = {}
             for i, index_value in enumerate(index_values):
                 colname = SPARK_INDEX_NAME_FORMAT(i)
                 sdf = sdf.withColumn(colname, SF.lit(index_value))
@@ -9651,7 +9651,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                 ).with_filter(SF.lit(False))
             )
 
-        column_labels: Union[defaultdict, OrderedDict] = defaultdict(dict)
+        column_labels: Dict[Label, Dict[Any, Column]] = defaultdict(dict)
         index_values = set()
         should_returns_series = False
         for label in self._internal.column_labels:
@@ -9666,7 +9666,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
             index_values.add(value)
 
-        column_labels = OrderedDict(sorted(column_labels.items(), key=lambda x: x[0]))
+        column_labels = dict(sorted(column_labels.items(), key=lambda x: x[0]))
 
         index_name = self._internal.column_label_names[-1]
         column_label_names = self._internal.column_label_names[:-1]
@@ -11184,7 +11184,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # |[2, 3, 4]|[6, 7, 8]|
             # +---------+---------+
 
-            cols_dict: Dict[str, List[Column]] = OrderedDict()
+            cols_dict: Dict[str, List[Column]] = {}
             for column in percentile_col_names:
                 cols_dict[column] = list()
                 for i in range(len(qq)):

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -21,7 +21,7 @@ A wrapper for GroupedData to behave similar to pandas GroupBy.
 
 from abc import ABCMeta, abstractmethod
 import inspect
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import product
@@ -288,7 +288,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         else:
             agg_cols = [col.name for col in self._agg_columns]
-            func_or_funcs = OrderedDict([(col, func_or_funcs) for col in agg_cols])
+            func_or_funcs = {col: func_or_funcs for col in agg_cols}
 
         psdf: DataFrame = DataFrame(
             GroupBy._spark_groupby(self._psdf, func_or_funcs, self._groupkeys)

--- a/python/pyspark/pandas/numpy_compat.py
+++ b/python/pyspark/pandas/numpy_compat.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from collections import OrderedDict
 from typing import Any, Callable, no_type_check
 
 import numpy as np
@@ -26,131 +25,115 @@ from pyspark.pandas.base import IndexOpsMixin
 from pyspark.pandas.spark import functions as SF
 
 
-unary_np_spark_mappings = OrderedDict(
-    {
-        "abs": F.abs,
-        "absolute": F.abs,
-        "arccos": F.acos,
-        "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore[call-overload]
-        "arcsin": F.asin,
-        "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore[call-overload]
-        "arctan": F.atan,
-        "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore[call-overload]
-        "bitwise_not": F.bitwiseNOT,
-        "cbrt": F.cbrt,
-        "ceil": F.ceil,
-        # It requires complex type which pandas-on-Spark does not support yet
-        "conj": lambda _: NotImplemented,
-        "conjugate": lambda _: NotImplemented,  # It requires complex type
-        "cos": F.cos,
-        "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),  # type: ignore[call-overload]
-        "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),  # type: ignore[call-overload]
-        "degrees": F.degrees,
-        "exp": F.exp,
-        "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),  # type: ignore[call-overload]
-        "expm1": F.expm1,
-        "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),  # type: ignore[call-overload]
-        "floor": F.floor,
-        "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
-        # and it cannot be supported via pandas UDF.
-        "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore[call-overload]
-        "isfinite": lambda c: c != float("inf"),
-        "isinf": lambda c: c == float("inf"),
-        "isnan": F.isnan,
-        "isnat": lambda c: NotImplemented,  # pandas-on-Spark and PySpark does not have Nat concept.
-        "log": F.log,
-        "log10": F.log10,
-        "log1p": F.log1p,
-        "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),  # type: ignore[call-overload]
-        "logical_not": lambda c: ~(c.cast(BooleanType())),
-        "matmul": lambda _: NotImplemented,  # Can return a NumPy array in pandas.
-        "negative": lambda c: c * -1,
-        "positive": lambda c: c,
-        "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),  # type: ignore[call-overload]
-        "radians": F.radians,
-        "reciprocal": pandas_udf(  # type: ignore[call-overload]
-            lambda s: np.reciprocal(s), DoubleType()
-        ),
-        "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore[call-overload]
-        "sign": lambda c: F.when(c == 0, 0).when(c < 0, -1).otherwise(1),
-        "signbit": lambda c: F.when(c < 0, True).otherwise(False),
-        "sin": F.sin,
-        "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),  # type: ignore[call-overload]
-        "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),  # type: ignore[call-overload]
-        "sqrt": F.sqrt,
-        "square": pandas_udf(lambda s: np.square(s), DoubleType()),  # type: ignore[call-overload]
-        "tan": F.tan,
-        "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),  # type: ignore[call-overload]
-        "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore[call-overload]
-    }
-)
+unary_np_spark_mappings = {
+    "abs": F.abs,
+    "absolute": F.abs,
+    "arccos": F.acos,
+    "arccosh": pandas_udf(lambda s: np.arccosh(s), DoubleType()),  # type: ignore[call-overload]
+    "arcsin": F.asin,
+    "arcsinh": pandas_udf(lambda s: np.arcsinh(s), DoubleType()),  # type: ignore[call-overload]
+    "arctan": F.atan,
+    "arctanh": pandas_udf(lambda s: np.arctanh(s), DoubleType()),  # type: ignore[call-overload]
+    "bitwise_not": F.bitwiseNOT,
+    "cbrt": F.cbrt,
+    "ceil": F.ceil,
+    # It requires complex type which pandas-on-Spark does not support yet
+    "conj": lambda _: NotImplemented,
+    "conjugate": lambda _: NotImplemented,  # It requires complex type
+    "cos": F.cos,
+    "cosh": pandas_udf(lambda s: np.cosh(s), DoubleType()),  # type: ignore[call-overload]
+    "deg2rad": pandas_udf(lambda s: np.deg2rad(s), DoubleType()),  # type: ignore[call-overload]
+    "degrees": F.degrees,
+    "exp": F.exp,
+    "exp2": pandas_udf(lambda s: np.exp2(s), DoubleType()),  # type: ignore[call-overload]
+    "expm1": F.expm1,
+    "fabs": pandas_udf(lambda s: np.fabs(s), DoubleType()),  # type: ignore[call-overload]
+    "floor": F.floor,
+    "frexp": lambda _: NotImplemented,  # 'frexp' output lengths become different
+    # and it cannot be supported via pandas UDF.
+    "invert": pandas_udf(lambda s: np.invert(s), DoubleType()),  # type: ignore[call-overload]
+    "isfinite": lambda c: c != float("inf"),
+    "isinf": lambda c: c == float("inf"),
+    "isnan": F.isnan,
+    "isnat": lambda c: NotImplemented,  # pandas-on-Spark and PySpark does not have Nat concept.
+    "log": F.log,
+    "log10": F.log10,
+    "log1p": F.log1p,
+    "log2": pandas_udf(lambda s: np.log2(s), DoubleType()),  # type: ignore[call-overload]
+    "logical_not": lambda c: ~(c.cast(BooleanType())),
+    "matmul": lambda _: NotImplemented,  # Can return a NumPy array in pandas.
+    "negative": lambda c: c * -1,
+    "positive": lambda c: c,
+    "rad2deg": pandas_udf(lambda s: np.rad2deg(s), DoubleType()),  # type: ignore[call-overload]
+    "radians": F.radians,
+    "reciprocal": pandas_udf(  # type: ignore[call-overload]
+        lambda s: np.reciprocal(s), DoubleType()
+    ),
+    "rint": pandas_udf(lambda s: np.rint(s), DoubleType()),  # type: ignore[call-overload]
+    "sign": lambda c: F.when(c == 0, 0).when(c < 0, -1).otherwise(1),
+    "signbit": lambda c: F.when(c < 0, True).otherwise(False),
+    "sin": F.sin,
+    "sinh": pandas_udf(lambda s: np.sinh(s), DoubleType()),  # type: ignore[call-overload]
+    "spacing": pandas_udf(lambda s: np.spacing(s), DoubleType()),  # type: ignore[call-overload]
+    "sqrt": F.sqrt,
+    "square": pandas_udf(lambda s: np.square(s), DoubleType()),  # type: ignore[call-overload]
+    "tan": F.tan,
+    "tanh": pandas_udf(lambda s: np.tanh(s), DoubleType()),  # type: ignore[call-overload]
+    "trunc": pandas_udf(lambda s: np.trunc(s), DoubleType()),  # type: ignore[call-overload]
+}
 
-binary_np_spark_mappings = OrderedDict(
-    {
-        "arctan2": F.atan2,
-        "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
-        "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
-        "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
-        "copysign": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.copysign(s1, s2), DoubleType()
-        ),
-        "float_power": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.float_power(s1, s2), DoubleType()
-        ),
-        "floor_divide": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.floor_divide(s1, s2), DoubleType()
-        ),
-        "fmax": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.fmax(s1, s2), DoubleType()
-        ),
-        "fmin": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.fmin(s1, s2), DoubleType()
-        ),
-        "fmod": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.fmod(s1, s2), DoubleType()
-        ),
-        "gcd": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.gcd(s1, s2), DoubleType()
-        ),
-        "heaviside": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.heaviside(s1, s2), DoubleType()
-        ),
-        "hypot": F.hypot,
-        "lcm": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.lcm(s1, s2), DoubleType()
-        ),
-        "ldexp": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.ldexp(s1, s2), DoubleType()
-        ),
-        "left_shift": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.left_shift(s1, s2), LongType()
-        ),
-        "logaddexp": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.logaddexp(s1, s2), DoubleType()
-        ),
-        "logaddexp2": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()
-        ),
-        "logical_and": lambda c1, c2: c1.cast(BooleanType()) & c2.cast(BooleanType()),
-        "logical_or": lambda c1, c2: c1.cast(BooleanType()) | c2.cast(BooleanType()),
-        "logical_xor": lambda c1, c2: (
-            # mimics xor by logical operators.
-            (c1.cast(BooleanType()) | c2.cast(BooleanType()))
-            & (~(c1.cast(BooleanType())) | ~(c2.cast(BooleanType())))
-        ),
-        "maximum": F.greatest,
-        "minimum": F.least,
-        "modf": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.modf(s1, s2), DoubleType()
-        ),
-        "nextafter": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.nextafter(s1, s2), DoubleType()
-        ),
-        "right_shift": pandas_udf(  # type: ignore[call-overload]
-            lambda s1, s2: np.right_shift(s1, s2), LongType()
-        ),
-    }
-)
+binary_np_spark_mappings = {
+    "arctan2": F.atan2,
+    "bitwise_and": lambda c1, c2: c1.bitwiseAND(c2),
+    "bitwise_or": lambda c1, c2: c1.bitwiseOR(c2),
+    "bitwise_xor": lambda c1, c2: c1.bitwiseXOR(c2),
+    "copysign": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.copysign(s1, s2), DoubleType()
+    ),
+    "float_power": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.float_power(s1, s2), DoubleType()
+    ),
+    "floor_divide": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.floor_divide(s1, s2), DoubleType()
+    ),
+    "fmax": pandas_udf(lambda s1, s2: np.fmax(s1, s2), DoubleType()),  # type: ignore[call-overload]
+    "fmin": pandas_udf(lambda s1, s2: np.fmin(s1, s2), DoubleType()),  # type: ignore[call-overload]
+    "fmod": pandas_udf(lambda s1, s2: np.fmod(s1, s2), DoubleType()),  # type: ignore[call-overload]
+    "gcd": pandas_udf(lambda s1, s2: np.gcd(s1, s2), DoubleType()),  # type: ignore[call-overload]
+    "heaviside": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.heaviside(s1, s2), DoubleType()
+    ),
+    "hypot": F.hypot,
+    "lcm": pandas_udf(lambda s1, s2: np.lcm(s1, s2), DoubleType()),  # type: ignore[call-overload]
+    "ldexp": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.ldexp(s1, s2), DoubleType()
+    ),
+    "left_shift": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.left_shift(s1, s2), LongType()
+    ),
+    "logaddexp": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.logaddexp(s1, s2), DoubleType()
+    ),
+    "logaddexp2": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.logaddexp2(s1, s2), DoubleType()
+    ),
+    "logical_and": lambda c1, c2: c1.cast(BooleanType()) & c2.cast(BooleanType()),
+    "logical_or": lambda c1, c2: c1.cast(BooleanType()) | c2.cast(BooleanType()),
+    "logical_xor": lambda c1, c2: (
+        # mimics xor by logical operators.
+        (c1.cast(BooleanType()) | c2.cast(BooleanType()))
+        & (~(c1.cast(BooleanType())) | ~(c2.cast(BooleanType())))
+    ),
+    "maximum": F.greatest,
+    "minimum": F.least,
+    "modf": pandas_udf(lambda s1, s2: np.modf(s1, s2), DoubleType()),  # type: ignore[call-overload]
+    "nextafter": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.nextafter(s1, s2), DoubleType()
+    ),
+    "right_shift": pandas_udf(  # type: ignore[call-overload]
+        lambda s1, s2: np.right_shift(s1, s2), LongType()
+    ),
+}
 
 
 # Copied from pandas.

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -19,7 +19,6 @@ Commonly used utils in pandas-on-Spark.
 """
 
 import functools
-from collections import OrderedDict
 from contextlib import contextmanager
 import os
 from typing import (
@@ -441,7 +440,7 @@ def align_diff_frames(
     )
 
     # 3. Restore the names back and deduplicate columns.
-    this_labels = OrderedDict()
+    this_labels: Dict[Label, Label] = {}
     # Add columns in an order of its original frame.
     for this_label in this_column_labels:
         for new_label in applied._internal.column_labels:
@@ -449,7 +448,7 @@ def align_diff_frames(
                 this_labels[new_label[1:]] = new_label
 
     # After that, we will add the rest columns.
-    other_labels = OrderedDict()
+    other_labels: Dict[Label, Label] = {}
     for new_label in applied._internal.column_labels:
         if new_label[1:] not in this_labels:
             other_labels[new_label[1:]] = new_label

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -199,12 +199,6 @@ class PandasGroupedOpsMixin:
         into memory, so the user should be aware of the potential OOM risk if data is skewed
         and certain groups are too large to fit in memory.
 
-        If returning a new `pandas.DataFrame` constructed with a dictionary, it is
-        recommended to explicitly index the columns by name to ensure the positions are correct,
-        or alternatively use an `OrderedDict`.
-        For example, `pd.DataFrame({'id': ids, 'a': data}, columns=['id', 'a'])` or
-        `pd.DataFrame(OrderedDict([('id', ids), ('a', data)]))`.
-
         This API is experimental.
 
         See Also
@@ -332,12 +326,6 @@ class PandasCogroupedOps:
         This function requires a full shuffle. All the data of a cogroup will be loaded
         into memory, so the user should be aware of the potential OOM risk if data is skewed
         and certain groups are too large to fit in memory.
-
-        If returning a new `pandas.DataFrame` constructed with a dictionary, it is
-        recommended to explicitly index the columns by name to ensure the positions are correct,
-        or alternatively use an `OrderedDict`.
-        For example, `pd.DataFrame({'id': ids, 'a': data}, columns=['id', 'a'])` or
-        `pd.DataFrame(OrderedDict([('id', ids), ('a', data)]))`.
 
         This API is experimental.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Removes unnecessary usages of `OrderedDict`.

### Why are the changes needed?

Now that supported Python is 3.7 and above, we can remove unnecessary usages of `OrderedDict` because built-in `dict` guarantees the insertion order.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.