### PR TITLE
[SPARK-37478][SQL][TESTS][FOLLOWUP] Unify v1 and v2 DROP NAMESPACE error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -140,10 +140,10 @@ class InMemoryCatalog(
       if (!cascade) {
         // If cascade is false, make sure the database is empty.
         if (catalog(db).tables.nonEmpty) {
-          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db, "tables")
+          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db)
         }
         if (catalog(db).functions.nonEmpty) {
-          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db, "functions")
+          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db)
         }
       }
       // Remove the database.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -140,10 +140,10 @@ class InMemoryCatalog(
       if (!cascade) {
         // If cascade is false, make sure the database is empty.
         if (catalog(db).tables.nonEmpty) {
-          throw QueryCompilationErrors.databaseNotEmptyError(db, "tables")
+          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db, "tables")
         }
         if (catalog(db).functions.nonEmpty) {
-          throw QueryCompilationErrors.databaseNotEmptyError(db, "functions")
+          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db, "functions")
         }
       }
       // Remove the database.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -139,10 +139,7 @@ class InMemoryCatalog(
     if (catalog.contains(db)) {
       if (!cascade) {
         // If cascade is false, make sure the database is empty.
-        if (catalog(db).tables.nonEmpty) {
-          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db)
-        }
-        if (catalog(db).functions.nonEmpty) {
+        if (catalog(db).tables.nonEmpty || catalog(db).functions.nonEmpty) {
           throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db)
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -540,14 +540,14 @@ object QueryCompilationErrors {
       s"rename temporary view from '$oldName' to '$newName': destination view already exists")
   }
 
-  def cannotDropNonemptyDatabaseError(db: String, details: String): Throwable = {
+  def cannotDropNonemptyDatabaseError(db: String): Throwable = {
     new AnalysisException(s"Cannot drop a non-empty database: $db. " +
-      s"One or more $details exist. Use CASCADE option to drop a non-empty database.")
+      "Use CASCADE option to drop a non-empty database.")
   }
 
   def cannotDropNonemptyNamespaceError(namespace: Seq[String]): Throwable = {
     new AnalysisException(s"Cannot drop a non-empty namespace: ${namespace.quoted}. " +
-        "Use CASCADE option to drop a non-empty namespace.")
+      "Use CASCADE option to drop a non-empty namespace.")
   }
 
   def invalidNameForTableOrDatabaseError(name: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -541,12 +541,12 @@ object QueryCompilationErrors {
   }
 
   def cannotDropNonemptyDatabaseError(db: String, details: String): Throwable = {
-    new AnalysisException(s"Cannot drop a non-empty database: $db. One or more $details exist.")
+    new AnalysisException(s"Cannot drop a non-empty database: $db. " +
+      "Use CASCADE option to drop a non-empty database.")
   }
 
   def cannotDropNonemptyNamespaceError(namespace: Seq[String]): Throwable = {
-    new AnalysisException(
-      s"Cannot drop a non-empty namespace: ${namespace.quoted}. " +
+    new AnalysisException(s"Cannot drop a non-empty namespace: ${namespace.quoted}. " +
         "Use CASCADE option to drop a non-empty namespace.")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -540,8 +540,14 @@ object QueryCompilationErrors {
       s"rename temporary view from '$oldName' to '$newName': destination view already exists")
   }
 
-  def databaseNotEmptyError(db: String, details: String): Throwable = {
-    new AnalysisException(s"Database $db is not empty. One or more $details exist.")
+  def cannotDropNonemptyDatabaseError(db: String, details: String): Throwable = {
+    new AnalysisException(s"Cannot drop a non-empty database: $db. One or more $details exist.")
+  }
+
+  def cannotDropNonemptyNamespaceError(namespace: Seq[String]): Throwable = {
+    new AnalysisException(
+      s"Cannot drop a non-empty namespace: ${namespace.quoted}. " +
+        "Use CASCADE option to drop a non-empty namespace.")
   }
 
   def invalidNameForTableOrDatabaseError(name: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -542,7 +542,7 @@ object QueryCompilationErrors {
 
   def cannotDropNonemptyDatabaseError(db: String, details: String): Throwable = {
     new AnalysisException(s"Cannot drop a non-empty database: $db. " +
-      "Use CASCADE option to drop a non-empty database.")
+      s"One or more $details exist. Use CASCADE option to drop a non-empty database.")
   }
 
   def cannotDropNonemptyNamespaceError(namespace: Seq[String]): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -610,12 +610,6 @@ object QueryExecutionErrors {
         "Schema of v1 relation: " + v1Schema)
   }
 
-  def cannotDropNonemptyNamespaceError(namespace: Seq[String]): Throwable = {
-    new SparkException(
-      s"Cannot drop a non-empty namespace: ${namespace.quoted}. " +
-        "Use CASCADE option to drop a non-empty namespace.")
-  }
-
   def noRecordsFromEmptyDataReaderError(): Throwable = {
     new IOException("No records should be returned from EmptyDataReader")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropNamespaceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropNamespaceExec.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.CatalogPlugin
-import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.errors.QueryCompilationErrors
 
 /**
  * Physical plan node for dropping a namespace.
@@ -42,12 +42,12 @@ case class DropNamespaceExec(
       if (!cascade) {
         if (catalog.asTableCatalog.listTables(ns).nonEmpty
           || nsCatalog.listNamespaces(ns).nonEmpty) {
-          throw QueryExecutionErrors.cannotDropNonemptyNamespaceError(namespace)
+          throw QueryCompilationErrors.cannotDropNonemptyNamespaceError(namespace)
         }
       }
 
       if (!nsCatalog.dropNamespace(ns)) {
-        throw QueryExecutionErrors.cannotDropNonemptyNamespaceError(namespace)
+        throw QueryCompilationErrors.cannotDropNonemptyNamespaceError(namespace)
       }
     } else if (!ifExists) {
       throw QueryCompilationErrors.noSuchNamespaceError(ns)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DropNamespaceSuite.scala
@@ -31,12 +31,7 @@ import org.apache.spark.sql.execution.command
 trait DropNamespaceSuiteBase extends command.DropNamespaceSuiteBase {
   override protected def builtinTopNamespaces: Seq[String] = Seq("default")
 
-  override protected def assertDropFails(): Unit = {
-    val e = intercept[AnalysisException] {
-      sql(s"DROP NAMESPACE $catalog.ns")
-    }
-    assert(e.getMessage.contains("Database ns is not empty. One or more tables exist"))
-  }
+  override protected def namespaceAlias(): String = "database"
 
   test("drop default namespace") {
     val message = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DropNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DropNamespaceSuite.scala
@@ -17,18 +17,9 @@
 
 package org.apache.spark.sql.execution.command.v2
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.execution.command
 
 /**
  * The class contains tests for the `DROP NAMESPACE` command to check V2 table catalogs.
  */
-class DropNamespaceSuite extends command.DropNamespaceSuiteBase with CommandSuiteBase {
-  // TODO: Unify the error that throws from v1 and v2 test suite into `AnalysisException`
-  override protected def assertDropFails(): Unit = {
-    val e = intercept[SparkException] {
-      sql(s"DROP NAMESPACE $catalog.ns")
-    }
-    assert(e.getMessage.contains("Cannot drop a non-empty namespace: ns"))
-  }
-}
+class DropNamespaceSuite extends command.DropNamespaceSuiteBase with CommandSuiteBase

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -202,7 +202,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       case NonFatal(exception) =>
         if (exception.getClass.getName.equals("org.apache.hadoop.hive.ql.metadata.HiveException")
           && exception.getMessage.contains(s"Database $db is not empty.")) {
-          throw new AnalysisException(s"Cannot drop a non-empty database: $db")
+          throw new AnalysisException(s"Cannot drop a non-empty database: $db.")
         } else throw exception
     }
   }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -196,7 +196,15 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       db: String,
       ignoreIfNotExists: Boolean,
       cascade: Boolean): Unit = withClient {
-    client.dropDatabase(db, ignoreIfNotExists, cascade)
+    try {
+      client.dropDatabase(db, ignoreIfNotExists, cascade)
+    } catch {
+      case NonFatal(exception) =>
+        if (exception.getClass.getName.equals("org.apache.hadoop.hive.ql.metadata.HiveException")
+          && exception.getMessage.contains(s"Database $db is not empty.")) {
+          throw new AnalysisException(s"Cannot drop a non-empty database: $db")
+        } else throw exception
+    }
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils}
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.DDLUtils
 import org.apache.spark.sql.execution.datasources.{PartitioningUtils, SourceOptions}
 import org.apache.spark.sql.hive.client.HiveClient
@@ -202,7 +203,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
       case NonFatal(exception) =>
         if (exception.getClass.getName.equals("org.apache.hadoop.hive.ql.metadata.HiveException")
           && exception.getMessage.contains(s"Database $db is not empty.")) {
-          throw new AnalysisException(s"Cannot drop a non-empty database: $db.")
+          throw QueryCompilationErrors.cannotDropNonemptyDatabaseError(db)
         } else throw exception
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1235,7 +1235,7 @@ class HiveDDLSuite
     if (tableExists && !cascade) {
       assertAnalysisError(
         sqlDropDatabase,
-        s"Database $dbName is not empty. One or more tables exist.")
+        s"Cannot drop a non-empty database: $dbName.")
       // the database directory was not removed
       assert(fs.exists(new Path(expectedDBLocation)))
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
According to [#cmt](https://github.com/apache/spark/pull/34819#discussion_r763629569), unify the error of v1, v2 and hive external catalog in DROP NAMESPACE tests.


### Why are the changes needed?
Currently, v1 and hive external catalog command throw `AnalysisException`, while v2 command throws `SparkException`. The error messages of v1 and hive catalog are also completely different from v2.
So this PR is for unifying those errors to `AnalysisException`. The error message will have one difference between v1/hive and v2: `Cannot drop a non-empty database: ...` vs `Cannot drop a non-empty namespace: ...`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
v1/v2 and Hive v1 DropNamespaceSuite:

```$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *DropNamespaceSuite"```
