### PR TITLE
[SPARK-37833][INFRA] Add `precondition` job to skip the main GitHub Action jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -96,15 +96,48 @@ jobs:
           echo '::set-output name=hadoop::hadoop3'
         fi
 
+  precondition:
+    name: Check changes
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_PREV_SHA: ${{ github.event.before }}
+    outputs:
+      required: ${{ steps.set-outputs.outputs.required }}
+    steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        repository: apache/spark
+        ref: master
+    - name: Sync the current branch with the latest in Apache Spark
+      if: github.repository != 'apache/spark'
+      run: |
+        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit"
+    - name: Check all modules
+      id: set-outputs
+      run: |
+        build=`./dev/is-changed.py -m avro,build,catalyst,core,docker-integration-tests,examples,graphx,hadoop-cloud,hive,hive-thriftserver,kubernetes,kvstore,launcher,mesos,mllib,mllib-local,network-common,network-shuffle,pyspark-core,pyspark-ml,pyspark-mllib,pyspark-pandas,pyspark-pandas-slow,pyspark-resource,pyspark-sql,pyspark-streaming,repl,sketch,spark-ganglia-lgpl,sparkr,sql,sql-kafka-0-10,streaming,streaming-kafka-0-10,streaming-kinesis-asl,tags,unsafe,yarn`
+        pyspark=`./dev/is-changed.py -m avro,build,catalyst,core,graphx,hive,kvstore,launcher,mllib,mllib-local,network-common,network-shuffle,pyspark-core,pyspark-ml,pyspark-mllib,pyspark-pandas,pyspark-pandas-slow,pyspark-resource,pyspark-sql,pyspark-streaming,repl,sketch,sql,tags,unsafe`
+        sparkr=`./dev/is-changed.py -m avro,build,catalyst,core,hive,kvstore,launcher,mllib,mllib-local,network-common,network-shuffle,repl,sketch,sparkr,sql,tags,unsafe`
+        tpcds=`./dev/is-changed.py -m build,catalyst,core,hive,kvstore,launcher,network-common,network-shuffle,repl,sketch,sql,tags,unsafe`
+        docker=`./dev/is-changed.py -m build,catalyst,core,docker-integration-tests,hive,kvstore,launcher,network-common,network-shuffle,repl,sketch,sql,tags,unsafe`
+        echo "{\"build\": \"$build\", \"pyspark\": \"$pyspark\", \"sparkr\": \"$sparkr\", \"tpcds\": \"$tpcds\", \"docker\": \"$docker\"}" > required.json
+        cat required.json
+        echo "::set-output name=required::$(cat required.json)"
+
   # Build: build Spark and run the tests for specified modules.
   build:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
-    needs: configure-jobs
+    needs: [configure-jobs, precondition]
     # Run scheduled jobs for Apache Spark only
     # Run regular jobs for commit in both Apache Spark and forked repository
     if: >-
       (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled')
-      || needs.configure-jobs.outputs.type == 'regular'
+      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
     runs-on: ubuntu-20.04
     strategy:
@@ -242,15 +275,16 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
+
   pyspark:
-    needs: configure-jobs
+    needs: [configure-jobs, precondition]
     # Run PySpark coverage scheduled jobs for Apache Spark only
     # Run scheduled jobs with JDK 17 in Apache Spark
     # Run regular jobs for commit in both Apache Spark and forked repository
     if: >-
       (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled')
       || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
-      || needs.configure-jobs.outputs.type == 'regular'
+      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).pyspark == 'true')
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
@@ -351,9 +385,9 @@ jobs:
         path: "**/target/unit-tests.log"
 
   sparkr:
-    needs: configure-jobs
+    needs: [configure-jobs, precondition]
     if: >-
-      needs.configure-jobs.outputs.type == 'regular'
+      (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).sparkr == 'true')
       || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
@@ -530,8 +564,8 @@ jobs:
         bundle exec jekyll build
 
   java-11-17:
-    needs: configure-jobs
-    if: needs.configure-jobs.outputs.type == 'regular'
+    needs: [configure-jobs, precondition]
+    if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
     name: Java ${{ matrix.java }} build with Maven
     strategy:
       fail-fast: false
@@ -585,8 +619,8 @@ jobs:
         rm -rf ~/.m2/repository/org/apache/spark
 
   scala-213:
-    needs: configure-jobs
-    if: needs.configure-jobs.outputs.type == 'regular'
+    needs: [configure-jobs, precondition]
+    if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
     steps:
@@ -630,8 +664,8 @@ jobs:
         ./build/sbt -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 compile test:compile
 
   tpcds-1g:
-    needs: configure-jobs
-    if: needs.configure-jobs.outputs.type == 'regular'
+    needs: [configure-jobs, precondition]
+    if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).tpcds == 'true'
     name: Run TPC-DS queries with SF=1
     runs-on: ubuntu-20.04
     env:
@@ -724,8 +758,8 @@ jobs:
         path: "**/target/unit-tests.log"
 
   docker-integration-tests:
-    needs: configure-jobs
-    if: needs.configure-jobs.outputs.type == 'regular'
+    needs: [configure-jobs, precondition]
+    if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).docker == 'true'
     name: Run Docker integration tests
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -275,7 +275,6 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
-
   pyspark:
     needs: [configure-jobs, precondition]
     # Run PySpark coverage scheduled jobs for Apache Spark only

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -66,7 +66,6 @@ def main():
     changed_modules = determine_modules_to_test(
         determine_modules_for_files(changed_files), deduplicated=False
     )
-
     module_names = [m.name for m in changed_modules]
     if len(changed_modules) == 0:
         print("false")

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -54,17 +54,18 @@ def main():
     opts = parse_opts()
 
     test_modules = opts.modules.split(",")
-    changed_files = identify_changed_files_from_git_commits(
-        "HEAD", target_ref=os.environ["APACHE_SPARK_REF"]
-    )
+    changed_files = []
     if os.environ.get("APACHE_SPARK_REF"):
-        changed_modules = determine_modules_to_test(
-            determine_modules_for_files(changed_files), deduplicated=False
+        changed_files = identify_changed_files_from_git_commits(
+            "HEAD", target_ref=os.environ["APACHE_SPARK_REF"]
         )
     elif os.environ.get("GITHUB_PREV_SHA"):
         changed_files = identify_changed_files_from_git_commits(
             os.environ["GITHUB_SHA"], target_ref=os.environ["GITHUB_PREV_SHA"]
         )
+    changed_modules = determine_modules_to_test(
+        determine_modules_for_files(changed_files), deduplicated=False
+    )
 
     module_names = [m.name for m in changed_modules]
     if len(changed_modules) == 0:

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -57,9 +57,15 @@ def main():
     changed_files = identify_changed_files_from_git_commits(
         "HEAD", target_ref=os.environ["APACHE_SPARK_REF"]
     )
-    changed_modules = determine_modules_to_test(
-        determine_modules_for_files(changed_files), deduplicated=False
-    )
+    if os.environ.get("APACHE_SPARK_REF", "") != "":
+        changed_modules = determine_modules_to_test(
+            determine_modules_for_files(changed_files), deduplicated=False
+        )
+    elif os.environ.get("GITHUB_PREV_SHA", "") != "":
+        changed_files = identify_changed_files_from_git_commits(
+            os.environ["GITHUB_SHA"], target_ref=os.environ["GITHUB_PREV_SHA"]
+        )
+
     module_names = [m.name for m in changed_modules]
     if len(changed_modules) == 0:
         print("false")

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -57,11 +57,11 @@ def main():
     changed_files = identify_changed_files_from_git_commits(
         "HEAD", target_ref=os.environ["APACHE_SPARK_REF"]
     )
-    if os.environ.get("APACHE_SPARK_REF", "") != "":
+    if os.environ.get("APACHE_SPARK_REF"):
         changed_modules = determine_modules_to_test(
             determine_modules_for_files(changed_files), deduplicated=False
         )
-    elif os.environ.get("GITHUB_PREV_SHA", "") != "":
+    elif os.environ.get("GITHUB_PREV_SHA"):
         changed_files = identify_changed_files_from_git_commits(
             os.environ["GITHUB_SHA"], target_ref=os.environ["GITHUB_PREV_SHA"]
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to introduce `precondition` jobs to skip the main GitHub Action jobs.

### Why are the changes needed?

This will save huge community GitHub Action resource and speed up our develop and PR review process.
- For example, GitHub Action will run only `linter` job for `docs` only PR.

<img width="468" alt="Screen Shot 2022-01-07 at 12 10 50 AM" src="https://user-images.githubusercontent.com/9700541/148512753-bd9b7e49-0e7b-47dd-9ce5-31f684dac666.png">


### Does this PR introduce _any_ user-facing change?

No. This is a dev-only infra.

### How was this patch tested?

Manually review and check the result on this PR.