### PR TITLE
[SPARK-37724][SQL] ANSI mode: disable ANSI reserved keywords by default

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -309,20 +309,19 @@ When ANSI mode is on, it throws exceptions for invalid operations. You can use t
   - `try_divide`: identical to the division operator `/`, except that it returns `NULL` result instead of throwing an exception on dividing 0.
   - `try_element_at`: identical to the function `element_at`, except that it returns `NULL` result instead of throwing an exception on array's index out of bound or map's key not found.
 
-### SQL Keywords
+### SQL Keywords (optional, disabled by default)
 
-When `spark.sql.ansi.enabled` is true, Spark SQL will use the ANSI mode parser.
-In this mode, Spark SQL has two kinds of keywords:
-* Reserved keywords: Keywords that are reserved and can't be used as identifiers for table, view, column, function, alias, etc.
+When both `spark.sql.ansi.enabled` and `spark.sql.ansi.enforceReservedKeywords` are true, Spark SQL will use the ANSI mode parser.
+
+With the ANSI mode parser, Spark SQL has two kinds of keywords:
 * Non-reserved keywords: Keywords that have a special meaning only in particular contexts and can be used as identifiers in other contexts. For example, `EXPLAIN SELECT ...` is a command, but EXPLAIN can be used as identifiers in other places.
+* Reserved keywords: Keywords that are reserved and can't be used as identifiers for table, view, column, function, alias, etc.
 
-When the ANSI mode is disabled, Spark SQL has two kinds of keywords:
+With the default parser, Spark SQL has two kinds of keywords:
 * Non-reserved keywords: Same definition as the one when the ANSI mode enabled.
 * Strict-non-reserved keywords: A strict version of non-reserved keywords, which can not be used as table alias.
 
-If you want to still use reserved keywords as identifiers with ANSI mode, you can set `spark.sql.ansi.enforceReservedKeywords` to false.
-
-By default `spark.sql.ansi.enabled` is false and `spark.sql.ansi.enforceReservedKeywords` is true.
+By default, both `spark.sql.ansi.enabled` and `spark.sql.ansi.enforceReservedKeywords` are false.
 
 Below is a list of all the keywords in Spark SQL.
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2663,7 +2663,7 @@ object SQLConf {
       "and/or identifiers for table, view, function, etc.")
     .version("3.3.0")
     .booleanConf
-    .createWithDefault(true)
+    .createWithDefault(false)
 
   val ALLOW_CAST_BETWEEN_DATETIME_AND_NUMERIC_IN_ANSI =
     buildConf("spark.sql.ansi.allowCastBetweenDatetimeAndNumeric")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -928,7 +928,8 @@ class ExpressionParserSuite extends AnalysisTest {
   }
 
   test("current date/timestamp braceless expressions") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true",
+      SQLConf.ENFORCE_RESERVED_KEYWORDS.key -> "true") {
       assertEqual("current_date", CurrentDate())
       assertEqual("current_timestamp", CurrentTimestamp())
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/TableIdentifierParserSuite.scala
@@ -304,7 +304,8 @@ class TableIdentifierParserSuite extends SQLKeywordUtils {
   }
 
   test("table identifier - reserved/non-reserved keywords if ANSI mode enabled") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true",
+      SQLConf.ENFORCE_RESERVED_KEYWORDS.key -> "true") {
       reservedKeywordsInAnsiMode.foreach { keyword =>
         val errMsg = intercept[ParseException] {
           parseTableIdentifier(keyword)

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -97,15 +97,9 @@ true
 -- !query
 select current_date() = current_date()
 -- !query schema
-struct<>
+struct<(current_date() = current_date()):boolean>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'current_date'(line 1, pos 7)
-
-== SQL ==
-select current_date() = current_date()
--------^^^
+true
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/higher-order-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/higher-order-functions.sql.out
@@ -259,29 +259,17 @@ struct<v:map<int,int>>
 -- !query
 select transform(ys, all -> all * all) as v from values (array(32, 97)) as t(ys)
 -- !query schema
-struct<>
+struct<v:array<int>>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'all'(line 1, pos 21)
-
-== SQL ==
-select transform(ys, all -> all * all) as v from values (array(32, 97)) as t(ys)
----------------------^^^
+[1024,9409]
 
 
 -- !query
 select transform(ys, (all, i) -> all + i) as v from values (array(32, 97)) as t(ys)
 -- !query schema
-struct<>
+struct<v:array<int>>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'all'(line 1, pos 22)
-
-== SQL ==
-select transform(ys, (all, i) -> all + i) as v from values (array(32, 97)) as t(ys)
-----------------------^^^
+[32,98]
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/parse-schema-string.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/parse-schema-string.sql.out
@@ -5,23 +5,9 @@
 -- !query
 select from_csv('1', 'create INT')
 -- !query schema
-struct<>
+struct<from_csv(1):struct<create:int>>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Cannot parse the data type: 
-no viable alternative at input 'create'(line 1, pos 0)
-
-== SQL ==
-create INT
-^^^
-
-Failed fallback parsing: 
-no viable alternative at input 'create'(line 1, pos 0)
-
-== SQL ==
-create INT
-^^^
-; line 1 pos 7
+{"create":1}
 
 
 -- !query
@@ -35,23 +21,9 @@ struct<from_csv(1):struct<cube:int>>
 -- !query
 select from_json('{"create":1}', 'create INT')
 -- !query schema
-struct<>
+struct<from_json({"create":1}):struct<create:int>>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Cannot parse the data type: 
-no viable alternative at input 'create'(line 1, pos 0)
-
-== SQL ==
-create INT
-^^^
-
-Failed fallback parsing: 
-no viable alternative at input 'create'(line 1, pos 0)
-
-== SQL ==
-create INT
-^^^
-; line 1 pos 7
+{"create":1}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/timestamp.sql.out
@@ -63,15 +63,9 @@ true
 -- !query
 select current_timestamp() = current_timestamp()
 -- !query schema
-struct<>
+struct<(current_timestamp() = current_timestamp()):boolean>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'current_timestamp'(line 1, pos 7)
-
-== SQL ==
-select current_timestamp() = current_timestamp()
--------^^^
+true
 
 
 -- !query
@@ -265,10 +259,10 @@ struct<>
 -- !query
 select typeof(current_date), typeof(current_timestamp) from ttf1
 -- !query schema
-struct<typeof(current_date()):string,typeof(current_timestamp()):string>
+struct<typeof(current_date):string,typeof(current_timestamp):string>
 -- !query output
-date	timestamp
-date	timestamp
+int	int
+int	int
 
 
 -- !query
@@ -285,15 +279,10 @@ struct<>
 -- !query
 select current_date = current_date(), current_timestamp = current_timestamp(), a, b from ttf2
 -- !query schema
-struct<>
+struct<(current_date() = current_date()):boolean,(current_timestamp() = current_timestamp()):boolean,a:int,b:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'current_date'(line 1, pos 22)
-
-== SQL ==
-select current_date = current_date(), current_timestamp = current_timestamp(), a, b from ttf2
-----------------------^^^
+true	true	1	2
+true	true	2	3
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
@@ -65,14 +65,8 @@ CREATE VIEW key_dependent_view_no_cols AS
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'FROM'(line 2, pos 10)
-
-== SQL ==
-CREATE VIEW key_dependent_view_no_cols AS
-   SELECT FROM view_base_table GROUP BY key HAVING length(data) > 0
-----------^^^
+org.apache.spark.sql.AnalysisException
+Column 'FROM' does not exist. Did you mean one of the following? []; line 2 pos 10
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/union.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/union.sql.out
@@ -76,20 +76,29 @@ struct<two:int>
 -- !query
 SELECT 1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
 -- !query schema
-struct<three:int>
+struct<>
 -- !query output
-1
-2
-3
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {<EOF>, ';'}(line 1, pos 39)
+
+== SQL ==
+SELECT 1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
+---------------------------------------^^^
 
 
 -- !query
 SELECT 1 AS two UNION SELECT 2 UNION SELECT 2 ORDER BY 1
 -- !query schema
-struct<two:int>
+struct<>
 -- !query output
-1
-2
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {<EOF>, ';'}(line 1, pos 37)
+
+== SQL ==
+SELECT 1 AS two UNION SELECT 2 UNION SELECT 2 ORDER BY 1
+-------------------------------------^^^
 
 
 -- !query
@@ -158,20 +167,29 @@ struct<two:double>
 -- !query
 SELECT 1.1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
 -- !query schema
-struct<three:decimal(11,1)>
+struct<>
 -- !query output
-1.1
-2.0
-3.0
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {<EOF>, ';'}(line 1, pos 41)
+
+== SQL ==
+SELECT 1.1 AS three UNION SELECT 2 UNION SELECT 3 ORDER BY 1
+-----------------------------------------^^^
 
 
 -- !query
 SELECT double(1.1) AS two UNION SELECT 2 UNION SELECT double(2.0) ORDER BY 1
 -- !query schema
-struct<two:double>
+struct<>
 -- !query output
-1.1
-2.0
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {<EOF>, ';'}(line 1, pos 47)
+
+== SQL ==
+SELECT double(1.1) AS two UNION SELECT 2 UNION SELECT double(2.0) ORDER BY 1
+-----------------------------------------------^^^
 
 
 -- !query
@@ -359,33 +377,57 @@ struct<q1:bigint>
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6) INTERSECT SELECT 4,5,6
 -- !query schema
-struct<1:int,2:int,3:int>
+struct<>
 -- !query output
-4	5	6
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {')', ',', 'CLUSTER', 'DISTRIBUTE', 'EXCEPT', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LATERAL', 'LIMIT', 'ORDER', 'MINUS', 'SORT', 'UNION', 'WHERE', 'WINDOW', '-'}(line 1, pos 20)
+
+== SQL ==
+(SELECT 1,2,3 UNION SELECT 4,5,6) INTERSECT SELECT 4,5,6
+--------------------^^^
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) INTERSECT SELECT 4,5,6
 -- !query schema
-struct<1:int,2:int,3:int>
+struct<>
 -- !query output
-4	5	6
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {')', ',', 'CLUSTER', 'DISTRIBUTE', 'EXCEPT', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LATERAL', 'LIMIT', 'ORDER', 'MINUS', 'SORT', 'UNION', 'WHERE', 'WINDOW', '-'}(line 1, pos 20)
+
+== SQL ==
+(SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) INTERSECT SELECT 4,5,6
+--------------------^^^
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6) EXCEPT SELECT 4,5,6
 -- !query schema
-struct<1:int,2:int,3:int>
+struct<>
 -- !query output
-1	2	3
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {')', ',', 'CLUSTER', 'DISTRIBUTE', 'EXCEPT', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LATERAL', 'LIMIT', 'ORDER', 'MINUS', 'SORT', 'UNION', 'WHERE', 'WINDOW', '-'}(line 1, pos 20)
+
+== SQL ==
+(SELECT 1,2,3 UNION SELECT 4,5,6) EXCEPT SELECT 4,5,6
+--------------------^^^
 
 
 -- !query
 (SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) EXCEPT SELECT 4,5,6
 -- !query schema
-struct<1:int,2:int,3:int>
+struct<>
 -- !query output
-1	2	3
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {')', ',', 'CLUSTER', 'DISTRIBUTE', 'EXCEPT', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LATERAL', 'LIMIT', 'ORDER', 'MINUS', 'SORT', 'UNION', 'WHERE', 'WINDOW', '-'}(line 1, pos 20)
+
+== SQL ==
+(SELECT 1,2,3 UNION SELECT 4,5,6 ORDER BY 1,2) EXCEPT SELECT 4,5,6
+--------------------^^^
 
 
 -- !query
@@ -684,9 +726,13 @@ SELECT cast('3.4' as decimal(38, 18)) UNION SELECT 'foo'
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.AnalysisException
-Union can only be performed on tables with the compatible column types. The first column of the second table is string type which is not compatible with decimal(38,18) at same column of first table
-To fix the error, you might need to add explicit type casts. If necessary set spark.sql.ansi.enabled to false to bypass this error.
+org.apache.spark.sql.catalyst.parser.ParseException
+
+mismatched input 'SELECT' expecting {<EOF>, ';'}(line 1, pos 44)
+
+== SQL ==
+SELECT cast('3.4' as decimal(38, 18)) UNION SELECT 'foo'
+--------------------------------------------^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
@@ -329,11 +329,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input 'ORDER'(line 1, pos 27)
+mismatched input 'BY' expecting {')', ',', '-'}(line 1, pos 33)
 
 == SQL ==
 SELECT * FROM rank() OVER (ORDER BY random())
----------------------------^^^
+---------------------------------^^^
 
 
 -- !query
@@ -361,11 +361,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input 'ORDER'(line 1, pos 39)
+extraneous input 'BY' expecting {')', ',', 'ORDER', 'RANGE', 'ROWS', 'SORT'}(line 1, pos 45)
 
 == SQL ==
 select rank() OVER (PARTITION BY four, ORDER BY ten) FROM tenk1
----------------------------------------^^^
+---------------------------------------------^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/with.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/with.sql.out
@@ -350,11 +350,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input 'with'(line 1, pos 18)
+DataType baz is not supported.(line 1, pos 23)
 
 == SQL ==
 create table foo (with baz)
-------------------^^^
+-----------------------^^^
 
 
 -- !query
@@ -364,11 +364,11 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-no viable alternative at input 'with'(line 1, pos 18)
+DataType ordinality is not supported.(line 1, pos 23)
 
 == SQL ==
 create table foo (with ordinality)
-------------------^^^
+-----------------------^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/timestampNTZ/timestamp-ansi.sql.out
@@ -63,15 +63,9 @@ true
 -- !query
 select current_timestamp() = current_timestamp()
 -- !query schema
-struct<>
+struct<(current_timestamp() = current_timestamp()):boolean>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'current_timestamp'(line 1, pos 7)
-
-== SQL ==
-select current_timestamp() = current_timestamp()
--------^^^
+true
 
 
 -- !query
@@ -265,10 +259,10 @@ struct<>
 -- !query
 select typeof(current_date), typeof(current_timestamp) from ttf1
 -- !query schema
-struct<typeof(current_date()):string,typeof(current_timestamp()):string>
+struct<typeof(current_date):string,typeof(current_timestamp):string>
 -- !query output
-date	timestamp
-date	timestamp
+int	int
+int	int
 
 
 -- !query
@@ -285,15 +279,10 @@ struct<>
 -- !query
 select current_date = current_date(), current_timestamp = current_timestamp(), a, b from ttf2
 -- !query schema
-struct<>
+struct<(current_date() = current_date()):boolean,(current_timestamp() = current_timestamp()):boolean,a:int,b:int>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
-
-no viable alternative at input 'current_date'(line 1, pos 22)
-
-== SQL ==
-select current_date = current_date(), current_timestamp = current_timestamp(), a, b from ttf2
-----------------------^^^
+true	true	1	2
+true	true	2	3
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -50,7 +50,8 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
       val df = sql("select current_user(), current_user")
       checkAnswer(df, Row(user, user))
     }
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true",
+      SQLConf.ENFORCE_RESERVED_KEYWORDS.key -> "true") {
       val df = sql("select current_user")
       checkAnswer(df, Row(spark.sparkContext.sparkUser))
       val e = intercept[ParseException](sql("select current_user()"))

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -139,6 +139,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       }
 
       exec(s"set ${SQLConf.ANSI_ENABLED.key}=true")
+      exec(s"set ${SQLConf.ENFORCE_RESERVED_KEYWORDS.key}=true")
       val opHandle2 = exec("select current_user")
       assert(client.fetchResults(opHandle2).toTRowSet.getColumns.get(0)
         .getStringVal.getValues.get(0) === clientUser)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Disable ANSI reserved keywords by default in ANSI mode
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The reserved keywords thing is a big stopper for many users that want to try ANSI mode. They have to update the SQL queries to pass the parser, which is nothing about data quality but just trouble. Also, there could some existing table names conflict with the ANSI reserved keyword, e.g. `USER`.

By disabling the feature as default, I think we can get better adoption of the ANSI mode.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, disable ANSI reserved keywords by default in ANSI mode

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing UT.
Doc preview:
![image](https://user-images.githubusercontent.com/1097932/147209126-197da967-ea96-4c94-ad12-b2f3c1edac8b.png)
