### PR TITLE
[SPARK-37863][CORE] Add submitTime for Spark Application

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -856,6 +856,9 @@ private[spark] class SparkSubmit extends Logging {
     if (args.verbose && isSqlShell(childMainClass)) {
       childArgs ++= Seq("--verbose")
     }
+
+    sparkConf.set("spark.app.submitTime", System.currentTimeMillis().toString)
+
     (childArgs.toSeq, childClasspath.toSeq, sparkConf, childMainClass)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add submitTime for Spark Application


### Why are the changes needed?
Spark Driver may take a long time to startup when running with cluster mode, if YARN temporarily does not have enough resources, or HDFS's performance is poor due to high pressure.

After`submitTime` is added, we can get `submitTIme` from Spark UI or Spark REST API and detect such situation by comparing it with the `spark.app.startTime`(already exists) .
![image](https://user-images.githubusercontent.com/88070094/148897057-be0d1367-2d97-4e3d-9d76-c1020c76e67a.png)

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Use existing tests