### PR TITLE
[SPARK-36885][PYTHON][FOLLOWUP] Fix drop subset inline type hint

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3310,7 +3310,10 @@ class DataFrameNaFunctions:
         self.df = df
 
     def drop(
-        self, how: str = "any", thresh: Optional[int] = None, subset: Optional[List[str]] = None
+        self,
+        how: str = "any",
+        thresh: Optional[int] = None,
+        subset: Optional[Union[str, Tuple[str, ...], List[str]]] = None,
     ) -> DataFrame:
         return self.df.dropna(how=how, thresh=thresh, subset=subset)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix drop subset inline type hint


### Why are the changes needed?
it should be same with `DataFrame.dropna`:
https://github.com/apache/spark/blob/90003398745bfee78416074ed786e986fcb2c8cd/python/pyspark/sql/dataframe.py#L2359

See also: https://github.com/apache/spark/pull/35191#discussion_r784446470

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
