### PR TITLE
[SPARK-37774][BUILD] Upgrade log4j from 2.17 to 2.17.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -186,10 +186,10 @@ lapack/2.2.1//lapack-2.2.1.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.17.0//log4j-1.2-api-2.17.0.jar
-log4j-api/2.17.0//log4j-api-2.17.0.jar
-log4j-core/2.17.0//log4j-core-2.17.0.jar
-log4j-slf4j-impl/2.17.0//log4j-slf4j-impl-2.17.0.jar
+log4j-1.2-api/2.17.1//log4j-1.2-api-2.17.1.jar
+log4j-api/2.17.1//log4j-api-2.17.1.jar
+log4j-core/2.17.1//log4j-core-2.17.1.jar
+log4j-slf4j-impl/2.17.1//log4j-slf4j-impl-2.17.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 macro-compat_2.12/1.1.1//macro-compat_2.12-1.1.1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -173,10 +173,10 @@ lapack/2.2.1//lapack-2.2.1.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.17.0//log4j-1.2-api-2.17.0.jar
-log4j-api/2.17.0//log4j-api-2.17.0.jar
-log4j-core/2.17.0//log4j-core-2.17.0.jar
-log4j-slf4j-impl/2.17.0//log4j-slf4j-impl-2.17.0.jar
+log4j-1.2-api/2.17.1//log4j-1.2-api-2.17.1.jar
+log4j-api/2.17.1//log4j-api-2.17.1.jar
+log4j-core/2.17.1//log4j-core-2.17.1.jar
+log4j-slf4j-impl/2.17.1//log4j-slf4j-impl-2.17.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 macro-compat_2.12/1.1.1//macro-compat_2.12-1.1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.30</slf4j.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <hadoop.version>3.3.1</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>
     <yarn.version>${hadoop.version}</yarn.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update `log4j` from 2.17 to 2.17.1


### Why are the changes needed?
There is another CVE ([CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)) in [Log4j 2.17](https://issues.apache.org/jira/browse/LOG4J2-3293)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

rely on existent tests
