### PR TITLE
[SPARK-37834][PYTHON][INFRA] Reenable length check in Python linter

### DIFF
--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -20,7 +20,11 @@
 import os
 import sys
 from argparse import ArgumentParser
-from sparktestsupport.utils import determine_modules_for_files, determine_modules_to_test, identify_changed_files_from_git_commits
+from sparktestsupport.utils import (
+    determine_modules_for_files,
+    determine_modules_to_test,
+    identify_changed_files_from_git_commits
+)
 import sparktestsupport.modules as modules
 
 
@@ -52,8 +56,10 @@ def main():
     opts = parse_opts()
 
     test_modules = opts.modules.split(",")
-    changed_files = identify_changed_files_from_git_commits("HEAD", target_ref=os.environ["APACHE_SPARK_REF"])
-    changed_modules = determine_modules_to_test(determine_modules_for_files(changed_files), deduplicated=False)
+    changed_files = identify_changed_files_from_git_commits(
+        "HEAD", target_ref=os.environ["APACHE_SPARK_REF"])
+    changed_modules = determine_modules_to_test(
+        determine_modules_for_files(changed_files), deduplicated=False)
     module_names = [m.name for m in changed_modules]
     if len(changed_modules) == 0:
         print("false")

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -26,7 +26,12 @@ import subprocess
 
 from sparktestsupport import SPARK_HOME, USER_HOME, ERROR_CODES
 from sparktestsupport.shellutils import exit_from_command_with_retcode, run_cmd, rm_r, which
-from sparktestsupport.utils import determine_modules_for_files, determine_modules_to_test, determine_tags_to_exclude, identify_changed_files_from_git_commits
+from sparktestsupport.utils import (
+    determine_modules_for_files,
+    determine_modules_to_test,
+    determine_tags_to_exclude,
+    identify_changed_files_from_git_commits
+)
 import sparktestsupport.modules as modules
 
 

--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -20,7 +20,6 @@ ignore =
     E226,
     E305,
     E402,
-    E501,
     E722,
     E731,
     E741,
@@ -30,7 +29,7 @@ ignore =
     W503,
     W504,
 per-file-ignores =
-    python/pyspark/ml/param/shared.py: F405,
+    python/pyspark/ml/param/shared.py: F405 E501,
 exclude =
     */target/*,
     docs/.local_ruby_bundle/,

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -289,7 +289,8 @@ class SparkContext:
         # they will be passed back to us through a TCP server
         assert self._gateway is not None
         auth_token = self._gateway.gateway_parameters.auth_token
-        self._accumulatorServer = accumulators._start_update_server(auth_token)  # type: ignore[attr-defined]
+        start_update_server = accumulators._start_update_server  # type: ignore[attr-defined]
+        self._accumulatorServer = start_update_server(auth_token)
         (host, port) = self._accumulatorServer.server_address
         assert self._jvm is not None
         self._javaAccumulator = self._jvm.PythonAccumulatorV2(host, port, auth_token)
@@ -364,7 +365,9 @@ class SparkContext:
             raise KeyboardInterrupt()
 
         # see http://stackoverflow.com/questions/23206787/
-        if isinstance(threading.current_thread(), threading._MainThread):  # type: ignore[attr-defined]
+        if isinstance(
+            threading.current_thread(), threading._MainThread  # type: ignore[attr-defined]
+        ):
             signal.signal(signal.SIGINT, signal_handler)
 
     def __repr__(self) -> str:
@@ -657,7 +660,9 @@ class SparkContext:
         # Make sure we distribute data evenly if it's smaller than self.batchSize
         if "__len__" not in dir(c):
             c = list(c)  # Make it a list so we can compute its length
-        batchSize = max(1, min(len(c) // numSlices, self._batchSize or 1024))  # type: ignore[arg-type]
+        batchSize = max(
+            1, min(len(c) // numSlices, self._batchSize or 1024)  # type: ignore[arg-type]
+        )
         serializer = BatchedSerializer(self._unbatched_serializer, batchSize)
 
         def reader_func(temp_filename: str) -> JavaObject:
@@ -1160,7 +1165,10 @@ class SparkContext:
         ['Hello', 'World!']
         """
         first_jrdd_deserializer = rdds[0]._jrdd_deserializer  # type: ignore[attr-defined]
-        if any(x._jrdd_deserializer != first_jrdd_deserializer for x in rdds):  # type: ignore[attr-defined]
+        if any(
+            x._jrdd_deserializer != first_jrdd_deserializer  # type: ignore[attr-defined]
+            for x in rdds
+        ):
             rdds = [x._reserialize() for x in rdds]  # type: ignore[attr-defined]
         gw = SparkContext._gateway
         assert gw is not None
@@ -1181,7 +1189,9 @@ class SparkContext:
         jrdds = gw.new_array(cls, len(rdds))
         for i in range(0, len(rdds)):
             jrdds[i] = rdds[i]._jrdd  # type: ignore[attr-defined]
-        return RDD(self._jsc.union(jrdds), self, rdds[0]._jrdd_deserializer)  # type: ignore[attr-defined]
+        return RDD(
+            self._jsc.union(jrdds), self, rdds[0]._jrdd_deserializer  # type: ignore[attr-defined]
+        )
 
     def broadcast(self, value: T) -> "Broadcast[T]":
         """
@@ -1438,8 +1448,12 @@ class SparkContext:
         # SparkContext#runJob.
         mappedRDD = rdd.mapPartitions(partitionFunc)
         assert self._jvm is not None
-        sock_info = self._jvm.PythonRDD.runJob(self._jsc.sc(), mappedRDD._jrdd, partitions)  # type: ignore[attr-defined]
-        return list(_load_from_socket(sock_info, mappedRDD._jrdd_deserializer))  # type: ignore[attr-defined]
+        sock_info = self._jvm.PythonRDD.runJob(
+            self._jsc.sc(), mappedRDD._jrdd, partitions  # type: ignore[attr-defined]
+        )
+        return list(
+            _load_from_socket(sock_info, mappedRDD._jrdd_deserializer)  # type: ignore[attr-defined]
+        )
 
     def show_profiles(self) -> None:
         """Print the profile stats to stdout"""

--- a/python/pyspark/files.py
+++ b/python/pyspark/files.py
@@ -62,4 +62,4 @@ class SparkFiles:
             # This will have to change if we support multiple SparkContexts:
             assert cls._sc is not None
             assert cls._sc._jvm is not None
-            return cls._sc._jvm.org.apache.spark.SparkFiles.getRootDirectory()  # type: ignore[attr-defined]
+            return cls._sc._jvm.org.apache.spark.SparkFiles.getRootDirectory()

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -67,7 +67,9 @@ def _to_java_object_rdd(rdd: RDD) -> JavaObject:
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(CPickleSerializer()))  # type: ignore[attr-defined]
     assert rdd.ctx._jvm is not None
-    return rdd.ctx._jvm.org.apache.spark.ml.python.MLSerDe.pythonToJava(rdd._jrdd, True)  # type: ignore[attr-defined]
+    return rdd.ctx._jvm.org.apache.spark.ml.python.MLSerDe.pythonToJava(
+        rdd._jrdd, True  # type: ignore[attr-defined]
+    )
 
 
 def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
@@ -87,7 +89,7 @@ def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
     else:
         data = bytearray(CPickleSerializer().dumps(obj))
         assert sc._jvm is not None
-        obj = sc._jvm.org.apache.spark.ml.python.MLSerDe.loads(data)  # type: ignore[attr-defined]
+        obj = sc._jvm.org.apache.spark.ml.python.MLSerDe.loads(data)
     return obj
 
 
@@ -102,17 +104,17 @@ def _java2py(sc: SparkContext, r: "JavaObjectOrPickleDump", encoding: str = "byt
         assert sc._jvm is not None
 
         if clsName == "JavaRDD":
-            jrdd = sc._jvm.org.apache.spark.ml.python.MLSerDe.javaToPython(r)  # type: ignore[attr-defined]
+            jrdd = sc._jvm.org.apache.spark.ml.python.MLSerDe.javaToPython(r)
             return RDD(jrdd, sc)
 
         if clsName == "Dataset":
             return DataFrame(r, SparkSession(sc)._wrapped)
 
         if clsName in _picklable_classes:
-            r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)  # type: ignore[attr-defined]
+            r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)
         elif isinstance(r, (JavaArray, JavaList)):
             try:
-                r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)  # type: ignore[attr-defined]
+                r = sc._jvm.org.apache.spark.ml.python.MLSerDe.dumps(r)
             except Py4JJavaError:
                 pass  # not picklable
 

--- a/python/pyspark/ml/param/_shared_params_code_gen.py
+++ b/python/pyspark/ml/param/_shared_params_code_gen.py
@@ -108,8 +108,8 @@ if __name__ == "__main__":
         (
             "probabilityCol",
             "Column name for predicted class conditional probabilities. "
-            + "Note: Not all models output well-calibrated probability estimates! These probabilities "
-            + "should be treated as confidences, not precise probabilities.",
+            + "Note: Not all models output well-calibrated probability estimates! "
+            + "These probabilities should be treated as confidences, not precise probabilities.",
             "'probability'",
             "TypeConverters.toString",
         ),
@@ -133,7 +133,8 @@ if __name__ == "__main__":
             "checkpointInterval",
             "set checkpoint interval (>= 1) or disable checkpoint (-1). "
             + "E.g. 10 means that the cache will get checkpointed every 10 iterations. Note: "
-            + "this setting will be ignored if the checkpoint directory is not set in the SparkContext.",
+            + "this setting will be ignored if the checkpoint directory is not set in "
+            + "the SparkContext.",
             None,
             "TypeConverters.toInt",
         ),
@@ -160,8 +161,8 @@ if __name__ == "__main__":
         (
             "handleInvalid",
             "how to handle invalid entries. Options are skip (which will filter "
-            + "out rows with bad values), or error (which will throw an error). More options may be "
-            + "added later.",
+            + "out rows with bad values), or error (which will throw an error). "
+            + "More options may be added later.",
             None,
             "TypeConverters.toString",
         ),
@@ -230,9 +231,9 @@ if __name__ == "__main__":
         (
             "collectSubModels",
             "Param for whether to collect a list of sub-models trained during "
-            + "tuning. If set to false, then only the single best sub-model will be available after "
-            + "fitting. If set to true, then all sub-models will be available. Warning: For large "
-            + "models, collecting all sub-models can cause OOMs on the Spark driver.",
+            + "tuning. If set to false, then only the single best sub-model will be available "
+            + "after fitting. If set to true, then all sub-models will be available. Warning: "
+            + "For large models, collecting all sub-models can cause OOMs on the Spark driver.",
             "False",
             "TypeConverters.toBoolean",
         ),
@@ -262,8 +263,8 @@ if __name__ == "__main__":
             "maxBlockSizeInMB",
             "maximum memory in MB for stacking input data into blocks. Data is "
             + "stacked within partitions. If more than remaining data size in a partition then it "
-            + "is adjusted to the data size. Default 0.0 represents choosing optimal value, depends "
-            + "on specific algorithm. Must be >= 0.",
+            + "is adjusted to the data size. Default 0.0 represents choosing optimal value, "
+            + "depends on specific algorithm. Must be >= 0.",
             "0.0",
             "TypeConverters.toFloat",
         ),

--- a/python/pyspark/mllib/common.py
+++ b/python/pyspark/mllib/common.py
@@ -69,7 +69,9 @@ def _to_java_object_rdd(rdd: RDD) -> JavaObject:
     """
     rdd = rdd._reserialize(AutoBatchedSerializer(CPickleSerializer()))  # type: ignore[attr-defined]
     assert rdd.ctx._jvm is not None
-    return rdd.ctx._jvm.org.apache.spark.mllib.api.python.SerDe.pythonToJava(rdd._jrdd, True)  # type: ignore[attr-defined]
+    return rdd.ctx._jvm.org.apache.spark.mllib.api.python.SerDe.pythonToJava(
+        rdd._jrdd, True  # type: ignore[attr-defined]
+    )
 
 
 def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
@@ -89,7 +91,7 @@ def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
     else:
         data = bytearray(CPickleSerializer().dumps(obj))
         assert sc._jvm is not None
-        obj = sc._jvm.org.apache.spark.mllib.api.python.SerDe.loads(data)  # type: ignore[attr-defined]
+        obj = sc._jvm.org.apache.spark.mllib.api.python.SerDe.loads(data)
     return obj
 
 
@@ -104,17 +106,17 @@ def _java2py(sc: SparkContext, r: "JavaObjectOrPickleDump", encoding: str = "byt
         assert sc._jvm is not None
 
         if clsName == "JavaRDD":
-            jrdd = sc._jvm.org.apache.spark.mllib.api.python.SerDe.javaToPython(r)  # type: ignore[attr-defined]
+            jrdd = sc._jvm.org.apache.spark.mllib.api.python.SerDe.javaToPython(r)
             return RDD(jrdd, sc)
 
         if clsName == "Dataset":
             return DataFrame(r, SparkSession(sc)._wrapped)
 
         if clsName in _picklable_classes:
-            r = sc._jvm.org.apache.spark.mllib.api.python.SerDe.dumps(r)  # type: ignore[attr-defined]
+            r = sc._jvm.org.apache.spark.mllib.api.python.SerDe.dumps(r)
         elif isinstance(r, (JavaArray, JavaList)):
             try:
-                r = sc._jvm.org.apache.spark.mllib.api.python.SerDe.dumps(r)  # type: ignore[attr-defined]
+                r = sc._jvm.org.apache.spark.mllib.api.python.SerDe.dumps(r)
             except Py4JJavaError:
                 pass  # not pickable
 

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -134,10 +134,14 @@ def _auto_patch_pandas() -> None:
     if sys.version_info >= (3, 7):
         # Just in case pandas implements '__class_getitem__' later.
         if not _frame_has_class_getitem:
-            pd.DataFrame.__class_getitem__ = lambda params: DataFrame.__class_getitem__(params)  # type: ignore[assignment,attr-defined]
+            pd.DataFrame.__class_getitem__ = (  # type: ignore[assignment,attr-defined]
+                lambda params: DataFrame.__class_getitem__(params)
+            )
 
         if not _series_has_class_getitem:
-            pd.Series.__class_getitem__ = lambda params: Series.__class_getitem__(params)  # type: ignore[assignment,attr-defined]
+            pd.Series.__class_getitem__ = (  # type: ignore[assignment,attr-defined]
+                lambda params: Series.__class_getitem__(params)
+            )
 
 
 _auto_patch_spark()

--- a/python/pyspark/pandas/accessors.py
+++ b/python/pyspark/pandas/accessors.py
@@ -709,7 +709,7 @@ class PandasOnSparkFrameMethods:
                 self_applied = DataFrame(self._psdf._internal.resolved_copy)
 
                 output_func = GroupBy._make_pandas_df_builder_func(
-                    self_applied, func, return_schema, retain_index=should_retain_index  # type: ignore[arg-type]
+                    self_applied, func, return_schema, should_retain_index  # type: ignore[arg-type]
                 )
                 columns = self_applied._internal.spark_columns
 

--- a/python/pyspark/pandas/categorical.py
+++ b/python/pyspark/pandas/categorical.py
@@ -18,7 +18,11 @@ from typing import Any, Callable, List, Optional, Union, TYPE_CHECKING, cast
 import warnings
 
 import pandas as pd
-from pandas.api.types import CategoricalDtype, is_dict_like, is_list_like  # type: ignore[attr-defined]
+from pandas.api.types import (  # type: ignore[attr-defined]
+    CategoricalDtype,
+    is_dict_like,
+    is_list_like,
+)
 
 from pyspark.pandas.internal import InternalField
 from pyspark.pandas.spark import functions as SF

--- a/python/pyspark/pandas/data_type_ops/num_ops.py
+++ b/python/pyspark/pandas/data_type_ops/num_ops.py
@@ -20,7 +20,11 @@ from typing import Any, Union
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_bool_dtype, is_integer_dtype, CategoricalDtype  # type: ignore[attr-defined]
+from pandas.api.types import (  # type: ignore[attr-defined]
+    is_bool_dtype,
+    is_integer_dtype,
+    CategoricalDtype,
+)
 
 from pyspark.pandas._typing import Dtype, IndexOpsLike, SeriesOrIndex
 from pyspark.pandas.base import column_op, IndexOpsMixin, numpy_column_op

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3998,7 +3998,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     raise ValueError('"column" must have length equal to number of column levels.')
             else:
                 raise NotImplementedError(
-                    "Assigning column name as tuple is only supported for MultiIndex columns for now."
+                    "Assigning column name as tuple is only supported for MultiIndex columns "
+                    "for now."
                 )
 
         if column in self.columns:
@@ -8932,8 +8933,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             # Here we try to flat the multiple map into single list that contains each calculated
             # percentile using `chain`.
             # e.g. flat the `[<map object at 0x7fc1907dc280>, <map object at 0x7fc1907dcc70>]`
-            # to `[Column<'percentile_approx(A, 0.2, 10000)'>, Column<'percentile_approx(B, 0.2, 10000)'>,
-            # Column<'percentile_approx(A, 0.5, 10000)'>, Column<'percentile_approx(B, 0.5, 10000)'>]`
+            # to `[Column<'percentile_approx(A, 0.2, 10000)'>,
+            # Column<'percentile_approx(B, 0.2, 10000)'>,
+            # Column<'percentile_approx(A, 0.5, 10000)'>,
+            # Column<'percentile_approx(B, 0.5, 10000)'>]`
             perc_exprs = chain(
                 *[
                     map(F.percentile_approx, column_names, [percentile] * column_length)
@@ -8967,8 +8970,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             stat_values = sdf.first()
 
             num_stats = int(len(exprs) / column_length)
-            # `column_name_stats_kv` is key-value store that has column name as key, and the stats as values
-            # e.g. {"A": [{count_value}, {min_value}, ...], "B": [{count_value}, {min_value} ...]}
+            # `column_name_stats_kv` is key-value store that has column name as key, and
+            # the stats as values e.g. {"A": [{count_value}, {min_value}, ...],
+            # "B": [{count_value}, {min_value} ...]}
             column_name_stats_kv: Dict[str, List[str]] = defaultdict(list)
             for i, column_name in enumerate(column_names):
                 for first_stat_idx in range(num_stats):
@@ -12158,7 +12162,11 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         row_1   3   2   1   0
         row_2  10  20  30  40
         """
-        return DataFrame(pd.DataFrame.from_dict(data, orient=orient, dtype=dtype, columns=columns))  # type: ignore[arg-type]
+        return DataFrame(
+            pd.DataFrame.from_dict(
+                data, orient=orient, dtype=dtype, columns=columns  # type: ignore[arg-type]
+            )
+        )
 
     # Override the `groupby` to specify the actual return type annotation.
     def groupby(

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2927,9 +2927,13 @@ class Frame(object, metaclass=ABCMeta):
 
         if isinstance(self, ps.Series):
             if indexes_increasing:
-                result = first_series(self.to_frame().loc[before:after]).rename(self.name)  # type: ignore[arg-type, assignment]
+                result = first_series(
+                    self.to_frame().loc[before:after]  # type: ignore[arg-type, assignment]
+                ).rename(self.name)
             else:
-                result = first_series(self.to_frame().loc[after:before]).rename(self.name)  # type: ignore[arg-type,assignment]
+                result = first_series(
+                    self.to_frame().loc[after:before]  # type: ignore[arg-type,assignment]
+                ).rename(self.name)
         elif isinstance(self, ps.DataFrame):
             if axis == 0:
                 if indexes_increasing:

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -267,7 +267,9 @@ class Index(IndexOpsMixin):
         )
         return DataFrame(internal).index
 
-    spark: "SparkIndexOpsMethods" = CachedAccessor("spark", SparkIndexMethods)  # type: ignore[assignment]
+    spark: "SparkIndexOpsMethods" = CachedAccessor(  # type: ignore[assignment]
+        "spark", SparkIndexMethods
+    )
 
     # This method is used via `DataFrame.info` API internally.
     def _summary(self, name: Optional[str] = None) -> str:
@@ -559,7 +561,9 @@ class Index(IndexOpsMixin):
             "`to_numpy` loads all data into the driver's memory. "
             "It should only be used if the resulting NumPy ndarray is expected to be small."
         )
-        result = np.asarray(self._to_internal_pandas()._values, dtype=dtype)  # type: ignore[arg-type,attr-defined]
+        result = np.asarray(
+            self._to_internal_pandas()._values, dtype=dtype  # type: ignore[arg-type,attr-defined]
+        )
         if copy:
             result = result.copy()
         return result

--- a/python/pyspark/pandas/indexes/timedelta.py
+++ b/python/pyspark/pandas/indexes/timedelta.py
@@ -68,19 +68,25 @@ class TimedeltaIndex(Index):
     --------
     >>> from datetime import timedelta
     >>> ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)])
-    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
+    ... # doctest: +NORMALIZE_WHITESPACE
+    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'],
+    dtype='timedelta64[ns]', freq=None)
 
     From an Series:
 
     >>> s = ps.Series([timedelta(1), timedelta(microseconds=2)], index=[10, 20])
     >>> ps.TimedeltaIndex(s)
-    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
+    ... # doctest: +NORMALIZE_WHITESPACE
+    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'],
+    dtype='timedelta64[ns]', freq=None)
 
     From an Index:
 
     >>> idx = ps.TimedeltaIndex([timedelta(1), timedelta(microseconds=2)])
     >>> ps.TimedeltaIndex(idx)
-    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'], dtype='timedelta64[ns]', freq=None)
+    ... # doctest: +NORMALIZE_WHITESPACE
+    TimedeltaIndex(['1 days 00:00:00', '0 days 00:00:00.000002'],
+    dtype='timedelta64[ns]', freq=None)
     """
 
     @no_type_check

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -41,7 +41,11 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype, is_list_like  # type: ignore[attr-defined]
+from pandas.api.types import (  # type: ignore[attr-defined]
+    is_datetime64_dtype,
+    is_datetime64tz_dtype,
+    is_list_like,
+)
 from pandas.tseries.offsets import DateOffset
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -2027,20 +2031,23 @@ def timedelta_range(
     The closed parameter specifies which endpoint is included.
     The default behavior is to include both endpoints.
 
-    >>> ps.timedelta_range(start='1 day', periods=4, closed='right')  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.timedelta_range(start='1 day', periods=4, closed='right')
+    ... # doctest: +NORMALIZE_WHITESPACE
     TimedeltaIndex(['2 days', '3 days', '4 days'], dtype='timedelta64[ns]', freq=None)
 
     The freq parameter specifies the frequency of the TimedeltaIndex.
     Only fixed frequencies can be passed, non-fixed frequencies such as ‘M’ (month end) will raise.
 
-    >>> ps.timedelta_range(start='1 day', end='2 days', freq='6H')  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.timedelta_range(start='1 day', end='2 days', freq='6H')
+    ... # doctest: +NORMALIZE_WHITESPACE
     TimedeltaIndex(['1 days 00:00:00', '1 days 06:00:00', '1 days 12:00:00',
                     '1 days 18:00:00', '2 days 00:00:00'],
                    dtype='timedelta64[ns]', freq=None)
 
     Specify start, end, and periods; the frequency is generated automatically (linearly spaced).
 
-    >>> ps.timedelta_range(start='1 day', end='5 days', periods=4)  # doctest: +NORMALIZE_WHITESPACE
+    >>> ps.timedelta_range(start='1 day', end='5 days', periods=4)
+    ... # doctest: +NORMALIZE_WHITESPACE
     TimedeltaIndex(['1 days 00:00:00', '2 days 08:00:00', '3 days 16:00:00',
                     '5 days 00:00:00'],
                    dtype='timedelta64[ns]', freq=None)
@@ -2533,7 +2540,9 @@ def concat(
             concat_psdf = concat_psdf[column_labels]
 
         if ignore_index:
-            concat_psdf.columns = list(map(str, _range(len(concat_psdf.columns))))  # type: ignore[assignment]
+            concat_psdf.columns = list(  # type: ignore[assignment]
+                map(str, _range(len(concat_psdf.columns)))
+            )
 
         if sort:
             concat_psdf = concat_psdf.sort_index()

--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -375,7 +375,8 @@ class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
             kwds = self.kwds.copy()
 
             label = pprint_thing(label if len(label) > 1 else label[0])
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             label = (
                 self._mark_right_label(label, index=i)
                 if hasattr(self, "_mark_right_label")
@@ -389,7 +390,8 @@ class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
 
             kwds = self._make_plot_keywords(kwds, y)
             artists = self._plot(ax, y, column_num=i, stacking_id=stacking_id, **kwds)
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             self._append_legend_handles_labels(artists[0], label) if hasattr(
                 self, "_append_legend_handles_labels"
             ) else self._add_legend_handle(artists[0], label, index=i)
@@ -475,7 +477,8 @@ class PandasOnSparkKdePlot(PandasKdePlot, KdePlotBase):
             kwds = self.kwds.copy()
 
             label = pprint_thing(label if len(label) > 1 else label[0])
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             label = (
                 self._mark_right_label(label, index=i)
                 if hasattr(self, "_mark_right_label")
@@ -489,7 +492,8 @@ class PandasOnSparkKdePlot(PandasKdePlot, KdePlotBase):
 
             kwds = self._make_plot_keywords(kwds, y)
             artists = self._plot(ax, y, column_num=i, stacking_id=stacking_id, **kwds)
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             self._append_legend_handles_labels(artists[0], label) if hasattr(
                 self, "_append_legend_handles_labels"
             ) else self._add_legend_handle(artists[0], label, index=i)

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -47,7 +47,11 @@ import numpy as np
 import pandas as pd
 from pandas.core.accessor import CachedAccessor
 from pandas.io.formats.printing import pprint_thing
-from pandas.api.types import is_list_like, is_hashable, CategoricalDtype  # type: ignore[attr-defined]
+from pandas.api.types import (  # type: ignore[attr-defined]
+    is_list_like,
+    is_hashable,
+    CategoricalDtype,
+)
 from pandas.tseries.frequencies import DateOffset
 from pyspark.sql import functions as F, Column, DataFrame as SparkDataFrame
 from pyspark.sql.types import (
@@ -444,7 +448,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         )
         return first_series(DataFrame(internal))
 
-    spark: "SparkIndexOpsMethods" = CachedAccessor("spark", SparkSeriesMethods)  # type: ignore[assignment]
+    spark: "SparkIndexOpsMethods" = CachedAccessor(  # type: ignore[assignment]
+        "spark", SparkSeriesMethods
+    )
 
     @property
     def dtypes(self) -> Dtype:

--- a/python/pyspark/pandas/sql_formatter.py
+++ b/python/pyspark/pandas/sql_formatter.py
@@ -89,7 +89,8 @@ def sql(
             ...     ),
             ... )
             >>> new_psdf = psdf.reset_index()
-            >>> ps.sql("SELECT * FROM {new_psdf}", index_col=["index1", "index2"], new_psdf=new_psdf)
+            >>> ps.sql(
+            ...     "SELECT * FROM {new_psdf}", index_col=["index1", "index2"], new_psdf=new_psdf)
             ... # doctest: +NORMALIZE_WHITESPACE
                            A  B
             index1 index2

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -5825,8 +5825,9 @@ class DataFrameTest(PandasOnSparkTestCase, SQLTestUtils):
         )
         pdf = psdf.to_pandas()
         # NOTE: Set `datetime_is_numeric=True` for pandas:
-        # FutureWarning: Treating datetime data as categorical rather than numeric in `.describe` is deprecated
-        # and will be removed in a future version of pandas. Specify `datetime_is_numeric=True` to silence this
+        # FutureWarning: Treating datetime data as categorical rather than numeric in
+        # `.describe` is deprecated and will be removed in a future version of pandas.
+        # Specify `datetime_is_numeric=True` to silence this
         # warning and adopt the future behavior now.
         # NOTE: Compare the result except percentiles, since we use approximate percentile
         # so the result is different from pandas.

--- a/python/pyspark/resource/profile.py
+++ b/python/pyspark/resource/profile.py
@@ -155,12 +155,9 @@ class ResourceProfileBuilder:
                 )
         else:
             if self._java_resource_profile_builder is not None:
-                if (
-                    resourceRequest._java_executor_resource_requests is not None  # type: ignore[attr-defined]
-                ):
-                    self._java_resource_profile_builder.require(
-                        resourceRequest._java_executor_resource_requests  # type: ignore[attr-defined]
-                    )
+                r = resourceRequest._java_executor_resource_requests  # type: ignore[attr-defined]
+                if r is not None:
+                    self._java_resource_profile_builder.require(r)
                 else:
                     execReqs = ExecutorResourceRequests(
                         self._jvm, resourceRequest.requests  # type: ignore[attr-defined]

--- a/python/pyspark/resource/requests.py
+++ b/python/pyspark/resource/requests.py
@@ -304,12 +304,9 @@ class TaskResourceRequests:
 
         _jvm = _jvm or SparkContext._jvm  # type: ignore[attr-defined]
         if _jvm is not None:
-            assert SparkContext._jvm is not None
             self._java_task_resource_requests: Optional[
                 JavaObject
-            ] = (
-                SparkContext._jvm.org.apache.spark.resource.TaskResourceRequests()  # type: ignore[attr-defined]
-            )
+            ] = _jvm.org.apache.spark.resource.TaskResourceRequests()
             if _requests is not None:
                 for k, v in _requests.items():
                     if k == self._CPUS:

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -345,9 +345,8 @@ class Catalog:
         if path is not None:
             options["path"] = path
         if source is None:
-            source = (
-                self._sparkSession._wrapped._conf.defaultDataSourceName()  # type: ignore[attr-defined]
-            )
+            c = self._sparkSession._wrapped._conf
+            source = c.defaultDataSourceName()  # type: ignore[attr-defined]
         if description is None:
             description = ""
         if schema is None:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -2748,8 +2748,8 @@ def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) 
         The column name or column to use as the timestamp for windowing by time.
         The time column must be of TimestampType.
     gapDuration : :class:`~pyspark.sql.Column` or str
-        A Python string literal or column specifying the timeout of the session. It could be static value,
-        e.g. `10 minutes`, `1 second`, or an expression/UDF that specifies gap
+        A Python string literal or column specifying the timeout of the session. It could be
+        static value, e.g. `10 minutes`, `1 second`, or an expression/UDF that specifies gap
         duration dynamically based on the input row.
 
     Examples
@@ -3139,8 +3139,8 @@ def overlay(
     pos : :class:`~pyspark.sql.Column` or str or int
         column name, column, or int containing the starting position in src
     len : :class:`~pyspark.sql.Column` or str or int
-        column name, column, or int containing the number of bytes to replace in src string by 'replace'
-        defaults to -1, which represents the length of the 'replace' string
+        column name, column, or int containing the number of bytes to replace in src
+        string by 'replace' defaults to -1, which represents the length of the 'replace' string
 
     Examples
     --------

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -134,8 +134,9 @@ class PandasConversionMixin:
 
                     # Rename columns to avoid duplicated column names.
                     tmp_column_names = ["col_{}".format(i) for i in range(len(self.columns))]
+                    c = self.sql_ctx._conf
                     self_destruct = (
-                        self.sql_ctx._conf.arrowPySparkSelfDestructEnabled()  # type: ignore[attr-defined]
+                        c.arrowPySparkSelfDestructEnabled()  # type: ignore[attr-defined]
                     )
                     batches = self.toDF(*tmp_column_names)._collect_as_arrow(
                         split_batches=self_destruct
@@ -561,7 +562,10 @@ class SparkConversionMixin:
         require_minimum_pandas_version()
         require_minimum_pyarrow_version()
 
-        from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype  # type: ignore[attr-defined]
+        from pandas.api.types import (  # type: ignore[attr-defined]
+            is_datetime64_dtype,
+            is_datetime64tz_dtype,
+        )
         import pyarrow as pa
 
         # Create the Spark schema from list of names passed in with Arrow types

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -267,7 +267,10 @@ def _check_series_convert_timestamps_internal(
 
     require_minimum_pandas_version()
 
-    from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype  # type: ignore[attr-defined]
+    from pandas.api.types import (  # type: ignore[attr-defined]
+        is_datetime64_dtype,
+        is_datetime64tz_dtype,
+    )
 
     # TODO: handle nested timestamps, such as ArrayType(TimestampType())?
     if is_datetime64_dtype(s.dtype):
@@ -333,7 +336,10 @@ def _check_series_convert_timestamps_localize(
     require_minimum_pandas_version()
 
     import pandas as pd
-    from pandas.api.types import is_datetime64tz_dtype, is_datetime64_dtype  # type: ignore[attr-defined]
+    from pandas.api.types import (  # type: ignore[attr-defined]
+        is_datetime64tz_dtype,
+        is_datetime64_dtype,
+    )
 
     from_tz = from_timezone or _get_local_timezone()
     to_tz = to_timezone or _get_local_timezone()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -670,9 +670,7 @@ class SparkSession(SparkConversionMixin):
             conf = SparkConf()
             assert SparkContext._jvm is not None
             if cast(str, conf.get("spark.sql.catalogImplementation", "hive")).lower() == "hive":
-                (
-                    SparkContext._jvm.org.apache.hadoop.hive.conf.HiveConf()  # type: ignore[attr-defined]
-                )
+                SparkContext._jvm.org.apache.hadoop.hive.conf.HiveConf()
                 return SparkSession.builder.enableHiveSupport().getOrCreate()
             else:
                 return SparkSession._getActiveSessionOrCreate()

--- a/python/pyspark/sql/streaming.py
+++ b/python/pyspark/sql/streaming.py
@@ -1069,16 +1069,14 @@ class DataStreamWriter:
                     "Value for processingTime must be a non empty string. Got: %s" % processingTime
                 )
             interval = processingTime.strip()
-            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.ProcessingTime(  # type: ignore[attr-defined]
+            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.ProcessingTime(
                 interval
             )
 
         elif once is not None:
             if once is not True:
                 raise ValueError("Value for once must be True. Got: %s" % once)
-            jTrigger = (
-                self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Once()  # type: ignore[attr-defined]
-            )
+            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Once()
 
         elif continuous is not None:
             if type(continuous) != str or len(continuous.strip()) == 0:
@@ -1086,15 +1084,13 @@ class DataStreamWriter:
                     "Value for continuous must be a non empty string. Got: %s" % continuous
                 )
             interval = continuous.strip()
-            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Continuous(  # type: ignore[attr-defined]
+            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Continuous(
                 interval
             )
         else:
             if availableNow is not True:
                 raise ValueError("Value for availableNow must be True. Got: %s" % availableNow)
-            jTrigger = (
-                self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.AvailableNow()  # type: ignore[attr-defined]
-            )
+            jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.AvailableNow()
 
         self._jwrite = self._jwrite.trigger(jTrigger)
         return self

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -53,11 +53,7 @@ class CapturedException(Exception):
         self.stackTrace = (
             stackTrace
             if stackTrace is not None
-            else (
-                SparkContext._jvm.org.apache.spark.util.Utils.exceptionString(  # type: ignore[attr-defined]
-                    origin
-                )
-            )
+            else (SparkContext._jvm.org.apache.spark.util.Utils.exceptionString(origin))
         )
         self.cause = convert_exception(cause) if cause is not None else None
         if self.cause is None and origin is not None and origin.getCause() is not None:

--- a/python/pyspark/streaming/kinesis.py
+++ b/python/pyspark/streaming/kinesis.py
@@ -156,10 +156,10 @@ class KinesisUtils:
         jlevel = ssc._sc._getJavaStorageLevel(storageLevel)  # type: ignore[attr-defined]
         jduration = ssc._jduration(checkpointInterval)  # type: ignore[attr-defined]
 
+        jvm = ssc._jvm  # type: ignore[attr-defined]
+
         try:
-            helper = (
-                ssc._jvm.org.apache.spark.streaming.kinesis.KinesisUtilsPythonHelper()  # type: ignore[attr-defined]
-            )
+            helper = jvm.org.apache.spark.streaming.kinesis.KinesisUtilsPythonHelper()
         except TypeError as e:
             if str(e) == "'JavaPackage' object is not callable":
                 _print_missing_jar(

--- a/python/pyspark/tests/test_readwrite.py
+++ b/python/pyspark/tests/test_readwrite.py
@@ -231,8 +231,9 @@ class OutputFormatTests(ReusedPySparkTestCase):
         )
         self.assertEqual(result, data)
 
+        fmt = "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
         conf = {
-            "mapreduce.job.outputformat.class": "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat",
+            "mapreduce.job.outputformat.class": fmt,
             "mapreduce.job.output.key.class": "org.apache.hadoop.io.IntWritable",
             "mapreduce.job.output.value.class": "org.apache.hadoop.io.Text",
             "mapreduce.output.fileoutputformat.outputdir": basepath + "/newdataset/",
@@ -332,8 +333,9 @@ class OutputFormatTests(ReusedPySparkTestCase):
         result4 = sorted(self.sc.sequenceFile(basepath + "/reserialize/dataset").collect())
         self.assertEqual(result4, data)
 
+        fmt = "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
         conf5 = {
-            "mapreduce.job.outputformat.class": "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat",
+            "mapreduce.job.outputformat.class": fmt,
             "mapreduce.job.output.key.class": "org.apache.hadoop.io.IntWritable",
             "mapreduce.job.output.value.class": "org.apache.hadoop.io.IntWritable",
             "mapreduce.output.fileoutputformat.outputdir": basepath + "/reserialize/newdataset",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reenables length check in Python linter (E501 in flake8) that is disabled from https://github.com/apache/spark/pull/34297

### Why are the changes needed?

To have the consistent style, and follow the convention.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Existing unitttest should cover all.