### PR TITLE
[SPARK-37833][INFRA][FOLLOW-UP] Run checking modules of precondition only in forked repository

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,6 +116,7 @@ jobs:
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit"
     - name: Check all modules
+      if: github.repository != 'apache/spark'
       id: set-outputs
       run: |
         build=`./dev/is-changed.py -m avro,build,catalyst,core,docker-integration-tests,examples,graphx,hadoop-cloud,hive,hive-thriftserver,kubernetes,kvstore,launcher,mesos,mllib,mllib-local,network-common,network-shuffle,pyspark-core,pyspark-ml,pyspark-mllib,pyspark-pandas,pyspark-pandas-slow,pyspark-resource,pyspark-sql,pyspark-streaming,repl,sketch,spark-ganglia-lgpl,sparkr,sql,sql-kafka-0-10,streaming,streaming-kafka-0-10,streaming-kinesis-asl,tags,unsafe,yarn`


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/35121. We should run "Check all modules" in precondition job only in the forked repository because `is-changed.py` requires `APACHE_SPARK_REF` to be set: https://github.com/apache/spark/blob/master/dev/is-changed.py#L60

### Why are the changes needed?

To fix broken build in main branch. PRs are not affected.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Should be merged to test.