### PR TITLE
[SPARK-37864][SQL] Support vectorized read boolean values use RLE encoding with Parquet DataPage V2

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.types.Decimal;
 
 import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
 /**
@@ -292,6 +293,14 @@ public class VectorizedColumnReader {
         return new VectorizedDeltaByteArrayReader();
       case DELTA_BINARY_PACKED:
         return new VectorizedDeltaBinaryPackedReader();
+      case RLE:
+        PrimitiveType.PrimitiveTypeName typeName = this.descriptor.getPrimitiveType().getPrimitiveTypeName();
+        // RLE encoding only supports boolean type `Values`, and ``bitwidth` is always 1.
+        if (typeName == BOOLEAN) {
+          return new VectorizedRleValuesReader(1);
+        } else {
+          throw new UnsupportedOperationException("RLE encoding is not supported for values of type: " + typeName);
+        }
       default:
         throw new UnsupportedOperationException("Unsupported encoding: " + encoding);
     }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -295,7 +295,7 @@ public class VectorizedColumnReader {
         return new VectorizedDeltaBinaryPackedReader();
       case RLE:
         PrimitiveType.PrimitiveTypeName typeName = this.descriptor.getPrimitiveType().getPrimitiveTypeName();
-        // RLE encoding only supports boolean type `Values`, and ``bitwidth` is always 1.
+        // RLE encoding only supports boolean type `Values`, and  `bitwidth` is always 1.
         if (typeName == BOOLEAN) {
           return new VectorizedRleValuesReader(1);
         } else {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -294,12 +294,14 @@ public class VectorizedColumnReader {
       case DELTA_BINARY_PACKED:
         return new VectorizedDeltaBinaryPackedReader();
       case RLE:
-        PrimitiveType.PrimitiveTypeName typeName = this.descriptor.getPrimitiveType().getPrimitiveTypeName();
+        PrimitiveType.PrimitiveTypeName typeName =
+          this.descriptor.getPrimitiveType().getPrimitiveTypeName();
         // RLE encoding only supports boolean type `Values`, and  `bitwidth` is always 1.
         if (typeName == BOOLEAN) {
           return new VectorizedRleValuesReader(1);
         } else {
-          throw new UnsupportedOperationException("RLE encoding is not supported for values of type: " + typeName);
+          throw new UnsupportedOperationException(
+            "RLE encoding is not supported for values of type: " + typeName);
         }
       default:
         throw new UnsupportedOperationException("Unsupported encoding: " + encoding);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -40,6 +40,7 @@ import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
  * This encoding is used in multiple places:
  *  - Definition/Repetition levels
  *  - Dictionary ids.
+ *  - Boolean type values of Parquet DataPageV2
  */
 public final class VectorizedRleValuesReader extends ValuesReader
     implements VectorizedValuesReader {
@@ -369,7 +370,25 @@ public final class VectorizedRleValuesReader extends ValuesReader
 
   @Override
   public void readBooleans(int total, WritableColumnVector c, int rowId) {
-    throw new UnsupportedOperationException("only readInts is valid.");
+    int left = total;
+    while (left > 0) {
+      if (this.currentCount == 0) this.readNextGroup();
+      int n = Math.min(left, this.currentCount);
+      switch (mode) {
+        case RLE:
+          c.putBooleans(rowId, n, currentValue != 0);
+          break;
+        case PACKED:
+          for (int i = 0; i < n; ++i) {
+            // For Boolean types, `currentBuffer[currentBufferIdx++]` can only be 0 or 1
+            c.putByte(rowId + i, (byte) currentBuffer[currentBufferIdx++]);
+          }
+          break;
+      }
+      rowId += n;
+      left -= n;
+      currentCount -= n;
+    }
   }
 
   @Override
@@ -407,7 +426,7 @@ public final class VectorizedRleValuesReader extends ValuesReader
 
   @Override
   public void skipBooleans(int total) {
-    throw new UnsupportedOperationException("only skipIntegers is valid");
+    skipIntegers(total);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedRleValuesReader.java
@@ -408,25 +408,12 @@ public final class VectorizedRleValuesReader extends ValuesReader
 
   @Override
   public void skipIntegers(int total) {
-    int left = total;
-    while (left > 0) {
-      if (this.currentCount == 0) this.readNextGroup();
-      int n = Math.min(left, this.currentCount);
-      switch (mode) {
-        case RLE:
-          break;
-        case PACKED:
-          currentBufferIdx += n;
-          break;
-      }
-      currentCount -= n;
-      left -= n;
-    }
+    skipValues(total);
   }
 
   @Override
   public void skipBooleans(int total) {
-    skipIntegers(total);
+    skipValues(total);
   }
 
   @Override
@@ -550,6 +537,26 @@ public final class VectorizedRleValuesReader extends ValuesReader
       }
     } catch (IOException e) {
       throw new ParquetDecodingException("Failed to read from input stream", e);
+    }
+  }
+
+  /**
+   * Skip `n` values from the current reader.
+   */
+  private void skipValues(int n) {
+    int left = n;
+    while (left > 0) {
+      if (this.currentCount == 0) this.readNextGroup();
+      int num = Math.min(left, this.currentCount);
+      switch (mode) {
+        case RLE:
+          break;
+        case PACKED:
+          currentBufferIdx += num;
+          break;
+      }
+      currentCount -= num;
+      left -= num;
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
@@ -47,8 +47,6 @@ import org.apache.spark.sql.vectorized.ColumnVector
  */
 object DataSourceReadBenchmark extends SqlBasedBenchmark {
 
-  private val parquetDataPageVersions = Seq("V1", "V2")
-
   override def getSparkSession: SparkSession = {
     val conf = new SparkConf()
       .setAppName("DataSourceReadBenchmark")
@@ -57,7 +55,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
       .setIfMissing("spark.driver.memory", "3g")
       .setIfMissing("spark.executor.memory", "3g")
 
-    val sparkSession = SparkSession.builder().config(conf).getOrCreate()
+    val sparkSession = SparkSession.builder.config(conf).getOrCreate()
 
     // Set default configs. Individual cases will change them if necessary.
     sparkSession.conf.set(SQLConf.ORC_FILTER_PUSHDOWN_ENABLED.key, "true")
@@ -80,14 +78,14 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
 
     saveAsCsvTable(testDf, dir.getCanonicalPath + "/csv")
     saveAsJsonTable(testDf, dir.getCanonicalPath + "/json")
-    saveAsParquetV1Table(testDf, dir.getCanonicalPath + "/parquetV1")
+    saveAsParquetTable(testDf, dir.getCanonicalPath + "/parquet")
     saveAsParquetV2Table(testDf, dir.getCanonicalPath + "/parquetV2")
     saveAsOrcTable(testDf, dir.getCanonicalPath + "/orc")
   }
 
   private def saveAsCsvTable(df: DataFrameWriter[Row], dir: String): Unit = {
-    df.mode("overwrite").option("compression", "gzip").option("header", value = true).csv(dir)
-    spark.read.option("header", value = true).csv(dir).createOrReplaceTempView("csvTable")
+    df.mode("overwrite").option("compression", "gzip").option("header", true).csv(dir)
+    spark.read.option("header", true).csv(dir).createOrReplaceTempView("csvTable")
   }
 
   private def saveAsJsonTable(df: DataFrameWriter[Row], dir: String): Unit = {
@@ -95,9 +93,9 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
     spark.read.json(dir).createOrReplaceTempView("jsonTable")
   }
 
-  private def saveAsParquetV1Table(df: DataFrameWriter[Row], dir: String): Unit = {
+  private def saveAsParquetTable(df: DataFrameWriter[Row], dir: String): Unit = {
     df.mode("overwrite").option("compression", "snappy").parquet(dir)
-    spark.read.parquet(dir).createOrReplaceTempView("parquetV1Table")
+    spark.read.parquet(dir).createOrReplaceTempView("parquetTable")
   }
 
   private def saveAsParquetV2Table(df: DataFrameWriter[Row], dir: String): Unit = {
@@ -127,7 +125,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
       output = output)
 
     withTempPath { dir =>
-      withTempTable("t1", "csvTable", "jsonTable", "parquetV1Table", "parquetV2Table", "orcTable") {
+      withTempTable("t1", "csvTable", "jsonTable", "parquetTable", "orcTable") {
         import spark.implicits._
         spark.range(values).map(_ => Random.nextLong).createOrReplaceTempView("t1")
 
@@ -146,15 +144,13 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql(s"select $query from jsonTable").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          sqlBenchmark.addCase(s"SQL Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select $query from parquet${version}Table").noop()
-          }
+        sqlBenchmark.addCase("SQL Parquet Vectorized") { _ =>
+          spark.sql(s"select $query from parquetTable").noop()
+        }
 
-          sqlBenchmark.addCase(s"SQL Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select $query from parquet${version}Table").noop()
-            }
+        sqlBenchmark.addCase("SQL Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql(s"select $query from parquetTable").noop()
           }
         }
 
@@ -170,84 +166,73 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
 
         sqlBenchmark.run()
 
-        parquetDataPageVersions.foreach { version =>
-          // Driving the parquet reader in batch mode directly.
-          val files = SpecificParquetRecordReaderBase
-            .listDirectory(new File(dir, s"parquet$version")).toArray
-          val enableOffHeapColumnVector = spark.sessionState.conf.offHeapColumnVectorEnabled
-          val vectorizedReaderBatchSize = spark.sessionState.conf.parquetVectorizedReaderBatchSize
-          parquetReaderBenchmark.addCase(s"ParquetReader Vectorized: DataPage$version") { _ =>
-            var longSum = 0L
-            var doubleSum = 0.0
-            val aggregateValue: (ColumnVector, Int) => Unit = dataType match {
-              case BooleanType =>
-                (col: ColumnVector, i: Int) => if (col.getBoolean(i)) longSum += 1L
-              case ByteType =>
-                (col: ColumnVector, i: Int) => longSum += col.getByte(i)
-              case ShortType =>
-                (col: ColumnVector, i: Int) => longSum += col.getShort(i)
-              case IntegerType =>
-                (col: ColumnVector, i: Int) => longSum += col.getInt(i)
-              case LongType =>
-                (col: ColumnVector, i: Int) => longSum += col.getLong(i)
-              case FloatType =>
-                (col: ColumnVector, i: Int) => doubleSum += col.getFloat(i)
-              case DoubleType =>
-                (col: ColumnVector, i: Int) => doubleSum += col.getDouble(i)
-            }
-
-            files.map(_.asInstanceOf[String]).foreach { p =>
-              val reader = new VectorizedParquetRecordReader(
-                enableOffHeapColumnVector, vectorizedReaderBatchSize)
-              try {
-                reader.initialize(p, ("id" :: Nil).asJava)
-                val batch = reader.resultBatch()
-                val col = batch.column(0)
-                while (reader.nextBatch()) {
-                  val numRows = batch.numRows()
-                  var i = 0
-                  while (i < numRows) {
-                    if (!col.isNullAt(i)) aggregateValue(col, i)
-                    i += 1
-                  }
-                }
-              } finally {
-                reader.close()
-              }
-            }
+        // Driving the parquet reader in batch mode directly.
+        val files = SpecificParquetRecordReaderBase.listDirectory(new File(dir, "parquet")).toArray
+        val enableOffHeapColumnVector = spark.sessionState.conf.offHeapColumnVectorEnabled
+        val vectorizedReaderBatchSize = spark.sessionState.conf.parquetVectorizedReaderBatchSize
+        parquetReaderBenchmark.addCase("ParquetReader Vectorized") { _ =>
+          var longSum = 0L
+          var doubleSum = 0.0
+          val aggregateValue: (ColumnVector, Int) => Unit = dataType match {
+            case BooleanType => (col: ColumnVector, i: Int) => if (col.getBoolean(i)) longSum += 1L
+            case ByteType => (col: ColumnVector, i: Int) => longSum += col.getByte(i)
+            case ShortType => (col: ColumnVector, i: Int) => longSum += col.getShort(i)
+            case IntegerType => (col: ColumnVector, i: Int) => longSum += col.getInt(i)
+            case LongType => (col: ColumnVector, i: Int) => longSum += col.getLong(i)
+            case FloatType => (col: ColumnVector, i: Int) => doubleSum += col.getFloat(i)
+            case DoubleType => (col: ColumnVector, i: Int) => doubleSum += col.getDouble(i)
           }
 
-          // Decoding in vectorized but having the reader return rows.
-          parquetReaderBenchmark
-            .addCase(s"ParquetReader Vectorized -> Row: DataPage$version") { _ =>
-            var longSum = 0L
-            var doubleSum = 0.0
-            val aggregateValue: (InternalRow) => Unit = dataType match {
-              case BooleanType => (col: InternalRow) => if (col.getBoolean(0)) longSum += 1L
-              case ByteType => (col: InternalRow) => longSum += col.getByte(0)
-              case ShortType => (col: InternalRow) => longSum += col.getShort(0)
-              case IntegerType => (col: InternalRow) => longSum += col.getInt(0)
-              case LongType => (col: InternalRow) => longSum += col.getLong(0)
-              case FloatType => (col: InternalRow) => doubleSum += col.getFloat(0)
-              case DoubleType => (col: InternalRow) => doubleSum += col.getDouble(0)
-            }
-
-            files.map(_.asInstanceOf[String]).foreach { p =>
-              val reader = new VectorizedParquetRecordReader(
-                enableOffHeapColumnVector, vectorizedReaderBatchSize)
-              try {
-                reader.initialize(p, ("id" :: Nil).asJava)
-                val batch = reader.resultBatch()
-                while (reader.nextBatch()) {
-                  val it = batch.rowIterator()
-                  while (it.hasNext) {
-                    val record = it.next()
-                    if (!record.isNullAt(0)) aggregateValue(record)
-                  }
+          files.map(_.asInstanceOf[String]).foreach { p =>
+            val reader = new VectorizedParquetRecordReader(
+              enableOffHeapColumnVector, vectorizedReaderBatchSize)
+            try {
+              reader.initialize(p, ("id" :: Nil).asJava)
+              val batch = reader.resultBatch()
+              val col = batch.column(0)
+              while (reader.nextBatch()) {
+                val numRows = batch.numRows()
+                var i = 0
+                while (i < numRows) {
+                  if (!col.isNullAt(i)) aggregateValue(col, i)
+                  i += 1
                 }
-              } finally {
-                reader.close()
               }
+            } finally {
+              reader.close()
+            }
+          }
+        }
+
+        // Decoding in vectorized but having the reader return rows.
+        parquetReaderBenchmark.addCase("ParquetReader Vectorized -> Row") { num =>
+          var longSum = 0L
+          var doubleSum = 0.0
+          val aggregateValue: (InternalRow) => Unit = dataType match {
+            case BooleanType => (col: InternalRow) => if (col.getBoolean(0)) longSum += 1L
+            case ByteType => (col: InternalRow) => longSum += col.getByte(0)
+            case ShortType => (col: InternalRow) => longSum += col.getShort(0)
+            case IntegerType => (col: InternalRow) => longSum += col.getInt(0)
+            case LongType => (col: InternalRow) => longSum += col.getLong(0)
+            case FloatType => (col: InternalRow) => doubleSum += col.getFloat(0)
+            case DoubleType => (col: InternalRow) => doubleSum += col.getDouble(0)
+          }
+
+          files.map(_.asInstanceOf[String]).foreach { p =>
+            val reader = new VectorizedParquetRecordReader(
+              enableOffHeapColumnVector, vectorizedReaderBatchSize)
+            try {
+              reader.initialize(p, ("id" :: Nil).asJava)
+              val batch = reader.resultBatch()
+              while (reader.nextBatch()) {
+                val it = batch.rowIterator()
+                while (it.hasNext) {
+                  val record = it.next()
+                  if (!record.isNullAt(0)) aggregateValue(record)
+                }
+              }
+            } finally {
+              reader.close()
             }
           }
         }
@@ -261,7 +246,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
     val benchmark = new Benchmark("Int and String Scan", values, output = output)
 
     withTempPath { dir =>
-      withTempTable("t1", "csvTable", "jsonTable", "parquetV1Table", "parquetV2Table", "orcTable") {
+      withTempTable("t1", "csvTable", "jsonTable", "parquetTable", "orcTable") {
         import spark.implicits._
         spark.range(values).map(_ => Random.nextLong).createOrReplaceTempView("t1")
 
@@ -277,15 +262,13 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql("select sum(c1), sum(length(c2)) from jsonTable").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"SQL Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select sum(c1), sum(length(c2)) from parquet${version}Table").noop()
-          }
+        benchmark.addCase("SQL Parquet Vectorized") { _ =>
+          spark.sql("select sum(c1), sum(length(c2)) from parquetTable").noop()
+        }
 
-          benchmark.addCase(s"SQL Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select sum(c1), sum(length(c2)) from parquet${version}Table").noop()
-            }
+        benchmark.addCase("SQL Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql("select sum(c1), sum(length(c2)) from parquetTable").noop()
           }
         }
 
@@ -308,7 +291,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
     val benchmark = new Benchmark("Repeated String", values, output = output)
 
     withTempPath { dir =>
-      withTempTable("t1", "csvTable", "jsonTable", "parquetV1Table", "parquetV2Table", "orcTable") {
+      withTempTable("t1", "csvTable", "jsonTable", "parquetTable", "orcTable") {
         import spark.implicits._
         spark.range(values).map(_ => Random.nextLong).createOrReplaceTempView("t1")
 
@@ -324,18 +307,15 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql("select sum(length(c1)) from jsonTable").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"SQL Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select sum(length(c1)) from parquet${version}Table").noop()
-          }
-
-          benchmark.addCase(s"SQL Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select sum(length(c1)) from parquet${version}Table").noop()
-            }
-          }
+        benchmark.addCase("SQL Parquet Vectorized") { _ =>
+          spark.sql("select sum(length(c1)) from parquetTable").noop()
         }
 
+        benchmark.addCase("SQL Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql("select sum(length(c1)) from parquetTable").noop()
+          }
+        }
 
         benchmark.addCase("SQL ORC Vectorized") { _ =>
           spark.sql("select sum(length(c1)) from orcTable").noop()
@@ -356,7 +336,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
     val benchmark = new Benchmark("Partitioned Table", values, output = output)
 
     withTempPath { dir =>
-      withTempTable("t1", "csvTable", "jsonTable", "parquetV1Table", "parquetV2Table", "orcTable") {
+      withTempTable("t1", "csvTable", "jsonTable", "parquetTable", "orcTable") {
         import spark.implicits._
         spark.range(values).map(_ => Random.nextLong).createOrReplaceTempView("t1")
 
@@ -370,15 +350,13 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql("select sum(id) from jsonTable").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"Data column - Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select sum(id) from parquet${version}Table").noop()
-          }
+        benchmark.addCase("Data column - Parquet Vectorized") { _ =>
+          spark.sql("select sum(id) from parquetTable").noop()
+        }
 
-          benchmark.addCase(s"Data column - Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select sum(id) from parquet${version}Table").noop()
-            }
+        benchmark.addCase("Data column - Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql("select sum(id) from parquetTable").noop()
           }
         }
 
@@ -400,15 +378,13 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql("select sum(p) from jsonTable").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"Partition column - Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select sum(p) from parquet${version}Table").noop()
-          }
+        benchmark.addCase("Partition column - Parquet Vectorized") { _ =>
+          spark.sql("select sum(p) from parquetTable").noop()
+        }
 
-          benchmark.addCase(s"Partition column - Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select sum(p) from parquet${version}Table").noop()
-            }
+        benchmark.addCase("Partition column - Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql("select sum(p) from parquetTable").noop()
           }
         }
 
@@ -430,15 +406,13 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql("select sum(p), sum(id) from jsonTable").noop()
         }
 
+        benchmark.addCase("Both columns - Parquet Vectorized") { _ =>
+          spark.sql("select sum(p), sum(id) from parquetTable").noop()
+        }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"Both columns - Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select sum(p), sum(id) from parquet${version}Table").noop()
-          }
-          benchmark.addCase(s"Both columns - Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select sum(p), sum(id) from parquet${version}Table").noop()
-            }
+        benchmark.addCase("Both columns - Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql("select sum(p), sum(id) from parquetTable").noop()
           }
         }
 
@@ -463,7 +437,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
       new Benchmark(s"String with Nulls Scan ($percentageOfNulls%)", values, output = output)
 
     withTempPath { dir =>
-      withTempTable("t1", "csvTable", "jsonTable", "parquetV1Table", "parquetV2Table", "orcTable") {
+      withTempTable("t1", "csvTable", "jsonTable", "parquetTable", "orcTable") {
         spark.range(values).createOrReplaceTempView("t1")
 
         prepareTable(
@@ -482,42 +456,39 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
             "not NULL and c2 is not NULL").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"SQL Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"select sum(length(c2)) from parquet${version}Table where c1 is " +
+        benchmark.addCase("SQL Parquet Vectorized") { _ =>
+          spark.sql("select sum(length(c2)) from parquetTable where c1 is " +
+            "not NULL and c2 is not NULL").noop()
+        }
+
+        benchmark.addCase("SQL Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql("select sum(length(c2)) from parquetTable where c1 is " +
               "not NULL and c2 is not NULL").noop()
           }
+        }
 
-          benchmark.addCase(s"SQL Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"select sum(length(c2)) from parquet${version}Table where c1 is " +
-                "not NULL and c2 is not NULL").noop()
-            }
-          }
-
-          val files = SpecificParquetRecordReaderBase
-            .listDirectory(new File(dir, s"parquet$version")).toArray
-          val enableOffHeapColumnVector = spark.sessionState.conf.offHeapColumnVectorEnabled
-          val vectorizedReaderBatchSize = spark.sessionState.conf.parquetVectorizedReaderBatchSize
-          benchmark.addCase(s"ParquetReader Vectorized: DataPage$version") { _ =>
-            var sum = 0
-            files.map(_.asInstanceOf[String]).foreach { p =>
-              val reader = new VectorizedParquetRecordReader(
-                enableOffHeapColumnVector, vectorizedReaderBatchSize)
-              try {
-                reader.initialize(p, ("c1" :: "c2" :: Nil).asJava)
-                val batch = reader.resultBatch()
-                while (reader.nextBatch()) {
-                  val rowIterator = batch.rowIterator()
-                  while (rowIterator.hasNext) {
-                    val row = rowIterator.next()
-                    val value = row.getUTF8String(0)
-                    if (!row.isNullAt(0) && !row.isNullAt(1)) sum += value.numBytes()
-                  }
+        val files = SpecificParquetRecordReaderBase.listDirectory(new File(dir, "parquet")).toArray
+        val enableOffHeapColumnVector = spark.sessionState.conf.offHeapColumnVectorEnabled
+        val vectorizedReaderBatchSize = spark.sessionState.conf.parquetVectorizedReaderBatchSize
+        benchmark.addCase("ParquetReader Vectorized") { num =>
+          var sum = 0
+          files.map(_.asInstanceOf[String]).foreach { p =>
+            val reader = new VectorizedParquetRecordReader(
+              enableOffHeapColumnVector, vectorizedReaderBatchSize)
+            try {
+              reader.initialize(p, ("c1" :: "c2" :: Nil).asJava)
+              val batch = reader.resultBatch()
+              while (reader.nextBatch()) {
+                val rowIterator = batch.rowIterator()
+                while (rowIterator.hasNext) {
+                  val row = rowIterator.next()
+                  val value = row.getUTF8String(0)
+                  if (!row.isNullAt(0) && !row.isNullAt(1)) sum += value.numBytes()
                 }
-              } finally {
-                reader.close()
               }
+            } finally {
+              reader.close()
             }
           }
         }
@@ -546,7 +517,7 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
       output = output)
 
     withTempPath { dir =>
-      withTempTable("t1", "csvTable", "jsonTable", "parquetV1Table", "parquetV2Table", "orcTable") {
+      withTempTable("t1", "csvTable", "jsonTable", "parquetTable", "orcTable") {
         import spark.implicits._
         val middle = width / 2
         val selectExpr = (1 to width).map(i => s"value as c$i")
@@ -563,15 +534,13 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql(s"SELECT sum(c$middle) FROM jsonTable").noop()
         }
 
-        parquetDataPageVersions.foreach { version =>
-          benchmark.addCase(s"SQL Parquet Vectorized: DataPage$version") { _ =>
-            spark.sql(s"SELECT sum(c$middle) FROM parquet${version}Table").noop()
-          }
+        benchmark.addCase("SQL Parquet Vectorized") { _ =>
+          spark.sql(s"SELECT sum(c$middle) FROM parquetTable").noop()
+        }
 
-          benchmark.addCase(s"SQL Parquet MR: DataPage$version") { _ =>
-            withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
-              spark.sql(s"SELECT sum(c$middle) FROM parquet${version}Table").noop()
-            }
+        benchmark.addCase("SQL Parquet MR") { _ =>
+          withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+            spark.sql(s"SELECT sum(c$middle) FROM parquetTable").noop()
           }
         }
 
@@ -596,7 +565,6 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
         dataType => numericScanBenchmark(1024 * 1024 * 15, dataType)
       }
     }
-
     runBenchmark("Int and String Scan") {
       intStringScanBenchmark(1024 * 1024 * 10)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Parquet v2 data page write Boolean Values use RLE encoding, when read v2 boolean type values it will throw exceptions as follows now:

```java
Caused by: java.lang.UnsupportedOperationException: Unsupported encoding: RLE
    at org.apache.spark.sql.execution.datasources.parquet.VectorizedColumnReader.getValuesReader(VectorizedColumnReader.java:305) ~[classes/:?]
    at org.apache.spark.sql.execution.datasources.parquet.VectorizedColumnReader.initDataReader(VectorizedColumnReader.java:277) ~[classes/:?]
    at org.apache.spark.sql.execution.datasources.parquet.VectorizedColumnReader.readPageV2(VectorizedColumnReader.java:344) ~[classes/:?]
    at 
```

This PR extends the `readBooleans` and `skipBooleans` of `VectorizedRleValuesReader` to ensure that the above scenario can pass.

### Why are the changes needed?
Support Parquet v2 data page RLE encoding  for the vectorized read path

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add new test case
