### PR TITLE
[SPARK-37750][SQL][FOLLOWUP] Change SQLConf parameter name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -233,7 +233,7 @@ case class GetArrayStructFields(
 case class GetArrayItem(
     child: Expression,
     ordinal: Expression,
-    failOnError: Boolean = SQLConf.get.ansiFailOnElementNotExists)
+    failOnError: Boolean = SQLConf.get.strictIndexOperator)
   extends BinaryExpression with GetArrayItemUtil with ExpectsInputTypes with ExtractValue {
 
   def this(child: Expression, ordinal: Expression) = this(child, ordinal, SQLConf.get.ansiEnabled)
@@ -441,7 +441,7 @@ trait GetMapValueUtil extends BinaryExpression with ImplicitCastInputTypes {
 case class GetMapValue(
     child: Expression,
     key: Expression,
-    failOnError: Boolean = SQLConf.get.ansiFailOnElementNotExists)
+    failOnError: Boolean = SQLConf.get.strictIndexOperator)
   extends GetMapValueUtil with ExtractValue {
 
   def this(child: Expression, key: Expression) = this(child, key, SQLConf.get.ansiEnabled)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4138,7 +4138,7 @@ class SQLConf extends Serializable with Logging {
 
   def enforceReservedKeywords: Boolean = ansiEnabled && getConf(ENFORCE_RESERVED_KEYWORDS)
 
-  def ansiFailOnElementNotExists: Boolean = ansiEnabled && getConf(ANSI_STRICT_INDEX_OPERATOR)
+  def strictIndexOperator: Boolean = ansiEnabled && getConf(ANSI_STRICT_INDEX_OPERATOR)
 
   def timestampType: AtomicType = getConf(TIMESTAMP_TYPE) match {
     case "TIMESTAMP_LTZ" =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR changes ansiFailOnElementNotExists to strictIndexOperator.

### Why are the changes needed?
strictIndexOperator aligns with ANSI_STRICT_INDEX_OPERATOR.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.