### PR TITLE
[SPARK-37693][TESTS] Fix ChildProcAppHandleSuite failed in Jenkins maven test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2824,7 +2824,7 @@
               <JAVA_HOME>${test.java.home}</JAVA_HOME>
             </environmentVariables>
             <systemProperties>
-              <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+              <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
               <derby.system.durability>test</derby.system.durability>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
@@ -2876,7 +2876,7 @@
               <JAVA_HOME>${test.java.home}</JAVA_HOME>
             </environmentVariables>
             <systemProperties>
-              <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+              <log4j.configurationFile>file:src/test/resources/log4j2.properties</log4j.configurationFile>
               <derby.system.durability>test</derby.system.durability>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
@@ -3315,7 +3315,7 @@
             </goals>
             <configuration>
               <excludes>
-                <exclude>log4j.properties</exclude>
+                <exclude>log4j2.properties</exclude>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-6035 merged, there are some test failed in Jenkins maven test like [spark-master-test-maven-hadoop-3.2/3522](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-maven-hadoop-3.2/3522/#showFailuresLink) , this pr fixed maven configuration to pass the failed tests.

### Why are the changes needed?
Fix Jenkins maven test.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass the Jenkins or GitHub Action

- Manual test

run `mvn clean install -pl launcher -am`

**Before**

```
[ERROR] Tests run: 11, Failures: 3, Errors: 0, Skipped: 0, Time elapsed: 0.522 s <<< FAILURE! - in org.apache.spark.launcher.ChildProcAppHandleSuite
[ERROR] org.apache.spark.launcher.ChildProcAppHandleSuite.testRedirectOutputToLog  Time elapsed: 0.207 s  <<< FAILURE!
java.lang.AssertionError
	at org.apache.spark.launcher.ChildProcAppHandleSuite.testRedirectOutputToLog(ChildProcAppHandleSuite.java:146)

[ERROR] org.apache.spark.launcher.ChildProcAppHandleSuite.testRedirectErrorToLog  Time elapsed: 0.032 s  <<< FAILURE!
java.lang.AssertionError
	at org.apache.spark.launcher.ChildProcAppHandleSuite.testRedirectErrorToLog(ChildProcAppHandleSuite.java:130)

[ERROR] org.apache.spark.launcher.ChildProcAppHandleSuite.testRedirectToLog  Time elapsed: 0.016 s  <<< FAILURE!
java.lang.AssertionError
	at org.apache.spark.launcher.ChildProcAppHandleSuite.testRedirectToLog(ChildProcAppHandleSuite.java:114)

[INFO] Running org.apache.spark.launcher.SparkSubmitOptionParserSuite
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.193 s - in org.apache.spark.launcher.SparkSubmitOptionParserSuite
[INFO] Running org.apache.spark.launcher.CommandBuilderUtilsSuite
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.apache.spark.launcher.CommandBuilderUtilsSuite
[INFO] Running org.apache.spark.launcher.InProcessLauncherSuite
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s - in org.apache.spark.launcher.InProcessLauncherSuite
[INFO] Running org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s - in org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
[INFO] Running org.apache.spark.launcher.LauncherServerSuite
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s - in org.apache.spark.launcher.LauncherServerSuite
[DEBUG] Closing the fork 1 after saying GoodBye.
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ChildProcAppHandleSuite.testRedirectErrorToLog:130
[ERROR]   ChildProcAppHandleSuite.testRedirectOutputToLog:146
[ERROR]   ChildProcAppHandleSuite.testRedirectToLog:114
[INFO] 
[ERROR] Tests run: 46, Failures: 3, Errors: 0, Skipped: 0
```

**After**
```
[INFO] Running org.apache.spark.launcher.ChildProcAppHandleSuite
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.68 s - in org.apache.spark.launcher.ChildProcAppHandleSuite
[INFO] Running org.apache.spark.launcher.SparkSubmitOptionParserSuite
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.19 s - in org.apache.spark.launcher.SparkSubmitOptionParserSuite
[INFO] Running org.apache.spark.launcher.CommandBuilderUtilsSuite
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.apache.spark.launcher.CommandBuilderUtilsSuite
[INFO] Running org.apache.spark.launcher.InProcessLauncherSuite
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 s - in org.apache.spark.launcher.InProcessLauncherSuite
[INFO] Running org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 s - in org.apache.spark.launcher.SparkSubmitCommandBuilderSuite
[INFO] Running org.apache.spark.launcher.LauncherServerSuite
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in org.apache.spark.launcher.LauncherServerSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0
```
