### PR TITLE
[SPARK-37721][PYTHON] Fix SPARK_HOME key error when running PySpark test

### DIFF
--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -27,6 +27,7 @@ from py4j.java_gateway import (  # type: ignore[import]
 from py4j.protocol import Py4JJavaError  # type: ignore[import]
 
 from pyspark import SparkContext
+from pyspark.find_spark_home import _find_spark_home
 
 if TYPE_CHECKING:
     from pyspark.sql.context import SQLContext
@@ -245,12 +246,7 @@ def require_test_compiled() -> None:
     import os
     import glob
 
-    try:
-        spark_home = os.environ["SPARK_HOME"]
-    except KeyError:
-        raise RuntimeError("SPARK_HOME is not defined in environment")
-
-    test_class_path = os.path.join(spark_home, "sql", "core", "target", "*", "test-classes")
+    test_class_path = os.path.join(_find_spark_home(), "sql", "core", "target", "*", "test-classes")
     paths = glob.glob(test_class_path)
 
     if len(paths) == 0:

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -22,6 +22,7 @@ import sys
 import unittest
 from time import time, sleep
 
+from pyspark.find_spark_home import _find_spark_home
 from pyspark import SparkContext, SparkConf
 
 
@@ -43,7 +44,7 @@ except ImportError:
     pass
 
 
-SPARK_HOME = os.environ["SPARK_HOME"]
+SPARK_HOME = _find_spark_home()
 
 
 def read_int(b):

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -22,8 +22,8 @@ import sys
 import unittest
 from time import time, sleep
 
-from pyspark.find_spark_home import _find_spark_home
 from pyspark import SparkContext, SparkConf
+from pyspark.find_spark_home import _find_spark_home
 
 
 have_scipy = False
@@ -153,7 +153,7 @@ class ByteArrayOutput:
 def search_jar(project_relative_path, sbt_jar_name_prefix, mvn_jar_name_prefix):
     # Note that 'sbt_jar_name_prefix' and 'mvn_jar_name_prefix' are used since the prefix can
     # vary for SBT or Maven specifically. See also SPARK-26856
-    project_full_path = os.path.join(os.environ["SPARK_HOME"], project_relative_path)
+    project_full_path = os.path.join(SPARK_HOME, project_relative_path)
 
     # We should ignore the following jars
     ignored_jar_suffixes = ("javadoc.jar", "sources.jar", "test-sources.jar", "tests.jar")

--- a/python/pyspark/tests/test_appsubmit.py
+++ b/python/pyspark/tests/test_appsubmit.py
@@ -23,13 +23,15 @@ import tempfile
 import unittest
 import zipfile
 
+from pyspark.testing.utils import SPARK_HOME
+
 
 class SparkSubmitTests(unittest.TestCase):
     def setUp(self):
         self.programDir = tempfile.mkdtemp()
         tmp_dir = tempfile.gettempdir()
         self.sparkSubmit = [
-            os.path.join(os.environ.get("SPARK_HOME"), "bin", "spark-submit"),
+            os.path.join(SPARK_HOME, "bin", "spark-submit"),
             "--conf",
             "spark.driver.extraJavaOptions=-Djava.io.tmpdir={0}".format(tmp_dir),
             "--conf",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace `os.environ["SPARK_HOME"]` direct access with `_find_spark_home` in pyspark testing utils.

### Why are the changes needed?
When running PySpark unit test in WSL with PyCharm, all test raise the `KeyError: 'SPARK_HOME'`
```
Launching unittests with arguments python -m unittest test_rdd.RDDTests.test_range in /home/yikun/spark/python/pyspark/testsTraceback (most recent call last):
  File "/mnt/d/Program Files/JetBrains/PyCharm 2021.1.3/plugins/python/helpers/pycharm/_jb_unittest_runner.py", line 35, in <module>
    sys.exit(main(argv=args, module=None, testRunner=unittestpy.TeamcityTestRunner, buffer=not JB_DISABLE_BUFFERING))
  File "/usr/lib/python3.8/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python3.8/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/usr/lib/python3.8/unittest/main.py", line 158, in createTests
    self.test = self.testLoader.loadTestsFromNames(self.testNames,
  File "/usr/lib/python3.8/unittest/loader.py", line 220, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.8/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/yikun/spark/python/pyspark/tests/test_rdd.py", line 37, in <module>
    from pyspark.testing.utils import ReusedPySparkTestCase, SPARK_HOME, QuietTest
  File "/home/yikun/spark/python/pyspark/testing/utils.py", line 47, in <module>
    SPARK_HOME = os.environ["SPARK_HOME"]#_find_spark_home()
  File "/usr/lib/python3.8/os.py", line 675, in __getitem__
    raise KeyError(key) from None
KeyError: 'SPARK_HOME' 
```

We should use `_find_spark_home` to get SPARK_HOME rather than access `os.environ`.

### Does this PR introduce _any_ user-facing change?
No, test only

### How was this patch tested?
- UT passed.
- Run test in Win WSL.
