### PR TITLE
[SPARK-37838][TESTS] Upgrade scalatestplus artifacts to 3.3.0-SNAP3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1075,13 +1075,13 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.9</version>
+        <version>3.3.0-SNAP3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
-        <version>3.2.9.0</version>
+        <version>3.3.0.0-SNAP3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1093,7 +1093,7 @@
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-3-141_${scala.binary.version}</artifactId>
-        <version>3.2.9.0</version>
+        <version>3.3.0.0-SNAP3</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr upgrade scalatestplus artifacts to 3.3.0-SNAP3.

### Why are the changes needed?

To workaround exception when running tests on local machine.
```
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt clean "sql/testOnly *PlanStability*Suite"
...
[info] compiling 315 Scala sources and 29 Java sources to /Users/yumwang/spark/SPARK-31890/core/target/scala-2.12/test-classes ...
[error] /Users/yumwang/spark/core/src/test/scala/org/apache/spark/SparkContextInfoSuite.scala:22:8: Symbol 'type org.scalactic.TripleEquals' is missing from the classpath.
[error] This symbol is required by 'trait org.scalatest.Assertions'.
[error] Make sure that type TripleEquals is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
[error] A full rebuild may help if 'Assertions.class' was compiled against an incompatible version of org.scalactic.
[error] import org.scalatest.Assertions
[error]        ^
[error] one error found
[error] (core / Test / compileIncremental) Compilation failed
[error] Total time: 26 s, completed Jan 7, 2022 2:44:35 PM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.
