### PR TITLE
[SPARK-37823][INFRA][TESTS] Add `is-changed.py` dev script

### DIFF
--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -17,9 +17,12 @@
 # limitations under the License.
 #
 
+import os
+import sys
 from argparse import ArgumentParser
-from utils import *
+from sparktestsupport.utils import determine_modules_for_files, determine_modules_to_test, identify_changed_files_from_git_commits
 import sparktestsupport.modules as modules
+
 
 def parse_opts():
     parser = ArgumentParser(

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from argparse import ArgumentParser
+from utils import *
+import sparktestsupport.modules as modules
+
+def parse_opts():
+    parser = ArgumentParser(
+        prog="is-changed"
+    )
+
+    parser.add_argument(
+        "-f", "--fail", action='store_true',
+        help="Exit with 1 if there is no relevant change."
+    )
+
+    default_value = ",".join(sorted([m.name for m in modules.all_modules]))
+    parser.add_argument(
+        "-m", "--modules", type=str,
+        default=default_value,
+        help="A comma-separated list of modules to test "
+             "(default: %s)" % default_value
+    )
+
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        parser.error("Unsupported arguments: %s" % ' '.join(unknown))
+    return args
+
+
+def main():
+    opts = parse_opts()
+
+    test_modules = opts.modules.split(",")
+    changed_files = identify_changed_files_from_git_commits("HEAD", target_ref=os.environ["APACHE_SPARK_REF"])
+    changed_modules = determine_modules_to_test(determine_modules_for_files(changed_files), deduplicated=False)
+    module_names = [m.name for m in changed_modules]
+    if len(changed_modules) == 0:
+        print("false")
+        if opts.fail:
+            sys.exit(1)
+    elif 'root' in test_modules or modules.root in changed_modules:
+        print("true")
+    elif len(set(test_modules).intersection(module_names)) == 0:
+        print("false")
+        if opts.fail:
+            sys.exit(1)
+    else:
+        print("true")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -621,7 +621,8 @@ def main():
 
 def _test():
     import doctest
-    failure_count = doctest.testmod()[0]
+    import sparktestsupport.utils
+    failure_count = doctest.testmod(sparktestsupport.utils)[0] + doctest.testmod()[0]
     if failure_count:
         sys.exit(-1)
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -23,11 +23,10 @@ import os
 import re
 import sys
 import subprocess
-from utils import *
 
 from sparktestsupport import SPARK_HOME, USER_HOME, ERROR_CODES
 from sparktestsupport.shellutils import exit_from_command_with_retcode, run_cmd, rm_r, which
-from sparktestsupport.toposort import toposort_flatten
+from sparktestsupport.utils import determine_modules_for_files, determine_modules_to_test, determine_tags_to_exclude, identify_changed_files_from_git_commits
 import sparktestsupport.modules as modules
 
 

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 import subprocess
+from utils import *
 
 from sparktestsupport import SPARK_HOME, USER_HOME, ERROR_CODES
 from sparktestsupport.shellutils import exit_from_command_with_retcode, run_cmd, rm_r, which
@@ -30,136 +31,11 @@ from sparktestsupport.toposort import toposort_flatten
 import sparktestsupport.modules as modules
 
 
-# -------------------------------------------------------------------------------------------------
-# Functions for traversing module dependency graph
-# -------------------------------------------------------------------------------------------------
-
-
-def determine_modules_for_files(filenames):
-    """
-    Given a list of filenames, return the set of modules that contain those files.
-    If a file is not associated with a more specific submodule, then this method will consider that
-    file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions,
-    and `appveyor.yml` is always ignored because this file is dedicated only to AppVeyor builds.
-
-    >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
-    ['pyspark-core', 'sql']
-    >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
-    ['root']
-    >>> [x.name for x in determine_modules_for_files(["appveyor.yml"])]
-    []
-    """
-    changed_modules = set()
-    for filename in filenames:
-        if filename in ("appveyor.yml",):
-            continue
-        if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
-            continue
-        matched_at_least_one_module = False
-        for module in modules.all_modules:
-            if module.contains_file(filename):
-                changed_modules.add(module)
-                matched_at_least_one_module = True
-        if not matched_at_least_one_module:
-            changed_modules.add(modules.root)
-    return changed_modules
-
-
-def identify_changed_files_from_git_commits(patch_sha, target_branch=None, target_ref=None):
-    """
-    Given a git commit and target ref, use the set of files changed in the diff in order to
-    determine which modules' tests should be run.
-
-    >>> [x.name for x in determine_modules_for_files( \
-            identify_changed_files_from_git_commits("fc0a1475ef", target_ref="5da21f07"))]
-    ['graphx']
-    >>> 'root' in [x.name for x in determine_modules_for_files( \
-         identify_changed_files_from_git_commits("50a0496a43", target_ref="6765ef9"))]
-    True
-    """
-    if target_branch is None and target_ref is None:
-        raise AttributeError("must specify either target_branch or target_ref")
-    elif target_branch is not None and target_ref is not None:
-        raise AttributeError("must specify either target_branch or target_ref, not both")
-    if target_branch is not None:
-        diff_target = target_branch
-        run_cmd(['git', 'fetch', 'origin', str(target_branch+':'+target_branch)])
-    else:
-        diff_target = target_ref
-    raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
-                                         universal_newlines=True)
-    # Remove any empty strings
-    return [f for f in raw_output.split('\n') if f]
-
-
 def setup_test_environ(environ):
     print("[info] Setup the following environment variables for tests: ")
     for (k, v) in environ.items():
         print("%s=%s" % (k, v))
         os.environ[k] = v
-
-
-def determine_modules_to_test(changed_modules, deduplicated=True):
-    """
-    Given a set of modules that have changed, compute the transitive closure of those modules'
-    dependent modules in order to determine the set of modules that should be tested.
-
-    Returns a topologically-sorted list of modules (ties are broken by sorting on module names).
-    If ``deduplicated`` is disabled, the modules are returned without tacking the deduplication
-    by dependencies into account.
-
-    >>> [x.name for x in determine_modules_to_test([modules.root])]
-    ['root']
-    >>> [x.name for x in determine_modules_to_test([modules.build])]
-    ['root']
-    >>> [x.name for x in determine_modules_to_test([modules.core])]
-    ['root']
-    >>> [x.name for x in determine_modules_to_test([modules.launcher])]
-    ['root']
-    >>> [x.name for x in determine_modules_to_test([modules.graphx])]
-    ['graphx', 'examples']
-    >>> [x.name for x in determine_modules_to_test([modules.sql])]
-    ... # doctest: +NORMALIZE_WHITESPACE
-    ['sql', 'avro', 'docker-integration-tests', 'hive', 'mllib', 'sql-kafka-0-10', 'examples',
-     'hive-thriftserver', 'pyspark-sql', 'repl', 'sparkr',
-     'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-ml']
-    >>> sorted([x.name for x in determine_modules_to_test(
-    ...     [modules.sparkr, modules.sql], deduplicated=False)])
-    ... # doctest: +NORMALIZE_WHITESPACE
-    ['avro', 'docker-integration-tests', 'examples', 'hive', 'hive-thriftserver', 'mllib',
-     'pyspark-ml', 'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-sql',
-     'repl', 'sparkr', 'sql', 'sql-kafka-0-10']
-    >>> sorted([x.name for x in determine_modules_to_test(
-    ...     [modules.sql, modules.core], deduplicated=False)])
-    ... # doctest: +NORMALIZE_WHITESPACE
-    ['avro', 'catalyst', 'core', 'docker-integration-tests', 'examples', 'graphx', 'hive',
-     'hive-thriftserver', 'mllib', 'mllib-local', 'pyspark-core', 'pyspark-ml', 'pyspark-mllib',
-     'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-resource', 'pyspark-sql',
-     'pyspark-streaming', 'repl', 'root', 'sparkr', 'sql', 'sql-kafka-0-10', 'streaming',
-     'streaming-kafka-0-10', 'streaming-kinesis-asl']
-    """
-    modules_to_test = set()
-    for module in changed_modules:
-        modules_to_test = modules_to_test.union(
-            determine_modules_to_test(module.dependent_modules, deduplicated))
-    modules_to_test = modules_to_test.union(set(changed_modules))
-
-    if not deduplicated:
-        return modules_to_test
-
-    # If we need to run all of the tests, then we should short-circuit and return 'root'
-    if modules.root in modules_to_test:
-        return [modules.root]
-    return toposort_flatten(
-        {m: set(m.dependencies).intersection(modules_to_test) for m in modules_to_test}, sort=True)
-
-
-def determine_tags_to_exclude(changed_modules):
-    tags = []
-    for m in modules.all_modules:
-        if m not in changed_modules:
-            tags += m.test_tags
-    return tags
 
 
 # -------------------------------------------------------------------------------------------------

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -20,12 +20,14 @@
 import os
 import sys
 import subprocess
-import sparktestsupport.modules as modules
+from sparktestsupport import modules
+from sparktestsupport.shellutils import run_cmd
 from sparktestsupport.toposort import toposort_flatten
 
 # -------------------------------------------------------------------------------------------------
 # Functions for traversing module dependency graph
 # -------------------------------------------------------------------------------------------------
+
 
 def determine_modules_for_files(filenames):
     """

--- a/dev/utils.py
+++ b/dev/utils.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import subprocess
+import sparktestsupport.modules as modules
+from sparktestsupport.toposort import toposort_flatten
+
+# -------------------------------------------------------------------------------------------------
+# Functions for traversing module dependency graph
+# -------------------------------------------------------------------------------------------------
+
+def determine_modules_for_files(filenames):
+    """
+    Given a list of filenames, return the set of modules that contain those files.
+    If a file is not associated with a more specific submodule, then this method will consider that
+    file to belong to the 'root' module. `.github` directory is counted only in GitHub Actions,
+    and `appveyor.yml` is always ignored because this file is dedicated only to AppVeyor builds.
+
+    >>> sorted(x.name for x in determine_modules_for_files(["python/pyspark/a.py", "sql/core/foo"]))
+    ['pyspark-core', 'sql']
+    >>> [x.name for x in determine_modules_for_files(["file_not_matched_by_any_subproject"])]
+    ['root']
+    >>> [x.name for x in determine_modules_for_files(["appveyor.yml"])]
+    []
+    """
+    changed_modules = set()
+    for filename in filenames:
+        if filename in ("appveyor.yml",):
+            continue
+        if ("GITHUB_ACTIONS" not in os.environ) and filename.startswith(".github"):
+            continue
+        matched_at_least_one_module = False
+        for module in modules.all_modules:
+            if module.contains_file(filename):
+                changed_modules.add(module)
+                matched_at_least_one_module = True
+        if not matched_at_least_one_module:
+            changed_modules.add(modules.root)
+    return changed_modules
+
+
+def identify_changed_files_from_git_commits(patch_sha, target_branch=None, target_ref=None):
+    """
+    Given a git commit and target ref, use the set of files changed in the diff in order to
+    determine which modules' tests should be run.
+
+    >>> [x.name for x in determine_modules_for_files( \
+            identify_changed_files_from_git_commits("fc0a1475ef", target_ref="5da21f07"))]
+    ['graphx']
+    >>> 'root' in [x.name for x in determine_modules_for_files( \
+         identify_changed_files_from_git_commits("50a0496a43", target_ref="6765ef9"))]
+    True
+    """
+    if target_branch is None and target_ref is None:
+        raise AttributeError("must specify either target_branch or target_ref")
+    elif target_branch is not None and target_ref is not None:
+        raise AttributeError("must specify either target_branch or target_ref, not both")
+    if target_branch is not None:
+        diff_target = target_branch
+        run_cmd(['git', 'fetch', 'origin', str(target_branch+':'+target_branch)])
+    else:
+        diff_target = target_ref
+    raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
+                                         universal_newlines=True)
+    # Remove any empty strings
+    return [f for f in raw_output.split('\n') if f]
+
+
+def determine_modules_to_test(changed_modules, deduplicated=True):
+    """
+    Given a set of modules that have changed, compute the transitive closure of those modules'
+    dependent modules in order to determine the set of modules that should be tested.
+
+    Returns a topologically-sorted list of modules (ties are broken by sorting on module names).
+    If ``deduplicated`` is disabled, the modules are returned without tacking the deduplication
+    by dependencies into account.
+
+    >>> [x.name for x in determine_modules_to_test([modules.root])]
+    ['root']
+    >>> [x.name for x in determine_modules_to_test([modules.build])]
+    ['root']
+    >>> [x.name for x in determine_modules_to_test([modules.core])]
+    ['root']
+    >>> [x.name for x in determine_modules_to_test([modules.launcher])]
+    ['root']
+    >>> [x.name for x in determine_modules_to_test([modules.graphx])]
+    ['graphx', 'examples']
+    >>> [x.name for x in determine_modules_to_test([modules.sql])]
+    ... # doctest: +NORMALIZE_WHITESPACE
+    ['sql', 'avro', 'docker-integration-tests', 'hive', 'mllib', 'sql-kafka-0-10', 'examples',
+     'hive-thriftserver', 'pyspark-sql', 'repl', 'sparkr',
+     'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-ml']
+    >>> sorted([x.name for x in determine_modules_to_test(
+    ...     [modules.sparkr, modules.sql], deduplicated=False)])
+    ... # doctest: +NORMALIZE_WHITESPACE
+    ['avro', 'docker-integration-tests', 'examples', 'hive', 'hive-thriftserver', 'mllib',
+     'pyspark-ml', 'pyspark-mllib', 'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-sql',
+     'repl', 'sparkr', 'sql', 'sql-kafka-0-10']
+    >>> sorted([x.name for x in determine_modules_to_test(
+    ...     [modules.sql, modules.core], deduplicated=False)])
+    ... # doctest: +NORMALIZE_WHITESPACE
+    ['avro', 'catalyst', 'core', 'docker-integration-tests', 'examples', 'graphx', 'hive',
+     'hive-thriftserver', 'mllib', 'mllib-local', 'pyspark-core', 'pyspark-ml', 'pyspark-mllib',
+     'pyspark-pandas', 'pyspark-pandas-slow', 'pyspark-resource', 'pyspark-sql',
+     'pyspark-streaming', 'repl', 'root', 'sparkr', 'sql', 'sql-kafka-0-10', 'streaming',
+     'streaming-kafka-0-10', 'streaming-kinesis-asl']
+    """
+    modules_to_test = set()
+    for module in changed_modules:
+        modules_to_test = modules_to_test.union(
+            determine_modules_to_test(module.dependent_modules, deduplicated))
+    modules_to_test = modules_to_test.union(set(changed_modules))
+
+    if not deduplicated:
+        return modules_to_test
+
+    # If we need to run all of the tests, then we should short-circuit and return 'root'
+    if modules.root in modules_to_test:
+        return [modules.root]
+    return toposort_flatten(
+        {m: set(m.dependencies).intersection(modules_to_test) for m in modules_to_test}, sort=True)
+
+
+def determine_tags_to_exclude(changed_modules):
+    tags = []
+    for m in modules.all_modules:
+        if m not in changed_modules:
+            tags += m.test_tags
+    return tags
+
+
+def _test():
+    import doctest
+    failure_count = doctest.testmod()[0]
+    if failure_count:
+        sys.exit(-1)
+
+if __name__ == "__main__":
+    _test()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `is-changed.py` dev script to reuse in CIs for various purposes in the future.
To do that, file change detection codes are moved into a new file, `dev/utils.py`.

```
$ dev/is-changed.py -h
usage: is-changed [-h] [-f] [-m MODULES]

optional arguments:
  -h, --help            show this help message and exit
  -f, --fail            Exit with 1 if there is no relevant change.
  -m MODULES, --modules MODULES
                        A comma-separated list of modules to test (default: avro,build,catalyst,core,docker-integration-tests,docs,examples,graphx,hadoop-cloud,hive,hive-
                        thriftserver,kubernetes,kvstore,launcher,mesos,mllib,mllib-local,network-common,network-shuffle,pyspark-core,pyspark-ml,pyspark-mllib,pyspark-pandas,pyspark-pandas-slow,pyspark-
                        resource,pyspark-sql,pyspark-streaming,repl,root,sketch,spark-ganglia-lgpl,sparkr,sql,sql-kafka-0-10,streaming,streaming-kafka-0-10,streaming-kinesis-asl,tags,unsafe,yarn)
```

### Why are the changes needed?

This can be used in CI to save the community resources.

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only test script change.

### How was this patch tested?

This should pass the existing CIs.

The following is a manual test.
```
$ APACHE_SPARK_REF=HEAD dev/is-changed.py         
false

$ APACHE_SPARK_REF=08dd010860 dev/is-changed.py        
true
```

This also supports `module` arguments to check the required modules exactly.
```
$ git diff HEAD~1       
diff --git a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
index 252dd5bad3..e415ee05e2 100644
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1,4 +1,5 @@
 /*
+
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

$ APACHE_SPARK_REF=HEAD~1 dev/is-changed.py -m sql
true

$ APACHE_SPARK_REF=HEAD~1 dev/is-changed.py -m catalyst
true

$ APACHE_SPARK_REF=HEAD~1 dev/is-changed.py -m docs    
false
```