### PR TITLE
[SPARK-37853][CORE] Clean up deprecation compilation warning related to log4j2

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -62,6 +62,8 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
     }
     val config = logger.getContext.getConfiguration()
     def log4jFileAppender() = {
+      // SPARK-37853: We can't use the chained API invocation mode because
+      // `AbstractFilterable.Builder.asBuilder()` method will return `Any` in Scala.
       val builder: Log4jFileAppender.Builder[_] = Log4jFileAppender.newBuilder()
       builder.withAppend(false)
       builder.withBufferedIo(false)

--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -61,12 +61,21 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
       PatternLayout.newBuilder().withPattern(DEFAULT_LAYOUT).build()
     }
     val config = logger.getContext.getConfiguration()
-    val fa = Log4jFileAppender.createAppender(localLogFile, "false", "false",
-      DriverLogger.APPENDER_NAME, "true", "false", "false", "4000", layout, null,
-      "false", null, config);
+    def log4jFileAppender() = {
+      val builder: Log4jFileAppender.Builder[_] = Log4jFileAppender.newBuilder()
+      builder.withAppend(false)
+      builder.withBufferedIo(false)
+      builder.setConfiguration(config)
+      builder.withFileName(localLogFile)
+      builder.setIgnoreExceptions(false)
+      builder.setLayout(layout)
+      builder.setName(DriverLogger.APPENDER_NAME)
+      builder.build()
+    }
+    val fa = log4jFileAppender()
     logger.addAppender(fa)
     fa.start()
-    logInfo(s"Added a local log appender at: ${localLogFile}")
+    logInfo(s"Added a local log appender at: $localLogFile")
   }
 
   def startSync(hadoopConf: Configuration): Unit = {

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark
 
-// scalastyle:off
 import java.io.File
 import java.nio.file.Path
 import java.util.{Locale, TimeZone}
@@ -27,9 +26,9 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.commons.io.FileUtils
 import org.apache.logging.log4j._
+import org.apache.logging.log4j.core.{LogEvent, Logger, LoggerContext}
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.Property
-import org.apache.logging.log4j.core.{LogEvent, Logger, LoggerContext}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Failed, Outcome}
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -21,17 +21,15 @@ package org.apache.spark
 import java.io.File
 import java.nio.file.Path
 import java.util.{Locale, TimeZone}
-
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
-
 import org.apache.commons.io.FileUtils
 import org.apache.logging.log4j._
 import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.Property
 import org.apache.logging.log4j.core.{LogEvent, Logger, LoggerContext}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Failed, Outcome}
 import org.scalatest.funsuite.AnyFunSuite
-
 import org.apache.spark.deploy.LocalSparkCluster
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Tests.IS_TESTING
@@ -265,7 +263,7 @@ abstract class SparkFunSuite
   }
 
   class LogAppender(msg: String = "", maxEvents: Int = 1000)
-      extends AbstractAppender("logAppender", null, null) {
+      extends AbstractAppender("logAppender", null, null, true, Property.EMPTY_ARRAY) {
     private val _loggingEvents = new ArrayBuffer[LogEvent]()
     private var _threshold: Level = Level.INFO
 

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -21,8 +21,10 @@ package org.apache.spark
 import java.io.File
 import java.nio.file.Path
 import java.util.{Locale, TimeZone}
+
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.commons.io.FileUtils
 import org.apache.logging.log4j._
 import org.apache.logging.log4j.core.appender.AbstractAppender
@@ -30,6 +32,7 @@ import org.apache.logging.log4j.core.config.Property
 import org.apache.logging.log4j.core.{LogEvent, Logger, LoggerContext}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, BeforeAndAfterEach, Failed, Outcome}
 import org.scalatest.funsuite.AnyFunSuite
+
 import org.apache.spark.deploy.LocalSparkCluster
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Tests.IS_TESTING

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -548,8 +548,8 @@ abstract class AvroSuite
     val fixed = spark.read.format("avro").load(testAvro).select("fixed3").collect()
     assert(fixed.map(_(0).asInstanceOf[Array[Byte]]).exists(p => p(1) == 3))
 
-    val enumCol = spark.read.format("avro").load(testAvro).select("enum").collect()
-    assert(enumCol.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
+    val enum = spark.read.format("avro").load(testAvro).select("enum").collect()
+    assert(enum.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
 
     val record = spark.read.format("avro").load(testAvro).select("record").collect()
     assert(record(0)(0).getClass.toString.contains("Row"))

--- a/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/external/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -548,8 +548,8 @@ abstract class AvroSuite
     val fixed = spark.read.format("avro").load(testAvro).select("fixed3").collect()
     assert(fixed.map(_(0).asInstanceOf[Array[Byte]]).exists(p => p(1) == 3))
 
-    val enum = spark.read.format("avro").load(testAvro).select("enum").collect()
-    assert(enum.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
+    val enumCol = spark.read.format("avro").load(testAvro).select("enum").collect()
+    assert(enumCol.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
 
     val record = spark.read.format("avro").load(testAvro).select("record").collect()
     assert(record(0)(0).getClass.toString.contains("Row"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
The are 2 deprecation compilation warning related to log4j2:
```
[WARNING] [Warn] /spark-source/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala:64: [deprecation @ org.apache.spark.util.logging.DriverLogger.addLogAppender.fa | origin=org.apache.logging.log4j.core.appender.FileAppender.createAppender | version=] method createAppender in class FileAppender is deprecated
[WARNING] [Warn] /spark-source/core/src/test/scala/org/apache/spark/SparkFunSuite.scala:268: [deprecation @ org.apache.spark.SparkFunSuite.LogAppender.<init> | origin=org.apache.logging.log4j.core.appender.AbstractAppender.<init> | version=] constructor AbstractAppender in class AbstractAppender is deprecated
```

In order to fix the above compilation warning, the main change of this pr as follows:
1.  `Log4jFileAppender.Builder` is used instead of `Log4jFileAppender.createAppender` to fix compilation warning of `DriverLogger`, and the configuration of some default values is omitted refer to SPARK-6305. 

The initial status of `Log4jFileAppender.Builder` as follows:

```java
fileName = null
append = true
locking = false
advertise = false
advertiseUri = null
createOnDemand = false
filePermissions = null
fileOwner = null
fileGroup = null
bufferedIo = true
bufferSize = 8192
immediateFlush = true
ignoreExceptions = true
layout = null
name = null
configuration = null
filter = null
propertyArray = null
```

And we can't use the chained API invocation mode because `AbstractFilterable.Builder.asBuilder()` method will return `Any` in Scala.
 
2. Use the recommended constructor of `AbstractAppender` refer to javadoc to fix compilation warning  in `SparkFunSuite`.

### Why are the changes needed?
Clean up deprecation compilation warning related to log4j2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA