### PR TITLE
[SPARK-37806][K8S] Support minimum number of tasks per executor before being rolled

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -168,6 +168,16 @@ private[spark] object Config extends Logging {
       .checkValues(ExecutorRollPolicy.values.map(_.toString))
       .createWithDefault(ExecutorRollPolicy.TOTAL_GC_TIME.toString)
 
+  val MINIMUM_TASKS_PER_EXECUTOR_BEFORE_ROLLING =
+    ConfigBuilder("spark.kubernetes.executor.minTasksPerExecutorBeforeRolling")
+      .doc("The minimum number of tasks per executor before rolling. " +
+        "Spark will not roll newly created executors whose total number of tasks is smaller" +
+        "than this configuration. The default value is zero.")
+      .version("3.3.0")
+      .intConf
+      .checkValue(_ >= 0, "The minimum number of tasks should be non-negative.")
+      .createWithDefault(0)
+
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"
   val KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX = "spark.kubernetes.authenticate.driver.mounted"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -171,7 +171,7 @@ private[spark] object Config extends Logging {
   val MINIMUM_TASKS_PER_EXECUTOR_BEFORE_ROLLING =
     ConfigBuilder("spark.kubernetes.executor.minTasksPerExecutorBeforeRolling")
       .doc("The minimum number of tasks per executor before rolling. " +
-        "Spark will not roll newly created executors whose total number of tasks is smaller" +
+        "Spark will not roll executors whose total number of tasks is smaller " +
         "than this configuration. The default value is zero.")
       .version("3.3.0")
       .intConf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support a new configuration to support the minimum number of tasks per executor before being selected as the executor rolling target.

### Why are the changes needed?

Newly created executors might have a long initial setup time during its initial tasks.
In this case, some rolling policies like `AVERAGE_DURATION` might kill those newly created executors.
This PR aims to protect newly created executors until `totalTasks` reaches the minimum number of tasks.

### Does this PR introduce _any_ user-facing change?

No. The default value is 0.

### How was this patch tested?

Pass the CIs with the newly added test case.