### PR TITLE
[SPARK-37689][SQL] Expand should be supported in PropagateEmptyRelation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -121,6 +121,7 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
       case Aggregate(ge, _, _) if ge.nonEmpty && !p.isStreaming => empty(p)
       // Generators like Hive-style UDTF may return their records within `close`.
       case Generate(_: Explode, _, _, _, _, _) => empty(p)
+      case Expand(_, _, _) => empty(p)
       case _ => p
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We  meet a case that when there is a empty relation, HashAggregateExec still triggered to execute and return an empty result. It's not necessary.  
![image](https://user-images.githubusercontent.com/46485123/146725110-27496536-f1f7-4fac-ae2c-0f6f81159bba.png)
It's caused by there is an  `Expand(EmptyLocalRelation())`, and it's not propagated,  this pr support propagate `Expand` with empty LocalRelation

### Why are the changes needed?
Avoid unnecessary execution.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT
