### PR TITLE
[SPARK-37699][K8S][TEST] Fix failed K8S integration test in SparkConfPropagateSuite

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -42,15 +42,13 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
       sparkAppConf.set("spark.kubernetes.executor.deleteOnTermination", "false")
 
       val log4jExpectedLog =
-        s"log4j: Reading configuration from URL file:/opt/spark/conf/log4j2.properties"
+        Seq("Reconfiguration complete for context", "at URI /opt/spark/conf/log4j2.properties")
 
       runSparkApplicationAndVerifyCompletion(
         appResource = containerLocalSparkDistroExamplesJar,
         mainClass = SPARK_PI_MAIN_CLASS,
-        expectedDriverLogOnCompletion = (Seq("DEBUG",
-          log4jExpectedLog,
-          "Pi is roughly 3")),
-        expectedExecutorLogOnCompletion = Seq(log4jExpectedLog),
+        expectedDriverLogOnCompletion = Seq("DEBUG", "Pi is roughly 3") ++ log4jExpectedLog,
+        expectedExecutorLogOnCompletion = log4jExpectedLog,
         appArgs = Array.empty[String],
         driverPodChecker = doBasicDriverPodCheck,
         executorPodChecker = doBasicExecutorPodCheck,

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -34,8 +34,12 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
     val content = Source.createBufferedSource(loggingConfURL.openStream()).getLines().mkString("\n")
     val logConfFilePath = s"${sparkHomeDir.toFile}/conf/log4j2.properties"
 
+    k8sSuite.logWarning(s"logConfFilePath: $logConfFilePath")
+
     try {
-      Files.write(new File(logConfFilePath).toPath, content.getBytes)
+      val logConfFile = new File(logConfFilePath)
+      Files.write(logConfFile.toPath, content.getBytes)
+      assert(Files.exists(logConfFile.toPath), s"${logConfFile.toPath} does not exist!")
 
       sparkAppConf.set("spark.driver.extraJavaOptions",
         s"-Dlog4j2.debug -Dlog4j.configurationFile=$logConfFilePath")

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SparkConfPropagateSuite.scala
@@ -32,17 +32,19 @@ private[spark] trait SparkConfPropagateSuite { k8sSuite: KubernetesSuite =>
     assert(loggingConfURL != null, "Logging configuration file not available.")
 
     val content = Source.createBufferedSource(loggingConfURL.openStream()).getLines().mkString("\n")
-    val logConfFilePath = s"${sparkHomeDir.toFile}/conf/log4j.properties"
+    val logConfFilePath = s"${sparkHomeDir.toFile}/conf/log4j2.properties"
 
     try {
       Files.write(new File(logConfFilePath).toPath, content.getBytes)
 
-      sparkAppConf.set("spark.driver.extraJavaOptions", "-Dlog4j2.debug")
-      sparkAppConf.set("spark.executor.extraJavaOptions", "-Dlog4j2.debug")
+      sparkAppConf.set("spark.driver.extraJavaOptions",
+        s"-Dlog4j2.debug -Dlog4j.configurationFile=$logConfFilePath")
+      sparkAppConf.set("spark.executor.extraJavaOptions",
+        s"-Dlog4j2.debug -Dlog4j.configurationFile=$logConfFilePath")
       sparkAppConf.set("spark.kubernetes.executor.deleteOnTermination", "false")
 
       val log4jExpectedLog =
-        s"log4j: Reading configuration from URL file:/opt/spark/conf/log4j.properties"
+        s"log4j: Reading configuration from URL file:/opt/spark/conf/log4j2.properties"
 
       runSparkApplicationAndVerifyCompletion(
         appResource = containerLocalSparkDistroExamplesJar,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch was proposed to fix K8S integration test in `SparkConfPropagateSuite`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

After migration of log42, we need to update the related log4j properties file and expected log message for the K8S integration test.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, test only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Pass K8S integration test in SparkConfPropagateSuite