### PR TITLE
[SPARK-37578][SQL] Update task metrics from ds v2 custom metrics

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/CustomTaskMetric.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/CustomTaskMetric.java
@@ -29,6 +29,10 @@ import org.apache.spark.sql.connector.read.PartitionReader;
  * The metrics will be gathered during query execution back to the driver and then combined. How
  * the task metrics are combined is defined by corresponding {@link CustomMetric} with same metric
  * name. The final result will be shown up in the data source scan operator in Spark UI.
+ * <p>
+ * There are a few special metric names: "bytesWritten" and "recordsWritten". If the data source
+ * defines custom metrics with the same names, the metric values will also be updated to
+ * corresponding task metrics.
  *
  * @since 3.2.0
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
@@ -17,12 +17,15 @@
 
 package org.apache.spark.sql.execution.metric
 
+import org.apache.spark.TaskContext
 import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 
 object CustomMetrics {
   private[spark] val V2_CUSTOM = "v2Custom"
 
   private[spark] val NUM_ROWS_PER_UPDATE = 100
+
+  private[spark] val builtInOutputMetrics = Set("bytesWritten", "recordsWritten")
 
   /**
    * Given a class name, builds and returns a metric type for a V2 custom metric class
@@ -52,7 +55,18 @@ object CustomMetrics {
       currentMetricsValues: Seq[CustomTaskMetric],
       customMetrics: Map[String, SQLMetric]): Unit = {
     currentMetricsValues.foreach { metric =>
-      customMetrics.get(metric.name()).map(_.set(metric.value()))
+      val metricName = metric.name()
+      val metricValue = metric.value()
+      customMetrics.get(metricName).map(_.set(metricValue))
+
+      if (builtInOutputMetrics.contains(metricName)) {
+        Option(TaskContext.get()).map(_.taskMetrics().outputMetrics).foreach { outputMetrics =>
+          metricName match {
+            case "bytesWritten" => outputMetrics.setBytesWritten(metricValue)
+            case "recordsWritten" => outputMetrics.setRecordsWritten(metricValue)
+          }
+        }
+      }
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
@@ -25,7 +25,7 @@ object CustomMetrics {
 
   private[spark] val NUM_ROWS_PER_UPDATE = 100
 
-  private[spark] val builtInOutputMetrics = Set("bytesWritten", "recordsWritten")
+  private[spark] val BUILTIN_OUTPUT_METRICS = Set("bytesWritten", "recordsWritten")
 
   /**
    * Given a class name, builds and returns a metric type for a V2 custom metric class
@@ -59,11 +59,12 @@ object CustomMetrics {
       val metricValue = metric.value()
       customMetrics.get(metricName).map(_.set(metricValue))
 
-      if (builtInOutputMetrics.contains(metricName)) {
+      if (BUILTIN_OUTPUT_METRICS.contains(metricName)) {
         Option(TaskContext.get()).map(_.taskMetrics().outputMetrics).foreach { outputMetrics =>
           metricName match {
             case "bytesWritten" => outputMetrics.setBytesWritten(metricValue)
             case "recordsWritten" => outputMetrics.setRecordsWritten(metricValue)
+            case _ => // no-op
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.ui
 
 import java.util.Properties
 
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -900,6 +900,46 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
       assert(innerMetric.isDefined)
     }
   }
+
+  test("SPARK-37578: Update output metrics from Datasource v2") {
+    withTempDir { dir =>
+      val statusStore = spark.sharedState.statusStore
+      val oldCount = statusStore.executionsList().size
+
+      val bytesWritten = new ArrayBuffer[Long]()
+      val recordsWritten = new ArrayBuffer[Long]()
+
+      val bytesWrittenListener = new SparkListener() {
+        override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+          bytesWritten += taskEnd.taskMetrics.outputMetrics.bytesWritten
+          recordsWritten += taskEnd.taskMetrics.outputMetrics.recordsWritten
+        }
+      }
+      spark.sparkContext.addSparkListener(bytesWrittenListener)
+
+      try {
+        val cls = classOf[CustomMetricsDataSource].getName
+        spark.range(0, 10, 1, 2).select('id as 'i, -'id as 'j).write.format(cls)
+          .option("path", dir.getCanonicalPath).mode("append").save()
+
+        // Wait until the new execution is started and being tracked.
+        eventually(timeout(10.seconds), interval(10.milliseconds)) {
+          assert(statusStore.executionsCount() >= oldCount)
+        }
+
+        // Wait for listener to finish computing the metrics for the execution.
+        eventually(timeout(10.seconds), interval(10.milliseconds)) {
+          assert(statusStore.executionsList().nonEmpty &&
+            statusStore.executionsList().last.metricValues != null)
+        }
+
+        assert(bytesWritten.sum == 246)
+        assert(recordsWritten.sum == 20)
+      } finally {
+        spark.sparkContext.removeSparkListener(bytesWrittenListener)
+      }
+    }
+  }
 }
 
 
@@ -993,6 +1033,22 @@ class SimpleCustomMetric extends CustomMetric {
   }
 }
 
+class BytesWrittenCustomMetric extends CustomMetric {
+  override def name(): String = "bytesWritten"
+  override def description(): String = "bytesWritten metric"
+  override def aggregateTaskMetrics(taskMetrics: Array[Long]): String = {
+    s"bytesWritten: ${taskMetrics.mkString(", ")}"
+  }
+}
+
+class RecordsWrittenCustomMetric extends CustomMetric {
+  override def name(): String = "recordsWritten"
+  override def description(): String = "recordsWritten metric"
+  override def aggregateTaskMetrics(taskMetrics: Array[Long]): String = {
+    s"recordsWritten: ${taskMetrics.mkString(", ")}"
+  }
+}
+
 // The followings are for custom metrics of V2 data source.
 object CustomMetricReaderFactory extends PartitionReaderFactory {
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
@@ -1046,7 +1102,15 @@ class CustomMetricsCSVDataWriter(fs: FileSystem, file: Path) extends CSVDataWrit
       override def name(): String = "inner_metric"
       override def value(): Long = 54321;
     }
-    Array(metric, innerMetric)
+    val bytesWrittenMetric = new CustomTaskMetric {
+      override def name(): String = "bytesWritten"
+      override def value(): Long = 123;
+    }
+    val recordsWrittenMetric = new CustomTaskMetric {
+      override def name(): String = "recordsWritten"
+      override def value(): Long = 10;
+    }
+    Array(metric, innerMetric, bytesWrittenMetric, recordsWrittenMetric)
   }
 }
 
@@ -1088,7 +1152,8 @@ class CustomMetricsDataSource extends SimpleWritableDataSource {
         }
 
         override def supportedCustomMetrics(): Array[CustomMetric] = {
-          Array(new SimpleCustomMetric, new Outer.InnerCustomMetric)
+          Array(new SimpleCustomMetric, new Outer.InnerCustomMetric,
+            new BytesWrittenCustomMetric, new RecordsWrittenCustomMetric)
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -904,7 +904,7 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
   test("SPARK-37578: Update output metrics from Datasource v2") {
     withTempDir { dir =>
       val statusStore = spark.sharedState.statusStore
-      val oldCount = statusStore.executionsList().size
+      val oldCount = statusStore.executionsCount()
 
       val bytesWritten = new ArrayBuffer[Long]()
       val recordsWritten = new ArrayBuffer[Long]()
@@ -924,7 +924,7 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
 
         // Wait until the new execution is started and being tracked.
         eventually(timeout(10.seconds), interval(10.milliseconds)) {
-          assert(statusStore.executionsCount() >= oldCount)
+          assert(statusStore.executionsCount() > oldCount)
         }
 
         // Wait for listener to finish computing the metrics for the execution.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch proposes to update task metrics from datasource v2 custom metrics.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We have updated task metrics such as `bytesWritten` and `recordsWritten` from built-in data source v2 format e.g. Parquet. For other data source v2 formats, we can define some builtin metric names so Spark can also recognize them and update task metrics.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Some special DS v2 custom metrics are updated to task metrics.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added unit test.
