### PR TITLE
[SPARK-37842][SQL] Use `multi-catch` to simplify duplicate exception handling behavior in Java code

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/PlainSaslServer.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/PlainSaslServer.java
@@ -104,10 +104,8 @@ public class PlainSaslServer implements SaslServer {
       }
     } catch (IllegalStateException eL) {
       throw new SaslException("Invalid message format", eL);
-    } catch (IOException eI) {
-      throw new SaslException("Error validating the login", eI);
-    } catch (UnsupportedCallbackException eU) {
-      throw new SaslException("Error validating the login", eU);
+    } catch (IOException | UnsupportedCallbackException e) {
+      throw new SaslException("Error validating the login", e);
     }
     return null;
   }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/CLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/CLIService.java
@@ -87,9 +87,7 @@ public class CLIService extends CompositeService implements ICLIService {
       try {
         HiveAuthFactory.loginFromKeytab(hiveConf);
         this.serviceUGI = Utils.getUGI();
-      } catch (IOException e) {
-        throw new ServiceException("Unable to login to kerberos with given principal/keytab", e);
-      } catch (LoginException e) {
+      } catch (IOException | LoginException e) {
         throw new ServiceException("Unable to login to kerberos with given principal/keytab", e);
       }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -329,10 +329,6 @@ public class SQLOperation extends ExecuteStatementOperation {
         return decode(convey, rowSet);
       }
       return rowSet;
-    } catch (IOException e) {
-      throw new HiveSQLException(e);
-    } catch (CommandNeedRetryException e) {
-      throw new HiveSQLException(e);
     } catch (Exception e) {
       throw new HiveSQLException(e);
     } finally {

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/SQLOperation.java
@@ -17,7 +17,6 @@
 
 package org.apache.hive.service.cli.operation;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.security.PrivilegedExceptionAction;
 import java.sql.SQLException;
@@ -34,7 +33,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Schema;
-import org.apache.hadoop.hive.ql.CommandNeedRetryException;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.ExplainTask;

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -414,9 +414,7 @@ public class HiveSessionImpl implements HiveSession {
   public IMetaStoreClient getMetaStoreClient() throws HiveSQLException {
     try {
       return Hive.get(getHiveConf()).getMSC();
-    } catch (HiveException e) {
-      throw new HiveSQLException("Failed to get metastore connection", e);
-    } catch (MetaException e) {
+    } catch (HiveException | MetaException e) {
       throw new HiveSQLException("Failed to get metastore connection", e);
     }
   }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionProxy.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionProxy.java
@@ -74,9 +74,7 @@ public class HiveSessionProxy implements InvocationHandler {
         throw (HiveSQLException)e.getCause();
       }
       throw new RuntimeException(e.getCause());
-    } catch (IllegalArgumentException e) {
-      throw new RuntimeException(e);
-    } catch (IllegalAccessException e) {
+    } catch (IllegalArgumentException | IllegalAccessException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Java 7 began to support the `Multiple exception catching`, This pr uses it to simplify exception handling in Java code.

**Before**

```java
} catch (FirstException ex) {
     logger.error(ex);
     throw ex;
} catch (SecondException ex) {
     logger.error(ex);
     throw ex;
}
```

**After**

```java
} catch (FirstException | SecondException ex) {
    logger.error(ex);
    throw ex;
}
```

### Why are the changes needed?
Code simplification




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA
