### PR TITLE
[SPARK-37680][CORE] Support RocksDB backend in Spark History Server

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreSerializer.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVStoreSerializer.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.spark.annotation.Private;
 
 /**
- * Serializer used to translate between app-defined types and the LevelDB store.
+ * Serializer used to translate between app-defined types and the disk-based stores.
  *
  * <p>
  * The serializer is based on Jackson, so values are written as JSON. It also allows "naked strings"

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -138,7 +138,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     val dir = hybridStoreDiskBackend match {
       case "leveldb" => "listing.ldb"
       case "rocksdb" => "listing.rdb"
-      case db => throw new IllegalStateException(s"$db is not supported.")
+      case db => throw new IllegalArgumentException(s"$db is not supported.")
     }
     val dbPath = Files.createDirectories(new File(path, dir).toPath()).toFile()
     Utils.chmod700(dbPath)

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdfs.DistributedFileSystem
 import org.apache.hadoop.hdfs.protocol.HdfsConstants
 import org.apache.hadoop.security.AccessControlException
 import org.fusesource.leveldbjni.internal.NativeDB
+import org.rocksdb.RocksDBException
 
 import org.apache.spark.{SecurityManager, SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -130,10 +131,16 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private val fastInProgressParsing = conf.get(FAST_IN_PROGRESS_PARSING)
 
   private val hybridStoreEnabled = conf.get(History.HYBRID_STORE_ENABLED)
+  private val hybridStoreDiskBackend = conf.get(History.HYBRID_STORE_DISK_BACKEND)
 
   // Visible for testing.
   private[history] val listing: KVStore = storePath.map { path =>
-    val dbPath = Files.createDirectories(new File(path, "listing.ldb").toPath()).toFile()
+    val dir = hybridStoreDiskBackend match {
+      case "leveldb" => "listing.ldb"
+      case "rocksdb" => "listing.rdb"
+      case db => throw new IllegalStateException(s"$db is not supported.")
+    }
+    val dbPath = Files.createDirectories(new File(path, dir).toPath()).toFile()
     Utils.chmod700(dbPath)
 
     val metadata = new FsHistoryProviderMetadata(CURRENT_LISTING_VERSION,
@@ -149,8 +156,8 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         logInfo("Detected incompatible DB versions, deleting...")
         path.listFiles().foreach(Utils.deleteRecursively)
         open(dbPath, metadata)
-      case dbExc: NativeDB.DBException =>
-        // Get rid of the corrupted listing.ldb and re-create it.
+      case dbExc @ (_: NativeDB.DBException | _: RocksDBException) =>
+        // Get rid of the corrupted data and re-create it.
         logWarning(s"Failed to load disk store $dbPath :", dbExc)
         Utils.deleteRecursively(dbPath)
         open(dbPath, metadata)
@@ -1214,11 +1221,11 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       } catch {
         case e: Exception =>
           logInfo(s"Failed to create HybridStore for $appId/${attempt.info.attemptId}." +
-            " Using LevelDB.", e)
+            s" Using $hybridStoreDiskBackend.", e)
       }
     }
 
-    createLevelDBStore(dm, appId, attempt, metadata)
+    createDiskStore(dm, appId, attempt, metadata)
   }
 
   private def createHybridStore(
@@ -1257,24 +1264,24 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
       }
     }
 
-    // Create a LevelDB and start a background thread to dump data to LevelDB
+    // Create a disk-base KVStore and start a background thread to dump data to it
     var lease: dm.Lease = null
     try {
       logInfo(s"Leasing disk manager space for app $appId / ${attempt.info.attemptId}...")
       lease = dm.lease(reader.totalSize, reader.compressionCodec.isDefined)
-      val levelDB = KVUtils.open(lease.tmpPath, metadata)
-      hybridStore.setLevelDB(levelDB)
-      hybridStore.switchToLevelDB(new HybridStore.SwitchToLevelDBListener {
-        override def onSwitchToLevelDBSuccess: Unit = {
-          logInfo(s"Completely switched to LevelDB for app $appId / ${attempt.info.attemptId}.")
-          levelDB.close()
+      val diskStore = KVUtils.open(lease.tmpPath, metadata)
+      hybridStore.setDiskStore(diskStore)
+      hybridStore.switchToDiskStore(new HybridStore.SwitchToDiskStoreListener {
+        override def onSwitchToDiskStoreSuccess: Unit = {
+          logInfo(s"Completely switched to diskStore for app $appId / ${attempt.info.attemptId}.")
+          diskStore.close()
           val newStorePath = lease.commit(appId, attempt.info.attemptId)
-          hybridStore.setLevelDB(KVUtils.open(newStorePath, metadata))
+          hybridStore.setDiskStore(KVUtils.open(newStorePath, metadata))
           memoryManager.release(appId, attempt.info.attemptId)
         }
-        override def onSwitchToLevelDBFail(e: Exception): Unit = {
-          logWarning(s"Failed to switch to LevelDB for app $appId / ${attempt.info.attemptId}", e)
-          levelDB.close()
+        override def onSwitchToDiskStoreFail(e: Exception): Unit = {
+          logWarning(s"Failed to switch to diskStore for app $appId / ${attempt.info.attemptId}", e)
+          diskStore.close()
           lease.rollback()
         }
       }, appId, attempt.info.attemptId)
@@ -1291,7 +1298,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     hybridStore
   }
 
-  private def createLevelDBStore(
+  private def createDiskStore(
       dm: HistoryServerDiskManager,
       appId: String,
       attempt: AttemptInfoWrapper,

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -87,7 +87,7 @@ private class HistoryServerDiskManager(
       listing.delete(info.getClass(), info.path)
     }
 
-    // Reading level db would trigger table file compaction, then it may cause size of level db
+    // Reading disk-based KVStore may trigger table file compaction, then it may cause size of
     // directory changed. When service restarts, "currentUsage" is calculated from real directory
     // size. Update "ApplicationStoreInfo.size" to ensure "currentUsage" equals
     // sum of "ApplicationStoreInfo.size".
@@ -162,8 +162,8 @@ private class HistoryServerDiskManager(
    * @param delete Whether to delete the store from disk.
    */
   def release(appId: String, attemptId: Option[String], delete: Boolean = false): Unit = {
-    // Because LevelDB may modify the structure of the store files even when just reading, update
-    // the accounting for this application when it's closed.
+    // Because disk-based stores may modify the structure of the store files even when just reading,
+    // update the accounting for this application when it's closed.
     val oldSizeOpt = active.synchronized {
       active.remove(appId -> attemptId)
     }

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -211,4 +211,11 @@ private[spark] object History {
     .version("3.1.0")
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("2g")
+
+  val HYBRID_STORE_DISK_BACKEND = ConfigBuilder("spark.history.store.hybridStore.diskBackend")
+    .doc("Specifies a disk-based store used in hybrid store; 'leveldb' or 'rocksdb'.")
+    .version("3.3.0")
+    .stringConf
+    .checkValues(Set("leveldb", "rocksdb"))
+    .createWithDefault("leveldb")
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `RocksDB` backend in Spark History Server via a new configuration,
`spark.history.store.hybridStore.diskBackend`.

### Why are the changes needed?

Currently, Spark History Server's `HybridStore` uses `LevelDB` which is not working on Java 17 native Apple Silicon VM.
`RocksDB` will support Java 17 native Apple Silicon VM in Apache Spark 3.3 timeframe.

- `spark.history.store.hybridStore.diskBackend=leveldb` (default)
```
$ sbin/start-history-server.sh
$ tree leveldb
leveldb
├── apps
├── listing.ldb
│   ├── 000003.log
│   ├── CURRENT
│   ├── LOCK
│   ├── LOG
│   └── MANIFEST-000002
└── temp
```

- `spark.history.store.hybridStore.diskBackend=rocksdb` (New)
```
$ sbin/start-history-server.sh
$ tree rocksdb
rocksdb
├── apps
├── listing.rdb
│   ├── 000007.sst
│   ├── 000009.log
│   ├── CURRENT
│   ├── IDENTITY
│   ├── LOCK
│   ├── LOG
│   ├── LOG.old.1639812937513190
│   ├── MANIFEST-000008
│   └── OPTIONS-000011
└── temp
```

### Does this PR introduce _any_ user-facing change?

Yes, this introduce a new configuration.

### How was this patch tested?

Pass the CIs.