### PR TITLE
[SPARK-37899][SQL] EliminateInnerJoin to support convert inner join to left semi join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -81,6 +81,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         PushProjectionThroughUnion,
         ReorderJoin,
         EliminateOuterJoin,
+        EliminateInnerJoin,
         PushDownPredicates,
         PushDownLeftSemiAntiJoin,
         PushLeftSemiLeftAntiThroughJoin,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import scala.annotation.tailrec
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.ExtractFiltersAndInnerJoins
+import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, ExtractFiltersAndInnerJoins}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
@@ -188,6 +188,26 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
 }
 
 /**
+ * Convert inner join to left semi join
+ */
+object EliminateInnerJoin extends Rule[LogicalPlan] with PredicateHelper with JoinSelectionHelper {
+  def apply(plan: LogicalPlan): LogicalPlan = {
+      plan.transformWithPruning(
+        _.containsPattern(INNER_LIKE_JOIN), ruleId) {
+        case p @ Project(_,
+            j @ ExtractEquiJoinKeys(
+              Inner, _, rightKeys: Seq[Expression], None, _, left, right: Aggregate, _))
+          if right.groupOnly && p.references.subsetOf(left.outputSet) &&
+            getBroadcastBuildSide(j, conf).contains(BuildRight) &&
+            rightKeys.distinct.size == right.output.distinct.size &&
+            rightKeys.distinct.zip(right.output.distinct)
+              .forall { case (a, b) => a.semanticEquals(b) } =>
+          p.copy(child = j.copy(joinType = LeftSemi))
+      }
+  }
+}
+
+/**
  * PythonUDF in join condition can't be evaluated if it refers to attributes from both join sides.
  * See `ExtractPythonUDFs` for details. This rule will detect un-evaluable PythonUDF and pull them
  * out from join condition.
@@ -340,11 +360,15 @@ trait JoinSelectionHelper {
     }
   }
 
-  def canPlanAsBroadcastHashJoin(join: Join, conf: SQLConf): Boolean = {
+  def getBroadcastBuildSide(join: Join, conf: SQLConf): Option[BuildSide] = {
     getBroadcastBuildSide(join.left, join.right, join.joinType,
-      join.hint, hintOnly = true, conf).isDefined ||
+      join.hint, hintOnly = true, conf).orElse(
       getBroadcastBuildSide(join.left, join.right, join.joinType,
-        join.hint, hintOnly = false, conf).isDefined
+        join.hint, hintOnly = false, conf))
+  }
+
+  def canPlanAsBroadcastHashJoin(join: Join, conf: SQLConf): Boolean = {
+    getBroadcastBuildSide(join, conf).isDefined
   }
 
   def hintToBroadcastLeft(hint: JoinHint): Boolean = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -111,6 +111,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.EliminateAggregateFilter" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateLimits" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateMapObjects" ::
+      "org.apache.spark.sql.catalyst.optimizer.EliminateInnerJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateOuterJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.EliminateSerialization" ::
       "org.apache.spark.sql.catalyst.optimizer.LikeSimplification" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InnerJoinEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InnerJoinEliminationSuite.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions.{AttributeMap, AttributeReference}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
+import org.apache.spark.sql.types.IntegerType
+
+class InnerJoinEliminationSuite extends PlanTest {
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Subqueries", Once,
+        EliminateSubqueryAliases) ::
+      Batch("Outer Join Elimination", Once,
+        EliminateInnerJoin,
+        PushPredicateThroughJoin) :: Nil
+  }
+
+  private val a = AttributeReference("a", IntegerType)()
+  private val b = AttributeReference("b", IntegerType)()
+  private val c = AttributeReference("c", IntegerType)()
+  private val d = AttributeReference("d", IntegerType)()
+  private val e = AttributeReference("e", IntegerType)()
+  private val f = AttributeReference("f", IntegerType)()
+
+  private val testRelation1 = StatsTestPlan(
+    outputList = Seq(a, b, c),
+    attributeStats = AttributeMap.empty,
+    rowCount = 100000,
+    size = Some(100000 * 3 * (8 + 4)))
+
+  private val testRelation2 = StatsTestPlan(
+    outputList = Seq(d, e, f),
+    attributeStats = AttributeMap.empty,
+    rowCount = 1000,
+    size = Some(1000 * 3 * (8 + 4)))
+
+  private val x = testRelation1.subquery('x)
+  private val y = testRelation2.groupBy('d, 'e)('d, 'e).subquery('y)
+
+  test("Inner join to left semi join") {
+    comparePlans(
+      Optimize.execute(
+        x.join(y, Inner,
+          Option("x.a".attr === "y.d".attr && "x.b".attr === "y.e".attr)).select('a).analyze),
+      x.join(y, LeftSemi,
+        Option("x.a".attr === "y.d".attr && "x.b".attr === "y.e".attr)).select('a).analyze)
+  }
+
+  test("Inner join to left semi join and rightKeys has duplicate values") {
+    val joinCondition = Option("x.a".attr === "y.d".attr && "x.b".attr === "y.e".attr &&
+      "x.c".attr === "y.e".attr)
+    comparePlans(
+      Optimize.execute(x.join(y, Inner, joinCondition).select('a).analyze),
+      x.join(y, LeftSemi, joinCondition).select('a).analyze)
+  }
+
+  test("Inner join to left semi join and right output has duplicate values") {
+    val right = testRelation2.groupBy('d, 'e)('d, 'e, 'e).subquery('y)
+    val joinCondition = Option("x.a".attr === "y.d".attr && "x.b".attr === "y.e".attr &&
+      "x.c".attr === "y.e".attr)
+    comparePlans(
+      Optimize.execute(x.join(right, Inner, joinCondition).select('a).analyze),
+      x.join(right, LeftSemi, joinCondition).select('a).analyze)
+  }
+
+  test("Inner join to left semi join and should sort rightKeys") {
+    val joinCondition = Option("x.b".attr === "y.e".attr && "x.c".attr === "y.e".attr &&
+      "x.a".attr === "y.d".attr)
+    comparePlans(
+      Optimize.execute(x.join(y, Inner, joinCondition).select('a).analyze),
+      x.join(y, LeftSemi, joinCondition).select('a).analyze)
+  }
+
+  test("Negative case: contains both side of attribute") {
+    val originPlan = x.join(y, Inner, Option("x.a".attr === "y.d".attr)).select('a, 'd).analyze
+    comparePlans(Optimize.execute(originPlan), originPlan)
+  }
+
+  test("Negative case: right side can not guarantee unique") {
+    val originPlan = x.join(y, Inner, Option("x.a".attr === "y.d".attr)).select('a).analyze
+    comparePlans(Optimize.execute(originPlan), originPlan)
+  }
+
+  test("Negative case: join condition is not an attribute") {
+    val originPlan = x.join(y, Inner, Option("x.a".attr + 1 === "y.d".attr + 1)).select('a).analyze
+    comparePlans(Optimize.execute(originPlan), originPlan)
+  }
+
+  test("Negative case: BroadcastBuildSide is BuildLeft") {
+    val testRelation3 = StatsTestPlan(
+      outputList = Seq(a, b, c),
+      attributeStats = AttributeMap.empty,
+      rowCount = 100,
+      size = Some(100 * 3 * (8 + 4))).as("x")
+
+    val originPlan =
+      testRelation3.join(y, Inner, Option("x.a".attr === "y.d".attr)).select('a).analyze
+    comparePlans(Optimize.execute(originPlan), originPlan)
+  }
+
+}

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -1,130 +1,118 @@
 == Physical Plan ==
-TakeOrderedAndProject (126)
-+- * HashAggregate (125)
-   +- Exchange (124)
-      +- * HashAggregate (123)
-         +- * Expand (122)
-            +- Union (121)
-               :- * Project (82)
-               :  +- * Filter (81)
-               :     +- * HashAggregate (80)
-               :        +- Exchange (79)
-               :           +- * HashAggregate (78)
-               :              +- * Project (77)
-               :                 +- * BroadcastHashJoin Inner BuildRight (76)
-               :                    :- * Project (66)
-               :                    :  +- * BroadcastHashJoin Inner BuildRight (65)
-               :                    :     :- * SortMergeJoin LeftSemi (63)
-               :                    :     :  :- * Sort (5)
-               :                    :     :  :  +- Exchange (4)
-               :                    :     :  :     +- * Filter (3)
-               :                    :     :  :        +- * ColumnarToRow (2)
-               :                    :     :  :           +- Scan parquet default.store_sales (1)
-               :                    :     :  +- * Sort (62)
-               :                    :     :     +- Exchange (61)
-               :                    :     :        +- * Project (60)
-               :                    :     :           +- * BroadcastHashJoin Inner BuildRight (59)
-               :                    :     :              :- * Filter (8)
-               :                    :     :              :  +- * ColumnarToRow (7)
-               :                    :     :              :     +- Scan parquet default.item (6)
-               :                    :     :              +- BroadcastExchange (58)
-               :                    :     :                 +- * HashAggregate (57)
-               :                    :     :                    +- Exchange (56)
-               :                    :     :                       +- * HashAggregate (55)
-               :                    :     :                          +- * SortMergeJoin LeftSemi (54)
-               :                    :     :                             :- * Sort (42)
-               :                    :     :                             :  +- Exchange (41)
-               :                    :     :                             :     +- * HashAggregate (40)
-               :                    :     :                             :        +- Exchange (39)
-               :                    :     :                             :           +- * HashAggregate (38)
-               :                    :     :                             :              +- * Project (37)
-               :                    :     :                             :                 +- * BroadcastHashJoin Inner BuildRight (36)
-               :                    :     :                             :                    :- * Project (14)
-               :                    :     :                             :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-               :                    :     :                             :                    :     :- * Filter (11)
-               :                    :     :                             :                    :     :  +- * ColumnarToRow (10)
-               :                    :     :                             :                    :     :     +- Scan parquet default.store_sales (9)
-               :                    :     :                             :                    :     +- ReusedExchange (12)
-               :                    :     :                             :                    +- BroadcastExchange (35)
-               :                    :     :                             :                       +- * SortMergeJoin LeftSemi (34)
-               :                    :     :                             :                          :- * Sort (19)
-               :                    :     :                             :                          :  +- Exchange (18)
-               :                    :     :                             :                          :     +- * Filter (17)
-               :                    :     :                             :                          :        +- * ColumnarToRow (16)
-               :                    :     :                             :                          :           +- Scan parquet default.item (15)
-               :                    :     :                             :                          +- * Sort (33)
-               :                    :     :                             :                             +- Exchange (32)
-               :                    :     :                             :                                +- * Project (31)
-               :                    :     :                             :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-               :                    :     :                             :                                      :- * Project (25)
-               :                    :     :                             :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-               :                    :     :                             :                                      :     :- * Filter (22)
-               :                    :     :                             :                                      :     :  +- * ColumnarToRow (21)
-               :                    :     :                             :                                      :     :     +- Scan parquet default.catalog_sales (20)
-               :                    :     :                             :                                      :     +- ReusedExchange (23)
-               :                    :     :                             :                                      +- BroadcastExchange (29)
-               :                    :     :                             :                                         +- * Filter (28)
-               :                    :     :                             :                                            +- * ColumnarToRow (27)
-               :                    :     :                             :                                               +- Scan parquet default.item (26)
-               :                    :     :                             +- * Sort (53)
-               :                    :     :                                +- Exchange (52)
-               :                    :     :                                   +- * Project (51)
-               :                    :     :                                      +- * BroadcastHashJoin Inner BuildRight (50)
-               :                    :     :                                         :- * Project (48)
-               :                    :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (47)
-               :                    :     :                                         :     :- * Filter (45)
-               :                    :     :                                         :     :  +- * ColumnarToRow (44)
-               :                    :     :                                         :     :     +- Scan parquet default.web_sales (43)
-               :                    :     :                                         :     +- ReusedExchange (46)
-               :                    :     :                                         +- ReusedExchange (49)
-               :                    :     +- ReusedExchange (64)
-               :                    +- BroadcastExchange (75)
-               :                       +- * SortMergeJoin LeftSemi (74)
-               :                          :- * Sort (71)
-               :                          :  +- Exchange (70)
-               :                          :     +- * Filter (69)
-               :                          :        +- * ColumnarToRow (68)
-               :                          :           +- Scan parquet default.item (67)
-               :                          +- * Sort (73)
-               :                             +- ReusedExchange (72)
-               :- * Project (101)
-               :  +- * Filter (100)
-               :     +- * HashAggregate (99)
-               :        +- Exchange (98)
-               :           +- * HashAggregate (97)
-               :              +- * Project (96)
-               :                 +- * BroadcastHashJoin Inner BuildRight (95)
-               :                    :- * Project (93)
-               :                    :  +- * BroadcastHashJoin Inner BuildRight (92)
-               :                    :     :- * SortMergeJoin LeftSemi (90)
-               :                    :     :  :- * Sort (87)
-               :                    :     :  :  +- Exchange (86)
-               :                    :     :  :     +- * Filter (85)
-               :                    :     :  :        +- * ColumnarToRow (84)
-               :                    :     :  :           +- Scan parquet default.catalog_sales (83)
-               :                    :     :  +- * Sort (89)
-               :                    :     :     +- ReusedExchange (88)
-               :                    :     +- ReusedExchange (91)
-               :                    +- ReusedExchange (94)
-               +- * Project (120)
-                  +- * Filter (119)
-                     +- * HashAggregate (118)
-                        +- Exchange (117)
-                           +- * HashAggregate (116)
-                              +- * Project (115)
-                                 +- * BroadcastHashJoin Inner BuildRight (114)
-                                    :- * Project (112)
-                                    :  +- * BroadcastHashJoin Inner BuildRight (111)
-                                    :     :- * SortMergeJoin LeftSemi (109)
-                                    :     :  :- * Sort (106)
-                                    :     :  :  +- Exchange (105)
-                                    :     :  :     +- * Filter (104)
-                                    :     :  :        +- * ColumnarToRow (103)
-                                    :     :  :           +- Scan parquet default.web_sales (102)
-                                    :     :  +- * Sort (108)
-                                    :     :     +- ReusedExchange (107)
-                                    :     +- ReusedExchange (110)
-                                    +- ReusedExchange (113)
+TakeOrderedAndProject (114)
++- * HashAggregate (113)
+   +- Exchange (112)
+      +- * HashAggregate (111)
+         +- * Expand (110)
+            +- Union (109)
+               :- * Project (76)
+               :  +- * Filter (75)
+               :     +- * HashAggregate (74)
+               :        +- Exchange (73)
+               :           +- * HashAggregate (72)
+               :              +- * Project (71)
+               :                 +- * BroadcastHashJoin Inner BuildRight (70)
+               :                    :- * Project (63)
+               :                    :  +- * BroadcastHashJoin Inner BuildRight (62)
+               :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (60)
+               :                    :     :  :- * Filter (3)
+               :                    :     :  :  +- * ColumnarToRow (2)
+               :                    :     :  :     +- Scan parquet default.store_sales (1)
+               :                    :     :  +- BroadcastExchange (59)
+               :                    :     :     +- * Project (58)
+               :                    :     :        +- * BroadcastHashJoin LeftSemi BuildRight (57)
+               :                    :     :           :- * Filter (6)
+               :                    :     :           :  +- * ColumnarToRow (5)
+               :                    :     :           :     +- Scan parquet default.item (4)
+               :                    :     :           +- BroadcastExchange (56)
+               :                    :     :              +- * HashAggregate (55)
+               :                    :     :                 +- Exchange (54)
+               :                    :     :                    +- * HashAggregate (53)
+               :                    :     :                       +- * SortMergeJoin LeftSemi (52)
+               :                    :     :                          :- * Sort (40)
+               :                    :     :                          :  +- Exchange (39)
+               :                    :     :                          :     +- * HashAggregate (38)
+               :                    :     :                          :        +- Exchange (37)
+               :                    :     :                          :           +- * HashAggregate (36)
+               :                    :     :                          :              +- * Project (35)
+               :                    :     :                          :                 +- * BroadcastHashJoin Inner BuildRight (34)
+               :                    :     :                          :                    :- * Project (12)
+               :                    :     :                          :                    :  +- * BroadcastHashJoin Inner BuildRight (11)
+               :                    :     :                          :                    :     :- * Filter (9)
+               :                    :     :                          :                    :     :  +- * ColumnarToRow (8)
+               :                    :     :                          :                    :     :     +- Scan parquet default.store_sales (7)
+               :                    :     :                          :                    :     +- ReusedExchange (10)
+               :                    :     :                          :                    +- BroadcastExchange (33)
+               :                    :     :                          :                       +- * SortMergeJoin LeftSemi (32)
+               :                    :     :                          :                          :- * Sort (17)
+               :                    :     :                          :                          :  +- Exchange (16)
+               :                    :     :                          :                          :     +- * Filter (15)
+               :                    :     :                          :                          :        +- * ColumnarToRow (14)
+               :                    :     :                          :                          :           +- Scan parquet default.item (13)
+               :                    :     :                          :                          +- * Sort (31)
+               :                    :     :                          :                             +- Exchange (30)
+               :                    :     :                          :                                +- * Project (29)
+               :                    :     :                          :                                   +- * BroadcastHashJoin Inner BuildRight (28)
+               :                    :     :                          :                                      :- * Project (23)
+               :                    :     :                          :                                      :  +- * BroadcastHashJoin Inner BuildRight (22)
+               :                    :     :                          :                                      :     :- * Filter (20)
+               :                    :     :                          :                                      :     :  +- * ColumnarToRow (19)
+               :                    :     :                          :                                      :     :     +- Scan parquet default.catalog_sales (18)
+               :                    :     :                          :                                      :     +- ReusedExchange (21)
+               :                    :     :                          :                                      +- BroadcastExchange (27)
+               :                    :     :                          :                                         +- * Filter (26)
+               :                    :     :                          :                                            +- * ColumnarToRow (25)
+               :                    :     :                          :                                               +- Scan parquet default.item (24)
+               :                    :     :                          +- * Sort (51)
+               :                    :     :                             +- Exchange (50)
+               :                    :     :                                +- * Project (49)
+               :                    :     :                                   +- * BroadcastHashJoin Inner BuildRight (48)
+               :                    :     :                                      :- * Project (46)
+               :                    :     :                                      :  +- * BroadcastHashJoin Inner BuildRight (45)
+               :                    :     :                                      :     :- * Filter (43)
+               :                    :     :                                      :     :  +- * ColumnarToRow (42)
+               :                    :     :                                      :     :     +- Scan parquet default.web_sales (41)
+               :                    :     :                                      :     +- ReusedExchange (44)
+               :                    :     :                                      +- ReusedExchange (47)
+               :                    :     +- ReusedExchange (61)
+               :                    +- BroadcastExchange (69)
+               :                       +- * BroadcastHashJoin LeftSemi BuildRight (68)
+               :                          :- * Filter (66)
+               :                          :  +- * ColumnarToRow (65)
+               :                          :     +- Scan parquet default.item (64)
+               :                          +- ReusedExchange (67)
+               :- * Project (92)
+               :  +- * Filter (91)
+               :     +- * HashAggregate (90)
+               :        +- Exchange (89)
+               :           +- * HashAggregate (88)
+               :              +- * Project (87)
+               :                 +- * BroadcastHashJoin Inner BuildRight (86)
+               :                    :- * Project (84)
+               :                    :  +- * BroadcastHashJoin Inner BuildRight (83)
+               :                    :     :- * BroadcastHashJoin LeftSemi BuildRight (81)
+               :                    :     :  :- * Filter (79)
+               :                    :     :  :  +- * ColumnarToRow (78)
+               :                    :     :  :     +- Scan parquet default.catalog_sales (77)
+               :                    :     :  +- ReusedExchange (80)
+               :                    :     +- ReusedExchange (82)
+               :                    +- ReusedExchange (85)
+               +- * Project (108)
+                  +- * Filter (107)
+                     +- * HashAggregate (106)
+                        +- Exchange (105)
+                           +- * HashAggregate (104)
+                              +- * Project (103)
+                                 +- * BroadcastHashJoin Inner BuildRight (102)
+                                    :- * Project (100)
+                                    :  +- * BroadcastHashJoin Inner BuildRight (99)
+                                    :     :- * BroadcastHashJoin LeftSemi BuildRight (97)
+                                    :     :  :- * Filter (95)
+                                    :     :  :  +- * ColumnarToRow (94)
+                                    :     :  :     +- Scan parquet default.web_sales (93)
+                                    :     :  +- ReusedExchange (96)
+                                    :     +- ReusedExchange (98)
+                                    +- ReusedExchange (101)
 
 
 (1) Scan parquet default.store_sales
@@ -135,755 +123,707 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_item_sk#1)
 
-(4) Exchange
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [id=#6]
-
-(5) Sort [codegen id : 2]
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
-
-(6) Scan parquet default.item
-Output [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(4) Scan parquet default.item
+Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(5) ColumnarToRow [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(8) Filter [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
-Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
+(6) Filter [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
+Condition : ((isnotnull(i_brand_id#7) AND isnotnull(i_class_id#8)) AND isnotnull(i_category_id#9))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(7) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(8) ColumnarToRow [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(9) Filter [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
+Condition : isnotnull(ss_item_sk#10)
 
-(12) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#14]
+(10) ReusedExchange [Reuses operator id: 143]
+Output [1]: [d_date_sk#13]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(11) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(12) Project [codegen id : 9]
+Output [1]: [ss_item_sk#10]
+Input [3]: [ss_item_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(13) Scan parquet default.item
+Output [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(14) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(15) Filter [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Condition : (((isnotnull(i_item_sk#14) AND isnotnull(i_brand_id#15)) AND isnotnull(i_class_id#16)) AND isnotnull(i_category_id#17))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(16) Exchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: hashpartitioning(coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17), 5), ENSURE_REQUIREMENTS, [id=#18]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(17) Sort [codegen id : 3]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: [coalesce(i_brand_id#15, 0) ASC NULLS FIRST, isnull(i_brand_id#15) ASC NULLS FIRST, coalesce(i_class_id#16, 0) ASC NULLS FIRST, isnull(i_class_id#16) ASC NULLS FIRST, coalesce(i_category_id#17, 0) ASC NULLS FIRST, isnull(i_category_id#17) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(18) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#20), dynamicpruningexpression(cs_sold_date_sk#20 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(19) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(20) Filter [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
+Condition : isnotnull(cs_item_sk#19)
 
-(23) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#22]
+(21) ReusedExchange [Reuses operator id: 143]
+Output [1]: [d_date_sk#21]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(22) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#20]
+Right keys [1]: [d_date_sk#21]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(23) Project [codegen id : 6]
+Output [1]: [cs_item_sk#19]
+Input [3]: [cs_item_sk#19, cs_sold_date_sk#20, d_date_sk#21]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(24) Scan parquet default.item
+Output [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(25) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(26) Filter [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Condition : isnotnull(i_item_sk#22)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(27) BroadcastExchange
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(28) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#19]
+Right keys [1]: [i_item_sk#22]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(29) Project [codegen id : 6]
+Output [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Input [5]: [cs_item_sk#19, i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(30) Exchange
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: hashpartitioning(coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25), 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(31) Sort [codegen id : 7]
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: [coalesce(i_brand_id#23, 0) ASC NULLS FIRST, isnull(i_brand_id#23) ASC NULLS FIRST, coalesce(i_class_id#24, 0) ASC NULLS FIRST, isnull(i_class_id#24) ASC NULLS FIRST, coalesce(i_category_id#25, 0) ASC NULLS FIRST, isnull(i_category_id#25) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(32) SortMergeJoin [codegen id : 8]
+Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
+Right keys [6]: [coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(33) BroadcastExchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_item_sk#10]
+Right keys [1]: [i_item_sk#14]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(35) Project [codegen id : 9]
+Output [3]: [i_brand_id#15 AS brand_id#29, i_class_id#16 AS class_id#30, i_category_id#17 AS category_id#31]
+Input [5]: [ss_item_sk#10, i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(36) HashAggregate [codegen id : 9]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
+
+(37) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#32]
+
+(38) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
 (39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31), 5), ENSURE_REQUIREMENTS, [id=#33]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+(40) Sort [codegen id : 11]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: [coalesce(brand_id#29, 0) ASC NULLS FIRST, isnull(brand_id#29) ASC NULLS FIRST, coalesce(class_id#30, 0) ASC NULLS FIRST, isnull(class_id#30) ASC NULLS FIRST, coalesce(category_id#31, 0) ASC NULLS FIRST, isnull(category_id#31) ASC NULLS FIRST], false, 0
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
-
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
-
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(41) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#35), dynamicpruningexpression(ws_sold_date_sk#35 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(42) ColumnarToRow [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(43) Filter [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
+Condition : isnotnull(ws_item_sk#34)
 
-(46) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#37]
+(44) ReusedExchange [Reuses operator id: 143]
+Output [1]: [d_date_sk#36]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(45) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_sold_date_sk#35]
+Right keys [1]: [d_date_sk#36]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(46) Project [codegen id : 14]
+Output [1]: [ws_item_sk#34]
+Input [3]: [ws_item_sk#34, ws_sold_date_sk#35, d_date_sk#36]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(47) ReusedExchange [Reuses operator id: 27]
+Output [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(48) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_item_sk#34]
+Right keys [1]: [i_item_sk#37]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(49) Project [codegen id : 14]
+Output [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [5]: [ws_item_sk#34, i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(50) Exchange
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: hashpartitioning(coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40), 5), ENSURE_REQUIREMENTS, [id=#41]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(51) Sort [codegen id : 15]
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: [coalesce(i_brand_id#38, 0) ASC NULLS FIRST, isnull(i_brand_id#38) ASC NULLS FIRST, coalesce(i_class_id#39, 0) ASC NULLS FIRST, isnull(i_class_id#39) ASC NULLS FIRST, coalesce(i_category_id#40, 0) ASC NULLS FIRST, isnull(i_category_id#40) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(52) SortMergeJoin [codegen id : 16]
+Left keys [6]: [coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31)]
+Right keys [6]: [coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40)]
 Join condition: None
 
-(55) HashAggregate [codegen id : 18]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(53) HashAggregate [codegen id : 16]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(56) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#43]
+(54) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(57) HashAggregate [codegen id : 19]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(55) HashAggregate [codegen id : 17]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(58) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+(56) BroadcastExchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
-(59) BroadcastHashJoin [codegen id : 20]
-Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+(57) BroadcastHashJoin [codegen id : 18]
+Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Right keys [3]: [brand_id#29, class_id#30, category_id#31]
 Join condition: None
 
-(60) Project [codegen id : 20]
-Output [1]: [i_item_sk#7 AS ss_item_sk#45]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+(58) Project [codegen id : 18]
+Output [1]: [i_item_sk#6 AS ss_item_sk#44]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(61) Exchange
-Input [1]: [ss_item_sk#45]
-Arguments: hashpartitioning(ss_item_sk#45, 5), ENSURE_REQUIREMENTS, [id=#46]
+(59) BroadcastExchange
+Input [1]: [ss_item_sk#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
 
-(62) Sort [codegen id : 21]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(63) SortMergeJoin [codegen id : 45]
+(60) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [ss_item_sk#45]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(64) ReusedExchange [Reuses operator id: 150]
-Output [1]: [d_date_sk#47]
+(61) ReusedExchange [Reuses operator id: 138]
+Output [1]: [d_date_sk#46]
 
-(65) BroadcastHashJoin [codegen id : 45]
+(62) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#47]
+Right keys [1]: [d_date_sk#46]
 Join condition: None
 
-(66) Project [codegen id : 45]
+(63) Project [codegen id : 39]
 Output [3]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3]
-Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#47]
+Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#46]
 
-(67) Scan parquet default.item
-Output [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(64) Scan parquet default.item
+Output [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(68) ColumnarToRow [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(65) ColumnarToRow [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(69) Filter [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Condition : isnotnull(i_item_sk#48)
+(66) Filter [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Condition : isnotnull(i_item_sk#47)
 
-(70) Exchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: hashpartitioning(i_item_sk#48, 5), ENSURE_REQUIREMENTS, [id=#52]
+(67) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(71) Sort [codegen id : 24]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: [i_item_sk#48 ASC NULLS FIRST], false, 0
-
-(72) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(73) Sort [codegen id : 43]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(74) SortMergeJoin [codegen id : 44]
-Left keys [1]: [i_item_sk#48]
-Right keys [1]: [ss_item_sk#45]
+(68) BroadcastHashJoin [codegen id : 38]
+Left keys [1]: [i_item_sk#47]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(75) BroadcastExchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+(69) BroadcastExchange
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
 
-(76) BroadcastHashJoin [codegen id : 45]
+(70) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#48]
+Right keys [1]: [i_item_sk#47]
 Join condition: None
 
-(77) Project [codegen id : 45]
-Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(71) Project [codegen id : 39]
+Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(78) HashAggregate [codegen id : 45]
-Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(72) HashAggregate [codegen id : 39]
+Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#54, isEmpty#55, count#56]
-Results [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
+Aggregate Attributes [3]: [sum#52, isEmpty#53, count#54]
+Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
 
-(79) Exchange
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Arguments: hashpartitioning(i_brand_id#49, i_class_id#50, i_category_id#51, 5), ENSURE_REQUIREMENTS, [id=#60]
+(73) Exchange
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), ENSURE_REQUIREMENTS, [id=#58]
 
-(80) HashAggregate [codegen id : 46]
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(74) HashAggregate [codegen id : 40]
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61, count(1)#62]
-Results [5]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61 AS sales#63, count(1)#62 AS number_sales#64]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59, count(1)#60]
+Results [5]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59 AS sales#61, count(1)#60 AS number_sales#62]
 
-(81) Filter [codegen id : 46]
-Input [5]: [i_brand_id#49, i_class_id#50, i_category_id#51, sales#63, number_sales#64]
-Condition : (isnotnull(sales#63) AND (cast(sales#63 as decimal(32,6)) > cast(Subquery scalar-subquery#65, [id=#66] as decimal(32,6))))
+(75) Filter [codegen id : 40]
+Input [5]: [i_brand_id#48, i_class_id#49, i_category_id#50, sales#61, number_sales#62]
+Condition : (isnotnull(sales#61) AND (cast(sales#61 as decimal(32,6)) > cast(Subquery scalar-subquery#63, [id=#64] as decimal(32,6))))
 
-(82) Project [codegen id : 46]
-Output [6]: [sales#63, number_sales#64, store AS channel#67, i_brand_id#49, i_class_id#50, i_category_id#51]
-Input [5]: [i_brand_id#49, i_class_id#50, i_category_id#51, sales#63, number_sales#64]
+(76) Project [codegen id : 40]
+Output [6]: [sales#61, number_sales#62, store AS channel#65, i_brand_id#48, i_class_id#49, i_category_id#50]
+Input [5]: [i_brand_id#48, i_class_id#49, i_category_id#50, sales#61, number_sales#62]
 
-(83) Scan parquet default.catalog_sales
-Output [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
+(77) Scan parquet default.catalog_sales
+Output [4]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#71), dynamicpruningexpression(cs_sold_date_sk#71 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#69), dynamicpruningexpression(cs_sold_date_sk#69 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(84) ColumnarToRow [codegen id : 47]
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
+(78) ColumnarToRow [codegen id : 79]
+Input [4]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69]
 
-(85) Filter [codegen id : 47]
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
-Condition : isnotnull(cs_item_sk#68)
+(79) Filter [codegen id : 79]
+Input [4]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69]
+Condition : isnotnull(cs_item_sk#66)
 
-(86) Exchange
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
-Arguments: hashpartitioning(cs_item_sk#68, 5), ENSURE_REQUIREMENTS, [id=#72]
+(80) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(87) Sort [codegen id : 48]
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
-Arguments: [cs_item_sk#68 ASC NULLS FIRST], false, 0
-
-(88) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(89) Sort [codegen id : 67]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(90) SortMergeJoin [codegen id : 91]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [ss_item_sk#45]
+(81) BroadcastHashJoin [codegen id : 79]
+Left keys [1]: [cs_item_sk#66]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(91) ReusedExchange [Reuses operator id: 150]
-Output [1]: [d_date_sk#73]
+(82) ReusedExchange [Reuses operator id: 138]
+Output [1]: [d_date_sk#70]
 
-(92) BroadcastHashJoin [codegen id : 91]
-Left keys [1]: [cs_sold_date_sk#71]
-Right keys [1]: [d_date_sk#73]
+(83) BroadcastHashJoin [codegen id : 79]
+Left keys [1]: [cs_sold_date_sk#69]
+Right keys [1]: [d_date_sk#70]
 Join condition: None
 
-(93) Project [codegen id : 91]
-Output [3]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70]
-Input [5]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71, d_date_sk#73]
+(84) Project [codegen id : 79]
+Output [3]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68]
+Input [5]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69, d_date_sk#70]
 
-(94) ReusedExchange [Reuses operator id: 75]
-Output [4]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77]
+(85) ReusedExchange [Reuses operator id: 69]
+Output [4]: [i_item_sk#71, i_brand_id#72, i_class_id#73, i_category_id#74]
 
-(95) BroadcastHashJoin [codegen id : 91]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [i_item_sk#74]
+(86) BroadcastHashJoin [codegen id : 79]
+Left keys [1]: [cs_item_sk#66]
+Right keys [1]: [i_item_sk#71]
 Join condition: None
 
-(96) Project [codegen id : 91]
-Output [5]: [cs_quantity#69, cs_list_price#70, i_brand_id#75, i_class_id#76, i_category_id#77]
-Input [7]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77]
+(87) Project [codegen id : 79]
+Output [5]: [cs_quantity#67, cs_list_price#68, i_brand_id#72, i_class_id#73, i_category_id#74]
+Input [7]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, i_item_sk#71, i_brand_id#72, i_class_id#73, i_category_id#74]
 
-(97) HashAggregate [codegen id : 91]
-Input [5]: [cs_quantity#69, cs_list_price#70, i_brand_id#75, i_class_id#76, i_category_id#77]
-Keys [3]: [i_brand_id#75, i_class_id#76, i_category_id#77]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#78, isEmpty#79, count#80]
-Results [6]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum#81, isEmpty#82, count#83]
+(88) HashAggregate [codegen id : 79]
+Input [5]: [cs_quantity#67, cs_list_price#68, i_brand_id#72, i_class_id#73, i_category_id#74]
+Keys [3]: [i_brand_id#72, i_class_id#73, i_category_id#74]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
+Aggregate Attributes [3]: [sum#75, isEmpty#76, count#77]
+Results [6]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum#78, isEmpty#79, count#80]
 
-(98) Exchange
-Input [6]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum#81, isEmpty#82, count#83]
-Arguments: hashpartitioning(i_brand_id#75, i_class_id#76, i_category_id#77, 5), ENSURE_REQUIREMENTS, [id=#84]
+(89) Exchange
+Input [6]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum#78, isEmpty#79, count#80]
+Arguments: hashpartitioning(i_brand_id#72, i_class_id#73, i_category_id#74, 5), ENSURE_REQUIREMENTS, [id=#81]
 
-(99) HashAggregate [codegen id : 92]
-Input [6]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum#81, isEmpty#82, count#83]
-Keys [3]: [i_brand_id#75, i_class_id#76, i_category_id#77]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#85, count(1)#86]
-Results [5]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#85 AS sales#87, count(1)#86 AS number_sales#88]
+(90) HashAggregate [codegen id : 80]
+Input [6]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum#78, isEmpty#79, count#80]
+Keys [3]: [i_brand_id#72, i_class_id#73, i_category_id#74]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#82, count(1)#83]
+Results [5]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#82 AS sales#84, count(1)#83 AS number_sales#85]
 
-(100) Filter [codegen id : 92]
-Input [5]: [i_brand_id#75, i_class_id#76, i_category_id#77, sales#87, number_sales#88]
-Condition : (isnotnull(sales#87) AND (cast(sales#87 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#65, [id=#66] as decimal(32,6))))
+(91) Filter [codegen id : 80]
+Input [5]: [i_brand_id#72, i_class_id#73, i_category_id#74, sales#84, number_sales#85]
+Condition : (isnotnull(sales#84) AND (cast(sales#84 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#63, [id=#64] as decimal(32,6))))
 
-(101) Project [codegen id : 92]
-Output [6]: [sales#87, number_sales#88, catalog AS channel#89, i_brand_id#75, i_class_id#76, i_category_id#77]
-Input [5]: [i_brand_id#75, i_class_id#76, i_category_id#77, sales#87, number_sales#88]
+(92) Project [codegen id : 80]
+Output [6]: [sales#84, number_sales#85, catalog AS channel#86, i_brand_id#72, i_class_id#73, i_category_id#74]
+Input [5]: [i_brand_id#72, i_class_id#73, i_category_id#74, sales#84, number_sales#85]
 
-(102) Scan parquet default.web_sales
-Output [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
+(93) Scan parquet default.web_sales
+Output [4]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#93), dynamicpruningexpression(ws_sold_date_sk#93 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#90), dynamicpruningexpression(ws_sold_date_sk#90 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(103) ColumnarToRow [codegen id : 93]
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
+(94) ColumnarToRow [codegen id : 119]
+Input [4]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
 
-(104) Filter [codegen id : 93]
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
-Condition : isnotnull(ws_item_sk#90)
+(95) Filter [codegen id : 119]
+Input [4]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Condition : isnotnull(ws_item_sk#87)
+
+(96) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
+
+(97) BroadcastHashJoin [codegen id : 119]
+Left keys [1]: [ws_item_sk#87]
+Right keys [1]: [ss_item_sk#44]
+Join condition: None
+
+(98) ReusedExchange [Reuses operator id: 138]
+Output [1]: [d_date_sk#91]
+
+(99) BroadcastHashJoin [codegen id : 119]
+Left keys [1]: [ws_sold_date_sk#90]
+Right keys [1]: [d_date_sk#91]
+Join condition: None
+
+(100) Project [codegen id : 119]
+Output [3]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89]
+Input [5]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90, d_date_sk#91]
+
+(101) ReusedExchange [Reuses operator id: 69]
+Output [4]: [i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95]
+
+(102) BroadcastHashJoin [codegen id : 119]
+Left keys [1]: [ws_item_sk#87]
+Right keys [1]: [i_item_sk#92]
+Join condition: None
+
+(103) Project [codegen id : 119]
+Output [5]: [ws_quantity#88, ws_list_price#89, i_brand_id#93, i_class_id#94, i_category_id#95]
+Input [7]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95]
+
+(104) HashAggregate [codegen id : 119]
+Input [5]: [ws_quantity#88, ws_list_price#89, i_brand_id#93, i_class_id#94, i_category_id#95]
+Keys [3]: [i_brand_id#93, i_class_id#94, i_category_id#95]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
+Aggregate Attributes [3]: [sum#96, isEmpty#97, count#98]
+Results [6]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum#99, isEmpty#100, count#101]
 
 (105) Exchange
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
-Arguments: hashpartitioning(ws_item_sk#90, 5), ENSURE_REQUIREMENTS, [id=#94]
+Input [6]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum#99, isEmpty#100, count#101]
+Arguments: hashpartitioning(i_brand_id#93, i_class_id#94, i_category_id#95, 5), ENSURE_REQUIREMENTS, [id=#102]
 
-(106) Sort [codegen id : 94]
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
-Arguments: [ws_item_sk#90 ASC NULLS FIRST], false, 0
+(106) HashAggregate [codegen id : 120]
+Input [6]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum#99, isEmpty#100, count#101]
+Keys [3]: [i_brand_id#93, i_class_id#94, i_category_id#95]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true))#103, count(1)#104]
+Results [5]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true))#103 AS sales#105, count(1)#104 AS number_sales#106]
 
-(107) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
+(107) Filter [codegen id : 120]
+Input [5]: [i_brand_id#93, i_class_id#94, i_category_id#95, sales#105, number_sales#106]
+Condition : (isnotnull(sales#105) AND (cast(sales#105 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#63, [id=#64] as decimal(32,6))))
 
-(108) Sort [codegen id : 113]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
+(108) Project [codegen id : 120]
+Output [6]: [sales#105, number_sales#106, web AS channel#107, i_brand_id#93, i_class_id#94, i_category_id#95]
+Input [5]: [i_brand_id#93, i_class_id#94, i_category_id#95, sales#105, number_sales#106]
 
-(109) SortMergeJoin [codegen id : 137]
-Left keys [1]: [ws_item_sk#90]
-Right keys [1]: [ss_item_sk#45]
-Join condition: None
+(109) Union
 
-(110) ReusedExchange [Reuses operator id: 150]
-Output [1]: [d_date_sk#95]
+(110) Expand [codegen id : 121]
+Input [6]: [sales#61, number_sales#62, channel#65, i_brand_id#48, i_class_id#49, i_category_id#50]
+Arguments: [[sales#61, number_sales#62, channel#65, i_brand_id#48, i_class_id#49, i_category_id#50, 0], [sales#61, number_sales#62, channel#65, i_brand_id#48, i_class_id#49, null, 1], [sales#61, number_sales#62, channel#65, i_brand_id#48, null, null, 3], [sales#61, number_sales#62, channel#65, null, null, null, 7], [sales#61, number_sales#62, null, null, null, null, 15]], [sales#61, number_sales#62, channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112]
 
-(111) BroadcastHashJoin [codegen id : 137]
-Left keys [1]: [ws_sold_date_sk#93]
-Right keys [1]: [d_date_sk#95]
-Join condition: None
+(111) HashAggregate [codegen id : 121]
+Input [7]: [sales#61, number_sales#62, channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112]
+Keys [5]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112]
+Functions [2]: [partial_sum(sales#61), partial_sum(number_sales#62)]
+Aggregate Attributes [3]: [sum#113, isEmpty#114, sum#115]
+Results [8]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112, sum#116, isEmpty#117, sum#118]
 
-(112) Project [codegen id : 137]
-Output [3]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92]
-Input [5]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93, d_date_sk#95]
+(112) Exchange
+Input [8]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112, sum#116, isEmpty#117, sum#118]
+Arguments: hashpartitioning(channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112, 5), ENSURE_REQUIREMENTS, [id=#119]
 
-(113) ReusedExchange [Reuses operator id: 75]
-Output [4]: [i_item_sk#96, i_brand_id#97, i_class_id#98, i_category_id#99]
+(113) HashAggregate [codegen id : 122]
+Input [8]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112, sum#116, isEmpty#117, sum#118]
+Keys [5]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, spark_grouping_id#112]
+Functions [2]: [sum(sales#61), sum(number_sales#62)]
+Aggregate Attributes [2]: [sum(sales#61)#120, sum(number_sales#62)#121]
+Results [6]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, sum(sales#61)#120 AS sum(sales)#122, sum(number_sales#62)#121 AS sum(number_sales)#123]
 
-(114) BroadcastHashJoin [codegen id : 137]
-Left keys [1]: [ws_item_sk#90]
-Right keys [1]: [i_item_sk#96]
-Join condition: None
-
-(115) Project [codegen id : 137]
-Output [5]: [ws_quantity#91, ws_list_price#92, i_brand_id#97, i_class_id#98, i_category_id#99]
-Input [7]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, i_item_sk#96, i_brand_id#97, i_class_id#98, i_category_id#99]
-
-(116) HashAggregate [codegen id : 137]
-Input [5]: [ws_quantity#91, ws_list_price#92, i_brand_id#97, i_class_id#98, i_category_id#99]
-Keys [3]: [i_brand_id#97, i_class_id#98, i_category_id#99]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#100, isEmpty#101, count#102]
-Results [6]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum#103, isEmpty#104, count#105]
-
-(117) Exchange
-Input [6]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum#103, isEmpty#104, count#105]
-Arguments: hashpartitioning(i_brand_id#97, i_class_id#98, i_category_id#99, 5), ENSURE_REQUIREMENTS, [id=#106]
-
-(118) HashAggregate [codegen id : 138]
-Input [6]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum#103, isEmpty#104, count#105]
-Keys [3]: [i_brand_id#97, i_class_id#98, i_category_id#99]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true))#107, count(1)#108]
-Results [5]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true))#107 AS sales#109, count(1)#108 AS number_sales#110]
-
-(119) Filter [codegen id : 138]
-Input [5]: [i_brand_id#97, i_class_id#98, i_category_id#99, sales#109, number_sales#110]
-Condition : (isnotnull(sales#109) AND (cast(sales#109 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#65, [id=#66] as decimal(32,6))))
-
-(120) Project [codegen id : 138]
-Output [6]: [sales#109, number_sales#110, web AS channel#111, i_brand_id#97, i_class_id#98, i_category_id#99]
-Input [5]: [i_brand_id#97, i_class_id#98, i_category_id#99, sales#109, number_sales#110]
-
-(121) Union
-
-(122) Expand [codegen id : 139]
-Input [6]: [sales#63, number_sales#64, channel#67, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: [[sales#63, number_sales#64, channel#67, i_brand_id#49, i_class_id#50, i_category_id#51, 0], [sales#63, number_sales#64, channel#67, i_brand_id#49, i_class_id#50, null, 1], [sales#63, number_sales#64, channel#67, i_brand_id#49, null, null, 3], [sales#63, number_sales#64, channel#67, null, null, null, 7], [sales#63, number_sales#64, null, null, null, null, 15]], [sales#63, number_sales#64, channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116]
-
-(123) HashAggregate [codegen id : 139]
-Input [7]: [sales#63, number_sales#64, channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116]
-Keys [5]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116]
-Functions [2]: [partial_sum(sales#63), partial_sum(number_sales#64)]
-Aggregate Attributes [3]: [sum#117, isEmpty#118, sum#119]
-Results [8]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116, sum#120, isEmpty#121, sum#122]
-
-(124) Exchange
-Input [8]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116, sum#120, isEmpty#121, sum#122]
-Arguments: hashpartitioning(channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116, 5), ENSURE_REQUIREMENTS, [id=#123]
-
-(125) HashAggregate [codegen id : 140]
-Input [8]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116, sum#120, isEmpty#121, sum#122]
-Keys [5]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, spark_grouping_id#116]
-Functions [2]: [sum(sales#63), sum(number_sales#64)]
-Aggregate Attributes [2]: [sum(sales#63)#124, sum(number_sales#64)#125]
-Results [6]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, sum(sales#63)#124 AS sum(sales)#126, sum(number_sales#64)#125 AS sum(number_sales)#127]
-
-(126) TakeOrderedAndProject
-Input [6]: [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, sum(sales)#126, sum(number_sales)#127]
-Arguments: 100, [channel#112 ASC NULLS FIRST, i_brand_id#113 ASC NULLS FIRST, i_class_id#114 ASC NULLS FIRST, i_category_id#115 ASC NULLS FIRST], [channel#112, i_brand_id#113, i_class_id#114, i_category_id#115, sum(sales)#126, sum(number_sales)#127]
+(114) TakeOrderedAndProject
+Input [6]: [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, sum(sales)#122, sum(number_sales)#123]
+Arguments: 100, [channel#108 ASC NULLS FIRST, i_brand_id#109 ASC NULLS FIRST, i_class_id#110 ASC NULLS FIRST, i_category_id#111 ASC NULLS FIRST], [channel#108, i_brand_id#109, i_class_id#110, i_category_id#111, sum(sales)#122, sum(number_sales)#123]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 81 Hosting Expression = Subquery scalar-subquery#65, [id=#66]
-* HashAggregate (145)
-+- Exchange (144)
-   +- * HashAggregate (143)
-      +- Union (142)
-         :- * Project (131)
-         :  +- * BroadcastHashJoin Inner BuildRight (130)
-         :     :- * ColumnarToRow (128)
-         :     :  +- Scan parquet default.store_sales (127)
-         :     +- ReusedExchange (129)
-         :- * Project (136)
-         :  +- * BroadcastHashJoin Inner BuildRight (135)
-         :     :- * ColumnarToRow (133)
-         :     :  +- Scan parquet default.catalog_sales (132)
-         :     +- ReusedExchange (134)
-         +- * Project (141)
-            +- * BroadcastHashJoin Inner BuildRight (140)
-               :- * ColumnarToRow (138)
-               :  +- Scan parquet default.web_sales (137)
-               +- ReusedExchange (139)
+Subquery:1 Hosting operator id = 75 Hosting Expression = Subquery scalar-subquery#63, [id=#64]
+* HashAggregate (133)
++- Exchange (132)
+   +- * HashAggregate (131)
+      +- Union (130)
+         :- * Project (119)
+         :  +- * BroadcastHashJoin Inner BuildRight (118)
+         :     :- * ColumnarToRow (116)
+         :     :  +- Scan parquet default.store_sales (115)
+         :     +- ReusedExchange (117)
+         :- * Project (124)
+         :  +- * BroadcastHashJoin Inner BuildRight (123)
+         :     :- * ColumnarToRow (121)
+         :     :  +- Scan parquet default.catalog_sales (120)
+         :     +- ReusedExchange (122)
+         +- * Project (129)
+            +- * BroadcastHashJoin Inner BuildRight (128)
+               :- * ColumnarToRow (126)
+               :  +- Scan parquet default.web_sales (125)
+               +- ReusedExchange (127)
 
 
-(127) Scan parquet default.store_sales
-Output [3]: [ss_quantity#128, ss_list_price#129, ss_sold_date_sk#130]
+(115) Scan parquet default.store_sales
+Output [3]: [ss_quantity#124, ss_list_price#125, ss_sold_date_sk#126]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#130), dynamicpruningexpression(ss_sold_date_sk#130 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#126), dynamicpruningexpression(ss_sold_date_sk#126 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(128) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#128, ss_list_price#129, ss_sold_date_sk#130]
+(116) ColumnarToRow [codegen id : 2]
+Input [3]: [ss_quantity#124, ss_list_price#125, ss_sold_date_sk#126]
 
-(129) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#131]
+(117) ReusedExchange [Reuses operator id: 143]
+Output [1]: [d_date_sk#127]
 
-(130) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#130]
-Right keys [1]: [d_date_sk#131]
+(118) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_sold_date_sk#126]
+Right keys [1]: [d_date_sk#127]
 Join condition: None
 
-(131) Project [codegen id : 2]
-Output [2]: [ss_quantity#128 AS quantity#132, ss_list_price#129 AS list_price#133]
-Input [4]: [ss_quantity#128, ss_list_price#129, ss_sold_date_sk#130, d_date_sk#131]
+(119) Project [codegen id : 2]
+Output [2]: [ss_quantity#124 AS quantity#128, ss_list_price#125 AS list_price#129]
+Input [4]: [ss_quantity#124, ss_list_price#125, ss_sold_date_sk#126, d_date_sk#127]
 
-(132) Scan parquet default.catalog_sales
-Output [3]: [cs_quantity#134, cs_list_price#135, cs_sold_date_sk#136]
+(120) Scan parquet default.catalog_sales
+Output [3]: [cs_quantity#130, cs_list_price#131, cs_sold_date_sk#132]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#136), dynamicpruningexpression(cs_sold_date_sk#136 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#132), dynamicpruningexpression(cs_sold_date_sk#132 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(133) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#134, cs_list_price#135, cs_sold_date_sk#136]
+(121) ColumnarToRow [codegen id : 4]
+Input [3]: [cs_quantity#130, cs_list_price#131, cs_sold_date_sk#132]
 
-(134) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#137]
+(122) ReusedExchange [Reuses operator id: 143]
+Output [1]: [d_date_sk#133]
 
-(135) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#136]
-Right keys [1]: [d_date_sk#137]
+(123) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#132]
+Right keys [1]: [d_date_sk#133]
 Join condition: None
 
-(136) Project [codegen id : 4]
-Output [2]: [cs_quantity#134 AS quantity#138, cs_list_price#135 AS list_price#139]
-Input [4]: [cs_quantity#134, cs_list_price#135, cs_sold_date_sk#136, d_date_sk#137]
+(124) Project [codegen id : 4]
+Output [2]: [cs_quantity#130 AS quantity#134, cs_list_price#131 AS list_price#135]
+Input [4]: [cs_quantity#130, cs_list_price#131, cs_sold_date_sk#132, d_date_sk#133]
 
-(137) Scan parquet default.web_sales
-Output [3]: [ws_quantity#140, ws_list_price#141, ws_sold_date_sk#142]
+(125) Scan parquet default.web_sales
+Output [3]: [ws_quantity#136, ws_list_price#137, ws_sold_date_sk#138]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#142), dynamicpruningexpression(ws_sold_date_sk#142 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#138), dynamicpruningexpression(ws_sold_date_sk#138 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(138) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#140, ws_list_price#141, ws_sold_date_sk#142]
+(126) ColumnarToRow [codegen id : 6]
+Input [3]: [ws_quantity#136, ws_list_price#137, ws_sold_date_sk#138]
 
-(139) ReusedExchange [Reuses operator id: 155]
-Output [1]: [d_date_sk#143]
+(127) ReusedExchange [Reuses operator id: 143]
+Output [1]: [d_date_sk#139]
 
-(140) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#142]
-Right keys [1]: [d_date_sk#143]
+(128) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#138]
+Right keys [1]: [d_date_sk#139]
 Join condition: None
 
-(141) Project [codegen id : 6]
-Output [2]: [ws_quantity#140 AS quantity#144, ws_list_price#141 AS list_price#145]
-Input [4]: [ws_quantity#140, ws_list_price#141, ws_sold_date_sk#142, d_date_sk#143]
+(129) Project [codegen id : 6]
+Output [2]: [ws_quantity#136 AS quantity#140, ws_list_price#137 AS list_price#141]
+Input [4]: [ws_quantity#136, ws_list_price#137, ws_sold_date_sk#138, d_date_sk#139]
 
-(142) Union
+(130) Union
 
-(143) HashAggregate [codegen id : 7]
-Input [2]: [quantity#132, list_price#133]
+(131) HashAggregate [codegen id : 7]
+Input [2]: [quantity#128, list_price#129]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#132 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#133 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#146, count#147]
-Results [2]: [sum#148, count#149]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#128 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#129 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#142, count#143]
+Results [2]: [sum#144, count#145]
 
-(144) Exchange
-Input [2]: [sum#148, count#149]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#150]
+(132) Exchange
+Input [2]: [sum#144, count#145]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#146]
 
-(145) HashAggregate [codegen id : 8]
-Input [2]: [sum#148, count#149]
+(133) HashAggregate [codegen id : 8]
+Input [2]: [sum#144, count#145]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#132 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#133 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#132 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#133 as decimal(12,2)))), DecimalType(18,2), true))#151]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#132 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#133 as decimal(12,2)))), DecimalType(18,2), true))#151 AS average_sales#152]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#128 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#129 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#128 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#129 as decimal(12,2)))), DecimalType(18,2), true))#147]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#128 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#129 as decimal(12,2)))), DecimalType(18,2), true))#147 AS average_sales#148]
 
-Subquery:2 Hosting operator id = 127 Hosting Expression = ss_sold_date_sk#130 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 115 Hosting Expression = ss_sold_date_sk#126 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 132 Hosting Expression = cs_sold_date_sk#136 IN dynamicpruning#13
+Subquery:3 Hosting operator id = 120 Hosting Expression = cs_sold_date_sk#132 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 137 Hosting Expression = ws_sold_date_sk#142 IN dynamicpruning#13
+Subquery:4 Hosting operator id = 125 Hosting Expression = ws_sold_date_sk#138 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (150)
-+- * Project (149)
-   +- * Filter (148)
-      +- * ColumnarToRow (147)
-         +- Scan parquet default.date_dim (146)
+BroadcastExchange (138)
++- * Project (137)
+   +- * Filter (136)
+      +- * ColumnarToRow (135)
+         +- Scan parquet default.date_dim (134)
 
 
-(146) Scan parquet default.date_dim
-Output [3]: [d_date_sk#47, d_year#153, d_moy#154]
+(134) Scan parquet default.date_dim
+Output [3]: [d_date_sk#46, d_year#149, d_moy#150]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(147) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#47, d_year#153, d_moy#154]
+(135) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#46, d_year#149, d_moy#150]
 
-(148) Filter [codegen id : 1]
-Input [3]: [d_date_sk#47, d_year#153, d_moy#154]
-Condition : ((((isnotnull(d_year#153) AND isnotnull(d_moy#154)) AND (d_year#153 = 2001)) AND (d_moy#154 = 11)) AND isnotnull(d_date_sk#47))
+(136) Filter [codegen id : 1]
+Input [3]: [d_date_sk#46, d_year#149, d_moy#150]
+Condition : ((((isnotnull(d_year#149) AND isnotnull(d_moy#150)) AND (d_year#149 = 2001)) AND (d_moy#150 = 11)) AND isnotnull(d_date_sk#46))
 
-(149) Project [codegen id : 1]
-Output [1]: [d_date_sk#47]
-Input [3]: [d_date_sk#47, d_year#153, d_moy#154]
+(137) Project [codegen id : 1]
+Output [1]: [d_date_sk#46]
+Input [3]: [d_date_sk#46, d_year#149, d_moy#150]
 
-(150) BroadcastExchange
-Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#155]
+(138) BroadcastExchange
+Input [1]: [d_date_sk#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#151]
 
-Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
-BroadcastExchange (155)
-+- * Project (154)
-   +- * Filter (153)
-      +- * ColumnarToRow (152)
-         +- Scan parquet default.date_dim (151)
+Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
+BroadcastExchange (143)
++- * Project (142)
+   +- * Filter (141)
+      +- * ColumnarToRow (140)
+         +- Scan parquet default.date_dim (139)
 
 
-(151) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#156]
+(139) Scan parquet default.date_dim
+Output [2]: [d_date_sk#13, d_year#152]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(152) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#156]
+(140) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#152]
 
-(153) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#156]
-Condition : (((isnotnull(d_year#156) AND (d_year#156 >= 1999)) AND (d_year#156 <= 2001)) AND isnotnull(d_date_sk#14))
+(141) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#152]
+Condition : (((isnotnull(d_year#152) AND (d_year#152 >= 1999)) AND (d_year#152 <= 2001)) AND isnotnull(d_date_sk#13))
 
-(154) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#156]
+(142) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_year#152]
 
-(155) BroadcastExchange
-Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#157]
+(143) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#153]
 
-Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:7 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#20 IN dynamicpruning#12
 
-Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#35 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 100 Hosting Expression = ReusedSubquery Subquery scalar-subquery#65, [id=#66]
+Subquery:9 Hosting operator id = 91 Hosting Expression = ReusedSubquery Subquery scalar-subquery#63, [id=#64]
 
-Subquery:10 Hosting operator id = 83 Hosting Expression = cs_sold_date_sk#71 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 77 Hosting Expression = cs_sold_date_sk#69 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 119 Hosting Expression = ReusedSubquery Subquery scalar-subquery#65, [id=#66]
+Subquery:11 Hosting operator id = 107 Hosting Expression = ReusedSubquery Subquery scalar-subquery#63, [id=#64]
 
-Subquery:12 Hosting operator id = 102 Hosting Expression = ws_sold_date_sk#93 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 93 Hosting Expression = ws_sold_date_sk#90 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
@@ -1,21 +1,21 @@
 TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),sum(number_sales)]
-  WholeStageCodegen (140)
+  WholeStageCodegen (122)
     HashAggregate [channel,i_brand_id,i_class_id,i_category_id,spark_grouping_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum(sales),sum(number_sales),sum,isEmpty,sum]
       InputAdapter
         Exchange [channel,i_brand_id,i_class_id,i_category_id,spark_grouping_id] #1
-          WholeStageCodegen (139)
+          WholeStageCodegen (121)
             HashAggregate [channel,i_brand_id,i_class_id,i_category_id,spark_grouping_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
               Expand [sales,number_sales,channel,i_brand_id,i_class_id,i_category_id]
                 InputAdapter
                   Union
-                    WholeStageCodegen (46)
+                    WholeStageCodegen (40)
                       Project [sales,number_sales,i_brand_id,i_class_id,i_category_id]
                         Filter [sales]
                           Subquery #3
                             WholeStageCodegen (8)
                               HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
                                 InputAdapter
-                                  Exchange #18
+                                  Exchange #16
                                     WholeStageCodegen (7)
                                       HashAggregate [quantity,list_price] [sum,count,sum,count]
                                         InputAdapter
@@ -28,7 +28,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                       Scan parquet default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
                                                         ReusedSubquery [d_date_sk] #2
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #10
+                                                    ReusedExchange [d_date_sk] #9
                                             WholeStageCodegen (4)
                                               Project [cs_quantity,cs_list_price]
                                                 BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -37,7 +37,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                       Scan parquet default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
                                                         ReusedSubquery [d_date_sk] #2
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #10
+                                                    ReusedExchange [d_date_sk] #9
                                             WholeStageCodegen (6)
                                               Project [ws_quantity,ws_list_price]
                                                 BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -46,228 +46,192 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                       Scan parquet default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
                                                         ReusedSubquery [d_date_sk] #2
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #10
+                                                    ReusedExchange [d_date_sk] #9
                           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum,isEmpty,count]
                             InputAdapter
                               Exchange [i_brand_id,i_class_id,i_category_id] #2
-                                WholeStageCodegen (45)
+                                WholeStageCodegen (39)
                                   HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                     Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                                       BroadcastHashJoin [ss_item_sk,i_item_sk]
                                         Project [ss_item_sk,ss_quantity,ss_list_price]
                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                            SortMergeJoin [ss_item_sk,ss_item_sk]
-                                              InputAdapter
-                                                WholeStageCodegen (2)
-                                                  Sort [ss_item_sk]
-                                                    InputAdapter
-                                                      Exchange [ss_item_sk] #3
-                                                        WholeStageCodegen (1)
-                                                          Filter [ss_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #1
-                                                                    BroadcastExchange #4
-                                                                      WholeStageCodegen (1)
-                                                                        Project [d_date_sk]
-                                                                          Filter [d_year,d_moy,d_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
-                                              InputAdapter
-                                                WholeStageCodegen (21)
-                                                  Sort [ss_item_sk]
-                                                    InputAdapter
-                                                      Exchange [ss_item_sk] #5
-                                                        WholeStageCodegen (20)
-                                                          Project [i_item_sk]
-                                                            BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                                              Filter [i_brand_id,i_class_id,i_category_id]
+                                            BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                                              Filter [ss_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
+                                                      SubqueryBroadcast [d_date_sk] #1
+                                                        BroadcastExchange #3
+                                                          WholeStageCodegen (1)
+                                                            Project [d_date_sk]
+                                                              Filter [d_year,d_moy,d_date_sk]
                                                                 ColumnarToRow
                                                                   InputAdapter
-                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                              InputAdapter
-                                                                BroadcastExchange #6
-                                                                  WholeStageCodegen (19)
-                                                                    HashAggregate [brand_id,class_id,category_id]
-                                                                      InputAdapter
-                                                                        Exchange [brand_id,class_id,category_id] #7
-                                                                          WholeStageCodegen (18)
-                                                                            HashAggregate [brand_id,class_id,category_id]
-                                                                              SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                InputAdapter
-                                                                                  WholeStageCodegen (13)
-                                                                                    Sort [brand_id,class_id,category_id]
-                                                                                      InputAdapter
-                                                                                        Exchange [brand_id,class_id,category_id] #8
-                                                                                          WholeStageCodegen (12)
-                                                                                            HashAggregate [brand_id,class_id,category_id]
-                                                                                              InputAdapter
-                                                                                                Exchange [brand_id,class_id,category_id] #9
-                                                                                                  WholeStageCodegen (11)
-                                                                                                    HashAggregate [brand_id,class_id,category_id]
-                                                                                                      Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                        BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                          Project [ss_item_sk]
-                                                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                              Filter [ss_item_sk]
-                                                                                                                ColumnarToRow
-                                                                                                                  InputAdapter
-                                                                                                                    Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                                                      SubqueryBroadcast [d_date_sk] #2
-                                                                                                                        BroadcastExchange #10
-                                                                                                                          WholeStageCodegen (1)
-                                                                                                                            Project [d_date_sk]
-                                                                                                                              Filter [d_year,d_date_sk]
-                                                                                                                                ColumnarToRow
-                                                                                                                                  InputAdapter
-                                                                                                                                    Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                              InputAdapter
-                                                                                                                ReusedExchange [d_date_sk] #10
-                                                                                                          InputAdapter
-                                                                                                            BroadcastExchange #11
-                                                                                                              WholeStageCodegen (10)
-                                                                                                                SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                  InputAdapter
-                                                                                                                    WholeStageCodegen (5)
-                                                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                        InputAdapter
-                                                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #12
-                                                                                                                            WholeStageCodegen (4)
-                                                                                                                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                ColumnarToRow
-                                                                                                                                  InputAdapter
-                                                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                  InputAdapter
-                                                                                                                    WholeStageCodegen (9)
-                                                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                        InputAdapter
-                                                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #13
-                                                                                                                            WholeStageCodegen (8)
-                                                                                                                              Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                                  Project [cs_item_sk]
-                                                                                                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                                      Filter [cs_item_sk]
-                                                                                                                                        ColumnarToRow
-                                                                                                                                          InputAdapter
-                                                                                                                                            Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                                              ReusedSubquery [d_date_sk] #2
-                                                                                                                                      InputAdapter
-                                                                                                                                        ReusedExchange [d_date_sk] #10
-                                                                                                                                  InputAdapter
-                                                                                                                                    BroadcastExchange #14
-                                                                                                                                      WholeStageCodegen (7)
-                                                                                                                                        Filter [i_item_sk]
-                                                                                                                                          ColumnarToRow
-                                                                                                                                            InputAdapter
-                                                                                                                                              Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                InputAdapter
-                                                                                  WholeStageCodegen (17)
-                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                      InputAdapter
-                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #15
-                                                                                          WholeStageCodegen (16)
-                                                                                            Project [i_brand_id,i_class_id,i_category_id]
-                                                                                              BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                Project [ws_item_sk]
-                                                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                    Filter [ws_item_sk]
-                                                                                                      ColumnarToRow
-                                                                                                        InputAdapter
-                                                                                                          Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                                            ReusedSubquery [d_date_sk] #2
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [d_date_sk] #10
-                                                                                                InputAdapter
-                                                                                                  ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14
-                                            InputAdapter
-                                              ReusedExchange [d_date_sk] #4
-                                        InputAdapter
-                                          BroadcastExchange #16
-                                            WholeStageCodegen (44)
-                                              SortMergeJoin [i_item_sk,ss_item_sk]
-                                                InputAdapter
-                                                  WholeStageCodegen (24)
-                                                    Sort [i_item_sk]
-                                                      InputAdapter
-                                                        Exchange [i_item_sk] #17
-                                                          WholeStageCodegen (23)
-                                                            Filter [i_item_sk]
-                                                              ColumnarToRow
+                                                                    Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
+                                              InputAdapter
+                                                BroadcastExchange #4
+                                                  WholeStageCodegen (18)
+                                                    Project [i_item_sk]
+                                                      BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
+                                                        Filter [i_brand_id,i_class_id,i_category_id]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                        InputAdapter
+                                                          BroadcastExchange #5
+                                                            WholeStageCodegen (17)
+                                                              HashAggregate [brand_id,class_id,category_id]
                                                                 InputAdapter
-                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                  Exchange [brand_id,class_id,category_id] #6
+                                                                    WholeStageCodegen (16)
+                                                                      HashAggregate [brand_id,class_id,category_id]
+                                                                        SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                          InputAdapter
+                                                                            WholeStageCodegen (11)
+                                                                              Sort [brand_id,class_id,category_id]
+                                                                                InputAdapter
+                                                                                  Exchange [brand_id,class_id,category_id] #7
+                                                                                    WholeStageCodegen (10)
+                                                                                      HashAggregate [brand_id,class_id,category_id]
+                                                                                        InputAdapter
+                                                                                          Exchange [brand_id,class_id,category_id] #8
+                                                                                            WholeStageCodegen (9)
+                                                                                              HashAggregate [brand_id,class_id,category_id]
+                                                                                                Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                    Project [ss_item_sk]
+                                                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                        Filter [ss_item_sk]
+                                                                                                          ColumnarToRow
+                                                                                                            InputAdapter
+                                                                                                              Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                                                SubqueryBroadcast [d_date_sk] #2
+                                                                                                                  BroadcastExchange #9
+                                                                                                                    WholeStageCodegen (1)
+                                                                                                                      Project [d_date_sk]
+                                                                                                                        Filter [d_year,d_date_sk]
+                                                                                                                          ColumnarToRow
+                                                                                                                            InputAdapter
+                                                                                                                              Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                                                        InputAdapter
+                                                                                                          ReusedExchange [d_date_sk] #9
+                                                                                                    InputAdapter
+                                                                                                      BroadcastExchange #10
+                                                                                                        WholeStageCodegen (8)
+                                                                                                          SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                                            InputAdapter
+                                                                                                              WholeStageCodegen (3)
+                                                                                                                Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                                  InputAdapter
+                                                                                                                    Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                                                      WholeStageCodegen (2)
+                                                                                                                        Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                                          ColumnarToRow
+                                                                                                                            InputAdapter
+                                                                                                                              Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                            InputAdapter
+                                                                                                              WholeStageCodegen (7)
+                                                                                                                Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                                  InputAdapter
+                                                                                                                    Exchange [i_brand_id,i_class_id,i_category_id] #12
+                                                                                                                      WholeStageCodegen (6)
+                                                                                                                        Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                          BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                            Project [cs_item_sk]
+                                                                                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                                                Filter [cs_item_sk]
+                                                                                                                                  ColumnarToRow
+                                                                                                                                    InputAdapter
+                                                                                                                                      Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                                                        ReusedSubquery [d_date_sk] #2
+                                                                                                                                InputAdapter
+                                                                                                                                  ReusedExchange [d_date_sk] #9
+                                                                                                                            InputAdapter
+                                                                                                                              BroadcastExchange #13
+                                                                                                                                WholeStageCodegen (5)
+                                                                                                                                  Filter [i_item_sk]
+                                                                                                                                    ColumnarToRow
+                                                                                                                                      InputAdapter
+                                                                                                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                          InputAdapter
+                                                                            WholeStageCodegen (15)
+                                                                              Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                InputAdapter
+                                                                                  Exchange [i_brand_id,i_class_id,i_category_id] #14
+                                                                                    WholeStageCodegen (14)
+                                                                                      Project [i_brand_id,i_class_id,i_category_id]
+                                                                                        BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                          Project [ws_item_sk]
+                                                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                              Filter [ws_item_sk]
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                                                      ReusedSubquery [d_date_sk] #2
+                                                                                              InputAdapter
+                                                                                                ReusedExchange [d_date_sk] #9
+                                                                                          InputAdapter
+                                                                                            ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk] #3
+                                        InputAdapter
+                                          BroadcastExchange #15
+                                            WholeStageCodegen (38)
+                                              BroadcastHashJoin [i_item_sk,ss_item_sk]
+                                                Filter [i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                 InputAdapter
-                                                  WholeStageCodegen (43)
-                                                    Sort [ss_item_sk]
-                                                      InputAdapter
-                                                        ReusedExchange [ss_item_sk] #5
-                    WholeStageCodegen (92)
+                                                  ReusedExchange [ss_item_sk] #4
+                    WholeStageCodegen (80)
                       Project [sales,number_sales,i_brand_id,i_class_id,i_category_id]
                         Filter [sales]
                           ReusedSubquery [average_sales] #3
                           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum,isEmpty,count]
                             InputAdapter
-                              Exchange [i_brand_id,i_class_id,i_category_id] #19
-                                WholeStageCodegen (91)
+                              Exchange [i_brand_id,i_class_id,i_category_id] #17
+                                WholeStageCodegen (79)
                                   HashAggregate [i_brand_id,i_class_id,i_category_id,cs_quantity,cs_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                     Project [cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
                                       BroadcastHashJoin [cs_item_sk,i_item_sk]
                                         Project [cs_item_sk,cs_quantity,cs_list_price]
                                           BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                            SortMergeJoin [cs_item_sk,ss_item_sk]
+                                            BroadcastHashJoin [cs_item_sk,ss_item_sk]
+                                              Filter [cs_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.catalog_sales [cs_item_sk,cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                      ReusedSubquery [d_date_sk] #1
                                               InputAdapter
-                                                WholeStageCodegen (48)
-                                                  Sort [cs_item_sk]
-                                                    InputAdapter
-                                                      Exchange [cs_item_sk] #20
-                                                        WholeStageCodegen (47)
-                                                          Filter [cs_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.catalog_sales [cs_item_sk,cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #1
-                                              InputAdapter
-                                                WholeStageCodegen (67)
-                                                  Sort [ss_item_sk]
-                                                    InputAdapter
-                                                      ReusedExchange [ss_item_sk] #5
+                                                ReusedExchange [ss_item_sk] #4
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #4
+                                              ReusedExchange [d_date_sk] #3
                                         InputAdapter
-                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #16
-                    WholeStageCodegen (138)
+                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                    WholeStageCodegen (120)
                       Project [sales,number_sales,i_brand_id,i_class_id,i_category_id]
                         Filter [sales]
                           ReusedSubquery [average_sales] #3
                           HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),sales,number_sales,sum,isEmpty,count]
                             InputAdapter
-                              Exchange [i_brand_id,i_class_id,i_category_id] #21
-                                WholeStageCodegen (137)
+                              Exchange [i_brand_id,i_class_id,i_category_id] #18
+                                WholeStageCodegen (119)
                                   HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                     Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
                                       BroadcastHashJoin [ws_item_sk,i_item_sk]
                                         Project [ws_item_sk,ws_quantity,ws_list_price]
                                           BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                            SortMergeJoin [ws_item_sk,ss_item_sk]
+                                            BroadcastHashJoin [ws_item_sk,ss_item_sk]
+                                              Filter [ws_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet default.web_sales [ws_item_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                      ReusedSubquery [d_date_sk] #1
                                               InputAdapter
-                                                WholeStageCodegen (94)
-                                                  Sort [ws_item_sk]
-                                                    InputAdapter
-                                                      Exchange [ws_item_sk] #22
-                                                        WholeStageCodegen (93)
-                                                          Filter [ws_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.web_sales [ws_item_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #1
-                                              InputAdapter
-                                                WholeStageCodegen (113)
-                                                  Sort [ss_item_sk]
-                                                    InputAdapter
-                                                      ReusedExchange [ss_item_sk] #5
+                                                ReusedExchange [ss_item_sk] #4
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #4
+                                              ReusedExchange [d_date_sk] #3
                                         InputAdapter
-                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #16
+                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -1,106 +1,97 @@
 == Physical Plan ==
-TakeOrderedAndProject (102)
-+- * BroadcastHashJoin Inner BuildRight (101)
-   :- * Filter (81)
-   :  +- * HashAggregate (80)
-   :     +- Exchange (79)
-   :        +- * HashAggregate (78)
-   :           +- * Project (77)
-   :              +- * BroadcastHashJoin Inner BuildRight (76)
-   :                 :- * Project (66)
-   :                 :  +- * BroadcastHashJoin Inner BuildRight (65)
-   :                 :     :- * SortMergeJoin LeftSemi (63)
-   :                 :     :  :- * Sort (5)
-   :                 :     :  :  +- Exchange (4)
-   :                 :     :  :     +- * Filter (3)
-   :                 :     :  :        +- * ColumnarToRow (2)
-   :                 :     :  :           +- Scan parquet default.store_sales (1)
-   :                 :     :  +- * Sort (62)
-   :                 :     :     +- Exchange (61)
-   :                 :     :        +- * Project (60)
-   :                 :     :           +- * BroadcastHashJoin Inner BuildRight (59)
-   :                 :     :              :- * Filter (8)
-   :                 :     :              :  +- * ColumnarToRow (7)
-   :                 :     :              :     +- Scan parquet default.item (6)
-   :                 :     :              +- BroadcastExchange (58)
-   :                 :     :                 +- * HashAggregate (57)
-   :                 :     :                    +- Exchange (56)
-   :                 :     :                       +- * HashAggregate (55)
-   :                 :     :                          +- * SortMergeJoin LeftSemi (54)
-   :                 :     :                             :- * Sort (42)
-   :                 :     :                             :  +- Exchange (41)
-   :                 :     :                             :     +- * HashAggregate (40)
-   :                 :     :                             :        +- Exchange (39)
-   :                 :     :                             :           +- * HashAggregate (38)
-   :                 :     :                             :              +- * Project (37)
-   :                 :     :                             :                 +- * BroadcastHashJoin Inner BuildRight (36)
-   :                 :     :                             :                    :- * Project (14)
-   :                 :     :                             :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-   :                 :     :                             :                    :     :- * Filter (11)
-   :                 :     :                             :                    :     :  +- * ColumnarToRow (10)
-   :                 :     :                             :                    :     :     +- Scan parquet default.store_sales (9)
-   :                 :     :                             :                    :     +- ReusedExchange (12)
-   :                 :     :                             :                    +- BroadcastExchange (35)
-   :                 :     :                             :                       +- * SortMergeJoin LeftSemi (34)
-   :                 :     :                             :                          :- * Sort (19)
-   :                 :     :                             :                          :  +- Exchange (18)
-   :                 :     :                             :                          :     +- * Filter (17)
-   :                 :     :                             :                          :        +- * ColumnarToRow (16)
-   :                 :     :                             :                          :           +- Scan parquet default.item (15)
-   :                 :     :                             :                          +- * Sort (33)
-   :                 :     :                             :                             +- Exchange (32)
-   :                 :     :                             :                                +- * Project (31)
-   :                 :     :                             :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-   :                 :     :                             :                                      :- * Project (25)
-   :                 :     :                             :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-   :                 :     :                             :                                      :     :- * Filter (22)
-   :                 :     :                             :                                      :     :  +- * ColumnarToRow (21)
-   :                 :     :                             :                                      :     :     +- Scan parquet default.catalog_sales (20)
-   :                 :     :                             :                                      :     +- ReusedExchange (23)
-   :                 :     :                             :                                      +- BroadcastExchange (29)
-   :                 :     :                             :                                         +- * Filter (28)
-   :                 :     :                             :                                            +- * ColumnarToRow (27)
-   :                 :     :                             :                                               +- Scan parquet default.item (26)
-   :                 :     :                             +- * Sort (53)
-   :                 :     :                                +- Exchange (52)
-   :                 :     :                                   +- * Project (51)
-   :                 :     :                                      +- * BroadcastHashJoin Inner BuildRight (50)
-   :                 :     :                                         :- * Project (48)
-   :                 :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (47)
-   :                 :     :                                         :     :- * Filter (45)
-   :                 :     :                                         :     :  +- * ColumnarToRow (44)
-   :                 :     :                                         :     :     +- Scan parquet default.web_sales (43)
-   :                 :     :                                         :     +- ReusedExchange (46)
-   :                 :     :                                         +- ReusedExchange (49)
-   :                 :     +- ReusedExchange (64)
-   :                 +- BroadcastExchange (75)
-   :                    +- * SortMergeJoin LeftSemi (74)
-   :                       :- * Sort (71)
-   :                       :  +- Exchange (70)
-   :                       :     +- * Filter (69)
-   :                       :        +- * ColumnarToRow (68)
-   :                       :           +- Scan parquet default.item (67)
-   :                       +- * Sort (73)
-   :                          +- ReusedExchange (72)
-   +- BroadcastExchange (100)
-      +- * Filter (99)
-         +- * HashAggregate (98)
-            +- Exchange (97)
-               +- * HashAggregate (96)
-                  +- * Project (95)
-                     +- * BroadcastHashJoin Inner BuildRight (94)
-                        :- * Project (92)
-                        :  +- * BroadcastHashJoin Inner BuildRight (91)
-                        :     :- * SortMergeJoin LeftSemi (89)
-                        :     :  :- * Sort (86)
-                        :     :  :  +- Exchange (85)
-                        :     :  :     +- * Filter (84)
-                        :     :  :        +- * ColumnarToRow (83)
-                        :     :  :           +- Scan parquet default.store_sales (82)
-                        :     :  +- * Sort (88)
-                        :     :     +- ReusedExchange (87)
-                        :     +- ReusedExchange (90)
-                        +- ReusedExchange (93)
+TakeOrderedAndProject (93)
++- * BroadcastHashJoin Inner BuildRight (92)
+   :- * Filter (75)
+   :  +- * HashAggregate (74)
+   :     +- Exchange (73)
+   :        +- * HashAggregate (72)
+   :           +- * Project (71)
+   :              +- * BroadcastHashJoin Inner BuildRight (70)
+   :                 :- * Project (63)
+   :                 :  +- * BroadcastHashJoin Inner BuildRight (62)
+   :                 :     :- * BroadcastHashJoin LeftSemi BuildRight (60)
+   :                 :     :  :- * Filter (3)
+   :                 :     :  :  +- * ColumnarToRow (2)
+   :                 :     :  :     +- Scan parquet default.store_sales (1)
+   :                 :     :  +- BroadcastExchange (59)
+   :                 :     :     +- * Project (58)
+   :                 :     :        +- * BroadcastHashJoin LeftSemi BuildRight (57)
+   :                 :     :           :- * Filter (6)
+   :                 :     :           :  +- * ColumnarToRow (5)
+   :                 :     :           :     +- Scan parquet default.item (4)
+   :                 :     :           +- BroadcastExchange (56)
+   :                 :     :              +- * HashAggregate (55)
+   :                 :     :                 +- Exchange (54)
+   :                 :     :                    +- * HashAggregate (53)
+   :                 :     :                       +- * SortMergeJoin LeftSemi (52)
+   :                 :     :                          :- * Sort (40)
+   :                 :     :                          :  +- Exchange (39)
+   :                 :     :                          :     +- * HashAggregate (38)
+   :                 :     :                          :        +- Exchange (37)
+   :                 :     :                          :           +- * HashAggregate (36)
+   :                 :     :                          :              +- * Project (35)
+   :                 :     :                          :                 +- * BroadcastHashJoin Inner BuildRight (34)
+   :                 :     :                          :                    :- * Project (12)
+   :                 :     :                          :                    :  +- * BroadcastHashJoin Inner BuildRight (11)
+   :                 :     :                          :                    :     :- * Filter (9)
+   :                 :     :                          :                    :     :  +- * ColumnarToRow (8)
+   :                 :     :                          :                    :     :     +- Scan parquet default.store_sales (7)
+   :                 :     :                          :                    :     +- ReusedExchange (10)
+   :                 :     :                          :                    +- BroadcastExchange (33)
+   :                 :     :                          :                       +- * SortMergeJoin LeftSemi (32)
+   :                 :     :                          :                          :- * Sort (17)
+   :                 :     :                          :                          :  +- Exchange (16)
+   :                 :     :                          :                          :     +- * Filter (15)
+   :                 :     :                          :                          :        +- * ColumnarToRow (14)
+   :                 :     :                          :                          :           +- Scan parquet default.item (13)
+   :                 :     :                          :                          +- * Sort (31)
+   :                 :     :                          :                             +- Exchange (30)
+   :                 :     :                          :                                +- * Project (29)
+   :                 :     :                          :                                   +- * BroadcastHashJoin Inner BuildRight (28)
+   :                 :     :                          :                                      :- * Project (23)
+   :                 :     :                          :                                      :  +- * BroadcastHashJoin Inner BuildRight (22)
+   :                 :     :                          :                                      :     :- * Filter (20)
+   :                 :     :                          :                                      :     :  +- * ColumnarToRow (19)
+   :                 :     :                          :                                      :     :     +- Scan parquet default.catalog_sales (18)
+   :                 :     :                          :                                      :     +- ReusedExchange (21)
+   :                 :     :                          :                                      +- BroadcastExchange (27)
+   :                 :     :                          :                                         +- * Filter (26)
+   :                 :     :                          :                                            +- * ColumnarToRow (25)
+   :                 :     :                          :                                               +- Scan parquet default.item (24)
+   :                 :     :                          +- * Sort (51)
+   :                 :     :                             +- Exchange (50)
+   :                 :     :                                +- * Project (49)
+   :                 :     :                                   +- * BroadcastHashJoin Inner BuildRight (48)
+   :                 :     :                                      :- * Project (46)
+   :                 :     :                                      :  +- * BroadcastHashJoin Inner BuildRight (45)
+   :                 :     :                                      :     :- * Filter (43)
+   :                 :     :                                      :     :  +- * ColumnarToRow (42)
+   :                 :     :                                      :     :     +- Scan parquet default.web_sales (41)
+   :                 :     :                                      :     +- ReusedExchange (44)
+   :                 :     :                                      +- ReusedExchange (47)
+   :                 :     +- ReusedExchange (61)
+   :                 +- BroadcastExchange (69)
+   :                    +- * BroadcastHashJoin LeftSemi BuildRight (68)
+   :                       :- * Filter (66)
+   :                       :  +- * ColumnarToRow (65)
+   :                       :     +- Scan parquet default.item (64)
+   :                       +- ReusedExchange (67)
+   +- BroadcastExchange (91)
+      +- * Filter (90)
+         +- * HashAggregate (89)
+            +- Exchange (88)
+               +- * HashAggregate (87)
+                  +- * Project (86)
+                     +- * BroadcastHashJoin Inner BuildRight (85)
+                        :- * Project (83)
+                        :  +- * BroadcastHashJoin Inner BuildRight (82)
+                        :     :- * BroadcastHashJoin LeftSemi BuildRight (80)
+                        :     :  :- * Filter (78)
+                        :     :  :  +- * ColumnarToRow (77)
+                        :     :  :     +- Scan parquet default.store_sales (76)
+                        :     :  +- ReusedExchange (79)
+                        :     +- ReusedExchange (81)
+                        +- ReusedExchange (84)
 
 
 (1) Scan parquet default.store_sales
@@ -111,578 +102,597 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_item_sk#1)
 
-(4) Exchange
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [id=#6]
-
-(5) Sort [codegen id : 2]
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
-
-(6) Scan parquet default.item
-Output [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(4) Scan parquet default.item
+Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(5) ColumnarToRow [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(8) Filter [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
-Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
+(6) Filter [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
+Condition : ((isnotnull(i_brand_id#7) AND isnotnull(i_class_id#8)) AND isnotnull(i_category_id#9))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(7) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(8) ColumnarToRow [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(9) Filter [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
+Condition : isnotnull(ss_item_sk#10)
 
-(12) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#14]
+(10) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#13]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(11) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(12) Project [codegen id : 9]
+Output [1]: [ss_item_sk#10]
+Input [3]: [ss_item_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(13) Scan parquet default.item
+Output [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(14) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(15) Filter [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Condition : (((isnotnull(i_item_sk#14) AND isnotnull(i_brand_id#15)) AND isnotnull(i_class_id#16)) AND isnotnull(i_category_id#17))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(16) Exchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: hashpartitioning(coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17), 5), ENSURE_REQUIREMENTS, [id=#18]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(17) Sort [codegen id : 3]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: [coalesce(i_brand_id#15, 0) ASC NULLS FIRST, isnull(i_brand_id#15) ASC NULLS FIRST, coalesce(i_class_id#16, 0) ASC NULLS FIRST, isnull(i_class_id#16) ASC NULLS FIRST, coalesce(i_category_id#17, 0) ASC NULLS FIRST, isnull(i_category_id#17) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(18) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#20), dynamicpruningexpression(cs_sold_date_sk#20 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(19) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(20) Filter [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
+Condition : isnotnull(cs_item_sk#19)
 
-(23) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#22]
+(21) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#21]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(22) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#20]
+Right keys [1]: [d_date_sk#21]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(23) Project [codegen id : 6]
+Output [1]: [cs_item_sk#19]
+Input [3]: [cs_item_sk#19, cs_sold_date_sk#20, d_date_sk#21]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(24) Scan parquet default.item
+Output [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(25) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(26) Filter [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Condition : isnotnull(i_item_sk#22)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(27) BroadcastExchange
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(28) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#19]
+Right keys [1]: [i_item_sk#22]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(29) Project [codegen id : 6]
+Output [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Input [5]: [cs_item_sk#19, i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(30) Exchange
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: hashpartitioning(coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25), 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(31) Sort [codegen id : 7]
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: [coalesce(i_brand_id#23, 0) ASC NULLS FIRST, isnull(i_brand_id#23) ASC NULLS FIRST, coalesce(i_class_id#24, 0) ASC NULLS FIRST, isnull(i_class_id#24) ASC NULLS FIRST, coalesce(i_category_id#25, 0) ASC NULLS FIRST, isnull(i_category_id#25) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(32) SortMergeJoin [codegen id : 8]
+Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
+Right keys [6]: [coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(33) BroadcastExchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_item_sk#10]
+Right keys [1]: [i_item_sk#14]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(35) Project [codegen id : 9]
+Output [3]: [i_brand_id#15 AS brand_id#29, i_class_id#16 AS class_id#30, i_category_id#17 AS category_id#31]
+Input [5]: [ss_item_sk#10, i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(36) HashAggregate [codegen id : 9]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
+
+(37) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#32]
+
+(38) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
 (39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31), 5), ENSURE_REQUIREMENTS, [id=#33]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+(40) Sort [codegen id : 11]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: [coalesce(brand_id#29, 0) ASC NULLS FIRST, isnull(brand_id#29) ASC NULLS FIRST, coalesce(class_id#30, 0) ASC NULLS FIRST, isnull(class_id#30) ASC NULLS FIRST, coalesce(category_id#31, 0) ASC NULLS FIRST, isnull(category_id#31) ASC NULLS FIRST], false, 0
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
-
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
-
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(41) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#35), dynamicpruningexpression(ws_sold_date_sk#35 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(42) ColumnarToRow [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(43) Filter [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
+Condition : isnotnull(ws_item_sk#34)
 
-(46) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#37]
+(44) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#36]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(45) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_sold_date_sk#35]
+Right keys [1]: [d_date_sk#36]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(46) Project [codegen id : 14]
+Output [1]: [ws_item_sk#34]
+Input [3]: [ws_item_sk#34, ws_sold_date_sk#35, d_date_sk#36]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(47) ReusedExchange [Reuses operator id: 27]
+Output [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(48) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_item_sk#34]
+Right keys [1]: [i_item_sk#37]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(49) Project [codegen id : 14]
+Output [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [5]: [ws_item_sk#34, i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(50) Exchange
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: hashpartitioning(coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40), 5), ENSURE_REQUIREMENTS, [id=#41]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(51) Sort [codegen id : 15]
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: [coalesce(i_brand_id#38, 0) ASC NULLS FIRST, isnull(i_brand_id#38) ASC NULLS FIRST, coalesce(i_class_id#39, 0) ASC NULLS FIRST, isnull(i_class_id#39) ASC NULLS FIRST, coalesce(i_category_id#40, 0) ASC NULLS FIRST, isnull(i_category_id#40) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(52) SortMergeJoin [codegen id : 16]
+Left keys [6]: [coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31)]
+Right keys [6]: [coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40)]
 Join condition: None
 
-(55) HashAggregate [codegen id : 18]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(53) HashAggregate [codegen id : 16]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(56) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#43]
+(54) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(57) HashAggregate [codegen id : 19]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(55) HashAggregate [codegen id : 17]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(58) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+(56) BroadcastExchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
-(59) BroadcastHashJoin [codegen id : 20]
-Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+(57) BroadcastHashJoin [codegen id : 18]
+Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Right keys [3]: [brand_id#29, class_id#30, category_id#31]
 Join condition: None
 
-(60) Project [codegen id : 20]
-Output [1]: [i_item_sk#7 AS ss_item_sk#45]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+(58) Project [codegen id : 18]
+Output [1]: [i_item_sk#6 AS ss_item_sk#44]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(61) Exchange
-Input [1]: [ss_item_sk#45]
-Arguments: hashpartitioning(ss_item_sk#45, 5), ENSURE_REQUIREMENTS, [id=#46]
+(59) BroadcastExchange
+Input [1]: [ss_item_sk#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
 
-(62) Sort [codegen id : 21]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(63) SortMergeJoin [codegen id : 45]
+(60) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [ss_item_sk#45]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(64) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#47]
+(61) ReusedExchange [Reuses operator id: 117]
+Output [1]: [d_date_sk#46]
 
-(65) BroadcastHashJoin [codegen id : 45]
+(62) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#47]
+Right keys [1]: [d_date_sk#46]
 Join condition: None
 
-(66) Project [codegen id : 45]
+(63) Project [codegen id : 39]
 Output [3]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3]
-Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#47]
+Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#46]
 
-(67) Scan parquet default.item
-Output [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(64) Scan parquet default.item
+Output [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(68) ColumnarToRow [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(65) ColumnarToRow [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(69) Filter [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Condition : (((isnotnull(i_item_sk#48) AND isnotnull(i_brand_id#49)) AND isnotnull(i_class_id#50)) AND isnotnull(i_category_id#51))
+(66) Filter [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Condition : (((isnotnull(i_item_sk#47) AND isnotnull(i_brand_id#48)) AND isnotnull(i_class_id#49)) AND isnotnull(i_category_id#50))
 
-(70) Exchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: hashpartitioning(i_item_sk#48, 5), ENSURE_REQUIREMENTS, [id=#52]
+(67) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(71) Sort [codegen id : 24]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: [i_item_sk#48 ASC NULLS FIRST], false, 0
-
-(72) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(73) Sort [codegen id : 43]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(74) SortMergeJoin [codegen id : 44]
-Left keys [1]: [i_item_sk#48]
-Right keys [1]: [ss_item_sk#45]
+(68) BroadcastHashJoin [codegen id : 38]
+Left keys [1]: [i_item_sk#47]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(75) BroadcastExchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+(69) BroadcastExchange
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
 
-(76) BroadcastHashJoin [codegen id : 45]
+(70) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#48]
+Right keys [1]: [i_item_sk#47]
 Join condition: None
 
-(77) Project [codegen id : 45]
-Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(71) Project [codegen id : 39]
+Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(78) HashAggregate [codegen id : 45]
-Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(72) HashAggregate [codegen id : 39]
+Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#54, isEmpty#55, count#56]
-Results [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
+Aggregate Attributes [3]: [sum#52, isEmpty#53, count#54]
+Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
 
-(79) Exchange
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Arguments: hashpartitioning(i_brand_id#49, i_class_id#50, i_category_id#51, 5), ENSURE_REQUIREMENTS, [id=#60]
+(73) Exchange
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), ENSURE_REQUIREMENTS, [id=#58]
 
-(80) HashAggregate [codegen id : 92]
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(74) HashAggregate [codegen id : 80]
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61, count(1)#62]
-Results [6]: [store AS channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61 AS sales#64, count(1)#62 AS number_sales#65]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59, count(1)#60]
+Results [6]: [store AS channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59 AS sales#62, count(1)#60 AS number_sales#63]
 
-(81) Filter [codegen id : 92]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65]
-Condition : (isnotnull(sales#64) AND (cast(sales#64 as decimal(32,6)) > cast(Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(75) Filter [codegen id : 80]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63]
+Condition : (isnotnull(sales#62) AND (cast(sales#62 as decimal(32,6)) > cast(Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(82) Scan parquet default.store_sales
-Output [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
+(76) Scan parquet default.store_sales
+Output [4]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#71), dynamicpruningexpression(ss_sold_date_sk#71 IN dynamicpruning#72)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#69), dynamicpruningexpression(ss_sold_date_sk#69 IN dynamicpruning#70)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(83) ColumnarToRow [codegen id : 46]
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
+(77) ColumnarToRow [codegen id : 78]
+Input [4]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69]
 
-(84) Filter [codegen id : 46]
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
-Condition : isnotnull(ss_item_sk#68)
+(78) Filter [codegen id : 78]
+Input [4]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69]
+Condition : isnotnull(ss_item_sk#66)
 
-(85) Exchange
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
-Arguments: hashpartitioning(ss_item_sk#68, 5), ENSURE_REQUIREMENTS, [id=#73]
+(79) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(86) Sort [codegen id : 47]
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
-Arguments: [ss_item_sk#68 ASC NULLS FIRST], false, 0
-
-(87) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(88) Sort [codegen id : 66]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(89) SortMergeJoin [codegen id : 90]
-Left keys [1]: [ss_item_sk#68]
-Right keys [1]: [ss_item_sk#45]
+(80) BroadcastHashJoin [codegen id : 78]
+Left keys [1]: [ss_item_sk#66]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(90) ReusedExchange [Reuses operator id: 140]
-Output [1]: [d_date_sk#74]
+(81) ReusedExchange [Reuses operator id: 131]
+Output [1]: [d_date_sk#71]
 
-(91) BroadcastHashJoin [codegen id : 90]
-Left keys [1]: [ss_sold_date_sk#71]
-Right keys [1]: [d_date_sk#74]
+(82) BroadcastHashJoin [codegen id : 78]
+Left keys [1]: [ss_sold_date_sk#69]
+Right keys [1]: [d_date_sk#71]
 Join condition: None
 
-(92) Project [codegen id : 90]
-Output [3]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70]
-Input [5]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71, d_date_sk#74]
+(83) Project [codegen id : 78]
+Output [3]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68]
+Input [5]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69, d_date_sk#71]
 
-(93) ReusedExchange [Reuses operator id: 75]
-Output [4]: [i_item_sk#75, i_brand_id#76, i_class_id#77, i_category_id#78]
+(84) ReusedExchange [Reuses operator id: 69]
+Output [4]: [i_item_sk#72, i_brand_id#73, i_class_id#74, i_category_id#75]
 
-(94) BroadcastHashJoin [codegen id : 90]
-Left keys [1]: [ss_item_sk#68]
-Right keys [1]: [i_item_sk#75]
+(85) BroadcastHashJoin [codegen id : 78]
+Left keys [1]: [ss_item_sk#66]
+Right keys [1]: [i_item_sk#72]
 Join condition: None
 
-(95) Project [codegen id : 90]
-Output [5]: [ss_quantity#69, ss_list_price#70, i_brand_id#76, i_class_id#77, i_category_id#78]
-Input [7]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, i_item_sk#75, i_brand_id#76, i_class_id#77, i_category_id#78]
+(86) Project [codegen id : 78]
+Output [5]: [ss_quantity#67, ss_list_price#68, i_brand_id#73, i_class_id#74, i_category_id#75]
+Input [7]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, i_item_sk#72, i_brand_id#73, i_class_id#74, i_category_id#75]
 
-(96) HashAggregate [codegen id : 90]
-Input [5]: [ss_quantity#69, ss_list_price#70, i_brand_id#76, i_class_id#77, i_category_id#78]
-Keys [3]: [i_brand_id#76, i_class_id#77, i_category_id#78]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#79, isEmpty#80, count#81]
-Results [6]: [i_brand_id#76, i_class_id#77, i_category_id#78, sum#82, isEmpty#83, count#84]
+(87) HashAggregate [codegen id : 78]
+Input [5]: [ss_quantity#67, ss_list_price#68, i_brand_id#73, i_class_id#74, i_category_id#75]
+Keys [3]: [i_brand_id#73, i_class_id#74, i_category_id#75]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
+Aggregate Attributes [3]: [sum#76, isEmpty#77, count#78]
+Results [6]: [i_brand_id#73, i_class_id#74, i_category_id#75, sum#79, isEmpty#80, count#81]
 
-(97) Exchange
-Input [6]: [i_brand_id#76, i_class_id#77, i_category_id#78, sum#82, isEmpty#83, count#84]
-Arguments: hashpartitioning(i_brand_id#76, i_class_id#77, i_category_id#78, 5), ENSURE_REQUIREMENTS, [id=#85]
+(88) Exchange
+Input [6]: [i_brand_id#73, i_class_id#74, i_category_id#75, sum#79, isEmpty#80, count#81]
+Arguments: hashpartitioning(i_brand_id#73, i_class_id#74, i_category_id#75, 5), ENSURE_REQUIREMENTS, [id=#82]
 
-(98) HashAggregate [codegen id : 91]
-Input [6]: [i_brand_id#76, i_class_id#77, i_category_id#78, sum#82, isEmpty#83, count#84]
-Keys [3]: [i_brand_id#76, i_class_id#77, i_category_id#78]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#86, count(1)#87]
-Results [6]: [store AS channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#86 AS sales#89, count(1)#87 AS number_sales#90]
+(89) HashAggregate [codegen id : 79]
+Input [6]: [i_brand_id#73, i_class_id#74, i_category_id#75, sum#79, isEmpty#80, count#81]
+Keys [3]: [i_brand_id#73, i_class_id#74, i_category_id#75]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#83, count(1)#84]
+Results [6]: [store AS channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#83 AS sales#86, count(1)#84 AS number_sales#87]
 
-(99) Filter [codegen id : 91]
-Input [6]: [channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Condition : (isnotnull(sales#89) AND (cast(sales#89 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(90) Filter [codegen id : 79]
+Input [6]: [channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
+Condition : (isnotnull(sales#86) AND (cast(sales#86 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(100) BroadcastExchange
-Input [6]: [channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#91]
+(91) BroadcastExchange
+Input [6]: [channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#88]
 
-(101) BroadcastHashJoin [codegen id : 92]
-Left keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
-Right keys [3]: [i_brand_id#76, i_class_id#77, i_category_id#78]
+(92) BroadcastHashJoin [codegen id : 80]
+Left keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
+Right keys [3]: [i_brand_id#73, i_class_id#74, i_category_id#75]
 Join condition: None
 
-(102) TakeOrderedAndProject
-Input [12]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65, channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Arguments: 100, [i_brand_id#49 ASC NULLS FIRST, i_class_id#50 ASC NULLS FIRST, i_category_id#51 ASC NULLS FIRST], [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65, channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
+(93) TakeOrderedAndProject
+Input [12]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63, channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
+Arguments: 100, [i_brand_id#48 ASC NULLS FIRST, i_class_id#49 ASC NULLS FIRST, i_category_id#50 ASC NULLS FIRST], [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63, channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 81 Hosting Expression = Subquery scalar-subquery#66, [id=#67]
-* HashAggregate (121)
-+- Exchange (120)
-   +- * HashAggregate (119)
-      +- Union (118)
-         :- * Project (107)
-         :  +- * BroadcastHashJoin Inner BuildRight (106)
-         :     :- * ColumnarToRow (104)
-         :     :  +- Scan parquet default.store_sales (103)
-         :     +- ReusedExchange (105)
-         :- * Project (112)
-         :  +- * BroadcastHashJoin Inner BuildRight (111)
-         :     :- * ColumnarToRow (109)
-         :     :  +- Scan parquet default.catalog_sales (108)
-         :     +- ReusedExchange (110)
-         +- * Project (117)
-            +- * BroadcastHashJoin Inner BuildRight (116)
-               :- * ColumnarToRow (114)
-               :  +- Scan parquet default.web_sales (113)
-               +- ReusedExchange (115)
+Subquery:1 Hosting operator id = 75 Hosting Expression = Subquery scalar-subquery#64, [id=#65]
+* HashAggregate (112)
++- Exchange (111)
+   +- * HashAggregate (110)
+      +- Union (109)
+         :- * Project (98)
+         :  +- * BroadcastHashJoin Inner BuildRight (97)
+         :     :- * ColumnarToRow (95)
+         :     :  +- Scan parquet default.store_sales (94)
+         :     +- ReusedExchange (96)
+         :- * Project (103)
+         :  +- * BroadcastHashJoin Inner BuildRight (102)
+         :     :- * ColumnarToRow (100)
+         :     :  +- Scan parquet default.catalog_sales (99)
+         :     +- ReusedExchange (101)
+         +- * Project (108)
+            +- * BroadcastHashJoin Inner BuildRight (107)
+               :- * ColumnarToRow (105)
+               :  +- Scan parquet default.web_sales (104)
+               +- ReusedExchange (106)
 
 
-(103) Scan parquet default.store_sales
-Output [3]: [ss_quantity#92, ss_list_price#93, ss_sold_date_sk#94]
+(94) Scan parquet default.store_sales
+Output [3]: [ss_quantity#89, ss_list_price#90, ss_sold_date_sk#91]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#94), dynamicpruningexpression(ss_sold_date_sk#94 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#91), dynamicpruningexpression(ss_sold_date_sk#91 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(104) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#92, ss_list_price#93, ss_sold_date_sk#94]
+(95) ColumnarToRow [codegen id : 2]
+Input [3]: [ss_quantity#89, ss_list_price#90, ss_sold_date_sk#91]
 
-(105) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#95]
+(96) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#92]
 
-(106) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#94]
-Right keys [1]: [d_date_sk#95]
+(97) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_sold_date_sk#91]
+Right keys [1]: [d_date_sk#92]
 Join condition: None
 
-(107) Project [codegen id : 2]
-Output [2]: [ss_quantity#92 AS quantity#96, ss_list_price#93 AS list_price#97]
-Input [4]: [ss_quantity#92, ss_list_price#93, ss_sold_date_sk#94, d_date_sk#95]
+(98) Project [codegen id : 2]
+Output [2]: [ss_quantity#89 AS quantity#93, ss_list_price#90 AS list_price#94]
+Input [4]: [ss_quantity#89, ss_list_price#90, ss_sold_date_sk#91, d_date_sk#92]
 
-(108) Scan parquet default.catalog_sales
-Output [3]: [cs_quantity#98, cs_list_price#99, cs_sold_date_sk#100]
+(99) Scan parquet default.catalog_sales
+Output [3]: [cs_quantity#95, cs_list_price#96, cs_sold_date_sk#97]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#100), dynamicpruningexpression(cs_sold_date_sk#100 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#97), dynamicpruningexpression(cs_sold_date_sk#97 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(109) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#98, cs_list_price#99, cs_sold_date_sk#100]
+(100) ColumnarToRow [codegen id : 4]
+Input [3]: [cs_quantity#95, cs_list_price#96, cs_sold_date_sk#97]
 
-(110) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#101]
+(101) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#98]
 
-(111) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#100]
-Right keys [1]: [d_date_sk#101]
+(102) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#97]
+Right keys [1]: [d_date_sk#98]
 Join condition: None
 
-(112) Project [codegen id : 4]
-Output [2]: [cs_quantity#98 AS quantity#102, cs_list_price#99 AS list_price#103]
-Input [4]: [cs_quantity#98, cs_list_price#99, cs_sold_date_sk#100, d_date_sk#101]
+(103) Project [codegen id : 4]
+Output [2]: [cs_quantity#95 AS quantity#99, cs_list_price#96 AS list_price#100]
+Input [4]: [cs_quantity#95, cs_list_price#96, cs_sold_date_sk#97, d_date_sk#98]
 
-(113) Scan parquet default.web_sales
-Output [3]: [ws_quantity#104, ws_list_price#105, ws_sold_date_sk#106]
+(104) Scan parquet default.web_sales
+Output [3]: [ws_quantity#101, ws_list_price#102, ws_sold_date_sk#103]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#106), dynamicpruningexpression(ws_sold_date_sk#106 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#103), dynamicpruningexpression(ws_sold_date_sk#103 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(114) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#104, ws_list_price#105, ws_sold_date_sk#106]
+(105) ColumnarToRow [codegen id : 6]
+Input [3]: [ws_quantity#101, ws_list_price#102, ws_sold_date_sk#103]
 
-(115) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#107]
+(106) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#104]
 
-(116) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#106]
-Right keys [1]: [d_date_sk#107]
+(107) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#103]
+Right keys [1]: [d_date_sk#104]
 Join condition: None
 
-(117) Project [codegen id : 6]
-Output [2]: [ws_quantity#104 AS quantity#108, ws_list_price#105 AS list_price#109]
-Input [4]: [ws_quantity#104, ws_list_price#105, ws_sold_date_sk#106, d_date_sk#107]
+(108) Project [codegen id : 6]
+Output [2]: [ws_quantity#101 AS quantity#105, ws_list_price#102 AS list_price#106]
+Input [4]: [ws_quantity#101, ws_list_price#102, ws_sold_date_sk#103, d_date_sk#104]
 
-(118) Union
+(109) Union
 
-(119) HashAggregate [codegen id : 7]
-Input [2]: [quantity#96, list_price#97]
+(110) HashAggregate [codegen id : 7]
+Input [2]: [quantity#93, list_price#94]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#110, count#111]
-Results [2]: [sum#112, count#113]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#107, count#108]
+Results [2]: [sum#109, count#110]
 
-(120) Exchange
-Input [2]: [sum#112, count#113]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#114]
+(111) Exchange
+Input [2]: [sum#109, count#110]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#111]
 
-(121) HashAggregate [codegen id : 8]
-Input [2]: [sum#112, count#113]
+(112) HashAggregate [codegen id : 8]
+Input [2]: [sum#109, count#110]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))#115]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))#115 AS average_sales#116]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))#112]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))#112 AS average_sales#113]
 
-Subquery:2 Hosting operator id = 103 Hosting Expression = ss_sold_date_sk#94 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 94 Hosting Expression = ss_sold_date_sk#91 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 108 Hosting Expression = cs_sold_date_sk#100 IN dynamicpruning#13
+Subquery:3 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#97 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 113 Hosting Expression = ws_sold_date_sk#106 IN dynamicpruning#13
+Subquery:4 Hosting operator id = 104 Hosting Expression = ws_sold_date_sk#103 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (117)
++- * Project (116)
+   +- * Filter (115)
+      +- * ColumnarToRow (114)
+         +- Scan parquet default.date_dim (113)
+
+
+(113) Scan parquet default.date_dim
+Output [2]: [d_date_sk#46, d_week_seq#114]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_week_seq:int>
+
+(114) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#46, d_week_seq#114]
+
+(115) Filter [codegen id : 1]
+Input [2]: [d_date_sk#46, d_week_seq#114]
+Condition : ((isnotnull(d_week_seq#114) AND (d_week_seq#114 = Subquery scalar-subquery#115, [id=#116])) AND isnotnull(d_date_sk#46))
+
+(116) Project [codegen id : 1]
+Output [1]: [d_date_sk#46]
+Input [2]: [d_date_sk#46, d_week_seq#114]
+
+(117) BroadcastExchange
+Input [1]: [d_date_sk#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#117]
+
+Subquery:6 Hosting operator id = 115 Hosting Expression = Subquery scalar-subquery#115, [id=#116]
+* Project (121)
++- * Filter (120)
+   +- * ColumnarToRow (119)
+      +- Scan parquet default.date_dim (118)
+
+
+(118) Scan parquet default.date_dim
+Output [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,2000), EqualTo(d_moy,12), EqualTo(d_dom,11)]
+ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
+
+(119) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+
+(120) Filter [codegen id : 1]
+Input [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+Condition : (((((isnotnull(d_year#119) AND isnotnull(d_moy#120)) AND isnotnull(d_dom#121)) AND (d_year#119 = 2000)) AND (d_moy#120 = 12)) AND (d_dom#121 = 11))
+
+(121) Project [codegen id : 1]
+Output [1]: [d_week_seq#118]
+Input [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+
+Subquery:7 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (126)
 +- * Project (125)
    +- * Filter (124)
@@ -691,141 +701,86 @@ BroadcastExchange (126)
 
 
 (122) Scan parquet default.date_dim
-Output [2]: [d_date_sk#47, d_week_seq#117]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_week_seq:int>
-
-(123) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#47, d_week_seq#117]
-
-(124) Filter [codegen id : 1]
-Input [2]: [d_date_sk#47, d_week_seq#117]
-Condition : ((isnotnull(d_week_seq#117) AND (d_week_seq#117 = Subquery scalar-subquery#118, [id=#119])) AND isnotnull(d_date_sk#47))
-
-(125) Project [codegen id : 1]
-Output [1]: [d_date_sk#47]
-Input [2]: [d_date_sk#47, d_week_seq#117]
-
-(126) BroadcastExchange
-Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#120]
-
-Subquery:6 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#118, [id=#119]
-* Project (130)
-+- * Filter (129)
-   +- * ColumnarToRow (128)
-      +- Scan parquet default.date_dim (127)
-
-
-(127) Scan parquet default.date_dim
-Output [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,2000), EqualTo(d_moy,12), EqualTo(d_dom,11)]
-ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
-
-(128) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-
-(129) Filter [codegen id : 1]
-Input [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-Condition : (((((isnotnull(d_year#122) AND isnotnull(d_moy#123)) AND isnotnull(d_dom#124)) AND (d_year#122 = 2000)) AND (d_moy#123 = 12)) AND (d_dom#124 = 11))
-
-(130) Project [codegen id : 1]
-Output [1]: [d_week_seq#121]
-Input [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-
-Subquery:7 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
-BroadcastExchange (135)
-+- * Project (134)
-   +- * Filter (133)
-      +- * ColumnarToRow (132)
-         +- Scan parquet default.date_dim (131)
-
-
-(131) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#125]
+Output [2]: [d_date_sk#13, d_year#122]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(132) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#125]
+(123) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#122]
 
-(133) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#125]
-Condition : (((isnotnull(d_year#125) AND (d_year#125 >= 1999)) AND (d_year#125 <= 2001)) AND isnotnull(d_date_sk#14))
+(124) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#122]
+Condition : (((isnotnull(d_year#122) AND (d_year#122 >= 1999)) AND (d_year#122 <= 2001)) AND isnotnull(d_date_sk#13))
 
-(134) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#125]
+(125) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_year#122]
 
-(135) BroadcastExchange
-Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#126]
+(126) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#123]
 
-Subquery:8 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#20 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:9 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#35 IN dynamicpruning#12
 
-Subquery:10 Hosting operator id = 99 Hosting Expression = ReusedSubquery Subquery scalar-subquery#66, [id=#67]
+Subquery:10 Hosting operator id = 90 Hosting Expression = ReusedSubquery Subquery scalar-subquery#64, [id=#65]
 
-Subquery:11 Hosting operator id = 82 Hosting Expression = ss_sold_date_sk#71 IN dynamicpruning#72
-BroadcastExchange (140)
-+- * Project (139)
-   +- * Filter (138)
-      +- * ColumnarToRow (137)
-         +- Scan parquet default.date_dim (136)
+Subquery:11 Hosting operator id = 76 Hosting Expression = ss_sold_date_sk#69 IN dynamicpruning#70
+BroadcastExchange (131)
++- * Project (130)
+   +- * Filter (129)
+      +- * ColumnarToRow (128)
+         +- Scan parquet default.date_dim (127)
 
 
-(136) Scan parquet default.date_dim
-Output [2]: [d_date_sk#74, d_week_seq#127]
+(127) Scan parquet default.date_dim
+Output [2]: [d_date_sk#71, d_week_seq#124]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(137) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#74, d_week_seq#127]
+(128) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#71, d_week_seq#124]
 
-(138) Filter [codegen id : 1]
-Input [2]: [d_date_sk#74, d_week_seq#127]
-Condition : ((isnotnull(d_week_seq#127) AND (d_week_seq#127 = Subquery scalar-subquery#128, [id=#129])) AND isnotnull(d_date_sk#74))
+(129) Filter [codegen id : 1]
+Input [2]: [d_date_sk#71, d_week_seq#124]
+Condition : ((isnotnull(d_week_seq#124) AND (d_week_seq#124 = Subquery scalar-subquery#125, [id=#126])) AND isnotnull(d_date_sk#71))
 
-(139) Project [codegen id : 1]
-Output [1]: [d_date_sk#74]
-Input [2]: [d_date_sk#74, d_week_seq#127]
+(130) Project [codegen id : 1]
+Output [1]: [d_date_sk#71]
+Input [2]: [d_date_sk#71, d_week_seq#124]
 
-(140) BroadcastExchange
-Input [1]: [d_date_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#130]
+(131) BroadcastExchange
+Input [1]: [d_date_sk#71]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#127]
 
-Subquery:12 Hosting operator id = 138 Hosting Expression = Subquery scalar-subquery#128, [id=#129]
-* Project (144)
-+- * Filter (143)
-   +- * ColumnarToRow (142)
-      +- Scan parquet default.date_dim (141)
+Subquery:12 Hosting operator id = 129 Hosting Expression = Subquery scalar-subquery#125, [id=#126]
+* Project (135)
++- * Filter (134)
+   +- * ColumnarToRow (133)
+      +- Scan parquet default.date_dim (132)
 
 
-(141) Scan parquet default.date_dim
-Output [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
+(132) Scan parquet default.date_dim
+Output [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,11)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
-(142) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
+(133) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
 
-(143) Filter [codegen id : 1]
-Input [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
-Condition : (((((isnotnull(d_year#132) AND isnotnull(d_moy#133)) AND isnotnull(d_dom#134)) AND (d_year#132 = 1999)) AND (d_moy#133 = 12)) AND (d_dom#134 = 11))
+(134) Filter [codegen id : 1]
+Input [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
+Condition : (((((isnotnull(d_year#129) AND isnotnull(d_moy#130)) AND isnotnull(d_dom#131)) AND (d_year#129 = 1999)) AND (d_moy#130 = 12)) AND (d_dom#131 = 11))
 
-(144) Project [codegen id : 1]
-Output [1]: [d_week_seq#131]
-Input [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
+(135) Project [codegen id : 1]
+Output [1]: [d_week_seq#128]
+Input [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -1,12 +1,12 @@
 TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_sales,channel,i_brand_id,i_class_id,i_category_id,sales,number_sales]
-  WholeStageCodegen (92)
+  WholeStageCodegen (80)
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Filter [sales]
         Subquery #4
           WholeStageCodegen (8)
             HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
               InputAdapter
-                Exchange #17
+                Exchange #15
                   WholeStageCodegen (7)
                     HashAggregate [quantity,list_price] [sum,count,sum,count]
                       InputAdapter
@@ -19,7 +19,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
                                       ReusedSubquery [d_date_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #9
+                                  ReusedExchange [d_date_sk] #8
                           WholeStageCodegen (4)
                             Project [cs_quantity,cs_list_price]
                               BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -28,7 +28,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
                                       ReusedSubquery [d_date_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #9
+                                  ReusedExchange [d_date_sk] #8
                           WholeStageCodegen (6)
                             Project [ws_quantity,ws_list_price]
                               BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -37,216 +37,189 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
                                       ReusedSubquery [d_date_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #9
+                                  ReusedExchange [d_date_sk] #8
         HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
           InputAdapter
             Exchange [i_brand_id,i_class_id,i_category_id] #1
-              WholeStageCodegen (45)
+              WholeStageCodegen (39)
                 HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                   Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                     BroadcastHashJoin [ss_item_sk,i_item_sk]
                       Project [ss_item_sk,ss_quantity,ss_list_price]
                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                          SortMergeJoin [ss_item_sk,ss_item_sk]
-                            InputAdapter
-                              WholeStageCodegen (2)
-                                Sort [ss_item_sk]
-                                  InputAdapter
-                                    Exchange [ss_item_sk] #2
-                                      WholeStageCodegen (1)
-                                        Filter [ss_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #3
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_week_seq,d_date_sk]
-                                                          Subquery #2
-                                                            WholeStageCodegen (1)
-                                                              Project [d_week_seq]
-                                                                Filter [d_year,d_moy,d_dom]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.date_dim [d_date_sk,d_week_seq]
-                            InputAdapter
-                              WholeStageCodegen (21)
-                                Sort [ss_item_sk]
-                                  InputAdapter
-                                    Exchange [ss_item_sk] #4
-                                      WholeStageCodegen (20)
-                                        Project [i_item_sk]
-                                          BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                            Filter [i_brand_id,i_class_id,i_category_id]
+                          BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                            Filter [ss_item_sk]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
+                                    SubqueryBroadcast [d_date_sk] #1
+                                      BroadcastExchange #2
+                                        WholeStageCodegen (1)
+                                          Project [d_date_sk]
+                                            Filter [d_week_seq,d_date_sk]
+                                              Subquery #2
+                                                WholeStageCodegen (1)
+                                                  Project [d_week_seq]
+                                                    Filter [d_year,d_moy,d_dom]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
                                               ColumnarToRow
                                                 InputAdapter
-                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                            InputAdapter
-                                              BroadcastExchange #5
-                                                WholeStageCodegen (19)
-                                                  HashAggregate [brand_id,class_id,category_id]
-                                                    InputAdapter
-                                                      Exchange [brand_id,class_id,category_id] #6
-                                                        WholeStageCodegen (18)
-                                                          HashAggregate [brand_id,class_id,category_id]
-                                                            SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                              InputAdapter
-                                                                WholeStageCodegen (13)
-                                                                  Sort [brand_id,class_id,category_id]
-                                                                    InputAdapter
-                                                                      Exchange [brand_id,class_id,category_id] #7
-                                                                        WholeStageCodegen (12)
-                                                                          HashAggregate [brand_id,class_id,category_id]
-                                                                            InputAdapter
-                                                                              Exchange [brand_id,class_id,category_id] #8
-                                                                                WholeStageCodegen (11)
-                                                                                  HashAggregate [brand_id,class_id,category_id]
-                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                        Project [ss_item_sk]
-                                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                            Filter [ss_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                                    SubqueryBroadcast [d_date_sk] #3
-                                                                                                      BroadcastExchange #9
-                                                                                                        WholeStageCodegen (1)
-                                                                                                          Project [d_date_sk]
-                                                                                                            Filter [d_year,d_date_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                            InputAdapter
-                                                                                              ReusedExchange [d_date_sk] #9
-                                                                                        InputAdapter
-                                                                                          BroadcastExchange #10
-                                                                                            WholeStageCodegen (10)
-                                                                                              SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                InputAdapter
-                                                                                                  WholeStageCodegen (5)
-                                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                      InputAdapter
-                                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #11
-                                                                                                          WholeStageCodegen (4)
-                                                                                                            Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                InputAdapter
-                                                                                                  WholeStageCodegen (9)
-                                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                      InputAdapter
-                                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #12
-                                                                                                          WholeStageCodegen (8)
-                                                                                                            Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                              BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                Project [cs_item_sk]
-                                                                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                    Filter [cs_item_sk]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                            ReusedSubquery [d_date_sk] #3
-                                                                                                                    InputAdapter
-                                                                                                                      ReusedExchange [d_date_sk] #9
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #13
-                                                                                                                    WholeStageCodegen (7)
-                                                                                                                      Filter [i_item_sk]
-                                                                                                                        ColumnarToRow
-                                                                                                                          InputAdapter
-                                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                              InputAdapter
-                                                                WholeStageCodegen (17)
-                                                                  Sort [i_brand_id,i_class_id,i_category_id]
-                                                                    InputAdapter
-                                                                      Exchange [i_brand_id,i_class_id,i_category_id] #14
-                                                                        WholeStageCodegen (16)
-                                                                          Project [i_brand_id,i_class_id,i_category_id]
-                                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                              Project [ws_item_sk]
-                                                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                  Filter [ws_item_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                          ReusedSubquery [d_date_sk] #3
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk] #9
-                                                                              InputAdapter
-                                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
-                          InputAdapter
-                            ReusedExchange [d_date_sk] #3
-                      InputAdapter
-                        BroadcastExchange #15
-                          WholeStageCodegen (44)
-                            SortMergeJoin [i_item_sk,ss_item_sk]
-                              InputAdapter
-                                WholeStageCodegen (24)
-                                  Sort [i_item_sk]
-                                    InputAdapter
-                                      Exchange [i_item_sk] #16
-                                        WholeStageCodegen (23)
-                                          Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                            ColumnarToRow
+                                                  Scan parquet default.date_dim [d_date_sk,d_week_seq]
+                            InputAdapter
+                              BroadcastExchange #3
+                                WholeStageCodegen (18)
+                                  Project [i_item_sk]
+                                    BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
+                                      Filter [i_brand_id,i_class_id,i_category_id]
+                                        ColumnarToRow
+                                          InputAdapter
+                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                      InputAdapter
+                                        BroadcastExchange #4
+                                          WholeStageCodegen (17)
+                                            HashAggregate [brand_id,class_id,category_id]
                                               InputAdapter
-                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                Exchange [brand_id,class_id,category_id] #5
+                                                  WholeStageCodegen (16)
+                                                    HashAggregate [brand_id,class_id,category_id]
+                                                      SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                        InputAdapter
+                                                          WholeStageCodegen (11)
+                                                            Sort [brand_id,class_id,category_id]
+                                                              InputAdapter
+                                                                Exchange [brand_id,class_id,category_id] #6
+                                                                  WholeStageCodegen (10)
+                                                                    HashAggregate [brand_id,class_id,category_id]
+                                                                      InputAdapter
+                                                                        Exchange [brand_id,class_id,category_id] #7
+                                                                          WholeStageCodegen (9)
+                                                                            HashAggregate [brand_id,class_id,category_id]
+                                                                              Project [i_brand_id,i_class_id,i_category_id]
+                                                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                  Project [ss_item_sk]
+                                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                      Filter [ss_item_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                              SubqueryBroadcast [d_date_sk] #3
+                                                                                                BroadcastExchange #8
+                                                                                                  WholeStageCodegen (1)
+                                                                                                    Project [d_date_sk]
+                                                                                                      Filter [d_year,d_date_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                                      InputAdapter
+                                                                                        ReusedExchange [d_date_sk] #8
+                                                                                  InputAdapter
+                                                                                    BroadcastExchange #9
+                                                                                      WholeStageCodegen (8)
+                                                                                        SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                          InputAdapter
+                                                                                            WholeStageCodegen (3)
+                                                                                              Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                InputAdapter
+                                                                                                  Exchange [i_brand_id,i_class_id,i_category_id] #10
+                                                                                                    WholeStageCodegen (2)
+                                                                                                      Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                          InputAdapter
+                                                                                            WholeStageCodegen (7)
+                                                                                              Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                InputAdapter
+                                                                                                  Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                                    WholeStageCodegen (6)
+                                                                                                      Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                          Project [cs_item_sk]
+                                                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                              Filter [cs_item_sk]
+                                                                                                                ColumnarToRow
+                                                                                                                  InputAdapter
+                                                                                                                    Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                                      ReusedSubquery [d_date_sk] #3
+                                                                                                              InputAdapter
+                                                                                                                ReusedExchange [d_date_sk] #8
+                                                                                                          InputAdapter
+                                                                                                            BroadcastExchange #12
+                                                                                                              WholeStageCodegen (5)
+                                                                                                                Filter [i_item_sk]
+                                                                                                                  ColumnarToRow
+                                                                                                                    InputAdapter
+                                                                                                                      Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                        InputAdapter
+                                                          WholeStageCodegen (15)
+                                                            Sort [i_brand_id,i_class_id,i_category_id]
+                                                              InputAdapter
+                                                                Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                                  WholeStageCodegen (14)
+                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                        Project [ws_item_sk]
+                                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                            Filter [ws_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                                    ReusedSubquery [d_date_sk] #3
+                                                                            InputAdapter
+                                                                              ReusedExchange [d_date_sk] #8
+                                                                        InputAdapter
+                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                          InputAdapter
+                            ReusedExchange [d_date_sk] #2
+                      InputAdapter
+                        BroadcastExchange #14
+                          WholeStageCodegen (38)
+                            BroadcastHashJoin [i_item_sk,ss_item_sk]
+                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                               InputAdapter
-                                WholeStageCodegen (43)
-                                  Sort [ss_item_sk]
-                                    InputAdapter
-                                      ReusedExchange [ss_item_sk] #4
+                                ReusedExchange [ss_item_sk] #3
       InputAdapter
-        BroadcastExchange #18
-          WholeStageCodegen (91)
+        BroadcastExchange #16
+          WholeStageCodegen (79)
             Filter [sales]
               ReusedSubquery [average_sales] #4
               HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                 InputAdapter
-                  Exchange [i_brand_id,i_class_id,i_category_id] #19
-                    WholeStageCodegen (90)
+                  Exchange [i_brand_id,i_class_id,i_category_id] #17
+                    WholeStageCodegen (78)
                       HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                         Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                           BroadcastHashJoin [ss_item_sk,i_item_sk]
                             Project [ss_item_sk,ss_quantity,ss_list_price]
                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                SortMergeJoin [ss_item_sk,ss_item_sk]
+                                BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                                  Filter [ss_item_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
+                                          SubqueryBroadcast [d_date_sk] #5
+                                            BroadcastExchange #18
+                                              WholeStageCodegen (1)
+                                                Project [d_date_sk]
+                                                  Filter [d_week_seq,d_date_sk]
+                                                    Subquery #6
+                                                      WholeStageCodegen (1)
+                                                        Project [d_week_seq]
+                                                          Filter [d_year,d_moy,d_dom]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet default.date_dim [d_date_sk,d_week_seq]
                                   InputAdapter
-                                    WholeStageCodegen (47)
-                                      Sort [ss_item_sk]
-                                        InputAdapter
-                                          Exchange [ss_item_sk] #20
-                                            WholeStageCodegen (46)
-                                              Filter [ss_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                      SubqueryBroadcast [d_date_sk] #5
-                                                        BroadcastExchange #21
-                                                          WholeStageCodegen (1)
-                                                            Project [d_date_sk]
-                                                              Filter [d_week_seq,d_date_sk]
-                                                                Subquery #6
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_week_seq]
-                                                                      Filter [d_year,d_moy,d_dom]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.date_dim [d_date_sk,d_week_seq]
-                                  InputAdapter
-                                    WholeStageCodegen (66)
-                                      Sort [ss_item_sk]
-                                        InputAdapter
-                                          ReusedExchange [ss_item_sk] #4
+                                    ReusedExchange [ss_item_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #21
+                                  ReusedExchange [d_date_sk] #18
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -1,106 +1,97 @@
 == Physical Plan ==
-TakeOrderedAndProject (102)
-+- * BroadcastHashJoin Inner BuildRight (101)
-   :- * Filter (81)
-   :  +- * HashAggregate (80)
-   :     +- Exchange (79)
-   :        +- * HashAggregate (78)
-   :           +- * Project (77)
-   :              +- * BroadcastHashJoin Inner BuildRight (76)
-   :                 :- * Project (66)
-   :                 :  +- * BroadcastHashJoin Inner BuildRight (65)
-   :                 :     :- * SortMergeJoin LeftSemi (63)
-   :                 :     :  :- * Sort (5)
-   :                 :     :  :  +- Exchange (4)
-   :                 :     :  :     +- * Filter (3)
-   :                 :     :  :        +- * ColumnarToRow (2)
-   :                 :     :  :           +- Scan parquet default.store_sales (1)
-   :                 :     :  +- * Sort (62)
-   :                 :     :     +- Exchange (61)
-   :                 :     :        +- * Project (60)
-   :                 :     :           +- * BroadcastHashJoin Inner BuildRight (59)
-   :                 :     :              :- * Filter (8)
-   :                 :     :              :  +- * ColumnarToRow (7)
-   :                 :     :              :     +- Scan parquet default.item (6)
-   :                 :     :              +- BroadcastExchange (58)
-   :                 :     :                 +- * HashAggregate (57)
-   :                 :     :                    +- Exchange (56)
-   :                 :     :                       +- * HashAggregate (55)
-   :                 :     :                          +- * SortMergeJoin LeftSemi (54)
-   :                 :     :                             :- * Sort (42)
-   :                 :     :                             :  +- Exchange (41)
-   :                 :     :                             :     +- * HashAggregate (40)
-   :                 :     :                             :        +- Exchange (39)
-   :                 :     :                             :           +- * HashAggregate (38)
-   :                 :     :                             :              +- * Project (37)
-   :                 :     :                             :                 +- * BroadcastHashJoin Inner BuildRight (36)
-   :                 :     :                             :                    :- * Project (14)
-   :                 :     :                             :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-   :                 :     :                             :                    :     :- * Filter (11)
-   :                 :     :                             :                    :     :  +- * ColumnarToRow (10)
-   :                 :     :                             :                    :     :     +- Scan parquet default.store_sales (9)
-   :                 :     :                             :                    :     +- ReusedExchange (12)
-   :                 :     :                             :                    +- BroadcastExchange (35)
-   :                 :     :                             :                       +- * SortMergeJoin LeftSemi (34)
-   :                 :     :                             :                          :- * Sort (19)
-   :                 :     :                             :                          :  +- Exchange (18)
-   :                 :     :                             :                          :     +- * Filter (17)
-   :                 :     :                             :                          :        +- * ColumnarToRow (16)
-   :                 :     :                             :                          :           +- Scan parquet default.item (15)
-   :                 :     :                             :                          +- * Sort (33)
-   :                 :     :                             :                             +- Exchange (32)
-   :                 :     :                             :                                +- * Project (31)
-   :                 :     :                             :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-   :                 :     :                             :                                      :- * Project (25)
-   :                 :     :                             :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-   :                 :     :                             :                                      :     :- * Filter (22)
-   :                 :     :                             :                                      :     :  +- * ColumnarToRow (21)
-   :                 :     :                             :                                      :     :     +- Scan parquet default.catalog_sales (20)
-   :                 :     :                             :                                      :     +- ReusedExchange (23)
-   :                 :     :                             :                                      +- BroadcastExchange (29)
-   :                 :     :                             :                                         +- * Filter (28)
-   :                 :     :                             :                                            +- * ColumnarToRow (27)
-   :                 :     :                             :                                               +- Scan parquet default.item (26)
-   :                 :     :                             +- * Sort (53)
-   :                 :     :                                +- Exchange (52)
-   :                 :     :                                   +- * Project (51)
-   :                 :     :                                      +- * BroadcastHashJoin Inner BuildRight (50)
-   :                 :     :                                         :- * Project (48)
-   :                 :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (47)
-   :                 :     :                                         :     :- * Filter (45)
-   :                 :     :                                         :     :  +- * ColumnarToRow (44)
-   :                 :     :                                         :     :     +- Scan parquet default.web_sales (43)
-   :                 :     :                                         :     +- ReusedExchange (46)
-   :                 :     :                                         +- ReusedExchange (49)
-   :                 :     +- ReusedExchange (64)
-   :                 +- BroadcastExchange (75)
-   :                    +- * SortMergeJoin LeftSemi (74)
-   :                       :- * Sort (71)
-   :                       :  +- Exchange (70)
-   :                       :     +- * Filter (69)
-   :                       :        +- * ColumnarToRow (68)
-   :                       :           +- Scan parquet default.item (67)
-   :                       +- * Sort (73)
-   :                          +- ReusedExchange (72)
-   +- BroadcastExchange (100)
-      +- * Filter (99)
-         +- * HashAggregate (98)
-            +- Exchange (97)
-               +- * HashAggregate (96)
-                  +- * Project (95)
-                     +- * BroadcastHashJoin Inner BuildRight (94)
-                        :- * Project (92)
-                        :  +- * BroadcastHashJoin Inner BuildRight (91)
-                        :     :- * SortMergeJoin LeftSemi (89)
-                        :     :  :- * Sort (86)
-                        :     :  :  +- Exchange (85)
-                        :     :  :     +- * Filter (84)
-                        :     :  :        +- * ColumnarToRow (83)
-                        :     :  :           +- Scan parquet default.store_sales (82)
-                        :     :  +- * Sort (88)
-                        :     :     +- ReusedExchange (87)
-                        :     +- ReusedExchange (90)
-                        +- ReusedExchange (93)
+TakeOrderedAndProject (93)
++- * BroadcastHashJoin Inner BuildRight (92)
+   :- * Filter (75)
+   :  +- * HashAggregate (74)
+   :     +- Exchange (73)
+   :        +- * HashAggregate (72)
+   :           +- * Project (71)
+   :              +- * BroadcastHashJoin Inner BuildRight (70)
+   :                 :- * Project (63)
+   :                 :  +- * BroadcastHashJoin Inner BuildRight (62)
+   :                 :     :- * BroadcastHashJoin LeftSemi BuildRight (60)
+   :                 :     :  :- * Filter (3)
+   :                 :     :  :  +- * ColumnarToRow (2)
+   :                 :     :  :     +- Scan parquet default.store_sales (1)
+   :                 :     :  +- BroadcastExchange (59)
+   :                 :     :     +- * Project (58)
+   :                 :     :        +- * BroadcastHashJoin LeftSemi BuildRight (57)
+   :                 :     :           :- * Filter (6)
+   :                 :     :           :  +- * ColumnarToRow (5)
+   :                 :     :           :     +- Scan parquet default.item (4)
+   :                 :     :           +- BroadcastExchange (56)
+   :                 :     :              +- * HashAggregate (55)
+   :                 :     :                 +- Exchange (54)
+   :                 :     :                    +- * HashAggregate (53)
+   :                 :     :                       +- * SortMergeJoin LeftSemi (52)
+   :                 :     :                          :- * Sort (40)
+   :                 :     :                          :  +- Exchange (39)
+   :                 :     :                          :     +- * HashAggregate (38)
+   :                 :     :                          :        +- Exchange (37)
+   :                 :     :                          :           +- * HashAggregate (36)
+   :                 :     :                          :              +- * Project (35)
+   :                 :     :                          :                 +- * BroadcastHashJoin Inner BuildRight (34)
+   :                 :     :                          :                    :- * Project (12)
+   :                 :     :                          :                    :  +- * BroadcastHashJoin Inner BuildRight (11)
+   :                 :     :                          :                    :     :- * Filter (9)
+   :                 :     :                          :                    :     :  +- * ColumnarToRow (8)
+   :                 :     :                          :                    :     :     +- Scan parquet default.store_sales (7)
+   :                 :     :                          :                    :     +- ReusedExchange (10)
+   :                 :     :                          :                    +- BroadcastExchange (33)
+   :                 :     :                          :                       +- * SortMergeJoin LeftSemi (32)
+   :                 :     :                          :                          :- * Sort (17)
+   :                 :     :                          :                          :  +- Exchange (16)
+   :                 :     :                          :                          :     +- * Filter (15)
+   :                 :     :                          :                          :        +- * ColumnarToRow (14)
+   :                 :     :                          :                          :           +- Scan parquet default.item (13)
+   :                 :     :                          :                          +- * Sort (31)
+   :                 :     :                          :                             +- Exchange (30)
+   :                 :     :                          :                                +- * Project (29)
+   :                 :     :                          :                                   +- * BroadcastHashJoin Inner BuildRight (28)
+   :                 :     :                          :                                      :- * Project (23)
+   :                 :     :                          :                                      :  +- * BroadcastHashJoin Inner BuildRight (22)
+   :                 :     :                          :                                      :     :- * Filter (20)
+   :                 :     :                          :                                      :     :  +- * ColumnarToRow (19)
+   :                 :     :                          :                                      :     :     +- Scan parquet default.catalog_sales (18)
+   :                 :     :                          :                                      :     +- ReusedExchange (21)
+   :                 :     :                          :                                      +- BroadcastExchange (27)
+   :                 :     :                          :                                         +- * Filter (26)
+   :                 :     :                          :                                            +- * ColumnarToRow (25)
+   :                 :     :                          :                                               +- Scan parquet default.item (24)
+   :                 :     :                          +- * Sort (51)
+   :                 :     :                             +- Exchange (50)
+   :                 :     :                                +- * Project (49)
+   :                 :     :                                   +- * BroadcastHashJoin Inner BuildRight (48)
+   :                 :     :                                      :- * Project (46)
+   :                 :     :                                      :  +- * BroadcastHashJoin Inner BuildRight (45)
+   :                 :     :                                      :     :- * Filter (43)
+   :                 :     :                                      :     :  +- * ColumnarToRow (42)
+   :                 :     :                                      :     :     +- Scan parquet default.web_sales (41)
+   :                 :     :                                      :     +- ReusedExchange (44)
+   :                 :     :                                      +- ReusedExchange (47)
+   :                 :     +- ReusedExchange (61)
+   :                 +- BroadcastExchange (69)
+   :                    +- * BroadcastHashJoin LeftSemi BuildRight (68)
+   :                       :- * Filter (66)
+   :                       :  +- * ColumnarToRow (65)
+   :                       :     +- Scan parquet default.item (64)
+   :                       +- ReusedExchange (67)
+   +- BroadcastExchange (91)
+      +- * Filter (90)
+         +- * HashAggregate (89)
+            +- Exchange (88)
+               +- * HashAggregate (87)
+                  +- * Project (86)
+                     +- * BroadcastHashJoin Inner BuildRight (85)
+                        :- * Project (83)
+                        :  +- * BroadcastHashJoin Inner BuildRight (82)
+                        :     :- * BroadcastHashJoin LeftSemi BuildRight (80)
+                        :     :  :- * Filter (78)
+                        :     :  :  +- * ColumnarToRow (77)
+                        :     :  :     +- Scan parquet default.store_sales (76)
+                        :     :  +- ReusedExchange (79)
+                        :     +- ReusedExchange (81)
+                        +- ReusedExchange (84)
 
 
 (1) Scan parquet default.store_sales
@@ -111,578 +102,597 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_item_sk#1)
 
-(4) Exchange
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [id=#6]
-
-(5) Sort [codegen id : 2]
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
-
-(6) Scan parquet default.item
-Output [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(4) Scan parquet default.item
+Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(5) ColumnarToRow [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(8) Filter [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
-Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
+(6) Filter [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
+Condition : ((isnotnull(i_brand_id#7) AND isnotnull(i_class_id#8)) AND isnotnull(i_category_id#9))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(7) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(8) ColumnarToRow [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(9) Filter [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
+Condition : isnotnull(ss_item_sk#10)
 
-(12) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#14]
+(10) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#13]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(11) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(12) Project [codegen id : 9]
+Output [1]: [ss_item_sk#10]
+Input [3]: [ss_item_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(13) Scan parquet default.item
+Output [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(14) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(15) Filter [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Condition : (((isnotnull(i_item_sk#14) AND isnotnull(i_brand_id#15)) AND isnotnull(i_class_id#16)) AND isnotnull(i_category_id#17))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(16) Exchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: hashpartitioning(coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17), 5), ENSURE_REQUIREMENTS, [id=#18]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(17) Sort [codegen id : 3]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: [coalesce(i_brand_id#15, 0) ASC NULLS FIRST, isnull(i_brand_id#15) ASC NULLS FIRST, coalesce(i_class_id#16, 0) ASC NULLS FIRST, isnull(i_class_id#16) ASC NULLS FIRST, coalesce(i_category_id#17, 0) ASC NULLS FIRST, isnull(i_category_id#17) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(18) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#20), dynamicpruningexpression(cs_sold_date_sk#20 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(19) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(20) Filter [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
+Condition : isnotnull(cs_item_sk#19)
 
-(23) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#22]
+(21) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#21]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(22) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#20]
+Right keys [1]: [d_date_sk#21]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(23) Project [codegen id : 6]
+Output [1]: [cs_item_sk#19]
+Input [3]: [cs_item_sk#19, cs_sold_date_sk#20, d_date_sk#21]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(24) Scan parquet default.item
+Output [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(25) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(26) Filter [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Condition : isnotnull(i_item_sk#22)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(27) BroadcastExchange
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(28) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#19]
+Right keys [1]: [i_item_sk#22]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(29) Project [codegen id : 6]
+Output [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Input [5]: [cs_item_sk#19, i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(30) Exchange
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: hashpartitioning(coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25), 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(31) Sort [codegen id : 7]
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: [coalesce(i_brand_id#23, 0) ASC NULLS FIRST, isnull(i_brand_id#23) ASC NULLS FIRST, coalesce(i_class_id#24, 0) ASC NULLS FIRST, isnull(i_class_id#24) ASC NULLS FIRST, coalesce(i_category_id#25, 0) ASC NULLS FIRST, isnull(i_category_id#25) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(32) SortMergeJoin [codegen id : 8]
+Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
+Right keys [6]: [coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(33) BroadcastExchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_item_sk#10]
+Right keys [1]: [i_item_sk#14]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(35) Project [codegen id : 9]
+Output [3]: [i_brand_id#15 AS brand_id#29, i_class_id#16 AS class_id#30, i_category_id#17 AS category_id#31]
+Input [5]: [ss_item_sk#10, i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(36) HashAggregate [codegen id : 9]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
+
+(37) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#32]
+
+(38) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
 (39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31), 5), ENSURE_REQUIREMENTS, [id=#33]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+(40) Sort [codegen id : 11]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: [coalesce(brand_id#29, 0) ASC NULLS FIRST, isnull(brand_id#29) ASC NULLS FIRST, coalesce(class_id#30, 0) ASC NULLS FIRST, isnull(class_id#30) ASC NULLS FIRST, coalesce(category_id#31, 0) ASC NULLS FIRST, isnull(category_id#31) ASC NULLS FIRST], false, 0
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
-
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
-
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(41) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#35), dynamicpruningexpression(ws_sold_date_sk#35 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(42) ColumnarToRow [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(43) Filter [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
+Condition : isnotnull(ws_item_sk#34)
 
-(46) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#37]
+(44) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#36]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(45) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_sold_date_sk#35]
+Right keys [1]: [d_date_sk#36]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(46) Project [codegen id : 14]
+Output [1]: [ws_item_sk#34]
+Input [3]: [ws_item_sk#34, ws_sold_date_sk#35, d_date_sk#36]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(47) ReusedExchange [Reuses operator id: 27]
+Output [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(48) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_item_sk#34]
+Right keys [1]: [i_item_sk#37]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(49) Project [codegen id : 14]
+Output [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [5]: [ws_item_sk#34, i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(50) Exchange
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: hashpartitioning(coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40), 5), ENSURE_REQUIREMENTS, [id=#41]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(51) Sort [codegen id : 15]
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: [coalesce(i_brand_id#38, 0) ASC NULLS FIRST, isnull(i_brand_id#38) ASC NULLS FIRST, coalesce(i_class_id#39, 0) ASC NULLS FIRST, isnull(i_class_id#39) ASC NULLS FIRST, coalesce(i_category_id#40, 0) ASC NULLS FIRST, isnull(i_category_id#40) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(52) SortMergeJoin [codegen id : 16]
+Left keys [6]: [coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31)]
+Right keys [6]: [coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40)]
 Join condition: None
 
-(55) HashAggregate [codegen id : 18]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(53) HashAggregate [codegen id : 16]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(56) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#43]
+(54) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(57) HashAggregate [codegen id : 19]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(55) HashAggregate [codegen id : 17]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(58) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+(56) BroadcastExchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
-(59) BroadcastHashJoin [codegen id : 20]
-Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+(57) BroadcastHashJoin [codegen id : 18]
+Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Right keys [3]: [brand_id#29, class_id#30, category_id#31]
 Join condition: None
 
-(60) Project [codegen id : 20]
-Output [1]: [i_item_sk#7 AS ss_item_sk#45]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+(58) Project [codegen id : 18]
+Output [1]: [i_item_sk#6 AS ss_item_sk#44]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(61) Exchange
-Input [1]: [ss_item_sk#45]
-Arguments: hashpartitioning(ss_item_sk#45, 5), ENSURE_REQUIREMENTS, [id=#46]
+(59) BroadcastExchange
+Input [1]: [ss_item_sk#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
 
-(62) Sort [codegen id : 21]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(63) SortMergeJoin [codegen id : 45]
+(60) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [ss_item_sk#45]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(64) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#47]
+(61) ReusedExchange [Reuses operator id: 117]
+Output [1]: [d_date_sk#46]
 
-(65) BroadcastHashJoin [codegen id : 45]
+(62) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#47]
+Right keys [1]: [d_date_sk#46]
 Join condition: None
 
-(66) Project [codegen id : 45]
+(63) Project [codegen id : 39]
 Output [3]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3]
-Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#47]
+Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#46]
 
-(67) Scan parquet default.item
-Output [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(64) Scan parquet default.item
+Output [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(68) ColumnarToRow [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(65) ColumnarToRow [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(69) Filter [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Condition : (((isnotnull(i_item_sk#48) AND isnotnull(i_brand_id#49)) AND isnotnull(i_class_id#50)) AND isnotnull(i_category_id#51))
+(66) Filter [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Condition : (((isnotnull(i_item_sk#47) AND isnotnull(i_brand_id#48)) AND isnotnull(i_class_id#49)) AND isnotnull(i_category_id#50))
 
-(70) Exchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: hashpartitioning(i_item_sk#48, 5), ENSURE_REQUIREMENTS, [id=#52]
+(67) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(71) Sort [codegen id : 24]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: [i_item_sk#48 ASC NULLS FIRST], false, 0
-
-(72) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(73) Sort [codegen id : 43]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(74) SortMergeJoin [codegen id : 44]
-Left keys [1]: [i_item_sk#48]
-Right keys [1]: [ss_item_sk#45]
+(68) BroadcastHashJoin [codegen id : 38]
+Left keys [1]: [i_item_sk#47]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(75) BroadcastExchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+(69) BroadcastExchange
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
 
-(76) BroadcastHashJoin [codegen id : 45]
+(70) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#48]
+Right keys [1]: [i_item_sk#47]
 Join condition: None
 
-(77) Project [codegen id : 45]
-Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(71) Project [codegen id : 39]
+Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(78) HashAggregate [codegen id : 45]
-Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(72) HashAggregate [codegen id : 39]
+Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#54, isEmpty#55, count#56]
-Results [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
+Aggregate Attributes [3]: [sum#52, isEmpty#53, count#54]
+Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
 
-(79) Exchange
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Arguments: hashpartitioning(i_brand_id#49, i_class_id#50, i_category_id#51, 5), ENSURE_REQUIREMENTS, [id=#60]
+(73) Exchange
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), ENSURE_REQUIREMENTS, [id=#58]
 
-(80) HashAggregate [codegen id : 92]
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(74) HashAggregate [codegen id : 80]
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61, count(1)#62]
-Results [6]: [store AS channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61 AS sales#64, count(1)#62 AS number_sales#65]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59, count(1)#60]
+Results [6]: [store AS channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59 AS sales#62, count(1)#60 AS number_sales#63]
 
-(81) Filter [codegen id : 92]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65]
-Condition : (isnotnull(sales#64) AND (cast(sales#64 as decimal(32,6)) > cast(Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(75) Filter [codegen id : 80]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63]
+Condition : (isnotnull(sales#62) AND (cast(sales#62 as decimal(32,6)) > cast(Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(82) Scan parquet default.store_sales
-Output [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
+(76) Scan parquet default.store_sales
+Output [4]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#71), dynamicpruningexpression(ss_sold_date_sk#71 IN dynamicpruning#72)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#69), dynamicpruningexpression(ss_sold_date_sk#69 IN dynamicpruning#70)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(83) ColumnarToRow [codegen id : 46]
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
+(77) ColumnarToRow [codegen id : 78]
+Input [4]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69]
 
-(84) Filter [codegen id : 46]
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
-Condition : isnotnull(ss_item_sk#68)
+(78) Filter [codegen id : 78]
+Input [4]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69]
+Condition : isnotnull(ss_item_sk#66)
 
-(85) Exchange
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
-Arguments: hashpartitioning(ss_item_sk#68, 5), ENSURE_REQUIREMENTS, [id=#73]
+(79) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(86) Sort [codegen id : 47]
-Input [4]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71]
-Arguments: [ss_item_sk#68 ASC NULLS FIRST], false, 0
-
-(87) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(88) Sort [codegen id : 66]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(89) SortMergeJoin [codegen id : 90]
-Left keys [1]: [ss_item_sk#68]
-Right keys [1]: [ss_item_sk#45]
+(80) BroadcastHashJoin [codegen id : 78]
+Left keys [1]: [ss_item_sk#66]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(90) ReusedExchange [Reuses operator id: 140]
-Output [1]: [d_date_sk#74]
+(81) ReusedExchange [Reuses operator id: 131]
+Output [1]: [d_date_sk#71]
 
-(91) BroadcastHashJoin [codegen id : 90]
-Left keys [1]: [ss_sold_date_sk#71]
-Right keys [1]: [d_date_sk#74]
+(82) BroadcastHashJoin [codegen id : 78]
+Left keys [1]: [ss_sold_date_sk#69]
+Right keys [1]: [d_date_sk#71]
 Join condition: None
 
-(92) Project [codegen id : 90]
-Output [3]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70]
-Input [5]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, ss_sold_date_sk#71, d_date_sk#74]
+(83) Project [codegen id : 78]
+Output [3]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68]
+Input [5]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, ss_sold_date_sk#69, d_date_sk#71]
 
-(93) ReusedExchange [Reuses operator id: 75]
-Output [4]: [i_item_sk#75, i_brand_id#76, i_class_id#77, i_category_id#78]
+(84) ReusedExchange [Reuses operator id: 69]
+Output [4]: [i_item_sk#72, i_brand_id#73, i_class_id#74, i_category_id#75]
 
-(94) BroadcastHashJoin [codegen id : 90]
-Left keys [1]: [ss_item_sk#68]
-Right keys [1]: [i_item_sk#75]
+(85) BroadcastHashJoin [codegen id : 78]
+Left keys [1]: [ss_item_sk#66]
+Right keys [1]: [i_item_sk#72]
 Join condition: None
 
-(95) Project [codegen id : 90]
-Output [5]: [ss_quantity#69, ss_list_price#70, i_brand_id#76, i_class_id#77, i_category_id#78]
-Input [7]: [ss_item_sk#68, ss_quantity#69, ss_list_price#70, i_item_sk#75, i_brand_id#76, i_class_id#77, i_category_id#78]
+(86) Project [codegen id : 78]
+Output [5]: [ss_quantity#67, ss_list_price#68, i_brand_id#73, i_class_id#74, i_category_id#75]
+Input [7]: [ss_item_sk#66, ss_quantity#67, ss_list_price#68, i_item_sk#72, i_brand_id#73, i_class_id#74, i_category_id#75]
 
-(96) HashAggregate [codegen id : 90]
-Input [5]: [ss_quantity#69, ss_list_price#70, i_brand_id#76, i_class_id#77, i_category_id#78]
-Keys [3]: [i_brand_id#76, i_class_id#77, i_category_id#78]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#79, isEmpty#80, count#81]
-Results [6]: [i_brand_id#76, i_class_id#77, i_category_id#78, sum#82, isEmpty#83, count#84]
+(87) HashAggregate [codegen id : 78]
+Input [5]: [ss_quantity#67, ss_list_price#68, i_brand_id#73, i_class_id#74, i_category_id#75]
+Keys [3]: [i_brand_id#73, i_class_id#74, i_category_id#75]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
+Aggregate Attributes [3]: [sum#76, isEmpty#77, count#78]
+Results [6]: [i_brand_id#73, i_class_id#74, i_category_id#75, sum#79, isEmpty#80, count#81]
 
-(97) Exchange
-Input [6]: [i_brand_id#76, i_class_id#77, i_category_id#78, sum#82, isEmpty#83, count#84]
-Arguments: hashpartitioning(i_brand_id#76, i_class_id#77, i_category_id#78, 5), ENSURE_REQUIREMENTS, [id=#85]
+(88) Exchange
+Input [6]: [i_brand_id#73, i_class_id#74, i_category_id#75, sum#79, isEmpty#80, count#81]
+Arguments: hashpartitioning(i_brand_id#73, i_class_id#74, i_category_id#75, 5), ENSURE_REQUIREMENTS, [id=#82]
 
-(98) HashAggregate [codegen id : 91]
-Input [6]: [i_brand_id#76, i_class_id#77, i_category_id#78, sum#82, isEmpty#83, count#84]
-Keys [3]: [i_brand_id#76, i_class_id#77, i_category_id#78]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#86, count(1)#87]
-Results [6]: [store AS channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#86 AS sales#89, count(1)#87 AS number_sales#90]
+(89) HashAggregate [codegen id : 79]
+Input [6]: [i_brand_id#73, i_class_id#74, i_category_id#75, sum#79, isEmpty#80, count#81]
+Keys [3]: [i_brand_id#73, i_class_id#74, i_category_id#75]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#83, count(1)#84]
+Results [6]: [store AS channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#83 AS sales#86, count(1)#84 AS number_sales#87]
 
-(99) Filter [codegen id : 91]
-Input [6]: [channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Condition : (isnotnull(sales#89) AND (cast(sales#89 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(90) Filter [codegen id : 79]
+Input [6]: [channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
+Condition : (isnotnull(sales#86) AND (cast(sales#86 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(100) BroadcastExchange
-Input [6]: [channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#91]
+(91) BroadcastExchange
+Input [6]: [channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [id=#88]
 
-(101) BroadcastHashJoin [codegen id : 92]
-Left keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
-Right keys [3]: [i_brand_id#76, i_class_id#77, i_category_id#78]
+(92) BroadcastHashJoin [codegen id : 80]
+Left keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
+Right keys [3]: [i_brand_id#73, i_class_id#74, i_category_id#75]
 Join condition: None
 
-(102) TakeOrderedAndProject
-Input [12]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65, channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
-Arguments: 100, [i_brand_id#49 ASC NULLS FIRST, i_class_id#50 ASC NULLS FIRST, i_category_id#51 ASC NULLS FIRST], [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65, channel#88, i_brand_id#76, i_class_id#77, i_category_id#78, sales#89, number_sales#90]
+(93) TakeOrderedAndProject
+Input [12]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63, channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
+Arguments: 100, [i_brand_id#48 ASC NULLS FIRST, i_class_id#49 ASC NULLS FIRST, i_category_id#50 ASC NULLS FIRST], [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63, channel#85, i_brand_id#73, i_class_id#74, i_category_id#75, sales#86, number_sales#87]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 81 Hosting Expression = Subquery scalar-subquery#66, [id=#67]
-* HashAggregate (121)
-+- Exchange (120)
-   +- * HashAggregate (119)
-      +- Union (118)
-         :- * Project (107)
-         :  +- * BroadcastHashJoin Inner BuildRight (106)
-         :     :- * ColumnarToRow (104)
-         :     :  +- Scan parquet default.store_sales (103)
-         :     +- ReusedExchange (105)
-         :- * Project (112)
-         :  +- * BroadcastHashJoin Inner BuildRight (111)
-         :     :- * ColumnarToRow (109)
-         :     :  +- Scan parquet default.catalog_sales (108)
-         :     +- ReusedExchange (110)
-         +- * Project (117)
-            +- * BroadcastHashJoin Inner BuildRight (116)
-               :- * ColumnarToRow (114)
-               :  +- Scan parquet default.web_sales (113)
-               +- ReusedExchange (115)
+Subquery:1 Hosting operator id = 75 Hosting Expression = Subquery scalar-subquery#64, [id=#65]
+* HashAggregate (112)
++- Exchange (111)
+   +- * HashAggregate (110)
+      +- Union (109)
+         :- * Project (98)
+         :  +- * BroadcastHashJoin Inner BuildRight (97)
+         :     :- * ColumnarToRow (95)
+         :     :  +- Scan parquet default.store_sales (94)
+         :     +- ReusedExchange (96)
+         :- * Project (103)
+         :  +- * BroadcastHashJoin Inner BuildRight (102)
+         :     :- * ColumnarToRow (100)
+         :     :  +- Scan parquet default.catalog_sales (99)
+         :     +- ReusedExchange (101)
+         +- * Project (108)
+            +- * BroadcastHashJoin Inner BuildRight (107)
+               :- * ColumnarToRow (105)
+               :  +- Scan parquet default.web_sales (104)
+               +- ReusedExchange (106)
 
 
-(103) Scan parquet default.store_sales
-Output [3]: [ss_quantity#92, ss_list_price#93, ss_sold_date_sk#94]
+(94) Scan parquet default.store_sales
+Output [3]: [ss_quantity#89, ss_list_price#90, ss_sold_date_sk#91]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#94), dynamicpruningexpression(ss_sold_date_sk#94 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#91), dynamicpruningexpression(ss_sold_date_sk#91 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(104) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#92, ss_list_price#93, ss_sold_date_sk#94]
+(95) ColumnarToRow [codegen id : 2]
+Input [3]: [ss_quantity#89, ss_list_price#90, ss_sold_date_sk#91]
 
-(105) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#95]
+(96) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#92]
 
-(106) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#94]
-Right keys [1]: [d_date_sk#95]
+(97) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_sold_date_sk#91]
+Right keys [1]: [d_date_sk#92]
 Join condition: None
 
-(107) Project [codegen id : 2]
-Output [2]: [ss_quantity#92 AS quantity#96, ss_list_price#93 AS list_price#97]
-Input [4]: [ss_quantity#92, ss_list_price#93, ss_sold_date_sk#94, d_date_sk#95]
+(98) Project [codegen id : 2]
+Output [2]: [ss_quantity#89 AS quantity#93, ss_list_price#90 AS list_price#94]
+Input [4]: [ss_quantity#89, ss_list_price#90, ss_sold_date_sk#91, d_date_sk#92]
 
-(108) Scan parquet default.catalog_sales
-Output [3]: [cs_quantity#98, cs_list_price#99, cs_sold_date_sk#100]
+(99) Scan parquet default.catalog_sales
+Output [3]: [cs_quantity#95, cs_list_price#96, cs_sold_date_sk#97]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#100), dynamicpruningexpression(cs_sold_date_sk#100 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#97), dynamicpruningexpression(cs_sold_date_sk#97 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(109) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#98, cs_list_price#99, cs_sold_date_sk#100]
+(100) ColumnarToRow [codegen id : 4]
+Input [3]: [cs_quantity#95, cs_list_price#96, cs_sold_date_sk#97]
 
-(110) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#101]
+(101) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#98]
 
-(111) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#100]
-Right keys [1]: [d_date_sk#101]
+(102) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#97]
+Right keys [1]: [d_date_sk#98]
 Join condition: None
 
-(112) Project [codegen id : 4]
-Output [2]: [cs_quantity#98 AS quantity#102, cs_list_price#99 AS list_price#103]
-Input [4]: [cs_quantity#98, cs_list_price#99, cs_sold_date_sk#100, d_date_sk#101]
+(103) Project [codegen id : 4]
+Output [2]: [cs_quantity#95 AS quantity#99, cs_list_price#96 AS list_price#100]
+Input [4]: [cs_quantity#95, cs_list_price#96, cs_sold_date_sk#97, d_date_sk#98]
 
-(113) Scan parquet default.web_sales
-Output [3]: [ws_quantity#104, ws_list_price#105, ws_sold_date_sk#106]
+(104) Scan parquet default.web_sales
+Output [3]: [ws_quantity#101, ws_list_price#102, ws_sold_date_sk#103]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#106), dynamicpruningexpression(ws_sold_date_sk#106 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#103), dynamicpruningexpression(ws_sold_date_sk#103 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(114) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#104, ws_list_price#105, ws_sold_date_sk#106]
+(105) ColumnarToRow [codegen id : 6]
+Input [3]: [ws_quantity#101, ws_list_price#102, ws_sold_date_sk#103]
 
-(115) ReusedExchange [Reuses operator id: 135]
-Output [1]: [d_date_sk#107]
+(106) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#104]
 
-(116) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#106]
-Right keys [1]: [d_date_sk#107]
+(107) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#103]
+Right keys [1]: [d_date_sk#104]
 Join condition: None
 
-(117) Project [codegen id : 6]
-Output [2]: [ws_quantity#104 AS quantity#108, ws_list_price#105 AS list_price#109]
-Input [4]: [ws_quantity#104, ws_list_price#105, ws_sold_date_sk#106, d_date_sk#107]
+(108) Project [codegen id : 6]
+Output [2]: [ws_quantity#101 AS quantity#105, ws_list_price#102 AS list_price#106]
+Input [4]: [ws_quantity#101, ws_list_price#102, ws_sold_date_sk#103, d_date_sk#104]
 
-(118) Union
+(109) Union
 
-(119) HashAggregate [codegen id : 7]
-Input [2]: [quantity#96, list_price#97]
+(110) HashAggregate [codegen id : 7]
+Input [2]: [quantity#93, list_price#94]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#110, count#111]
-Results [2]: [sum#112, count#113]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#107, count#108]
+Results [2]: [sum#109, count#110]
 
-(120) Exchange
-Input [2]: [sum#112, count#113]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#114]
+(111) Exchange
+Input [2]: [sum#109, count#110]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#111]
 
-(121) HashAggregate [codegen id : 8]
-Input [2]: [sum#112, count#113]
+(112) HashAggregate [codegen id : 8]
+Input [2]: [sum#109, count#110]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))#115]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#96 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#97 as decimal(12,2)))), DecimalType(18,2), true))#115 AS average_sales#116]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))#112]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#93 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#94 as decimal(12,2)))), DecimalType(18,2), true))#112 AS average_sales#113]
 
-Subquery:2 Hosting operator id = 103 Hosting Expression = ss_sold_date_sk#94 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 94 Hosting Expression = ss_sold_date_sk#91 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 108 Hosting Expression = cs_sold_date_sk#100 IN dynamicpruning#13
+Subquery:3 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#97 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 113 Hosting Expression = ws_sold_date_sk#106 IN dynamicpruning#13
+Subquery:4 Hosting operator id = 104 Hosting Expression = ws_sold_date_sk#103 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (117)
++- * Project (116)
+   +- * Filter (115)
+      +- * ColumnarToRow (114)
+         +- Scan parquet default.date_dim (113)
+
+
+(113) Scan parquet default.date_dim
+Output [2]: [d_date_sk#46, d_week_seq#114]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_week_seq:int>
+
+(114) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#46, d_week_seq#114]
+
+(115) Filter [codegen id : 1]
+Input [2]: [d_date_sk#46, d_week_seq#114]
+Condition : ((isnotnull(d_week_seq#114) AND (d_week_seq#114 = Subquery scalar-subquery#115, [id=#116])) AND isnotnull(d_date_sk#46))
+
+(116) Project [codegen id : 1]
+Output [1]: [d_date_sk#46]
+Input [2]: [d_date_sk#46, d_week_seq#114]
+
+(117) BroadcastExchange
+Input [1]: [d_date_sk#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#117]
+
+Subquery:6 Hosting operator id = 115 Hosting Expression = Subquery scalar-subquery#115, [id=#116]
+* Project (121)
++- * Filter (120)
+   +- * ColumnarToRow (119)
+      +- Scan parquet default.date_dim (118)
+
+
+(118) Scan parquet default.date_dim
+Output [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,16)]
+ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
+
+(119) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+
+(120) Filter [codegen id : 1]
+Input [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+Condition : (((((isnotnull(d_year#119) AND isnotnull(d_moy#120)) AND isnotnull(d_dom#121)) AND (d_year#119 = 1999)) AND (d_moy#120 = 12)) AND (d_dom#121 = 16))
+
+(121) Project [codegen id : 1]
+Output [1]: [d_week_seq#118]
+Input [4]: [d_week_seq#118, d_year#119, d_moy#120, d_dom#121]
+
+Subquery:7 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
 BroadcastExchange (126)
 +- * Project (125)
    +- * Filter (124)
@@ -691,141 +701,86 @@ BroadcastExchange (126)
 
 
 (122) Scan parquet default.date_dim
-Output [2]: [d_date_sk#47, d_week_seq#117]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_week_seq:int>
-
-(123) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#47, d_week_seq#117]
-
-(124) Filter [codegen id : 1]
-Input [2]: [d_date_sk#47, d_week_seq#117]
-Condition : ((isnotnull(d_week_seq#117) AND (d_week_seq#117 = Subquery scalar-subquery#118, [id=#119])) AND isnotnull(d_date_sk#47))
-
-(125) Project [codegen id : 1]
-Output [1]: [d_date_sk#47]
-Input [2]: [d_date_sk#47, d_week_seq#117]
-
-(126) BroadcastExchange
-Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#120]
-
-Subquery:6 Hosting operator id = 124 Hosting Expression = Subquery scalar-subquery#118, [id=#119]
-* Project (130)
-+- * Filter (129)
-   +- * ColumnarToRow (128)
-      +- Scan parquet default.date_dim (127)
-
-
-(127) Scan parquet default.date_dim
-Output [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1999), EqualTo(d_moy,12), EqualTo(d_dom,16)]
-ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
-
-(128) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-
-(129) Filter [codegen id : 1]
-Input [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-Condition : (((((isnotnull(d_year#122) AND isnotnull(d_moy#123)) AND isnotnull(d_dom#124)) AND (d_year#122 = 1999)) AND (d_moy#123 = 12)) AND (d_dom#124 = 16))
-
-(130) Project [codegen id : 1]
-Output [1]: [d_week_seq#121]
-Input [4]: [d_week_seq#121, d_year#122, d_moy#123, d_dom#124]
-
-Subquery:7 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
-BroadcastExchange (135)
-+- * Project (134)
-   +- * Filter (133)
-      +- * ColumnarToRow (132)
-         +- Scan parquet default.date_dim (131)
-
-
-(131) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#125]
+Output [2]: [d_date_sk#13, d_year#122]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(132) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#125]
+(123) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#122]
 
-(133) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#125]
-Condition : (((isnotnull(d_year#125) AND (d_year#125 >= 1998)) AND (d_year#125 <= 2000)) AND isnotnull(d_date_sk#14))
+(124) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#122]
+Condition : (((isnotnull(d_year#122) AND (d_year#122 >= 1998)) AND (d_year#122 <= 2000)) AND isnotnull(d_date_sk#13))
 
-(134) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#125]
+(125) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_year#122]
 
-(135) BroadcastExchange
-Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#126]
+(126) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#123]
 
-Subquery:8 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#20 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:9 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#35 IN dynamicpruning#12
 
-Subquery:10 Hosting operator id = 99 Hosting Expression = ReusedSubquery Subquery scalar-subquery#66, [id=#67]
+Subquery:10 Hosting operator id = 90 Hosting Expression = ReusedSubquery Subquery scalar-subquery#64, [id=#65]
 
-Subquery:11 Hosting operator id = 82 Hosting Expression = ss_sold_date_sk#71 IN dynamicpruning#72
-BroadcastExchange (140)
-+- * Project (139)
-   +- * Filter (138)
-      +- * ColumnarToRow (137)
-         +- Scan parquet default.date_dim (136)
+Subquery:11 Hosting operator id = 76 Hosting Expression = ss_sold_date_sk#69 IN dynamicpruning#70
+BroadcastExchange (131)
++- * Project (130)
+   +- * Filter (129)
+      +- * ColumnarToRow (128)
+         +- Scan parquet default.date_dim (127)
 
 
-(136) Scan parquet default.date_dim
-Output [2]: [d_date_sk#74, d_week_seq#127]
+(127) Scan parquet default.date_dim
+Output [2]: [d_date_sk#71, d_week_seq#124]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(137) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#74, d_week_seq#127]
+(128) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#71, d_week_seq#124]
 
-(138) Filter [codegen id : 1]
-Input [2]: [d_date_sk#74, d_week_seq#127]
-Condition : ((isnotnull(d_week_seq#127) AND (d_week_seq#127 = Subquery scalar-subquery#128, [id=#129])) AND isnotnull(d_date_sk#74))
+(129) Filter [codegen id : 1]
+Input [2]: [d_date_sk#71, d_week_seq#124]
+Condition : ((isnotnull(d_week_seq#124) AND (d_week_seq#124 = Subquery scalar-subquery#125, [id=#126])) AND isnotnull(d_date_sk#71))
 
-(139) Project [codegen id : 1]
-Output [1]: [d_date_sk#74]
-Input [2]: [d_date_sk#74, d_week_seq#127]
+(130) Project [codegen id : 1]
+Output [1]: [d_date_sk#71]
+Input [2]: [d_date_sk#71, d_week_seq#124]
 
-(140) BroadcastExchange
-Input [1]: [d_date_sk#74]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#130]
+(131) BroadcastExchange
+Input [1]: [d_date_sk#71]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#127]
 
-Subquery:12 Hosting operator id = 138 Hosting Expression = Subquery scalar-subquery#128, [id=#129]
-* Project (144)
-+- * Filter (143)
-   +- * ColumnarToRow (142)
-      +- Scan parquet default.date_dim (141)
+Subquery:12 Hosting operator id = 129 Hosting Expression = Subquery scalar-subquery#125, [id=#126]
+* Project (135)
++- * Filter (134)
+   +- * ColumnarToRow (133)
+      +- Scan parquet default.date_dim (132)
 
 
-(141) Scan parquet default.date_dim
-Output [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
+(132) Scan parquet default.date_dim
+Output [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), IsNotNull(d_dom), EqualTo(d_year,1998), EqualTo(d_moy,12), EqualTo(d_dom,16)]
 ReadSchema: struct<d_week_seq:int,d_year:int,d_moy:int,d_dom:int>
 
-(142) ColumnarToRow [codegen id : 1]
-Input [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
+(133) ColumnarToRow [codegen id : 1]
+Input [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
 
-(143) Filter [codegen id : 1]
-Input [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
-Condition : (((((isnotnull(d_year#132) AND isnotnull(d_moy#133)) AND isnotnull(d_dom#134)) AND (d_year#132 = 1998)) AND (d_moy#133 = 12)) AND (d_dom#134 = 16))
+(134) Filter [codegen id : 1]
+Input [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
+Condition : (((((isnotnull(d_year#129) AND isnotnull(d_moy#130)) AND isnotnull(d_dom#131)) AND (d_year#129 = 1998)) AND (d_moy#130 = 12)) AND (d_dom#131 = 16))
 
-(144) Project [codegen id : 1]
-Output [1]: [d_week_seq#131]
-Input [4]: [d_week_seq#131, d_year#132, d_moy#133, d_dom#134]
+(135) Project [codegen id : 1]
+Output [1]: [d_week_seq#128]
+Input [4]: [d_week_seq#128, d_year#129, d_moy#130, d_dom#131]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
@@ -1,12 +1,12 @@
 TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_sales,channel,i_brand_id,i_class_id,i_category_id,sales,number_sales]
-  WholeStageCodegen (92)
+  WholeStageCodegen (80)
     BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
       Filter [sales]
         Subquery #4
           WholeStageCodegen (8)
             HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
               InputAdapter
-                Exchange #17
+                Exchange #15
                   WholeStageCodegen (7)
                     HashAggregate [quantity,list_price] [sum,count,sum,count]
                       InputAdapter
@@ -19,7 +19,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
                                       ReusedSubquery [d_date_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #9
+                                  ReusedExchange [d_date_sk] #8
                           WholeStageCodegen (4)
                             Project [cs_quantity,cs_list_price]
                               BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -28,7 +28,7 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
                                       ReusedSubquery [d_date_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #9
+                                  ReusedExchange [d_date_sk] #8
                           WholeStageCodegen (6)
                             Project [ws_quantity,ws_list_price]
                               BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -37,216 +37,189 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                     Scan parquet default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
                                       ReusedSubquery [d_date_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #9
+                                  ReusedExchange [d_date_sk] #8
         HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
           InputAdapter
             Exchange [i_brand_id,i_class_id,i_category_id] #1
-              WholeStageCodegen (45)
+              WholeStageCodegen (39)
                 HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                   Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                     BroadcastHashJoin [ss_item_sk,i_item_sk]
                       Project [ss_item_sk,ss_quantity,ss_list_price]
                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                          SortMergeJoin [ss_item_sk,ss_item_sk]
-                            InputAdapter
-                              WholeStageCodegen (2)
-                                Sort [ss_item_sk]
-                                  InputAdapter
-                                    Exchange [ss_item_sk] #2
-                                      WholeStageCodegen (1)
-                                        Filter [ss_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #3
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_week_seq,d_date_sk]
-                                                          Subquery #2
-                                                            WholeStageCodegen (1)
-                                                              Project [d_week_seq]
-                                                                Filter [d_year,d_moy,d_dom]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.date_dim [d_date_sk,d_week_seq]
-                            InputAdapter
-                              WholeStageCodegen (21)
-                                Sort [ss_item_sk]
-                                  InputAdapter
-                                    Exchange [ss_item_sk] #4
-                                      WholeStageCodegen (20)
-                                        Project [i_item_sk]
-                                          BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                            Filter [i_brand_id,i_class_id,i_category_id]
+                          BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                            Filter [ss_item_sk]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
+                                    SubqueryBroadcast [d_date_sk] #1
+                                      BroadcastExchange #2
+                                        WholeStageCodegen (1)
+                                          Project [d_date_sk]
+                                            Filter [d_week_seq,d_date_sk]
+                                              Subquery #2
+                                                WholeStageCodegen (1)
+                                                  Project [d_week_seq]
+                                                    Filter [d_year,d_moy,d_dom]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
                                               ColumnarToRow
                                                 InputAdapter
-                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                            InputAdapter
-                                              BroadcastExchange #5
-                                                WholeStageCodegen (19)
-                                                  HashAggregate [brand_id,class_id,category_id]
-                                                    InputAdapter
-                                                      Exchange [brand_id,class_id,category_id] #6
-                                                        WholeStageCodegen (18)
-                                                          HashAggregate [brand_id,class_id,category_id]
-                                                            SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                              InputAdapter
-                                                                WholeStageCodegen (13)
-                                                                  Sort [brand_id,class_id,category_id]
-                                                                    InputAdapter
-                                                                      Exchange [brand_id,class_id,category_id] #7
-                                                                        WholeStageCodegen (12)
-                                                                          HashAggregate [brand_id,class_id,category_id]
-                                                                            InputAdapter
-                                                                              Exchange [brand_id,class_id,category_id] #8
-                                                                                WholeStageCodegen (11)
-                                                                                  HashAggregate [brand_id,class_id,category_id]
-                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                        Project [ss_item_sk]
-                                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                            Filter [ss_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                                    SubqueryBroadcast [d_date_sk] #3
-                                                                                                      BroadcastExchange #9
-                                                                                                        WholeStageCodegen (1)
-                                                                                                          Project [d_date_sk]
-                                                                                                            Filter [d_year,d_date_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                            InputAdapter
-                                                                                              ReusedExchange [d_date_sk] #9
-                                                                                        InputAdapter
-                                                                                          BroadcastExchange #10
-                                                                                            WholeStageCodegen (10)
-                                                                                              SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                InputAdapter
-                                                                                                  WholeStageCodegen (5)
-                                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                      InputAdapter
-                                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #11
-                                                                                                          WholeStageCodegen (4)
-                                                                                                            Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                InputAdapter
-                                                                                                  WholeStageCodegen (9)
-                                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                      InputAdapter
-                                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #12
-                                                                                                          WholeStageCodegen (8)
-                                                                                                            Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                              BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                Project [cs_item_sk]
-                                                                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                    Filter [cs_item_sk]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                            ReusedSubquery [d_date_sk] #3
-                                                                                                                    InputAdapter
-                                                                                                                      ReusedExchange [d_date_sk] #9
-                                                                                                                InputAdapter
-                                                                                                                  BroadcastExchange #13
-                                                                                                                    WholeStageCodegen (7)
-                                                                                                                      Filter [i_item_sk]
-                                                                                                                        ColumnarToRow
-                                                                                                                          InputAdapter
-                                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                              InputAdapter
-                                                                WholeStageCodegen (17)
-                                                                  Sort [i_brand_id,i_class_id,i_category_id]
-                                                                    InputAdapter
-                                                                      Exchange [i_brand_id,i_class_id,i_category_id] #14
-                                                                        WholeStageCodegen (16)
-                                                                          Project [i_brand_id,i_class_id,i_category_id]
-                                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                              Project [ws_item_sk]
-                                                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                  Filter [ws_item_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                          ReusedSubquery [d_date_sk] #3
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk] #9
-                                                                              InputAdapter
-                                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
-                          InputAdapter
-                            ReusedExchange [d_date_sk] #3
-                      InputAdapter
-                        BroadcastExchange #15
-                          WholeStageCodegen (44)
-                            SortMergeJoin [i_item_sk,ss_item_sk]
-                              InputAdapter
-                                WholeStageCodegen (24)
-                                  Sort [i_item_sk]
-                                    InputAdapter
-                                      Exchange [i_item_sk] #16
-                                        WholeStageCodegen (23)
-                                          Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                            ColumnarToRow
+                                                  Scan parquet default.date_dim [d_date_sk,d_week_seq]
+                            InputAdapter
+                              BroadcastExchange #3
+                                WholeStageCodegen (18)
+                                  Project [i_item_sk]
+                                    BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
+                                      Filter [i_brand_id,i_class_id,i_category_id]
+                                        ColumnarToRow
+                                          InputAdapter
+                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                      InputAdapter
+                                        BroadcastExchange #4
+                                          WholeStageCodegen (17)
+                                            HashAggregate [brand_id,class_id,category_id]
                                               InputAdapter
-                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                Exchange [brand_id,class_id,category_id] #5
+                                                  WholeStageCodegen (16)
+                                                    HashAggregate [brand_id,class_id,category_id]
+                                                      SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                        InputAdapter
+                                                          WholeStageCodegen (11)
+                                                            Sort [brand_id,class_id,category_id]
+                                                              InputAdapter
+                                                                Exchange [brand_id,class_id,category_id] #6
+                                                                  WholeStageCodegen (10)
+                                                                    HashAggregate [brand_id,class_id,category_id]
+                                                                      InputAdapter
+                                                                        Exchange [brand_id,class_id,category_id] #7
+                                                                          WholeStageCodegen (9)
+                                                                            HashAggregate [brand_id,class_id,category_id]
+                                                                              Project [i_brand_id,i_class_id,i_category_id]
+                                                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                  Project [ss_item_sk]
+                                                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                      Filter [ss_item_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                              SubqueryBroadcast [d_date_sk] #3
+                                                                                                BroadcastExchange #8
+                                                                                                  WholeStageCodegen (1)
+                                                                                                    Project [d_date_sk]
+                                                                                                      Filter [d_year,d_date_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                                      InputAdapter
+                                                                                        ReusedExchange [d_date_sk] #8
+                                                                                  InputAdapter
+                                                                                    BroadcastExchange #9
+                                                                                      WholeStageCodegen (8)
+                                                                                        SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                          InputAdapter
+                                                                                            WholeStageCodegen (3)
+                                                                                              Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                InputAdapter
+                                                                                                  Exchange [i_brand_id,i_class_id,i_category_id] #10
+                                                                                                    WholeStageCodegen (2)
+                                                                                                      Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                          InputAdapter
+                                                                                            WholeStageCodegen (7)
+                                                                                              Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                InputAdapter
+                                                                                                  Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                                    WholeStageCodegen (6)
+                                                                                                      Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                          Project [cs_item_sk]
+                                                                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                              Filter [cs_item_sk]
+                                                                                                                ColumnarToRow
+                                                                                                                  InputAdapter
+                                                                                                                    Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                                      ReusedSubquery [d_date_sk] #3
+                                                                                                              InputAdapter
+                                                                                                                ReusedExchange [d_date_sk] #8
+                                                                                                          InputAdapter
+                                                                                                            BroadcastExchange #12
+                                                                                                              WholeStageCodegen (5)
+                                                                                                                Filter [i_item_sk]
+                                                                                                                  ColumnarToRow
+                                                                                                                    InputAdapter
+                                                                                                                      Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                        InputAdapter
+                                                          WholeStageCodegen (15)
+                                                            Sort [i_brand_id,i_class_id,i_category_id]
+                                                              InputAdapter
+                                                                Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                                  WholeStageCodegen (14)
+                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                        Project [ws_item_sk]
+                                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                            Filter [ws_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                                    ReusedSubquery [d_date_sk] #3
+                                                                            InputAdapter
+                                                                              ReusedExchange [d_date_sk] #8
+                                                                        InputAdapter
+                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                          InputAdapter
+                            ReusedExchange [d_date_sk] #2
+                      InputAdapter
+                        BroadcastExchange #14
+                          WholeStageCodegen (38)
+                            BroadcastHashJoin [i_item_sk,ss_item_sk]
+                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                               InputAdapter
-                                WholeStageCodegen (43)
-                                  Sort [ss_item_sk]
-                                    InputAdapter
-                                      ReusedExchange [ss_item_sk] #4
+                                ReusedExchange [ss_item_sk] #3
       InputAdapter
-        BroadcastExchange #18
-          WholeStageCodegen (91)
+        BroadcastExchange #16
+          WholeStageCodegen (79)
             Filter [sales]
               ReusedSubquery [average_sales] #4
               HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                 InputAdapter
-                  Exchange [i_brand_id,i_class_id,i_category_id] #19
-                    WholeStageCodegen (90)
+                  Exchange [i_brand_id,i_class_id,i_category_id] #17
+                    WholeStageCodegen (78)
                       HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                         Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                           BroadcastHashJoin [ss_item_sk,i_item_sk]
                             Project [ss_item_sk,ss_quantity,ss_list_price]
                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                SortMergeJoin [ss_item_sk,ss_item_sk]
+                                BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                                  Filter [ss_item_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
+                                          SubqueryBroadcast [d_date_sk] #5
+                                            BroadcastExchange #18
+                                              WholeStageCodegen (1)
+                                                Project [d_date_sk]
+                                                  Filter [d_week_seq,d_date_sk]
+                                                    Subquery #6
+                                                      WholeStageCodegen (1)
+                                                        Project [d_week_seq]
+                                                          Filter [d_year,d_moy,d_dom]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet default.date_dim [d_date_sk,d_week_seq]
                                   InputAdapter
-                                    WholeStageCodegen (47)
-                                      Sort [ss_item_sk]
-                                        InputAdapter
-                                          Exchange [ss_item_sk] #20
-                                            WholeStageCodegen (46)
-                                              Filter [ss_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                      SubqueryBroadcast [d_date_sk] #5
-                                                        BroadcastExchange #21
-                                                          WholeStageCodegen (1)
-                                                            Project [d_date_sk]
-                                                              Filter [d_week_seq,d_date_sk]
-                                                                Subquery #6
-                                                                  WholeStageCodegen (1)
-                                                                    Project [d_week_seq]
-                                                                      Filter [d_year,d_moy,d_dom]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.date_dim [d_week_seq,d_year,d_moy,d_dom]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.date_dim [d_date_sk,d_week_seq]
-                                  InputAdapter
-                                    WholeStageCodegen (66)
-                                      Sort [ss_item_sk]
-                                        InputAdapter
-                                          ReusedExchange [ss_item_sk] #4
+                                    ReusedExchange [ss_item_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #21
+                                  ReusedExchange [d_date_sk] #18
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
+                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -1,150 +1,138 @@
 == Physical Plan ==
-TakeOrderedAndProject (146)
-+- * HashAggregate (145)
-   +- Exchange (144)
-      +- * HashAggregate (143)
-         +- Union (142)
-            :- * HashAggregate (121)
-            :  +- Exchange (120)
-            :     +- * HashAggregate (119)
-            :        +- Union (118)
-            :           :- * Filter (81)
-            :           :  +- * HashAggregate (80)
-            :           :     +- Exchange (79)
-            :           :        +- * HashAggregate (78)
-            :           :           +- * Project (77)
-            :           :              +- * BroadcastHashJoin Inner BuildRight (76)
-            :           :                 :- * Project (66)
-            :           :                 :  +- * BroadcastHashJoin Inner BuildRight (65)
-            :           :                 :     :- * SortMergeJoin LeftSemi (63)
-            :           :                 :     :  :- * Sort (5)
-            :           :                 :     :  :  +- Exchange (4)
-            :           :                 :     :  :     +- * Filter (3)
-            :           :                 :     :  :        +- * ColumnarToRow (2)
-            :           :                 :     :  :           +- Scan parquet default.store_sales (1)
-            :           :                 :     :  +- * Sort (62)
-            :           :                 :     :     +- Exchange (61)
-            :           :                 :     :        +- * Project (60)
-            :           :                 :     :           +- * BroadcastHashJoin Inner BuildRight (59)
-            :           :                 :     :              :- * Filter (8)
-            :           :                 :     :              :  +- * ColumnarToRow (7)
-            :           :                 :     :              :     +- Scan parquet default.item (6)
-            :           :                 :     :              +- BroadcastExchange (58)
-            :           :                 :     :                 +- * HashAggregate (57)
-            :           :                 :     :                    +- Exchange (56)
-            :           :                 :     :                       +- * HashAggregate (55)
-            :           :                 :     :                          +- * SortMergeJoin LeftSemi (54)
-            :           :                 :     :                             :- * Sort (42)
-            :           :                 :     :                             :  +- Exchange (41)
-            :           :                 :     :                             :     +- * HashAggregate (40)
-            :           :                 :     :                             :        +- Exchange (39)
-            :           :                 :     :                             :           +- * HashAggregate (38)
-            :           :                 :     :                             :              +- * Project (37)
-            :           :                 :     :                             :                 +- * BroadcastHashJoin Inner BuildRight (36)
-            :           :                 :     :                             :                    :- * Project (14)
-            :           :                 :     :                             :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-            :           :                 :     :                             :                    :     :- * Filter (11)
-            :           :                 :     :                             :                    :     :  +- * ColumnarToRow (10)
-            :           :                 :     :                             :                    :     :     +- Scan parquet default.store_sales (9)
-            :           :                 :     :                             :                    :     +- ReusedExchange (12)
-            :           :                 :     :                             :                    +- BroadcastExchange (35)
-            :           :                 :     :                             :                       +- * SortMergeJoin LeftSemi (34)
-            :           :                 :     :                             :                          :- * Sort (19)
-            :           :                 :     :                             :                          :  +- Exchange (18)
-            :           :                 :     :                             :                          :     +- * Filter (17)
-            :           :                 :     :                             :                          :        +- * ColumnarToRow (16)
-            :           :                 :     :                             :                          :           +- Scan parquet default.item (15)
-            :           :                 :     :                             :                          +- * Sort (33)
-            :           :                 :     :                             :                             +- Exchange (32)
-            :           :                 :     :                             :                                +- * Project (31)
-            :           :                 :     :                             :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-            :           :                 :     :                             :                                      :- * Project (25)
-            :           :                 :     :                             :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-            :           :                 :     :                             :                                      :     :- * Filter (22)
-            :           :                 :     :                             :                                      :     :  +- * ColumnarToRow (21)
-            :           :                 :     :                             :                                      :     :     +- Scan parquet default.catalog_sales (20)
-            :           :                 :     :                             :                                      :     +- ReusedExchange (23)
-            :           :                 :     :                             :                                      +- BroadcastExchange (29)
-            :           :                 :     :                             :                                         +- * Filter (28)
-            :           :                 :     :                             :                                            +- * ColumnarToRow (27)
-            :           :                 :     :                             :                                               +- Scan parquet default.item (26)
-            :           :                 :     :                             +- * Sort (53)
-            :           :                 :     :                                +- Exchange (52)
-            :           :                 :     :                                   +- * Project (51)
-            :           :                 :     :                                      +- * BroadcastHashJoin Inner BuildRight (50)
-            :           :                 :     :                                         :- * Project (48)
-            :           :                 :     :                                         :  +- * BroadcastHashJoin Inner BuildRight (47)
-            :           :                 :     :                                         :     :- * Filter (45)
-            :           :                 :     :                                         :     :  +- * ColumnarToRow (44)
-            :           :                 :     :                                         :     :     +- Scan parquet default.web_sales (43)
-            :           :                 :     :                                         :     +- ReusedExchange (46)
-            :           :                 :     :                                         +- ReusedExchange (49)
-            :           :                 :     +- ReusedExchange (64)
-            :           :                 +- BroadcastExchange (75)
-            :           :                    +- * SortMergeJoin LeftSemi (74)
-            :           :                       :- * Sort (71)
-            :           :                       :  +- Exchange (70)
-            :           :                       :     +- * Filter (69)
-            :           :                       :        +- * ColumnarToRow (68)
-            :           :                       :           +- Scan parquet default.item (67)
-            :           :                       +- * Sort (73)
-            :           :                          +- ReusedExchange (72)
-            :           :- * Filter (99)
-            :           :  +- * HashAggregate (98)
-            :           :     +- Exchange (97)
-            :           :        +- * HashAggregate (96)
-            :           :           +- * Project (95)
-            :           :              +- * BroadcastHashJoin Inner BuildRight (94)
-            :           :                 :- * Project (92)
-            :           :                 :  +- * BroadcastHashJoin Inner BuildRight (91)
-            :           :                 :     :- * SortMergeJoin LeftSemi (89)
-            :           :                 :     :  :- * Sort (86)
-            :           :                 :     :  :  +- Exchange (85)
-            :           :                 :     :  :     +- * Filter (84)
-            :           :                 :     :  :        +- * ColumnarToRow (83)
-            :           :                 :     :  :           +- Scan parquet default.catalog_sales (82)
-            :           :                 :     :  +- * Sort (88)
-            :           :                 :     :     +- ReusedExchange (87)
-            :           :                 :     +- ReusedExchange (90)
-            :           :                 +- ReusedExchange (93)
-            :           +- * Filter (117)
-            :              +- * HashAggregate (116)
-            :                 +- Exchange (115)
-            :                    +- * HashAggregate (114)
-            :                       +- * Project (113)
-            :                          +- * BroadcastHashJoin Inner BuildRight (112)
-            :                             :- * Project (110)
-            :                             :  +- * BroadcastHashJoin Inner BuildRight (109)
-            :                             :     :- * SortMergeJoin LeftSemi (107)
-            :                             :     :  :- * Sort (104)
-            :                             :     :  :  +- Exchange (103)
-            :                             :     :  :     +- * Filter (102)
-            :                             :     :  :        +- * ColumnarToRow (101)
-            :                             :     :  :           +- Scan parquet default.web_sales (100)
-            :                             :     :  +- * Sort (106)
-            :                             :     :     +- ReusedExchange (105)
-            :                             :     +- ReusedExchange (108)
-            :                             +- ReusedExchange (111)
-            :- * HashAggregate (126)
-            :  +- Exchange (125)
-            :     +- * HashAggregate (124)
-            :        +- * HashAggregate (123)
-            :           +- ReusedExchange (122)
-            :- * HashAggregate (131)
-            :  +- Exchange (130)
-            :     +- * HashAggregate (129)
-            :        +- * HashAggregate (128)
-            :           +- ReusedExchange (127)
-            :- * HashAggregate (136)
-            :  +- Exchange (135)
-            :     +- * HashAggregate (134)
-            :        +- * HashAggregate (133)
-            :           +- ReusedExchange (132)
-            +- * HashAggregate (141)
-               +- Exchange (140)
-                  +- * HashAggregate (139)
-                     +- * HashAggregate (138)
-                        +- ReusedExchange (137)
+TakeOrderedAndProject (134)
++- * HashAggregate (133)
+   +- Exchange (132)
+      +- * HashAggregate (131)
+         +- Union (130)
+            :- * HashAggregate (109)
+            :  +- Exchange (108)
+            :     +- * HashAggregate (107)
+            :        +- Union (106)
+            :           :- * Filter (75)
+            :           :  +- * HashAggregate (74)
+            :           :     +- Exchange (73)
+            :           :        +- * HashAggregate (72)
+            :           :           +- * Project (71)
+            :           :              +- * BroadcastHashJoin Inner BuildRight (70)
+            :           :                 :- * Project (63)
+            :           :                 :  +- * BroadcastHashJoin Inner BuildRight (62)
+            :           :                 :     :- * BroadcastHashJoin LeftSemi BuildRight (60)
+            :           :                 :     :  :- * Filter (3)
+            :           :                 :     :  :  +- * ColumnarToRow (2)
+            :           :                 :     :  :     +- Scan parquet default.store_sales (1)
+            :           :                 :     :  +- BroadcastExchange (59)
+            :           :                 :     :     +- * Project (58)
+            :           :                 :     :        +- * BroadcastHashJoin LeftSemi BuildRight (57)
+            :           :                 :     :           :- * Filter (6)
+            :           :                 :     :           :  +- * ColumnarToRow (5)
+            :           :                 :     :           :     +- Scan parquet default.item (4)
+            :           :                 :     :           +- BroadcastExchange (56)
+            :           :                 :     :              +- * HashAggregate (55)
+            :           :                 :     :                 +- Exchange (54)
+            :           :                 :     :                    +- * HashAggregate (53)
+            :           :                 :     :                       +- * SortMergeJoin LeftSemi (52)
+            :           :                 :     :                          :- * Sort (40)
+            :           :                 :     :                          :  +- Exchange (39)
+            :           :                 :     :                          :     +- * HashAggregate (38)
+            :           :                 :     :                          :        +- Exchange (37)
+            :           :                 :     :                          :           +- * HashAggregate (36)
+            :           :                 :     :                          :              +- * Project (35)
+            :           :                 :     :                          :                 +- * BroadcastHashJoin Inner BuildRight (34)
+            :           :                 :     :                          :                    :- * Project (12)
+            :           :                 :     :                          :                    :  +- * BroadcastHashJoin Inner BuildRight (11)
+            :           :                 :     :                          :                    :     :- * Filter (9)
+            :           :                 :     :                          :                    :     :  +- * ColumnarToRow (8)
+            :           :                 :     :                          :                    :     :     +- Scan parquet default.store_sales (7)
+            :           :                 :     :                          :                    :     +- ReusedExchange (10)
+            :           :                 :     :                          :                    +- BroadcastExchange (33)
+            :           :                 :     :                          :                       +- * SortMergeJoin LeftSemi (32)
+            :           :                 :     :                          :                          :- * Sort (17)
+            :           :                 :     :                          :                          :  +- Exchange (16)
+            :           :                 :     :                          :                          :     +- * Filter (15)
+            :           :                 :     :                          :                          :        +- * ColumnarToRow (14)
+            :           :                 :     :                          :                          :           +- Scan parquet default.item (13)
+            :           :                 :     :                          :                          +- * Sort (31)
+            :           :                 :     :                          :                             +- Exchange (30)
+            :           :                 :     :                          :                                +- * Project (29)
+            :           :                 :     :                          :                                   +- * BroadcastHashJoin Inner BuildRight (28)
+            :           :                 :     :                          :                                      :- * Project (23)
+            :           :                 :     :                          :                                      :  +- * BroadcastHashJoin Inner BuildRight (22)
+            :           :                 :     :                          :                                      :     :- * Filter (20)
+            :           :                 :     :                          :                                      :     :  +- * ColumnarToRow (19)
+            :           :                 :     :                          :                                      :     :     +- Scan parquet default.catalog_sales (18)
+            :           :                 :     :                          :                                      :     +- ReusedExchange (21)
+            :           :                 :     :                          :                                      +- BroadcastExchange (27)
+            :           :                 :     :                          :                                         +- * Filter (26)
+            :           :                 :     :                          :                                            +- * ColumnarToRow (25)
+            :           :                 :     :                          :                                               +- Scan parquet default.item (24)
+            :           :                 :     :                          +- * Sort (51)
+            :           :                 :     :                             +- Exchange (50)
+            :           :                 :     :                                +- * Project (49)
+            :           :                 :     :                                   +- * BroadcastHashJoin Inner BuildRight (48)
+            :           :                 :     :                                      :- * Project (46)
+            :           :                 :     :                                      :  +- * BroadcastHashJoin Inner BuildRight (45)
+            :           :                 :     :                                      :     :- * Filter (43)
+            :           :                 :     :                                      :     :  +- * ColumnarToRow (42)
+            :           :                 :     :                                      :     :     +- Scan parquet default.web_sales (41)
+            :           :                 :     :                                      :     +- ReusedExchange (44)
+            :           :                 :     :                                      +- ReusedExchange (47)
+            :           :                 :     +- ReusedExchange (61)
+            :           :                 +- BroadcastExchange (69)
+            :           :                    +- * BroadcastHashJoin LeftSemi BuildRight (68)
+            :           :                       :- * Filter (66)
+            :           :                       :  +- * ColumnarToRow (65)
+            :           :                       :     +- Scan parquet default.item (64)
+            :           :                       +- ReusedExchange (67)
+            :           :- * Filter (90)
+            :           :  +- * HashAggregate (89)
+            :           :     +- Exchange (88)
+            :           :        +- * HashAggregate (87)
+            :           :           +- * Project (86)
+            :           :              +- * BroadcastHashJoin Inner BuildRight (85)
+            :           :                 :- * Project (83)
+            :           :                 :  +- * BroadcastHashJoin Inner BuildRight (82)
+            :           :                 :     :- * BroadcastHashJoin LeftSemi BuildRight (80)
+            :           :                 :     :  :- * Filter (78)
+            :           :                 :     :  :  +- * ColumnarToRow (77)
+            :           :                 :     :  :     +- Scan parquet default.catalog_sales (76)
+            :           :                 :     :  +- ReusedExchange (79)
+            :           :                 :     +- ReusedExchange (81)
+            :           :                 +- ReusedExchange (84)
+            :           +- * Filter (105)
+            :              +- * HashAggregate (104)
+            :                 +- Exchange (103)
+            :                    +- * HashAggregate (102)
+            :                       +- * Project (101)
+            :                          +- * BroadcastHashJoin Inner BuildRight (100)
+            :                             :- * Project (98)
+            :                             :  +- * BroadcastHashJoin Inner BuildRight (97)
+            :                             :     :- * BroadcastHashJoin LeftSemi BuildRight (95)
+            :                             :     :  :- * Filter (93)
+            :                             :     :  :  +- * ColumnarToRow (92)
+            :                             :     :  :     +- Scan parquet default.web_sales (91)
+            :                             :     :  +- ReusedExchange (94)
+            :                             :     +- ReusedExchange (96)
+            :                             +- ReusedExchange (99)
+            :- * HashAggregate (114)
+            :  +- Exchange (113)
+            :     +- * HashAggregate (112)
+            :        +- * HashAggregate (111)
+            :           +- ReusedExchange (110)
+            :- * HashAggregate (119)
+            :  +- Exchange (118)
+            :     +- * HashAggregate (117)
+            :        +- * HashAggregate (116)
+            :           +- ReusedExchange (115)
+            :- * HashAggregate (124)
+            :  +- Exchange (123)
+            :     +- * HashAggregate (122)
+            :        +- * HashAggregate (121)
+            :           +- ReusedExchange (120)
+            +- * HashAggregate (129)
+               +- Exchange (128)
+                  +- * HashAggregate (127)
+                     +- * HashAggregate (126)
+                        +- ReusedExchange (125)
 
 
 (1) Scan parquet default.store_sales
@@ -155,899 +143,851 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 1]
+(2) ColumnarToRow [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 1]
+(3) Filter [codegen id : 39]
 Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_item_sk#1)
 
-(4) Exchange
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [id=#6]
-
-(5) Sort [codegen id : 2]
-Input [4]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4]
-Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
-
-(6) Scan parquet default.item
-Output [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(4) Scan parquet default.item
+Output [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+(5) ColumnarToRow [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(8) Filter [codegen id : 20]
-Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
-Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
+(6) Filter [codegen id : 18]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
+Condition : ((isnotnull(i_brand_id#7) AND isnotnull(i_class_id#8)) AND isnotnull(i_category_id#9))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(7) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#11), dynamicpruningexpression(ss_sold_date_sk#11 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(8) ColumnarToRow [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(9) Filter [codegen id : 9]
+Input [2]: [ss_item_sk#10, ss_sold_date_sk#11]
+Condition : isnotnull(ss_item_sk#10)
 
-(12) ReusedExchange [Reuses operator id: 180]
-Output [1]: [d_date_sk#14]
+(10) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#13]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(11) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#13]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(12) Project [codegen id : 9]
+Output [1]: [ss_item_sk#10]
+Input [3]: [ss_item_sk#10, ss_sold_date_sk#11, d_date_sk#13]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(13) Scan parquet default.item
+Output [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(14) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(15) Filter [codegen id : 2]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Condition : (((isnotnull(i_item_sk#14) AND isnotnull(i_brand_id#15)) AND isnotnull(i_class_id#16)) AND isnotnull(i_category_id#17))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(16) Exchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: hashpartitioning(coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17), 5), ENSURE_REQUIREMENTS, [id=#18]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(17) Sort [codegen id : 3]
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: [coalesce(i_brand_id#15, 0) ASC NULLS FIRST, isnull(i_brand_id#15) ASC NULLS FIRST, coalesce(i_class_id#16, 0) ASC NULLS FIRST, isnull(i_class_id#16) ASC NULLS FIRST, coalesce(i_category_id#17, 0) ASC NULLS FIRST, isnull(i_category_id#17) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(18) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#20), dynamicpruningexpression(cs_sold_date_sk#20 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(19) ColumnarToRow [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(20) Filter [codegen id : 6]
+Input [2]: [cs_item_sk#19, cs_sold_date_sk#20]
+Condition : isnotnull(cs_item_sk#19)
 
-(23) ReusedExchange [Reuses operator id: 180]
-Output [1]: [d_date_sk#22]
+(21) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#21]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(22) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_sold_date_sk#20]
+Right keys [1]: [d_date_sk#21]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(23) Project [codegen id : 6]
+Output [1]: [cs_item_sk#19]
+Input [3]: [cs_item_sk#19, cs_sold_date_sk#20, d_date_sk#21]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(24) Scan parquet default.item
+Output [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(25) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(26) Filter [codegen id : 5]
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Condition : isnotnull(i_item_sk#22)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(27) BroadcastExchange
+Input [4]: [i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#26]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(28) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [cs_item_sk#19]
+Right keys [1]: [i_item_sk#22]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(29) Project [codegen id : 6]
+Output [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Input [5]: [cs_item_sk#19, i_item_sk#22, i_brand_id#23, i_class_id#24, i_category_id#25]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(30) Exchange
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: hashpartitioning(coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25), 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(31) Sort [codegen id : 7]
+Input [3]: [i_brand_id#23, i_class_id#24, i_category_id#25]
+Arguments: [coalesce(i_brand_id#23, 0) ASC NULLS FIRST, isnull(i_brand_id#23) ASC NULLS FIRST, coalesce(i_class_id#24, 0) ASC NULLS FIRST, isnull(i_class_id#24) ASC NULLS FIRST, coalesce(i_category_id#25, 0) ASC NULLS FIRST, isnull(i_category_id#25) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(32) SortMergeJoin [codegen id : 8]
+Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
+Right keys [6]: [coalesce(i_brand_id#23, 0), isnull(i_brand_id#23), coalesce(i_class_id#24, 0), isnull(i_class_id#24), coalesce(i_category_id#25, 0), isnull(i_category_id#25)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(33) BroadcastExchange
+Input [4]: [i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_item_sk#10]
+Right keys [1]: [i_item_sk#14]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(35) Project [codegen id : 9]
+Output [3]: [i_brand_id#15 AS brand_id#29, i_class_id#16 AS class_id#30, i_category_id#17 AS category_id#31]
+Input [5]: [ss_item_sk#10, i_item_sk#14, i_brand_id#15, i_class_id#16, i_category_id#17]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(36) HashAggregate [codegen id : 9]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
+
+(37) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#32]
+
+(38) HashAggregate [codegen id : 10]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
 (39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31), 5), ENSURE_REQUIREMENTS, [id=#33]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+(40) Sort [codegen id : 11]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: [coalesce(brand_id#29, 0) ASC NULLS FIRST, isnull(brand_id#29) ASC NULLS FIRST, coalesce(class_id#30, 0) ASC NULLS FIRST, isnull(class_id#30) ASC NULLS FIRST, coalesce(category_id#31, 0) ASC NULLS FIRST, isnull(category_id#31) ASC NULLS FIRST], false, 0
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
-
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
-
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(41) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#35), dynamicpruningexpression(ws_sold_date_sk#35 IN dynamicpruning#12)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(42) ColumnarToRow [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(43) Filter [codegen id : 14]
+Input [2]: [ws_item_sk#34, ws_sold_date_sk#35]
+Condition : isnotnull(ws_item_sk#34)
 
-(46) ReusedExchange [Reuses operator id: 180]
-Output [1]: [d_date_sk#37]
+(44) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#36]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(45) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_sold_date_sk#35]
+Right keys [1]: [d_date_sk#36]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(46) Project [codegen id : 14]
+Output [1]: [ws_item_sk#34]
+Input [3]: [ws_item_sk#34, ws_sold_date_sk#35, d_date_sk#36]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(47) ReusedExchange [Reuses operator id: 27]
+Output [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(48) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ws_item_sk#34]
+Right keys [1]: [i_item_sk#37]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(49) Project [codegen id : 14]
+Output [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [5]: [ws_item_sk#34, i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(50) Exchange
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: hashpartitioning(coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40), 5), ENSURE_REQUIREMENTS, [id=#41]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(51) Sort [codegen id : 15]
+Input [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Arguments: [coalesce(i_brand_id#38, 0) ASC NULLS FIRST, isnull(i_brand_id#38) ASC NULLS FIRST, coalesce(i_class_id#39, 0) ASC NULLS FIRST, isnull(i_class_id#39) ASC NULLS FIRST, coalesce(i_category_id#40, 0) ASC NULLS FIRST, isnull(i_category_id#40) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(52) SortMergeJoin [codegen id : 16]
+Left keys [6]: [coalesce(brand_id#29, 0), isnull(brand_id#29), coalesce(class_id#30, 0), isnull(class_id#30), coalesce(category_id#31, 0), isnull(category_id#31)]
+Right keys [6]: [coalesce(i_brand_id#38, 0), isnull(i_brand_id#38), coalesce(i_class_id#39, 0), isnull(i_class_id#39), coalesce(i_category_id#40, 0), isnull(i_category_id#40)]
 Join condition: None
 
-(55) HashAggregate [codegen id : 18]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(53) HashAggregate [codegen id : 16]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(56) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#43]
+(54) Exchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: hashpartitioning(brand_id#29, class_id#30, category_id#31, 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(57) HashAggregate [codegen id : 19]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(55) HashAggregate [codegen id : 17]
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Keys [3]: [brand_id#29, class_id#30, category_id#31]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#29, class_id#30, category_id#31]
 
-(58) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#44]
+(56) BroadcastExchange
+Input [3]: [brand_id#29, class_id#30, category_id#31]
+Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
-(59) BroadcastHashJoin [codegen id : 20]
-Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+(57) BroadcastHashJoin [codegen id : 18]
+Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
+Right keys [3]: [brand_id#29, class_id#30, category_id#31]
 Join condition: None
 
-(60) Project [codegen id : 20]
-Output [1]: [i_item_sk#7 AS ss_item_sk#45]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+(58) Project [codegen id : 18]
+Output [1]: [i_item_sk#6 AS ss_item_sk#44]
+Input [4]: [i_item_sk#6, i_brand_id#7, i_class_id#8, i_category_id#9]
 
-(61) Exchange
-Input [1]: [ss_item_sk#45]
-Arguments: hashpartitioning(ss_item_sk#45, 5), ENSURE_REQUIREMENTS, [id=#46]
+(59) BroadcastExchange
+Input [1]: [ss_item_sk#44]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#45]
 
-(62) Sort [codegen id : 21]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(63) SortMergeJoin [codegen id : 45]
+(60) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [ss_item_sk#45]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(64) ReusedExchange [Reuses operator id: 175]
-Output [1]: [d_date_sk#47]
+(61) ReusedExchange [Reuses operator id: 163]
+Output [1]: [d_date_sk#46]
 
-(65) BroadcastHashJoin [codegen id : 45]
+(62) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#47]
+Right keys [1]: [d_date_sk#46]
 Join condition: None
 
-(66) Project [codegen id : 45]
+(63) Project [codegen id : 39]
 Output [3]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3]
-Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#47]
+Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#46]
 
-(67) Scan parquet default.item
-Output [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(64) Scan parquet default.item
+Output [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(68) ColumnarToRow [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(65) ColumnarToRow [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(69) Filter [codegen id : 23]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Condition : isnotnull(i_item_sk#48)
+(66) Filter [codegen id : 38]
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Condition : isnotnull(i_item_sk#47)
 
-(70) Exchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: hashpartitioning(i_item_sk#48, 5), ENSURE_REQUIREMENTS, [id=#52]
+(67) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(71) Sort [codegen id : 24]
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: [i_item_sk#48 ASC NULLS FIRST], false, 0
-
-(72) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(73) Sort [codegen id : 43]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(74) SortMergeJoin [codegen id : 44]
-Left keys [1]: [i_item_sk#48]
-Right keys [1]: [ss_item_sk#45]
+(68) BroadcastHashJoin [codegen id : 38]
+Left keys [1]: [i_item_sk#47]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(75) BroadcastExchange
-Input [4]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#53]
+(69) BroadcastExchange
+Input [4]: [i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#51]
 
-(76) BroadcastHashJoin [codegen id : 45]
+(70) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#48]
+Right keys [1]: [i_item_sk#47]
 Join condition: None
 
-(77) Project [codegen id : 45]
-Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51]
+(71) Project [codegen id : 39]
+Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#47, i_brand_id#48, i_class_id#49, i_category_id#50]
 
-(78) HashAggregate [codegen id : 45]
-Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#49, i_class_id#50, i_category_id#51]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(72) HashAggregate [codegen id : 39]
+Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#48, i_class_id#49, i_category_id#50]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#54, isEmpty#55, count#56]
-Results [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
+Aggregate Attributes [3]: [sum#52, isEmpty#53, count#54]
+Results [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
 
-(79) Exchange
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Arguments: hashpartitioning(i_brand_id#49, i_class_id#50, i_category_id#51, 5), ENSURE_REQUIREMENTS, [id=#60]
+(73) Exchange
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Arguments: hashpartitioning(i_brand_id#48, i_class_id#49, i_category_id#50, 5), ENSURE_REQUIREMENTS, [id=#58]
 
-(80) HashAggregate [codegen id : 46]
-Input [6]: [i_brand_id#49, i_class_id#50, i_category_id#51, sum#57, isEmpty#58, count#59]
-Keys [3]: [i_brand_id#49, i_class_id#50, i_category_id#51]
+(74) HashAggregate [codegen id : 40]
+Input [6]: [i_brand_id#48, i_class_id#49, i_category_id#50, sum#55, isEmpty#56, count#57]
+Keys [3]: [i_brand_id#48, i_class_id#49, i_category_id#50]
 Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61, count(1)#62]
-Results [6]: [store AS channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#61 AS sales#64, count(1)#62 AS number_sales#65]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59, count(1)#60]
+Results [6]: [store AS channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum(CheckOverflow((promote_precision(cast(cast(ss_quantity#2 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price#3 as decimal(12,2)))), DecimalType(18,2), true))#59 AS sales#62, count(1)#60 AS number_sales#63]
 
-(81) Filter [codegen id : 46]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65]
-Condition : (isnotnull(sales#64) AND (cast(sales#64 as decimal(32,6)) > cast(Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(75) Filter [codegen id : 40]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63]
+Condition : (isnotnull(sales#62) AND (cast(sales#62 as decimal(32,6)) > cast(Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(82) Scan parquet default.catalog_sales
-Output [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
+(76) Scan parquet default.catalog_sales
+Output [4]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#71), dynamicpruningexpression(cs_sold_date_sk#71 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#69), dynamicpruningexpression(cs_sold_date_sk#69 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(83) ColumnarToRow [codegen id : 47]
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
+(77) ColumnarToRow [codegen id : 79]
+Input [4]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69]
 
-(84) Filter [codegen id : 47]
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
-Condition : isnotnull(cs_item_sk#68)
+(78) Filter [codegen id : 79]
+Input [4]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69]
+Condition : isnotnull(cs_item_sk#66)
 
-(85) Exchange
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
-Arguments: hashpartitioning(cs_item_sk#68, 5), ENSURE_REQUIREMENTS, [id=#72]
+(79) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
 
-(86) Sort [codegen id : 48]
-Input [4]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71]
-Arguments: [cs_item_sk#68 ASC NULLS FIRST], false, 0
-
-(87) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
-
-(88) Sort [codegen id : 67]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
-
-(89) SortMergeJoin [codegen id : 91]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [ss_item_sk#45]
+(80) BroadcastHashJoin [codegen id : 79]
+Left keys [1]: [cs_item_sk#66]
+Right keys [1]: [ss_item_sk#44]
 Join condition: None
 
-(90) ReusedExchange [Reuses operator id: 175]
-Output [1]: [d_date_sk#73]
+(81) ReusedExchange [Reuses operator id: 163]
+Output [1]: [d_date_sk#70]
 
-(91) BroadcastHashJoin [codegen id : 91]
-Left keys [1]: [cs_sold_date_sk#71]
-Right keys [1]: [d_date_sk#73]
+(82) BroadcastHashJoin [codegen id : 79]
+Left keys [1]: [cs_sold_date_sk#69]
+Right keys [1]: [d_date_sk#70]
 Join condition: None
 
-(92) Project [codegen id : 91]
-Output [3]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70]
-Input [5]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, cs_sold_date_sk#71, d_date_sk#73]
+(83) Project [codegen id : 79]
+Output [3]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68]
+Input [5]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, cs_sold_date_sk#69, d_date_sk#70]
 
-(93) ReusedExchange [Reuses operator id: 75]
-Output [4]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77]
+(84) ReusedExchange [Reuses operator id: 69]
+Output [4]: [i_item_sk#71, i_brand_id#72, i_class_id#73, i_category_id#74]
 
-(94) BroadcastHashJoin [codegen id : 91]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [i_item_sk#74]
+(85) BroadcastHashJoin [codegen id : 79]
+Left keys [1]: [cs_item_sk#66]
+Right keys [1]: [i_item_sk#71]
 Join condition: None
 
-(95) Project [codegen id : 91]
-Output [5]: [cs_quantity#69, cs_list_price#70, i_brand_id#75, i_class_id#76, i_category_id#77]
-Input [7]: [cs_item_sk#68, cs_quantity#69, cs_list_price#70, i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77]
+(86) Project [codegen id : 79]
+Output [5]: [cs_quantity#67, cs_list_price#68, i_brand_id#72, i_class_id#73, i_category_id#74]
+Input [7]: [cs_item_sk#66, cs_quantity#67, cs_list_price#68, i_item_sk#71, i_brand_id#72, i_class_id#73, i_category_id#74]
 
-(96) HashAggregate [codegen id : 91]
-Input [5]: [cs_quantity#69, cs_list_price#70, i_brand_id#75, i_class_id#76, i_category_id#77]
-Keys [3]: [i_brand_id#75, i_class_id#76, i_category_id#77]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#78, isEmpty#79, count#80]
-Results [6]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum#81, isEmpty#82, count#83]
+(87) HashAggregate [codegen id : 79]
+Input [5]: [cs_quantity#67, cs_list_price#68, i_brand_id#72, i_class_id#73, i_category_id#74]
+Keys [3]: [i_brand_id#72, i_class_id#73, i_category_id#74]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
+Aggregate Attributes [3]: [sum#75, isEmpty#76, count#77]
+Results [6]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum#78, isEmpty#79, count#80]
 
-(97) Exchange
-Input [6]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum#81, isEmpty#82, count#83]
-Arguments: hashpartitioning(i_brand_id#75, i_class_id#76, i_category_id#77, 5), ENSURE_REQUIREMENTS, [id=#84]
+(88) Exchange
+Input [6]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum#78, isEmpty#79, count#80]
+Arguments: hashpartitioning(i_brand_id#72, i_class_id#73, i_category_id#74, 5), ENSURE_REQUIREMENTS, [id=#81]
 
-(98) HashAggregate [codegen id : 92]
-Input [6]: [i_brand_id#75, i_class_id#76, i_category_id#77, sum#81, isEmpty#82, count#83]
-Keys [3]: [i_brand_id#75, i_class_id#76, i_category_id#77]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#85, count(1)#86]
-Results [6]: [catalog AS channel#87, i_brand_id#75, i_class_id#76, i_category_id#77, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#69 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#70 as decimal(12,2)))), DecimalType(18,2), true))#85 AS sales#88, count(1)#86 AS number_sales#89]
+(89) HashAggregate [codegen id : 80]
+Input [6]: [i_brand_id#72, i_class_id#73, i_category_id#74, sum#78, isEmpty#79, count#80]
+Keys [3]: [i_brand_id#72, i_class_id#73, i_category_id#74]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#82, count(1)#83]
+Results [6]: [catalog AS channel#84, i_brand_id#72, i_class_id#73, i_category_id#74, sum(CheckOverflow((promote_precision(cast(cast(cs_quantity#67 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price#68 as decimal(12,2)))), DecimalType(18,2), true))#82 AS sales#85, count(1)#83 AS number_sales#86]
 
-(99) Filter [codegen id : 92]
-Input [6]: [channel#87, i_brand_id#75, i_class_id#76, i_category_id#77, sales#88, number_sales#89]
-Condition : (isnotnull(sales#88) AND (cast(sales#88 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(90) Filter [codegen id : 80]
+Input [6]: [channel#84, i_brand_id#72, i_class_id#73, i_category_id#74, sales#85, number_sales#86]
+Condition : (isnotnull(sales#85) AND (cast(sales#85 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(100) Scan parquet default.web_sales
-Output [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
+(91) Scan parquet default.web_sales
+Output [4]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#93), dynamicpruningexpression(ws_sold_date_sk#93 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#90), dynamicpruningexpression(ws_sold_date_sk#90 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(101) ColumnarToRow [codegen id : 93]
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
+(92) ColumnarToRow [codegen id : 119]
+Input [4]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
 
-(102) Filter [codegen id : 93]
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
-Condition : isnotnull(ws_item_sk#90)
+(93) Filter [codegen id : 119]
+Input [4]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90]
+Condition : isnotnull(ws_item_sk#87)
+
+(94) ReusedExchange [Reuses operator id: 59]
+Output [1]: [ss_item_sk#44]
+
+(95) BroadcastHashJoin [codegen id : 119]
+Left keys [1]: [ws_item_sk#87]
+Right keys [1]: [ss_item_sk#44]
+Join condition: None
+
+(96) ReusedExchange [Reuses operator id: 163]
+Output [1]: [d_date_sk#91]
+
+(97) BroadcastHashJoin [codegen id : 119]
+Left keys [1]: [ws_sold_date_sk#90]
+Right keys [1]: [d_date_sk#91]
+Join condition: None
+
+(98) Project [codegen id : 119]
+Output [3]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89]
+Input [5]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, ws_sold_date_sk#90, d_date_sk#91]
+
+(99) ReusedExchange [Reuses operator id: 69]
+Output [4]: [i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95]
+
+(100) BroadcastHashJoin [codegen id : 119]
+Left keys [1]: [ws_item_sk#87]
+Right keys [1]: [i_item_sk#92]
+Join condition: None
+
+(101) Project [codegen id : 119]
+Output [5]: [ws_quantity#88, ws_list_price#89, i_brand_id#93, i_class_id#94, i_category_id#95]
+Input [7]: [ws_item_sk#87, ws_quantity#88, ws_list_price#89, i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95]
+
+(102) HashAggregate [codegen id : 119]
+Input [5]: [ws_quantity#88, ws_list_price#89, i_brand_id#93, i_class_id#94, i_category_id#95]
+Keys [3]: [i_brand_id#93, i_class_id#94, i_category_id#95]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
+Aggregate Attributes [3]: [sum#96, isEmpty#97, count#98]
+Results [6]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum#99, isEmpty#100, count#101]
 
 (103) Exchange
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
-Arguments: hashpartitioning(ws_item_sk#90, 5), ENSURE_REQUIREMENTS, [id=#94]
+Input [6]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum#99, isEmpty#100, count#101]
+Arguments: hashpartitioning(i_brand_id#93, i_class_id#94, i_category_id#95, 5), ENSURE_REQUIREMENTS, [id=#102]
 
-(104) Sort [codegen id : 94]
-Input [4]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93]
-Arguments: [ws_item_sk#90 ASC NULLS FIRST], false, 0
+(104) HashAggregate [codegen id : 120]
+Input [6]: [i_brand_id#93, i_class_id#94, i_category_id#95, sum#99, isEmpty#100, count#101]
+Keys [3]: [i_brand_id#93, i_class_id#94, i_category_id#95]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true))#103, count(1)#104]
+Results [6]: [web AS channel#105, i_brand_id#93, i_class_id#94, i_category_id#95, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#88 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#89 as decimal(12,2)))), DecimalType(18,2), true))#103 AS sales#106, count(1)#104 AS number_sales#107]
 
-(105) ReusedExchange [Reuses operator id: 61]
-Output [1]: [ss_item_sk#45]
+(105) Filter [codegen id : 120]
+Input [6]: [channel#105, i_brand_id#93, i_class_id#94, i_category_id#95, sales#106, number_sales#107]
+Condition : (isnotnull(sales#106) AND (cast(sales#106 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#64, [id=#65] as decimal(32,6))))
 
-(106) Sort [codegen id : 113]
-Input [1]: [ss_item_sk#45]
-Arguments: [ss_item_sk#45 ASC NULLS FIRST], false, 0
+(106) Union
 
-(107) SortMergeJoin [codegen id : 137]
-Left keys [1]: [ws_item_sk#90]
-Right keys [1]: [ss_item_sk#45]
-Join condition: None
+(107) HashAggregate [codegen id : 121]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sales#62, number_sales#63]
+Keys [4]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50]
+Functions [2]: [partial_sum(sales#62), partial_sum(number_sales#63)]
+Aggregate Attributes [3]: [sum#108, isEmpty#109, sum#110]
+Results [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
 
-(108) ReusedExchange [Reuses operator id: 175]
-Output [1]: [d_date_sk#95]
+(108) Exchange
+Input [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
+Arguments: hashpartitioning(channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, 5), ENSURE_REQUIREMENTS, [id=#114]
 
-(109) BroadcastHashJoin [codegen id : 137]
-Left keys [1]: [ws_sold_date_sk#93]
-Right keys [1]: [d_date_sk#95]
-Join condition: None
+(109) HashAggregate [codegen id : 122]
+Input [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
+Keys [4]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50]
+Functions [2]: [sum(sales#62), sum(number_sales#63)]
+Aggregate Attributes [2]: [sum(sales#62)#115, sum(number_sales#63)#116]
+Results [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum(sales#62)#115 AS sum_sales#117, sum(number_sales#63)#116 AS number_sales#118]
 
-(110) Project [codegen id : 137]
-Output [3]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92]
-Input [5]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, ws_sold_date_sk#93, d_date_sk#95]
+(110) ReusedExchange [Reuses operator id: 108]
+Output [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
 
-(111) ReusedExchange [Reuses operator id: 75]
-Output [4]: [i_item_sk#96, i_brand_id#97, i_class_id#98, i_category_id#99]
+(111) HashAggregate [codegen id : 244]
+Input [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
+Keys [4]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50]
+Functions [2]: [sum(sales#62), sum(number_sales#63)]
+Aggregate Attributes [2]: [sum(sales#62)#115, sum(number_sales#63)#116]
+Results [5]: [channel#61, i_brand_id#48, i_class_id#49, sum(sales#62)#115 AS sum_sales#117, sum(number_sales#63)#116 AS number_sales#118]
 
-(112) BroadcastHashJoin [codegen id : 137]
-Left keys [1]: [ws_item_sk#90]
-Right keys [1]: [i_item_sk#96]
-Join condition: None
+(112) HashAggregate [codegen id : 244]
+Input [5]: [channel#61, i_brand_id#48, i_class_id#49, sum_sales#117, number_sales#118]
+Keys [3]: [channel#61, i_brand_id#48, i_class_id#49]
+Functions [2]: [partial_sum(sum_sales#117), partial_sum(number_sales#118)]
+Aggregate Attributes [3]: [sum#119, isEmpty#120, sum#121]
+Results [6]: [channel#61, i_brand_id#48, i_class_id#49, sum#122, isEmpty#123, sum#124]
 
-(113) Project [codegen id : 137]
-Output [5]: [ws_quantity#91, ws_list_price#92, i_brand_id#97, i_class_id#98, i_category_id#99]
-Input [7]: [ws_item_sk#90, ws_quantity#91, ws_list_price#92, i_item_sk#96, i_brand_id#97, i_class_id#98, i_category_id#99]
+(113) Exchange
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, sum#122, isEmpty#123, sum#124]
+Arguments: hashpartitioning(channel#61, i_brand_id#48, i_class_id#49, 5), ENSURE_REQUIREMENTS, [id=#125]
 
-(114) HashAggregate [codegen id : 137]
-Input [5]: [ws_quantity#91, ws_list_price#92, i_brand_id#97, i_class_id#98, i_category_id#99]
-Keys [3]: [i_brand_id#97, i_class_id#98, i_category_id#99]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true)), partial_count(1)]
-Aggregate Attributes [3]: [sum#100, isEmpty#101, count#102]
-Results [6]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum#103, isEmpty#104, count#105]
+(114) HashAggregate [codegen id : 245]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, sum#122, isEmpty#123, sum#124]
+Keys [3]: [channel#61, i_brand_id#48, i_class_id#49]
+Functions [2]: [sum(sum_sales#117), sum(number_sales#118)]
+Aggregate Attributes [2]: [sum(sum_sales#117)#126, sum(number_sales#118)#127]
+Results [6]: [channel#61, i_brand_id#48, i_class_id#49, null AS i_category_id#128, sum(sum_sales#117)#126 AS sum(sum_sales)#129, sum(number_sales#118)#127 AS sum(number_sales)#130]
 
-(115) Exchange
-Input [6]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum#103, isEmpty#104, count#105]
-Arguments: hashpartitioning(i_brand_id#97, i_class_id#98, i_category_id#99, 5), ENSURE_REQUIREMENTS, [id=#106]
+(115) ReusedExchange [Reuses operator id: 108]
+Output [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
 
-(116) HashAggregate [codegen id : 138]
-Input [6]: [i_brand_id#97, i_class_id#98, i_category_id#99, sum#103, isEmpty#104, count#105]
-Keys [3]: [i_brand_id#97, i_class_id#98, i_category_id#99]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true)), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true))#107, count(1)#108]
-Results [6]: [web AS channel#109, i_brand_id#97, i_class_id#98, i_category_id#99, sum(CheckOverflow((promote_precision(cast(cast(ws_quantity#91 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price#92 as decimal(12,2)))), DecimalType(18,2), true))#107 AS sales#110, count(1)#108 AS number_sales#111]
+(116) HashAggregate [codegen id : 367]
+Input [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
+Keys [4]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50]
+Functions [2]: [sum(sales#62), sum(number_sales#63)]
+Aggregate Attributes [2]: [sum(sales#62)#115, sum(number_sales#63)#116]
+Results [4]: [channel#61, i_brand_id#48, sum(sales#62)#115 AS sum_sales#117, sum(number_sales#63)#116 AS number_sales#118]
 
-(117) Filter [codegen id : 138]
-Input [6]: [channel#109, i_brand_id#97, i_class_id#98, i_category_id#99, sales#110, number_sales#111]
-Condition : (isnotnull(sales#110) AND (cast(sales#110 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#66, [id=#67] as decimal(32,6))))
+(117) HashAggregate [codegen id : 367]
+Input [4]: [channel#61, i_brand_id#48, sum_sales#117, number_sales#118]
+Keys [2]: [channel#61, i_brand_id#48]
+Functions [2]: [partial_sum(sum_sales#117), partial_sum(number_sales#118)]
+Aggregate Attributes [3]: [sum#131, isEmpty#132, sum#133]
+Results [5]: [channel#61, i_brand_id#48, sum#134, isEmpty#135, sum#136]
 
-(118) Union
+(118) Exchange
+Input [5]: [channel#61, i_brand_id#48, sum#134, isEmpty#135, sum#136]
+Arguments: hashpartitioning(channel#61, i_brand_id#48, 5), ENSURE_REQUIREMENTS, [id=#137]
 
-(119) HashAggregate [codegen id : 139]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sales#64, number_sales#65]
-Keys [4]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51]
-Functions [2]: [partial_sum(sales#64), partial_sum(number_sales#65)]
-Aggregate Attributes [3]: [sum#112, isEmpty#113, sum#114]
-Results [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
+(119) HashAggregate [codegen id : 368]
+Input [5]: [channel#61, i_brand_id#48, sum#134, isEmpty#135, sum#136]
+Keys [2]: [channel#61, i_brand_id#48]
+Functions [2]: [sum(sum_sales#117), sum(number_sales#118)]
+Aggregate Attributes [2]: [sum(sum_sales#117)#138, sum(number_sales#118)#139]
+Results [6]: [channel#61, i_brand_id#48, null AS i_class_id#140, null AS i_category_id#141, sum(sum_sales#117)#138 AS sum(sum_sales)#142, sum(number_sales#118)#139 AS sum(number_sales)#143]
 
-(120) Exchange
-Input [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-Arguments: hashpartitioning(channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, 5), ENSURE_REQUIREMENTS, [id=#118]
+(120) ReusedExchange [Reuses operator id: 108]
+Output [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
 
-(121) HashAggregate [codegen id : 140]
-Input [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-Keys [4]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51]
-Functions [2]: [sum(sales#64), sum(number_sales#65)]
-Aggregate Attributes [2]: [sum(sales#64)#119, sum(number_sales#65)#120]
-Results [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum(sales#64)#119 AS sum_sales#121, sum(number_sales#65)#120 AS number_sales#122]
+(121) HashAggregate [codegen id : 490]
+Input [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
+Keys [4]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50]
+Functions [2]: [sum(sales#62), sum(number_sales#63)]
+Aggregate Attributes [2]: [sum(sales#62)#115, sum(number_sales#63)#116]
+Results [3]: [channel#61, sum(sales#62)#115 AS sum_sales#117, sum(number_sales#63)#116 AS number_sales#118]
 
-(122) ReusedExchange [Reuses operator id: 120]
-Output [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
+(122) HashAggregate [codegen id : 490]
+Input [3]: [channel#61, sum_sales#117, number_sales#118]
+Keys [1]: [channel#61]
+Functions [2]: [partial_sum(sum_sales#117), partial_sum(number_sales#118)]
+Aggregate Attributes [3]: [sum#144, isEmpty#145, sum#146]
+Results [4]: [channel#61, sum#147, isEmpty#148, sum#149]
 
-(123) HashAggregate [codegen id : 280]
-Input [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-Keys [4]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51]
-Functions [2]: [sum(sales#64), sum(number_sales#65)]
-Aggregate Attributes [2]: [sum(sales#64)#119, sum(number_sales#65)#120]
-Results [5]: [channel#63, i_brand_id#49, i_class_id#50, sum(sales#64)#119 AS sum_sales#121, sum(number_sales#65)#120 AS number_sales#122]
+(123) Exchange
+Input [4]: [channel#61, sum#147, isEmpty#148, sum#149]
+Arguments: hashpartitioning(channel#61, 5), ENSURE_REQUIREMENTS, [id=#150]
 
-(124) HashAggregate [codegen id : 280]
-Input [5]: [channel#63, i_brand_id#49, i_class_id#50, sum_sales#121, number_sales#122]
-Keys [3]: [channel#63, i_brand_id#49, i_class_id#50]
-Functions [2]: [partial_sum(sum_sales#121), partial_sum(number_sales#122)]
-Aggregate Attributes [3]: [sum#123, isEmpty#124, sum#125]
-Results [6]: [channel#63, i_brand_id#49, i_class_id#50, sum#126, isEmpty#127, sum#128]
+(124) HashAggregate [codegen id : 491]
+Input [4]: [channel#61, sum#147, isEmpty#148, sum#149]
+Keys [1]: [channel#61]
+Functions [2]: [sum(sum_sales#117), sum(number_sales#118)]
+Aggregate Attributes [2]: [sum(sum_sales#117)#151, sum(number_sales#118)#152]
+Results [6]: [channel#61, null AS i_brand_id#153, null AS i_class_id#154, null AS i_category_id#155, sum(sum_sales#117)#151 AS sum(sum_sales)#156, sum(number_sales#118)#152 AS sum(number_sales)#157]
 
-(125) Exchange
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, sum#126, isEmpty#127, sum#128]
-Arguments: hashpartitioning(channel#63, i_brand_id#49, i_class_id#50, 5), ENSURE_REQUIREMENTS, [id=#129]
+(125) ReusedExchange [Reuses operator id: 108]
+Output [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
 
-(126) HashAggregate [codegen id : 281]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, sum#126, isEmpty#127, sum#128]
-Keys [3]: [channel#63, i_brand_id#49, i_class_id#50]
-Functions [2]: [sum(sum_sales#121), sum(number_sales#122)]
-Aggregate Attributes [2]: [sum(sum_sales#121)#130, sum(number_sales#122)#131]
-Results [6]: [channel#63, i_brand_id#49, i_class_id#50, null AS i_category_id#132, sum(sum_sales#121)#130 AS sum(sum_sales)#133, sum(number_sales#122)#131 AS sum(number_sales)#134]
+(126) HashAggregate [codegen id : 613]
+Input [7]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum#111, isEmpty#112, sum#113]
+Keys [4]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50]
+Functions [2]: [sum(sales#62), sum(number_sales#63)]
+Aggregate Attributes [2]: [sum(sales#62)#115, sum(number_sales#63)#116]
+Results [2]: [sum(sales#62)#115 AS sum_sales#117, sum(number_sales#63)#116 AS number_sales#118]
 
-(127) ReusedExchange [Reuses operator id: 120]
-Output [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-
-(128) HashAggregate [codegen id : 421]
-Input [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-Keys [4]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51]
-Functions [2]: [sum(sales#64), sum(number_sales#65)]
-Aggregate Attributes [2]: [sum(sales#64)#119, sum(number_sales#65)#120]
-Results [4]: [channel#63, i_brand_id#49, sum(sales#64)#119 AS sum_sales#121, sum(number_sales#65)#120 AS number_sales#122]
-
-(129) HashAggregate [codegen id : 421]
-Input [4]: [channel#63, i_brand_id#49, sum_sales#121, number_sales#122]
-Keys [2]: [channel#63, i_brand_id#49]
-Functions [2]: [partial_sum(sum_sales#121), partial_sum(number_sales#122)]
-Aggregate Attributes [3]: [sum#135, isEmpty#136, sum#137]
-Results [5]: [channel#63, i_brand_id#49, sum#138, isEmpty#139, sum#140]
-
-(130) Exchange
-Input [5]: [channel#63, i_brand_id#49, sum#138, isEmpty#139, sum#140]
-Arguments: hashpartitioning(channel#63, i_brand_id#49, 5), ENSURE_REQUIREMENTS, [id=#141]
-
-(131) HashAggregate [codegen id : 422]
-Input [5]: [channel#63, i_brand_id#49, sum#138, isEmpty#139, sum#140]
-Keys [2]: [channel#63, i_brand_id#49]
-Functions [2]: [sum(sum_sales#121), sum(number_sales#122)]
-Aggregate Attributes [2]: [sum(sum_sales#121)#142, sum(number_sales#122)#143]
-Results [6]: [channel#63, i_brand_id#49, null AS i_class_id#144, null AS i_category_id#145, sum(sum_sales#121)#142 AS sum(sum_sales)#146, sum(number_sales#122)#143 AS sum(number_sales)#147]
-
-(132) ReusedExchange [Reuses operator id: 120]
-Output [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-
-(133) HashAggregate [codegen id : 562]
-Input [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-Keys [4]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51]
-Functions [2]: [sum(sales#64), sum(number_sales#65)]
-Aggregate Attributes [2]: [sum(sales#64)#119, sum(number_sales#65)#120]
-Results [3]: [channel#63, sum(sales#64)#119 AS sum_sales#121, sum(number_sales#65)#120 AS number_sales#122]
-
-(134) HashAggregate [codegen id : 562]
-Input [3]: [channel#63, sum_sales#121, number_sales#122]
-Keys [1]: [channel#63]
-Functions [2]: [partial_sum(sum_sales#121), partial_sum(number_sales#122)]
-Aggregate Attributes [3]: [sum#148, isEmpty#149, sum#150]
-Results [4]: [channel#63, sum#151, isEmpty#152, sum#153]
-
-(135) Exchange
-Input [4]: [channel#63, sum#151, isEmpty#152, sum#153]
-Arguments: hashpartitioning(channel#63, 5), ENSURE_REQUIREMENTS, [id=#154]
-
-(136) HashAggregate [codegen id : 563]
-Input [4]: [channel#63, sum#151, isEmpty#152, sum#153]
-Keys [1]: [channel#63]
-Functions [2]: [sum(sum_sales#121), sum(number_sales#122)]
-Aggregate Attributes [2]: [sum(sum_sales#121)#155, sum(number_sales#122)#156]
-Results [6]: [channel#63, null AS i_brand_id#157, null AS i_class_id#158, null AS i_category_id#159, sum(sum_sales#121)#155 AS sum(sum_sales)#160, sum(number_sales#122)#156 AS sum(number_sales)#161]
-
-(137) ReusedExchange [Reuses operator id: 120]
-Output [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-
-(138) HashAggregate [codegen id : 703]
-Input [7]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum#115, isEmpty#116, sum#117]
-Keys [4]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51]
-Functions [2]: [sum(sales#64), sum(number_sales#65)]
-Aggregate Attributes [2]: [sum(sales#64)#119, sum(number_sales#65)#120]
-Results [2]: [sum(sales#64)#119 AS sum_sales#121, sum(number_sales#65)#120 AS number_sales#122]
-
-(139) HashAggregate [codegen id : 703]
-Input [2]: [sum_sales#121, number_sales#122]
+(127) HashAggregate [codegen id : 613]
+Input [2]: [sum_sales#117, number_sales#118]
 Keys: []
-Functions [2]: [partial_sum(sum_sales#121), partial_sum(number_sales#122)]
-Aggregate Attributes [3]: [sum#162, isEmpty#163, sum#164]
-Results [3]: [sum#165, isEmpty#166, sum#167]
+Functions [2]: [partial_sum(sum_sales#117), partial_sum(number_sales#118)]
+Aggregate Attributes [3]: [sum#158, isEmpty#159, sum#160]
+Results [3]: [sum#161, isEmpty#162, sum#163]
 
-(140) Exchange
-Input [3]: [sum#165, isEmpty#166, sum#167]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#168]
+(128) Exchange
+Input [3]: [sum#161, isEmpty#162, sum#163]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#164]
 
-(141) HashAggregate [codegen id : 704]
-Input [3]: [sum#165, isEmpty#166, sum#167]
+(129) HashAggregate [codegen id : 614]
+Input [3]: [sum#161, isEmpty#162, sum#163]
 Keys: []
-Functions [2]: [sum(sum_sales#121), sum(number_sales#122)]
-Aggregate Attributes [2]: [sum(sum_sales#121)#169, sum(number_sales#122)#170]
-Results [6]: [null AS channel#171, null AS i_brand_id#172, null AS i_class_id#173, null AS i_category_id#174, sum(sum_sales#121)#169 AS sum(sum_sales)#175, sum(number_sales#122)#170 AS sum(number_sales)#176]
+Functions [2]: [sum(sum_sales#117), sum(number_sales#118)]
+Aggregate Attributes [2]: [sum(sum_sales#117)#165, sum(number_sales#118)#166]
+Results [6]: [null AS channel#167, null AS i_brand_id#168, null AS i_class_id#169, null AS i_category_id#170, sum(sum_sales#117)#165 AS sum(sum_sales)#171, sum(number_sales#118)#166 AS sum(number_sales)#172]
 
-(142) Union
+(130) Union
 
-(143) HashAggregate [codegen id : 705]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
-Keys [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
+(131) HashAggregate [codegen id : 615]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
+Keys [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
 Functions: []
 Aggregate Attributes: []
-Results [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
+Results [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
 
-(144) Exchange
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
-Arguments: hashpartitioning(channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122, 5), ENSURE_REQUIREMENTS, [id=#177]
+(132) Exchange
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
+Arguments: hashpartitioning(channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118, 5), ENSURE_REQUIREMENTS, [id=#173]
 
-(145) HashAggregate [codegen id : 706]
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
-Keys [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
+(133) HashAggregate [codegen id : 616]
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
+Keys [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
 Functions: []
 Aggregate Attributes: []
-Results [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
+Results [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
 
-(146) TakeOrderedAndProject
-Input [6]: [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
-Arguments: 100, [channel#63 ASC NULLS FIRST, i_brand_id#49 ASC NULLS FIRST, i_class_id#50 ASC NULLS FIRST, i_category_id#51 ASC NULLS FIRST], [channel#63, i_brand_id#49, i_class_id#50, i_category_id#51, sum_sales#121, number_sales#122]
+(134) TakeOrderedAndProject
+Input [6]: [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
+Arguments: 100, [channel#61 ASC NULLS FIRST, i_brand_id#48 ASC NULLS FIRST, i_class_id#49 ASC NULLS FIRST, i_category_id#50 ASC NULLS FIRST], [channel#61, i_brand_id#48, i_class_id#49, i_category_id#50, sum_sales#117, number_sales#118]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 81 Hosting Expression = Subquery scalar-subquery#66, [id=#67]
-* HashAggregate (165)
-+- Exchange (164)
-   +- * HashAggregate (163)
-      +- Union (162)
-         :- * Project (151)
-         :  +- * BroadcastHashJoin Inner BuildRight (150)
-         :     :- * ColumnarToRow (148)
-         :     :  +- Scan parquet default.store_sales (147)
-         :     +- ReusedExchange (149)
-         :- * Project (156)
-         :  +- * BroadcastHashJoin Inner BuildRight (155)
-         :     :- * ColumnarToRow (153)
-         :     :  +- Scan parquet default.catalog_sales (152)
-         :     +- ReusedExchange (154)
-         +- * Project (161)
-            +- * BroadcastHashJoin Inner BuildRight (160)
-               :- * ColumnarToRow (158)
-               :  +- Scan parquet default.web_sales (157)
-               +- ReusedExchange (159)
+Subquery:1 Hosting operator id = 75 Hosting Expression = Subquery scalar-subquery#64, [id=#65]
+* HashAggregate (153)
++- Exchange (152)
+   +- * HashAggregate (151)
+      +- Union (150)
+         :- * Project (139)
+         :  +- * BroadcastHashJoin Inner BuildRight (138)
+         :     :- * ColumnarToRow (136)
+         :     :  +- Scan parquet default.store_sales (135)
+         :     +- ReusedExchange (137)
+         :- * Project (144)
+         :  +- * BroadcastHashJoin Inner BuildRight (143)
+         :     :- * ColumnarToRow (141)
+         :     :  +- Scan parquet default.catalog_sales (140)
+         :     +- ReusedExchange (142)
+         +- * Project (149)
+            +- * BroadcastHashJoin Inner BuildRight (148)
+               :- * ColumnarToRow (146)
+               :  +- Scan parquet default.web_sales (145)
+               +- ReusedExchange (147)
 
 
-(147) Scan parquet default.store_sales
-Output [3]: [ss_quantity#178, ss_list_price#179, ss_sold_date_sk#180]
+(135) Scan parquet default.store_sales
+Output [3]: [ss_quantity#174, ss_list_price#175, ss_sold_date_sk#176]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#180), dynamicpruningexpression(ss_sold_date_sk#180 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#176), dynamicpruningexpression(ss_sold_date_sk#176 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
-(148) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#178, ss_list_price#179, ss_sold_date_sk#180]
+(136) ColumnarToRow [codegen id : 2]
+Input [3]: [ss_quantity#174, ss_list_price#175, ss_sold_date_sk#176]
 
-(149) ReusedExchange [Reuses operator id: 180]
-Output [1]: [d_date_sk#181]
+(137) ReusedExchange [Reuses operator id: 168]
+Output [1]: [d_date_sk#177]
 
-(150) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#180]
-Right keys [1]: [d_date_sk#181]
+(138) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_sold_date_sk#176]
+Right keys [1]: [d_date_sk#177]
 Join condition: None
 
-(151) Project [codegen id : 2]
-Output [2]: [ss_quantity#178 AS quantity#182, ss_list_price#179 AS list_price#183]
-Input [4]: [ss_quantity#178, ss_list_price#179, ss_sold_date_sk#180, d_date_sk#181]
+(139) Project [codegen id : 2]
+Output [2]: [ss_quantity#174 AS quantity#178, ss_list_price#175 AS list_price#179]
+Input [4]: [ss_quantity#174, ss_list_price#175, ss_sold_date_sk#176, d_date_sk#177]
 
-(152) Scan parquet default.catalog_sales
-Output [3]: [cs_quantity#184, cs_list_price#185, cs_sold_date_sk#186]
+(140) Scan parquet default.catalog_sales
+Output [3]: [cs_quantity#180, cs_list_price#181, cs_sold_date_sk#182]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#186), dynamicpruningexpression(cs_sold_date_sk#186 IN dynamicpruning#187)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#182), dynamicpruningexpression(cs_sold_date_sk#182 IN dynamicpruning#183)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
-(153) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#184, cs_list_price#185, cs_sold_date_sk#186]
+(141) ColumnarToRow [codegen id : 4]
+Input [3]: [cs_quantity#180, cs_list_price#181, cs_sold_date_sk#182]
 
-(154) ReusedExchange [Reuses operator id: 170]
-Output [1]: [d_date_sk#188]
+(142) ReusedExchange [Reuses operator id: 158]
+Output [1]: [d_date_sk#184]
 
-(155) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#186]
-Right keys [1]: [d_date_sk#188]
+(143) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#182]
+Right keys [1]: [d_date_sk#184]
 Join condition: None
 
-(156) Project [codegen id : 4]
-Output [2]: [cs_quantity#184 AS quantity#189, cs_list_price#185 AS list_price#190]
-Input [4]: [cs_quantity#184, cs_list_price#185, cs_sold_date_sk#186, d_date_sk#188]
+(144) Project [codegen id : 4]
+Output [2]: [cs_quantity#180 AS quantity#185, cs_list_price#181 AS list_price#186]
+Input [4]: [cs_quantity#180, cs_list_price#181, cs_sold_date_sk#182, d_date_sk#184]
 
-(157) Scan parquet default.web_sales
-Output [3]: [ws_quantity#191, ws_list_price#192, ws_sold_date_sk#193]
+(145) Scan parquet default.web_sales
+Output [3]: [ws_quantity#187, ws_list_price#188, ws_sold_date_sk#189]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#193), dynamicpruningexpression(ws_sold_date_sk#193 IN dynamicpruning#187)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#189), dynamicpruningexpression(ws_sold_date_sk#189 IN dynamicpruning#183)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
-(158) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#191, ws_list_price#192, ws_sold_date_sk#193]
+(146) ColumnarToRow [codegen id : 6]
+Input [3]: [ws_quantity#187, ws_list_price#188, ws_sold_date_sk#189]
 
-(159) ReusedExchange [Reuses operator id: 170]
-Output [1]: [d_date_sk#194]
+(147) ReusedExchange [Reuses operator id: 158]
+Output [1]: [d_date_sk#190]
 
-(160) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#193]
-Right keys [1]: [d_date_sk#194]
+(148) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#189]
+Right keys [1]: [d_date_sk#190]
 Join condition: None
 
-(161) Project [codegen id : 6]
-Output [2]: [ws_quantity#191 AS quantity#195, ws_list_price#192 AS list_price#196]
-Input [4]: [ws_quantity#191, ws_list_price#192, ws_sold_date_sk#193, d_date_sk#194]
+(149) Project [codegen id : 6]
+Output [2]: [ws_quantity#187 AS quantity#191, ws_list_price#188 AS list_price#192]
+Input [4]: [ws_quantity#187, ws_list_price#188, ws_sold_date_sk#189, d_date_sk#190]
 
-(162) Union
+(150) Union
 
-(163) HashAggregate [codegen id : 7]
-Input [2]: [quantity#182, list_price#183]
+(151) HashAggregate [codegen id : 7]
+Input [2]: [quantity#178, list_price#179]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#182 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#183 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [2]: [sum#197, count#198]
-Results [2]: [sum#199, count#200]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(cast(quantity#178 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#179 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [2]: [sum#193, count#194]
+Results [2]: [sum#195, count#196]
 
-(164) Exchange
-Input [2]: [sum#199, count#200]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#201]
+(152) Exchange
+Input [2]: [sum#195, count#196]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#197]
 
-(165) HashAggregate [codegen id : 8]
-Input [2]: [sum#199, count#200]
+(153) HashAggregate [codegen id : 8]
+Input [2]: [sum#195, count#196]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#182 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#183 as decimal(12,2)))), DecimalType(18,2), true))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#182 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#183 as decimal(12,2)))), DecimalType(18,2), true))#202]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#182 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#183 as decimal(12,2)))), DecimalType(18,2), true))#202 AS average_sales#203]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#178 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#179 as decimal(12,2)))), DecimalType(18,2), true))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#178 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#179 as decimal(12,2)))), DecimalType(18,2), true))#198]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(cast(quantity#178 as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price#179 as decimal(12,2)))), DecimalType(18,2), true))#198 AS average_sales#199]
 
-Subquery:2 Hosting operator id = 147 Hosting Expression = ss_sold_date_sk#180 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 135 Hosting Expression = ss_sold_date_sk#176 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 152 Hosting Expression = cs_sold_date_sk#186 IN dynamicpruning#187
-BroadcastExchange (170)
-+- * Project (169)
-   +- * Filter (168)
-      +- * ColumnarToRow (167)
-         +- Scan parquet default.date_dim (166)
+Subquery:3 Hosting operator id = 140 Hosting Expression = cs_sold_date_sk#182 IN dynamicpruning#183
+BroadcastExchange (158)
++- * Project (157)
+   +- * Filter (156)
+      +- * ColumnarToRow (155)
+         +- Scan parquet default.date_dim (154)
 
 
-(166) Scan parquet default.date_dim
-Output [2]: [d_date_sk#188, d_year#204]
+(154) Scan parquet default.date_dim
+Output [2]: [d_date_sk#184, d_year#200]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(167) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#188, d_year#204]
+(155) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#184, d_year#200]
 
-(168) Filter [codegen id : 1]
-Input [2]: [d_date_sk#188, d_year#204]
-Condition : (((isnotnull(d_year#204) AND (d_year#204 >= 1998)) AND (d_year#204 <= 2000)) AND isnotnull(d_date_sk#188))
+(156) Filter [codegen id : 1]
+Input [2]: [d_date_sk#184, d_year#200]
+Condition : (((isnotnull(d_year#200) AND (d_year#200 >= 1998)) AND (d_year#200 <= 2000)) AND isnotnull(d_date_sk#184))
 
-(169) Project [codegen id : 1]
-Output [1]: [d_date_sk#188]
-Input [2]: [d_date_sk#188, d_year#204]
+(157) Project [codegen id : 1]
+Output [1]: [d_date_sk#184]
+Input [2]: [d_date_sk#184, d_year#200]
 
-(170) BroadcastExchange
-Input [1]: [d_date_sk#188]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#205]
+(158) BroadcastExchange
+Input [1]: [d_date_sk#184]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#201]
 
-Subquery:4 Hosting operator id = 157 Hosting Expression = ws_sold_date_sk#193 IN dynamicpruning#187
+Subquery:4 Hosting operator id = 145 Hosting Expression = ws_sold_date_sk#189 IN dynamicpruning#183
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (175)
-+- * Project (174)
-   +- * Filter (173)
-      +- * ColumnarToRow (172)
-         +- Scan parquet default.date_dim (171)
+BroadcastExchange (163)
++- * Project (162)
+   +- * Filter (161)
+      +- * ColumnarToRow (160)
+         +- Scan parquet default.date_dim (159)
 
 
-(171) Scan parquet default.date_dim
-Output [3]: [d_date_sk#47, d_year#206, d_moy#207]
+(159) Scan parquet default.date_dim
+Output [3]: [d_date_sk#46, d_year#202, d_moy#203]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(172) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#47, d_year#206, d_moy#207]
+(160) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#46, d_year#202, d_moy#203]
 
-(173) Filter [codegen id : 1]
-Input [3]: [d_date_sk#47, d_year#206, d_moy#207]
-Condition : ((((isnotnull(d_year#206) AND isnotnull(d_moy#207)) AND (d_year#206 = 2000)) AND (d_moy#207 = 11)) AND isnotnull(d_date_sk#47))
+(161) Filter [codegen id : 1]
+Input [3]: [d_date_sk#46, d_year#202, d_moy#203]
+Condition : ((((isnotnull(d_year#202) AND isnotnull(d_moy#203)) AND (d_year#202 = 2000)) AND (d_moy#203 = 11)) AND isnotnull(d_date_sk#46))
 
-(174) Project [codegen id : 1]
-Output [1]: [d_date_sk#47]
-Input [3]: [d_date_sk#47, d_year#206, d_moy#207]
+(162) Project [codegen id : 1]
+Output [1]: [d_date_sk#46]
+Input [3]: [d_date_sk#46, d_year#202, d_moy#203]
 
-(175) BroadcastExchange
-Input [1]: [d_date_sk#47]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#208]
+(163) BroadcastExchange
+Input [1]: [d_date_sk#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#204]
 
-Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
-BroadcastExchange (180)
-+- * Project (179)
-   +- * Filter (178)
-      +- * ColumnarToRow (177)
-         +- Scan parquet default.date_dim (176)
+Subquery:6 Hosting operator id = 7 Hosting Expression = ss_sold_date_sk#11 IN dynamicpruning#12
+BroadcastExchange (168)
++- * Project (167)
+   +- * Filter (166)
+      +- * ColumnarToRow (165)
+         +- Scan parquet default.date_dim (164)
 
 
-(176) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#209]
+(164) Scan parquet default.date_dim
+Output [2]: [d_date_sk#13, d_year#205]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(177) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#209]
+(165) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#205]
 
-(178) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#209]
-Condition : (((isnotnull(d_year#209) AND (d_year#209 >= 1999)) AND (d_year#209 <= 2001)) AND isnotnull(d_date_sk#14))
+(166) Filter [codegen id : 1]
+Input [2]: [d_date_sk#13, d_year#205]
+Condition : (((isnotnull(d_year#205) AND (d_year#205 >= 1999)) AND (d_year#205 <= 2001)) AND isnotnull(d_date_sk#13))
 
-(179) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#209]
+(167) Project [codegen id : 1]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_year#205]
 
-(180) BroadcastExchange
-Input [1]: [d_date_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#210]
+(168) BroadcastExchange
+Input [1]: [d_date_sk#13]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#206]
 
-Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:7 Hosting operator id = 18 Hosting Expression = cs_sold_date_sk#20 IN dynamicpruning#12
 
-Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 41 Hosting Expression = ws_sold_date_sk#35 IN dynamicpruning#12
 
-Subquery:9 Hosting operator id = 99 Hosting Expression = ReusedSubquery Subquery scalar-subquery#66, [id=#67]
+Subquery:9 Hosting operator id = 90 Hosting Expression = ReusedSubquery Subquery scalar-subquery#64, [id=#65]
 
-Subquery:10 Hosting operator id = 82 Hosting Expression = cs_sold_date_sk#71 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 76 Hosting Expression = cs_sold_date_sk#69 IN dynamicpruning#5
 
-Subquery:11 Hosting operator id = 117 Hosting Expression = ReusedSubquery Subquery scalar-subquery#66, [id=#67]
+Subquery:11 Hosting operator id = 105 Hosting Expression = ReusedSubquery Subquery scalar-subquery#64, [id=#65]
 
-Subquery:12 Hosting operator id = 100 Hosting Expression = ws_sold_date_sk#93 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 91 Hosting Expression = ws_sold_date_sk#90 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -1,27 +1,27 @@
 TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
-  WholeStageCodegen (706)
+  WholeStageCodegen (616)
     HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
       InputAdapter
         Exchange [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales] #1
-          WholeStageCodegen (705)
+          WholeStageCodegen (615)
             HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum_sales,number_sales]
               InputAdapter
                 Union
-                  WholeStageCodegen (140)
+                  WholeStageCodegen (122)
                     HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                       InputAdapter
                         Exchange [channel,i_brand_id,i_class_id,i_category_id] #2
-                          WholeStageCodegen (139)
+                          WholeStageCodegen (121)
                             HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               InputAdapter
                                 Union
-                                  WholeStageCodegen (46)
+                                  WholeStageCodegen (40)
                                     Filter [sales]
                                       Subquery #3
                                         WholeStageCodegen (8)
                                           HashAggregate [sum,count] [avg(CheckOverflow((promote_precision(cast(cast(quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(list_price as decimal(12,2)))), DecimalType(18,2), true)),average_sales,sum,count]
                                             InputAdapter
-                                              Exchange #19
+                                              Exchange #17
                                                 WholeStageCodegen (7)
                                                   HashAggregate [quantity,list_price] [sum,count,sum,count]
                                                     InputAdapter
@@ -34,7 +34,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                   Scan parquet default.store_sales [ss_quantity,ss_list_price,ss_sold_date_sk]
                                                                     ReusedSubquery [d_date_sk] #2
                                                               InputAdapter
-                                                                ReusedExchange [d_date_sk] #11
+                                                                ReusedExchange [d_date_sk] #10
                                                         WholeStageCodegen (4)
                                                           Project [cs_quantity,cs_list_price]
                                                             BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
@@ -42,7 +42,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                 InputAdapter
                                                                   Scan parquet default.catalog_sales [cs_quantity,cs_list_price,cs_sold_date_sk]
                                                                     SubqueryBroadcast [d_date_sk] #4
-                                                                      BroadcastExchange #20
+                                                                      BroadcastExchange #18
                                                                         WholeStageCodegen (1)
                                                                           Project [d_date_sk]
                                                                             Filter [d_year,d_date_sk]
@@ -50,7 +50,7 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                                 InputAdapter
                                                                                   Scan parquet default.date_dim [d_date_sk,d_year]
                                                               InputAdapter
-                                                                ReusedExchange [d_date_sk] #20
+                                                                ReusedExchange [d_date_sk] #18
                                                         WholeStageCodegen (6)
                                                           Project [ws_quantity,ws_list_price]
                                                             BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
@@ -59,261 +59,225 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                   Scan parquet default.web_sales [ws_quantity,ws_list_price,ws_sold_date_sk]
                                                                     ReusedSubquery [d_date_sk] #4
                                                               InputAdapter
-                                                                ReusedExchange [d_date_sk] #20
+                                                                ReusedExchange [d_date_sk] #18
                                       HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ss_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ss_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                                         InputAdapter
                                           Exchange [i_brand_id,i_class_id,i_category_id] #3
-                                            WholeStageCodegen (45)
+                                            WholeStageCodegen (39)
                                               HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                                 Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
                                                   BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                     Project [ss_item_sk,ss_quantity,ss_list_price]
                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                        SortMergeJoin [ss_item_sk,ss_item_sk]
-                                                          InputAdapter
-                                                            WholeStageCodegen (2)
-                                                              Sort [ss_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [ss_item_sk] #4
-                                                                    WholeStageCodegen (1)
-                                                                      Filter [ss_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
-                                                                              SubqueryBroadcast [d_date_sk] #1
-                                                                                BroadcastExchange #5
-                                                                                  WholeStageCodegen (1)
-                                                                                    Project [d_date_sk]
-                                                                                      Filter [d_year,d_moy,d_date_sk]
-                                                                                        ColumnarToRow
-                                                                                          InputAdapter
-                                                                                            Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
-                                                          InputAdapter
-                                                            WholeStageCodegen (21)
-                                                              Sort [ss_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [ss_item_sk] #6
-                                                                    WholeStageCodegen (20)
-                                                                      Project [i_item_sk]
-                                                                        BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                                                          Filter [i_brand_id,i_class_id,i_category_id]
+                                                        BroadcastHashJoin [ss_item_sk,ss_item_sk]
+                                                          Filter [ss_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.store_sales [ss_item_sk,ss_quantity,ss_list_price,ss_sold_date_sk]
+                                                                  SubqueryBroadcast [d_date_sk] #1
+                                                                    BroadcastExchange #4
+                                                                      WholeStageCodegen (1)
+                                                                        Project [d_date_sk]
+                                                                          Filter [d_year,d_moy,d_date_sk]
                                                                             ColumnarToRow
                                                                               InputAdapter
-                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #7
-                                                                              WholeStageCodegen (19)
-                                                                                HashAggregate [brand_id,class_id,category_id]
-                                                                                  InputAdapter
-                                                                                    Exchange [brand_id,class_id,category_id] #8
-                                                                                      WholeStageCodegen (18)
-                                                                                        HashAggregate [brand_id,class_id,category_id]
-                                                                                          SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                            InputAdapter
-                                                                                              WholeStageCodegen (13)
-                                                                                                Sort [brand_id,class_id,category_id]
-                                                                                                  InputAdapter
-                                                                                                    Exchange [brand_id,class_id,category_id] #9
-                                                                                                      WholeStageCodegen (12)
-                                                                                                        HashAggregate [brand_id,class_id,category_id]
-                                                                                                          InputAdapter
-                                                                                                            Exchange [brand_id,class_id,category_id] #10
-                                                                                                              WholeStageCodegen (11)
-                                                                                                                HashAggregate [brand_id,class_id,category_id]
-                                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                                      Project [ss_item_sk]
-                                                                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                          Filter [ss_item_sk]
-                                                                                                                            ColumnarToRow
-                                                                                                                              InputAdapter
-                                                                                                                                Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                                                                  SubqueryBroadcast [d_date_sk] #2
-                                                                                                                                    BroadcastExchange #11
-                                                                                                                                      WholeStageCodegen (1)
-                                                                                                                                        Project [d_date_sk]
-                                                                                                                                          Filter [d_year,d_date_sk]
-                                                                                                                                            ColumnarToRow
-                                                                                                                                              InputAdapter
-                                                                                                                                                Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                                          InputAdapter
-                                                                                                                            ReusedExchange [d_date_sk] #11
-                                                                                                                      InputAdapter
-                                                                                                                        BroadcastExchange #12
-                                                                                                                          WholeStageCodegen (10)
-                                                                                                                            SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                              InputAdapter
-                                                                                                                                WholeStageCodegen (5)
-                                                                                                                                  Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                    InputAdapter
-                                                                                                                                      Exchange [i_brand_id,i_class_id,i_category_id] #13
-                                                                                                                                        WholeStageCodegen (4)
-                                                                                                                                          Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                            ColumnarToRow
-                                                                                                                                              InputAdapter
-                                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                              InputAdapter
-                                                                                                                                WholeStageCodegen (9)
-                                                                                                                                  Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                    InputAdapter
-                                                                                                                                      Exchange [i_brand_id,i_class_id,i_category_id] #14
-                                                                                                                                        WholeStageCodegen (8)
-                                                                                                                                          Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                                              Project [cs_item_sk]
-                                                                                                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                                                  Filter [cs_item_sk]
-                                                                                                                                                    ColumnarToRow
-                                                                                                                                                      InputAdapter
-                                                                                                                                                        Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                                                          ReusedSubquery [d_date_sk] #2
-                                                                                                                                                  InputAdapter
-                                                                                                                                                    ReusedExchange [d_date_sk] #11
-                                                                                                                                              InputAdapter
-                                                                                                                                                BroadcastExchange #15
-                                                                                                                                                  WholeStageCodegen (7)
-                                                                                                                                                    Filter [i_item_sk]
-                                                                                                                                                      ColumnarToRow
-                                                                                                                                                        InputAdapter
-                                                                                                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                            InputAdapter
-                                                                                              WholeStageCodegen (17)
-                                                                                                Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                  InputAdapter
-                                                                                                    Exchange [i_brand_id,i_class_id,i_category_id] #16
-                                                                                                      WholeStageCodegen (16)
-                                                                                                        Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                          BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                            Project [ws_item_sk]
-                                                                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                                Filter [ws_item_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                                                        ReusedSubquery [d_date_sk] #2
-                                                                                                                InputAdapter
-                                                                                                                  ReusedExchange [d_date_sk] #11
-                                                                                                            InputAdapter
-                                                                                                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #15
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #5
-                                                    InputAdapter
-                                                      BroadcastExchange #17
-                                                        WholeStageCodegen (44)
-                                                          SortMergeJoin [i_item_sk,ss_item_sk]
-                                                            InputAdapter
-                                                              WholeStageCodegen (24)
-                                                                Sort [i_item_sk]
-                                                                  InputAdapter
-                                                                    Exchange [i_item_sk] #18
-                                                                      WholeStageCodegen (23)
-                                                                        Filter [i_item_sk]
-                                                                          ColumnarToRow
+                                                                                Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
+                                                          InputAdapter
+                                                            BroadcastExchange #5
+                                                              WholeStageCodegen (18)
+                                                                Project [i_item_sk]
+                                                                  BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
+                                                                    Filter [i_brand_id,i_class_id,i_category_id]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                    InputAdapter
+                                                                      BroadcastExchange #6
+                                                                        WholeStageCodegen (17)
+                                                                          HashAggregate [brand_id,class_id,category_id]
                                                                             InputAdapter
-                                                                              Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                              Exchange [brand_id,class_id,category_id] #7
+                                                                                WholeStageCodegen (16)
+                                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                                    SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                      InputAdapter
+                                                                                        WholeStageCodegen (11)
+                                                                                          Sort [brand_id,class_id,category_id]
+                                                                                            InputAdapter
+                                                                                              Exchange [brand_id,class_id,category_id] #8
+                                                                                                WholeStageCodegen (10)
+                                                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                                                    InputAdapter
+                                                                                                      Exchange [brand_id,class_id,category_id] #9
+                                                                                                        WholeStageCodegen (9)
+                                                                                                          HashAggregate [brand_id,class_id,category_id]
+                                                                                                            Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                                Project [ss_item_sk]
+                                                                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                                    Filter [ss_item_sk]
+                                                                                                                      ColumnarToRow
+                                                                                                                        InputAdapter
+                                                                                                                          Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                                                            SubqueryBroadcast [d_date_sk] #2
+                                                                                                                              BroadcastExchange #10
+                                                                                                                                WholeStageCodegen (1)
+                                                                                                                                  Project [d_date_sk]
+                                                                                                                                    Filter [d_year,d_date_sk]
+                                                                                                                                      ColumnarToRow
+                                                                                                                                        InputAdapter
+                                                                                                                                          Scan parquet default.date_dim [d_date_sk,d_year]
+                                                                                                                    InputAdapter
+                                                                                                                      ReusedExchange [d_date_sk] #10
+                                                                                                                InputAdapter
+                                                                                                                  BroadcastExchange #11
+                                                                                                                    WholeStageCodegen (8)
+                                                                                                                      SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                                                        InputAdapter
+                                                                                                                          WholeStageCodegen (3)
+                                                                                                                            Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                                              InputAdapter
+                                                                                                                                Exchange [i_brand_id,i_class_id,i_category_id] #12
+                                                                                                                                  WholeStageCodegen (2)
+                                                                                                                                    Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                                                      ColumnarToRow
+                                                                                                                                        InputAdapter
+                                                                                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                                        InputAdapter
+                                                                                                                          WholeStageCodegen (7)
+                                                                                                                            Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                                              InputAdapter
+                                                                                                                                Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                                                                                                  WholeStageCodegen (6)
+                                                                                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                                        Project [cs_item_sk]
+                                                                                                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                                                            Filter [cs_item_sk]
+                                                                                                                                              ColumnarToRow
+                                                                                                                                                InputAdapter
+                                                                                                                                                  Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                                                                    ReusedSubquery [d_date_sk] #2
+                                                                                                                                            InputAdapter
+                                                                                                                                              ReusedExchange [d_date_sk] #10
+                                                                                                                                        InputAdapter
+                                                                                                                                          BroadcastExchange #14
+                                                                                                                                            WholeStageCodegen (5)
+                                                                                                                                              Filter [i_item_sk]
+                                                                                                                                                ColumnarToRow
+                                                                                                                                                  InputAdapter
+                                                                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                      InputAdapter
+                                                                                        WholeStageCodegen (15)
+                                                                                          Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                            InputAdapter
+                                                                                              Exchange [i_brand_id,i_class_id,i_category_id] #15
+                                                                                                WholeStageCodegen (14)
+                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                    BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                                      Project [ws_item_sk]
+                                                                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                                          Filter [ws_item_sk]
+                                                                                                            ColumnarToRow
+                                                                                                              InputAdapter
+                                                                                                                Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                                                                  ReusedSubquery [d_date_sk] #2
+                                                                                                          InputAdapter
+                                                                                                            ReusedExchange [d_date_sk] #10
+                                                                                                      InputAdapter
+                                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14
+                                                        InputAdapter
+                                                          ReusedExchange [d_date_sk] #4
+                                                    InputAdapter
+                                                      BroadcastExchange #16
+                                                        WholeStageCodegen (38)
+                                                          BroadcastHashJoin [i_item_sk,ss_item_sk]
+                                                            Filter [i_item_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                             InputAdapter
-                                                              WholeStageCodegen (43)
-                                                                Sort [ss_item_sk]
-                                                                  InputAdapter
-                                                                    ReusedExchange [ss_item_sk] #6
-                                  WholeStageCodegen (92)
+                                                              ReusedExchange [ss_item_sk] #5
+                                  WholeStageCodegen (80)
                                     Filter [sales]
                                       ReusedSubquery [average_sales] #3
                                       HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(cs_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(cs_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                                         InputAdapter
-                                          Exchange [i_brand_id,i_class_id,i_category_id] #21
-                                            WholeStageCodegen (91)
+                                          Exchange [i_brand_id,i_class_id,i_category_id] #19
+                                            WholeStageCodegen (79)
                                               HashAggregate [i_brand_id,i_class_id,i_category_id,cs_quantity,cs_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                                 Project [cs_quantity,cs_list_price,i_brand_id,i_class_id,i_category_id]
                                                   BroadcastHashJoin [cs_item_sk,i_item_sk]
                                                     Project [cs_item_sk,cs_quantity,cs_list_price]
                                                       BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                        SortMergeJoin [cs_item_sk,ss_item_sk]
+                                                        BroadcastHashJoin [cs_item_sk,ss_item_sk]
+                                                          Filter [cs_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.catalog_sales [cs_item_sk,cs_quantity,cs_list_price,cs_sold_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
                                                           InputAdapter
-                                                            WholeStageCodegen (48)
-                                                              Sort [cs_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [cs_item_sk] #22
-                                                                    WholeStageCodegen (47)
-                                                                      Filter [cs_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.catalog_sales [cs_item_sk,cs_quantity,cs_list_price,cs_sold_date_sk]
-                                                                              ReusedSubquery [d_date_sk] #1
-                                                          InputAdapter
-                                                            WholeStageCodegen (67)
-                                                              Sort [ss_item_sk]
-                                                                InputAdapter
-                                                                  ReusedExchange [ss_item_sk] #6
+                                                            ReusedExchange [ss_item_sk] #5
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #5
+                                                          ReusedExchange [d_date_sk] #4
                                                     InputAdapter
-                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #17
-                                  WholeStageCodegen (138)
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #16
+                                  WholeStageCodegen (120)
                                     Filter [sales]
                                       ReusedSubquery [average_sales] #3
                                       HashAggregate [i_brand_id,i_class_id,i_category_id,sum,isEmpty,count] [sum(CheckOverflow((promote_precision(cast(cast(ws_quantity as decimal(10,0)) as decimal(12,2))) * promote_precision(cast(ws_list_price as decimal(12,2)))), DecimalType(18,2), true)),count(1),channel,sales,number_sales,sum,isEmpty,count]
                                         InputAdapter
-                                          Exchange [i_brand_id,i_class_id,i_category_id] #23
-                                            WholeStageCodegen (137)
+                                          Exchange [i_brand_id,i_class_id,i_category_id] #20
+                                            WholeStageCodegen (119)
                                               HashAggregate [i_brand_id,i_class_id,i_category_id,ws_quantity,ws_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                                                 Project [ws_quantity,ws_list_price,i_brand_id,i_class_id,i_category_id]
                                                   BroadcastHashJoin [ws_item_sk,i_item_sk]
                                                     Project [ws_item_sk,ws_quantity,ws_list_price]
                                                       BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                        SortMergeJoin [ws_item_sk,ss_item_sk]
+                                                        BroadcastHashJoin [ws_item_sk,ss_item_sk]
+                                                          Filter [ws_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.web_sales [ws_item_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #1
                                                           InputAdapter
-                                                            WholeStageCodegen (94)
-                                                              Sort [ws_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [ws_item_sk] #24
-                                                                    WholeStageCodegen (93)
-                                                                      Filter [ws_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet default.web_sales [ws_item_sk,ws_quantity,ws_list_price,ws_sold_date_sk]
-                                                                              ReusedSubquery [d_date_sk] #1
-                                                          InputAdapter
-                                                            WholeStageCodegen (113)
-                                                              Sort [ss_item_sk]
-                                                                InputAdapter
-                                                                  ReusedExchange [ss_item_sk] #6
+                                                            ReusedExchange [ss_item_sk] #5
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #5
+                                                          ReusedExchange [d_date_sk] #4
                                                     InputAdapter
-                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #17
-                  WholeStageCodegen (281)
+                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #16
+                  WholeStageCodegen (245)
                     HashAggregate [channel,i_brand_id,i_class_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel,i_brand_id,i_class_id] #25
-                          WholeStageCodegen (280)
+                        Exchange [channel,i_brand_id,i_class_id] #21
+                          WholeStageCodegen (244)
                             HashAggregate [channel,i_brand_id,i_class_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                                 InputAdapter
                                   ReusedExchange [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] #2
-                  WholeStageCodegen (422)
+                  WholeStageCodegen (368)
                     HashAggregate [channel,i_brand_id,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel,i_brand_id] #26
-                          WholeStageCodegen (421)
+                        Exchange [channel,i_brand_id] #22
+                          WholeStageCodegen (367)
                             HashAggregate [channel,i_brand_id,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                                 InputAdapter
                                   ReusedExchange [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] #2
-                  WholeStageCodegen (563)
+                  WholeStageCodegen (491)
                     HashAggregate [channel,sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange [channel] #27
-                          WholeStageCodegen (562)
+                        Exchange [channel] #23
+                          WholeStageCodegen (490)
                             HashAggregate [channel,sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                                 InputAdapter
                                   ReusedExchange [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] #2
-                  WholeStageCodegen (704)
+                  WholeStageCodegen (614)
                     HashAggregate [sum,isEmpty,sum] [sum(sum_sales),sum(number_salesL),channel,i_brand_id,i_class_id,i_category_id,sum(sum_sales),sum(number_sales),sum,isEmpty,sum]
                       InputAdapter
-                        Exchange #28
-                          WholeStageCodegen (703)
+                        Exchange #24
+                          WholeStageCodegen (613)
                             HashAggregate [sum_sales,number_sales] [sum,isEmpty,sum,sum,isEmpty,sum]
                               HashAggregate [channel,i_brand_id,i_class_id,i_category_id,sum,isEmpty,sum] [sum(sales),sum(number_salesL),sum_sales,number_sales,sum,isEmpty,sum]
                                 InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new rule(`EliminateInnerJoin`) to support convert inner join to left semi join. It has two advantages:
1. Statistics are more accurate and more `BroadcastHashJoin`s can be planned.
2. We have 2 other rules(`PushDownLeftSemiAntiJoin` and `PushLeftSemiLeftAntiThroughJoin`) to optimize left semi join.

This is a real case:
```scala
sql("CREATE TABLE t1 using parquet AS SELECT id AS a, id AS b, id AS c FROM range(10000000)")
sql("CREATE TABLE t2 using parquet AS SELECT id AS a, id AS b, id AS c FROM range(10000000)")
sql("CREATE TABLE t3 using parquet AS SELECT id AS a, id AS b, id AS c FROM range(1000)")

sql(
  """
    |SELECT tmp1.*
    |FROM   (SELECT *
    |        FROM   t1
    |        UNION
    |        SELECT *
    |        FROM   t2) tmp1
    |       INNER JOIN (SELECT DISTINCT a,
    |                                   b
    |                   FROM   t3) tmp2
    |               ON tmp1.a = tmp2.a
    |                  AND tmp1.b = tmp2.b 
  """.stripMargin).explain
```

Before this pr:
```
== Optimized Logical Plan ==
Project [a#12L, b#13L, c#14L]
+- Join Inner, ((a#12L = a#18L) AND (b#13L = b#19L))
   :- Aggregate [a#12L, b#13L, c#14L], [a#12L, b#13L, c#14L]
   :  +- Union false, false
   :     :- Filter (isnotnull(a#12L) AND isnotnull(b#13L))
   :     :  +- Relation default.t1[a#12L,b#13L,c#14L] parquet
   :     +- Filter (isnotnull(a#15L) AND isnotnull(b#16L))
   :        +- Relation default.t2[a#15L,b#16L,c#17L] parquet
   +- Aggregate [a#18L, b#19L], [a#18L, b#19L]
      +- Project [a#18L, b#19L]
         +- Filter (isnotnull(a#18L) AND isnotnull(b#19L))
            +- Relation default.t3[a#18L,b#19L,c#20L] parquet
```

After this pr:
```
Aggregate [a#12L, b#13L, c#14L], [a#12L, b#13L, c#14L]
+- Union false, false
   :- Join LeftSemi, ((a#12L = a#18L) AND (b#13L = b#19L))
   :  :- Filter (isnotnull(a#12L) AND isnotnull(b#13L))
   :  :  +- Relation default.t1[a#12L,b#13L,c#14L] parquet
   :  +- Aggregate [a#18L, b#19L], [a#18L, b#19L]
   :     +- Project [a#18L, b#19L]
   :        +- Filter (isnotnull(a#18L) AND isnotnull(b#19L))
   :           +- Relation default.t3[a#18L,b#19L,c#20L] parquet
   +- Join LeftSemi, ((a#15L = a#18L) AND (b#16L = b#19L))
      :- Filter (isnotnull(a#15L) AND isnotnull(b#16L))
      :  +- Relation default.t2[a#15L,b#16L,c#17L] parquet
      +- Aggregate [a#18L, b#19L], [a#18L, b#19L]
         +- Project [a#18L, b#19L]
            +- Filter (isnotnull(a#18L) AND isnotnull(b#19L))
               +- Relation default.t3[a#18L,b#19L,c#20L] parquet
```

### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and TPC-DS benchmark test.

SQL | Before this PR(Seconds) | After this PR(Seconds)
-- | -- | --
q14a | 174  | 150

