### PR TITLE
[SPARK-33084][TEST][FollowUP] Fix a flaky test in SparkContextSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1074,7 +1074,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       dependencyJars.foreach(jar => assert(sc.listJars().exists(_.contains(jar))))
 
       eventually(timeout(10.seconds), interval(1.second)) {
-        assert(logAppender.loggingEvents.count(_.getMessage.getFormattedMessage.contains(
+        assert(logAppender.nonNullLogEvents().count(_.getMessage.getFormattedMessage.contains(
           "Added dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
       }
@@ -1082,10 +1082,11 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       // test dependency jars exist
       sc.addJar("ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")
       eventually(timeout(10.seconds), interval(1.second)) {
-        assert(logAppender.loggingEvents.count(_.getMessage.getFormattedMessage.contains(
+        assert(logAppender.nonNullLogEvents().count(_.getMessage.getFormattedMessage.contains(
           "The dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
-        val existMsg = logAppender.loggingEvents.filter(_.getMessage.getFormattedMessage.contains(
+        val existMsg = logAppender.nonNullLogEvents().filter(
+          _.getMessage.getFormattedMessage.contains(
           "The dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true"))
           .head.getMessage.getFormattedMessage

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1074,7 +1074,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       dependencyJars.foreach(jar => assert(sc.listJars().exists(_.contains(jar))))
 
       eventually(timeout(10.seconds), interval(1.second)) {
-        assert(logAppender.nonNullLogEvents().count(_.getMessage.getFormattedMessage.contains(
+        assert(logAppender.loggingEvents.count(_.getMessage.getFormattedMessage.contains(
           "Added dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
       }
@@ -1082,10 +1082,10 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
       // test dependency jars exist
       sc.addJar("ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")
       eventually(timeout(10.seconds), interval(1.second)) {
-        assert(logAppender.nonNullLogEvents().count(_.getMessage.getFormattedMessage.contains(
+        assert(logAppender.loggingEvents.count(_.getMessage.getFormattedMessage.contains(
           "The dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
-        val existMsg = logAppender.nonNullLogEvents().filter(
+        val existMsg = logAppender.loggingEvents.filter(
           _.getMessage.getFormattedMessage.contains(
           "The dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true"))

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1085,8 +1085,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
         assert(logAppender.loggingEvents.count(_.getMessage.getFormattedMessage.contains(
           "The dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true")) == 1)
-        val existMsg = logAppender.loggingEvents.filter(
-          _.getMessage.getFormattedMessage.contains(
+        val existMsg = logAppender.loggingEvents.filter(_.getMessage.getFormattedMessage.contains(
           "The dependency jars of Ivy URI " +
             "ivy://org.apache.hive:hive-storage-api:2.7.0?transitive=true"))
           .head.getMessage.getFormattedMessage

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -266,18 +266,18 @@ abstract class SparkFunSuite
 
   class LogAppender(msg: String = "", maxEvents: Int = 1000)
       extends AbstractAppender("logAppender", null, null) {
-    val loggingEvents = new ArrayBuffer[LogEvent]()
+    private val _loggingEvents = new ArrayBuffer[LogEvent]()
     private var _threshold: Level = Level.INFO
 
     override def append(loggingEvent: LogEvent): Unit = loggingEvent.synchronized {
       val copyEvent = loggingEvent.toImmutable
       if (copyEvent.getLevel.isMoreSpecificThan(_threshold)) {
-        if (loggingEvents.size >= maxEvents) {
+        if (_loggingEvents.size >= maxEvents) {
           val loggingInfo = if (msg == "") "." else s" while logging $msg."
           throw new IllegalStateException(
             s"Number of events reached the limit of $maxEvents$loggingInfo")
         }
-        loggingEvents.append(copyEvent)
+        _loggingEvents.append(copyEvent)
       }
     }
 
@@ -285,6 +285,6 @@ abstract class SparkFunSuite
       _threshold = threshold
     }
 
-    def nonNullLogEvents(): ArrayBuffer[LogEvent] = loggingEvents.filterNot(_ == null)
+    def loggingEvents: ArrayBuffer[LogEvent] = _loggingEvents.filterNot(_ == null)
   }
 }

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -284,5 +284,7 @@ abstract class SparkFunSuite
     def setThreshold(threshold: Level): Unit = {
       _threshold = threshold
     }
+
+    def nonNullLogEvents(): Seq[LogEvent] = loggingEvents.filterNot(_ == null)
   }
 }

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -285,6 +285,6 @@ abstract class SparkFunSuite
       _threshold = threshold
     }
 
-    def nonNullLogEvents(): Seq[LogEvent] = loggingEvents.filterNot(_ == null)
+    def nonNullLogEvents(): ArrayBuffer[LogEvent] = loggingEvents.filterNot(_ == null)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The test case `SPARK-33084: Add jar support Ivy URI -- transitive=true will download dependency jars` in `SparkContextSuite` is becoming flaky:

- https://github.com/gengliangwang/spark/runs/4698825652?check_suite_focus=true
- https://github.com/gengliangwang/spark/runs/4698331067?check_suite_focus=true
- https://github.com/AngersZhuuuu/spark/runs/4697626841?check_suite_focus=true

The reason is that some of the events in `LogAppender` are null so that there is NPE:
```
[info]   Cause: java.lang.NullPointerException:
[info]   at org.apache.spark.SparkContextSuite.$anonfun$new$128(SparkContextSuite.scala:1077)
[info]   at org.apache.spark.SparkContextSuite.$anonfun$new$128$adapted(SparkContextSuite.scala:1077)
```
This PR is to fix the issue to unblock PR builders.  

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix flaky test

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Just tests