### PR TITLE
[SPARK-37911][SQL] Unify the output of spark.version and select version()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -242,11 +242,11 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release version and the second being a git revision.""",
+  usage = """_FUNC_() - Returns the release version of Spark.""",
   examples = """
     Examples:
       > SELECT _FUNC_();
-       3.1.0 a6d6ea3efedbad14d99c24143834cd4e2e52fb40
+       3.1.0
   """,
   since = "3.0.0",
   group = "misc_funcs")
@@ -257,7 +257,7 @@ case class SparkVersion() extends LeafExpression with CodegenFallback {
   override def dataType: DataType = StringType
   override def prettyName: String = "version"
   override def eval(input: InternalRow): Any = {
-    UTF8String.fromString(SPARK_VERSION_SHORT + " " + SPARK_REVISION)
+    UTF8String.fromString(SPARK_VERSION_SHORT)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
+import org.apache.spark.SPARK_VERSION_SHORT
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedSeed
 import org.apache.spark.sql.catalyst.expressions.codegen._

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -40,7 +40,7 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
     val df = sql("SELECT version()")
     checkAnswer(
       df,
-      Row(SPARK_VERSION_SHORT + " " + SPARK_REVISION))
+      Row(SPARK_VERSION_SHORT))
     assert(df.schema.fieldNames === Seq("version()"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
+import org.apache.spark.SPARK_VERSION_SHORT
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, There are different outputs in `spark.version` and `spark.sql("select version()")`

`spark.sql("select version()")` output major release version with revision and I guess the revision is unuseful for user

### Why are the changes needed?
Unify the output of version

### Does this PR introduce _any_ user-facing change?
Yes, but just unify output of version

### How was this patch tested?
Exist ut
