### PR TITLE
[SPARK-37828][SQL] Push down filters through RebalancePartitions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1614,6 +1614,7 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     case _: Pivot => true
     case _: RepartitionByExpression => true
     case _: Repartition => true
+    case _: RebalancePartitions => true
     case _: ScriptTransformation => true
     case _: Sort => true
     case _: BatchEvalPython => true

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -1407,4 +1407,12 @@ class FilterPushdownSuite extends PlanTest {
       condition = Some("x.a".attr === "z.a".attr)).analyze
     comparePlans(optimized, correctAnswer)
   }
+
+  test("SPARK-37828: Push down filters through RebalancePartitions") {
+    val originalQuery = RebalancePartitions(Seq.empty, testRelation).where('a > 3)
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    val correctAnswer = RebalancePartitions(Seq.empty, testRelation.where('a > 3)).analyze
+    comparePlans(optimized, correctAnswer)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Push down filters through RebalancePartitions. How to reproduce this issue:
```scala
spark.sql("SELECT * FROM (SELECT /*+ REBALANCE */ * FROM range(10)) t1 WHERE id = 3").explain(true)
```
Output:
```
== Optimized Logical Plan ==
Filter (id#0L = 3)
+- RebalancePartitions
   +- Range (0, 10, step=1, splits=None)
```
After this pr:
```
RebalancePartitions
+- Filter (id#0L = 3)
   +- Range (0, 10, step=1, splits=None)
```

### Why are the changes needed?

Improve query performance.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.
