### PR TITLE
[MINOR][PYTHON][DOCS] Fix documentation for Python's recentProgress & lastProgress

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2999,9 +2999,9 @@ query.awaitTermination()   # block until query is terminated, with stop() or wit
 
 query.exception()       # the exception if the query has been terminated with error
 
-query.recentProgress()  # an array of the most recent progress updates for this query
+query.recentProgress  # a list of the most recent progress updates for this query
 
-query.lastProgress()    # the most recent progress update of this streaming query
+query.lastProgress    # the most recent progress update of this streaming query
 
 {% endhighlight %}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This small PR fixes incorrect documentation in Structured Streaming Guide where Python's  `recentProgress` & `lastProgress` where shown as functions although they are [properties](https://github.com/apache/spark/blob/master/python/pyspark/sql/streaming.py#L117), so if they are called as functions it generates error:

```
>>> query.lastProgress()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'dict' object is not callable
```

### Why are the changes needed?

The documentation was erroneous, and needs to be fixed to avoid confusion by readers

### Does this PR introduce _any_ user-facing change?

yes, it's a fix of the documentation

### How was this patch tested?

Not necessary