### PR TITLE
[SPARK-37733][BUILD] Change log level of tests to WARN

### DIFF
--- a/common/kvstore/src/test/resources/log4j2.properties
+++ b/common/kvstore/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = debug
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/common/network-common/src/test/resources/log4j2.properties
+++ b/common/network-common/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = debug
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/common/network-shuffle/src/test/resources/log4j2.properties
+++ b/common/network-shuffle/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = debug
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/core/src/test/resources/log4j2.properties
+++ b/core/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File

--- a/external/avro/src/test/resources/log4j2.properties
+++ b/external/avro/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/external/docker-integration-tests/src/test/resources/log4j2.properties
+++ b/external/docker-integration-tests/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File

--- a/external/kafka-0-10-sql/src/test/resources/log4j2.properties
+++ b/external/kafka-0-10-sql/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/external/kafka-0-10-token-provider/src/test/resources/log4j2.properties
+++ b/external/kafka-0-10-token-provider/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/external/kafka-0-10/src/test/resources/log4j2.properties
+++ b/external/kafka-0-10/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/external/kinesis-asl/src/test/resources/log4j2.properties
+++ b/external/kinesis-asl/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/graphx/src/test/resources/log4j2.properties
+++ b/graphx/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/hadoop-cloud/src/test/resources/log4j2.properties
+++ b/hadoop-cloud/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File

--- a/launcher/src/test/resources/log4j2.properties
+++ b/launcher/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file core/target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = ${sys:test.appender:-File}
 
 appender.file.type = File

--- a/mllib/src/test/resources/log4j2.properties
+++ b/mllib/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/repl/src/test/resources/log4j2.properties
+++ b/repl/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = file
 
 appender.file.type = File

--- a/resource-managers/kubernetes/core/src/test/resources/log4j2.properties
+++ b/resource-managers/kubernetes/core/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/resource-managers/kubernetes/integration-tests/src/test/resources/log4j2.properties
+++ b/resource-managers/kubernetes/integration-tests/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/integration-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/resource-managers/mesos/src/test/resources/log4j2.properties
+++ b/resource-managers/mesos/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = debug
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/resource-managers/yarn/src/test/resources/log4j2.properties
+++ b/resource-managers/yarn/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = debug
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/sql/catalyst/src/test/resources/log4j2.properties
+++ b/sql/catalyst/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File

--- a/sql/core/src/test/resources/log4j2.properties
+++ b/sql/core/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file core/target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.file.ref = File
 

--- a/sql/hive-thriftserver/src/test/resources/log4j2.properties
+++ b/sql/hive-thriftserver/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file hive-thriftserver/target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.file.ref = File
 

--- a/sql/hive/src/test/resources/log4j2.properties
+++ b/sql/hive/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file core/target/unit-tests.log
-rootLogger.level = debug
+rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.file.ref = File
 

--- a/streaming/src/test/resources/log4j2.properties
+++ b/streaming/src/test/resources/log4j2.properties
@@ -16,7 +16,7 @@
 #
 
 # Set everything to be logged to the file target/unit-tests.log
-rootLogger.level = info
+rootLogger.level = warn
 rootLogger.appenderRef.file.ref = File
 
 appender.file.type = File


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change log level of tests to WARN

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
After https://github.com/apache/spark/pull/34895, the log level of tests becomes either "INFO" or "DEBUG", this increases the log output file to over 100MB!
E.g https://github.com/gengliangwang/spark/runs/4623214509?check_suite_focus=true

This makes it difficult to find the CI test failures. Changing the log level of tests to WARN should help.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It's just conf change.