### PR TITLE
[SPARK-37880][BUILD] Upgrade Scala to 2.13.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3581,7 +3581,7 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>2.13.7</scala.version>
+        <scala.version>2.13.8</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
       </properties>
       <build>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to update from Scala 2.13.7 to Scala 2.13.8 for Apache Spark 3.3.

### Why are the changes needed?
Scala 2.13.8 is a maintenance release for 2.13 line and the release notes as follows:
- https://github.com/scala/scala/releases/tag/v2.13.8



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass the GitHub Action Scala 2.13 job

- Manual test (Will add)