### PR TITLE
[SPARK-37701][PYTHON] Implement `ps.to_timedelta` method

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/general_functions.rst
+++ b/python/docs/source/reference/pyspark.pandas/general_functions.rst
@@ -65,4 +65,5 @@ Top-level dealing with datetimelike
 
    to_datetime
    date_range
+   to_timedelta
    timedelta_range

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1971,13 +1971,10 @@ def to_timedelta(
         return arg.transform(pandas_to_timedelta)
 
     else:
-        return cast(
-            TimedeltaIndex,
-            pd.to_timedelta(
-                arg=arg,
-                unit=unit,
-                errors=errors,
-            ),
+        return pd.to_timedelta(
+            arg=arg,
+            unit=unit,
+            errors=errors,
         )
 
 

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -105,6 +105,7 @@ __all__ = [
     "read_html",
     "to_datetime",
     "date_range",
+    "to_timedelta",
     "timedelta_range",
     "get_dummies",
     "concat",
@@ -1885,6 +1886,99 @@ def date_range(
             )
         ),
     )
+
+
+@no_type_check
+def to_timedelta(
+    arg,
+    unit: Optional[str] = None,
+    errors: str = "raise",
+):
+    """
+    Convert argument to timedelta.
+
+    Parameters
+    ----------
+    arg : str, timedelta, list-like or Series
+        The data to be converted to timedelta.
+    unit : str, optional
+        Denotes the unit of the arg for numeric `arg`. Defaults to ``"ns"``.
+
+        Possible values:
+        * 'W'
+        * 'D' / 'days' / 'day'
+        * 'hours' / 'hour' / 'hr' / 'h'
+        * 'm' / 'minute' / 'min' / 'minutes' / 'T'
+        * 'S' / 'seconds' / 'sec' / 'second'
+        * 'ms' / 'milliseconds' / 'millisecond' / 'milli' / 'millis' / 'L'
+        * 'us' / 'microseconds' / 'microsecond' / 'micro' / 'micros' / 'U'
+        * 'ns' / 'nanoseconds' / 'nano' / 'nanos' / 'nanosecond' / 'N'
+
+        Must not be specified when `arg` context strings and ``errors="raise"``.
+    errors : {'ignore', 'raise', 'coerce'}, default 'raise'
+        - If 'raise', then invalid parsing will raise an exception.
+        - If 'coerce', then invalid parsing will be set as NaT.
+        - If 'ignore', then invalid parsing will return the input.
+
+    Returns
+    -------
+    ret : timedelta64 or TimedeltaIndex if parsing succeeded.
+
+    See Also
+    --------
+    DataFrame.astype : Cast argument to a specified dtype.
+    to_datetime : Convert argument to datetime.
+
+    Notes
+    -----
+    If the precision is higher than nanoseconds, the precision of the duration is
+    truncated to nanoseconds for string inputs.
+
+    Examples
+    --------
+    Parsing a single string to a Timedelta:
+
+    >>> ps.to_timedelta('1 days 06:05:01.00003')
+    Timedelta('1 days 06:05:01.000030')
+    >>> ps.to_timedelta('15.5us')
+    Timedelta('0 days 00:00:00.000015500')
+
+    Parsing a list or array of strings:
+
+    >>> ps.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])  # doctest: +NORMALIZE_WHITESPACE
+    TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015500', NaT],
+                   dtype='timedelta64[ns]', freq=None)
+
+    Converting numbers by specifying the `unit` keyword argument:
+
+    >>> ps.to_timedelta(np.arange(5), unit='s')  # doctest: +NORMALIZE_WHITESPACE
+    TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:01', '0 days 00:00:02',
+                    '0 days 00:00:03', '0 days 00:00:04'],
+                   dtype='timedelta64[ns]', freq=None)
+    >>> ps.to_timedelta(np.arange(5), unit='d')  # doctest: +NORMALIZE_WHITESPACE
+    TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'],
+                   dtype='timedelta64[ns]', freq=None)
+    """
+
+    def pandas_to_timedelta(pser: pd.Series) -> np.timedelta64:
+        return pd.to_timedelta(
+            arg=pser,
+            unit=unit,
+            errors=errors,
+        )
+
+    if isinstance(arg, Series):
+        return arg.transform(pandas_to_timedelta)
+
+    else:
+        return cast(
+            TimedeltaIndex,
+            pd.to_timedelta(
+                arg=arg,
+                unit=unit,
+                errors=errors,
+            ),
+        )
 
 
 def timedelta_range(

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1922,7 +1922,7 @@ def to_timedelta(
 
     Returns
     -------
-    ret : timedelta64 or TimedeltaIndex if parsing succeeded.
+    ret : timedelta64, TimedeltaIndex or Series of timedelta64 if parsing succeeded.
 
     See Also
     --------

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -18,6 +18,7 @@
 import itertools
 
 import pandas as pd
+import numpy as np
 
 from pyspark import pandas as ps
 from pyspark.pandas.namespace import _get_index_map, read_delta
@@ -233,6 +234,32 @@ class NamespaceTest(PandasOnSparkTestCase, SQLTestUtils):
         )
         self.assertRaises(
             AssertionError, lambda: ps.date_range(start="1/1/2018", periods=5, freq="N")
+        )
+
+    def test_to_timedelta(self):
+        self.assert_eq(
+            ps.to_timedelta("1 days 06:05:01.00003"),
+            pd.to_timedelta("1 days 06:05:01.00003"),
+        )
+        self.assert_eq(
+            ps.to_timedelta("15.5us"),
+            pd.to_timedelta("15.5us"),
+        )
+        self.assert_eq(
+            ps.to_timedelta(["1 days 06:05:01.00003", "15.5us", "nan"]),
+            pd.to_timedelta(["1 days 06:05:01.00003", "15.5us", "nan"]),
+        )
+        self.assert_eq(
+            ps.to_timedelta(np.arange(5), unit="s"),
+            pd.to_timedelta(np.arange(5), unit="s"),
+        )
+        self.assert_eq(
+            ps.to_timedelta(ps.Series([1, 2]), unit="d"),
+            pd.to_timedelta(pd.Series([1, 2]), unit="d"),
+        )
+        self.assert_eq(
+            ps.to_timedelta(pd.Series([1, 2]), unit="d"),
+            pd.to_timedelta(pd.Series([1, 2]), unit="d"),
         )
 
     def test_timedelta_range(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `ps.to_timedelta` method

### Why are the changes needed?
To be consistent with pandas

### Does this PR introduce _any_ user-facing change?
Yes.

`ps.to_timedelta` is supported.

```py
>>> ps.to_timedelta('1 days 06:05:01.00003')
Timedelta('1 days 06:05:01.000030')
>>> ps.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])
TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015500', NaT], dtype='timedelta64[ns]', freq=None)
>>> ps.to_timedelta(pd.Series([1, 2]), unit="d")
0   1 days
1   2 days
dtype: timedelta64[ns]
```

### How was this patch tested?
Unit tests.
