### PR TITLE
[SPARK-37463][SQL] Read/Write Timestamp ntz from/to Orc uses int64

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
@@ -27,7 +27,6 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.TimestampType;
-import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -37,7 +36,6 @@ import org.apache.spark.unsafe.types.UTF8String;
  */
 public class OrcAtomicColumnVector extends OrcColumnVector {
   private final boolean isTimestamp;
-  private final boolean isTimestampNTZ;
   private final boolean isDate;
 
   // Column vector for each type. Only 1 is populated for any type.
@@ -54,12 +52,6 @@ public class OrcAtomicColumnVector extends OrcColumnVector {
       isTimestamp = true;
     } else {
       isTimestamp = false;
-    }
-
-    if (type instanceof TimestampNTZType) {
-      isTimestampNTZ = true;
-    } else {
-      isTimestampNTZ = false;
     }
 
     if (type instanceof DateType) {
@@ -113,8 +105,6 @@ public class OrcAtomicColumnVector extends OrcColumnVector {
     int index = getRowIndex(rowId);
     if (isTimestamp) {
       return DateTimeUtils.fromJavaTimestamp(timestampData.asScratchTimestamp(index));
-    } else if (isTimestampNTZ) {
-      return OrcUtils.fromOrcNTZ(timestampData.asScratchTimestamp(index));
     } else {
       return longData.vector[index];
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
@@ -27,7 +27,6 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.TimestampType;
-import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
@@ -103,7 +103,7 @@ public class OrcAtomicColumnVector extends OrcColumnVector {
   @Override
   public long getLong(int rowId) {
     int index = getRowIndex(rowId);
-    if (isTimestamp && timestampData != null) {
+    if (isTimestamp) {
       return DateTimeUtils.fromJavaTimestamp(timestampData.asScratchTimestamp(index));
     } else {
       return longData.vector[index];

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcAtomicColumnVector.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.TimestampType;
+import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -103,7 +104,7 @@ public class OrcAtomicColumnVector extends OrcColumnVector {
   @Override
   public long getLong(int rowId) {
     int index = getRowIndex(rowId);
-    if (isTimestamp) {
+    if (isTimestamp && timestampData != null) {
       return DateTimeUtils.fromJavaTimestamp(timestampData.asScratchTimestamp(index));
     } else {
       return longData.vector[index];

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -105,7 +105,7 @@ class OrcDeserializer(
       case IntegerType | _: YearMonthIntervalType => (ordinal, value) =>
         updater.setInt(ordinal, value.asInstanceOf[IntWritable].get)
 
-      case LongType | _: DayTimeIntervalType => (ordinal, value) =>
+      case LongType | _: DayTimeIntervalType | _: TimestampNTZType => (ordinal, value) =>
         updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
 
       case FloatType => (ordinal, value) =>
@@ -128,9 +128,6 @@ class OrcDeserializer(
 
       case TimestampType => (ordinal, value) =>
         updater.setLong(ordinal, DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
-
-      case TimestampNTZType => (ordinal, value) =>
-        updater.setLong(ordinal, OrcUtils.fromOrcNTZ(value.asInstanceOf[OrcTimestamp]))
 
       case DecimalType.Fixed(precision, scale) => (ordinal, value) =>
         val v = OrcShimUtils.getDecimal(value)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -127,7 +127,12 @@ class OrcDeserializer(
         updater.setInt(ordinal, OrcShimUtils.getGregorianDays(value))
 
       case TimestampType => (ordinal, value) =>
-        updater.setLong(ordinal, DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
+        if (value.isInstanceOf[OrcTimestamp]) {
+          updater.setLong(ordinal,
+            DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
+        } else {
+          updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
+        }
 
       case DecimalType.Fixed(precision, scale) => (ordinal, value) =>
         val v = OrcShimUtils.getDecimal(value)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -130,11 +130,9 @@ class OrcDeserializer(
         // When reading as Spark LTZ, the ORC value can be either `OrcTimestamp`
         // (which maps to Spark LTZ) or `LongWritable` (which maps to Spark NTZ)
         if (value.isInstanceOf[OrcTimestamp]) {
-          // Spark takes Orc timestamp as timestampLTZ, so read it as the Timestamp.
           updater.setLong(ordinal,
             DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
         } else {
-          // Spark takes Orc bigint as timestampNTZ, so read the original value directly.
           updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -127,14 +127,7 @@ class OrcDeserializer(
         updater.setInt(ordinal, OrcShimUtils.getGregorianDays(value))
 
       case TimestampType => (ordinal, value) =>
-        // When reading as Spark LTZ, the ORC value can be either `OrcTimestamp`
-        // (which maps to Spark LTZ) or `LongWritable` (which maps to Spark NTZ)
-        if (value.isInstanceOf[OrcTimestamp]) {
-          updater.setLong(ordinal,
-            DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
-        } else {
-          updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
-        }
+        updater.setLong(ordinal, DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
 
       case DecimalType.Fixed(precision, scale) => (ordinal, value) =>
         val v = OrcShimUtils.getDecimal(value)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -127,6 +127,8 @@ class OrcDeserializer(
         updater.setInt(ordinal, OrcShimUtils.getGregorianDays(value))
 
       case TimestampType => (ordinal, value) =>
+        // When reading as Spark LTZ, the ORC value can be either `OrcTimestamp`
+        // (which maps to Spark LTZ) or `LongWritable` (which maps to Spark NTZ)
         if (value.isInstanceOf[OrcTimestamp]) {
           // Spark takes Orc timestamp as timestampLTZ, so read it as the Timestamp.
           updater.setLong(ordinal,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -128,9 +128,11 @@ class OrcDeserializer(
 
       case TimestampType => (ordinal, value) =>
         if (value.isInstanceOf[OrcTimestamp]) {
+          // Spark takes Orc timestamp as timestampLTZ, so read it as the Timestamp.
           updater.setLong(ordinal,
             DateTimeUtils.fromJavaTimestamp(value.asInstanceOf[OrcTimestamp]))
         } else {
+          // Spark takes Orc bigint as timestampNTZ, so read the original value directly.
           updater.setLong(ordinal, value.asInstanceOf[LongWritable].get)
         }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -142,12 +142,10 @@ class OrcFileFormat
 
       val fs = filePath.getFileSystem(conf)
       val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
-      val (resultedColPruneInfo, orcSchema) =
-        Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions)) { reader =>
-          val orcSchema = reader.getSchema
-          (OrcUtils.requestedColumnIds(
-            isCaseSensitive, dataSchema, requiredSchema, orcSchema, conf), orcSchema)
-        }
+      val orcSchema =
+        Utils.tryWithResource(OrcFile.createReader(filePath, readerOptions))(_.getSchema)
+      val resultedColPruneInfo = OrcUtils.requestedColumnIds(
+        isCaseSensitive, dataSchema, requiredSchema, orcSchema, conf)
 
       if (resultedColPruneInfo.isEmpty) {
         Iterator.empty

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -160,9 +160,9 @@ class OrcFileFormat
           }
         }
 
-        val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
+        val (requestedColIds, canPruneCols, orcCatalystSchema) = resultedColPruneInfo.get
         val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
-          dataSchema, resultSchema, partitionSchema, conf)
+          dataSchema, orcCatalystSchema, resultSchema, partitionSchema, conf)
         assert(requestedColIds.length == requiredSchema.length,
           "[BUG] requested column IDs do not match required schema")
         val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFileFormat.scala
@@ -160,9 +160,8 @@ class OrcFileFormat
         }
 
         val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-        val orcCatalystSchema = OrcUtils.toCatalystSchema(orcSchema)
         val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
-          dataSchema, resultSchema, orcCatalystSchema, partitionSchema, conf)
+          dataSchema, resultSchema, partitionSchema, conf)
         assert(requestedColIds.length == requiredSchema.length,
           "[BUG] requested column IDs do not match required schema")
         val taskConf = new Configuration(conf)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
@@ -142,11 +142,11 @@ private[sql] object OrcFilters extends OrcFiltersBase {
   def getPredicateLeafType(dataType: DataType): PredicateLeaf.Type = dataType match {
     case BooleanType => PredicateLeaf.Type.BOOLEAN
     case ByteType | ShortType | IntegerType | LongType |
-         _: AnsiIntervalType => PredicateLeaf.Type.LONG
+         _: AnsiIntervalType | TimestampNTZType => PredicateLeaf.Type.LONG
     case FloatType | DoubleType => PredicateLeaf.Type.FLOAT
     case StringType => PredicateLeaf.Type.STRING
     case DateType => PredicateLeaf.Type.DATE
-    case TimestampType | TimestampNTZType => PredicateLeaf.Type.TIMESTAMP
+    case TimestampType => PredicateLeaf.Type.TIMESTAMP
     case _: DecimalType => PredicateLeaf.Type.DECIMAL
     case _ => throw QueryExecutionErrors.unsupportedOperationForDataTypeError(dataType)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilters.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.orc
 
-import java.sql.Timestamp
 import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period}
 
 import org.apache.hadoop.hive.common.`type`.HiveDecimal
@@ -170,11 +169,7 @@ private[sql] object OrcFilters extends OrcFiltersBase {
     case _: TimestampType if value.isInstanceOf[Instant] =>
       toJavaTimestamp(instantToMicros(value.asInstanceOf[Instant]))
     case _: TimestampNTZType if value.isInstanceOf[LocalDateTime] =>
-      val orcTimestamp = OrcUtils.toOrcNTZ(localDateTimeToMicros(value.asInstanceOf[LocalDateTime]))
-      // Hive meets OrcTimestamp will throw ClassNotFoundException, So convert it.
-      val timestamp = new Timestamp(orcTimestamp.getTime)
-      timestamp.setNanos(orcTimestamp.getNanos)
-      timestamp
+      localDateTimeToMicros(value.asInstanceOf[LocalDateTime])
     case _: YearMonthIntervalType =>
       IntervalUtils.periodToMonths(value.asInstanceOf[Period]).longValue()
     case _: DayTimeIntervalType =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -98,7 +98,7 @@ class OrcSerializer(dataSchema: StructType) {
       }
 
 
-    case LongType | _: DayTimeIntervalType =>
+    case LongType | _: DayTimeIntervalType | _: TimestampNTZType =>
       if (reuseObj) {
         val result = new LongWritable()
         (getter, ordinal) =>
@@ -146,8 +146,6 @@ class OrcSerializer(dataSchema: StructType) {
       val result = new OrcTimestamp(ts.getTime)
       result.setNanos(ts.getNanos)
       result
-
-    case TimestampNTZType => (getter, ordinal) => OrcUtils.toOrcNTZ(getter.getLong(ordinal))
 
     case DecimalType.Fixed(precision, scale) =>
       OrcShimUtils.getHiveDecimalWritable(precision, scale)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.hadoop.hive.serde2.io.DateWritable
 import org.apache.hadoop.io.{BooleanWritable, ByteWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, ShortWritable, WritableComparable}
 import org.apache.orc.{BooleanColumnStatistics, ColumnStatistics, DateColumnStatistics, DoubleColumnStatistics, IntegerColumnStatistics, OrcConf, OrcFile, Reader, TypeDescription, Writer}
-import org.apache.orc.mapred.OrcTimestamp
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
@@ -39,8 +38,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.catalyst.util.{quoteIdentifier, CharVarcharUtils, DateTimeUtils}
-import org.apache.spark.sql.catalyst.util.DateTimeConstants._
+import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils}
+import org.apache.spark.sql.catalyst.util.DateTimeConstants.{MICROS_PER_MILLIS, NANOS_PER_MICROS}
+import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.datasources.{AggregatePushDownUtils, SchemaMergeUtils}
@@ -295,8 +295,7 @@ object OrcUtils extends Logging {
       s"array<${orcTypeDescriptionString(a.elementType)}>"
     case m: MapType =>
       s"map<${orcTypeDescriptionString(m.keyType)},${orcTypeDescriptionString(m.valueType)}>"
-    case TimestampNTZType => TypeDescription.Category.TIMESTAMP.getName
-    case _: DayTimeIntervalType => LongType.catalogString
+    case _: DayTimeIntervalType | _: TimestampNTZType => LongType.catalogString
     case _: YearMonthIntervalType => IntegerType.catalogString
     case _ => dt.catalogString
   }
@@ -306,16 +305,14 @@ object OrcUtils extends Logging {
       dt match {
         case y: YearMonthIntervalType =>
           val typeDesc = new TypeDescription(TypeDescription.Category.INT)
-          typeDesc.setAttribute(
-            CATALYST_TYPE_ATTRIBUTE_NAME, y.typeName)
+          typeDesc.setAttribute(CATALYST_TYPE_ATTRIBUTE_NAME, y.typeName)
           Some(typeDesc)
         case d: DayTimeIntervalType =>
           val typeDesc = new TypeDescription(TypeDescription.Category.LONG)
-          typeDesc.setAttribute(
-            CATALYST_TYPE_ATTRIBUTE_NAME, d.typeName)
+          typeDesc.setAttribute(CATALYST_TYPE_ATTRIBUTE_NAME, d.typeName)
           Some(typeDesc)
         case n: TimestampNTZType =>
-          val typeDesc = new TypeDescription(TypeDescription.Category.TIMESTAMP)
+          val typeDesc = new TypeDescription(TypeDescription.Category.LONG)
           typeDesc.setAttribute(CATALYST_TYPE_ATTRIBUTE_NAME, n.typeName)
           Some(typeDesc)
         case t: TimestampType =>
@@ -538,11 +535,11 @@ object OrcUtils extends Logging {
       (ts.getNanos / NANOS_PER_MICROS) % MICROS_PER_MILLIS
   }
 
-  def toOrcNTZ(micros: Long): OrcTimestamp = {
-    val seconds = Math.floorDiv(micros, MICROS_PER_SECOND)
-    val nanos = (micros - seconds * MICROS_PER_SECOND) * NANOS_PER_MICROS
-    val result = new OrcTimestamp(seconds * MILLIS_PER_SECOND)
-    result.setNanos(nanos.toInt)
-    result
-  }
+//  def toOrcNTZ(micros: Long): OrcTimestamp = {
+//    val seconds = Math.floorDiv(micros, MICROS_PER_SECOND)
+//    val nanos = (micros - seconds * MICROS_PER_SECOND) * NANOS_PER_MICROS
+//    val result = new OrcTimestamp(seconds * MILLIS_PER_SECOND)
+//    result.setNanos(nanos.toInt)
+//    result
+//  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -278,7 +278,7 @@ object OrcUtils extends Logging {
   }
 
   /**
-   * Given two `StructType` object, this methods converts it to corresponding string representation
+   * Given a `StructType` object, this methods converts it to corresponding string representation
    * in ORC.
    */
   def getOrcSchemaString(dt: DataType): String = dt match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -358,6 +358,8 @@ private[parquet] class ParquetRowConverter(
       case StringType =>
         new ParquetStringConverter(updater)
 
+      // As long as the parquet type is INT64 timestamp, whether logical annotation
+      // `isAdjustedToUTC` is false or true, it will be read as Spark's TimestampLTZ type
       case TimestampType
         if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
            parquetType.getLogicalTypeAnnotation
@@ -368,6 +370,8 @@ private[parquet] class ParquetRowConverter(
           }
         }
 
+      // As long as the parquet type is INT64 timestamp, whether logical annotation
+      // `isAdjustedToUTC` is false or true, it will be read as Spark's TimestampLTZ type
       case TimestampType
         if parquetType.getLogicalTypeAnnotation.isInstanceOf[TimestampLogicalTypeAnnotation] &&
           parquetType.getLogicalTypeAnnotation

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -97,8 +97,9 @@ case class OrcPartitionReaderFactory(
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader[InternalRow]
     } else {
-      val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      OrcUtils.orcResultSchemaString(canPruneCols, dataSchema, resultSchema, partitionSchema, conf)
+      val (requestedColIds, canPruneCols, orcCatalystSchema) = resultedColPruneInfo.get
+      OrcUtils.orcResultSchemaString(
+        canPruneCols, dataSchema, orcCatalystSchema, resultSchema, partitionSchema, conf)
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -140,9 +141,9 @@ case class OrcPartitionReaderFactory(
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader
     } else {
-      val (requestedDataColIds, canPruneCols) = resultedColPruneInfo.get
+      val (requestedDataColIds, canPruneCols, orcCatalystSchema) = resultedColPruneInfo.get
       val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
-        dataSchema, resultSchema, partitionSchema, conf)
+        dataSchema, orcCatalystSchema, resultSchema, partitionSchema, conf)
       val requestedColIds = requestedDataColIds ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -96,8 +96,7 @@ case class OrcPartitionReaderFactory(
       new EmptyPartitionReader[InternalRow]
     } else {
       val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      OrcUtils.orcResultSchemaString(canPruneCols,
-        dataSchema, resultSchema, partitionSchema, conf)
+      OrcUtils.orcResultSchemaString(canPruneCols, dataSchema, resultSchema, partitionSchema, conf)
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -88,7 +88,9 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = new Path(new URI(file.filePath))
 
-    val (resultedColPruneInfo, orcSchema) = getResultedColPruneInfoAndOrcSchema(filePath, conf)
+    val orcSchema = Utils.tryWithResource(createORCReader(filePath, conf))(_.getSchema)
+    val resultedColPruneInfo = OrcUtils.requestedColumnIds(
+      isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf)
 
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader[InternalRow]
@@ -129,7 +131,9 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = new Path(new URI(file.filePath))
 
-    val (resultedColPruneInfo, orcSchema) = getResultedColPruneInfoAndOrcSchema(filePath, conf)
+    val orcSchema = Utils.tryWithResource(createORCReader(filePath, conf))(_.getSchema)
+    val resultedColPruneInfo = OrcUtils.requestedColumnIds(
+      isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf)
 
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -88,12 +88,7 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = new Path(new URI(file.filePath))
 
-    val (resultedColPruneInfo, orcSchema) =
-      Utils.tryWithResource(createORCReader(filePath, conf)) { reader =>
-        val orcSchema = reader.getSchema
-        (OrcUtils.requestedColumnIds(
-          isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf), orcSchema)
-      }
+    val (resultedColPruneInfo, orcSchema) = getResultedColPruneInfoAndOrcSchema(filePath, conf)
 
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader[InternalRow]
@@ -134,12 +129,7 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = new Path(new URI(file.filePath))
 
-    val (resultedColPruneInfo, orcSchema) =
-      Utils.tryWithResource(createORCReader(filePath, conf)) { reader =>
-        val orcSchema = reader.getSchema
-        (OrcUtils.requestedColumnIds(
-          isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf), orcSchema)
-      }
+    val (resultedColPruneInfo, orcSchema) = getResultedColPruneInfoAndOrcSchema(filePath, conf)
 
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader
@@ -180,6 +170,15 @@ case class OrcPartitionReaderFactory(
     val fs = filePath.getFileSystem(conf)
     val readerOptions = OrcFile.readerOptions(conf).filesystem(fs)
     OrcFile.createReader(filePath, readerOptions)
+  }
+
+  private def getResultedColPruneInfoAndOrcSchema(
+      filePath: Path, conf: Configuration): (Option[(Array[Int], Boolean)], TypeDescription) = {
+    Utils.tryWithResource(createORCReader(filePath, conf)) { reader =>
+      val orcSchema = reader.getSchema
+      (OrcUtils.requestedColumnIds(
+        isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf), orcSchema)
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -96,9 +96,8 @@ case class OrcPartitionReaderFactory(
       new EmptyPartitionReader[InternalRow]
     } else {
       val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      val orcCatalystSchema = OrcUtils.toCatalystSchema(orcSchema)
       OrcUtils.orcResultSchemaString(canPruneCols,
-        dataSchema, resultSchema, orcCatalystSchema, partitionSchema, conf)
+        dataSchema, resultSchema, partitionSchema, conf)
       assert(requestedColIds.length == readDataSchema.length,
         "[BUG] requested column IDs do not match required schema")
 
@@ -139,9 +138,8 @@ case class OrcPartitionReaderFactory(
       new EmptyPartitionReader
     } else {
       val (requestedDataColIds, canPruneCols) = resultedColPruneInfo.get
-      val orcCatalystSchema = OrcUtils.toCatalystSchema(orcSchema)
       val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
-        dataSchema, resultSchema, orcCatalystSchema, partitionSchema, conf)
+        dataSchema, resultSchema, partitionSchema, conf)
       val requestedColIds = requestedDataColIds ++ Array.fill(partitionSchema.length)(-1)
       assert(requestedColIds.length == resultSchema.length,
         "[BUG] requested column IDs do not match required schema")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -174,15 +174,6 @@ case class OrcPartitionReaderFactory(
     OrcFile.createReader(filePath, readerOptions)
   }
 
-  private def getResultedColPruneInfoAndOrcSchema(
-      filePath: Path, conf: Configuration): (Option[(Array[Int], Boolean)], TypeDescription) = {
-    Utils.tryWithResource(createORCReader(filePath, conf)) { reader =>
-      val orcSchema = reader.getSchema
-      (OrcUtils.requestedColumnIds(
-        isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf), orcSchema)
-    }
-  }
-
   /**
    * Build reader with aggregate push down.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcPartitionReaderFactory.scala
@@ -88,17 +88,18 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = new Path(new URI(file.filePath))
 
-    val (resultedColPruneInfo, reader) =
+    val (resultedColPruneInfo, orcSchema) =
       Utils.tryWithResource(createORCReader(filePath, conf)) { reader =>
+        val orcSchema = reader.getSchema
         (OrcUtils.requestedColumnIds(
-          isCaseSensitive, dataSchema, readDataSchema, reader, conf), reader)
+          isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf), orcSchema)
       }
 
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader[InternalRow]
     } else {
       val (requestedColIds, canPruneCols) = resultedColPruneInfo.get
-      val orcCatalystSchema = OrcUtils.toCatalystSchema(reader.getSchema)
+      val orcCatalystSchema = OrcUtils.toCatalystSchema(orcSchema)
       OrcUtils.orcResultSchemaString(canPruneCols,
         dataSchema, resultSchema, orcCatalystSchema, partitionSchema, conf)
       assert(requestedColIds.length == readDataSchema.length,
@@ -133,17 +134,18 @@ case class OrcPartitionReaderFactory(
     }
     val filePath = new Path(new URI(file.filePath))
 
-    val (resultedColPruneInfo, reader) =
+    val (resultedColPruneInfo, orcSchema) =
       Utils.tryWithResource(createORCReader(filePath, conf)) { reader =>
+        val orcSchema = reader.getSchema
         (OrcUtils.requestedColumnIds(
-          isCaseSensitive, dataSchema, readDataSchema, reader, conf), reader)
+          isCaseSensitive, dataSchema, readDataSchema, orcSchema, conf), orcSchema)
       }
 
     if (resultedColPruneInfo.isEmpty) {
       new EmptyPartitionReader
     } else {
       val (requestedDataColIds, canPruneCols) = resultedColPruneInfo.get
-      val orcCatalystSchema = OrcUtils.toCatalystSchema(reader.getSchema)
+      val orcCatalystSchema = OrcUtils.toCatalystSchema(orcSchema)
       val resultSchemaString = OrcUtils.orcResultSchemaString(canPruneCols,
         dataSchema, resultSchema, orcCatalystSchema, partitionSchema, conf)
       val requestedColIds = requestedDataColIds ++ Array.fill(partitionSchema.length)(-1)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
@@ -43,7 +43,7 @@ case class OrcWrite(
 
     val conf = job.getConfiguration
 
-    conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute, OrcUtils.getOrcSchemaString(dataSchema, None))
+    conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute, OrcUtils.getOrcSchemaString(dataSchema))
 
     conf.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
@@ -43,8 +43,7 @@ case class OrcWrite(
 
     val conf = job.getConfiguration
 
-    conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute,
-      OrcUtils.orcTypeDescriptionString(dataSchema, None))
+    conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute, OrcUtils.getOrcSchemaString(dataSchema, None))
 
     conf.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
@@ -43,7 +43,8 @@ case class OrcWrite(
 
     val conf = job.getConfiguration
 
-    conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute, OrcUtils.orcTypeDescriptionString(dataSchema))
+    conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute,
+      OrcUtils.orcTypeDescriptionString(dataSchema, dataSchema))
 
     conf.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcWrite.scala
@@ -44,7 +44,7 @@ case class OrcWrite(
     val conf = job.getConfiguration
 
     conf.set(MAPRED_OUTPUT_SCHEMA.getAttribute,
-      OrcUtils.orcTypeDescriptionString(dataSchema, dataSchema))
+      OrcUtils.orcTypeDescriptionString(dataSchema, None))
 
     conf.set(COMPRESS.getAttribute, orcOptions.compressionCodec)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.orc
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
-import java.time.{LocalDateTime, ZoneOffset}
+import java.time.LocalDateTime
 import java.util.TimeZone
 
 import org.apache.hadoop.conf.Configuration

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
 import java.time.LocalDateTime
+import java.util.TimeZone
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -801,6 +802,35 @@ abstract class OrcQuerySuite extends OrcQueryTest with SharedSparkSession {
       withAllNativeOrcReaders {
         checkAnswer(spark.read.orc(file), data.toDF().collect())
       }
+    }
+  }
+
+  test("SPARK-37463: read/write Timestamp ntz to Orc with different time zone") {
+    val localTimeZone = TimeZone.getDefault
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+
+      val sqlText = """
+                      |select
+                      | timestamp_ntz '2021-06-01 00:00:00' ts_ntz1,
+                      | timestamp_ntz '1883-11-16 00:00:00.0' as ts_ntz2,
+                      | timestamp_ntz '2021-03-14 02:15:00.0' as ts_ntz3
+                      |""".stripMargin
+
+      val df = sql(sqlText)
+
+      df.write.mode("overwrite").orc("ts_ntz_orc")
+
+      val query = "select * from `orc`.`ts_ntz_orc`"
+
+      Seq("America/Los_Angeles", "UTC", "Europe/Amsterdam").foreach { tz =>
+        TimeZone.setDefault(TimeZone.getTimeZone(tz))
+        withAllNativeOrcReaders {
+          checkAnswer(sql(query), df)
+        }
+      }
+    } finally {
+      TimeZone.setDefault(localTimeZone)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.orc
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneOffset}
 import java.util.TimeZone
 
 import org.apache.hadoop.conf.Configuration


### PR DESCRIPTION
### What changes were proposed in this pull request?
#33588 (comment) show Spark cannot read/write timestamp ntz and ltz correctly. Based on the discussion https://github.com/apache/spark/pull/34741#issuecomment-983660633, we just to fix read/write timestamp ntz to Orc uses int64.

### Why are the changes needed?
Fix the bug about read/write timestamp ntz from/to Orc with different times zone.


### Does this PR introduce _any_ user-facing change?
Yes. Orc timestamp ntz is a new feature.


### How was this patch tested?
New tests.
