### PR TITLE
[SPARK-37801][BUILD] List PyPy3 packages in build_and_test workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -316,9 +316,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    - name: List Python packages (Python 3.9)
+    - name: List Python packages (Python 3.9, PyPy3)
       run: |
         python3.9 -m pip list
+        pypy3 -m pip list
     - name: Install Conda for pip packaging test
       run: |
         curl -s https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh


### PR DESCRIPTION
### What changes were proposed in this pull request?
List PyPy3 packages in build_and_test workflow



### Why are the changes needed?
As mentioned in https://github.com/apache/spark/pull/32737/files#r644158403 , pypy3 tests would also running in current test, the `pip list` info will help us to see what the pypy3 installed.

This would help see the pypy3 installed pakcages in x86 env and also future ARM self-hosted runner.


### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
CI passed, and PyPy3/Python3.9 pip list info shown.
