### PR TITLE
[SPARK-37756][PYTHON] Enable matplotlib test for pandas API on Spark

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -219,7 +219,7 @@ jobs:
     - name: Install Python packages (Python 3.8)
       if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
       run: |
-        python3.8 -m pip install 'numpy>=1.20.0' 'pyarrow<5.0.0' pandas scipy xmlrunner
+        python3.8 -m pip install 'numpy>=1.20.0' 'pyarrow<5.0.0' pandas scipy xmlrunner matplotlib
         python3.8 -m pip list
     # Run the tests.
     - name: Run tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -219,7 +219,7 @@ jobs:
     - name: Install Python packages (Python 3.8)
       if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
       run: |
-        python3.8 -m pip install 'numpy>=1.20.0' 'pyarrow<5.0.0' pandas scipy xmlrunner matplotlib
+        python3.8 -m pip install 'numpy>=1.20.0' 'pyarrow<5.0.0' pandas scipy xmlrunner
         python3.8 -m pip list
     # Run the tests.
     - name: Run tests
@@ -330,6 +330,9 @@ jobs:
         # TODO(SPARK-36361): Install coverage in Python 3.9 and PyPy 3 in the base image
         python3.9 -m pip install coverage
         pypy3 -m pip install coverage
+        # TODO(SPARK-37761): Install matplotlib in Python 3.9 and PyPy 3 in the base image
+        python3.9 -m pip install matplotlib
+        pypy3 -m pip install matplotlib
         export PATH=$PATH:$HOME/miniconda/bin
         ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
     - name: Upload coverage to Codecov


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to install `matplotlib` for Python 3.9 in our base image, to enable `matplotlib` test for pandas API on Spark.

**Before**

```
Finished test(python3.9): pyspark.pandas.tests.plot.test_series_plot_matplotlib (0s) ... 14 tests were skipped
```

**After**

```
Finished test(python3.9): pyspark.pandas.tests.plot.test_series_plot_matplotlib (56s)
```

### Why are the changes needed?

Currently, some tests are skipped due to lack of `matplotlib` installed as below:

<img width="654" alt="Screen Shot 2021-12-28 at 12 16 48 PM" src="https://user-images.githubusercontent.com/44108233/147524255-e9abed91-f615-44b3-a260-3003a454867b.png">

So, we'd better to enable this to improve the test coverage.

### Does this PR introduce _any_ user-facing change?

No, it's test only.


### How was this patch tested?

The existing tests are should be passed.
