### PR TITLE
[SPARK-37735][K8S] Add appId interface to KubernetesConf

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -43,6 +43,7 @@ private[spark] abstract class KubernetesConf(val sparkConf: SparkConf) {
   def secretNamesToMountPaths: Map[String, String]
   def volumes: Seq[KubernetesVolumeSpec]
   def schedulerName: String
+  def appId: String
 
   def appName: String = get("spark.app.name", "spark")
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -218,6 +218,14 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(driverConf.schedulerName === "driverScheduler")
   }
 
+  test("SPARK-36059: access appId in KubernetesConf") {
+    val sparkConf = new SparkConf(false)
+    val execConf = KubernetesTestConf.createExecutorConf(sparkConf)
+    val driverConf = KubernetesTestConf.createExecutorConf(sparkConf)
+    assert(driverConf.asInstanceOf[KubernetesConf].appId === KubernetesTestConf.APP_ID)
+    assert(execConf.asInstanceOf[KubernetesConf].appId === KubernetesTestConf.APP_ID)
+  }
+
   test("SPARK-36566: get app name label") {
     assert(KubernetesConf.getAppNameLabel(" Job+Spark-Pi 2021") === "job-spark-pi-2021")
     assert(KubernetesConf.getAppNameLabel("a" * 63) === "a" * 63)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -218,10 +218,10 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(driverConf.schedulerName === "driverScheduler")
   }
 
-  test("SPARK-36059: access appId in KubernetesConf") {
+  test("SPARK-37735: access appId in KubernetesConf") {
     val sparkConf = new SparkConf(false)
+    val driverConf = KubernetesTestConf.createDriverConf(sparkConf)
     val execConf = KubernetesTestConf.createExecutorConf(sparkConf)
-    val driverConf = KubernetesTestConf.createExecutorConf(sparkConf)
     assert(driverConf.asInstanceOf[KubernetesConf].appId === KubernetesTestConf.APP_ID)
     assert(execConf.asInstanceOf[KubernetesConf].appId === KubernetesTestConf.APP_ID)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `appId` interface to KubernetesConf

### Why are the changes needed?
The `appId` now can be only accessed in `KuberntesDriverConf` and `KubernetesExecutorConf`, but can't be accesssed in `KubernetesConf`.

Some user featurestep are using `KubernetesConf` as init constructor parameter in order to share the featurestep between driver and executor. One of cases is customized feature step (such as volcano, yunikorn) is using appId as job identification.

So, we'd better add appId to KubernetesConf to help such featurestep access appId.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
