### PR TITLE
[SPARK-37636][SQL] Migrate CREATE NAMESPACE to use V2 command by default

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -214,16 +214,11 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case DropView(r: ResolvedView, ifExists) =>
       DropTableCommand(r.identifier.asTableIdentifier, ifExists, isView = true, purge = false)
 
-    case c @ CreateNamespace(ResolvedDBObjectName(catalog, name), _, _)
-        if isSessionCatalog(catalog) =>
-      if (name.length != 1) {
-        throw QueryCompilationErrors.invalidDatabaseNameError(name.quoted)
-      }
-
+    case c @ CreateNamespace(DatabaseNameInSessionCatalog(name), _, _) if conf.useV1Command =>
       val comment = c.properties.get(SupportsNamespaces.PROP_COMMENT)
       val location = c.properties.get(SupportsNamespaces.PROP_LOCATION)
       val newProperties = c.properties -- CatalogV2Util.NAMESPACE_RESERVED_PROPERTIES
-      CreateDatabaseCommand(name.head, c.ifNotExists, location, comment, newProperties)
+      CreateDatabaseCommand(name, c.ifNotExists, location, comment, newProperties)
 
     case d @ DropNamespace(DatabaseInSessionCatalog(db), _, _) =>
       DropDatabaseCommand(db, d.ifExists, d.cascade)
@@ -607,6 +602,16 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         assert(resolved.namespace.length > 1)
         throw QueryCompilationErrors.nestedDatabaseUnsupportedByV1SessionCatalogError(
           resolved.namespace.map(quoteIfNeeded).mkString("."))
+    }
+  }
+
+  private object DatabaseNameInSessionCatalog {
+    def unapply(resolved: ResolvedDBObjectName): Option[String] = resolved match {
+      case ResolvedDBObjectName(catalog, _) if !isSessionCatalog(catalog) => None
+      case ResolvedDBObjectName(_, Seq(dbName)) => Some(dbName)
+      case _ =>
+        assert(resolved.nameParts.length > 1)
+        throw QueryCompilationErrors.invalidDatabaseNameError(resolved.nameParts.quoted)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceSuiteBase.scala
@@ -50,8 +50,6 @@ trait CreateNamespaceSuiteBase extends QueryTest with DDLCommandTestUtils {
 
   protected def notFoundMsgPrefix: String
 
-  protected def alreadyExistErrorMessage: String = s"$notFoundMsgPrefix '$namespace' already exists"
-
   test("basic") {
     val ns = s"$catalog.$namespace"
     withNamespace(ns) {
@@ -92,7 +90,7 @@ trait CreateNamespaceSuiteBase extends QueryTest with DDLCommandTestUtils {
       val e = intercept[NamespaceAlreadyExistsException] {
         sql(s"CREATE NAMESPACE $ns")
       }
-      assert(e.getMessage.contains(alreadyExistErrorMessage))
+      assert(e.getMessage.contains(s"$notFoundMsgPrefix '$namespace' already exists"))
 
       // The following will be no-op since the namespace already exists.
       sql(s"CREATE NAMESPACE IF NOT EXISTS $ns")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceSuiteBase.scala
@@ -21,7 +21,8 @@ import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, CatalogV2Util, SupportsNamespaces}
 import org.apache.spark.sql.internal.SQLConf
@@ -88,9 +89,7 @@ trait CreateNamespaceSuiteBase extends QueryTest with DDLCommandTestUtils {
     withNamespace(ns) {
       sql(s"CREATE NAMESPACE $ns")
 
-      // TODO: HiveExternalCatalog throws DatabaseAlreadyExistsException, and
-      //   non-Hive catalogs throw NamespaceAlreadyExistsException.
-      val e = intercept[AnalysisException] {
+      val e = intercept[NamespaceAlreadyExistsException] {
         sql(s"CREATE NAMESPACE $ns")
       }
       assert(e.getMessage.contains(alreadyExistErrorMessage))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceSuiteBase.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, CatalogV2Util, SupportsNamespaces}
+import org.apache.spark.sql.execution.command.DDLCommandTestUtils.V1_COMMAND_VERSION
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -48,7 +49,8 @@ trait CreateNamespaceSuiteBase extends QueryTest with DDLCommandTestUtils {
 
   protected def namespaceArray: Array[String] = namespace.split('.')
 
-  protected def notFoundMsgPrefix: String
+  protected def notFoundMsgPrefix: String =
+    if (commandVersion == V1_COMMAND_VERSION) "Database" else "Namespace"
 
   test("basic") {
     val ns = s"$catalog.$namespace"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLCommandTestUtils.scala
@@ -173,3 +173,8 @@ trait DDLCommandTestUtils extends SQLTestUtils {
     part1Loc
   }
 }
+
+object DDLCommandTestUtils {
+  val V1_COMMAND_VERSION = "V1"
+  val V2_COMMAND_VERSION = "V2"
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TestsV1AndV2Commands.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TestsV1AndV2Commands.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.command
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
+import org.apache.spark.sql.execution.command.DDLCommandTestUtils.{V1_COMMAND_VERSION, V2_COMMAND_VERSION}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -28,7 +29,6 @@ import org.apache.spark.sql.internal.SQLConf
 trait TestsV1AndV2Commands extends DDLCommandTestUtils {
   private var _version: String = ""
   override def commandVersion: String = _version
-  def runningV1Command: Boolean = commandVersion == "V1"
 
   // Tests using V1 catalogs will run with `spark.sql.legacy.useV1Command` on and off
   // to test both V1 and V2 commands.
@@ -36,7 +36,7 @@ trait TestsV1AndV2Commands extends DDLCommandTestUtils {
     (implicit pos: Position): Unit = {
     Seq(true, false).foreach { useV1Command =>
       def setCommandVersion(): Unit = {
-        _version = if (useV1Command) "V1" else "V2"
+        _version = if (useV1Command) V1_COMMAND_VERSION else V2_COMMAND_VERSION
       }
       setCommandVersion()
       super.test(testName, testTags: _*) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateNamespaceSuite.scala
@@ -36,7 +36,6 @@ import org.apache.spark.sql.execution.command
 trait CreateNamespaceSuiteBase extends command.CreateNamespaceSuiteBase
     with command.TestsV1AndV2Commands {
   override def namespace: String = "db"
-  override def notFoundMsgPrefix: String = if (runningV1Command) "Database" else "Namespace"
 
   test("Create namespace using default warehouse path") {
     val ns = s"$catalog.$namespace"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/CreateNamespaceSuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.execution.command
 trait CreateNamespaceSuiteBase extends command.CreateNamespaceSuiteBase
     with command.TestsV1AndV2Commands {
   override def namespace: String = "db"
-  override def notFoundMsgPrefix: String = "Database"
+  override def notFoundMsgPrefix: String = if (runningV1Command) "Database" else "Namespace"
 
   test("Create namespace using default warehouse path") {
     val ns = s"$catalog.$namespace"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CreateNamespaceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/CreateNamespaceSuite.scala
@@ -24,5 +24,4 @@ import org.apache.spark.sql.execution.command
  */
 class CreateNamespaceSuite extends command.CreateNamespaceSuiteBase with CommandSuiteBase {
   override def namespace: String = "ns1.ns2"
-  override def notFoundMsgPrefix: String = "Namespace"
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -94,10 +94,22 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
   }
 
   /**
-   * Run some code involving `client` in a [[synchronized]] block and wrap certain
+   * Run some code involving `client` in a [[synchronized]] block and wrap non-fatal
    * exceptions thrown in the process in [[AnalysisException]].
    */
-  private def withClient[T](body: => T): T = synchronized {
+  private def withClient[T](body: => T): T = withClientWrappingException{
+    body
+  } {
+    _ => None // Will fallback to default wrapping strategy in withClientWrappingException.
+  }
+
+  /**
+   * Run some code involving `client` in a [[synchronized]] block and wrap non-fatal
+   * exceptions thrown in the process in [[AnalysisException]] using the given
+   * `wrapException` function.
+   */
+  private def withClientWrappingException[T](body: => T)
+      (wrapException: Throwable => Option[AnalysisException]): T = synchronized {
     try {
       body
     } catch {
@@ -108,8 +120,11 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
           case i: InvocationTargetException => i.getCause
           case o => o
         }
-        throw new AnalysisException(
-          e.getClass.getCanonicalName + ": " + e.getMessage, cause = Some(e))
+        wrapException(e) match {
+          case Some(wrapped) => throw wrapped
+          case None => throw new AnalysisException(
+            e.getClass.getCanonicalName + ": " + e.getMessage, cause = Some(e))
+        }
     }
   }
 
@@ -189,14 +204,16 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
 
   override def createDatabase(
       dbDefinition: CatalogDatabase,
-      ignoreIfExists: Boolean): Unit = {
-    try {
-      withClient {
-        client.createDatabase(dbDefinition, ignoreIfExists)
-      }
-    } catch {
-      case e: AnalysisException if e.message.contains("already exists") =>
-        throw new DatabaseAlreadyExistsException(dbDefinition.name)
+      ignoreIfExists: Boolean): Unit = withClientWrappingException {
+    client.createDatabase(dbDefinition, ignoreIfExists)
+  } { exception =>
+    if (exception.getClass.getName.equals(
+          "org.apache.hadoop.hive.metastore.api.AlreadyExistsException")
+        && exception.getMessage.contains(
+          s"Database ${dbDefinition.name} already exists")) {
+      Some(new DatabaseAlreadyExistsException(dbDefinition.name))
+    } else {
+      None
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -97,7 +97,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
    * Run some code involving `client` in a [[synchronized]] block and wrap non-fatal
    * exceptions thrown in the process in [[AnalysisException]].
    */
-  private def withClient[T](body: => T): T = withClientWrappingException{
+  private def withClient[T](body: => T): T = withClientWrappingException {
     body
   } {
     _ => None // Will fallback to default wrapping strategy in withClientWrappingException.

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/VersionsSuite.scala
@@ -183,6 +183,16 @@ class VersionsSuite extends SparkFunSuite with Logging {
       val tempDB = CatalogDatabase(
         "temporary", description = "test create", tempDatabasePath, Map())
       client.createDatabase(tempDB, ignoreIfExists = true)
+
+      try {
+        client.createDatabase(tempDB, ignoreIfExists = false)
+        assert(false, "createDatabase should throw AlreadyExistsException")
+      } catch {
+        case ex: Throwable =>
+          assert(ex.getClass.getName.equals(
+            "org.apache.hadoop.hive.metastore.api.AlreadyExistsException"))
+          assert(ex.getMessage.contains(s"Database ${tempDB.name} already exists"))
+      }
     }
 
     test(s"$version: create/get/alter database should pick right user name as owner") {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CreateNamespaceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CreateNamespaceSuite.scala
@@ -25,7 +25,4 @@ import org.apache.spark.sql.execution.command.v1
  */
 class CreateNamespaceSuite extends v1.CreateNamespaceSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[CreateNamespaceSuiteBase].commandVersion
-  override def alreadyExistErrorMessage: String =
-    s"$notFoundMsgPrefix $namespaceMessage already exists"
-  private def namespaceMessage: String = if (runningV1Command) s"$namespace" else s"'$namespace'"
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CreateNamespaceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/CreateNamespaceSuite.scala
@@ -25,5 +25,7 @@ import org.apache.spark.sql.execution.command.v1
  */
 class CreateNamespaceSuite extends v1.CreateNamespaceSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[CreateNamespaceSuiteBase].commandVersion
-  override def alreadyExistErrorMessage: String = s"$notFoundMsgPrefix $namespace already exists"
+  override def alreadyExistErrorMessage: String =
+    s"$notFoundMsgPrefix $namespaceMessage already exists"
+  private def namespaceMessage: String = if (runningV1Command) s"$namespace" else s"'$namespace'"
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to use V2 commands as default as outlined in [SPARK-36588](https://issues.apache.org/jira/browse/SPARK-36588), and this PR migrates `CREATE NAMESPACE` to use v2 command by default.

Note that the work to tests covering both v1/v2 were done in #35093.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's been a while since we introduced the v2 commands,  and it seems reasonable to use v2 commands by default even for the session catalog, with a legacy config to fall back to the v1 commands.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The error message will be slightly different if namespace already exists when v2 command is run against v1 catalog:
v1 command: `Database 'db' already exists"`
vs.
v2 command: `Namespace 'db' already exists"`

Also, the error message will be slightly different if namespace already exists when v1 command is run against Hive catalog:
Before: `Database db already exists"`
vs.
After: `Database 'db' already exists"`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Existing *CreateNamespaceSuite tests cover this PR's change.