### PR TITLE
[SPARK-37846][TESTS] Fix test logic by getting sleep interval in task

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala
@@ -81,25 +81,25 @@ class BlockManagerDecommissionIntegrationSuite extends SparkFunSuite with LocalS
     }
   }
 
-  testRetry(s"verify that an already running task which is going to cache data succeeds " +
-    s"on a decommissioned executor after task start") {
+  testRetry("verify that an already running task which is going to cache data succeeds " +
+    "on a decommissioned executor after task start") {
     runDecomTest(true, false, TaskStarted)
   }
 
-  test(s"verify that an already running task which is going to cache data succeeds " +
-    s"on a decommissioned executor after one task ends but before job ends") {
+  test("verify that an already running task which is going to cache data succeeds " +
+    "on a decommissioned executor after one task ends but before job ends") {
     runDecomTest(true, false, TaskEnded)
   }
 
-  test(s"verify that shuffle blocks are migrated") {
+  test("verify that shuffle blocks are migrated") {
     runDecomTest(false, true, JobEnded)
   }
 
-  test(s"verify that both migrations can work at the same time") {
+  test("verify that both migrations can work at the same time") {
     runDecomTest(true, true, JobEnded)
   }
 
-  test(s"SPARK-36782 not deadlock if MapOutput uses broadcast") {
+  test("SPARK-36782 not deadlock if MapOutput uses broadcast") {
     runDecomTest(false, true, JobEnded, forceMapOutputBroadcast = true)
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerDecommissionIntegrationSuite.scala
@@ -141,25 +141,25 @@ class BlockManagerDecommissionIntegrationSuite extends SparkFunSuite with LocalS
     val input = sc.parallelize(1 to numParts, numParts)
     val accum = sc.longAccumulator("mapperRunAccumulator")
 
-    val sleepIntervalMs = whenToDecom match {
-      // Increase the window of time b/w task started and ended so that we can decom within that.
-      case TaskStarted => 10000
-      // Make one task take a really short time so that we can decommission right after it is
-      // done but before its peers are done.
-      case TaskEnded =>
-        if (TaskContext.getPartitionId() == 0) {
-          100
-        } else {
-          1000
-        }
-      // No sleep otherwise
-      case _ => 0
-    }
-
     // Create a new RDD where we have sleep in each partition, we are also increasing
     // the value of accumulator in each partition
     val baseRdd = input.mapPartitions { x =>
       accum.add(1)
+
+      val sleepIntervalMs = whenToDecom match {
+        // Increase the window of time b/w task started and ended so that we can decom within that.
+        case "TASK_STARTED" => 10000
+        // Make one task take a really short time so that we can decommission right after it is
+        // done but before its peers are done.
+        case "TASK_ENDED" =>
+          if (TaskContext.getPartitionId() == 0) {
+            100
+          } else {
+            1000
+          }
+        // No sleep otherwise
+        case _ => 0
+      }
       if (sleepIntervalMs > 0) {
         Thread.sleep(sleepIntervalMs)
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently in the tests, `TaskContext.getPartitionId()` is called at driver side, so the sleep interval is always 100ms, which is not expected and makes some tests flaky (on my env it's mainly the test `"verify that an already running task which is going to cache data succeeds on a decommissioned executor after one task ends but before job ends"`).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Correct the test logic and make tests stable.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
By existing tests. I also iterated 10 times on the env where the test was flaky, after the change it never failed.