### PR TITLE
[SPARK-37391][SQL]JdbcConnectionProvider tells if it modifies security context

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/sql/jdbc/ExampleJdbcConnectionProvider.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/sql/jdbc/ExampleJdbcConnectionProvider.scala
@@ -30,4 +30,9 @@ class ExampleJdbcConnectionProvider extends JdbcConnectionProvider with Logging 
   override def canHandle(driver: Driver, options: Map[String, String]): Boolean = false
 
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = null
+
+  override def modifiesSecurityContext(
+    driver: Driver,
+    options: Map[String, String]
+  ): Boolean = false
 }

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -69,7 +69,10 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.shuffle.api.ShuffleMapOutputWriter.commitAllPartitions"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.shuffle.api.SingleSpillShuffleMapOutputWriter.transferMapSpillFile"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.shuffle.api.SingleSpillShuffleMapOutputWriter.transferMapSpillFile"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.shuffle.api.ShuffleMapOutputWriter.commitAllPartitions")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.shuffle.api.ShuffleMapOutputWriter.commitAllPartitions"),
+
+    // [SPARK-37391][SQL] JdbcConnectionProvider tells if it modifies security context
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.sql.jdbc.JdbcConnectionProvider.modifiesSecurityContext")
   )
 
   // Exclude rules for 3.1.x

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/BasicConnectionProvider.scala
@@ -48,4 +48,12 @@ private[jdbc] class BasicConnectionProvider extends JdbcConnectionProvider with 
     logDebug(s"JDBC connection initiated with URL: ${jdbcOptions.url} and properties: $properties")
     driver.connect(jdbcOptions.url, properties)
   }
+
+  override def modifiesSecurityContext(
+    driver: Driver,
+    options: Map[String, String]
+  ): Boolean = {
+    // BasicConnectionProvider is the default unsecure connection provider, so just return false
+    false
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcConnectionProvider.scala
@@ -53,12 +53,27 @@ abstract class JdbcConnectionProvider {
   def canHandle(driver: Driver, options: Map[String, String]): Boolean
 
   /**
-   * Opens connection toward the database. Since global JVM security configuration change may needed
-   * this API is called synchronized by `SecurityConfigurationLock` to avoid race.
+   * Opens connection to the database. Since global JVM security configuration change may be
+   * needed this API is called synchronized by `SecurityConfigurationLock` to avoid race when
+   * `modifiesSecurityContext` returns true for the given driver with the given options.
    *
    * @param driver  Java driver which initiates the connection
    * @param options Driver options which initiates the connection
    * @return a `Connection` object that represents a connection to the URL
    */
   def getConnection(driver: Driver, options: Map[String, String]): Connection
+
+  /**
+   * Checks if this connection provider instance needs to modify global security configuration to
+   * handle authentication and thus should synchronize access to the security configuration while
+   * the given driver is initiating a connection with the given options.
+   *
+   * @param driver  Java driver which initiates the connection
+   * @param options Driver options which initiates the connection
+   * @return True if the connection provider will need to modify the security configuration when
+   * initiating a connection with the given driver with the given options.
+   *
+   * @since 3.1.3
+   */
+  def modifiesSecurityContext(driver: Driver, options: Map[String, String]): Boolean
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/README.md
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/README.md
@@ -80,5 +80,6 @@ Implementation considerations:
 * CPs are running in heavy multi-threaded environment and adding a state into a CP is not advised.
   If any state added then it must be synchronized properly. It could cause quite some headache to
   hunt down such issues.
-* Some of the CPs are modifying the JVM global security context so `getConnection` method is
-  synchronized by `org.apache.spark.security.SecurityConfigurationLock` to avoid race.
+* Some of the CPs are modifying the JVM global security context so if the CP's
+  `modifiesSecurityContext` method returns `true` then the CP's `getConnection` method will
+  be called synchronized by `org.apache.spark.security.SecurityConfigurationLock` to avoid race.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/IntentionallyFaultyConnectionProvider.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/IntentionallyFaultyConnectionProvider.scala
@@ -27,6 +27,10 @@ private class IntentionallyFaultyConnectionProvider extends JdbcConnectionProvid
   override val name: String = "IntentionallyFaultyConnectionProvider"
   override def canHandle(driver: Driver, options: Map[String, String]): Boolean = true
   override def getConnection(driver: Driver, options: Map[String, String]): Connection = null
+  override def modifiesSecurityContext(
+    driver: Driver,
+    options: Map[String, String]
+  ): Boolean = false
 }
 
 private object IntentionallyFaultyConnectionProvider {


### PR DESCRIPTION
# branch-3.2 version!
For master version see : https://github.com/apache/spark/pull/34745

Augments the JdbcConnectionProvider API such that a provider can indicate that it will need to modify the global security configuration when establishing a connection, and as such, if access to the global security configuration should be synchronized to prevent races.


### What changes were proposed in this pull request?
As suggested by @gaborgsomogyi [here](https://github.com/apache/spark/pull/29024/files#r755788709), augments the `JdbcConnectionProvider` API to include a `modifiesSecurityContext` method that can be used by `ConnectionProvider` to determine when `SecurityConfigurationLock.synchronized` is required to avoid race conditions when establishing a JDBC connection.


### Why are the changes needed?
Provides a path forward for working around a significant bottleneck introduced by synchronizing `SecurityConfigurationLock` every time a connection is established. The synchronization isn't always needed and it should be at the discretion of the `JdbcConnectionProvider` to determine when locking is necessary. See [SPARK-37391](https://issues.apache.org/jira/browse/SPARK-37391) or [this thread](https://github.com/apache/spark/pull/29024/files#r754441783).


### Does this PR introduce _any_ user-facing change?
Any existing implementations of `JdbcConnectionProvider` will need to add a definition of `modifiesSecurityContext`. I'm also open to adding a default implementation, but it seemed to me that requiring an explicit implementation of the method was preferable.

A drop-in implementation that would continue the existing behavior is:
```scala
override def modifiesSecurityContext(
  driver: Driver,
  options: Map[String, String]
): Boolean = true
```


### How was this patch tested?
Unit tests. Also ran a real workflow by swapping in a locally published version of `spark-sql` into my local spark 3.2.0 installation's jars.