### PR TITLE
[SPARK-37496][SQL][FOLLOWUP] DataFrameWriter.saveAsTable should take write options in CTAS and RTAS

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -609,7 +609,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           partitioningAsV2,
           df.queryExecution.analyzed,
           tableSpec,
-          writeOptions = Map.empty,
+          writeOptions = extraOptions.toMap,
           orCreate = true) // Create the table if it doesn't exist
 
       case (other, _) =>
@@ -631,7 +631,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
           partitioningAsV2,
           df.queryExecution.analyzed,
           tableSpec,
-          Map.empty,
+          writeOptions = extraOptions.toMap,
           other == SaveMode.Ignore)
     }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
`DataFrameWriter.saveAsTable` should pass `extraOptions.toMap` as the write options in CTAS and RTAS


### Why are the changes needed?
bug fixing
please see https://github.com/apache/spark/pull/34754#discussion_r771059560 https://github.com/apache/spark/pull/34667#discussion_r771367364


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
new test
