### PR TITLE
[SPARK-37673][PYTHON] Implement `ps.timedelta_range` method

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/general_functions.rst
+++ b/python/docs/source/reference/pyspark.pandas/general_functions.rst
@@ -65,3 +65,4 @@ Top-level dealing with datetimelike
 
    to_datetime
    date_range
+   timedelta_range

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1940,7 +1940,7 @@ def timedelta_range(
     TimedeltaIndex(['2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
 
     The freq parameter specifies the frequency of the TimedeltaIndex.
-    Only fixed frequencies can be passed,non-fixed frequencies such as ‘M’ (month end) will raise.
+    Only fixed frequencies can be passed, non-fixed frequencies such as ‘M’ (month end) will raise.
 
     >>> ps.timedelta_range(start='1 day', end='2 days', freq='6H')  # doctest: +NORMALIZE_WHITESPACE
     TimedeltaIndex(['1 days 00:00:00', '1 days 06:00:00', '1 days 12:00:00',

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -235,6 +235,36 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
             AssertionError, lambda: ps.date_range(start="1/1/2018", periods=5, freq="N")
         )
 
+    def test_timedelta_range(self):
+        self.assert_eq(
+            ps.timedelta_range(start="1 day", end="3 days"),
+            pd.timedelta_range(start="1 day", end="3 days"),
+        )
+        self.assert_eq(
+            ps.timedelta_range(start="1 day", periods=3),
+            pd.timedelta_range(start="1 day", periods=3),
+        )
+        self.assert_eq(
+            ps.timedelta_range(end="3 days", periods=3),
+            pd.timedelta_range(end="3 days", periods=3),
+        )
+        self.assert_eq(
+            ps.timedelta_range(end="3 days", periods=3, closed='right'),
+            pd.timedelta_range(end="3 days", periods=3, closed='right'),
+        )
+        self.assert_eq(
+            ps.timedelta_range(start="1 day", end="3 days", freq='6H'),
+            pd.timedelta_range(start="1 day", end="3 days", freq='6H'),
+        )
+        self.assert_eq(
+            ps.timedelta_range(start="1 day", end="3 days", periods=4),
+            pd.timedelta_range(start="1 day", end="3 days", periods=4),
+        )
+
+        self.assertRaises(
+            AssertionError, lambda: ps.timedelta_range(start="1 day", periods=3, freq="ns")
+        )
+
     def test_concat_index_axis(self):
         pdf = pd.DataFrame({"A": [0, 2, 4], "B": [1, 3, 5], "C": [6, 7, 8]})
         # TODO: pdf.columns.names = ["ABC"]

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -249,12 +249,12 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
             pd.timedelta_range(end="3 days", periods=3),
         )
         self.assert_eq(
-            ps.timedelta_range(end="3 days", periods=3, closed='right'),
-            pd.timedelta_range(end="3 days", periods=3, closed='right'),
+            ps.timedelta_range(end="3 days", periods=3, closed="right"),
+            pd.timedelta_range(end="3 days", periods=3, closed="right"),
         )
         self.assert_eq(
-            ps.timedelta_range(start="1 day", end="3 days", freq='6H'),
-            pd.timedelta_range(start="1 day", end="3 days", freq='6H'),
+            ps.timedelta_range(start="1 day", end="3 days", freq="6H"),
+            pd.timedelta_range(start="1 day", end="3 days", freq="6H"),
         )
         self.assert_eq(
             ps.timedelta_range(start="1 day", end="3 days", periods=4),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `ps.timedelta_range` method.

The API is backed by `pd.timedelta_range` internally, following how `ps.date_range` is implemented.

### Why are the changes needed?
To be consistent with pandas API.


### Does this PR introduce _any_ user-facing change?
Yes. `ps.timedelta_range` is supported now.

```py
>>> ps.timedelta_range(start="1 day", end="3 days")
TimedeltaIndex(['1 days', '2 days', '3 days'], dtype='timedelta64[ns]', freq=None)
>>> ps.timedelta_range(start="1 day", periods=3)
TimedeltaIndex(['1 days', '2 days', '3 days'], dtype='timedelta64[ns]', freq=None)
>>> ps.timedelta_range(start='1 day', end='2 days', freq='6H')
TimedeltaIndex(['1 days 00:00:00', '1 days 06:00:00', '1 days 12:00:00',
                '1 days 18:00:00', '2 days 00:00:00'],
               dtype='timedelta64[ns]', freq=None)
```

### How was this patch tested?
Unit tests.