### PR TITLE
[WIP][SPARK-37877][SQL] Support clear shuffle dependencies eagerly for thrift server

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1124,6 +1124,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val THRIFTSERVER_CLEAN_SHUFFLE_DEPENDENCIES =
+    buildConf("spark.sql.thriftServer.cleanShuffleDependenciesOnStatementEnd")
+      .doc("When true")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val THRIFTSERVER_FORCE_CANCEL =
     buildConf("spark.sql.thriftServer.interruptOnCancel")
       .doc("When true, all running tasks will be interrupted if one cancels a query. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1126,7 +1126,8 @@ object SQLConf {
 
   val THRIFTSERVER_CLEAN_SHUFFLE_DEPENDENCIES =
     buildConf("spark.sql.thriftServer.cleanShuffleDependenciesOnStatementEnd")
-      .doc("When true")
+      .doc("When true, sql statements will clear shuffle dependencies eagerly after being" +
+        " executed in Thrift Server.")
       .version("3.3.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -33,7 +33,7 @@ import org.apache.hive.service.cli.session.HiveSession
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, SQLContext, Row => SparkRow}
+import org.apache.spark.sql.{DataFrame, Row => SparkRow, SQLContext}
 import org.apache.spark.sql.execution.HiveResult.{getTimeFormatters, toHiveString, TimeFormatters}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.VariableSubstitution

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -294,11 +294,11 @@ private[hive] class SparkExecuteStatementOperation(
 
       sqlContext.sparkContext.setJobGroup(statementId, substitutorStatement, forceCancel)
       val df = sqlContext.sql(statement)
+      logDebug(df.queryExecution.toString())
+      HiveThriftServer2.eventManager.onStatementParsed(statementId,
+        df.queryExecution.toString())
       rdd = df.rdd
       result = sqlContext.createDataFrame(df.rdd, df.schema)
-      logDebug(result.queryExecution.toString())
-      HiveThriftServer2.eventManager.onStatementParsed(statementId,
-        result.queryExecution.toString())
       iter = if (sqlContext.getConf(SQLConf.THRIFTSERVER_INCREMENTAL_COLLECT.key).toBoolean) {
         new IterableFetchIterator[SparkRow](new Iterable[SparkRow] {
           override def iterator: Iterator[SparkRow] = result.toLocalIterator.asScala


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


In this PR, we add a config to control whether thrift server operations will clear shuffle dependencies eagerly after being executed.

In long-running applications, like thrift server, with large driver JVMs, where there is little memory pressure on the driver, the driver gc may happen very occasionally or not at all. Not cleaning at all may lead to executors running out of disk space after a while.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


For the thrift server, it currently relies on a periodical system.gc to release shuffle meta/data e.t.c, which is not efficient enough towards its usage scenario as the gc does not always occur immediately. Unclean data may cause thrift server memory issues, like OOM, or disk issues on the work side, like no space left for the device.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

added new conf

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

