### PR TITLE
[SPARK-37885][PYTHON] Make pandas_udf to take type annotations with future annotations enabled

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -453,6 +453,7 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_pandas_udf_grouped_agg",
         "pyspark.sql.tests.test_pandas_udf_scalar",
         "pyspark.sql.tests.test_pandas_udf_typehints",
+        "pyspark.sql.tests.test_pandas_udf_typehints_with_future_annotations",
         "pyspark.sql.tests.test_pandas_udf_window",
         "pyspark.sql.tests.test_readwriter",
         "pyspark.sql.tests.test_serde",

--- a/python/pyspark/sql/tests/test_pandas_udf_typehints_with_future_annotations.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_typehints_with_future_annotations.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
+
+import sys
 import unittest
 from inspect import signature
 from typing import Union, Iterator, Tuple, cast, get_type_hints
@@ -40,7 +43,7 @@ if have_pandas:
     not have_pandas or not have_pyarrow,
     cast(str, pandas_requirement_message or pyarrow_requirement_message),
 )
-class PandasUDFTypeHintsTests(ReusedSQLTestCase):
+class PandasUDFTypeHintsWithFutureAnnotationsTests(ReusedSQLTestCase):
     def test_type_annotation_scalar(self):
         def func(col: pd.Series) -> pd.Series:
             pass
@@ -305,6 +308,10 @@ class PandasUDFTypeHintsTests(ReusedSQLTestCase):
         expected = df.selectExpr("id + 1 as id")
         assert_frame_equal(expected.toPandas(), actual.toPandas())
 
+    @unittest.skipIf(
+        sys.version_info < (3, 9),
+        "string annotations with future annotations do not work under Python<3.9",
+    )
     def test_string_type_annotation(self):
         def func(col: "pd.Series") -> "pd.Series":
             pass
@@ -357,7 +364,7 @@ class PandasUDFTypeHintsTests(ReusedSQLTestCase):
 
 
 if __name__ == "__main__":
-    from pyspark.sql.tests.test_pandas_udf_typehints import *  # noqa: #401
+    from pyspark.sql.tests.test_pandas_udf_typehints_with_future_annotations import *  # noqa: #401
 
     try:
         import xmlrunner  # type: ignore[import]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Makes `pandas_udf` to take type annotations with future annotations enabled.

### Why are the changes needed?

When using `from __future__ import annotations`, the type hints will be all strings, then pandas UDF type inference won't work as follows:

```py
>>> from __future__ import annotations
>>> from typing import Union
>>> import pandas as pd
>>> from pyspark.sql.functions import pandas_udf
>>> @pandas_udf("long")
... def plus_one(v: Union[pd.Series, pd.DataFrame]) -> pd.Series:
...     return v + 1

Traceback (most recent call last):
...
NotImplementedError: Unsupported signature: (v: 'Union[pd.Series, pd.DataFrame]') -> 'pd.Series'.
```

### Does this PR introduce _any_ user-facing change?

Yes. Users can use type annotations for pandas UDFs with the future annotations flag.

```py
>>> from __future__ import annotations
>>> from typing import Union
>>> import pandas as pd
>>> from pyspark.sql.functions import pandas_udf
>>> @pandas_udf("long")
... def plus_one(v: Union[pd.Series, pd.DataFrame]) -> pd.Series:
...     return v + 1
...
>>> df = spark.range(10).selectExpr("id", "id as v")
>>> df.select(plus_one(df.v).alias("plus_one")).show()
+--------+
|plus_one|
+--------+
|       1|
|       2|
|       3|
|       4|
|       5|
|       6|
|       7|
|       8|
|       9|
|      10|
+--------+
```

### How was this patch tested?

Added tests with the future annotations enabled.
