### PR TITLE
[SPARK-37795][BUILD][FOLLOWUP] Add a checkstyle rule to ban org.apache.log4j imports

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -189,5 +189,8 @@
             <property name="format" value="Objects\.toStringHelper"/>
             <property name="message" value="Avoid using Object.toStringHelper. Use ToStringBuilder instead." />
         </module>
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.apache.log4j" />
+        </module>
     </module>
 </module>


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a checkstyle rule to ban `org.apache.log4j` imports for Java source code.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
#35077 added a the same rule for scalastyle, it's applied for Scala source code but not for Java one.
Currently, we don't have Java source code which contains `org.apache.log4j` imports but it's better to be proactive.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I manually tested by modifing `ApplicationStatus.java` like as follows and run `dev/lint-java`.
```
+import org.apache.log4j.PropertyConfigurator;
+
 public enum ApplicationStatus {
   COMPLETED,
   RUNNING;
 
   public static ApplicationStatus fromString(String str) {
+    PropertyConfigurator.configure(new java.util.Properties());
     return EnumUtil.parseIgnoreCase(ApplicationStatus.class, str);
   }
```

I got the following error message as expected.
```
[ERROR] src/main/java/org/apache/spark/status/api/v1/ApplicationStatus.java:[22,1] (imports) IllegalImport: Illegal import - org.apache.log4j.PropertyConfigurator.
```