### PR TITLE
[SPARK-37773][PYTHON] Disable certain doctests of `ps.to_timedelta` for pandas<=1.0.5

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -1940,18 +1940,18 @@ def to_timedelta(
 
     >>> ps.to_timedelta('1 days 06:05:01.00003')
     Timedelta('1 days 06:05:01.000030')
-    >>> ps.to_timedelta('15.5us')
+    >>> ps.to_timedelta('15.5us')  # doctest: +SKIP
     Timedelta('0 days 00:00:00.000015500')
 
     Parsing a list or array of strings:
 
-    >>> ps.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])  # doctest: +SKIP
     TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015500', NaT],
                    dtype='timedelta64[ns]', freq=None)
 
     Converting numbers by specifying the `unit` keyword argument:
 
-    >>> ps.to_timedelta(np.arange(5), unit='s')  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.to_timedelta(np.arange(5), unit='s')  # doctest: +SKIP
     TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:01', '0 days 00:00:02',
                     '0 days 00:00:03', '0 days 00:00:04'],
                    dtype='timedelta64[ns]', freq=None)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable certain doctests of `ps.to_timedelta` for pandas<=1.0.5


### Why are the changes needed?
`ps.to_timedelta` is backed by `pd.to_timedelta` (in pandas).

Doctest results of `ps.to_timedelta`  are consistent with the latest pandas.

However, some of them (related to seconds) will fail with pandas <=1.0.5 since older pandas lose precision.

```py
# In pyspark.pandas.namespace.to_timedelta

Failed example:
    ps.to_timedelta('15.5us')
Expected:
    Timedelta('0 days 00:00:00.000015500')
<= pd 1.0.5:
    Timedelta('0 days 00:00:00.000015')


Failed example:
    ps.to_timedelta(['1 days 06:05:01.00003', '15.5us', 'nan'])  # doctest: +NORMALIZE_WHITESPACE
Expected:
    TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015500', NaT],
                   dtype='timedelta64[ns]', freq=None)
<= pd 1.0.5:
    TimedeltaIndex(['1 days 06:05:01.000030', '0 days 00:00:00.000015', NaT], dtype='timedelta64[ns]', freq=None)

Failed example:
    ps.to_timedelta(np.arange(5), unit='s')  # doctest: +NORMALIZE_WHITESPACE
Expected:
    TimedeltaIndex(['0 days 00:00:00', '0 days 00:00:01', '0 days 00:00:02',
                    '0 days 00:00:03', '0 days 00:00:04'],
                   dtype='timedelta64[ns]', freq=None)
<= pd 1.0.5:
    TimedeltaIndex(['00:00:00', '00:00:01', '00:00:02', '00:00:03', '00:00:04'], dtype='timedelta64[ns]', freq=None)
```

So we disable them.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manual tests.