### PR TITLE
[SPARK-37741][INFRA][DOCS] Remove Jenkins badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ and Structured Streaming for stream processing.
 <https://spark.apache.org/>
 
 [![GitHub Action Build](https://github.com/apache/spark/actions/workflows/build_and_test.yml/badge.svg?branch=master&event=push)](https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=branch%3Amaster+event%3Apush)
-[![Jenkins Build](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-3.2/badge/icon)](https://amplab.cs.berkeley.edu/jenkins/job/spark-master-test-sbt-hadoop-3.2)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
 [![PySpark Coverage](https://codecov.io/gh/apache/spark/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/spark)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Jenkins reached EOL, see https://mail-archives.apache.org/mod_mbox/spark-dev/202112.mbox/%3CCACdU-dTLuB--1GzAv6XfS-pCrcihhvDpUMrGe%3DfJXUYJpqiX9Q%40mail.gmail.com%3E.

This badge is not valid anymore.

### Why are the changes needed?

To remove an obsolete badge.

### Does this PR introduce _any_ user-facing change?

No, docs for dev only.

### How was this patch tested?

N/A
