### PR TITLE
[SPARK-37708][K8S] Provides basic images that support centos7

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.centos7
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.centos7
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM centos:centos7
+
+ARG spark_uid=185
+
+# Before building the docker image, first build and make a Spark distribution following
+# the instructions in http://spark.apache.org/docs/latest/building-spark.html.
+# If this docker file is being used in the context of building your images from a Spark
+# distribution, the docker build command should be invoked from the top level directory
+# of the Spark distribution. E.g.:
+# docker build -t spark:latest -f kubernetes/dockerfiles/spark/Dockerfile .
+
+RUN set -ex && \
+    ln -s /lib /lib64 && \
+    yum install -y wget  && \
+    yum install -y epel-release && \
+    yum install -y tini net-tools && \
+    yum install -y java-1.8.0-openjdk* && \
+    mkdir -p /opt/spark && \
+    mkdir -p /opt/spark/examples && \
+    mkdir -p /opt/spark/work-dir && \
+    touch /opt/spark/RELEASE && \
+    rm /bin/sh && \
+    ln -sv /bin/bash /bin/sh && \
+    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
+    rm -rf /var/cache/yum/*
+
+COPY jars /opt/spark/jars
+COPY bin /opt/spark/bin
+COPY sbin /opt/spark/sbin
+COPY kubernetes/dockerfiles/spark/entrypoint.sh /opt/
+COPY kubernetes/dockerfiles/spark/decom.sh /opt/
+COPY examples /opt/spark/examples
+COPY kubernetes/tests /opt/spark/tests
+COPY data /opt/spark/data
+
+ENV SPARK_HOME /opt/spark
+
+WORKDIR /opt/spark/work-dir
+RUN chmod g+w /opt/spark/work-dir
+RUN chmod a+x /opt/decom.sh
+RUN cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
+
+ENTRYPOINT [ "/opt/entrypoint.sh" ]
+
+# Specify the User that the actual main process will run as
+USER ${spark_uid}

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile.centos7
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile.centos7
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ARG base_img
+
+FROM $base_img
+WORKDIR /
+
+# Reset to root to run installation tasks
+USER 0
+
+RUN mkdir ${SPARK_HOME}/python
+RUN set -ex && \
+    yum install zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel readline-devel tk-devel gcc make libffi-devel -y && \
+    wget -O ${SPARK_HOME}/work-dir/Python-3.9.0.tgz https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz && \
+    cd ${SPARK_HOME}/work-dir/ && \
+    tar zxvf Python-3.9.0.tgz && \
+    cd Python-3.9.0 && \
+    ./configure prefix=/usr/lib/python3 && \
+    make && make install && \
+    ln -s /usr/lib/python3/bin/python3.9  /usr/bin/python3.9 && \
+    ln -s /usr/lib/python3/bin/python3.9  /usr/bin/python3 && \
+    ln -s /usr/lib/python3/bin/python3.9 /usr/local/lib/python3.9 && \
+    ln -s /usr/lib/python3/bin/python3.9 /usr/local/lib/python3 && \
+    ln -s /usr/lib/python3/bin/pip3.9 /usr/bin/pip3.9 && \
+    ln -s /usr/lib/python3/bin/pip3.9 /usr/bin/pip3  && \
+    ln -s /usr/lib/python3/bin/pip3.9 /usr/bin/pip  && \
+    pip3 install --upgrade pip setuptools && \
+    rm -rf ${SPARK_HOME}/work-dir/Python-3.9.0* && \
+    rm -rf /var/cache/yum/*
+
+COPY python/pyspark ${SPARK_HOME}/python/pyspark
+COPY python/lib ${SPARK_HOME}/python/lib
+
+WORKDIR /opt/spark/work-dir
+ENTRYPOINT [ "/opt/entrypoint.sh" ]
+
+# Specify the User that the actual main process will run as
+USER ${spark_uid}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
To adapt to the production environment, CentOS 7 basic image is provided.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If we compile Python on centos and run this package on K8S, I submit it this way：
`spark-submit  \
--archives s3a://zhongjingxiong/python3.6.9.tgz#python3.6 \
--conf spark.pyspark.driver.python=python3.6/bin/python3 \
--conf spark.pyspark.python=python3.6/bin/python3 \
examples/src/main/python/pi.py 10 `

We will report dependency loss.
>  Unpacking an archive s3a://zhongjingxiong/python3.6.9.tgz#python3 from /tmp/spark-0002ed81-3a01-4e40-a9b7-826295b86ece/python3.6.9.tgz to /opt/spark/work-dir/./python3
Traceback (most recent call last):
  File "/tmp/spark-0002ed81-3a01-4e40-a9b7-826295b86ece/pi.py", line 21, in <module>
    from pyspark.sql import SparkSession
  File "/opt/spark/python/lib/pyspark.zip/pyspark/__init__.py", line 121, in <module>
  File "/opt/spark/python/lib/pyspark.zip/pyspark/sql/__init__.py", line 42, in <module>
  File "/opt/spark/python/lib/pyspark.zip/pyspark/sql/types.py", line 27, in <module>
    async def _ag():
  File "/opt/spark/work-dir/python3/lib/python3.6/ctypes/__init__.py", line 7, in <module>
    from _ctypes import Union, Structure, Array
ImportError: libffi.so.6: cannot open shared object file: No such file or directory
22/01/07 22:56:11 INFO ShutdownHookManager: Shutdown hook called

But it works fine when running on YARN. Therefore, it is better to provide an image that supports centos to run Spark.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes,this is a new docker file exposed to the customer.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It has been deployed in the production environment.