### PR TITLE
[SPARK-37800][SQL][FOLLOW-UP] Remove duplicated LogicalPlan inheritance

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -812,7 +812,7 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("SPARK-37800: TreeNode.argString incorrectly formats arguments of type Set[_]") {
-    case class Node(set: Set[String], nested: Seq[Set[Int]]) extends LogicalPlan with LeafNode {
+    case class Node(set: Set[String], nested: Seq[Set[Int]]) extends LeafNode {
       val output: Seq[Attribute] = Nil
     }
     val node = Node(Set("second", "first"), Seq(Set(3, 1), Set(2, 1)))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/35084 that removes duplicated `LogicalPlan` inheritance because `LeafNode` always inherits `LogicalPlan`.

### Why are the changes needed?

To make the codes easier to read and less error-prone. e.g., if we switch `LeafNode` to an abstract class like `LogicalPlan` the complication fails.

To clarify, this is the only `LeafNode` instance in the current codebase that duplicately inherits `LogicalPlan`.

### Does this PR introduce _any_ user-facing change?

No, virtually no-op for now.

### How was this patch tested?

Existing test cases should cover.
