### PR TITLE
[SPARK-37879][INFRA] Show test report in GitHub Actions builds from PRs

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const endpoint = 'GET /repos/:owner/:repo/actions/workflows/:id/runs?&branch=:branch'
+            const endpoint = 'GET /repos/:owner/:repo/commits/:ref/check-runs'
 
             // TODO: Should use pull_request.user and pull_request.user.repos_url?
             // If a different person creates a commit to another forked repo,
@@ -46,8 +46,7 @@ jobs:
             const params = {
               owner: context.payload.pull_request.head.repo.owner.login,
               repo: context.payload.pull_request.head.repo.name,
-              id: 'build_and_test.yml',
-              branch: context.payload.pull_request.head.ref,
+              ref: context.payload.pull_request.head.ref,
             }
 
             console.log('Ref: ' + context.payload.pull_request.head.ref)
@@ -68,7 +67,7 @@ jobs:
             const head_sha = context.payload.pull_request.head.sha
             let status = 'queued'
 
-            if (!runs || runs.data.workflow_runs.length === 0) {
+            if (!runs || runs.data.check_runs.filter(r => r.name === "Configure jobs").length === 0) {
               status = 'completed'
               const conclusion = 'action_required'
 
@@ -100,15 +99,15 @@ jobs:
                 }
               })
             } else {
-              const runID = runs.data.workflow_runs[0].id
+              const runID = runs.data.check_runs.filter(r => r.name === "Configure jobs")[0].id
 
-              if (runs.data.workflow_runs[0].head_sha != context.payload.pull_request.head.sha) {
+              if (runs.data.check_runs[0].head_sha != context.payload.pull_request.head.sha) {
                 throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
               }
 
               const runUrl = 'https://github.com/'
                 + context.payload.pull_request.head.repo.full_name
-                + '/actions/runs/'
+                + '/runs/'
                 + runID
 
               github.checks.create({


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to show the link of Check run view instead of Actions view. Previously, when you add a new custom Check, e.g., [test_report.yml](https://github.com/apache/spark/blob/master/.github/workflows/test_report.yml), Actions view also showed this Check.

Now, seems GitHub Actions changed the behaviour - Actions view always includes the jobs initiated by the specific Workflow e.g., [build_and_test.yml](https://github.com/apache/spark/blob/master/.github/workflows/build_and_test.yml) does not include the custom Check added from [test_report.yml](https://github.com/apache/spark/blob/master/.github/workflows/test_report.yml).

To work around this problem, this PR proposes to show the link of:
Check run view e.g., https://github.com/apache/spark/runs/4785069876 ("Report test results" is included) instead of 
Actions view e.g., https://github.com/apache/spark/actions/runs/1686013487 ("Report test results" is missing) .

After this PR, when developers click the link here:

![Screen Shot 2022-01-12 at 10 07 26 PM](https://user-images.githubusercontent.com/6477701/149146026-80f3ac26-ba06-411f-9cb8-f5395ffd8432.png)

it will open a Check run view instead of Actions view which does not have test report tab.

### Why are the changes needed?

For developers to see the test report, and they can easily detect which test is failed.

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

Manually tested at https://github.com/HyukjinKwon/spark/pull/51.
