### PR TITLE
[SPARK-37881][CORE] Cleanup ShuffleBlockResolver from polluted methods to create a developer API

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -52,7 +52,7 @@ private[spark] class IndexShuffleBlockResolver(
     conf: SparkConf,
     // var for testing
     var _blockManager: BlockManager = null)
-  extends ShuffleBlockResolver
+  extends LocalDiskStoredShuffleBlockResolver
   with Logging with MigratableResolver {
 
   private lazy val blockManager = Option(_blockManager).getOrElse(SparkEnv.get.blockManager)
@@ -561,7 +561,7 @@ private[spark] class IndexShuffleBlockResolver(
     *
     * If the data for that block is not available, throws an unspecified exception.
     */
-   def getBlockData(
+   override def getBlockData(
       blockId: BlockId,
       dirs: Option[Array[String]] = None): ManagedBuffer = {
     val (shuffleId, mapId, startReduceId, endReduceId) = blockId match {

--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -465,11 +465,13 @@ private[spark] class IndexShuffleBlockResolver(
   }
 
   /**
+   * Retrieve the data for the specified merged shuffle block as multiple chunks.
+   *
    * This is only used for reading local merged block data. In such cases, all chunks in the
    * merged shuffle file need to be identified at once, so the ShuffleBlockFetcherIterator
    * knows how to consume local merged shuffle file as multiple chunks.
    */
-  override def getMergedBlockData(
+  def getMergedBlockData(
       blockId: ShuffleMergedBlockId,
       dirs: Option[Array[String]]): Seq[ManagedBuffer] = {
     val indexFile =
@@ -496,9 +498,10 @@ private[spark] class IndexShuffleBlockResolver(
   }
 
   /**
+   * Retrieve the meta data for the specified merged shuffle block.
    * This is only used for reading local merged block meta data.
    */
-  override def getMergedBlockMeta(
+  def getMergedBlockMeta(
       blockId: ShuffleMergedBlockId,
       dirs: Option[Array[String]]): MergedBlockMeta = {
     val indexFile =
@@ -550,9 +553,17 @@ private[spark] class IndexShuffleBlockResolver(
       .getOrElse(blockManager.diskBlockManager.getFile(fileName))
   }
 
-  override def getBlockData(
+   /**
+    * Retrieve the data for the specified block.
+    *
+    * When the dirs parameter is None then use the disk manager's local directories. Otherwise,
+    * read from the specified directories.
+    *
+    * If the data for that block is not available, throws an unspecified exception.
+    */
+   def getBlockData(
       blockId: BlockId,
-      dirs: Option[Array[String]]): ManagedBuffer = {
+      dirs: Option[Array[String]] = None): ManagedBuffer = {
     val (shuffleId, mapId, startReduceId, endReduceId) = blockId match {
       case id: ShuffleBlockId =>
         (id.shuffleId, id.mapId, id.reduceId, id.reduceId + 1)

--- a/core/src/main/scala/org/apache/spark/shuffle/LocalDiskStoredShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/LocalDiskStoredShuffleBlockResolver.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.network.buffer.ManagedBuffer
+import org.apache.spark.storage.BlockId
+
+/**
+ * :: DeveloperApi ::
+ * Trait for block resolvers where blocks are stored on the executor's local disks.
+ *
+ * In this case even host local blocks can be accessed directly (without fetching them via the
+ * network) assuming the directory structure of the source is known.
+ */
+@DeveloperApi
+trait LocalDiskStoredShuffleBlockResolver extends ShuffleBlockResolver {
+
+  /**
+   * Retrieve the data for the specified block.
+   *
+   * When the dirs parameter is None then use the disk manager's local directories. Otherwise,
+   * read from the specified directories (used for reading host local blocks).
+   *
+   * If the data for that block is not available, throws an unspecified exception.
+   */
+  def getBlockData(blockId: BlockId, dirs: Option[Array[String]] = None): ManagedBuffer
+
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockResolver.scala
@@ -17,43 +17,17 @@
 
 package org.apache.spark.shuffle
 
-import org.apache.spark.network.buffer.ManagedBuffer
-import org.apache.spark.network.shuffle.MergedBlockMeta
-import org.apache.spark.storage.{BlockId, ShuffleMergedBlockId}
+import org.apache.spark.annotation.DeveloperApi
 
-private[spark]
 /**
+ * :: DeveloperApi ::
  * Implementers of this trait understand how to retrieve block data for a logical shuffle block
  * identifier (i.e. map, reduce, and shuffle). Implementations may use files or file segments to
  * encapsulate shuffle data. This is used by the BlockStore to abstract over different shuffle
  * implementations when shuffle data is retrieved.
  */
+@DeveloperApi
 trait ShuffleBlockResolver {
-  type ShuffleId = Int
-
-  /**
-   * Retrieve the data for the specified block.
-   *
-   * When the dirs parameter is None then use the disk manager's local directories. Otherwise,
-   * read from the specified directories.
-   *
-   * If the data for that block is not available, throws an unspecified exception.
-   */
-  def getBlockData(blockId: BlockId, dirs: Option[Array[String]] = None): ManagedBuffer
-
-  /**
-   * Retrieve the data for the specified merged shuffle block as multiple chunks.
-   */
-  def getMergedBlockData(
-      blockId: ShuffleMergedBlockId,
-      dirs: Option[Array[String]]): Seq[ManagedBuffer]
-
-  /**
-   * Retrieve the meta data for the specified merged shuffle block.
-   */
-  def getMergedBlockMeta(
-      blockId: ShuffleMergedBlockId,
-      dirs: Option[Array[String]]): MergedBlockMeta
 
   def stop(): Unit
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

Cleaning up `ShuffleBlockResolver` from polluted methods to create a developer API.

### Why are the changes needed?

`ShuffleBlockResolver` is intended to be part of a generic Shuffle API but currently it contains local disk specific (and pushed based shuffle) methods.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing unit tests.