### PR TITLE
[SPARK-37868][PYTHON] Add eager_check for LocIndexer._select_cols_by_iterable

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -290,7 +290,8 @@ compute.eager_check             True                    'compute.eager_check' se
                                                         `Series.asof`, `Series.compare`,
                                                         `FractionalExtensionOps.astype`,
                                                         `IntegralExtensionOps.astype`,
-                                                        `FractionalOps.astype`, `DecimalOps.astype`.
+                                                        `FractionalOps.astype`, `DecimalOps.astype`,
+                                                        `LocIndexer._select_cols_by_iterable`.
 compute.isin_limit              80                      'compute.isin_limit' sets the limit for filtering by
                                                         'Column.isin(list)'. If the length of the ‘list’ is
                                                         above the limit, broadcast join is used instead for

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -204,7 +204,7 @@ _options: List[Option] = [
             "pandas-on-Spark skip the validation and will be slightly different from pandas. "
             "Affected APIs: `Series.dot`, `Series.asof`, `Series.compare`, "
             "`FractionalExtensionOps.astype`, `IntegralExtensionOps.astype`, "
-            "`FractionalOps.astype`, `DecimalOps.astype`."
+            "`FractionalOps.astype`, `DecimalOps.astype`, `LocIndexer._select_cols_by_iterable`."
         ),
         default=True,
         types=bool,

--- a/python/pyspark/pandas/indexing.py
+++ b/python/pyspark/pandas/indexing.py
@@ -32,6 +32,7 @@ import numpy as np
 
 from pyspark import pandas as ps  # noqa: F401
 from pyspark.pandas._typing import Label, Name, Scalar
+from pyspark.pandas.config import get_option
 from pyspark.pandas.internal import (
     DEFAULT_SERIES_NAME,
     InternalField,
@@ -1311,7 +1312,9 @@ class LocIndexer(LocIndexerLike):
                     % (len(cast(Sized, cols_sel)), len(self._internal.column_labels))
                 )
             if isinstance(cols_sel, pd.Series):
-                if not cols_sel.index.sort_values().equals(self._psdf.columns.sort_values()):
+                if get_option("compute.eager_check") and not cols_sel.index.sort_values().equals(
+                    self._psdf.columns.sort_values()
+                ):
                     raise SparkPandasIndexingError(
                         "Unalignable boolean Series provided as indexer "
                         "(index of the boolean Series and of the indexed object do not match)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip equal check in LocIndexer._select_cols_by_iterable if eager_check disable


### Why are the changes needed?
To improve the performance if eager_check disable.

### Does this PR introduce _any_ user-facing change?
Yes, with eager_check disable, didn't raise exception in nan case.


### How was this patch tested?
UT