### PR TITLE
[SPARK-37760][BUILD] Upgrade SBT to 1.6.0

### DIFF
--- a/dev/appveyor-install-dependencies.ps1
+++ b/dev/appveyor-install-dependencies.ps1
@@ -97,7 +97,7 @@ if (!(Test-Path $tools)) {
 # ========================== SBT
 Push-Location $tools
 
-$sbtVer = "1.5.8"
+$sbtVer = "1.6.0"
 Start-FileDownload "https://github.com/sbt/sbt/releases/download/v$sbtVer/sbt-$sbtVer.zip" "sbt.zip"
 
 # extract

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 # Please update the version in appveyor-install-dependencies.ps1 together.
-sbt.version=1.5.8
+sbt.version=1.6.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade SBT to 1.6.0 for better Java 17 compatibility.

### Why are the changes needed?

SBT 1.6.0 has many improvements. (https://github.com/sbt/sbt/releases/tag/v1.6.0)
- Java 17
  > The Scala version used to compile build.sbt is updated to Scala 2.12.15, which improves the compatibility with JDK 17+.

  > sbt.TrapExit is dropped due to Security Manager being deprecated in JDK 17. Calling sys.exit in run or test would shutdown the sbt session. Use forking to prevent it 
- Java 11
  > Fixes over-compilation of extended classes on JDK 11 
### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.