### PR TITLE
[SPARK-37879][INFRA] Show test report in GitHub Actions builds from PRs

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -39,6 +39,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const endpoint = 'GET /repos/:owner/:repo/actions/workflows/:id/runs?&branch=:branch'
+            const check_run_endpoint = 'GET /repos/:owner/:repo/commits/:ref/check-runs'
 
             // TODO: Should use pull_request.user and pull_request.user.repos_url?
             // If a different person creates a commit to another forked repo,
@@ -48,6 +49,11 @@ jobs:
               repo: context.payload.pull_request.head.repo.name,
               id: 'build_and_test.yml',
               branch: context.payload.pull_request.head.ref,
+            }
+            const check_run_params = {
+              owner: context.payload.pull_request.head.repo.owner.login,
+              repo: context.payload.pull_request.head.repo.name,
+              ref: context.payload.pull_request.head.ref,
             }
 
             console.log('Ref: ' + context.payload.pull_request.head.ref)
@@ -100,16 +106,29 @@ jobs:
                 }
               })
             } else {
-              const runID = runs.data.workflow_runs[0].id
+              const run_id = runs.data.workflow_runs[0].id
 
               if (runs.data.workflow_runs[0].head_sha != context.payload.pull_request.head.sha) {
                 throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
               }
 
-              const runUrl = 'https://github.com/'
+              // Here we get check run ID to provide Check run view instead of Actions view, see also SPARK-37879.
+              const check_runs = await github.request(check_run_endpoint, check_run_params)
+              const check_run_head = check_runs.data.check_runs.filter(r => r.name === "Configure jobs")[0]
+
+              if (check_run_head.head_sha != context.payload.pull_request.head.sha) {
+                throw new Error('There was a new unsynced commit pushed. Please retrigger the workflow.');
+              }
+
+              const check_run_url = 'https://github.com/'
+                + context.payload.pull_request.head.repo.full_name
+                + '/runs/'
+                + check_run_head.id
+
+              const actions_url = 'https://github.com/'
                 + context.payload.pull_request.head.repo.full_name
                 + '/actions/runs/'
-                + runID
+                + run_id
 
               github.checks.create({
                 owner: context.repo.owner,
@@ -119,13 +138,13 @@ jobs:
                 status: status,
                 output: {
                   title: 'Test results',
-                  summary: '[See test results](' + runUrl + ')',
+                  summary: '[See test results](' + check_run_url + ')',
                   text: JSON.stringify({
                     owner: context.payload.pull_request.head.repo.owner.login,
                     repo: context.payload.pull_request.head.repo.name,
-                    run_id: runID
+                    run_id: run_id
                   })
                 },
-                details_url: runUrl,
+                details_url: actions_url,
               })
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a retry of https://github.com/apache/spark/pull/35179. This PR does the same thing - replacing Actions view to Check run view for `See test results` link.

The main difference with the PR https://github.com/apache/spark/pull/35179 is that we now keep the Actions run id as is as metadata so this Actions run id can be used to update the status of tests in PRs at Apache Spark:

https://github.com/apache/spark/blob/85efc85f9aa93b3fac9e591c96efa38d4414adf8/.github/workflows/update_build_status.yml#L63-L74

Now this PR shouldn't affect [update_build_status.yml](https://github.com/apache/spark/blob/master/.github/workflows/update_build_status.yml) which was the main reason of a followup and revert.

### Why are the changes needed?

For developers to see the test report, and they can easily detect which test is failed.

### Does this PR introduce _any_ user-facing change?

No, dev-only

### How was this patch tested?

Tested in https://github.com/HyukjinKwon/spark/pull/51.
