### PR TITLE
[SPARK-37832][SQL] Orc struct converter should use an array to look up field converters rather than a linked list

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcSerializer.scala
@@ -154,7 +154,7 @@ class OrcSerializer(dataSchema: StructType) {
 
     case st: StructType => (getter, ordinal) =>
       val result = createOrcValue(st).asInstanceOf[OrcStruct]
-      val fieldConverters = st.map(_.dataType).map(newConverter(_))
+      val fieldConverters = st.map(_.dataType).map(newConverter(_)).toArray
       val numFields = st.length
       val struct = getter.getStruct(ordinal, numFields)
       var i = 0


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the Orc struct converter to index an array rather than a linked list when looking up field converters.

### Why are the changes needed?

Currently, the OrcSerializer's struct converter uses an index to look up each field converter in a linked list, resulting in a n*(n/2) average complexity per row (where n is the field count).

Simply converting the linked list to an array brings performance gains, especially for wide structs.

| field count | row count | master | pr    | improvement |
| ----------- | --------- | ------ | ----- | ----------- |
| 10          | 15728640  | 4729   | 4338  | none        |
| 100         | 157286    | 5270   | 4064  | 22%         |
| 600         | 26214     | 13548  | 4726  | 65%         | 

The above benchmarks were run on my local machine. Official benchmarks are forthcoming.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- Existing unit tests
- New benchmark (in a separate PR)
