### PR TITLE
[SPARK-37754][PYTHON] Fix black version in dev/reformat-python

### DIFF
--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -25,6 +25,9 @@ testpaths = [
 ]
 
 [tool.black]
+# When changing the version, we have to update
+# GitHub workflow version and dev/reformat-python
+required-version = "21.12b0"
 line-length = 100
 target-version = ['py37']
 include = '\.pyi?$'

--- a/dev/reformat-python
+++ b/dev/reformat-python
@@ -21,7 +21,7 @@ FWDIR="$( cd "$DIR"/.. && pwd )"
 cd "$FWDIR"
 
 BLACK_BUILD="python -m black"
-BLACK_VERSION="21.5b2"
+BLACK_VERSION="21.12b0"
 $BLACK_BUILD 2> /dev/null
 if [ $? -ne 0 ]; then
     echo "The '$BLACK_BUILD' command was not found. Please install Black, for example, via 'pip install black==$BLACK_VERSION'."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make version of `black` in `reformat-python` be consistent to `build_and_test.yml`

related to #35021


### Why are the changes needed?

If we install the old version of black recommended by `reformat-python`, it produces style error happening on `python/pyspark/shuffle.py`


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

This patch only changes the error message