### PR TITLE
[SPARK-37710][CORE] Add detailed log message for java.io.IOException occurring on Kryo flow

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -34,6 +34,7 @@ import scala.util.{Failure, Random, Success, Try}
 import scala.util.control.NonFatal
 
 import com.codahale.metrics.{MetricRegistry, MetricSet}
+import com.esotericsoftware.kryo.KryoException
 import com.google.common.cache.CacheBuilder
 import org.apache.commons.io.IOUtils
 
@@ -342,6 +343,12 @@ private[spark] class BlockManager(
             iter.close()
             false
         }
+      } catch {
+        case ex: KryoException if ex.getCause.isInstanceOf[IOException] =>
+          // We need to have detailed log message to catch environmental problems easily.
+          // Further details: https://issues.apache.org/jira/browse/SPARK-37710
+          processKryoException(ex, blockId)
+          throw ex
       } finally {
         IOUtils.closeQuietly(inputStream)
       }
@@ -926,28 +933,46 @@ private[spark] class BlockManager(
           })
           Some(new BlockResult(ci, DataReadMethod.Memory, info.size))
         } else if (level.useDisk && diskStore.contains(blockId)) {
-          val diskData = diskStore.getBytes(blockId)
-          val iterToReturn: Iterator[Any] = {
-            if (level.deserialized) {
-              val diskValues = serializerManager.dataDeserializeStream(
-                blockId,
-                diskData.toInputStream())(info.classTag)
-              maybeCacheDiskValuesInMemory(info, blockId, level, diskValues)
-            } else {
-              val stream = maybeCacheDiskBytesInMemory(info, blockId, level, diskData)
-                .map { _.toInputStream(dispose = false) }
-                .getOrElse { diskData.toInputStream() }
-              serializerManager.dataDeserializeStream(blockId, stream)(info.classTag)
+          try {
+            val diskData = diskStore.getBytes(blockId)
+            val iterToReturn: Iterator[Any] = {
+              if (level.deserialized) {
+                val diskValues = serializerManager.dataDeserializeStream(
+                  blockId,
+                  diskData.toInputStream())(info.classTag)
+                maybeCacheDiskValuesInMemory(info, blockId, level, diskValues)
+              } else {
+                val stream = maybeCacheDiskBytesInMemory(info, blockId, level, diskData)
+                  .map { _.toInputStream(dispose = false) }
+                  .getOrElse { diskData.toInputStream() }
+                serializerManager.dataDeserializeStream(blockId, stream)(info.classTag)
+              }
             }
+            val ci = CompletionIterator[Any, Iterator[Any]](iterToReturn, {
+              releaseLockAndDispose(blockId, diskData, taskContext)
+            })
+            Some(new BlockResult(ci, DataReadMethod.Disk, info.size))
+          } catch {
+            case ex: KryoException if ex.getCause.isInstanceOf[IOException] =>
+              // We need to have detailed log message to catch environmental problems easily.
+              // Further details: https://issues.apache.org/jira/browse/SPARK-37710
+              processKryoException(ex, blockId)
+              throw ex
           }
-          val ci = CompletionIterator[Any, Iterator[Any]](iterToReturn, {
-            releaseLockAndDispose(blockId, diskData, taskContext)
-          })
-          Some(new BlockResult(ci, DataReadMethod.Disk, info.size))
         } else {
           handleLocalReadFailure(blockId)
         }
     }
+  }
+
+  private def processKryoException(ex: KryoException, blockId: BlockId): Unit = {
+    var message =
+      "%s. %s - blockId: %s".format(ex.getMessage, blockManagerId.toString, blockId)
+    val file = diskBlockManager.getFile(blockId)
+    if (file.exists()) {
+      message = "%s - blockDiskPath: %s".format(message, file.getAbsolutePath)
+    }
+    logInfo(message)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
`java.io.IOException: Input/output error` usually points environmental issues such as disk read/write failures due to disk corruption, network access failures etc. This PR aims to be added clear error message to catch this kind of environmental cases occurring on `BlockManager` and logs with `BlockManager hostname`, `blockId` and `blockPath`.

### Why are the changes needed?
This kind of problems usually environmental problems and clear error message can help its analysis and save RCA time.

Following stack-trace is from `disk corruption` case:
```
com.esotericsoftware.kryo.KryoException: java.io.IOException: Input/output error
Serialization trace:
buffers (org.apache.spark.sql.execution.columnar.DefaultCachedBatch)
    at com.esotericsoftware.kryo.io.Input.fill(Input.java:166)
    at com.esotericsoftware.kryo.io.Input.require(Input.java:196)
    at com.esotericsoftware.kryo.io.Input.readBytes(Input.java:346)
    at com.esotericsoftware.kryo.io.Input.readBytes(Input.java:326)
    at com.esotericsoftware.kryo.serializers.DefaultArraySerializers$ByteArraySerializer.read(DefaultArraySerializers.java:55)
    at com.esotericsoftware.kryo.serializers.DefaultArraySerializers$ByteArraySerializer.read(DefaultArraySerializers.java:38)
    at com.esotericsoftware.kryo.Kryo.readObjectOrNull(Kryo.java:789)
    at com.esotericsoftware.kryo.serializers.DefaultArraySerializers$ObjectArraySerializer.read(DefaultArraySerializers.java:381)
    at com.esotericsoftware.kryo.serializers.DefaultArraySerializers$ObjectArraySerializer.read(DefaultArraySerializers.java:302)
    at com.esotericsoftware.kryo.Kryo.readObjectOrNull(Kryo.java:789)
    at com.esotericsoftware.kryo.serializers.ObjectField.read(ObjectField.java:132)
    at com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:543)
    at com.esotericsoftware.kryo.Kryo.readClassAndObject(Kryo.java:816)
    at org.apache.spark.serializer.KryoDeserializationStream.readObject(KryoSerializer.scala:296)
    at org.apache.spark.serializer.DeserializationStream$$anon$1.getNext(Serializer.scala:168)
    at org.apache.spark.util.NextIterator.hasNext(NextIterator.scala:73)
    at org.apache.spark.storage.memory.MemoryStore.putIterator(MemoryStore.scala:221)
    at org.apache.spark.storage.memory.MemoryStore.putIteratorAsValues(MemoryStore.scala:299)
    at org.apache.spark.storage.BlockManager.maybeCacheDiskValuesInMemory(BlockManager.scala:1569)
    at org.apache.spark.storage.BlockManager.getLocalValues(BlockManager.scala:877)
    at org.apache.spark.storage.BlockManager.get(BlockManager.scala:1163)
...
Caused by: java.io.IOException: Input/output error
    at java.io.FileInputStream.readBytes(Native Method)
    at java.io.FileInputStream.read(FileInputStream.java:255)
    at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
    at java.io.BufferedInputStream.read1(BufferedInputStream.java:286)
    at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
    at net.jpountz.lz4.LZ4BlockInputStream.tryReadFully(LZ4BlockInputStream.java:269)
    at net.jpountz.lz4.LZ4BlockInputStream.readFully(LZ4BlockInputStream.java:280)
    at net.jpountz.lz4.LZ4BlockInputStream.refill(LZ4BlockInputStream.java:243)
    at net.jpountz.lz4.LZ4BlockInputStream.read(LZ4BlockInputStream.java:157)
    at com.esotericsoftware.kryo.io.Input.fill(Input.java:164)
    ... 87 more 
```

Proposed Error Message:
```
java.io.IOException: Input/output error. BlockManagerId(driver, localhost, 58677, None) - blockId: test_my-block-id 
- blockDiskPath: /private/var/folders/kj/mccyycwn6mjdwnglw9g3k6pm0000gq/T/
blockmgr-24325b3a-0045-483a-98b8-673a2e07bed1/11/test_my-block-id
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added 2 new Unit Tests by reproducing the issue with `TestDiskCorruptedInputStream` and logging new error message when getting data blocks from disk.
