### PR TITLE
[SPARK-37369][SQL][FOLLOWUP] Override supportsRowBased in UnionExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -700,6 +700,8 @@ case class UnionExec(children: Seq[SparkPlan]) extends SparkPlan {
 
   override def supportsColumnar: Boolean = children.forall(_.supportsColumnar)
 
+  override def supportsRowBased: Boolean = children.forall(_.supportsRowBased)
+
   protected override def doExecuteColumnar(): RDD[ColumnarBatch] = {
     sparkContext.union(children.map(_.executeColumnar()))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In PR #34642, we added a `supportsRowBased` in `SparkPlan` in order to avoid
redundant `ColumnarToRow` transition in `InMemoryTableScan `. But, this optimization
also applies to Union if its children both support row-based output.
So, this PR adds the `supportsRowBased` implementation for `UnionExec`.


### Why are the changes needed?
followup PR


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests passed.
