### PR TITLE
[SPARK-37812][SQL] When deserializing an Orc struct, reuse the result row when possible

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -144,14 +144,14 @@ class OrcDeserializer(
           newWriter(dt, fieldUpdater)
         }.toArray
 
-        val containerUpdater = if (updater.isInstanceOf[RowUpdater]) {
-          updater
-        } else {
-          new CatalystDataUpdater {
-            override def set(ordinal: Int, value: Any) = {
-              updater.set(ordinal, value.asInstanceOf[SpecificInternalRow].copy())
+        val containerUpdater = updater match {
+          case r: RowUpdater => r
+          case _ =>
+            new CatalystDataUpdater {
+              override def set(ordinal: Int, value: Any) = {
+                updater.set(ordinal, value.asInstanceOf[SpecificInternalRow].copy())
+              }
             }
-          }
         }
 
         (ordinal, value) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcDeserializer.scala
@@ -147,6 +147,8 @@ class OrcDeserializer(
         val containerUpdater = updater match {
           case r: RowUpdater => r
           case _ =>
+            // If the struct is contained by an array or map, we cannot reuse the same result row.
+            // We must copy the result row before setting it into the array or map
             new CatalystDataUpdater {
               override def set(ordinal: Int, value: Any) = {
                 updater.set(ordinal, value.asInstanceOf[SpecificInternalRow].copy())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -844,6 +844,36 @@ abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
       }
     }
   }
+
+  test("struct in struct in array") {
+    withTempPath { file =>
+      val df = sql(
+        """SELECT
+          |  array(
+          |    named_struct(
+          |      'a', named_struct(
+          |        'a1', 1,
+          |        'a2', 2),
+          |      'b', named_struct(
+          |        'b1', 3,
+          |        'b2', 4)
+          |    ),
+          |    named_struct(
+          |      'a', named_struct(
+          |        'a1', 5,
+          |        'a2', 6),
+          |      'b', named_struct(
+          |        'b1', 7,
+          |        'b2', 8)
+          |    )
+          |  ) as col1
+          |
+          |""".stripMargin)
+      df.write.orc(file.getCanonicalPath)
+      val df2 = spark.read.orc(file.getCanonicalPath)
+      checkAnswer(df2, df.collect().toSeq)
+    }
+  }
 }
 
 class OrcSourceV1Suite extends OrcSourceSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -652,9 +652,9 @@ abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
         StructField("50",
           StructType(
             StructField("20", StringType) ::
-            StructField("30",
-              StructType(
-                StructField("40", StringType) :: Nil)) :: Nil))))
+              StructField("30",
+                StructType(
+                  StructField("40", StringType) :: Nil)) :: Nil))))
     }
 
     // test for struct in array
@@ -845,157 +845,151 @@ abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
     }
   }
 
-  // Test the various cases during deserialization where we may or may not copy
-  // a struct writer's result row
-  test("struct in an array") {
-    withTempPath { file =>
-      val df = sql(
-        """SELECT
-          |  array(
-          |    named_struct(
-          |      'a1', 1,
-          |      'a2', 2),
-          |    named_struct(
-          |      'a1', 3,
-          |      'a2', 4)
-          |  ) as col1
-          |""".stripMargin)
-      df.write.orc(file.getCanonicalPath)
-      val df2 = spark.read.orc(file.getCanonicalPath)
-      checkAnswer(df2, df.collect().toSeq)
-    }
-  }
+  test("SPARK-37812: Reuse result row when deserializing a struct") {
+    val queries = Seq(
+      // struct in an array
+      """SELECT
+        |  array(
+        |    named_struct(
+        |      'a1', 1,
+        |      'a2', 2),
+        |    named_struct(
+        |      'a1', 3,
+        |      'a2', 4)
+        |  ) as col1
+        |""".stripMargin,
 
-  test("struct in a map #1") {
-    withTempPath { file =>
-      val df = sql(
-        """SELECT
-          |  map(
-          |    'ns1',
-          |    named_struct(
-          |      'a1', 1,
-          |      'a2', 2),
-          |    'ns2',
-          |    named_struct(
-          |      'a1', 3,
-          |      'a2', 4)
-          |  ) as col1
-          |""".stripMargin)
-      df.write.orc(file.getCanonicalPath)
-      val df2 = spark.read.orc(file.getCanonicalPath)
-      checkAnswer(df2, df.collect().toSeq)
-    }
-  }
+      // struct as values in a map
+      """SELECT
+        |  map(
+        |    'ns1',
+        |    named_struct(
+        |      'a1', 1,
+        |      'a2', 2),
+        |    'ns2',
+        |    named_struct(
+        |      'a1', 3,
+        |      'a2', 4)
+        |  ) as col1
+        |""".stripMargin,
 
-  test("struct in a map #2") {
-    withTempPath { file =>
-      val df = sql(
-        """SELECT
-          |  map(
-          |    named_struct(
-          |      'a1', 1,
-          |      'a2', 2),
-          |    1,
-          |    named_struct(
-          |      'a1', 3,
-          |      'a2', 4),
-          |    2
-          |  ) as col1
-          |""".stripMargin)
-      df.write.orc(file.getCanonicalPath)
-      val df2 = spark.read.orc(file.getCanonicalPath)
-      checkAnswer(df2, df.collect().toSeq)
-    }
-  }
+      // struct as keys in a map
+      """SELECT
+        |  map(
+        |    named_struct(
+        |      'a1', 1,
+        |      'a2', 2),
+        |    1,
+        |    named_struct(
+        |      'a1', 3,
+        |      'a2', 4),
+        |    2
+        |  ) as col1
+        |""".stripMargin,
 
-  test("struct in a struct in an array") {
-    withTempPath { file =>
-      val df = sql(
-        """SELECT
-          |  array(
-          |    named_struct(
-          |      'a', named_struct(
-          |        'a1', 1,
-          |        'a2', 2),
-          |      'b', named_struct(
-          |        'b1', 3,
-          |        'b2', 4)
-          |    ),
-          |    named_struct(
-          |      'a', named_struct(
-          |        'a1', 5,
-          |        'a2', 6),
-          |      'b', named_struct(
-          |        'b1', 7,
-          |        'b2', 8)
-          |    )
-          |  ) as col1
-          |""".stripMargin)
-      df.write.orc(file.getCanonicalPath)
-      val df2 = spark.read.orc(file.getCanonicalPath)
-      checkAnswer(df2, df.collect().toSeq)
-    }
-  }
+      // struct in a struct in an array
+      """SELECT
+        |  array(
+        |    named_struct(
+        |      'a', named_struct(
+        |        'a1', 1,
+        |        'a2', 2),
+        |      'b', named_struct(
+        |        'b1', 3,
+        |        'b2', 4)
+        |    ),
+        |    named_struct(
+        |      'a', named_struct(
+        |        'a1', 5,
+        |        'a2', 6),
+        |      'b', named_struct(
+        |        'b1', 7,
+        |        'b2', 8)
+        |    )
+        |  ) as col1
+        |""".stripMargin,
 
-  test("struct in a struct in a map #1") {
-    withTempPath { file =>
-      val df = sql(
-        """SELECT
-          |  map(
-          |    'ns1',
-          |    named_struct(
-          |      'a', named_struct(
-          |        'a1', 1,
-          |        'a2', 2),
-          |      'b', named_struct(
-          |        'b1', 3,
-          |        'b2', 4)
-          |    ),
-          |    'ns2',
-          |    named_struct(
-          |      'a', named_struct(
-          |        'a1', 5,
-          |        'a2', 6),
-          |      'b', named_struct(
-          |        'b1', 7,
-          |        'b2', 8)
-          |    )
-          |  ) as col1
-          |""".stripMargin)
-      df.write.orc(file.getCanonicalPath)
-      val df2 = spark.read.orc(file.getCanonicalPath)
-      checkAnswer(df2, df.collect().toSeq)
-    }
-  }
+      // struct in a struct as values in a map
+      """SELECT
+        |  map(
+        |    'ns1',
+        |    named_struct(
+        |      'a', named_struct(
+        |        'a1', 1,
+        |        'a2', 2),
+        |      'b', named_struct(
+        |        'b1', 3,
+        |        'b2', 4)
+        |    ),
+        |    'ns2',
+        |    named_struct(
+        |      'a', named_struct(
+        |        'a1', 5,
+        |        'a2', 6),
+        |      'b', named_struct(
+        |        'b1', 7,
+        |        'b2', 8)
+        |    )
+        |  ) as col1
+        |""".stripMargin,
 
-  test("struct in a struct in a map #2") {
-    withTempPath { file =>
-      val df = sql(
-        """SELECT
-          |  map(
-          |    named_struct(
-          |      'a', named_struct(
-          |        'a1', 1,
-          |        'a2', 2),
-          |      'b', named_struct(
-          |        'b1', 3,
-          |        'b2', 4)
-          |    ),
-          |    1,
-          |    named_struct(
-          |      'a', named_struct(
-          |        'a1', 5,
-          |        'a2', 6),
-          |      'b', named_struct(
-          |        'b1', 7,
-          |        'b2', 8)
-          |    ),
-          |    2
-          |  ) as col1
-          |""".stripMargin)
-      df.write.orc(file.getCanonicalPath)
-      val df2 = spark.read.orc(file.getCanonicalPath)
-      checkAnswer(df2, df.collect().toSeq)
+      // struct in a struct as keys in a map
+      """SELECT
+        |  map(
+        |    named_struct(
+        |      'a', named_struct(
+        |        'a1', 1,
+        |        'a2', 2),
+        |      'b', named_struct(
+        |        'b1', 3,
+        |        'b2', 4)
+        |    ),
+        |    1,
+        |    named_struct(
+        |      'a', named_struct(
+        |        'a1', 5,
+        |        'a2', 6),
+        |      'b', named_struct(
+        |        'b1', 7,
+        |        'b2', 8)
+        |    ),
+        |    2
+        |  ) as col1
+        |""".stripMargin,
+
+      // multi-row test
+      """SELECT * FROM VALUES
+        |  (named_struct(
+        |    'a', 1,
+        |    'b', 2)),
+        |  (named_struct(
+        |    'a', 3,
+        |    'b', 4)),
+        |  (named_struct(
+        |    'a', 5,
+        |    'b', 6))
+        |tbl(c1)
+        |""".stripMargin
+    )
+
+    queries.foreach { query =>
+      withAllNativeOrcReaders {
+        Seq(true, false).foreach { vecReaderNestedColEnabled =>
+          // SPARK-37812 only applies to the configuration where
+          // ORC_VECTORIZED_READER_NESTED_COLUMN_ENABLED is false. However, these
+          // are good general correctness tests for the other configurations as well.
+          withSQLConf(SQLConf.ORC_VECTORIZED_READER_NESTED_COLUMN_ENABLED.key ->
+            vecReaderNestedColEnabled.toString) {
+            withTempPath { file =>
+              val df = sql(query)
+              // use coalesce so we write just 1 file for the multi-row case
+              df.coalesce(1).write.orc(file.getCanonicalPath)
+              val df2 = spark.read.orc(file.getCanonicalPath)
+              checkAnswer(df2, df.collect().toSeq)
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -652,9 +652,9 @@ abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
         StructField("50",
           StructType(
             StructField("20", StringType) ::
-              StructField("30",
-                StructType(
-                  StructField("40", StringType) :: Nil)) :: Nil))))
+            StructField("30",
+              StructType(
+                StructField("40", StringType) :: Nil)) :: Nil))))
     }
 
     // test for struct in array

--- a/sql/hive/benchmarks/OrcReadBenchmark-jdk11-results.txt
+++ b/sql/hive/benchmarks/OrcReadBenchmark-jdk11-results.txt
@@ -6,49 +6,49 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       928            976          51         16.9          59.0       1.0X
-Native ORC Vectorized                               257            342          70         61.1          16.4       3.6X
-Hive built-in ORC                                  1201           1233          45         13.1          76.4       0.8X
+Native ORC MR                                      1064           1070           9         14.8          67.6       1.0X
+Native ORC Vectorized                               237            326          73         66.3          15.1       4.5X
+Hive built-in ORC                                  1232           1330         139         12.8          78.3       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       884            893          13         17.8          56.2       1.0X
-Native ORC Vectorized                               222            305          73         70.8          14.1       4.0X
-Hive built-in ORC                                  1211           1270          83         13.0          77.0       0.7X
+Native ORC MR                                       947           1056         155         16.6          60.2       1.0X
+Native ORC Vectorized                               232            311          56         67.7          14.8       4.1X
+Hive built-in ORC                                  1317           1330          19         11.9          83.7       0.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       923            964          44         17.0          58.7       1.0X
-Native ORC Vectorized                               186            297          55         84.8          11.8       5.0X
-Hive built-in ORC                                  1347           1355          11         11.7          85.6       0.7X
+Native ORC MR                                       964           1070         150         16.3          61.3       1.0X
+Native ORC Vectorized                               275            304          32         57.2          17.5       3.5X
+Hive built-in ORC                                  1328           1336          11         11.8          84.4       0.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1032           1096          91         15.2          65.6       1.0X
-Native ORC Vectorized                               336            367          44         46.8          21.4       3.1X
-Hive built-in ORC                                  1381           1392          16         11.4          87.8       0.7X
+Native ORC MR                                      1006           1066          84         15.6          64.0       1.0X
+Native ORC Vectorized                               342            353          12         46.0          21.7       2.9X
+Hive built-in ORC                                  1361           1386          36         11.6          86.5       0.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1032           1045          19         15.2          65.6       1.0X
-Native ORC Vectorized                               340            362          15         46.2          21.6       3.0X
-Hive built-in ORC                                  1447           1478          45         10.9          92.0       0.7X
+Native ORC MR                                      1020           1026           8         15.4          64.8       1.0X
+Native ORC Vectorized                               352            381          23         44.7          22.4       2.9X
+Hive built-in ORC                                  1457           1457           0         10.8          92.7       0.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1055           1057           2         14.9          67.1       1.0X
-Native ORC Vectorized                               353            378          19         44.6          22.4       3.0X
-Hive built-in ORC                                  1401           1414          18         11.2          89.1       0.8X
+Native ORC MR                                      1036           1056          28         15.2          65.9       1.0X
+Native ORC Vectorized                               387            403          15         40.6          24.6       2.7X
+Hive built-in ORC                                  1409           1417          11         11.2          89.6       0.7X
 
 
 ================================================================================================
@@ -59,9 +59,9 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2009           2082         104          5.2         191.6       1.0X
-Native ORC Vectorized                              1300           1337          52          8.1         124.0       1.5X
-Hive built-in ORC                                  2423           2437          20          4.3         231.0       0.8X
+Native ORC MR                                      1993           2094         144          5.3         190.0       1.0X
+Native ORC Vectorized                              1290           1348          83          8.1         123.0       1.5X
+Hive built-in ORC                                  2336           2426         127          4.5         222.8       0.9X
 
 
 ================================================================================================
@@ -72,15 +72,15 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - Native ORC MR                        1068           1156         124         14.7          67.9       1.0X
-Data column - Native ORC Vectorized                 413            432          16         38.1          26.2       2.6X
-Data column - Hive built-in ORC                    1695           1790         135          9.3         107.7       0.6X
-Partition column - Native ORC MR                    734            791          68         21.4          46.6       1.5X
-Partition column - Native ORC Vectorized             63             88          23        249.9           4.0      17.0X
-Partition column - Hive built-in ORC               1063           1156         131         14.8          67.6       1.0X
-Both columns - Native ORC MR                       1147           1227         113         13.7          72.9       0.9X
-Both columns - Native ORC Vectorized                379            433          41         41.5          24.1       2.8X
-Both columns - Hive built-in ORC                   1633           1676          62          9.6         103.8       0.7X
+Data column - Native ORC MR                        1369           1384          22         11.5          87.0       1.0X
+Data column - Native ORC Vectorized                 406            428          20         38.7          25.8       3.4X
+Data column - Hive built-in ORC                    1444           1527         118         10.9          91.8       0.9X
+Partition column - Native ORC MR                    745            796          45         21.1          47.4       1.8X
+Partition column - Native ORC Vectorized             70             96          28        223.2           4.5      19.4X
+Partition column - Hive built-in ORC               1035           1063          39         15.2          65.8       1.3X
+Both columns - Native ORC MR                       1245           1306          86         12.6          79.2       1.1X
+Both columns - Native ORC Vectorized                385            424          35         40.9          24.5       3.6X
+Both columns - Hive built-in ORC                   1481           1566         120         10.6          94.2       0.9X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1044           1048           5         10.0          99.6       1.0X
-Native ORC Vectorized                               220            252          47         47.6          21.0       4.7X
-Hive built-in ORC                                  1274           1285          16          8.2         121.5       0.8X
+Native ORC MR                                      1102           1261         224          9.5         105.1       1.0X
+Native ORC Vectorized                               216            260          55         48.5          20.6       5.1X
+Hive built-in ORC                                  1299           1427         181          8.1         123.9       0.8X
 
 
 ================================================================================================
@@ -104,25 +104,25 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1685           1728          61          6.2         160.7       1.0X
-Native ORC Vectorized                               670            700          26         15.7          63.9       2.5X
-Hive built-in ORC                                  2224           2309         121          4.7         212.1       0.8X
+Native ORC MR                                      1632           1653          30          6.4         155.6       1.0X
+Native ORC Vectorized                               689            698           8         15.2          65.7       2.4X
+Hive built-in ORC                                  2224           2254          43          4.7         212.1       0.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1588           1615          38          6.6         151.4       1.0X
-Native ORC Vectorized                               802            822          18         13.1          76.5       2.0X
-Hive built-in ORC                                  2024           2106         116          5.2         193.0       0.8X
+Native ORC MR                                      1516           1555          54          6.9         144.6       1.0X
+Native ORC Vectorized                               782            801          19         13.4          74.6       1.9X
+Hive built-in ORC                                  2023           2110         123          5.2         192.9       0.7X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       889            898           9         11.8          84.8       1.0X
-Native ORC Vectorized                               278            348          67         37.7          26.6       3.2X
-Hive built-in ORC                                  1385           1442          81          7.6         132.0       0.6X
+Native ORC MR                                       879            931          48         11.9          83.8       1.0X
+Native ORC Vectorized                               250            342          85         42.0          23.8       3.5X
+Hive built-in ORC                                  1204           1219          20          8.7         114.9       0.7X
 
 
 ================================================================================================
@@ -133,25 +133,25 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       175            194          18          6.0         167.1       1.0X
-Native ORC Vectorized                                85            108          22         12.4          80.8       2.1X
-Hive built-in ORC                                   944           1021         108          1.1         900.4       0.2X
+Native ORC MR                                       159            192          24          6.6         151.4       1.0X
+Native ORC Vectorized                                85            116          32         12.3          81.0       1.9X
+Hive built-in ORC                                   790            853          99          1.3         753.9       0.2X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 200 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       186            217          27          5.6         177.4       1.0X
-Native ORC Vectorized                               124            146          26          8.5         117.8       1.5X
-Hive built-in ORC                                  1747           1798          72          0.6        1666.3       0.1X
+Native ORC MR                                       161            196          40          6.5         153.9       1.0X
+Native ORC Vectorized                               110            139          28          9.6         104.6       1.5X
+Hive built-in ORC                                  1549           1585          51          0.7        1476.8       0.1X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 300 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       236            266          40          4.4         224.8       1.0X
-Native ORC Vectorized                               180            209          28          5.8         171.2       1.3X
-Hive built-in ORC                                  2523           2532          12          0.4        2406.1       0.1X
+Native ORC MR                                       201            221          14          5.2         191.8       1.0X
+Native ORC Vectorized                               135            163          23          7.8         128.6       1.5X
+Hive built-in ORC                                  2166           2172           8          0.5        2065.6       0.1X
 
 
 ================================================================================================
@@ -162,33 +162,33 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1288           1306          25          0.8        1228.8       1.0X
-Native ORC Vectorized                               285            348          37          3.7         272.0       4.5X
-Hive built-in ORC                                   676            694          15          1.6         645.1       1.9X
+Native ORC MR                                       473            522          41          2.2         451.4       1.0X
+Native ORC Vectorized                               234            351          58          4.5         222.9       2.0X
+Hive built-in ORC                                   472            601         116          2.2         449.8       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 100 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       9615           9741         177          0.1        9170.0       1.0X
-Native ORC Vectorized                               2404           2444          56          0.4        2292.6       4.0X
-Hive built-in ORC                                   3504           3538          48          0.3        3341.7       2.7X
+Native ORC MR                                       3238           3394         221          0.3        3087.5       1.0X
+Native ORC Vectorized                               2724           2844         169          0.4        2598.2       1.2X
+Hive built-in ORC                                   3898           3934          52          0.3        3717.0       0.8X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 300 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      31759          31899         197          0.0       30288.1       1.0X
-Native ORC Vectorized                              29466          29481          20          0.0       28101.4       1.1X
-Hive built-in ORC                                  12544          12767         317          0.1       11962.5       2.5X
+Native ORC MR                                      10723          10890         236          0.1       10226.4       1.0X
+Native ORC Vectorized                               9966          10091         177          0.1        9503.9       1.1X
+Hive built-in ORC                                  12360          12482         172          0.1       11787.4       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 600 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      63543          64908        1931          0.0       60599.1       1.0X
-Native ORC Vectorized                              61319          61427         153          0.0       58478.0       1.0X
-Hive built-in ORC                                  25220          25403         259          0.0       24051.4       2.5X
+Native ORC MR                                      24875          25382         717          0.0       23722.6       1.0X
+Native ORC Vectorized                              22763          22830          95          0.0       21708.5       1.1X
+Hive built-in ORC                                  27783          28079         419          0.0       26496.0       0.9X
 
 
 ================================================================================================
@@ -199,24 +199,24 @@ OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Nested Struct Scan with 10 Elements, 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           10598          10627          42          0.1       10106.8       1.0X
-Native ORC Vectorized                                    1042           1066          34          1.0         993.7      10.2X
-Hive built-in ORC                                        4046           4558         725          0.3        3858.2       2.6X
+Native ORC MR                                            4175           4184          12          0.3        3982.0       1.0X
+Native ORC Vectorized                                    1476           1483           9          0.7        1407.9       2.8X
+Hive built-in ORC                                        4128           4150          31          0.3        3936.6       1.0X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Nested Struct Scan with 30 Elements, 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           31513          31540          38          0.0       30052.8       1.0X
-Native ORC Vectorized                                    2519           2579          85          0.4        2402.4      12.5X
-Hive built-in ORC                                       11881          11939          82          0.1       11330.6       2.7X
+Native ORC MR                                            9819           9945         178          0.1        9364.0       1.0X
+Native ORC Vectorized                                    3771           3809          54          0.3        3596.0       2.6X
+Hive built-in ORC                                       11067          11090          32          0.1       10554.8       0.9X
 
 OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Nested Struct Scan with 10 Elements, 30 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           29009          29202         274          0.0       27664.8       1.0X
-Native ORC Vectorized                                    4259           4269          13          0.2        4062.0       6.8X
-Hive built-in ORC                                        8633           8654          30          0.1        8232.9       3.4X
+Native ORC MR                                           10779          10781           3          0.1       10279.7       1.0X
+Native ORC Vectorized                                    7162           7392         325          0.1        6830.7       1.5X
+Hive built-in ORC                                        8417           8553         192          0.1        8027.5       1.3X
 
 

--- a/sql/hive/benchmarks/OrcReadBenchmark-jdk17-results.txt
+++ b/sql/hive/benchmarks/OrcReadBenchmark-jdk17-results.txt
@@ -6,49 +6,49 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       775            807          33         20.3          49.2       1.0X
-Native ORC Vectorized                               141            187          25        111.5           9.0       5.5X
-Hive built-in ORC                                  1124           1130           9         14.0          71.5       0.7X
+Native ORC MR                                       803            838          38         19.6          51.1       1.0X
+Native ORC Vectorized                               147            173          21        107.1           9.3       5.5X
+Hive built-in ORC                                  1098           1115          23         14.3          69.8       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       830            847          16         18.9          52.8       1.0X
-Native ORC Vectorized                               141            182          21        111.8           8.9       5.9X
-Hive built-in ORC                                  1192           1215          32         13.2          75.8       0.7X
+Native ORC MR                                       856            927          81         18.4          54.4       1.0X
+Native ORC Vectorized                               136            161          15        115.3           8.7       6.3X
+Hive built-in ORC                                  1188           1328         198         13.2          75.5       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       885            902          16         17.8          56.3       1.0X
-Native ORC Vectorized                               140            173          25        112.1           8.9       6.3X
-Hive built-in ORC                                  1211           1213           3         13.0          77.0       0.7X
+Native ORC MR                                       813            875         105         19.3          51.7       1.0X
+Native ORC Vectorized                               138            158          15        113.9           8.8       5.9X
+Hive built-in ORC                                  1158           1158           0         13.6          73.6       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       945            950           4         16.6          60.1       1.0X
-Native ORC Vectorized                               196            216          18         80.4          12.4       4.8X
-Hive built-in ORC                                  1262           1269          10         12.5          80.2       0.7X
+Native ORC MR                                       839            844           7         18.8          53.3       1.0X
+Native ORC Vectorized                               180            207          30         87.4          11.4       4.7X
+Hive built-in ORC                                  1358           1394          52         11.6          86.3       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       949            958           8         16.6          60.3       1.0X
-Native ORC Vectorized                               216            240          32         72.8          13.7       4.4X
-Hive built-in ORC                                  1242           1246           5         12.7          79.0       0.8X
+Native ORC MR                                       906            968          58         17.4          57.6       1.0X
+Native ORC Vectorized                               237            292          56         66.3          15.1       3.8X
+Hive built-in ORC                                  1395           1416          30         11.3          88.7       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1020           1036          22         15.4          64.9       1.0X
-Native ORC Vectorized                               258            270          13         60.9          16.4       4.0X
-Hive built-in ORC                                  1306           1318          17         12.0          83.0       0.8X
+Native ORC MR                                      1041           1060          27         15.1          66.2       1.0X
+Native ORC Vectorized                               265            320          44         59.4          16.8       3.9X
+Hive built-in ORC                                  1339           1374          49         11.7          85.2       0.8X
 
 
 ================================================================================================
@@ -59,9 +59,9 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1792           1821          41          5.9         170.9       1.0X
-Native ORC Vectorized                              1008           1050          59         10.4          96.1       1.8X
-Hive built-in ORC                                  2217           2238          29          4.7         211.5       0.8X
+Native ORC MR                                      2091           2136          63          5.0         199.5       1.0X
+Native ORC Vectorized                              1253           1260          10          8.4         119.5       1.7X
+Hive built-in ORC                                  2384           2391           9          4.4         227.4       0.9X
 
 
 ================================================================================================
@@ -72,15 +72,15 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - Native ORC MR                        1433           1441          11         11.0          91.1       1.0X
-Data column - Native ORC Vectorized                 193            240          54         81.6          12.2       7.4X
-Data column - Hive built-in ORC                    1686           1696          13          9.3         107.2       0.8X
-Partition column - Native ORC MR                    917            953          45         17.2          58.3       1.6X
-Partition column - Native ORC Vectorized             67             96          20        233.2           4.3      21.2X
-Partition column - Hive built-in ORC               1095           1144          69         14.4          69.6       1.3X
-Both columns - Native ORC MR                       1241           1264          31         12.7          78.9       1.2X
-Both columns - Native ORC Vectorized                198            238          36         79.6          12.6       7.2X
-Both columns - Hive built-in ORC                   1745           1859         161          9.0         110.9       0.8X
+Data column - Native ORC MR                        1549           1631         116         10.2          98.5       1.0X
+Data column - Native ORC Vectorized                 295            346          45         53.3          18.8       5.3X
+Data column - Hive built-in ORC                    1851           1896          64          8.5         117.7       0.8X
+Partition column - Native ORC MR                    850            868          19         18.5          54.1       1.8X
+Partition column - Native ORC Vectorized             54             67           9        288.7           3.5      28.4X
+Partition column - Hive built-in ORC               1131           1174          60         13.9          71.9       1.4X
+Both columns - Native ORC MR                       1069           1077          10         14.7          68.0       1.4X
+Both columns - Native ORC Vectorized                208            226          18         75.6          13.2       7.4X
+Both columns - Hive built-in ORC                   1811           1812           1          8.7         115.2       0.9X
 
 
 ================================================================================================
@@ -91,9 +91,9 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       847            856           8         12.4          80.8       1.0X
-Native ORC Vectorized                               190            214          18         55.3          18.1       4.5X
-Hive built-in ORC                                  1214           1217           5          8.6         115.8       0.7X
+Native ORC MR                                       825            830           5         12.7          78.6       1.0X
+Native ORC Vectorized                               199            207          10         52.8          18.9       4.2X
+Hive built-in ORC                                  1206           1210           6          8.7         115.0       0.7X
 
 
 ================================================================================================
@@ -104,25 +104,25 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1592           1782         269          6.6         151.8       1.0X
-Native ORC Vectorized                               628            636           9         16.7          59.9       2.5X
-Hive built-in ORC                                  2399           2504         148          4.4         228.8       0.7X
+Native ORC MR                                      1542           1572          42          6.8         147.1       1.0X
+Native ORC Vectorized                               523            582          66         20.1          49.8       3.0X
+Hive built-in ORC                                  2190           2190           0          4.8         208.9       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1528           1622         133          6.9         145.8       1.0X
-Native ORC Vectorized                               747            764          18         14.0          71.2       2.0X
-Hive built-in ORC                                  2222           2223           2          4.7         211.9       0.7X
+Native ORC MR                                      1490           1499          13          7.0         142.1       1.0X
+Native ORC Vectorized                               630            695          97         16.7          60.1       2.4X
+Hive built-in ORC                                  2112           2121          13          5.0         201.4       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       996           1050          77         10.5          94.9       1.0X
-Native ORC Vectorized                               360            401          36         29.2          34.3       2.8X
-Hive built-in ORC                                  1276           1281           7          8.2         121.7       0.8X
+Native ORC MR                                       815            830          23         12.9          77.7       1.0X
+Native ORC Vectorized                               225            249          26         46.5          21.5       3.6X
+Hive built-in ORC                                  1247           1259          16          8.4         119.0       0.7X
 
 
 ================================================================================================
@@ -133,25 +133,25 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       132            183          46          7.9         126.3       1.0X
-Native ORC Vectorized                                71             85          13         14.8          67.5       1.9X
-Hive built-in ORC                                   609            645          37          1.7         580.4       0.2X
+Native ORC MR                                       141            173          19          7.5         134.0       1.0X
+Native ORC Vectorized                                77             91           9         13.7          73.2       1.8X
+Hive built-in ORC                                   758            776          16          1.4         722.9       0.2X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 200 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       161            206          33          6.5         153.6       1.0X
-Native ORC Vectorized                               105            126          16         10.0         100.0       1.5X
-Hive built-in ORC                                  1355           1380          35          0.8        1292.2       0.1X
+Native ORC MR                                       190            232          29          5.5         181.4       1.0X
+Native ORC Vectorized                               118            149          41          8.9         112.7       1.6X
+Hive built-in ORC                                  1537           1558          30          0.7        1465.7       0.1X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Column Scan from 300 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       212            246          23          4.9         202.6       1.0X
-Native ORC Vectorized                               149            178          33          7.0         142.5       1.4X
-Hive built-in ORC                                  1723           1781          83          0.6        1642.8       0.1X
+Native ORC MR                                       237            268          28          4.4         226.0       1.0X
+Native ORC Vectorized                               165            188          17          6.4         157.2       1.4X
+Hive built-in ORC                                  2103           2171          96          0.5        2005.3       0.1X
 
 
 ================================================================================================
@@ -162,33 +162,33 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1154           1226         102          0.9        1100.3       1.0X
-Native ORC Vectorized                               294            322          33          3.6         280.7       3.9X
-Hive built-in ORC                                   636            673          42          1.6         606.8       1.8X
+Native ORC MR                                       278            294          12          3.8         265.5       1.0X
+Native ORC Vectorized                               213            246          41          4.9         202.9       1.3X
+Hive built-in ORC                                   536            586          40          2.0         511.0       0.5X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 100 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       9701           9922         313          0.1        9251.5       1.0X
-Native ORC Vectorized                               2830           2913         118          0.4        2698.5       3.4X
-Hive built-in ORC                                   3345           3514         239          0.3        3190.5       2.9X
+Native ORC MR                                       2235           2244          13          0.5        2131.8       1.0X
+Native ORC Vectorized                               3154           3159           7          0.3        3007.6       0.7X
+Hive built-in ORC                                   3740           4089         493          0.3        3567.0       0.6X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 300 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      29090          30104        1435          0.0       27742.1       1.0X
-Native ORC Vectorized                              28891          28997         149          0.0       27552.8       1.0X
-Hive built-in ORC                                   9118           9253         192          0.1        8695.3       3.2X
+Native ORC MR                                       7350           8577        1735          0.1        7009.2       1.0X
+Native ORC Vectorized                               7161           8481        1867          0.1        6829.0       1.0X
+Hive built-in ORC                                  10307          10909         851          0.1        9829.6       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Single Struct Column Scan with 600 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      66474          66582         153          0.0       63394.3       1.0X
-Native ORC Vectorized                              59070          59089          27          0.0       56333.5       1.1X
-Hive built-in ORC                                  21473          26589         NaN          0.0       20478.3       3.1X
+Native ORC MR                                      15931          18238         NaN          0.1       15192.6       1.0X
+Native ORC Vectorized                              15192          16500        1851          0.1       14487.9       1.0X
+Hive built-in ORC                                  29853          30027         247          0.0       28469.9       0.5X
 
 
 ================================================================================================
@@ -199,24 +199,24 @@ OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Nested Struct Scan with 10 Elements, 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           10799          11416         872          0.1       10299.2       1.0X
-Native ORC Vectorized                                    1315           1341          37          0.8        1253.8       8.2X
-Hive built-in ORC                                        4209           4250          59          0.2        4014.0       2.6X
+Native ORC MR                                            3399           3463          90          0.3        3241.5       1.0X
+Native ORC Vectorized                                    1513           1630         166          0.7        1442.7       2.2X
+Hive built-in ORC                                        3953           3960          10          0.3        3770.0       0.9X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Nested Struct Scan with 30 Elements, 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           31936          32000          90          0.0       30456.3       1.0X
-Native ORC Vectorized                                    3359           3409          70          0.3        3203.8       9.5X
-Hive built-in ORC                                       11972          12027          77          0.1       11417.4       2.7X
+Native ORC MR                                            7667           7684          24          0.1        7311.9       1.0X
+Native ORC Vectorized                                    3865           3881          22          0.3        3685.8       2.0X
+Hive built-in ORC                                       11223          11246          32          0.1       10703.5       0.7X
 
 OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Nested Struct Scan with 10 Elements, 30 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           28253          29573        1866          0.0       26943.9       1.0X
-Native ORC Vectorized                                    3849           4051         287          0.3        3670.3       7.3X
-Hive built-in ORC                                        8496           8607         157          0.1        8102.5       3.3X
+Native ORC MR                                            9506           9633         181          0.1        9065.4       1.0X
+Native ORC Vectorized                                    4170           4320         212          0.3        3976.4       2.3X
+Hive built-in ORC                                       12756          13821        1506          0.1       12164.7       0.7X
 
 

--- a/sql/hive/benchmarks/OrcReadBenchmark-results.txt
+++ b/sql/hive/benchmarks/OrcReadBenchmark-results.txt
@@ -3,52 +3,52 @@ SQL Single Numeric Column Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1007           1060          76         15.6          64.0       1.0X
-Native ORC Vectorized                               198            274          64         79.5          12.6       5.1X
-Hive built-in ORC                                  1216           1315         140         12.9          77.3       0.8X
+Native ORC MR                                      1016           1068          74         15.5          64.6       1.0X
+Native ORC Vectorized                               220            252          33         71.4          14.0       4.6X
+Hive built-in ORC                                  1274           1290          22         12.3          81.0       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1024           1184         226         15.4          65.1       1.0X
-Native ORC Vectorized                               165            204          33         95.6          10.5       6.2X
-Hive built-in ORC                                  1306           1328          32         12.0          83.0       0.8X
+Native ORC MR                                      1117           1142          36         14.1          71.0       1.0X
+Native ORC Vectorized                               157            189          20        100.4          10.0       7.1X
+Hive built-in ORC                                  1369           1399          42         11.5          87.1       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       924            972          71         17.0          58.7       1.0X
-Native ORC Vectorized                               180            210          27         87.6          11.4       5.1X
-Hive built-in ORC                                  1436           1448          17         11.0          91.3       0.6X
+Native ORC MR                                      1064           1189         177         14.8          67.6       1.0X
+Native ORC Vectorized                               179            204          25         87.9          11.4       5.9X
+Hive built-in ORC                                  1454           1468          20         10.8          92.4       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       972           1060         124         16.2          61.8       1.0X
-Native ORC Vectorized                               204            248          50         77.1          13.0       4.8X
-Hive built-in ORC                                  1389           1392           4         11.3          88.3       0.7X
+Native ORC MR                                      1070           1196         177         14.7          68.1       1.0X
+Native ORC Vectorized                               216            232          14         72.8          13.7       5.0X
+Hive built-in ORC                                  1484           1533          69         10.6          94.4       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       992            995           4         15.9          63.1       1.0X
-Native ORC Vectorized                               224            256          46         70.2          14.2       4.4X
-Hive built-in ORC                                  1289           1309          28         12.2          82.0       0.8X
+Native ORC MR                                      1164           1181          24         13.5          74.0       1.0X
+Native ORC Vectorized                               264            290          24         59.6          16.8       4.4X
+Hive built-in ORC                                  1536           1572          51         10.2          97.7       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1025           1051          37         15.4          65.1       1.0X
-Native ORC Vectorized                               268            301          35         58.6          17.1       3.8X
-Hive built-in ORC                                  1367           1380          19         11.5          86.9       0.7X
+Native ORC MR                                      1127           1174          67         14.0          71.7       1.0X
+Native ORC Vectorized                               285            302          17         55.2          18.1       4.0X
+Hive built-in ORC                                  1571           1582          16         10.0          99.9       0.7X
 
 
 ================================================================================================
@@ -56,12 +56,12 @@ Int and String Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      2081           2126          64          5.0         198.4       1.0X
-Native ORC Vectorized                              1196           1230          48          8.8         114.1       1.7X
-Hive built-in ORC                                  2482           2535          75          4.2         236.7       0.8X
+Native ORC MR                                      2329           2413         119          4.5         222.1       1.0X
+Native ORC Vectorized                              1274           1282          12          8.2         121.5       1.8X
+Hive built-in ORC                                  2622           2692          99          4.0         250.0       0.9X
 
 
 ================================================================================================
@@ -69,18 +69,18 @@ Partitioned Table Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Partitioned Table:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Data column - Native ORC MR                        1142           1259         166         13.8          72.6       1.0X
-Data column - Native ORC Vectorized                 221            249          33         71.2          14.0       5.2X
-Data column - Hive built-in ORC                    1543           1550          10         10.2          98.1       0.7X
-Partition column - Native ORC MR                    816            822          10         19.3          51.9       1.4X
-Partition column - Native ORC Vectorized             69             79           7        227.1           4.4      16.5X
-Partition column - Hive built-in ORC               1126           1227         143         14.0          71.6       1.0X
-Both columns - Native ORC MR                       1292           1304          17         12.2          82.1       0.9X
-Both columns - Native ORC Vectorized                222            252          19         70.7          14.1       5.1X
-Both columns - Hive built-in ORC                   1497           1535          54         10.5          95.2       0.8X
+Data column - Native ORC MR                        1304           1309           8         12.1          82.9       1.0X
+Data column - Native ORC Vectorized                 221            259          25         71.1          14.1       5.9X
+Data column - Hive built-in ORC                    1586           1606          28          9.9         100.8       0.8X
+Partition column - Native ORC MR                    868            889          29         18.1          55.2       1.5X
+Partition column - Native ORC Vectorized             71             85          18        222.3           4.5      18.4X
+Partition column - Hive built-in ORC               1210           1241          43         13.0          77.0       1.1X
+Both columns - Native ORC MR                       1397           1435          54         11.3          88.8       0.9X
+Both columns - Native ORC Vectorized                236            257          22         66.5          15.0       5.5X
+Both columns - Hive built-in ORC                   1723           1726           4          9.1         109.6       0.8X
 
 
 ================================================================================================
@@ -88,12 +88,12 @@ Repeated String Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       932            958          27         11.3          88.9       1.0X
-Native ORC Vectorized                               211            239          28         49.6          20.1       4.4X
-Hive built-in ORC                                  1330           1359          41          7.9         126.8       0.7X
+Native ORC MR                                      1074           1089          21          9.8         102.4       1.0X
+Native ORC Vectorized                               221            254          33         47.5          21.0       4.9X
+Hive built-in ORC                                  1435           1437           2          7.3         136.9       0.7X
 
 
 ================================================================================================
@@ -101,28 +101,28 @@ String with Nulls Scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1821           1847          37          5.8         173.7       1.0X
-Native ORC Vectorized                               594            630          40         17.6          56.7       3.1X
-Hive built-in ORC                                  2351           2449         139          4.5         224.2       0.8X
+Native ORC MR                                      1948           1964          21          5.4         185.8       1.0X
+Native ORC Vectorized                               666            687          31         15.7          63.5       2.9X
+Hive built-in ORC                                  2454           2489          50          4.3         234.0       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1603           1612          12          6.5         152.9       1.0X
-Native ORC Vectorized                               658            689          31         15.9          62.8       2.4X
-Hive built-in ORC                                  2189           2216          38          4.8         208.8       0.7X
+Native ORC MR                                      1744           1756          16          6.0         166.4       1.0X
+Native ORC Vectorized                               707            736          38         14.8          67.4       2.5X
+Hive built-in ORC                                  2225           2259          48          4.7         212.2       0.8X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       892           1014         173         11.8          85.0       1.0X
-Native ORC Vectorized                               252            273          16         41.7          24.0       3.5X
-Hive built-in ORC                                  1195           1268         103          8.8         114.0       0.7X
+Native ORC MR                                       996           1101         149         10.5          95.0       1.0X
+Native ORC Vectorized                               282            311          18         37.1          26.9       3.5X
+Hive built-in ORC                                  1405           1420          20          7.5         134.0       0.7X
 
 
 ================================================================================================
@@ -130,28 +130,28 @@ Single Column Scan From Wide Columns
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       143            182          26          7.3         136.3       1.0X
-Native ORC Vectorized                                81             97          17         12.9          77.4       1.8X
-Hive built-in ORC                                   803            839          62          1.3         765.8       0.2X
+Native ORC MR                                       153            180          17          6.8         146.2       1.0X
+Native ORC Vectorized                                85             99          18         12.3          81.4       1.8X
+Hive built-in ORC                                   912            971          97          1.2         869.4       0.2X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Column Scan from 200 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       184            256          43          5.7         175.4       1.0X
-Native ORC Vectorized                               126            160          31          8.4         119.7       1.5X
-Hive built-in ORC                                  1589           1640          72          0.7        1515.5       0.1X
+Native ORC MR                                       254            272          15          4.1         242.5       1.0X
+Native ORC Vectorized                               122            138          15          8.6         116.6       2.1X
+Hive built-in ORC                                  1772           1819          67          0.6        1689.5       0.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Column Scan from 300 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                       265            302          44          4.0         253.2       1.0X
-Native ORC Vectorized                               179            227          38          5.8         171.2       1.5X
-Hive built-in ORC                                  2342           2383          57          0.4        2234.0       0.1X
+Native ORC MR                                       233            271          31          4.5         222.5       1.0X
+Native ORC Vectorized                               162            184          25          6.5         154.8       1.4X
+Hive built-in ORC                                  2591           2602          16          0.4        2470.6       0.1X
 
 
 ================================================================================================
@@ -159,36 +159,36 @@ Struct scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Struct Column Scan with 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      1227           1236          13          0.9        1169.9       1.0X
-Native ORC Vectorized                               190            233          62          5.5         181.2       6.5X
-Hive built-in ORC                                   882            925          64          1.2         841.5       1.4X
+Native ORC MR                                       369            415          54          2.8         351.7       1.0X
+Native ORC Vectorized                               201            214           9          5.2         191.3       1.8X
+Hive built-in ORC                                   712            719           6          1.5         679.0       0.5X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Struct Column Scan with 100 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      10839          10916         109          0.1       10337.1       1.0X
-Native ORC Vectorized                               1700           1729          41          0.6        1621.5       6.4X
-Hive built-in ORC                                   6408           6512         148          0.2        6110.8       1.7X
+Native ORC MR                                       2764           2834          99          0.4        2636.2       1.0X
+Native ORC Vectorized                               1651           1669          26          0.6        1574.2       1.7X
+Hive built-in ORC                                   3957           3998          58          0.3        3774.0       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Struct Column Scan with 300 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      32949          33157         294          0.0       31422.8       1.0X
-Native ORC Vectorized                              31820          32106         404          0.0       30346.3       1.0X
-Hive built-in ORC                                  23077          23106          41          0.0       22008.0       1.4X
+Native ORC MR                                       9368          11693         NaN          0.1        8934.4       1.0X
+Native ORC Vectorized                               9324           9737         585          0.1        8891.6       1.0X
+Hive built-in ORC                                  13303          13665         512          0.1       12687.2       0.7X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Single Struct Column Scan with 600 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                      78431          78557         179          0.0       74797.5       1.0X
-Native ORC Vectorized                              76804          77609        1139          0.0       73245.9       1.0X
-Hive built-in ORC                                  56722          58217        2114          0.0       54094.1       1.4X
+Native ORC MR                                      32403          35146         NaN          0.0       30902.3       1.0X
+Native ORC Vectorized                              38268          39336        1511          0.0       36495.2       0.8X
+Hive built-in ORC                                  47590          48669        1525          0.0       45385.7       0.7X
 
 
 ================================================================================================
@@ -196,27 +196,27 @@ Nested Struct scan
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Nested Struct Scan with 10 Elements, 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           13075          13254         253          0.1       12468.9       1.0X
-Native ORC Vectorized                                     947            986          35          1.1         903.1      13.8X
-Hive built-in ORC                                        3857           3899          60          0.3        3678.2       3.4X
+Native ORC MR                                            5127           5720         838          0.2        4889.8       1.0X
+Native ORC Vectorized                                    1064           1067           4          1.0        1014.8       4.8X
+Hive built-in ORC                                        4622           4647          36          0.2        4407.6       1.1X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Nested Struct Scan with 30 Elements, 10 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           29873          29940          95          0.0       28489.4       1.0X
-Native ORC Vectorized                                    2347           2412          91          0.4        2238.6      12.7X
-Hive built-in ORC                                       10415          10464          70          0.1        9932.2       2.9X
+Native ORC MR                                           11342          11343           2          0.1       10816.3       1.0X
+Native ORC Vectorized                                    2889           2891           4          0.4        2755.1       3.9X
+Hive built-in ORC                                       12754          12890         192          0.1       12163.6       0.9X
 
 OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Nested Struct Scan with 10 Elements, 30 Fields:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Native ORC MR                                           27999          31076         699          0.0       26701.9       1.0X
-Native ORC Vectorized                                    2719           2725           8          0.4        2593.4      10.3X
-Hive built-in ORC                                        8701           9027         462          0.1        8297.5       3.2X
+Native ORC MR                                           12483          12602         167          0.1       11905.1       1.0X
+Native ORC Vectorized                                    3522           3615         132          0.3        3358.5       3.5X
+Hive built-in ORC                                        9775           9784          12          0.1        9322.4       1.3X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

When deserializing an Orc struct, reuse the result row when possible.

When the struct's parent is itself a struct, it is safe to reuse the result row, since some code (an ancestor of the parent, or some downstream processing) has already copied the parent's result row, and therefore our result row.

When the parent is a map or array, it is not safe to reuse the result row, because each element of the parent will point to the same result row. In this case, we must copy the result row before updating the parent.

Note, it is safe to reuse the result row even when the parent is a struct but the grandparent is a map or array, because the parent will copy its result row for each element of the grandparent (and thus copy our result row).

### Why are the changes needed?
This change speeds up deserialization of records containing Orc structs.

| struct size | master | pr    | improvement  |
| ----------- | ------ | ----- | ---------    |
| 10 fields   | 1463   | 296   | 4.94 times
| 100 fields  | 11818  | 2391  | 4.94 times |
| 300 fields  | 38938  | 8061  | 4.8 times |
| 600 fields  | 86735  | 30505 | 2.8 times |

The benchmark results for the PR are included in the PR. The benchmark results for master (with the new benchmark added) are [here](https://issues.apache.org/jira/secure/attachment/13038214/master_results.txt).



### Does this PR introduce _any_ user-facing change?
 No.


### How was this patch tested?

- New unit tests to check correctness (since sometimes the result row is reused, and sometimes it is not).
- New benchmarks.
