### PR TITLE
[SPARK-36644][SQL][FOLLOWUP] Push down boolean column filter for Data Srouce V2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -537,6 +537,9 @@ private[sql] object DataSourceV2Strategy {
     case expressions.Literal(false, BooleanType) =>
       Some(new V2AlwaysFalse)
 
+    case e @ pushableColumn(name) if e.dataType.isInstanceOf[BooleanType] =>
+      Some(new V2EqualTo(FieldReference(name), LiteralValue(true, BooleanType)))
+
     case _ => None
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2Suite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.catalog.{SupportsRead, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.connector.expressions.filter.{EqualTo => V2EqualTo, Filter => V2Filter, GreaterThan => V2GreaterThan}
+import org.apache.spark.sql.connector.expressions.filter.{Filter => V2Filter, GreaterThan => V2GreaterThan}
 import org.apache.spark.sql.connector.read._
 import org.apache.spark.sql.connector.read.partitioning.{ClusteredDistribution, Distribution, Partitioning}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -523,26 +523,6 @@ class DataSourceV2Suite extends QueryTest with SharedSparkSession with AdaptiveS
       }
     }
   }
-
-  test("SPARK-36644: Push down boolean column filter") {
-    Seq(classOf[BooleanDataSourceV2WithV2Filter]).foreach { cls =>
-      withClue(cls.getName) {
-        val df = spark.read.format(cls.getName).load()
-
-        val q1 = df.select('b)
-        checkAnswer(q1, (0 until 10).map(i => Row(i % 10 < 5)))
-        val batch1 = getBatchWithV2Filter(q1)
-        assert(batch1.filters.isEmpty)
-        assert(batch1.requiredSchema.fieldNames === Seq("b"))
-
-        val q2 = df.filter('b).select('b)
-        checkAnswer(q2, (0 until 5).map(i => Row(true)))
-        val batch2 = getBatchWithV2Filter(q2)
-        assert(batch2.filters.flatMap(_.references.map(_.describe)).toSet == Set("b"))
-        assert(batch2.requiredSchema.fieldNames === Seq("b"))
-      }
-    }
-  }
 }
 
 
@@ -785,7 +765,6 @@ class AdvancedReaderFactory(requiredSchema: StructType) extends PartitionReaderF
         val values = requiredSchema.map(_.name).map {
           case "i" => current
           case "j" => -current
-          case "b" => current % 10 < 5
         }
         InternalRow.fromSeq(values)
       }
@@ -990,48 +969,6 @@ class ReportStatisticsDataSource extends SimpleWritableDataSource {
       override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
         new MyScanBuilder
       }
-    }
-  }
-}
-
-class BooleanDataSourceV2WithV2Filter extends AdvancedDataSourceV2WithV2Filter {
-  override def inferSchema(options: CaseInsensitiveStringMap): StructType =
-    TestingV2Source.schema.add("b", "boolean")
-
-  override def getTable(options: CaseInsensitiveStringMap): Table = new SimpleBatchTable {
-    override def schema(): StructType = super.schema().add("b", "boolean")
-
-    override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
-      val scanBuilder = new AdvancedScanBuilderWithV2Filter() {
-        override def pushFilters(filters: Array[V2Filter]): Array[V2Filter] = {
-          val (supported, unsupported) = filters.partition {
-            case _: V2EqualTo => true
-            case _ => false
-          }
-          this.filters = supported
-          unsupported
-        }
-
-        override def toBatch: Batch = new AdvancedBatchWithV2Filter(filters, requiredSchema) {
-          override def planInputPartitions(): Array[InputPartition] = {
-            val bool = filters.collectFirst {
-              case eq: V2EqualTo => eq.value
-            }
-            val res = scala.collection.mutable.ArrayBuffer.empty[InputPartition]
-            if (bool.isEmpty) {
-              res.append(RangeInputPartition(0, 5))
-              res.append(RangeInputPartition(5, 10))
-            } else if (bool.get.value.asInstanceOf[Boolean]) {
-              res.append(RangeInputPartition(0, 5))
-            } else {
-              res.append(RangeInputPartition(5, 10))
-            }
-            res.toArray
-          }
-        }
-      }
-      scanBuilder.pruneColumns(TestingV2Source.schema.add("b", "boolean"))
-      scanBuilder
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2StrategySuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.connector.expressions.{FieldReference, LiteralValue}
+import org.apache.spark.sql.connector.expressions.filter.{EqualTo => V2EqualTo, Filter => V2Filter}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.BooleanType
+
+class DataSourceV2StrategySuite extends PlanTest with SharedSparkSession {
+  test("SPARK-36644: Push down boolean column filter") {
+    testTranslateFilter('col.boolean,
+      Some(new V2EqualTo(FieldReference("col"), LiteralValue(true, BooleanType))))
+  }
+
+  /**
+   * Translate the given Catalyst [[Expression]] into data source [[V2Filter]]
+   * then verify against the given [[V2Filter]].
+   */
+  def testTranslateFilter(catalystFilter: Expression, result: Option[V2Filter]): Unit = {
+    assertResult(result) {
+      DataSourceV2Strategy.translateFilterV2(catalystFilter, true)
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve `DataSourceV2Strategy` to be able to push down boolean column filters. Currently boolean column filters do not get pushed down and may cause unnecessary IO.
This is a follow up PR of the same change for (V1) `DataSourceStrategy`.


### Why are the changes needed?
The following query does not push down the filter in the current implementation
```
SELECT * FROM t WHERE boolean_field
```
although the following query pushes down the filter as expected.
```
SELECT * FROM t WHERE boolean_field = true
```
This is because the Physical Planner (`DataSourceV2Strategy`) currently only pushes down limited expression patterns like`EqualTo`.
It is fair for Spark SQL users to expect `boolean_field` performs the same as `boolean_field = true`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit tests