### PR TITLE
[SPARK-37775][TEST][PYTHON] Fix doctest mismatch mlflow >= 1.22.0

### DIFF
--- a/python/pyspark/pandas/mlflow.py
+++ b/python/pyspark/pandas/mlflow.py
@@ -145,8 +145,8 @@ def load_model(
     >>> d = mkdtemp("pandas_on_spark_mlflow")
     >>> set_tracking_uri("file:%s"%d)
     >>> client = MlflowClient()
-    >>> exp = mlflow.create_experiment("my_experiment")
-    >>> mlflow.set_experiment("my_experiment")
+    >>> exp_id = mlflow.create_experiment("my_experiment")
+    >>> exp = mlflow.set_experiment("my_experiment")
 
     We aim at learning this numerical function using a simple linear regressor.
 
@@ -165,7 +165,7 @@ def load_model(
     dataframe:
 
     >>> from pyspark.pandas.mlflow import load_model
-    >>> run_info = client.list_run_infos(exp)[-1]
+    >>> run_info = client.list_run_infos(exp_id)[-1]
     >>> model = load_model("runs:/{run_id}/model".format(run_id=run_info.run_uuid))
     >>> prediction_df = ps.DataFrame({"x1": [2.0], "x2": [4.0]})
     >>> prediction_df["prediction"] = model.predict(prediction_df)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix doctest mismatch when mlflow >= 1.22.0 .

### Why are the changes needed?
[`set_experiment` return experiment obj](https://github.com/mlflow/mlflow/commit/0f9d1e04975c69313ad57e4d7d428ab7befad69e#diff-b33420360cc29a5224c8d3080bbfcaa0ac1c8891416137e13be044fcdfdd26f9R135) after mlflow v1.22.0 rather than None .

The master CI passed because mlflow v1.21 is used, this error was triggered in [latest job on self-hosted ARM CI](https://github.com/Yikun/spark/runs/4655935913?check_suite_focus=true).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- pandas master UT passed. (v1.21)
- pandas with mlflow v1.22 passed: https://github.com/Yikun/spark/runs/4656965169?check_suite_focus=true
