### PR TITLE
[SPARK-8582][CORE] Checkpoint eagerly when asked to do so for real

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -684,7 +684,7 @@ class Dataset[T] private[sql](
       }
 
       if (eager) {
-        internalRdd.count()
+        internalRdd.doCheckpoint()
       }
 
       // Takes the first leaf partitioning whenever we see a `PartitioningCollection`. Otherwise the

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -25,6 +25,8 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
 import org.apache.spark.{SparkException, TaskContext}
+import org.apache.spark.TestUtils.withListener
+import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.{FooClassWithEnum, FooEnum, ScroogeLikeExample}
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
@@ -1457,8 +1459,29 @@ class DatasetSuite extends QueryTest
       }
 
       testCheckpointing("basic") {
-        val ds = spark.range(10).repartition($"id" % 2).filter($"id" > 5).orderBy($"id".desc)
-        val cp = if (reliable) ds.checkpoint(eager) else ds.localCheckpoint(eager)
+        val ds = spark
+          .range(10)
+          // Num partitions is set to 1 to avoid a RangePartitioner in the orderBy below
+          .repartition(1, $"id" % 2)
+          .filter($"id" > 5)
+          .orderBy($"id".desc)
+        @volatile var jobCounter = 0
+        val listener = new SparkListener {
+          override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+            jobCounter += 1
+          }
+        }
+        var cp = ds
+        withListener(spark.sparkContext, listener) { _ =>
+          // AQE adds a job per shuffle. The expression above does multiple shuffles and
+          // that screws up the job counting
+          withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+            cp = if (reliable) ds.checkpoint(eager) else ds.localCheckpoint(eager)
+          }
+        }
+        if (eager) {
+          assert(jobCounter === 1)
+        }
 
         val logicalRDD = cp.logicalPlan match {
           case plan: LogicalRDD => plan


### PR DESCRIPTION
Run checkpoint job only once when asked to do so eagerly.

### What changes were proposed in this pull request?

The flow is like so:
```
- df.checkpoint(eager = true, reliable = true)
  - rdd = get rdd from this df's physical plan
  - rdd.checkpoint (just marks checkpointData)
  - rdd.count (if eager = true)
    - SparkContext.runJob for all the partitions
      - DAGScheduler.runJob
      - rdd.doCheckpoint
        - ReliableCheckpointRDD#writeRDDToCheckpointDirectory
          - SparkContext.runJob for all the partitions
          - DAGScheduler.runJob (<-- This is the repeat job)
```

The local checkpointing case is better because there it will just
recompute the missing partitions.

We tried a fix where we just replaced `rdd.count` above with
`rdd.doCheckpoint` and it seemed to work and pass the unit tests.

So the new flow is simply:
```
- df.checkpoint(eager = true, reliable = true)
  - rdd = get rdd from this df's physical plan
  - rdd.checkpoint (just marks checkpointData)
  - rdd.doCheckpoint (if eager = true)
    - ReliableCheckpointRDD#writeRDDToCheckpointDirectory
      - SparkContext.runJob for all the partitions
      - DAGScheduler.runJob (<-- Only one job is run)
```

### Why are the changes needed?
This simple fix drastically improves spark jobs that make heavy use of
Dataframe.checkpoint.


### Does this PR introduce _any_ user-facing change?

Yes, it would make eager checkpointing jobs supposedly faster by doing half as many spark jobs.

### How was this patch tested?

Customer spark apps using checkpoint with this fix see half as many
spark jobs launched, seeing upto 50% less runtime in some cases.
Also, added one more unit test to check that only job is created.

This patch may have some interactions with the Spark-Streaming, since it
touches the codepaths enabled via the config
spark.checkpoint.checkpointAllMarkedAncestors, so would be happy to add
more testing there if pointed in the right direction.