### PR TITLE
[SPARK-30789][SQL][DOCS][FOLLOWUP] Add document for syntax `(IGNORE | RESPECT) NULLS`

### DIFF
--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -52,7 +52,7 @@ window_function [ nulls_option ] OVER
 
 * **nulls_option**
 
-    Specified to indicate whether skip null values in the determination of which row to use.
+    Specified to indicate whether skip null values in the determination of which row to use. `RESPECT NULLS` is supported by default if you do not specify `IGNORE NULLS`.
 
     **Syntax:**
 

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -188,6 +188,29 @@ SELECT name, salary,
 | Jane|  Marketing| 29000|29000|35000|
 | Jeff|  Marketing| 35000|29000|    0|
 +-----+-----------+------+-----+-----+
+
+SELECT id, v,
+     LEAD(v, 0) IGNORE NULLS OVER w lead,
+     LAG(v, 0) IGNORE NULLS OVER w lag,
+     NTH_VALUE(v, 2) IGNORE NULLS OVER w nth_value,
+     FIRST_VALUE(v) IGNORE NULLS OVER w first_value,
+     LAST_VALUE(v) IGNORE NULLS OVER w last_value
+ FROM test_ignore_null
+ WINDOW w AS (ORDER BY id)
+ ORDER BY id;
++--+----+----+----+---------+-----------+----------+
+|id|   v|lead| lag|nth_value|first_value|last_value|
++--+----+----+----+---------+-----------+----------+
+| 0|NULL|NULL|NULL|     NULL|       NULL|      NULL|
+| 1|   x|   x|   x|     NULL|          x|         x|
+| 2|NULL|NULL|NULL|     NULL|          x|         x|
+| 3|NULL|NULL|NULL|     NULL|          x|         x|
+| 4|   y|   y|   y|        y|          x|         y|
+| 5|NULL|NULL|NULL|        y|          x|         y|
+| 6|   z|   z|   z|        y|          x|         z|
+| 7|   v|   v|   v|        y|          x|         v|
+| 8|NULL|NULL|NULL|        y|          x|         v|
++--+----+----+----+---------+-----------+----------+
 ```
 
 ### Related Statements

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -26,7 +26,7 @@ Window functions operate on a group of rows, referred to as a window, and calcul
 ### Syntax
 
 ```sql
-window_function OVER
+window_function [ { IGNORE | RESPECT } NULLS ] OVER
 ( [  { PARTITION | DISTRIBUTE } BY partition_col_name = partition_col_val ( [ , ... ] ) ]
   { ORDER | SORT } BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ]
   [ window_frame ] )
@@ -39,16 +39,20 @@ window_function OVER
     * Ranking Functions
 
       **Syntax:** `RANK | DENSE_RANK | PERCENT_RANK | NTILE | ROW_NUMBER`
+      
+      Note: Cannot append `[ { IGNORE | RESPECT } NULLS ]`
 
     * Analytic Functions
 
-      **Syntax:** `CUME_DIST | LAG | LEAD`
+      **Syntax:** `[ CUME_DIST | [ LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE ] [ { IGNORE | RESPECT } NULLS ] ]`
 
     * Aggregate Functions
 
       **Syntax:** `MAX | MIN | COUNT | SUM | AVG | ...`
 
       Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for a complete list of Spark aggregate functions.
+
+      Note: Cannot append `[ { IGNORE | RESPECT } NULLS ]`
 
 * **window_frame**
 

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -58,7 +58,7 @@ window_function [ nulls_option ] OVER
 
     `{ IGNORE | RESPECT } NULLS`
 
-    **Note:**: Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` could append `{ IGNORE | RESPECT } NULLS`.
+    **Note:** Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` could append `{ IGNORE | RESPECT } NULLS`.
 
 * **window_frame**
 

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -58,7 +58,7 @@ window_function [ nulls_option ] OVER
 
     `{ IGNORE | RESPECT } NULLS`
 
-    **Note:**: Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` could append `[ { IGNORE | RESPECT } NULLS ]`.
+    **Note:**: Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` could append `{ IGNORE | RESPECT } NULLS`.
 
 * **window_frame**
 

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -52,13 +52,13 @@ window_function [ nulls_option ] OVER
 
 * **nulls_option**
 
-    Specified to indicate whether skip null values in the determination of which row to use. `RESPECT NULLS` is supported by default if you do not specify `IGNORE NULLS`.
+    Specifies whether or not to skip null values when evaluating the window function. `RESECT NULLS` means not skipping null values, while `IGNORE NULLS` means skipping. If not specified, the default is `RESECT NULLS`.
 
     **Syntax:**
 
     `{ IGNORE | RESPECT } NULLS`
 
-    **Note:** Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` could append `{ IGNORE | RESPECT } NULLS`.
+    **Note:** Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` can be used with `IGNORE NULLS`.
 
 * **window_frame**
 

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -26,7 +26,7 @@ Window functions operate on a group of rows, referred to as a window, and calcul
 ### Syntax
 
 ```sql
-window_function [ { IGNORE | RESPECT } NULLS ] OVER
+window_function [ nulls_option ] OVER
 ( [  { PARTITION | DISTRIBUTE } BY partition_col_name = partition_col_val ( [ , ... ] ) ]
   { ORDER | SORT } BY expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ]
   [ window_frame ] )
@@ -39,12 +39,10 @@ window_function [ { IGNORE | RESPECT } NULLS ] OVER
     * Ranking Functions
 
       **Syntax:** `RANK | DENSE_RANK | PERCENT_RANK | NTILE | ROW_NUMBER`
-      
-      Note: Cannot append `[ { IGNORE | RESPECT } NULLS ]`
 
     * Analytic Functions
 
-      **Syntax:** `[ CUME_DIST | [ LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE ] [ { IGNORE | RESPECT } NULLS ] ]`
+      **Syntax:** `CUME_DIST | LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE`
 
     * Aggregate Functions
 
@@ -52,7 +50,15 @@ window_function [ { IGNORE | RESPECT } NULLS ] OVER
 
       Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for a complete list of Spark aggregate functions.
 
-      Note: Cannot append `[ { IGNORE | RESPECT } NULLS ]`
+* **nulls_option**
+
+    Specified to indicate whether skip null values in the determination of which row to use.
+
+    **Syntax:**
+
+    `{ IGNORE | RESPECT } NULLS`
+
+    **Note:**: Only `LAG | LEAD | NTH_VALUE | FIRST_VALUE | LAST_VALUE` could append `[ { IGNORE | RESPECT } NULLS ]`.
 
 * **window_frame**
 

--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -196,14 +196,14 @@ SELECT name, salary,
 +-----+-----------+------+-----+-----+
 
 SELECT id, v,
-     LEAD(v, 0) IGNORE NULLS OVER w lead,
-     LAG(v, 0) IGNORE NULLS OVER w lag,
-     NTH_VALUE(v, 2) IGNORE NULLS OVER w nth_value,
-     FIRST_VALUE(v) IGNORE NULLS OVER w first_value,
-     LAST_VALUE(v) IGNORE NULLS OVER w last_value
- FROM test_ignore_null
- WINDOW w AS (ORDER BY id)
- ORDER BY id;
+    LEAD(v, 0) IGNORE NULLS OVER w lead,
+    LAG(v, 0) IGNORE NULLS OVER w lag,
+    NTH_VALUE(v, 2) IGNORE NULLS OVER w nth_value,
+    FIRST_VALUE(v) IGNORE NULLS OVER w first_value,
+    LAST_VALUE(v) IGNORE NULLS OVER w last_value
+    FROM test_ignore_null
+    WINDOW w AS (ORDER BY id)
+    ORDER BY id;
 +--+----+----+----+---------+-----------+----------+
 |id|   v|lead| lag|nth_value|first_value|last_value|
 +--+----+----+----+---------+-----------+----------+


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/30943 supports syntax `(IGNORE | RESPECT) NULLS for LEAD/LAG/NTH_VALUE/FIRST_VALUE/LAST_VALUE`, but update document.
The screen snapshot before this PR
![screenshot-20211231-174803](https://user-images.githubusercontent.com/8486025/147816336-debca074-0b84-48e8-9ed2-cb13f562cf12.png)

This PR adds document for syntax `(IGNORE | RESPECT) NULLS`

The screen snapshot after this PR
![image](https://user-images.githubusercontent.com/8486025/148141568-506e9232-a3c4-4a25-a5c6-65a5d5a2e066.png)

![image](https://user-images.githubusercontent.com/8486025/148061495-b7198417-9d4c-4c03-9060-385271ea9a46.png)


### Why are the changes needed?
Add document for syntax `(IGNORE | RESPECT) NULLS`


### Does this PR introduce _any_ user-facing change?
'No'. Just update docs.


### How was this patch tested?
Manual check.
