### PR TITLE
[SPARK-37675][CORE][SHUFFLE] Return PushMergedRemoteMetaFailedFetchResult if no available push-merged block

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
@@ -114,7 +114,7 @@ private class PushBasedFetchHelper(
       reduceId: Int,
       blockSize: Long,
       bitmaps: Array[RoaringBitmap]): ArrayBuffer[(BlockId, Long, Int)] = {
-    val approxChunkSize = blockSize / bitmaps.length
+    val approxChunkSize = if (bitmaps.isEmpty) 0 else blockSize / bitmaps.length
     val blocksToFetch = new ArrayBuffer[(BlockId, Long, Int)]()
     for (i <- bitmaps.indices) {
       val blockChunkId = ShuffleBlockChunkId(shuffleId, shuffleMergeId, reduceId, i)

--- a/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PushBasedFetchHelper.scala
@@ -114,7 +114,7 @@ private class PushBasedFetchHelper(
       reduceId: Int,
       blockSize: Long,
       bitmaps: Array[RoaringBitmap]): ArrayBuffer[(BlockId, Long, Int)] = {
-    val approxChunkSize = if (bitmaps.isEmpty) 0 else blockSize / bitmaps.length
+    val approxChunkSize = blockSize / bitmaps.length
     val blocksToFetch = new ArrayBuffer[(BlockId, Long, Int)]()
     for (i <- bitmaps.indices) {
       val blockChunkId = ShuffleBlockChunkId(shuffleId, shuffleMergeId, reduceId, i)

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -972,6 +972,9 @@ final class ShuffleBlockFetcherIterator(
 
         case PushMergedRemoteMetaFetchResult(
           shuffleId, shuffleMergeId, reduceId, blockSize, bitmaps, address) =>
+          // PushMergedRemoteMetaFailedFetchResult will be returned instead of
+          // PushMergedRemoteMetaFetchResult if no available push-merged block.
+          assert(bitmaps.length > 0)
           // The original meta request is processed so we decrease numBlocksToFetch and
           // numBlocksInFlightPerAddress by 1. We will collect new shuffle chunks request and the
           // count of this is added to numBlocksToFetch in collectFetchReqsFromMergedBlocks.


### PR DESCRIPTION
### What changes were proposed in this pull request?

When push-based shuffle enabled, reduce task will ask ESS for MergedMetas, then `PushMergedRemoteMetaFailedFetchResult` should be returned instead of `PushMergedRemoteMetaFetchResult` if there is no available push-merged block on ESS.

### Why are the changes needed?

Because that push-based shuffle works as best-effort, there are opportunities that no chunks of the block are available on ESS, in current implementation, it will cause reduce task failed with `ArithmeticException: / by zero`.

```
Caused by: java.lang.ArithmeticException: / by zero
	at org.apache.spark.storage.PushBasedFetchHelper.createChunkBlockInfosFromMetaResponse(PushBasedFetchHelper.scala:117)
	at org.apache.spark.storage.ShuffleBlockFetcherIterator.next(ShuffleBlockFetcherIterator.scala:980)
	at org.apache.spark.storage.ShuffleBlockFetcherIterator.next(ShuffleBlockFetcherIterator.scala:84)
	at org.apache.spark.util.CompletionIterator.next(CompletionIterator.scala:29)
```

After the change, a `PushMergedRemoteMetaFetchResult` will let reduce task fall back to fetching the original blocks.

### Does this PR introduce _any_ user-facing change?

Yes, it'a bug fix. The change makes push-based shuffle stable. Before this change, my 1T TPCDS test failed several times w/ `ArithmeticException: / by zero`, after the change, passed w/o any exception.

### How was this patch tested?

Existing tests, and run 1T TPCDS manually.