### PR TITLE
[SPARK-34544][PYTHON][FOLLOW-UP] Add pandas-stubs in dev/requirement.txt

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -21,6 +21,7 @@ coverage
 mypy
 git+https://github.com/typeddjango/pytest-mypy-plugins.git@b0020061f48e85743ee3335bd62a3a608d17c6bd
 flake8==3.9.0
+pandas-stubs
 
 # Documentation (SQL)
 mkdocs


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup of https://github.com/apache/spark/pull/34927 that adds `pandas-stubs` dependency into `dev/requirements.txt`.

### Why are the changes needed?

For easier development setup.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested as below:

```bash
pip install -r dev/requirements.txt
```