### PR TITLE
[SPARK-37866][TESTS] Set `file.encoding` to UTF-8 for SBT tests

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1155,7 +1155,7 @@ object TestSettings {
         "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
         "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED").mkString(" ")
-      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m $extraTestJavaArgs"
+      s"-Xmx4g -Xss4m -XX:MaxMetaspaceSize=$metaspaceSize -XX:ReservedCodeCacheSize=128m -Dfile.encoding=UTF-8 $extraTestJavaArgs"
         .split(" ").toSeq
     },
     javaOptions ++= {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `-Dfile.encoding=UTF-8` for SBT tests.

### Why are the changes needed?

To make the tests robust on various OSs with different locales.

**BEFORE**
```
$ LANG=C.UTF-8 build/sbt "sql/testOnly *.JDBCV2Suite -- -z non-ascii"
...
[info] - column name with non-ascii *** FAILED *** (2 seconds, 668 milliseconds)
[info]   "== Parsed Logical Plan ==
[info]   'Project [unresolvedalias('COUNT('?), None)]
[info]   +- 'UnresolvedRelation [h2, test, person], [], false
[info]
[info]   == Analyzed Logical Plan ==
[info]   count(?): bigint
[info]   Aggregate [count(?#x) AS count(?)#xL]
[info]   +- SubqueryAlias h2.test.person
[info]      +- RelationV2[?#x] test.person
[info]
[info]   == Optimized Logical Plan ==
[info]   Project [COUNT(U&"\540d")#xL AS count(?#x)#xL AS count(?)#xL]
[info]   +- RelationV2[COUNT(U&"\540d")#xL] test.person
[info]
[info]   == Physical Plan ==
[info]   *(1) Project [COUNT(U&"\540d")#xL AS count(?)#xL]
[info]   +- *(1) Scan org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCScan$$anon$1@df881a4 [COUNT(U&"\540d")#xL] PushedAggregates: [COUNT(`?`)], PushedFilters: [], PushedGroupByColumns: [], ReadSchema: struct<COUNT(U&"\540d"):bigint>
[info]
[info]   " did not contain "PushedAggregates: [COUNT(`名`)]" (ExplainSuite.scala:66)
```

**AFTER**
```
[info] JDBCV2Suite:
...
[info] - column name with non-ascii (2 seconds, 950 milliseconds)
...
[info] All tests passed.
[success] Total time: 21 s, completed Jan 11, 2022, 2:18:29 AM
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.