### PR TITLE
[SPARK-37818][DOCS] Add option in the description document for show create table

### DIFF
--- a/docs/sql-ref-syntax-aux-show-create-table.md
+++ b/docs/sql-ref-syntax-aux-show-create-table.md
@@ -26,7 +26,7 @@ license: |
 ### Syntax
 
 ```sql
-SHOW CREATE TABLE table_identifier
+SHOW CREATE TABLE table_identifier [ AS SERDE ]
 ```
 
 ### Parameters
@@ -36,6 +36,10 @@ SHOW CREATE TABLE table_identifier
     Specifies a table or view name, which may be optionally qualified with a database name.
 
     **Syntax:** `[ database_name. ] table_name`
+
+* **AS SERDE**
+
+    Just for generating Hive DDL for a Hive SerDe table.
 
 ### Examples
 

--- a/docs/sql-ref-syntax-aux-show-create-table.md
+++ b/docs/sql-ref-syntax-aux-show-create-table.md
@@ -39,7 +39,7 @@ SHOW CREATE TABLE table_identifier [ AS SERDE ]
 
 * **AS SERDE**
 
-    Just for generating Hive DDL for a Hive SerDe table.
+    Generates Hive DDL for a Hive SerDe table.
 
 ### Examples
 
@@ -59,6 +59,25 @@ SHOW CREATE TABLE test;
    'prop1' = 'value1',
    'prop2' = 'value2')
 +----------------------------------------------------+
+
+SHOW CREATE TABLE test AS SERDE;
++------------------------------------------------------------------------------+
+|                                                                createtab_stmt|
++------------------------------------------------------------------------------+
+|CREATE TABLE `default`.`test`(
+  `c` INT)
+ ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+ WITH SERDEPROPERTIES (
+   'serialization.format' = ',',
+   'field.delim' = ',')
+ STORED AS
+   INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+   OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+ TBLPROPERTIES (
+   'prop1' = 'value1',
+   'prop2' = 'value2',
+   'transient_lastDdlTime' = '1641800515')
++------------------------------------------------------------------------------+
 ```
 
 ### Related Statements


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add options in the description document for `SHOW CREATE TABLE ` command.
<img width="767" alt="1" src="https://user-images.githubusercontent.com/41178002/148747443-ecd6586f-e4c4-4ae4-8ea5-969896b7d416.png">
<img width="758" alt="2" src="https://user-images.githubusercontent.com/41178002/148747457-873bc0c3-08fa-4d31-89e7-b44440372462.png">


### Why are the changes needed?
[#discussion](https://github.com/apache/spark/pull/34719#discussion_r758189709)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
SKIP_API=1 SKIP_RDOC=1 SKIP_PYTHONDOC=1 SKIP_SCALADOC=1 bundle exec jekyll build
