### PR TITLE
[SPARK-37674][SQL] Reduce the output partition of output stage to avoid producing small files.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -512,6 +512,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DATAWRITE_PARTITION_SIZE_IN_BYTES =
+    buildConf("spark.sql.adaptive.dataWritePartitionSizeInBytes")
+      .doc("The advisory size in bytes of the shuffle partition during adaptive optimization " +
+        s"(when ${ADAPTIVE_EXECUTION_ENABLED.key} and ${COALESCE_PARTITIONS_ENABLED.key} is " +
+        s"true). It takes effect the finalStage with `DataWritingCommand` or `V2TableWriteExec` " +
+        s"coalesces small shuffle partitions or splits skewed shuffle partition")
+      .version("3.3.0")
+      .fallbackConf(ADVISORY_PARTITION_SIZE_IN_BYTES)
+
   val COALESCE_PARTITIONS_PARALLELISM_FIRST =
     buildConf("spark.sql.adaptive.coalescePartitions.parallelismFirst")
       .doc("When true, Spark does not respect the target size specified by " +


### PR DESCRIPTION

### What changes were proposed in this pull request?
Reduce the output partition of output stage to avoid producing small files.

### Why are the changes needed?

The partition size of the finalStage with `DataWritingCommand` or `V2TableWriteExec`  may use the `ADVISORY_PARTITION_SIZE_IN_BYTES` which is smaller one, and  may produce some small files, it is bad for production.

Sometime, we may adjust `ADVISORY_PARTITION_SIZE_IN_BYTES` to a big one to avoid above , but it is NOT a good idea, it may take effect other Jobs or stages to  coalesce small shuffle partitions or split skewed shuffle partition.

So we should introduce a new partition size instead of  `ADVISORY_PARTITION_SIZE_IN_BYTES`  for  the finalStage with `DataWritingCommand` or `V2TableWriteExec`  to avoid small files.


### Does this PR introduce _any_ user-facing change?

NO

### How was this patch tested?
Added unittests.
