### PR TITLE
[SPARK-37491][PYTHON]Fix Series.asof for unsorted values

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -66,6 +66,7 @@ from pyspark.sql.types import (
     NumericType,
     Row,
     StructType,
+    TimestampType,
 )
 from pyspark.sql.window import Window
 
@@ -5254,22 +5255,26 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         index_scol = self._internal.index_spark_columns[0]
         index_type = self._internal.spark_type_for(index_scol)
 
-        original_where: Union[Any, List] = []
         if np.nan in where:
             max_index = self._internal.spark_frame.select(F.last(index_scol)).take(1)[0][0]
-            original_where = where.copy()
-            where = [max_index if x is np.nan else x for x in where]
+            modified_where = [max_index if x is np.nan else x for x in where]
+            cond = [
+                F.last(
+                    F.when(index_scol <= SF.lit(index).cast(index_type), self.spark.column),
+                    ignorenulls=True,
+                )
+                for idx, index in enumerate(modified_where)
+            ]
+        else:
+            cond = [
+                F.last(
+                    F.when(index_scol <= SF.lit(index).cast(index_type), self.spark.column),
+                    ignorenulls=True,
+                )
+                for idx, index in enumerate(where)
+            ]
 
-        column_prefix_constant = "col_"
-        cond = [
-            F.last(
-                F.when(index_scol <= SF.lit(index).cast(index_type), self.spark.column),
-                ignorenulls=True,
-            ).alias(column_prefix_constant + str(index) + "_" + str(idx))
-            for idx, index in enumerate(where)
-        ]
         sdf = self._internal.spark_frame.select(cond)
-
         if not should_return_series:
             with sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
                 # Disable Arrow to keep row ordering.
@@ -5278,14 +5283,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         # The data is expected to be small so it's fine to transpose/use default index.
         with ps.option_context("compute.default_index_type", "distributed", "compute.max_rows", 1):
-            psdf = ps.DataFrame(sdf)  # type: DataFrame
-            if len(original_where) > 0:
-                df = pd.DataFrame(
-                    psdf.transpose().values, columns=[self.name], index=original_where
-                )
+            if len(where) == len(set(where)) and not isinstance(index_type, TimestampType):
+                psdf: DataFrame = DataFrame(sdf)
+                psdf.columns = pd.Index(where)
+                return first_series(psdf.transpose()).rename(self.name)
             else:
-                df = pd.DataFrame(psdf.transpose().values, columns=[self.name], index=where)
-            return df[df.columns[0]]
+                # If `where` has duplicate items, leverage the pandas directly
+                # since pandas API on Spark doesn't support the duplicate column name.
+                pdf: pd.DataFrame = sdf.limit(1).toPandas()
+                pdf.columns = pd.Index(where)
+                return first_series(DataFrame(pdf.transpose())).rename(self.name)
 
     def mad(self) -> float:
         """

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5275,7 +5275,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             .withColumn("identifier", col("values.identifier"))
             .withColumn("value", col("values.Koalas"))
             .drop("values")
-            .na.drop(subset="value")
+            .dropna(subset="value")
         )
         window_specification = Window.partitionBy("identifier").orderBy(index_scol.desc())
         sdf = (

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5266,7 +5266,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     (index_scol <= SF.lit(index).cast(index_type)) & spark_column.isNotNull()
                     if pd.notna(index)
                     # If index is nan then return monotonically_increasing_id,
-                    # if the value of col is not null.This will let max by
+                    # if the value of col is not null. This will let max by
                     # to return last index value , which is the behaviour of pandas
                     else spark_column.isNotNull(),
                     monotonically_increasing_id_column,

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5265,6 +5265,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 F.when(
                     (index_scol <= SF.lit(index).cast(index_type)) & spark_column.isNotNull()
                     if pd.notna(index)
+                    # If index is nan and the value of the col is not null
+                    # then return monotonically_increasing_id .This will let max by
+                    # to return last index value , which is the behaviour of pandas
                     else spark_column.isNotNull(),
                     monotonically_increasing_id_column,
                 ),

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5294,7 +5294,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         # +-----------------+----------------------------------+
 
         sdf = sdf.withColumn("combined_cols", F.array(columns)).drop(*columns)
-        print(sdf.schema)
         # After explode
         # +-----------------+---------------+
         # |__index_level_0__|         values|

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5254,7 +5254,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         index_scol = self._internal.index_spark_columns[0]
         index_type = self._internal.spark_type_for(index_scol)
 
-        original_where = []
+        original_where: Union[Any, List] = []
         if np.nan in where:
             max_index = self._internal.spark_frame.select(F.last(index_scol)).take(1)[0][0]
             original_where = where.copy()
@@ -5274,7 +5274,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             with sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
                 # Disable Arrow to keep row ordering.
                 result = cast(pd.DataFrame, sdf.limit(1).toPandas()).iloc[0, 0]
-                print(result)
             return result if result is not None else np.nan
 
         # The data is expected to be small so it's fine to transpose/use default index.

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5257,8 +5257,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         if np.nan in where:
             # When `where` is np.nan, pandas returns the last index value.
-            max_index = self._internal.spark_frame.select(F.last(index_scol)).take(1)[0][0]
-            modified_where = [max_index if x is np.nan else x for x in where]
+            last_index = self._internal.spark_frame.select(F.last(index_scol)).take(1)[0][0]
+            modified_where = [last_index if x is np.nan else x for x in where]
         else:
             modified_where = where
 
@@ -5269,7 +5269,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
             for idx, index in enumerate(modified_where)
         ]
-
         sdf = self._internal.spark_frame.select(cond)
         if not should_return_series:
             with sql_conf({SPARK_CONF_ARROW_ENABLED: False}):

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5253,33 +5253,97 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             where = [where]
         index_scol = self._internal.index_spark_columns[0]
         index_type = self._internal.spark_type_for(index_scol)
-        from pyspark.sql.functions import struct, lit, explode, col, row_number
+
+        # e.g where = [10, 20]
+        # In the comments below , will explain how the dataframe will look after transformations.
+        # e.g pd.Series([2, 1, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
 
         column_prefix_constant = "col_"
         cond = [
             F.when(
                 index_scol <= SF.lit(index).cast(index_type),
-                struct(
-                    lit(column_prefix_constant + str(index)).alias("identifier"),
-                    self.spark.column.alias("Koalas"),
+                F.struct(
+                    F.lit(column_prefix_constant + str(index) + "_" + str(idx)).alias("identifier"),
+                    self.spark.column.alias("col_value"),
                 ),
-            ).alias(column_prefix_constant + str(index))
-            for index in where
+            ).alias(column_prefix_constant + str(index) + "_" + str(idx))
+            for idx, index in enumerate(where)
         ]
         cond.append(index_scol)
+
+        #
+        # +---------------+---------------+-----------------+
+        # |       col_10_0|       col_20_1|__index_level_0__|
+        # +---------------+---------------+-----------------+
+        # |{col_10_0, 2.0}|{col_20_1, 2.0}|               10|
+        # |           null|{col_20_1, 1.0}|               20|
+        # |           null|           null|               30|
+        # |           null|           null|               40|
+        # +---------------+---------------+-----------------+
+
         sdf = self._internal.spark_frame.select(cond)
         columns = [cols for cols in sdf.columns if cols.startswith("col")]
+
+        # +-----------------+----------------------------------+
+        # |__index_level_0__|combined_cols                     |
+        # +-----------------+----------------------------------+
+        # |10               |[{col_10_0, 2.0}, {col_20_1, 2.0}]|
+        # |20               |[null, {col_20_1, 1.0}]           |
+        # |30               |[null, null]                      |
+        # |40               |[null, null]                      |
+        # +-----------------+----------------------------------+
+
         sdf = sdf.withColumn("combined_cols", F.array(columns)).drop(*columns)
+        print(sdf.schema)
+        # After explode
+        # +-----------------+---------------+
+        # |__index_level_0__|         values|
+        # +-----------------+---------------+
+        # |               10|{col_10_0, 2.0}|
+        # |               10|{col_20_1, 2.0}|
+        # |               20|           null|
+        # |               20|{col_20_1, 1.0}|
+        # |               30|           null|
+        # |               30|           null|
+        # |               40|           null|
+        # |               40|           null|
+        # +-----------------+---------------+
+        #  Final sdf after below transformations
+        # +-----------------+----------+-----+
+        # |__index_level_0__|identifier|value|
+        # +-----------------+----------+-----+
+        # |10               |col_10_0  |2.0  |
+        # |10               |col_20_1  |2.0  |
+        # |20               |col_20_1  |1.0  |
+        # +-----------------+----------+-----+
+
         sdf = (
-            sdf.select(index_scol, explode("combined_cols").alias("values"))
-            .withColumn("identifier", col("values.identifier"))
-            .withColumn("value", col("values.Koalas"))
+            sdf.select(index_scol, F.explode("combined_cols").alias("values"))
+            .withColumn("identifier", F.col("values.identifier"))
+            .withColumn("value", F.col("values.col_value"))
             .drop("values")
             .dropna(subset="value")
         )
         window_specification = Window.partitionBy("identifier").orderBy(index_scol.desc())
+
+        # After row number and window
+        # +-----------------+----------+-----+----------+
+        # |__index_level_0__|identifier|value|row_number|
+        # +-----------------+----------+-----+----------+
+        # |               10|  col_10_0|  2.0|         1|
+        # |               20|  col_20_1|  1.0|         1|
+        # |               10|  col_20_1|  2.0|         2|
+        # +-----------------+----------+-----+----------+
+        #  Final sdf value after below transformation
+        # +----------+-----+
+        # |identifier|value|
+        # +----------+-----+
+        # |col_10_0  |2.0  |
+        # |col_20_1  |1.0  |
+        # +----------+-----+
+
         sdf = (
-            sdf.withColumn("row_number", row_number().over(window_specification))
+            sdf.withColumn("row_number", F.row_number().over(window_specification))
             .filter("row_number == 1")
             .drop(index_scol)
             .drop("row_number")
@@ -5288,7 +5352,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         # Number of rows would be less, since only one row per index.  so collect can be done
         calculated_values = sdf.collect()
 
-        if len(calculated_values) == 0:
+        if len(calculated_values) == 0 and not should_return_series:
             return np.nan
 
         if not should_return_series:
@@ -5300,12 +5364,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         calculated_values_map = {data.identifier: data.value for data in calculated_values}
 
         complete_values = []
-        for data in where:
-            key = column_prefix_constant + str(data)
-            if key in calculated_values_map:
-                complete_values.append(calculated_values_map[key])
-            else:
-                complete_values.append(None)
+        if len(calculated_values) == 0:
+            complete_values = [np.nan] * len(where)
+        else:
+            for idx, data in enumerate(where):
+                key = column_prefix_constant + str(data) + "_" + str(idx)
+                if key in calculated_values_map:
+                    complete_values.append(calculated_values_map[key])
+                else:
+                    complete_values.append(None)
 
         df = pd.DataFrame(data=complete_values, columns=[self.name], index=where)
         return df[df.columns[0]]

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5265,9 +5265,6 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 F.when(
                     (index_scol <= SF.lit(index).cast(index_type)) & spark_column.isNotNull()
                     if pd.notna(index)
-                    # If index is nan then return monotonically_increasing_id,
-                    # if the value of col is not null. This will let max by
-                    # to return last index value , which is the behaviour of pandas
                     else spark_column.isNotNull(),
                     monotonically_increasing_id_column,
                 ),

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2115,6 +2115,32 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         psser = ps.from_pandas(pser)
         self.assert_eq(psser.asof([25, 25]), pser.asof([25, 25]))
 
+        pser = pd.Series([2, 1, np.nan, 4], index=["a", "b", "c", "d"], name="Koalas")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.asof(["a", "d"]), pser.asof(["a", "d"]))
+
+        pser = pd.Series(
+            [2, 1, np.nan, 4],
+            index=[
+                pd.Timestamp(2020, 1, 1),
+                pd.Timestamp(2020, 2, 2),
+                pd.Timestamp(2020, 3, 3),
+                pd.Timestamp(2020, 4, 4),
+            ],
+            name="Koalas",
+        )
+        psser = ps.from_pandas(pser)
+        self.assert_eq(
+            psser.asof([pd.Timestamp(2020, 1, 1)]),
+            pser.asof([pd.Timestamp(2020, 1, 1)]),
+        )
+
+        pser = pd.Series([2, np.nan, 1, 4], index=[10, 20, 30, 40], name="Koalas")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.asof(np.nan), pser.asof(np.nan))
+        self.assert_eq(psser.asof([np.nan, np.nan]), pser.asof([np.nan, np.nan]))
+        self.assert_eq(psser.asof([10, np.nan]), pser.asof([10, np.nan]))
+
     def test_squeeze(self):
         # Single value
         pser = pd.Series([90])

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2101,7 +2101,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
         pser = pd.Series([2, 1, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
         psser = ps.from_pandas(pser)
-        self.assert_eq(psser.asof([5, 25]), pser.asof([5, 25]))
+        self.assert_eq(psser.asof([5, 20]), pser.asof([5, 20]))
 
         pser = pd.Series([4, np.nan, np.nan, 2], index=[10, 20, 30, 40], name="Koalas")
         psser = ps.from_pandas(pser)
@@ -2110,6 +2110,10 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser = pd.Series([np.nan, 4, 1, 2], index=[10, 20, 30, 40], name="Koalas")
         psser = ps.from_pandas(pser)
         self.assert_eq(psser.asof([5, 35]), pser.asof([5, 35]))
+
+        pser = pd.Series([2, 1, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.asof([25, 25]), pser.asof([25, 25]))
 
     def test_squeeze(self):
         # Single value

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2099,6 +2099,18 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         with ps.option_context("compute.eager_check", False):
             self.assert_eq(psser.asof(20), 4.0)
 
+        pser = pd.Series([2, 1, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.asof([5, 25]), pser.asof([5, 25]))
+
+        pser = pd.Series([4, np.nan, np.nan, 2], index=[10, 20, 30, 40], name="Koalas")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.asof([5, 100]), pser.asof([5, 100]))
+
+        pser = pd.Series([np.nan, 4, 1, 2], index=[10, 20, 30, 40], name="Koalas")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.asof([5, 35]), pser.asof([5, 35]))
+
     def test_squeeze(self):
         # Single value
         pser = pd.Series([90])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix Series.asof when values of the series is not sorted

####  Before 
```python
import pandas as pd
from pyspark import pandas as ps
import numpy as np
pser = pd.Series([2, 1, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
psser = ps.from_pandas(pser)
psser.asof([5, 25])
5     NaN
25    2.0
Name: Koalas, dtype: float64

pser = pd.Series([4, np.nan, np.nan, 2], index=[10, 20, 30, 40], name="Koalas")
psser = ps.from_pandas(pser)
psser.asof([5, 100])

5      NaN
100    4.0
```

#### After

```python
import pandas as pd
from pyspark import pandas as ps
import numpy as np
pser = pd.Series([2, 1, np.nan, 4], index=[10, 20, 30, 40], name="Koalas")
psser = ps.from_pandas(pser)
psser.asof([5, 25])
5     NaN
25    1.0
Name: Koalas, dtype: float64

pser = pd.Series([4, np.nan, np.nan, 2], index=[10, 20, 30, 40], name="Koalas")
psser = ps.from_pandas(pser)
psser.asof([5, 100])
5      NaN
100    2.0
```


### Why are the changes needed?
There is a bug in ps.as_of, when the series is not sorted

### Does this PR introduce any user-facing change?
Yes user will be able to see the behavior exactly matching to pandas

### How was this patch tested?
unit tests