### PR TITLE
[SPARK-37905][INFRA] Make `merge_spark_pr.py` set primary author from the first commit in case of ties

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -135,11 +135,12 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
         continue_maybe(msg)
         had_conflicts = True
 
+    # First commit author should be considered as the primary author when the rank is the same
     commit_authors = run_cmd(
-        ["git", "log", "HEAD..%s" % pr_branch_name, "--pretty=format:%an <%ae>"]
+        ["git", "log", "HEAD..%s" % pr_branch_name, "--pretty=format:%an <%ae>", "--reverse"]
     ).split("\n")
     distinct_authors = sorted(
-        set(commit_authors), key=lambda x: commit_authors.count(x), reverse=True
+        list(dict.fromkeys(commit_authors)), key=lambda x: commit_authors.count(x), reverse=True
     )
     primary_author = input(
         'Enter primary author in the format of "name <email>" [%s]: ' % distinct_authors[0]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aim to make `merge_spark_pr.py` set the primary author from the first commit in case of ties.

### Why are the changes needed?

Currently, `merge_spark_pr.py` chooses the primary author randomly when there are two commits from two authors.

https://github.com/apache/spark/pull/35190

The best case could choose the primary author based on the number of lines, but it seems to hard. So, this PR aims to become better than before.

### Does this PR introduce _any_ user-facing change?

No. This is a dev only.

### How was this patch tested?

Manually.