### PR TITLE
[SPARK-37736][SQL]Comparison between string(great than Int.MaxValue) and int, cast string to long, rather than int

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1701,16 +1701,16 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
     val rule = TypeCoercion.PromoteStrings
     ruleTest(rule,
       GreaterThan(Literal("2147483648"), Literal(1)),
-      GreaterThan(Cast(Literal("2147483648"), LongType), Literal(1)))
+      GreaterThan(Cast(Literal("2147483648"), LongType), Cast(Literal(1), LongType)))
     ruleTest(rule,
       LessThan(Literal("2147483648"), Literal(1)),
-      LessThan(Cast(Literal("2147483648"), LongType), Literal(1)))
+      LessThan(Cast(Literal("2147483648"), LongType), Cast(Literal(1), LongType)))
     ruleTest(rule,
       GreaterThan(Literal(1), Literal("2147483648")),
-      GreaterThan(Literal(1), Cast(Literal("2147483648"), LongType)))
+      GreaterThan(Cast(Literal(1), LongType), Cast(Literal("2147483648"), LongType)))
     ruleTest(rule,
       LessThan(Literal(1), Literal("2147483648")),
-      LessThan(Literal(1), Cast(Literal("2147483648"), LongType)))
+      LessThan(Cast(Literal(1), LongType), Cast(Literal("2147483648"), LongType)))
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1696,6 +1696,22 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
       }
     }
   }
+
+  test("SPARK-37736: Comparison between string(great than Int.MaxValue) and int") {
+    val rule = TypeCoercion.PromoteStrings
+    ruleTest(rule,
+      GreaterThan(Literal("2147483648"), Literal(1)),
+      GreaterThan(Cast(Literal("2147483648"), LongType), Literal(1)))
+    ruleTest(rule,
+      LessThan(Literal("2147483648"), Literal(1)),
+      LessThan(Cast(Literal("2147483648"), LongType), Literal(1)))
+    ruleTest(rule,
+      GreaterThan(Literal(1), Literal("2147483648")),
+      GreaterThan(Literal(1), Cast(Literal("2147483648"), LongType)))
+    ruleTest(rule,
+      LessThan(Literal(1), Literal("2147483648")),
+      LessThan(Literal(1), Cast(Literal("2147483648"), LongType)))
+  }
 }
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Comparison between string(great than Int.MaxValue) and int, currently it return null,
but it should return true

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
it is a bug,
fix Comparison between string(great than Int.MaxValue) and int, currently it return null

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes,
before this pr:
```

>select '2147483648'>1;

NULL

```
after this pr:
```

>select '2147483648'>1;

true

```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new unit test
