### PR TITLE
[SPARK-37836][PYTHON][INFRA] Enable F841, E722, E305 and E226 for PEP 8 compliance

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,2 +1,0 @@
-pep8*.py
-pycodestyle*.py

--- a/dev/create-release/generate-contributors.py
+++ b/dev/create-release/generate-contributors.py
@@ -75,6 +75,8 @@ print("")
 def print_indented(_list):
     for x in _list:
         print("  %s" % x)
+
+
 if yesOrNoPrompt("Show all commits?"):
     print_indented(new_commits)
 print("==================================================================================\n")

--- a/dev/create-release/releaseutils.py
+++ b/dev/create-release/releaseutils.py
@@ -147,6 +147,7 @@ def get_commits(tag):
         commits.append(commit)
     return commits
 
+
 # Maintain a mapping for translating issue types to contributions in the release notes
 # This serves an additional function of warning the user against unknown issue types
 # Note: This list is partially derived from this link:

--- a/dev/create-release/translate-contributors.py
+++ b/dev/create-release/translate-contributors.py
@@ -137,6 +137,7 @@ def generate_candidates(author, issues):
         candidates[i] = (candidate, source)
     return candidates
 
+
 # Translate each invalid author by searching for possible candidates from GitHub and JIRA
 # In interactive mode, this script presents the user with a list of choices and have the user
 # select from this list. Additionally, the user may also choose to enter a custom name.

--- a/dev/github_jira_sync.py
+++ b/dev/github_jira_sync.py
@@ -161,7 +161,7 @@ for issue, pr in sorted(jira_prs, key=lambda kv: int(kv[1]['number'])):
     try:
         page = get_json(get_url(JIRA_API_BASE + "/rest/api/2/issue/" + issue + "/remotelink"))
         existing_links = map(lambda l: l['object']['url'], page)
-    except:
+    except BaseException:
         print("Failure reading JIRA %s (does it exist?)" % issue)
         print(sys.exc_info()[0])
         continue

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -147,9 +147,6 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
         distinct_authors = list(filter(lambda x: x != primary_author, distinct_authors))
         distinct_authors.insert(0, primary_author)
 
-    commits = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
-                      '--pretty=format:%h [%an] %s']).split("\n\n")
-
     merge_message_flags = []
 
     merge_message_flags += ["-m", title]
@@ -304,7 +301,7 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
                       "again (or leave blank and fix manually)." % (", ".join(fix_versions)))
         except KeyboardInterrupt:
             raise
-        except:
+        except BaseException:
             traceback.print_exc()
             print("Error setting fix version(s), try again (or leave blank and fix manually)")
 
@@ -350,14 +347,14 @@ def choose_jira_assignee(issue, asf_jira):
                 try:
                     id = int(raw_assignee)
                     assignee = candidates[id]
-                except:
+                except BaseException:
                     # assume it's a user id, and try to assign (might fail, we just prompt again)
                     assignee = asf_jira.user(raw_assignee)
                 asf_jira.assign_issue(issue.key, assignee.name)
                 return assignee
         except KeyboardInterrupt:
             raise
-        except:
+        except BaseException:
             traceback.print_exc()
             print("Error assigning JIRA, try again (or leave blank and fix manually)")
 
@@ -562,6 +559,7 @@ def main():
         print("Could not find jira-python library. Run 'sudo pip3 install jira' to install.")
         print("Exiting without trying to close the associated JIRA.")
 
+
 if __name__ == "__main__":
     import doctest
     (failure_count, test_count) = doctest.testmod()
@@ -569,6 +567,6 @@ if __name__ == "__main__":
         sys.exit(-1)
     try:
         main()
-    except:
+    except BaseException:
         clean_up()
         raise

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -94,6 +94,7 @@ class Module(object):
     def __hash__(self):
         return hash(self.name)
 
+
 tags = Module(
     name="tags",
     dependencies=[],

--- a/dev/sparktestsupport/utils.py
+++ b/dev/sparktestsupport/utils.py
@@ -77,7 +77,7 @@ def identify_changed_files_from_git_commits(patch_sha, target_branch=None, targe
         raise AttributeError("must specify either target_branch or target_ref, not both")
     if target_branch is not None:
         diff_target = target_branch
-        run_cmd(['git', 'fetch', 'origin', str(target_branch+':'+target_branch)])
+        run_cmd(['git', 'fetch', 'origin', str(target_branch + ':' + target_branch)])
     else:
         diff_target = target_ref
     raw_output = subprocess.check_output(['git', 'diff', '--name-only', patch_sha, diff_target],
@@ -154,6 +154,7 @@ def _test():
     failure_count = doctest.testmod()[0]
     if failure_count:
         sys.exit(-1)
+
 
 if __name__ == "__main__":
     _test()

--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -16,20 +16,24 @@
 
 [flake8]
 ignore =
-    E203,
-    E226,
-    E305,
-    E402,
-    E722,
+    E203, # Skip as black formatter adds a whitespace around ':'.
+    E402, # Module top level import is disabled for optional import check, etc.
+    F403, # Using wildcard discouraged but F401 can detect. Disabled to reduce the usage of noqa. 
+    # 1. Type hints with def are treated as redefinition (e.g., functions.log).
+    # 2. Some are used for testing.
+    F811,
+
+    # Below rules should be enabled in the future.
     E731,
     E741,
-    F403,
-    F811,
-    F841,
     W503,
     W504,
 per-file-ignores =
+    # F405 is ignored as shared.py is auto-generated.
+    # E501 can be removed after SPARK-37419.
     python/pyspark/ml/param/shared.py: F405 E501,
+    # Examples contain some unused variables.
+    examples/src/main/python/sql/datasource.py: F841,
 exclude =
     */target/*,
     docs/.local_ruby_bundle/,

--- a/examples/src/main/python/logistic_regression.py
+++ b/examples/src/main/python/logistic_regression.py
@@ -42,6 +42,7 @@ def readPointBatch(iterator):
         matrix[i] = np.fromstring(s.replace(',', ' '), dtype=np.float32, sep=' ')
     return [matrix]
 
+
 if __name__ == "__main__":
 
     if len(sys.argv) != 3:

--- a/examples/src/main/python/ml/bucketizer_example.py
+++ b/examples/src/main/python/ml/bucketizer_example.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     # Transform original data into its bucket index.
     bucketedData = bucketizer.transform(dataFrame)
 
-    print("Bucketizer output with %d buckets" % (len(bucketizer.getSplits())-1))
+    print("Bucketizer output with %d buckets" % (len(bucketizer.getSplits()) - 1))
     bucketedData.show()
     # $example off$
 

--- a/examples/src/main/python/sql/basic.py
+++ b/examples/src/main/python/sql/basic.py
@@ -197,6 +197,7 @@ def programmatic_schema_example(spark):
     # +-------+
     # $example off:programmatic_schema$
 
+
 if __name__ == "__main__":
     # $example on:init_session$
     spark = SparkSession \

--- a/examples/src/main/python/status_api_demo.py
+++ b/examples/src/main/python/status_api_demo.py
@@ -63,5 +63,6 @@ def main():
     print("Job results are:", result.get())
     sc.stop()
 
+
 if __name__ == "__main__":
     main()

--- a/examples/src/main/python/streaming/hdfs_wordcount.py
+++ b/examples/src/main/python/streaming/hdfs_wordcount.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     lines = ssc.textFileStream(sys.argv[1])
     counts = lines.flatMap(lambda line: line.split(" "))\
                   .map(lambda x: (x, 1))\
-                  .reduceByKey(lambda a, b: a+b)
+                  .reduceByKey(lambda a, b: a + b)
     counts.pprint()
 
     ssc.start()

--- a/examples/src/main/python/streaming/network_wordcount.py
+++ b/examples/src/main/python/streaming/network_wordcount.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     lines = ssc.socketTextStream(sys.argv[1], int(sys.argv[2]))
     counts = lines.flatMap(lambda line: line.split(" "))\
                   .map(lambda word: (word, 1))\
-                  .reduceByKey(lambda a, b: a+b)
+                  .reduceByKey(lambda a, b: a + b)
     counts.pprint()
 
     ssc.start()

--- a/examples/src/main/python/streaming/network_wordjoinsentiments.py
+++ b/examples/src/main/python/streaming/network_wordjoinsentiments.py
@@ -43,6 +43,7 @@ def print_happiest_words(rdd):
     for tuple in top_list:
         print("%s (%d happiness)" % (tuple[1], tuple[0]))
 
+
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: network_wordjoinsentiments.py <hostname> <port>", file=sys.stderr)

--- a/examples/src/main/python/streaming/recoverable_network_wordcount.py
+++ b/examples/src/main/python/streaming/recoverable_network_wordcount.py
@@ -95,6 +95,7 @@ def createContext(host, port, outputPath):
     wordCounts.foreachRDD(echo)
     return ssc
 
+
 if __name__ == "__main__":
     if len(sys.argv) != 5:
         print("Usage: recoverable_network_wordcount.py <hostname> <port> "

--- a/examples/src/main/python/streaming/sql_network_wordcount.py
+++ b/examples/src/main/python/streaming/sql_network_wordcount.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
             wordCountsDataFrame = \
                 spark.sql("select word, count(*) as total from words group by word")
             wordCountsDataFrame.show()
-        except:
+        except BaseException:
             pass
 
     words.foreachRDD(process)

--- a/external/kinesis-asl/src/main/python/examples/streaming/kinesis_wordcount_asl.py
+++ b/external/kinesis-asl/src/main/python/examples/streaming/kinesis_wordcount_asl.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
         ssc, appName, streamName, endpointUrl, regionName, InitialPositionInStream.LATEST, 2)
     counts = lines.flatMap(lambda line: line.split(" ")) \
         .map(lambda word: (word, 1)) \
-        .reduceByKey(lambda a, b: a+b)
+        .reduceByKey(lambda a, b: a + b)
     counts.pprint()
 
     ssc.start()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -209,7 +209,7 @@ class SparkContext:
                 profiler_cls,
                 udf_profiler_cls,
             )
-        except:
+        except BaseException:
             # If an error occurs, clean up in order to allow future SparkContext creation:
             self.stop()
             raise

--- a/python/pyspark/daemon.py
+++ b/python/pyspark/daemon.py
@@ -196,7 +196,7 @@ def manager():
                                     pass
                                 break
                             gc.collect()
-                    except:
+                    except BaseException:
                         traceback.print_exc()
                         os._exit(1)
                     else:

--- a/python/pyspark/ml/linalg/__init__.py
+++ b/python/pyspark/ml/linalg/__init__.py
@@ -60,7 +60,7 @@ try:
     import scipy.sparse
 
     _have_scipy = True
-except:
+except BaseException:
     # No SciPy in environment, but that's okay
     _have_scipy = False
 

--- a/python/pyspark/ml/tests/test_persistence.py
+++ b/python/pyspark/ml/tests/test_persistence.py
@@ -379,7 +379,7 @@ class PersistenceTest(SparkSessionTestCase):
         )
 
         lr = LogisticRegressionCls(maxIter=5, regParam=0.01)
-        ovr = OneVsRest(classifier=lr)
+        OneVsRest(classifier=lr)
 
         def reload_and_compare(ovr, suffix):
             model = ovr.fit(df)

--- a/python/pyspark/ml/tests/test_tuning.py
+++ b/python/pyspark/ml/tests/test_tuning.py
@@ -80,11 +80,7 @@ class InducedErrorEstimator(Estimator, HasInducedError):
 class ParamGridBuilderTests(SparkSessionTestCase):
     def test_addGrid(self):
         with self.assertRaises(TypeError):
-            grid = (
-                ParamGridBuilder()
-                .addGrid("must be an instance of Param", ["not", "string"])
-                .build()
-            )
+            (ParamGridBuilder().addGrid("must be an instance of Param", ["not", "string"]).build())
 
 
 class ValidatorTestUtilsMixin:

--- a/python/pyspark/ml/tests/test_wrapper.py
+++ b/python/pyspark/ml/tests/test_wrapper.py
@@ -67,7 +67,7 @@ class JavaWrapperMemoryTests(SparkSessionTestCase):
 
         try:
             summary.__del__()
-        except:
+        except BaseException:
             pass
 
         def condition():

--- a/python/pyspark/mllib/classification.py
+++ b/python/pyspark/mllib/classification.py
@@ -161,7 +161,7 @@ class LogisticRegressionModel(LinearClassificationModel):
     >>> from shutil import rmtree
     >>> try:
     ...    rmtree(path)
-    ... except:
+    ... except BaseException:
     ...    pass
     >>> multi_class_data = [
     ...     LabeledPoint(0.0, [0.0, 1.0, 0.0]),
@@ -537,7 +537,7 @@ class SVMModel(LinearClassificationModel):
     >>> from shutil import rmtree
     >>> try:
     ...    rmtree(path)
-    ... except:
+    ... except BaseException:
     ...    pass
     """
 

--- a/python/pyspark/mllib/linalg/__init__.py
+++ b/python/pyspark/mllib/linalg/__init__.py
@@ -63,7 +63,7 @@ try:
     import scipy.sparse
 
     _have_scipy = True
-except:
+except BaseException:
     # No SciPy in environment, but that's okay
     _have_scipy = False
 

--- a/python/pyspark/mllib/regression.py
+++ b/python/pyspark/mllib/regression.py
@@ -180,7 +180,7 @@ class LinearRegressionModel(LinearRegressionModelBase):
     >>> from shutil import rmtree
     >>> try:
     ...     rmtree(path)
-    ... except:
+    ... except BaseException:
     ...     pass
     >>> data = [
     ...     LabeledPoint(0.0, SparseVector(1, {0: 0.0})),
@@ -383,7 +383,7 @@ class LassoModel(LinearRegressionModelBase):
     >>> from shutil import rmtree
     >>> try:
     ...    rmtree(path)
-    ... except:
+    ... except BaseException:
     ...    pass
     >>> data = [
     ...     LabeledPoint(0.0, SparseVector(1, {0: 0.0})),
@@ -557,7 +557,7 @@ class RidgeRegressionModel(LinearRegressionModelBase):
     >>> from shutil import rmtree
     >>> try:
     ...    rmtree(path)
-    ... except:
+    ... except BaseException:
     ...    pass
     >>> data = [
     ...     LabeledPoint(0.0, SparseVector(1, {0: 0.0})),

--- a/python/pyspark/mllib/tests/test_algorithms.py
+++ b/python/pyspark/mllib/tests/test_algorithms.py
@@ -295,7 +295,7 @@ class ListTests(MLlibTestCase):
         GradientBoostedTrees.trainRegressor(
             rdd, categoricalFeaturesInfo=categoricalFeaturesInfo, numIterations=4, maxBins=32
         )
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(Exception):
             GradientBoostedTrees.trainRegressor(
                 rdd, categoricalFeaturesInfo=categoricalFeaturesInfo, numIterations=4, maxBins=1
             )

--- a/python/pyspark/mllib/tests/test_streaming_algorithms.py
+++ b/python/pyspark/mllib/tests/test_streaming_algorithms.py
@@ -303,7 +303,6 @@ class StreamingLogisticRegressionWithSGDTests(MLLibStreamingTestCase):
             true, predicted = zip(*rdd.collect())
             errors.append(self.calculate_accuracy_error(true, predicted))
 
-        true_predicted = []
         input_stream = self.ssc.queueStream(input_batches)
         predict_stream = self.ssc.queueStream(predict_batches)
         slr.trainOn(input_stream)

--- a/python/pyspark/mllib/tests/test_util.py
+++ b/python/pyspark/mllib/tests/test_util.py
@@ -61,7 +61,7 @@ class MLUtilsTests(MLlibTestCase):
             self.assertEqual(len(ret), 2)
             self.assertEqual(ret[0], DenseVector([1.0, 2.0, 3.0]))
             self.assertEqual(ret[1], DenseVector([1.0, 2.0, 3.0]))
-        except:
+        except BaseException:
             self.fail()
         finally:
             shutil.rmtree(load_vectors_path)

--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -383,7 +383,6 @@ class DataTypeOps(object, metaclass=ABCMeta):
             from pyspark.pandas.frame import DataFrame
             from pyspark.pandas.internal import NATURAL_ORDER_COLUMN_NAME, InternalField
 
-            len_right = len(right)
             if len(left) != len(right):
                 raise ValueError("Lengths must be equal")
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6477,14 +6477,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for inc in include_list:
             try:
                 include_spark_type.append(_parse_datatype_string(inc))
-            except:
+            except BaseException:
                 pass
 
         exclude_spark_type = []
         for exc in exclude_list:
             try:
                 exclude_spark_type.append(_parse_datatype_string(exc))
-            except:
+            except BaseException:
                 pass
 
         # Handle pandas types
@@ -6492,14 +6492,14 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         for inc in include_list:
             try:
                 include_numpy_type.append(infer_dtype_from_object(inc))
-            except:
+            except BaseException:
                 pass
 
         exclude_numpy_type = []
         for exc in exclude_list:
             try:
                 exclude_numpy_type.append(infer_dtype_from_object(exc))
-            except:
+            except BaseException:
                 pass
 
         column_labels = []

--- a/python/pyspark/pandas/sql_processor.py
+++ b/python/pyspark/pandas/sql_processor.py
@@ -206,7 +206,7 @@ def _get_local_scope() -> Dict[str, Any]:
     # Get 2 scopes above (_get_local_scope -> sql -> ...) to capture the vars there.
     try:
         return inspect.stack()[_CAPTURE_SCOPES][0].f_locals
-    except Exception as e:
+    except Exception:
         # TODO (rxin, thunterdb): use a more narrow scope exception.
         # See https://github.com/pyspark.pandas/pull/448
         return {}
@@ -222,7 +222,7 @@ def _get_ipython_scope() -> Dict[str, Any]:
 
         shell = get_ipython()
         return shell.user_ns
-    except Exception as e:
+    except Exception:
         # TODO (rxin, thunterdb): use a more narrow scope exception.
         # See https://github.com/pyspark.pandas/pull/448
         return None

--- a/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_boolean_ops.py
@@ -235,9 +235,9 @@ class BooleanOpsTest(PandasOnSparkTestCase, TestCasesUtils):
         self.assertRaises(TypeError, lambda: datetime.datetime(1994, 1, 1) ** b_psser)
 
     def test_rmod(self):
-        pdf, psdf = self.pdf, self.psdf
+        psdf = self.psdf
 
-        b_pser, b_psser = pdf["bool"], psdf["bool"]
+        b_psser = psdf["bool"]
         # 1 % False is 0.0 in pandas
         self.assert_eq(pd.Series([0, 0, None], dtype=float, name="bool"), 1 % b_psser)
         # 0.1 / True is 0.1 in pandas

--- a/python/pyspark/pandas/tests/test_dataframe_conversion.py
+++ b/python/pyspark/pandas/tests/test_dataframe_conversion.py
@@ -189,8 +189,7 @@ class DataFrameConversionTest(PandasOnSparkTestCase, SQLTestUtils, TestUtils):
             ]
             assert len(output_paths) > 0
             output_path = "%s/%s/%s" % (self.tmp_dir, partition_path, output_paths[0])
-            with open(output_path) as f:
-                self.assertEqual("[%s]" % open(output_path).read().strip(), expected)
+            self.assertEqual("[%s]" % open(output_path).read().strip(), expected)
 
     @unittest.skip("Pyperclip could not find a copy/paste mechanism for Linux.")
     def test_to_clipboard(self):

--- a/python/pyspark/pandas/tests/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/test_dataframe_spark_io.py
@@ -361,10 +361,6 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
                 1
             ).write.orc(path, mode="overwrite")
 
-            # `spark.write.orc` create a directory contains distributed orc files.
-            # But pandas only can read from file, not directory. Therefore, we need orc file path.
-            orc_file_path = glob.glob(os.path.join(path, "*.orc"))[0]
-
             expected = data.reset_index()[data.columns]
             actual = ps.read_orc(path)
             self.assertPandasEqual(expected, actual.to_pandas())

--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -44,29 +44,31 @@ class SeriesDateTimeTest(PandasOnSparkTestCase, SQLTestUtils):
     def check_func(self, func):
         self.assert_eq(func(self.ks_start_date), func(self.pd_start_date))
 
+    @unittest.skip(
+        "Those fail in certain OSs presumably due to different"
+        "timezone behaviours inherited from C library."
+    )
     def test_timestamp_subtraction(self):
         pdf = self.pdf1
         psdf = ps.from_pandas(pdf)
 
-        # Those fail in certain OSs presumably due to different
-        # timezone behaviours inherited from C library.
-
         actual = (psdf["end_date"] - psdf["start_date"] - 1).to_pandas()
         expected = (pdf["end_date"] - pdf["start_date"]) // np.timedelta64(1, "s") - 1
-        # self.assert_eq(actual, expected)
+        self.assert_eq(actual, expected)
 
         actual = (psdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31") - 1).to_pandas()
         expected = (pdf["end_date"] - pd.Timestamp("2012-1-1 12:45:31")) // np.timedelta64(
             1, "s"
         ) - 1
-        # self.assert_eq(actual, expected)
+        self.assert_eq(actual, expected)
 
         actual = (pd.Timestamp("2013-3-11 21:45:00") - psdf["start_date"] - 1).to_pandas()
         expected = (pd.Timestamp("2013-3-11 21:45:00") - pdf["start_date"]) // np.timedelta64(
             1, "s"
         ) - 1
-        # self.assert_eq(actual, expected)
+        self.assert_eq(actual, expected)
 
+    def test_timestamp_subtraction_errors(self):
         psdf = ps.DataFrame(
             {"a": pd.date_range("2016-12-31", "2017-01-08", freq="D"), "b": pd.Series(range(9))}
         )

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -996,7 +996,7 @@ class RDD:
         This method should only be used if the resulting array is expected
         to be small, as all the data is loaded into the driver's memory.
         """
-        with SCCallSiteSync(self.context) as css:
+        with SCCallSiteSync(self.context):
             sock_info = self.ctx._jvm.PythonRDD.collectAndServe(self._jrdd.rdd())
         return list(_load_from_socket(sock_info, self._jrdd_deserializer))
 
@@ -1014,7 +1014,7 @@ class RDD:
             FutureWarning,
         )
 
-        with SCCallSiteSync(self.context) as css:
+        with SCCallSiteSync(self.context):
             sock_info = self.ctx._jvm.PythonRDD.collectAndServeWithJobGroup(
                 self._jrdd.rdd(), groupId, description, interruptOnCancel
             )
@@ -2171,7 +2171,7 @@ class RDD:
 
         keyed = self.mapPartitionsWithIndex(add_shuffle_key, preservesPartitioning=True)
         keyed._bypass_serializer = True
-        with SCCallSiteSync(self.context) as css:
+        with SCCallSiteSync(self.context):
             pairRDD = self.ctx._jvm.PairwiseRDD(keyed._jrdd.rdd()).asJavaPairRDD()
             jpartitioner = self.ctx._jvm.PythonPartitioner(numPartitions, id(partitionFunc))
         jrdd = self.ctx._jvm.PythonRDD.valueOfPair(pairRDD.partitionBy(jpartitioner))
@@ -2826,7 +2826,7 @@ class RDD:
         >>> [x for x in rdd.toLocalIterator()]
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         """
-        with SCCallSiteSync(self.context) as css:
+        with SCCallSiteSync(self.context):
             sock_info = self.ctx._jvm.PythonRDD.toLocalIteratorAndServe(
                 self._jrdd.rdd(), prefetchPartitions
             )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -764,7 +764,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df.collect()
         [Row(age=2, name='Alice'), Row(age=5, name='Bob')]
         """
-        with SCCallSiteSync(self._sc) as css:
+        with SCCallSiteSync(self._sc):
             sock_info = self._jdf.collectToPython()
         return list(_load_from_socket(sock_info, BatchedSerializer(CPickleSerializer())))
 
@@ -787,7 +787,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> list(df.toLocalIterator())
         [Row(age=2, name='Alice'), Row(age=5, name='Bob')]
         """
-        with SCCallSiteSync(self._sc) as css:
+        with SCCallSiteSync(self._sc):
             sock_info = self._jdf.toPythonIterator(prefetchPartitions)
         return _local_iterator_from_socket(sock_info, BatchedSerializer(CPickleSerializer()))
 

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -64,7 +64,7 @@ class ColumnTests(ReusedSQLTestCase):
     def test_column_operators(self):
         ci = self.df.key
         cs = self.df.value
-        c = ci == cs
+        ci == cs
         self.assertTrue(isinstance((-ci - 1 - 2) % 3 * 2.5 / 3.5, Column))
         rcc = (1 + ci), (1 - ci), (1 * ci), (1 / ci), (1 % ci), (1 ** ci), (ci ** 1)
         self.assertTrue(all(isinstance(c, Column) for c in rcc))

--- a/python/pyspark/sql/tests/test_streaming.py
+++ b/python/pyspark/sql/tests/test_streaming.py
@@ -493,7 +493,7 @@ class StreamingTests(ReusedSQLTestCase):
         try:
             tester.run_streaming_query_on_writer(ForeachWriter(), 1)
             self.fail("bad writer did not fail the query")  # this is not expected
-        except StreamingQueryException as e:
+        except StreamingQueryException:
             # TODO: Verify whether original error message is inside the exception
             pass
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1033,11 +1033,11 @@ def _parse_datatype_string(s: str) -> DataType:
         try:
             # For backwards compatibility, "integer", "struct<fieldname: datatype>" and etc.
             return from_ddl_datatype(s)
-        except:
+        except BaseException:
             try:
                 # For backwards compatibility, "fieldname: datatype, fieldname: datatype" case.
                 return from_ddl_datatype("struct<%s>" % s.strip())
-            except:
+            except BaseException:
                 raise e
 
 

--- a/python/pyspark/streaming/tests/test_dstream.py
+++ b/python/pyspark/streaming/tests/test_dstream.py
@@ -371,7 +371,7 @@ class BasicOperationTests(PySparkStreamingTestCase):
         self.ssc.start()
         try:
             self.ssc.awaitTerminationOrTimeout(10)
-        except:
+        except BaseException:
             import traceback
 
             failure = traceback.format_exc()
@@ -394,7 +394,7 @@ class BasicOperationTests(PySparkStreamingTestCase):
         self.ssc.start()
         try:
             self.ssc.awaitTerminationOrTimeout(10)
-        except:
+        except BaseException:
             import traceback
 
             failure = traceback.format_exc()
@@ -420,7 +420,7 @@ class BasicOperationTests(PySparkStreamingTestCase):
         self.assertEqual(expected, self._collect(input_stream.map(failed_func), 3))
         try:
             self.ssc.awaitTerminationOrTimeout(10)
-        except:
+        except BaseException:
             import traceback
 
             failure = traceback.format_exc()
@@ -573,7 +573,7 @@ class CheckpointTests(unittest.TestCase):
         self.ssc = StreamingContext.getOrCreate(self.cpd, setup)
         try:
             self.ssc.start()
-        except:
+        except BaseException:
             import traceback
 
             failure = traceback.format_exc()

--- a/python/pyspark/streaming/tests/test_kinesis.py
+++ b/python/pyspark/streaming/tests/test_kinesis.py
@@ -92,7 +92,7 @@ class KinesisStreamTests(PySparkStreamingTestCase):
                     break
                 time.sleep(10)
             self.assertEqual(expectedOutput, set(outputBuffer))
-        except:
+        except BaseException:
             import traceback
 
             traceback.print_exc()

--- a/python/pyspark/streaming/util.py
+++ b/python/pyspark/streaming/util.py
@@ -78,7 +78,7 @@ class TransformFunction:
                     return r._jrdd
                 else:
                     return r.map(lambda x: x)._jrdd
-        except:
+        except BaseException:
             self.failure = traceback.format_exc()
 
     def getLastFailure(self):
@@ -118,7 +118,7 @@ class TransformFunctionSerializer:
             return bytearray(
                 self.serializer.dumps((func.func, func.rdd_wrap_func, func.deserializers))
             )
-        except:
+        except BaseException:
             self.failure = traceback.format_exc()
 
     def loads(self, data):
@@ -127,7 +127,7 @@ class TransformFunctionSerializer:
         try:
             f, wrap_func, deserializers = self.serializer.loads(bytes(data))
             return TransformFunction(self.ctx, f, *deserializers).rdd_wrapper(wrap_func)
-        except:
+        except BaseException:
             self.failure = traceback.format_exc()
 
     def getLastFailure(self):

--- a/python/pyspark/testing/streamingutils.py
+++ b/python/pyspark/testing/streamingutils.py
@@ -76,7 +76,7 @@ class PySparkStreamingTestCase(unittest.TestCase):
             jSparkContextOption = SparkContext._jvm.SparkContext.get()
             if jSparkContextOption.nonEmpty():
                 jSparkContextOption.get().stop()
-        except:
+        except BaseException:
             pass
 
     def setUp(self):
@@ -90,7 +90,7 @@ class PySparkStreamingTestCase(unittest.TestCase):
             jStreamingContextOption = StreamingContext._jvm.SparkContext.getActive()
             if jStreamingContextOption.nonEmpty():
                 jStreamingContextOption.get().stop(False)
-        except:
+        except BaseException:
             pass
 
     def wait_for(self, result, n):

--- a/python/pyspark/tests/test_context.py
+++ b/python/pyspark/tests/test_context.py
@@ -183,7 +183,7 @@ class ContextTests(unittest.TestCase):
     def test_parallelize_eager_cleanup(self):
         with SparkContext() as sc:
             temp_files = os.listdir(sc._temp_dir)
-            rdd = sc.parallelize([0, 1, 2])
+            sc.parallelize([0, 1, 2])
             post_parallelize_temp_files = os.listdir(sc._temp_dir)
             self.assertEqual(temp_files, post_parallelize_temp_files)
 
@@ -202,16 +202,16 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(SparkContext._active_spark_context, None)
 
     def test_with(self):
-        with SparkContext() as sc:
+        with SparkContext():
             self.assertNotEqual(SparkContext._active_spark_context, None)
         self.assertEqual(SparkContext._active_spark_context, None)
 
     def test_with_exception(self):
         try:
-            with SparkContext() as sc:
+            with SparkContext():
                 self.assertNotEqual(SparkContext._active_spark_context, None)
                 raise RuntimeError()
-        except:
+        except BaseException:
             pass
         self.assertEqual(SparkContext._active_spark_context, None)
 

--- a/python/pyspark/tests/test_profiler.py
+++ b/python/pyspark/tests/test_profiler.py
@@ -74,7 +74,7 @@ class ProfilerTests(PySparkTestCase):
     def do_computation(self):
         def heavy_foo(x):
             for i in range(1 << 18):
-                x = 1
+                x = 1  # noqa: F841
 
         rdd = self.sc.parallelize(range(100))
         rdd.foreach(heavy_foo)

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -116,7 +116,7 @@ class RDDTests(ReusedPySparkTestCase):
         rdd1 = self.sc.parallelize([1, 2])
         rdd2 = self.sc.parallelize([3, 4])
         cart = rdd1.cartesian(rdd2)
-        result = cart.map(lambda x_y3: x_y3[0] + x_y3[1]).collect()
+        cart.map(lambda x_y3: x_y3[0] + x_y3[1]).collect()
 
     def test_transforming_pickle_file(self):
         # Regression test for SPARK-2601

--- a/python/pyspark/tests/test_readwrite.py
+++ b/python/pyspark/tests/test_readwrite.py
@@ -231,9 +231,10 @@ class OutputFormatTests(ReusedPySparkTestCase):
         )
         self.assertEqual(result, data)
 
-        fmt = "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
         conf = {
-            "mapreduce.job.outputformat.class": fmt,
+            "mapreduce.job.outputformat.class": (
+                "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
+            ),
             "mapreduce.job.output.key.class": "org.apache.hadoop.io.IntWritable",
             "mapreduce.job.output.value.class": "org.apache.hadoop.io.Text",
             "mapreduce.output.fileoutputformat.outputdir": basepath + "/newdataset/",
@@ -333,9 +334,10 @@ class OutputFormatTests(ReusedPySparkTestCase):
         result4 = sorted(self.sc.sequenceFile(basepath + "/reserialize/dataset").collect())
         self.assertEqual(result4, data)
 
-        fmt = "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
         conf5 = {
-            "mapreduce.job.outputformat.class": fmt,
+            "mapreduce.job.outputformat.class": (
+                "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
+            ),
             "mapreduce.job.output.key.class": "org.apache.hadoop.io.IntWritable",
             "mapreduce.job.output.value.class": "org.apache.hadoop.io.IntWritable",
             "mapreduce.output.fileoutputformat.outputdir": basepath + "/reserialize/newdataset",

--- a/python/pyspark/tests/test_shuffle.py
+++ b/python/pyspark/tests/test_shuffle.py
@@ -103,17 +103,17 @@ class MergerTests(unittest.TestCase):
 
         # wrong create combiner
         m = ExternalMerger(Aggregator(stopit, legit_merge_value, legit_merge_combiners), 20)
-        with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+        with self.assertRaises((Py4JJavaError, RuntimeError)):
             m.mergeValues(data)
 
         # wrong merge value
         m = ExternalMerger(Aggregator(legit_create_combiner, stopit, legit_merge_combiners), 20)
-        with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+        with self.assertRaises((Py4JJavaError, RuntimeError)):
             m.mergeValues(data)
 
         # wrong merge combiners
         m = ExternalMerger(Aggregator(legit_create_combiner, legit_merge_value, stopit), 20)
-        with self.assertRaises((Py4JJavaError, RuntimeError)) as cm:
+        with self.assertRaises((Py4JJavaError, RuntimeError)):
             m.mergeCombiners(map(lambda x_y1: (x_y1[0], [x_y1[1]]), data))
 
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -114,7 +114,7 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
             [os.path.join(SPARK_HOME, "bin/pyspark")] + test_name.split(),
             stderr=per_test_output, stdout=per_test_output, env=env).wait()
         shutil.rmtree(tmp_dir, ignore_errors=True)
-    except:
+    except BaseException:
         LOGGER.exception("Got exception while running %s with %s", test_name, pyspark_python)
         # Here, we use os._exit() instead of sys.exit() in order to force Python to exit even if
         # this code is invoked from a thread other than the main thread.
@@ -133,7 +133,7 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
                     if not re.match('[0-9]+', decoded_line):
                         print(decoded_line, end='')
                 per_test_output.close()
-        except:
+        except BaseException:
             LOGGER.exception("Got an exception while trying to print failed test output")
         finally:
             print_red("\nHad test failures in %s with %s; see logs." % (test_name, pyspark_python))
@@ -156,7 +156,7 @@ def run_individual_python_test(target_dir, test_name, pyspark_python):
                 assert SKIPPED_TESTS is not None
                 SKIPPED_TESTS[key] = skipped_tests
             per_test_output.close()
-        except:
+        except BaseException:
             import traceback
             print_red("\nGot an exception while trying to store "
                       "skipped test output:\n%s" % traceback.format_exc())
@@ -234,7 +234,7 @@ def _check_coverage(python_exec):
         subprocess_check_output(
             [python_exec, "-c", "import coverage"],
             stderr=open(os.devnull, 'w'))
-    except:
+    except BaseException:
         print_red("Coverage is not installed in Python executable '%s' "
                   "but 'COVERAGE_PROCESS_START' environment variable is set, "
                   "exiting." % python_exec)

--- a/python/setup.py
+++ b/python/setup.py
@@ -102,7 +102,7 @@ if (in_spark):
     # Construct links for setup
     try:
         os.mkdir(TEMP_PATH)
-    except:
+    except BaseException:
         print("Temp path for symlink to parent already exists {0}".format(TEMP_PATH),
               file=sys.stderr)
         sys.exit(-1)

--- a/sql/hive/src/test/resources/data/scripts/input20_script.py
+++ b/sql/hive/src/test/resources/data/scripts/input20_script.py
@@ -25,6 +25,6 @@ while line:
     if line == tem:
         x += 1
     else:
-        print(str(x).strip()+'\t'+re.sub('\t', '_', line.strip()))
+        print(str(x).strip() + '\t' + re.sub('\t', '_', line.strip()))
         line = tem
         x = 1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable flake8 rules as below:

- [F841](https://www.flake8rules.com/rules/F841.html): Local variable name is assigned to but never used
- [E722](https://www.flake8rules.com/rules/E722.html): Do not use bare except, specify exception instead
- [E305](https://www.flake8rules.com/rules/E305.html): Expected 2 blank lines after end of function or class
- [E226](https://www.flake8rules.com/rules/E226.html):  Missing whitespace around arithmetic operator

We should probably still enable the rules below:

- [E731](https://www.flake8rules.com/rules/E731.html): Do not assign a lambda expression, use a def
- [E741](https://www.flake8rules.com/rules/E741.html): Do not use variables named 'I', 'O', or 'l' 
- [W503](https://www.flake8rules.com/rules/W503.html): Line break occurred before a binary operator
- [W504](https://www.flake8rules.com/rules/W504.html): Line break occurred after a binary operator

but the rules ^ are not enabled in this PR because:
- There are too many instances to fix. Maybe it's better to separate PRs
- Some require real code changes.
- W503 and W504 are sort of conflicted. We should investigate a bit more.

### Why are the changes needed?

To comply PEP 8.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I manually tested it Python linter.