### PR TITLE
[SPARK-37829][SQL] DataFrame.joinWith should return null rows for missing values

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.TestUtils.withListener
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.{FooClassWithEnum, FooEnum, ScroogeLikeExample}
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.execution.{LogicalRDD, RDDScanExec, SQLExecution}
@@ -2146,6 +2147,49 @@ class DatasetSuite extends QueryTest
       (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
       (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
       (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13))
+  }
+
+  test("SPARK-37829: DataFrame outer join") {
+    val left = Seq(ClassData("a", 1), ClassData("b", 2)).toDF().as("left")
+    val right = Seq(ClassData("x", 2), ClassData("y", 3)).toDF().as("right")
+    val joined = left.joinWith(right, $"left.b" === $"right.b", "left")
+
+    val leftFieldSchema = StructType(
+      Seq(
+        StructField("a", StringType),
+        StructField("b", IntegerType, nullable = false)
+      )
+    )
+    val rightFieldSchema = StructType(
+      Seq(
+        StructField("a", StringType),
+        StructField("b", IntegerType, nullable = false)
+      )
+    )
+    val expectedSchema = StructType(
+      Seq(
+        StructField(
+          "_1",
+          leftFieldSchema,
+          nullable = false
+        ),
+        // This is a left join, so the right output is nullable:
+        StructField(
+          "_2",
+          rightFieldSchema
+        )
+      )
+    )
+    assert(joined.schema === expectedSchema)
+
+    val result = joined.collect().toSet
+    val expected = Set(
+      new GenericRowWithSchema(Array("a", 1), leftFieldSchema) ->
+        null,
+      new GenericRowWithSchema(Array("b", 2), leftFieldSchema) ->
+        new GenericRowWithSchema(Array("x", 2), rightFieldSchema)
+    )
+    assert(result == expected)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
We add a unit test demonstrating a regression on `DataFrame.joinWith` and fix the regression by updating `ExpressionEncoder`. The fix is equivalent to reverting [this commit](https://github.com/apache/spark/commit/cd92f25be5a221e0d4618925f7bc9dfd3bb8cb59).

### Why are the changes needed?
Doing an outer-join using joinWith on DataFrames used to return missing values as null in Spark 2.4.8, but returns them as Rows with null values in Spark 3.0.0+.

The regression has been introduced in [this commit](https://github.com/apache/spark/commit/cd92f25be5a221e0d4618925f7bc9dfd3bb8cb59).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a unit test. This unit test succeeds with Spark 2.4.8 but fails with Spark 3.0.0+.

The new unit test does a left outer join on two DataFrames using the `joinWith` method.
The join is performed on the `b` field of `ClassData` (Ints).
The row `ClassData("a", 1)` on the left side of the join has no matching row on the right side of the join as there is no row with value `1` for field `b`.
The missing value (of Row type) is represented as a `GenericRowWithSchema(Array(null, null), rightFieldSchema)` instead of a `null` value making the test fail.

This new test is identical to [this one](https://github.com/apache/spark/blob/6061e60ed7691bf3ca0e0964acac4c53c69bcc07/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala#L1269-L1292) and only differs in that it uses DataFrames instead of Datasets.

I've run unit tests for the `sql-core` and `sql-catalyst` submodules locally with `./build/mvn clean package -pl sql/core,cql/catalyst`