### PR TITLE
[SPARK-36361][SPARK-37761][INFRA] Update GitHub Action image to 20211228

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -254,7 +254,7 @@ jobs:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20211116
+      image: dongjoon/apache-spark-github-action-image:20211228
     strategy:
       fail-fast: false
       matrix:
@@ -327,12 +327,6 @@ jobs:
     - name: Run tests
       env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
       run: |
-        # TODO(SPARK-36361): Install coverage in Python 3.9 and PyPy 3 in the base image
-        python3.9 -m pip install coverage
-        pypy3 -m pip install coverage
-        # TODO(SPARK-37761): Install matplotlib in Python 3.9 and PyPy 3 in the base image
-        python3.9 -m pip install matplotlib
-        pypy3 -m pip install matplotlib
         export PATH=$PATH:$HOME/miniconda/bin
         ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
     - name: Upload coverage to Codecov
@@ -363,7 +357,7 @@ jobs:
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20211116
+      image: dongjoon/apache-spark-github-action-image:20211228
     env:
       HADOOP_PROFILE: ${{ needs.configure-jobs.outputs.hadoop }}
       HIVE_PROFILE: hive2.3
@@ -434,7 +428,7 @@ jobs:
       PYSPARK_DRIVER_PYTHON: python3.9
       PYSPARK_PYTHON: python3.9
     container:
-      image: dongjoon/apache-spark-github-action-image:20211116
+      image: dongjoon/apache-spark-github-action-image:20211228
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `GitHub Action` image to 20211228.

### Why are the changes needed?

This has `coverage` and `matplotlib` library. The following is the full diff from the previous images. Please note that I didn't rebuilt the Docker image from the scratch because it fails with some reasons. This image is built based on the previous 20211116 and installed `coverage` and `matplotlib` with their transitive dependencies.

**Python3.9**
- coverage==6.2
- cycler==0.11.0
- fonttools==4.28.5
- kiwisolver==1.3.2
- matplotlib==3.5.1
- Pillow==8.4.0

**PyPy3**
- coverage==6.2
- cycler==0.11.0
- fonttools==4.28.5
- kiwisolver==1.3.2
- matplotlib==3.5.1
- packaging==21.3
- Pillow==8.4.0
- pyparsing==3.0.6

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the GitHub Action Jobs.