### PR TITLE
[SPARK-37858][SQL] Throw `SparkRuntimeException` with error classes from AES functions

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -159,5 +159,9 @@
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"
+  },
+  "INVALID_AES_KEY_LENGTH" : {
+    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s"],
+    "sqlState" : "42000"
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -71,6 +71,10 @@
   "INTERNAL_ERROR" : {
     "message" : [ "%s" ]
   },
+  "INVALID_AES_KEY_LENGTH" : {
+    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s" ],
+    "sqlState" : "42000"
+  },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s. If necessary set %s to false to bypass this error." ]
   },
@@ -137,6 +141,10 @@
     "message" : [ "Unrecognized SQL type %s" ],
     "sqlState" : "42000"
   },
+  "UNSUPPORTED_AES_MODE" : {
+    "message" : [ "The AES mode %s with the padding %s is not supported" ],
+    "sqlState" : "42000"
+  },
   "UNSUPPORTED_CHANGE_COLUMN" : {
     "message" : [ "Please add an implementation for a column change here" ],
     "sqlState" : "0A000"
@@ -159,13 +167,5 @@
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"
-  },
-  "INVALID_AES_KEY_LENGTH" : {
-    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s" ],
-    "sqlState" : "42000"
-  },
-  "UNSUPPORTED_AES_MODE" : {
-    "message" : [ "The AES mode %s with the padding %s is not supported" ],
-    "sqlState" : "42000"
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -147,7 +147,7 @@
   },
   "UNSUPPORTED_AES_MODE" : {
     "message" : [ "The AES mode %s with the padding %s is not supported" ],
-    "sqlState" : "42000"
+    "sqlState" : "0A000"
   },
   "UNSUPPORTED_CHANGE_COLUMN" : {
     "message" : [ "Please add an implementation for a column change here" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -161,7 +161,11 @@
     "sqlState" : "40000"
   },
   "INVALID_AES_KEY_LENGTH" : {
-    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s"],
+    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s" ],
+    "sqlState" : "42000"
+  },
+  "UNSUPPORTED_AES_MODE" : {
+    "message" : [ "The AES mode %s with the padding %s is not supported" ],
     "sqlState" : "42000"
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,7 +1,6 @@
 {
   "AES_CRYPTO_ERROR" : {
-    "message" : [ "AES crypto operation failed with: %s" ],
-    "sqlState" : "42000"
+    "message" : [ "AES crypto operation failed with: %s" ]
   },
   "AMBIGUOUS_FIELD_NAME" : {
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,4 +1,8 @@
 {
+  "AES_CRYPTO_ERROR" : {
+    "message" : [ "AES crypto operation failed with: %s" ],
+    "sqlState" : "42000"
+  },
   "AMBIGUOUS_FIELD_NAME" : {
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
     "sqlState" : "42000"

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -252,18 +252,6 @@ private[spark] class SparkSecurityException(
 }
 
 /**
- * Crypto exception thrown from Spark while performing a crypto operation.
- */
-private[spark] class SparkCryptoException(
-    errorClass: String,
-    messageParameters: Array[String])
-  extends SecurityException(
-    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-}
-
-/**
  * Array index out of bounds exception thrown from Spark with an error class.
  */
 private[spark] class SparkArrayIndexOutOfBoundsException(

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -252,6 +252,18 @@ private[spark] class SparkSecurityException(
 }
 
 /**
+ * Crypto exception thrown from Spark while performing a crypto operation.
+ */
+private[spark] class SparkCryptoException(
+    errorClass: String,
+    messageParameters: Array[String])
+  extends SecurityException(
+    SparkThrowableHelper.getMessage(errorClass, messageParameters)) with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+}
+
+/**
  * Array index out of bounds exception thrown from Spark with an error class.
  */
 private[spark] class SparkArrayIndexOutOfBoundsException(

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtils.java
@@ -90,7 +90,7 @@ public class ExpressionImplUtils {
         throw QueryExecutionErrors.aesModeUnsupportedError(mode, padding);
       }
     } catch (GeneralSecurityException e) {
-        throw new RuntimeException(e);
+      throw QueryExecutionErrors.aesCryptoError(e.getMessage());
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.InternalCompilerException
 
-import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkCryptoException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -1910,6 +1910,10 @@ object QueryExecutionErrors {
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
     new SparkUnsupportedOperationException("UNSUPPORTED_AES_MODE", Array(mode, padding))
+  }
+
+  def aesCryptoError(detailMessage: String): RuntimeException = {
+    new SparkCryptoException("AES_CRYPTO_ERROR", Array(detailMessage))
   }
 
   def hiveTableWithAnsiIntervalsError(tableName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1905,8 +1905,7 @@ object QueryExecutionErrors {
   }
 
   def invalidAesKeyLengthError(actualLength: Int): RuntimeException = {
-    new RuntimeException("The key length of aes_encrypt/aes_decrypt should be " +
-      s"one of 16, 24 or 32 bytes, but got: $actualLength")
+    new SparkIllegalArgumentException("INVALID_AES_KEY_LENGTH", Array(actualLength.toString))
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1909,8 +1909,7 @@ object QueryExecutionErrors {
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
-    new UnsupportedOperationException(
-      s"The AES mode $mode with the padding $padding is not supported")
+    new SparkUnsupportedOperationException("UNSUPPORTED_AES_MODE", Array(mode, padding))
   }
 
   def hiveTableWithAnsiIntervalsError(tableName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 import org.codehaus.commons.compiler.CompileException
 import org.codehaus.janino.InternalCompilerException
 
-import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkCryptoException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{Partition, SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkClassNotFoundException, SparkConcurrentModificationException, SparkDateTimeException, SparkException, SparkFileAlreadyExistsException, SparkFileNotFoundException, SparkIllegalArgumentException, SparkIllegalStateException, SparkIndexOutOfBoundsException, SparkNoSuchElementException, SparkNoSuchMethodException, SparkNumberFormatException, SparkRuntimeException, SparkSecurityException, SparkSQLException, SparkSQLFeatureNotSupportedException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -1905,15 +1905,15 @@ object QueryExecutionErrors {
   }
 
   def invalidAesKeyLengthError(actualLength: Int): RuntimeException = {
-    new SparkIllegalArgumentException("INVALID_AES_KEY_LENGTH", Array(actualLength.toString))
+    new SparkRuntimeException("INVALID_AES_KEY_LENGTH", Array(actualLength.toString))
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
-    new SparkUnsupportedOperationException("UNSUPPORTED_AES_MODE", Array(mode, padding))
+    new SparkRuntimeException("UNSUPPORTED_AES_MODE", Array(mode, padding))
   }
 
   def aesCryptoError(detailMessage: String): RuntimeException = {
-    new SparkCryptoException("AES_CRYPTO_ERROR", Array(detailMessage))
+    new SparkRuntimeException("AES_CRYPTO_ERROR", Array(detailMessage))
   }
 
   def hiveTableWithAnsiIntervalsError(tableName: String): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -261,14 +261,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     val encryptedEmptyText24 = "9RDK70sHNzqAFRcpfGM5gQ=="
     val encryptedEmptyText32 = "j9IDsCvlYXtcVJUf4FAjQQ=="
 
-    def checkUnsupportedMode(df: => DataFrame): Unit = {
-      val e = intercept[SparkException] {
-        df.collect
-      }.getCause
-      assert(e.isInstanceOf[UnsupportedOperationException])
-      assert(e.getMessage.matches("""The AES mode \w+ with the padding \w+ is not supported"""))
-    }
-
     val df1 = Seq("Spark", "").toDF
 
     // Successful encryption
@@ -306,10 +298,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     checkAnswer(
       df1.selectExpr("aes_encrypt(value, cast(null as binary))"),
       Seq(Row(null), Row(null)))
-
-    // Unsupported AES mode and padding in encrypt
-    checkUnsupportedMode(df1.selectExpr(s"aes_encrypt(value, '$key16', 'CBC')"))
-    checkUnsupportedMode(df1.selectExpr(s"aes_encrypt(value, '$key16', 'ECB', 'NoPadding')"))
 
     val df2 = Seq(
       (encryptedText16, encryptedText24, encryptedText32),
@@ -359,11 +347,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
         }
         assert(e.getMessage.contains("BadPaddingException"))
     }
-
-    // Unsupported AES mode and padding in decrypt
-    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GSM')"))
-    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value16, '$key16', 'GCM', 'PKCS')"))
-    checkUnsupportedMode(df2.selectExpr(s"aes_decrypt(value32, '$key32', 'ECB', 'None')"))
   }
 
   test("string function find_in_set") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -251,9 +251,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
     val key16 = "abcdefghijklmnop"
     val key24 = "abcdefghijklmnop12345678"
     val key32 = "abcdefghijklmnop12345678ABCDEFGH"
-    val dummyKey16 = "1234567812345678"
-    val dummyKey24 = "123456781234567812345678"
-    val dummyKey32 = "12345678123456781234567812345678"
     val encryptedText16 = "4Hv0UKCx6nfUeAoPZo1z+w=="
     val encryptedText24 = "NeTYNgA+PCQBN50DA//O2w=="
     val encryptedText32 = "9J3iZbIxnmaG+OIA9Amd+A=="
@@ -334,18 +331,6 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       checkAnswer(
         df2.selectExpr(s"aes_decrypt($colName, cast(null as binary))"),
         Seq(Row(null), Row(null)))
-    }
-
-    // Decryption failure - key mismatch
-    Seq(
-      ("value16", dummyKey16),
-      ("value24", dummyKey24),
-      ("value32", dummyKey32)).foreach {
-      case (colName, key) =>
-        val e = intercept[Exception] {
-          df2.selectExpr(s"aes_decrypt(unbase64($colName), binary('$key'), 'ECB')").collect
-        }
-        assert(e.getMessage.contains("BadPaddingException"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.errors
+
+import org.apache.spark.{SparkException, SparkIllegalArgumentException}
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  test("SPARK-37858: invalid AES key length") {
+    def checkInvalidKeyLength(df: => DataFrame): Unit = {
+      val e = intercept[SparkException] {
+        df.collect
+      }.getCause
+      assert(e.isInstanceOf[SparkIllegalArgumentException])
+      assert(e.getMessage.contains(
+        "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes"))
+    }
+
+    val df1 = Seq("Spark", "").toDF
+
+    // Encryption failure - invalid key length
+    checkInvalidKeyLength(df1.selectExpr("aes_encrypt(value, '12345678901234567')"))
+    checkInvalidKeyLength(df1.selectExpr("aes_encrypt(value, binary('123456789012345'))"))
+    checkInvalidKeyLength(df1.selectExpr("aes_encrypt(value, binary(''))"))
+
+    val encryptedText16 = "4Hv0UKCx6nfUeAoPZo1z+w=="
+    val encryptedText24 = "NeTYNgA+PCQBN50DA//O2w=="
+    val encryptedText32 = "9J3iZbIxnmaG+OIA9Amd+A=="
+    val encryptedEmptyText16 = "jmTOhz8XTbskI/zYFFgOFQ=="
+    val encryptedEmptyText24 = "9RDK70sHNzqAFRcpfGM5gQ=="
+    val encryptedEmptyText32 = "j9IDsCvlYXtcVJUf4FAjQQ=="
+    val df2 = Seq(
+      (encryptedText16, encryptedText24, encryptedText32),
+      (encryptedEmptyText16, encryptedEmptyText24, encryptedEmptyText32)
+    ).toDF("value16", "value24", "value32")
+
+    // Decryption failure - invalid key length
+    Seq("value16", "value24", "value32").foreach { colName =>
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), '12345678901234567')"))
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), binary('123456789012345'))"))
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), '')"))
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), binary(''))"))
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to throw `SparkRuntimeException` from the AES functions: `aes_encrypt()` and `aes_decrypt()` with the error classes:
- `INVALID_AES_KEY_LENGTH` in the case when the functions get a key of wrong length.
- `UNSUPPORTED_AES_MODE` if the `mode` and `padding` passed to the functions are not supported.
- `AES_CRYPTO_ERROR` when any error occurs during crypto operations.

New error classes are added to `error-classes.json`.

The tests for checking the errors are moved from `DataFrameFunctionsSuite` to new test suite `QueryExecutionErrorsSuite` .

### Why are the changes needed?
Porting AES functions to new error framework should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
Yes, but the AES functions `aes_encrypt()`/`aes_decrypt()` haven't released yet.

### How was this patch tested?
By running new test suite:
```
$ build/sbt "test:testOnly *SparkThrowableSuite"
$ build/sbt "test:testOnly *QueryExecutionErrorsSuite"
```