### PR TITLE
[SPARK-37175][SQL] Performance improvement to hash joins with many duplicate keys

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1141,7 +1141,8 @@ object TestSettings {
     (Test / javaOptions) += "-ea",
     (Test / javaOptions) ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")
-      val extraTestJavaArgs = Array("-XX:+IgnoreUnrecognizedVMOptions",
+      val heapSpaceSize = sys.env.get("HEAPSPACE_SIZE").getOrElse("4g")
+      val extraTestJavaArgs = Seq("-XX:+IgnoreUnrecognizedVMOptions",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
@@ -1154,13 +1155,14 @@ object TestSettings {
         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-        "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED").mkString(" ")
-      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m $extraTestJavaArgs"
-        .split(" ").toSeq
+        "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED")
+      Seq(s"-Xmx$heapSpaceSize", "-Xss4m", s"-XX:MaxMetaspaceSize=$metaspaceSize",
+      "-XX:ReservedCodeCacheSize=128m") ++ extraTestJavaArgs
     },
     javaOptions ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")
-      s"-Xmx4g -XX:MaxMetaspaceSize=$metaspaceSize".split(" ").toSeq
+      val heapSpaceSize = sys.env.get("HEAPSPACE_SIZE").getOrElse("4g")
+      Seq(s"-Xmx$heapSpaceSize", s"-XX:MaxMetaspaceSize=$metaspaceSize")
     },
     (Test / javaOptions) ++= {
       val jdwpEnabled = sys.props.getOrElse("test.jdwp.enabled", "false").toBoolean

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1160,7 +1160,7 @@ object TestSettings {
     },
     javaOptions ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")
-      s"-Xmx4g -XX:MaxMetaspaceSize=$metaspaceSize".split(" ").toSeq
+      s"-Xmx12g -XX:MaxMetaspaceSize=$metaspaceSize".split(" ").toSeq
     },
     (Test / javaOptions) ++= {
       val jdwpEnabled = sys.props.getOrElse("test.jdwp.enabled", "false").toBoolean

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1160,7 +1160,7 @@ object TestSettings {
     },
     javaOptions ++= {
       val metaspaceSize = sys.env.get("METASPACE_SIZE").getOrElse("1300m")
-      s"-Xmx12g -XX:MaxMetaspaceSize=$metaspaceSize".split(" ").toSeq
+      s"-Xmx4g -XX:MaxMetaspaceSize=$metaspaceSize".split(" ").toSeq
     },
     (Test / javaOptions) ++= {
       val jdwpEnabled = sys.props.getOrElse("test.jdwp.enabled", "false").toBoolean

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3387,7 +3387,7 @@ object SQLConf {
       "spatial locality. This provides a performance boost while iterating over the rows for a " +
       "given key due to increased cache hits")
     .version("3.3.0")
-    .intConf
+    .doubleConf
     .checkValue(_ > 1, "The value must be greater than 1.")
     .createOptional
 
@@ -3882,7 +3882,7 @@ class SQLConf extends Serializable with Logging {
   def broadcastHashJoinOutputPartitioningExpandLimit: Int =
     getConf(BROADCAST_HASH_JOIN_OUTPUT_PARTITIONING_EXPAND_LIMIT)
 
-  def hashedRelationReorderFactor: Option[Int] = getConf(HASHED_RELATION_REORDER_FACTOR)
+  def hashedRelationReorderFactor: Option[Double] = getConf(HASHED_RELATION_REORDER_FACTOR)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3380,6 +3380,17 @@ object SQLConf {
       .checkValue(_ >= 0, "The value must be non-negative.")
       .createWithDefault(8)
 
+  val HASHED_RELATION_REORDER_FACTOR = buildConf("spark.sql.hashedRelationReorderFactor")
+    .doc("The HashedRelation will be reordered if the number of unique keys times this factor is " +
+      "less than equal to the total number of keys in the HashedRelation. " +
+      "The reordering places all rows with the same key adjacent to each other to improve " +
+      "spatial locality. This provides a performance boost while iterating over the rows for a " +
+      "given key due to increased cache hits")
+    .version("3.3.0")
+    .intConf
+    .checkValue(_ > 1, "The value must be greater than 1.")
+    .createOptional
+
   val OPTIMIZE_NULL_AWARE_ANTI_JOIN =
     buildConf("spark.sql.optimizeNullAwareAntiJoin")
       .internal()
@@ -3870,6 +3881,8 @@ class SQLConf extends Serializable with Logging {
 
   def broadcastHashJoinOutputPartitioningExpandLimit: Int =
     getConf(BROADCAST_HASH_JOIN_OUTPUT_PARTITIONING_EXPAND_LIMIT)
+
+  def hashedRelationReorderFactor: Option[Int] = getConf(HASHED_RELATION_REORDER_FACTOR)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3382,7 +3382,7 @@ object SQLConf {
 
   val HASHED_RELATION_REORDER_FACTOR = buildConf("spark.sql.hashedRelationReorderFactor")
     .doc("The HashedRelation will be reordered if the number of unique keys times this factor is " +
-      "less than equal to the total number of keys in the HashedRelation. " +
+      "less than equal to the total number of rows in the HashedRelation. " +
       "The reordering places all rows with the same key adjacent to each other to improve " +
       "spatial locality. This provides a performance boost while iterating over the rows for a " +
       "given key due to increased cache hits")

--- a/sql/core/benchmarks/HashedRelationDataLocalityBenchmark-results.txt
+++ b/sql/core/benchmarks/HashedRelationDataLocalityBenchmark-results.txt
@@ -1,0 +1,40 @@
+================================================================================================
+LongHashedRelation MicroBenchmark
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+LongHashedRelation - duplicationMultiplier: 1:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 100000, Unique rows: 100000             36             38           1          2.8         357.2       1.0X
+Reorder map: true, Total rows: 100000, Unique rows: 100000              66             67           1          1.5         658.2       0.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+LongHashedRelation - duplicationMultiplier: 5:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 100000, Unique rows: 20000            107            111           5          0.9        1066.0       1.0X
+Reorder map: true, Total rows: 100000, Unique rows: 20000              89             90           1          1.1         888.8       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+LongHashedRelation - duplicationMultiplier: 8:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 100000, Unique rows: 12500            124            126           1          0.8        1243.2       1.0X
+Reorder map: true, Total rows: 100000, Unique rows: 12500             105            110           4          1.0        1049.0       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+LongHashedRelation - duplicationMultiplier: 10:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 100000, Unique rows: 10000            152            153           1          0.7        1515.9       1.0X
+Reorder map: true, Total rows: 100000, Unique rows: 10000             122            144          23          0.8        1216.1       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+LongHashedRelation - duplicationMultiplier: 20:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 100000, Unique rows: 5000            273            283          17          0.4        2726.5       1.0X
+Reorder map: true, Total rows: 100000, Unique rows: 5000             184            186           2          0.5        1839.1       1.5X
+
+

--- a/sql/core/benchmarks/HashedRelationDataLocalityBenchmark-results.txt
+++ b/sql/core/benchmarks/HashedRelationDataLocalityBenchmark-results.txt
@@ -2,39 +2,93 @@
 LongHashedRelation MicroBenchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-LongHashedRelation - duplicationMultiplier: 1:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+LongHashedRelation - duplicationMultiplier: 1:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 1000000            462            499          25          2.2         461.6       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 1000000             795            824          48          1.3         794.8       0.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+LongHashedRelation - duplicationMultiplier: 5:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 200000           1190           1196           8          0.8        1190.2       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 200000            1342           1442         203          0.7        1341.8       0.9X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+LongHashedRelation - duplicationMultiplier: 8:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 125000           1614           1678          85          0.6        1614.4       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 125000            1575           1621          64          0.6        1574.7       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+LongHashedRelation - duplicationMultiplier: 10:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 100000           1950           1962          17          0.5        1949.6       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 100000            1789           1828          62          0.6        1788.9       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+LongHashedRelation - duplicationMultiplier: 20:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-Reorder map: false, Total rows: 100000, Unique rows: 100000             36             38           1          2.8         357.2       1.0X
-Reorder map: true, Total rows: 100000, Unique rows: 100000              66             67           1          1.5         658.2       0.5X
+Reorder map: false, Total rows: 1000000, Unique rows: 50000           3538           3543           4          0.3        3538.3       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 50000            2258           2311          55          0.4        2257.6       1.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-LongHashedRelation - duplicationMultiplier: 5:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+LongHashedRelation - duplicationMultiplier: 500:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Reorder map: false, Total rows: 100000, Unique rows: 20000            107            111           5          0.9        1066.0       1.0X
-Reorder map: true, Total rows: 100000, Unique rows: 20000              89             90           1          1.1         888.8       1.2X
+Reorder map: false, Total rows: 1000000, Unique rows: 2000          79270          79302          43          0.0       79270.5       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 2000           36286          36303          19          0.0       36286.3       2.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-LongHashedRelation - duplicationMultiplier: 8:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+
+================================================================================================
+UnsafeHashedRelation MicroBenchmark
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+UnsafeHashedRelation - duplicationMultiplier: 1:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 1000000            593            597           4          1.7         593.5       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 1000000            1764           1994         159          0.6        1763.7       0.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+UnsafeHashedRelation - duplicationMultiplier: 5:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 200000           2005           2009           3          0.5        2005.1       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 200000            2474           2479           4          0.4        2474.3       0.8X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+UnsafeHashedRelation - duplicationMultiplier: 8:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 125000           3066           3271         200          0.3        3066.5       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 125000            2966           2972           7          0.3        2965.9       1.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+UnsafeHashedRelation - duplicationMultiplier: 10:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 100000           3627           3635           6          0.3        3627.4       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 100000            3408           3413           4          0.3        3408.1       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+UnsafeHashedRelation - duplicationMultiplier: 20:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------------------------
+Reorder map: false, Total rows: 1000000, Unique rows: 50000           6251           6259           7          0.2        6251.0       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 50000            4124           4137           9          0.2        4124.4       1.5X
+
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 3.10.0-1127.el7.x86_64
+Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz
+UnsafeHashedRelation - duplicationMultiplier: 500:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Reorder map: false, Total rows: 100000, Unique rows: 12500            124            126           1          0.8        1243.2       1.0X
-Reorder map: true, Total rows: 100000, Unique rows: 12500             105            110           4          1.0        1049.0       1.2X
-
-OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-LongHashedRelation - duplicationMultiplier: 10:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------
-Reorder map: false, Total rows: 100000, Unique rows: 10000            152            153           1          0.7        1515.9       1.0X
-Reorder map: true, Total rows: 100000, Unique rows: 10000             122            144          23          0.8        1216.1       1.2X
-
-OpenJDK 64-Bit Server VM 1.8.0_312-bre_2021_10_20_23_15-b00 on Mac OS X 12.1
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-LongHashedRelation - duplicationMultiplier: 20:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------------
-Reorder map: false, Total rows: 100000, Unique rows: 5000            273            283          17          0.4        2726.5       1.0X
-Reorder map: true, Total rows: 100000, Unique rows: 5000             184            186           2          0.5        1839.1       1.5X
+Reorder map: false, Total rows: 1000000, Unique rows: 2000         140165         140249         127          0.0      140164.8       1.0X
+Reorder map: true, Total rows: 1000000, Unique rows: 2000           46297          47223        1023          0.0       46297.4       3.0X
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -459,7 +459,7 @@ private[joins] object UnsafeHashedRelation extends Logging {
       isNullAware: Boolean = false,
       allowsNullKey: Boolean = false,
       ignoresDuplicatedKey: Boolean = false,
-      reorderFactor: Option[Int] = None): HashedRelation = {
+      reorderFactor: Option[Int]): HashedRelation = {
     require(!(isNullAware && allowsNullKey),
       "isNullAware and allowsNullKey cannot be enabled at same time")
 
@@ -1096,7 +1096,7 @@ private[joins] object LongHashedRelation extends Logging {
       sizeEstimate: Int,
       taskMemoryManager: TaskMemoryManager,
       isNullAware: Boolean = false,
-      reorderFactor: Option[Int] = None): HashedRelation = {
+      reorderFactor: Option[Int]): HashedRelation = {
 
     val map = new LongToUnsafeRowMap(taskMemoryManager, sizeEstimate)
     val keyGenerator = UnsafeProjection.create(key)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -497,9 +497,7 @@ private[joins] object UnsafeHashedRelation {
     // that ensuring such placement of the nodes improves performance
     val candidate = new UnsafeHashedRelation(key.size, numFields, binaryMap)
     if (binaryMap.numValues() > binaryMap.numKeys() * 2) {
-     val keys = candidate.valuesWithKeyIndex().map(_.getValue)
-        .map(keyGenerator).map(_.copy()).toArray
-      // val keys = candidate.keys().map(keyGenerator).map(_.copy()).toArray
+     val keys = candidate.keys.map(_.copy()).toArray
       val distinctKeys = keys.distinct
       scala.Console.err.print(s"Number of keys is ${keys.length}; distinct keys is " +
         s"${distinctKeys.length} key schema ${key}\n")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -510,6 +510,8 @@ private[joins] object UnsafeHashedRelation extends Logging {
         // Only 70% of the slots can be used before growing, more capacity help to reduce collision
         (binaryMap.numKeys() * 1.5 + 1).toInt,
         pageSizeBytes)
+      // candidate.keys() returns all keys and not just distinct keys thus distinct operation is
+      // applied to find unique keys
       candidate.keys().map(_.copy()).toArray.distinct.foreach { key =>
         val rowIter = candidate.get(key)
         while (rowIter.hasNext) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HashedRelationMetricsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HashedRelationMetricsBenchmark.scala
@@ -39,47 +39,74 @@ import org.apache.spark.sql.types.LongType
  */
 object HashedRelationMetricsBenchmark extends SqlBasedBenchmark {
 
-  def benchmarkLongToUnsafeRowMapMetrics(numRows: Int): Unit = {
-    runBenchmark("LongToUnsafeRowMap metrics") {
-      val benchmark = new Benchmark("LongToUnsafeRowMap metrics", numRows, output = output)
-      benchmark.addCase("LongToUnsafeRowMap") { iter =>
-        val taskMemoryManager = new TaskMemoryManager(
-          new UnifiedMemoryManager(
-            new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
-            Long.MaxValue,
-            Long.MaxValue / 2,
-            1),
-          0)
-        val unsafeProj = UnsafeProjection.create(Seq(BoundReference(0, LongType, false)))
+  private def helper(numRows: Long, offHeapEnabled: Boolean, duplicationFactor: Int,
+    cacheLocality: Boolean): Unit = {
+    val taskMemoryManager = new TaskMemoryManager(
+      new UnifiedMemoryManager(
+        new SparkConf().set(MEMORY_OFFHEAP_ENABLED, offHeapEnabled),
+        Long.MaxValue,
+        Long.MaxValue / 2,
+        1),
+      0)
+    val unsafeProj = UnsafeProjection.create(Seq(BoundReference(0, LongType, false)))
 
-        val keys = Range.Long(0, numRows, 1)
-        val map = new LongToUnsafeRowMap(taskMemoryManager, 1)
+    val keys = Range.Long(0, numRows, 1)
+    val map = new LongToUnsafeRowMap(taskMemoryManager, 1)
+    if (cacheLocality) {
+      keys.foreach { k =>
+        (0 until duplicationFactor).foreach { _ =>
+          map.append(k, unsafeProj(InternalRow(k)))
+        }
+      }
+    } else {
+      (0 until duplicationFactor).foreach { _ =>
         keys.foreach { k =>
           map.append(k, unsafeProj(InternalRow(k)))
         }
-        map.optimize()
+      }
+    }
+    map.optimize()
 
-        val threads = (0 to 100).map { _ =>
-          val thread = new Thread {
-            override def run: Unit = {
-              val row = unsafeProj(InternalRow(0L)).copy()
-              keys.foreach { k =>
-                assert(map.getValue(k, row) eq row)
-                assert(row.getLong(0) == k)
-              }
+    val threads = (0 to 100).map { _ =>
+      val thread = new Thread {
+        override def run: Unit = {
+          val row = unsafeProj(InternalRow(0L)).copy()
+          keys.foreach { k =>
+            assert(map.getValue(k, row) eq row)
+            assert(row.getLong(0) == k)
+          }
+        }
+      }
+      thread.start()
+      thread
+    }
+    threads.foreach(_.join())
+    map.free()
+  }
+
+  def benchmarkLongToUnsafeRowMapMetrics(numRows: Int): Unit = {
+    import scala.concurrent.duration._
+
+    runBenchmark("LongToUnsafeRowMap metrics") {
+      val benchmark = new Benchmark(s"LongToUnsafeRowMap metrics - numRows: $numRows", numRows,
+        minNumIters = 20, minTime = 20.seconds,
+        output = output)
+      Seq(false).foreach { offHeapEnabled =>
+        Seq(1, 16, 64, 256, 1024).foreach { keyDuplicationFactor =>
+          Seq(false, true).foreach { cacheLocality =>
+            benchmark.addCase(s"LongToUnsafeRowMap - offHeadEnabled: $offHeapEnabled, " +
+              s"keyDuplicationFactor: $keyDuplicationFactor, cacheLocality: $cacheLocality") { _ =>
+              helper(numRows, offHeapEnabled, keyDuplicationFactor, cacheLocality)
             }
           }
-          thread.start()
-          thread
         }
-        threads.foreach(_.join())
-        map.free()
       }
       benchmark.run()
     }
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    benchmarkLongToUnsafeRowMapMetrics(500000)
+    benchmarkLongToUnsafeRowMapMetrics(1000000)
+    benchmarkLongToUnsafeRowMapMetrics(2000000)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HashedRelationMetricsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/HashedRelationMetricsBenchmark.scala
@@ -22,7 +22,7 @@ import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.internal.config.MEMORY_OFFHEAP_ENABLED
 import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{BoundReference, UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, UnsafeProjection}
 import org.apache.spark.sql.execution.joins.LongToUnsafeRowMap
 import org.apache.spark.sql.types.LongType
 
@@ -39,82 +39,47 @@ import org.apache.spark.sql.types.LongType
  */
 object HashedRelationMetricsBenchmark extends SqlBasedBenchmark {
 
-  private def helper(numRows: Long, offHeapEnabled: Boolean, duplicationFactor: Int,
-    cacheLocality: Boolean): Unit = {
-    val taskMemoryManager = new TaskMemoryManager(
-      new UnifiedMemoryManager(
-        new SparkConf().set(MEMORY_OFFHEAP_ENABLED, offHeapEnabled),
-        Long.MaxValue,
-        Long.MaxValue / 2,
-        1),
-      0)
-    val unsafeProj = UnsafeProjection.create(Seq(BoundReference(0, LongType, false)))
-
-    val keys = Range.Long(0, numRows / duplicationFactor, 1)
-    val map = new LongToUnsafeRowMap(taskMemoryManager, numRows.toInt)
-
-    (0 until duplicationFactor).foreach { _ =>
-      keys.foreach { k =>
-        map.append(k, unsafeProj(InternalRow(k)))
-      }
-    }
-
-    val mapToQuery = if (cacheLocality) {
-      val compactMap = new LongToUnsafeRowMap(taskMemoryManager, numRows.toInt)
-      val stagingResultRow = new UnsafeRow(1)
-      map.keys().foreach { keyRow =>
-        val key = keyRow.getLong(0)
-        map.get(key, stagingResultRow).foreach { value =>
-          compactMap.append(key, value)
-        }
-      }
-      map.free()
-      compactMap
-    } else {
-      map
-    }
-    mapToQuery.optimize()
-
-    val threads = (0 to 7).map { _ =>
-      val thread = new Thread {
-        override def run: Unit = {
-          val row = unsafeProj(InternalRow(0L)).copy()
-          keys.foreach { k =>
-            mapToQuery.get(k, row).foreach { row =>
-              assert(row eq row)
-              assert(row.getLong(0) == k)
-            }
-          }
-        }
-      }
-      thread.start()
-      thread
-    }
-    threads.foreach(_.join())
-    mapToQuery.free()
-  }
-
   def benchmarkLongToUnsafeRowMapMetrics(numRows: Int): Unit = {
-    import scala.concurrent.duration._
-
     runBenchmark("LongToUnsafeRowMap metrics") {
-      Seq(false).foreach { offHeapEnabled =>
-        Seq(1000, 100000, 500000, 1000000, 2000000).foreach { keyDuplicationFactor =>
-          val benchmark = new Benchmark(s"LongToUnsafeRowMap metrics", numRows,
-            minNumIters = 20, minTime = 20.seconds, output = output)
-          Seq(false, true).foreach { cacheLocality =>
-            benchmark.addCase(s"LongToUnsafeRowMap - offHeadEnabled: $offHeapEnabled, " +
-              s"keyDuplicationFactor: $keyDuplicationFactor, cacheLocality: $cacheLocality") { _ =>
-              helper(numRows, offHeapEnabled, keyDuplicationFactor, cacheLocality)
+      val benchmark = new Benchmark("LongToUnsafeRowMap metrics", numRows, output = output)
+      benchmark.addCase("LongToUnsafeRowMap") { iter =>
+        val taskMemoryManager = new TaskMemoryManager(
+          new UnifiedMemoryManager(
+            new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),
+            Long.MaxValue,
+            Long.MaxValue / 2,
+            1),
+          0)
+        val unsafeProj = UnsafeProjection.create(Seq(BoundReference(0, LongType, false)))
+
+        val keys = Range.Long(0, numRows, 1)
+        val map = new LongToUnsafeRowMap(taskMemoryManager, 1)
+        keys.foreach { k =>
+          map.append(k, unsafeProj(InternalRow(k)))
+        }
+        map.optimize()
+
+        val threads = (0 to 100).map { _ =>
+          val thread = new Thread {
+            override def run: Unit = {
+              val row = unsafeProj(InternalRow(0L)).copy()
+              keys.foreach { k =>
+                assert(map.getValue(k, row) eq row)
+                assert(row.getLong(0) == k)
+              }
             }
           }
-          benchmark.run()
+          thread.start()
+          thread
         }
+        threads.foreach(_.join())
+        map.free()
       }
+      benchmark.run()
     }
   }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    benchmarkLongToUnsafeRowMapMetrics(80000000)
+    benchmarkLongToUnsafeRowMapMetrics(500000)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -36,9 +36,9 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.collection.CompactBuffer
 
-abstract class AbstractHashedRelationSuite extends SharedSparkSession {
+abstract class BaseHashedRelationSuite extends SharedSparkSession {
 
-  def mapReorderFactor: Option[Int]
+  def mapReorderFactor: Option[Double]
 
   val mm = new TaskMemoryManager(
     new UnifiedMemoryManager(
@@ -728,12 +728,12 @@ abstract class AbstractHashedRelationSuite extends SharedSparkSession {
   }
 }
 
-class HashedRelationWithReorderingSuite extends AbstractHashedRelationSuite {
-  override def mapReorderFactor: Option[Int] = Some(1)
+class HashedRelationWithReorderingSuite extends BaseHashedRelationSuite {
+  override def mapReorderFactor: Option[Double] = Some(1)
 
   // TOOD: add more tests
 }
 
-class HashedRelationWithoutReorderingSuite extends AbstractHashedRelationSuite {
-  override def mapReorderFactor: Option[Int] = None
+class HashedRelationWithoutReorderingSuite extends BaseHashedRelationSuite {
+  override def mapReorderFactor: Option[Double] = None
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/HashedRelationSuite.scala
@@ -36,7 +36,9 @@ import org.apache.spark.unsafe.map.BytesToBytesMap
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.collection.CompactBuffer
 
-class HashedRelationSuite extends SharedSparkSession {
+abstract class AbstractHashedRelationSuite extends SharedSparkSession {
+
+  def mapReorderFactor: Option[Int]
 
   val mm = new TaskMemoryManager(
     new UnifiedMemoryManager(
@@ -714,4 +716,14 @@ class HashedRelationSuite extends SharedSparkSession {
         assert(actualValues === expectedValues)
     }
   }
+}
+
+// TODO: implement this
+class HashedRelationWithReorderingSuite extends AbstractHashedRelationSuite {
+  override def mapReorderFactor: Option[Int] = Some(1)
+}
+
+// TODO: implement this
+class HashedRelationWithoutReorderingSuite extends AbstractHashedRelationSuite {
+  override def mapReorderFactor: Option[Int] = None
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
@@ -55,15 +55,16 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
       1),
     0)
 
-  // TODO: fix indent
-  private def benchmarkHelper(relationName: String,
-    totalRows: Int,
-    duplicationMultipliers: Seq[Int],
-    keyExpr: Seq[Expression],
-    relationGenerator: (Iterator[InternalRow],
-      Seq[Expression],
-      Int,
-      Option[Int]) => HashedRelation): Unit = {
+  private def benchmarkHelper(
+      relationName: String,
+      totalRows: Int,
+      duplicationMultipliers: Seq[Int],
+      keyExpr: Seq[Expression],
+      relationGenerator: (
+          Iterator[InternalRow],
+          Seq[Expression],
+          Int,
+          Option[Int]) => HashedRelation): Unit = {
 
     val keyGenerator = UnsafeProjection.create(keyExpr)
     val fieldsExpr = Seq(LongType, StringType, IntegerType, DoubleType).zipWithIndex.map {
@@ -121,8 +122,7 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
     }
     val keyExpr = Seq(BoundReference(0, LongType, nullable = false))
     val totalRows = 1000000
-    // TODO: rethink these numbers
-    val duplicationMultipliers = Array(1, 5, 8, 10, 20)
+    val duplicationMultipliers = Array(1, 5, 8, 10, 20, 500)
     benchmarkHelper("LongHashedRelation", totalRows, duplicationMultipliers, keyExpr,
       relationGenerator)
   }
@@ -136,8 +136,7 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
     val keyExpr = Seq(BoundReference(0, LongType, nullable = false),
       BoundReference(2, IntegerType, nullable = false))
     val totalRows = 1000000
-    // TODO: rethink these numbers
-    val duplicationMultipliers = Array(1, 5, 8, 10, 20)
+    val duplicationMultipliers = Array(1, 5, 8, 10, 20, 500)
     benchmarkHelper("UnsafeHashedRelation", totalRows, duplicationMultipliers, keyExpr,
       relationGenerator)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
@@ -116,7 +116,7 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
 
   private def runLongHashedRelationMicroBenchmark(): Unit = {
     val relationGenerator = (rowItr: Iterator[InternalRow], keyExpr: Seq[Expression],
-      sizeEstimate: Int, reorderFactor: Option[Int]) => {
+      sizeEstimate: Int, reorderFactor: Option[Double]) => {
       LongHashedRelation(rowItr, keyExpr, sizeEstimate, taskMemoryManager,
         reorderFactor = reorderFactor)
     }
@@ -129,7 +129,7 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
 
   private def runUnsafeHashedRelationMicroBenchmark(): Unit = {
     val relationGenerator = (rowItr: Iterator[InternalRow], keyExpr: Seq[Expression],
-      sizeEstimate: Int, reorderFactor: Option[Int]) => {
+      sizeEstimate: Int, reorderFactor: Option[Double]) => {
       UnsafeHashedRelation(rowItr, keyExpr, sizeEstimate, taskMemoryManager,
         reorderFactor = reorderFactor)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
@@ -31,6 +31,18 @@ import org.apache.spark.sql.execution.joins.{HashedRelation, LongHashedRelation,
 import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
+/**
+ * Synthetic Benchmark for HashedRelation re-ordering.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar> <spark sql test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/HashedRelationDataLocalityBenchmark-results.txt".
+ * }}}
+ */
 object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Logging {
 
   private val random = new Random(1234567L)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
@@ -64,7 +64,7 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
           Iterator[InternalRow],
           Seq[Expression],
           Int,
-          Option[Int]) => HashedRelation): Unit = {
+          Option[Double]) => HashedRelation): Unit = {
 
     val keyGenerator = UnsafeProjection.create(keyExpr)
     val fieldsExpr = Seq(LongType, StringType, IntegerType, DoubleType).zipWithIndex.map {
@@ -95,7 +95,7 @@ object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Loggin
         Seq(false, true).foreach { reorderMap =>
           benchmark.addCase(s"Reorder map: $reorderMap, Total rows: $totalRows," +
             s" Unique rows: $uniqueRows", 5) { _ =>
-            val reorderFactor = if (reorderMap) Some(duplicationMultiplier) else None
+            val reorderFactor = if (reorderMap) Some(duplicationMultiplier: Double) else None
             val hashedRelation = relationGenerator(shuffledRows.iterator, keyExpr,
               Math.toIntExact(uniqueRows), reorderFactor)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/benchmark/HashedRelationDataLocalityBenchmark.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins.benchmark
+
+import org.apache.spark.SparkConf
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.MEMORY_OFFHEAP_ENABLED
+import org.apache.spark.memory.{TaskMemoryManager, UnifiedMemoryManager}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, UnsafeProjection}
+import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
+import org.apache.spark.sql.execution.joins.LongHashedRelation
+import org.apache.spark.sql.internal.SQLConf.HASHED_RELATION_REORDER_FACTOR
+import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType, StringType}
+import org.apache.spark.unsafe.types.UTF8String
+
+object HashedRelationDataLocalityBenchmark extends SqlBasedBenchmark with Logging {
+
+  private val taskMemoryManager = new TaskMemoryManager(
+    new UnifiedMemoryManager(
+      new SparkConf().set(MEMORY_OFFHEAP_ENABLED, false),
+      Long.MaxValue,
+      Long.MaxValue / 2,
+      1),
+    0)
+
+  private def helper(benchmark: Benchmark)(f: => Unit): Unit = {
+    benchmark.addCase("HashedRelation reordering disabled", 1) { _ =>
+      f
+    }
+    benchmark.addCase("HashedRelation reordering enabled") { _ =>
+      withSQLConf((HASHED_RELATION_REORDER_FACTOR.key, "2")) {
+        f
+      }
+    }
+    benchmark.run()
+  }
+
+  private def runLongHashedRelationBenchmark(): Unit = {
+    val totalNumRow: Long = 10000000L
+    val keyExpr = Seq(BoundReference(0, LongType, nullable = false))
+    val keyGenerator = UnsafeProjection.create(keyExpr)
+
+    val fields = Seq(LongType, IntegerType, DoubleType, StringType)
+      .zipWithIndex.map {
+      case (dataType, ordinal) => BoundReference(ordinal, dataType, nullable = false)
+    }
+    val unsafeProj = UnsafeProjection.create(fields)
+
+    runBenchmark("runLongHashedRelationBenchmark") {
+      val benchmark = new Benchmark("LongHashedRelation", totalNumRow)
+      Array(1, 1000, 5000, 10000).foreach { keyDuplicationFactor =>
+        val seedRows = (0L until totalNumRow / keyDuplicationFactor).map { i =>
+          unsafeProj(
+            InternalRow(
+              i,
+              Int.MaxValue,
+              Double.MaxValue,
+              UTF8String.fromString(s"$i-${Int.MaxValue}-${Long.MaxValue}-${Double.MaxValue}"))
+          ).copy()
+        }
+
+        benchmark.addCase(s"keyDuplicationFactor $keyDuplicationFactor, " +
+          s"Total keys: $totalNumRow, Unique keys: ${seedRows.size}", 10) { _ =>
+
+          val rows = (0 until keyDuplicationFactor).flatMap(_ => seedRows).map(_.copy())
+          val longRelation = LongHashedRelation(rows.iterator, keyExpr, 10, taskMemoryManager,
+            reorderFactor = if (keyDuplicationFactor != 1) Some(keyDuplicationFactor) else None)
+
+          seedRows.foreach { seedRow =>
+            val key = keyGenerator(seedRow)
+            longRelation.get(key).foreach { fetchedRow =>
+              assert(seedRow.equals(fetchedRow))
+            }
+          }
+
+          longRelation.close()
+        }
+      }
+      benchmark.run()
+    }
+  }
+
+  private def runUnsafeHashedRelationBenchmark(): Unit = {
+
+  }
+
+  /**
+   * Main process of the whole benchmark.
+   * Implementations of this method are supposed to use the wrapper method `runBenchmark`
+   * for each benchmark scenario.
+   */
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    runLongHashedRelationBenchmark()
+    runUnsafeHashedRelationBenchmark()
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims at improving performance for Hash joins with many duplicate keys. 

A HashedRelation uses a map underneath to store rows against a corresponding key. A LongToUnsafeRowMap is used by LongHashedRelation and a BytesToBytesMap is used by UnsafeHashedRelation.
We propose to reorder the underlying map thereby placing all the rows for a given key adjacent in the memory to improve the spatial locality while iterating over them in the stream side of the join.

This is achieved in the following steps:
- creating another copy of the underlying map
- for all keys in the existing map
  - get the corresponding rows 
  - insert all the rows for the given key at once in the new map
- use the new map for look-ups

This optimization can be enabled by specifying `spark.sql.hashedRelationReorderFactor=<value>`.
Once the condition `number of rows >= number of unique keys * above value` is satisfied for the underlying map, the optimization will kick in.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There is no order maintained when the rows are added to the underlying map, thus for a given key, the corresponding rows are typically non-adjacent in memory, resulting in a poor spatial locality. Placing the rows for adjacent in memory yields a performance boost thereby reducing execution time.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Modified existing unit tests to run against the suggested improvement.
- Added a couple of cases to test the scenarios when the improvement throws an exception due to insufficient memory.
- Added a micro-benchmark that clearly indicates performance improvements when there are duplicate keys.
- Ran the four example queries mentioned in the JIRA in spark-sql as a final check for performance improvement.

### Credits
This work is based on the initial idea proposed by @bersprockets.