### PR TITLE
[SPARK-37820][SQL] Replace ApacheCommonBase64 with JavaBase64 for string funcs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.catalyst.expressions
 
 import java.net.{URI, URISyntaxException}
 import java.text.{BreakIterator, DecimalFormat, DecimalFormatSymbols}
+import java.util.{Base64 => JBase64}
 import java.util.{HashMap, Locale, Map => JMap}
 import java.util.regex.Pattern
 
 import scala.collection.mutable.ArrayBuffer
-
-import org.apache.commons.codec.binary.{Base64 => CommonsBase64}
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, FunctionRegistry, TypeCheckResult}
@@ -2345,13 +2344,13 @@ case class Base64(child: Expression)
   override def inputTypes: Seq[DataType] = Seq(BinaryType)
 
   protected override def nullSafeEval(bytes: Any): Any = {
-    UTF8String.fromBytes(CommonsBase64.encodeBase64(bytes.asInstanceOf[Array[Byte]]))
+    UTF8String.fromBytes(JBase64.getMimeEncoder.encode(bytes.asInstanceOf[Array[Byte]]))
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, (child) => {
       s"""${ev.value} = UTF8String.fromBytes(
-            ${classOf[CommonsBase64].getName}.encodeBase64($child));
+            ${classOf[JBase64].getName}.getMimeEncoder().encode($child));
        """})
   }
 
@@ -2377,12 +2376,12 @@ case class UnBase64(child: Expression)
   override def inputTypes: Seq[DataType] = Seq(StringType)
 
   protected override def nullSafeEval(string: Any): Any =
-    CommonsBase64.decodeBase64(string.asInstanceOf[UTF8String].toString)
+    JBase64.getMimeDecoder.decode(string.asInstanceOf[UTF8String].toString)
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(ctx, ev, (child) => {
       s"""
-         ${ev.value} = ${classOf[CommonsBase64].getName}.decodeBase64($child.toString());
+         ${ev.value} = ${classOf[JBase64].getName}.getMimeDecoder().decode($child.toString());
        """})
   }
 

--- a/sql/core/benchmarks/Base64Benchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/Base64Benchmark-jdk11-results.txt
@@ -1,56 +1,56 @@
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 encode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               2848           2930         132          7.0         142.4       1.0X
-apache                                            12281          14421        1142          1.6         614.1       0.2X
+java                                               4000           4121         204          5.0         200.0       1.0X
+apache                                            34197          34280          71          0.6        1709.9       0.1X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 encode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               3895           4151         236          5.1         194.8       1.0X
-apache                                            13238          14325        1127          1.5         661.9       0.3X
+java                                               4696           4761          62          4.3         234.8       1.0X
+apache                                            35117          35342         262          0.6        1755.9       0.1X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 encode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               4572           4638         113          4.4         228.6       1.0X
-apache                                            15585          15649          59          1.3         779.3       0.3X
+java                                               6059           6192         120          3.3         303.0       1.0X
+apache                                            36995          37108         109          0.5        1849.8       0.2X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 encode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               5339           5391          46          3.7         267.0       1.0X
-apache                                            16755          16899         153          1.2         837.8       0.3X
+java                                               6993           7032          52          2.9         349.6       1.0X
+apache                                            37686          37888         198          0.5        1884.3       0.2X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 decode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               3550           3552           3          5.6         177.5       1.0X
-apache                                            13286          13347         103          1.5         664.3       0.3X
+java                                               5322           5503         162          3.8         266.1       1.0X
+apache                                            35180          35391         195          0.6        1759.0       0.2X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 decode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               4575           4623          74          4.4         228.7       1.0X
-apache                                            14173          14283         103          1.4         708.6       0.3X
+java                                               6780           6814          38          2.9         339.0       1.0X
+apache                                            35161          35279         102          0.6        1758.1       0.2X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 decode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               6044           6087          41          3.3         302.2       1.0X
-apache                                            17261          17412         164          1.2         863.0       0.4X
+java                                               8941           9068         130          2.2         447.1       1.0X
+apache                                            41628          41704         122          0.5        2081.4       0.2X
 
-OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 decode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               7952           8190         236          2.5         397.6       1.0X
-apache                                            20086          20416         340          1.0        1004.3       0.4X
+java                                              10248          10336          77          2.0         512.4       1.0X
+apache                                            42702          42732          47          0.5        2135.1       0.2X
 

--- a/sql/core/benchmarks/Base64Benchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/Base64Benchmark-jdk11-results.txt
@@ -1,0 +1,56 @@
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               2848           2930         132          7.0         142.4       1.0X
+apache                                            12281          14421        1142          1.6         614.1       0.2X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               3895           4151         236          5.1         194.8       1.0X
+apache                                            13238          14325        1127          1.5         661.9       0.3X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               4572           4638         113          4.4         228.6       1.0X
+apache                                            15585          15649          59          1.3         779.3       0.3X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               5339           5391          46          3.7         267.0       1.0X
+apache                                            16755          16899         153          1.2         837.8       0.3X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               3550           3552           3          5.6         177.5       1.0X
+apache                                            13286          13347         103          1.5         664.3       0.3X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               4575           4623          74          4.4         228.7       1.0X
+apache                                            14173          14283         103          1.4         708.6       0.3X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               6044           6087          41          3.3         302.2       1.0X
+apache                                            17261          17412         164          1.2         863.0       0.4X
+
+OpenJDK 64-Bit Server VM 11.0.12+0 on Mac OS X 12.0.1
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               7952           8190         236          2.5         397.6       1.0X
+apache                                            20086          20416         340          1.0        1004.3       0.4X
+

--- a/sql/core/benchmarks/Base64Benchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/Base64Benchmark-jdk17-results.txt
@@ -1,0 +1,56 @@
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+encode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               3787           3862          75          5.3         189.3       1.0X
+apache                                            28972          29107         153          0.7        1448.6       0.1X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+encode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               4732           4741           8          4.2         236.6       1.0X
+apache                                            31133          31330         230          0.6        1556.6       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+encode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               5928           5940          11          3.4         296.4       1.0X
+apache                                            31932          31981          47          0.6        1596.6       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+encode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               6290           6312          36          3.2         314.5       1.0X
+apache                                            33568          33677         107          0.6        1678.4       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+decode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               5087           5162          67          3.9         254.4       1.0X
+apache                                            30471          30598         161          0.7        1523.6       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+decode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               6362           6384          22          3.1         318.1       1.0X
+apache                                            32436          32560         107          0.6        1621.8       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+decode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               8808           8812           5          2.3         440.4       1.0X
+apache                                            37324          37537         215          0.5        1866.2       0.2X
+
+OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+decode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               9904           9915          11          2.0         495.2       1.0X
+apache                                            39963          40190         215          0.5        1998.2       0.2X
+

--- a/sql/core/benchmarks/Base64Benchmark-results.txt
+++ b/sql/core/benchmarks/Base64Benchmark-results.txt
@@ -1,0 +1,56 @@
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               4479           4607         178          4.5         224.0       1.0X
+apache                                            13219          15017         NaN          1.5         661.0       0.3X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               5592           5920         349          3.6         279.6       1.0X
+apache                                            14732          14797          62          1.4         736.6       0.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               5818           6043         210          3.4         290.9       1.0X
+apache                                            16450          16875         550          1.2         822.5       0.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+encode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               7175           7382         231          2.8         358.8       1.0X
+apache                                            18694          18821         138          1.1         934.7       0.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               5112           5218         135          3.9         255.6       1.0X
+apache                                            14546          14742         239          1.4         727.3       0.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               7071           7294         195          2.8         353.6       1.0X
+apache                                            16702          16795          98          1.2         835.1       0.4X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                               8968           9204         396          2.2         448.4       1.0X
+apache                                            19000          19045          43          1.1         950.0       0.5X
+
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
+Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+decode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+java                                              10085          10292         179          2.0         504.3       1.0X
+apache                                            20670          20783         109          1.0        1033.5       0.5X
+

--- a/sql/core/benchmarks/Base64Benchmark-results.txt
+++ b/sql/core/benchmarks/Base64Benchmark-results.txt
@@ -1,56 +1,56 @@
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 encode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               4479           4607         178          4.5         224.0       1.0X
-apache                                            13219          15017         NaN          1.5         661.0       0.3X
+java                                               5408           5970         745          3.7         270.4       1.0X
+apache                                            35038          35285         216          0.6        1751.9       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 encode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               5592           5920         349          3.6         279.6       1.0X
-apache                                            14732          14797          62          1.4         736.6       0.4X
+java                                               5950           6191         209          3.4         297.5       1.0X
+apache                                            37222          37440         191          0.5        1861.1       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 encode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               5818           6043         210          3.4         290.9       1.0X
-apache                                            16450          16875         550          1.2         822.5       0.4X
+java                                               7472           7815         363          2.7         373.6       1.0X
+apache                                            40215          40300         143          0.5        2010.7       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 encode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               7175           7382         231          2.8         358.8       1.0X
-apache                                            18694          18821         138          1.1         934.7       0.4X
+java                                               9548           9721         296          2.1         477.4       1.0X
+apache                                            40876          41011         143          0.5        2043.8       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 decode for 1:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               5112           5218         135          3.9         255.6       1.0X
-apache                                            14546          14742         239          1.4         727.3       0.4X
+java                                               6835           7203         624          2.9         341.8       1.0X
+apache                                            37065          37202         184          0.5        1853.3       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 decode for 3:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               7071           7294         195          2.8         353.6       1.0X
-apache                                            16702          16795          98          1.2         835.1       0.4X
+java                                               8151           8292         187          2.5         407.5       1.0X
+apache                                            39188          39455         262          0.5        1959.4       0.2X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 decode for 5:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                               8968           9204         396          2.2         448.4       1.0X
-apache                                            19000          19045          43          1.1         950.0       0.5X
+java                                              11225          11582         429          1.8         561.2       1.0X
+apache                                            42835          42987         145          0.5        2141.8       0.3X
 
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_251-b08 on Mac OS X 10.16
-Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 decode for 7:                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-java                                              10085          10292         179          2.0         504.3       1.0X
-apache                                            20670          20783         109          1.0        1033.5       0.5X
+java                                              13722          13987         301          1.5         686.1       1.0X
+apache                                            44221          44443         354          0.5        2211.0       0.3X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/Base64Benchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/Base64Benchmark.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.benchmark
 import org.apache.spark.benchmark.Benchmark
 
 /**
- * Benchmark for measuring perf of different Base64 implementation
+ * Benchmark for measuring perf of different Base64 implementations
  * To run this benchmark:
  * {{{
  *   1. without sbt:

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/Base64Benchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/Base64Benchmark.scala
@@ -28,13 +28,12 @@ import org.apache.spark.benchmark.Benchmark
  *   2. build/sbt "sql/test:runMain <this class>"
  *   3. generate result:
  *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
- *      Results will be written to "benchmarks/IntervalBenchmark-results.txt".
+ *      Results will be written to "benchmarks/Base64Benchmark-results.txt".
  * }}}
  */
 object Base64Benchmark extends SqlBasedBenchmark {
   import spark.implicits._
   private val N = 20L * 1000 * 1000
-
 
   private def doEncode(len: Int, f: Array[Byte] => Array[Byte]): Unit = {
     spark.range(N).map(_ => "Spark" * len).foreach { s =>
@@ -76,5 +75,4 @@ object Base64Benchmark extends SqlBasedBenchmark {
       benchmark
     }.foreach(_.run())
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/Base64Benchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/Base64Benchmark.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+
+/**
+ * Benchmark for measuring perf of different Base64 implementation
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> --jars <spark core test jar> <sql core test jar>
+ *   2. build/sbt "sql/test:runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      Results will be written to "benchmarks/IntervalBenchmark-results.txt".
+ * }}}
+ */
+object Base64Benchmark extends SqlBasedBenchmark {
+  import spark.implicits._
+  private val N = 20L * 1000 * 1000
+
+
+  private def doEncode(len: Int, f: Array[Byte] => Array[Byte]): Unit = {
+    spark.range(N).map(_ => "Spark" * len).foreach { s =>
+      f(s.getBytes)
+      ()
+    }
+  }
+
+  private def doDecode(len: Int, f: Array[Byte] => Array[Byte]): Unit = {
+    spark.range(N).map(_ => "Spark" * len).map { s =>
+      // using the same encode func
+      java.util.Base64.getMimeEncoder.encode(s.getBytes)
+    }.foreach { s =>
+      f(s)
+      ()
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    Seq(1, 3, 5, 7).map { len =>
+      val benchmark = new Benchmark(s"encode for $len", N, output = output)
+      benchmark.addCase("java", 3) { _ =>
+        doEncode(len, x => java.util.Base64.getMimeEncoder().encode(x))
+      }
+      benchmark.addCase(s"apache", 3) { _ =>
+        doEncode(len, org.apache.commons.codec.binary.Base64.encodeBase64)
+      }
+      benchmark
+    }.foreach(_.run())
+
+    Seq(1, 3, 5, 7).map { len =>
+      val benchmark = new Benchmark(s"decode for $len", N, output = output)
+      benchmark.addCase("java", 3) { _ =>
+        doDecode(len, x => java.util.Base64.getMimeDecoder.decode(x))
+      }
+      benchmark.addCase(s"apache", 3) { _ =>
+        doDecode(len, org.apache.commons.codec.binary.Base64.decodeBase64)
+      }
+      benchmark
+    }.foreach(_.run())
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Replace Base64 on ApacheCommonBase64 with native support (https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html)  for Base-64 encode/decode.

ApacheCommonBase64 obeys http://www.ietf.org/rfc/rfc2045.txt with url-safe off according to its doc, so we choose `java.util.Base64.Decoder#RFC2045`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. Performace gain
  - http://java-performance.info/base64-encoding-and-decoding-performance/
  - have done benchmarks against jdk8/11, shown 2-5x faster

2. reduce dependencies after we replace other related places

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

NO


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- Existing StringExpressionSuite
- benchmarks
