### PR TITLE
[MINOR] Remove unused imports in Scala 2.13 Repl2Suite

### DIFF
--- a/repl/src/test/scala-2.13/org/apache/spark/repl/Repl2Suite.scala
+++ b/repl/src/test/scala-2.13/org/apache/spark/repl/Repl2Suite.scala
@@ -18,15 +18,10 @@
 package org.apache.spark.repl
 
 import java.io._
-import java.nio.file.Files
 
-import org.apache.log4j.{Level, LogManager, PropertyConfigurator}
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.{SparkContext, SparkFunSuite}
-import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 
 class Repl2Suite extends SparkFunSuite with BeforeAndAfterAll {
   test("propagation of local properties") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove unused imports in Scala 2.13 Repl2Suite. 


### Why are the changes needed?
This is the only unused import in Scala 2.13 except `scala.languageFeature.higherKinds`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass the Scala 2.13 GHA job. 