### PR TITLE
[SPARK-37644][SQL][FOLLOWUP] When partition column is same as group by key, pushing down aggregate completely.

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
  * push down aggregates.
  * <p>
  * If the data source can't fully complete the grouping work, then
- * {@link #supportCompletePushDown()} should return false, and Spark will group the data source
+ * {@link #supportCompletePushDown(Aggregation)} should return false, and Spark will group the data source
  * output again. For queries like "SELECT min(value) AS m FROM t GROUP BY key", after pushing down
  * the aggregate to the data source, the data source can still output data with duplicated keys,
  * which is OK as Spark will do GROUP BY key again. The final query plan can be something like this:

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -25,10 +25,11 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
  * push down aggregates.
  * <p>
  * If the data source can't fully complete the grouping work, then
- * {@link #supportCompletePushDown(Aggregation)} should return false, and Spark will group the data source
- * output again. For queries like "SELECT min(value) AS m FROM t GROUP BY key", after pushing down
- * the aggregate to the data source, the data source can still output data with duplicated keys,
- * which is OK as Spark will do GROUP BY key again. The final query plan can be something like this:
+ * {@link #supportCompletePushDown(Aggregation)} should return false, and Spark will group the data
+ * source output again. For queries like "SELECT min(value) AS m FROM t GROUP BY key", after
+ * pushing down the aggregate to the data source, the data source can still output data with
+ * duplicated keys, which is OK as Spark will do GROUP BY key again. The final query plan can be
+ * something like this:
  * <pre>
  *   Aggregate [key#1], [min(min_value#2) AS m#3]
  *     +- RelationV2[key#1, min_value#2]

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -50,16 +50,17 @@ public interface SupportsPushDownAggregates extends ScanBuilder {
    * Whether the datasource support complete aggregation push-down. Spark will do grouping again
    * if this method returns false.
    *
-   * @param groupAttrs group by attributes of aggregation.
+   * @param aggregation Aggregation in SQL statement.
    * @return true if the aggregation can be pushed down to datasource completely, false otherwise.
    */
-  default boolean supportCompletePushDown(String[] groupAttrs) { return false; }
+  default boolean supportCompletePushDown(Aggregation aggregation) { return false; }
 
   /**
    * Pushes down Aggregation to datasource. The order of the datasource scan output columns should
    * be: grouping columns, aggregate columns (in the same order as the aggregate functions in
    * the given Aggregation).
    *
+   * @param aggregation Aggregation in SQL statement.
    * @return true if the aggregation can be pushed down to datasource, false otherwise.
    */
   boolean pushAggregation(Aggregation aggregation);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -20,6 +20,8 @@ package org.apache.spark.sql.connector.read;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 
+import java.util.List;
+
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
  * push down aggregates.
@@ -50,9 +52,10 @@ public interface SupportsPushDownAggregates extends ScanBuilder {
    * Whether the datasource support complete aggregation push-down. Spark will do grouping again
    * if this method returns false.
    *
+   * @param groupAttrs group by attributes of aggregation.
    * @return true if the aggregation can be pushed down to datasource completely, false otherwise.
    */
-  default boolean supportCompletePushDown() { return false; }
+  default boolean supportCompletePushDown(String[] groupAttrs) { return false; }
 
   /**
    * Pushes down Aggregation to datasource. The order of the datasource scan output columns should

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -20,8 +20,6 @@ package org.apache.spark.sql.connector.read;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 
-import java.util.List;
-
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
  * push down aggregates.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -149,7 +149,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
 
                 val wrappedScan = getWrappedScan(scan, sHolder, pushedAggregates)
                 val scanRelation = DataSourceV2ScanRelation(sHolder.relation, wrappedScan, output)
-                if (r.supportCompletePushDown(groupAttrs.map(_.name).toArray)) {
+                if (r.supportCompletePushDown(pushedAggregates.get)) {
                   val projectExpressions = resultExpressions.map { expr =>
                     // TODO At present, only push down group by attribute is supported.
                     // In future, more attribute conversion is extended here. e.g. GetStructField

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -110,7 +110,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
               if (pushedAggregates.isEmpty) {
                 aggNode // return original plan node
               } else if (!supportPartialAggPushDown(pushedAggregates.get) &&
-                !r.supportCompletePushDown()) {
+                !r.supportCompletePushDown(pushedAggregates.get)) {
                 aggNode // return original plan node
               } else {
                 // No need to do column pruning because only the aggregate columns are used as

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -149,7 +149,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
 
                 val wrappedScan = getWrappedScan(scan, sHolder, pushedAggregates)
                 val scanRelation = DataSourceV2ScanRelation(sHolder.relation, wrappedScan, output)
-                if (r.supportCompletePushDown()) {
+                if (r.supportCompletePushDown(groupAttrs.map(_.name).toArray)) {
                   val projectExpressions = resultExpressions.map { expr =>
                     // TODO At present, only push down group by attribute is supported.
                     // In future, more attribute conversion is extended here. e.g. GetStructField

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -76,7 +76,7 @@ case class JDBCScanBuilder(
     lazy val fieldNames = aggregation.groupByColumns()(0).fieldNames()
     jdbcOptions.numPartitions.map(_ == 1).getOrElse(true) ||
       (aggregation.groupByColumns().length == 1 && fieldNames.length == 1 &&
-        jdbcOptions.partitionColumn.map(fieldNames(0).equalsIgnoreCase(_)).get)
+        jdbcOptions.partitionColumn.exists(fieldNames(0).equalsIgnoreCase(_)))
   }
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -73,11 +73,10 @@ case class JDBCScanBuilder(
   private var pushedGroupByCols: Option[Array[String]] = None
 
   override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
-    lazy val fieldNames = aggregation.groupByColumns().map(_.fieldNames.toSeq.quoted)
+    lazy val fieldNames = aggregation.groupByColumns()(0).fieldNames()
     jdbcOptions.numPartitions.map(_ == 1).getOrElse(true) ||
-      (aggregation.groupByColumns().length == 1 &&
-      jdbcOptions.partitionColumn.map(fieldNames(0).equalsIgnoreCase(_)).get)
+      (aggregation.groupByColumns().length == 1 && fieldNames.length == 1 &&
+        jdbcOptions.partitionColumn.map(fieldNames(0).equalsIgnoreCase(_)).get)
   }
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -72,8 +72,9 @@ case class JDBCScanBuilder(
 
   private var pushedGroupByCols: Option[Array[String]] = None
 
-  override def supportCompletePushDown: Boolean =
-    jdbcOptions.numPartitions.map(_ == 1).getOrElse(true)
+  override def supportCompletePushDown(groupAttrs: Array[String]): Boolean =
+    jdbcOptions.numPartitions.map(_ == 1).getOrElse(true) || (groupAttrs.length == 1 &&
+      jdbcOptions.partitionColumn.map(groupAttrs(0).equalsIgnoreCase(_)).get)
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {
     if (!jdbcOptions.pushDownAggregate) return false


### PR DESCRIPTION
### What changes were proposed in this pull request?
When JDBC option specifying the "partitionColumn" and it's the same as group by key, the aggregate push-down should be completely.


### Why are the changes needed?
Improve the datasource v2 complete aggregate pushdown.


### Does this PR introduce _any_ user-facing change?
'No'. Just change the inner implement.


### How was this patch tested?
New tests.
