### PR TITLE
[SPARK-37712][YARN] Spark request yarn cluster metrics slow cause delay

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -183,8 +183,10 @@ private[spark] class Client(
       yarnClient.init(hadoopConf)
       yarnClient.start()
 
-      logInfo("Requesting a new application from cluster with %d NodeManagers"
-        .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
+      if (log.isDebugEnabled) {
+        logDebug("Requesting a new application from cluster with %d NodeManagers"
+          .format(yarnClient.getYarnClusterMetrics.getNumNodeManagers))
+      }
 
       // Get a new application from our RM
       val newApp = yarnClient.createApplication()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark will request yarn cluster metrics and print a log about nodemanager number, it's not so important and this rpc is always slow
![image](https://user-images.githubusercontent.com/46485123/147055954-30698764-b313-419f-8759-772ad9f301ff.png)

We can make it as debug level


### Why are the changes needed?
Avoid unnecessary delay when submit application.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Not need
