### PR TITLE
[SPARK-37914][SQL] Make `RuntimeReplaceable` works for `AggregateFunction`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2198,7 +2198,10 @@ class Analyzer(override val catalogManager: CatalogManager)
           } else {
             AggregateExpression(agg, Complete, u.isDistinct, u.filter)
           }
-        case re: RuntimeReplaceable if re.isAggregate => validateFunction(re.child, numArgs, u)
+        // Replace with real aggregate function only if check input data types is success.
+        case re: RuntimeReplaceable if re.isAggregate && re.checkInputDataTypes().isSuccess =>
+          re.child.setTagValue(FunctionRegistry.FUNC_ALIAS, re.prettyName)
+          validateFunction(re.child, numArgs, u)
         // This function is not an aggregate function, just return the resolved one.
         case other if u.isDistinct =>
           throw QueryCompilationErrors.functionWithUnsupportedSyntaxError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2200,7 +2200,6 @@ class Analyzer(override val catalogManager: CatalogManager)
           }
         // Replace with real aggregate function only if check input data types is success.
         case re: RuntimeReplaceable if re.isAggregate && re.checkInputDataTypes().isSuccess =>
-          re.child.setTagValue(FunctionRegistry.FUNC_ALIAS, re.prettyName)
           validateFunction(re.child, numArgs, u)
         // This function is not an aggregate function, just return the resolved one.
         case other if u.isDistinct =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2198,6 +2198,7 @@ class Analyzer(override val catalogManager: CatalogManager)
           } else {
             AggregateExpression(agg, Complete, u.isDistinct, u.filter)
           }
+        case re: RuntimeReplaceable if re.isAggregate => validateFunction(re.child, numArgs, u)
         // This function is not an aggregate function, just return the resolved one.
         case other if u.isDistinct =>
           throw QueryCompilationErrors.functionWithUnsupportedSyntaxError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.util.Locale
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, DeclarativeAggregate}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -18,10 +18,9 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.util.Locale
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult, TypeCoercion}
-import org.apache.spark.sql.catalyst.expressions.aggregate.DeclarativeAggregate
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, DeclarativeAggregate}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, LeafLike, QuaternaryLike, TernaryLike, TreeNode, UnaryLike}
@@ -365,6 +364,8 @@ trait RuntimeReplaceable extends UnaryExpression with Unevaluable {
   // two `RuntimeReplaceable` are considered to be semantically equal if their "child" expressions
   // are semantically equal.
   override lazy val preCanonicalized: Expression = child.preCanonicalized
+
+  def isAggregate: Boolean = child.isInstanceOf[AggregateFunction]
 
   /**
    * Only used to generate SQL representation of this expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -366,7 +366,14 @@ trait RuntimeReplaceable extends UnaryExpression with Unevaluable {
   // are semantically equal.
   override lazy val preCanonicalized: Expression = child.preCanonicalized
 
-  def isAggregate: Boolean = child.isInstanceOf[AggregateFunction]
+  def isAggregate: Boolean = {
+    if (child.isInstanceOf[AggregateFunction]) {
+      true
+    } else {
+      assert(child.find(_.isInstanceOf[AggregateFunction]).isEmpty)
+      false
+    }
+  }
 
   /**
    * Only used to generate SQL representation of this expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, Literal, NullIf, RuntimeReplaceable}
+import org.apache.spark.sql.types.BooleanType
 
 @ExpressionDescription(
   usage = """
@@ -36,6 +38,17 @@ case class CountIf(predicate: Expression, child: Expression) extends RuntimeRepl
 
   def this(predicate: Expression) = {
     this(predicate, Count(new NullIf(predicate, Literal.FalseLiteral)))
+  }
+
+  override def prettyName: String = "count_if"
+
+  override def checkInputDataTypes(): TypeCheckResult = predicate.dataType match {
+    case BooleanType =>
+      TypeCheckResult.TypeCheckSuccess
+    case _ =>
+      TypeCheckResult.TypeCheckFailure(
+        s"function $prettyName requires boolean type, not ${predicate.dataType.catalogString}"
+      )
   }
 
   override def flatArguments: Iterator[Any] = Iterator(predicate)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RegrCount.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RegrCount.scala
@@ -17,10 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ImplicitCastInputTypes, UnevaluableAggregate}
-import org.apache.spark.sql.catalyst.trees.BinaryLike
-import org.apache.spark.sql.catalyst.trees.TreePattern.{REGR_COUNT, TreePattern}
-import org.apache.spark.sql.types.{AbstractDataType, DataType, LongType, NumericType}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, RuntimeReplaceable}
 
 @ExpressionDescription(
   usage = """
@@ -37,20 +34,16 @@ import org.apache.spark.sql.types.{AbstractDataType, DataType, LongType, Numeric
   """,
   group = "agg_funcs",
   since = "3.3.0")
-case class RegrCount(left: Expression, right: Expression)
-  extends UnevaluableAggregate with ImplicitCastInputTypes with BinaryLike[Expression] {
+case class RegrCount(left: Expression, right: Expression, child: Expression)
+  extends RuntimeReplaceable {
 
-  override def prettyName: String = "regr_count"
+  def this(left: Expression, right: Expression) = {
+    this(left, right, Count(Seq(left, right)))
+  }
 
-  override def nullable: Boolean = false
+  override def flatArguments: Iterator[Any] = Iterator(left, right)
+  override def exprsReplaced: Seq[Expression] = Seq(left, right)
 
-  override def dataType: DataType = LongType
-
-  override def inputTypes: Seq[AbstractDataType] = Seq(NumericType, NumericType)
-
-  final override val nodePatterns: Seq[TreePattern] = Seq(REGR_COUNT)
-
-  override protected def withNewChildrenInternal(
-      newLeft: Expression, newRight: Expression): RegrCount =
-    this.copy(left = newLeft, right = newRight)
+  override protected def withNewChildInternal(newChild: Expression): RegrCount =
+    copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RegrCount.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RegrCount.scala
@@ -17,7 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, RuntimeReplaceable}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ImplicitCastInputTypes, RuntimeReplaceable}
+import org.apache.spark.sql.types.{AbstractDataType, NumericType}
 
 @ExpressionDescription(
   usage = """
@@ -35,11 +36,15 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescript
   group = "agg_funcs",
   since = "3.3.0")
 case class RegrCount(left: Expression, right: Expression, child: Expression)
-  extends RuntimeReplaceable {
+  extends RuntimeReplaceable with ImplicitCastInputTypes {
 
   def this(left: Expression, right: Expression) = {
     this(left, right, Count(Seq(left, right)))
   }
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(NumericType, NumericType)
+
+  override def prettyName: String = "regr_count"
 
   override def flatArguments: Iterator[Any] = Iterator(left, right)
   override def exprsReplaced: Seq[Expression] = Seq(left, right)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RuntimeReplaceableBoolAggs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RuntimeReplaceableBoolAggs.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
-import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
+import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{AbstractDataType, BooleanType}
 
@@ -28,6 +28,15 @@ abstract class BoolAggBase(arg: Expression) extends RuntimeReplaceable
   override def exprsReplaced: Seq[Expression] = Seq(arg)
 
   override def inputTypes: Seq[AbstractDataType] = Seq(BooleanType)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    arg.dataType match {
+      case dt if dt != BooleanType =>
+        TypeCheckResult.TypeCheckFailure(s"Input to function '$prettyName' should have been " +
+          s"${BooleanType.simpleString}, but it's [${arg.dataType.catalogString}].")
+      case _ => TypeCheckResult.TypeCheckSuccess
+    }
+  }
 }
 
 @ExpressionDescription(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.CurrentUserContext.CURRENT_USER
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.TreePattern._
@@ -46,11 +45,8 @@ import org.apache.spark.util.Utils
  */
 object ReplaceExpressions extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformAllExpressionsWithPruning(
-    _.containsAnyPattern(RUNTIME_REPLACEABLE, COUNT_IF, BOOL_AGG)) {
+    _.containsAnyPattern(RUNTIME_REPLACEABLE)) {
     case e: RuntimeReplaceable => e.child
-    case CountIf(predicate) => Count(new NullIf(predicate, Literal.FalseLiteral))
-    case BoolOr(arg) => Max(arg)
-    case BoolAnd(arg) => Min(arg)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -46,12 +46,11 @@ import org.apache.spark.util.Utils
  */
 object ReplaceExpressions extends Rule[LogicalPlan] {
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformAllExpressionsWithPruning(
-    _.containsAnyPattern(RUNTIME_REPLACEABLE, COUNT_IF, BOOL_AGG, REGR_COUNT)) {
+    _.containsAnyPattern(RUNTIME_REPLACEABLE, COUNT_IF, BOOL_AGG)) {
     case e: RuntimeReplaceable => e.child
     case CountIf(predicate) => Count(new NullIf(predicate, Literal.FalseLiteral))
     case BoolOr(arg) => Max(arg)
     case BoolAnd(arg) => Min(arg)
-    case RegrCount(left, right) => Count(Seq(left, right))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -33,13 +33,11 @@ object TreePattern extends Enumeration  {
   val GROUPING_ANALYTICS: Value = Value
   val BINARY_ARITHMETIC: Value = Value
   val BINARY_COMPARISON: Value = Value
-  val BOOL_AGG: Value = Value
   val CASE_WHEN: Value = Value
   val CAST: Value = Value
   val COALESCE: Value = Value
   val CONCAT: Value = Value
   val COUNT: Value = Value
-  val COUNT_IF: Value = Value
   val CREATE_NAMED_STRUCT: Value = Value
   val CURRENT_LIKE: Value = Value
   val DESERIALIZE_TO_OBJECT: Value = Value

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -74,7 +74,6 @@ object TreePattern extends Enumeration  {
   val PIVOT: Value = Value
   val PLAN_EXPRESSION: Value = Value
   val PYTHON_UDF: Value = Value
-  val REGR_COUNT: Value = Value
   val RUNTIME_REPLACEABLE: Value = Value
   val SCALAR_SUBQUERY: Value = Value
   val SCALA_UDF: Value = Value

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -336,17 +336,17 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitAndAgg | bit_and | SELECT bit_and(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_and(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitOrAgg | bit_or | SELECT bit_or(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_or(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitXorAgg | bit_xor | SELECT bit_xor(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_xor(col):int> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | bool_and | SELECT bool_and(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<bool_and(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | every | SELECT every(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<every(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | any | SELECT any(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<any(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | bool_or | SELECT bool_or(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<bool_or(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | some | SELECT some(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<some(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | bool_and | SELECT bool_and(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<min(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | every | SELECT every(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<min(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | any | SELECT any(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | bool_or | SELECT bool_or(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | some | SELECT some(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectList | array_agg | SELECT array_agg(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_list(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectList | collect_list | SELECT collect_list(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_list(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet | collect_set | SELECT collect_set(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_set(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Corr | corr | SELECT corr(c1, c2) FROM VALUES (3, 2), (3, 3), (6, 4) as tab(c1, c2) | struct<corr(c1, c2):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Count | count | SELECT count(*) FROM VALUES (NULL), (5), (5), (20) AS tab(col) | struct<count(1):bigint> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.CountIf | count_if | SELECT count_if(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col) | struct<count_if(((col % 2) = 0)):bigint> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.CountIf | count_if | SELECT count_if(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col) | struct<count(nullif(((col % 2) = 0), false)):bigint> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CountMinSketchAgg | count_min_sketch | SELECT hex(count_min_sketch(col, 0.5d, 0.5d, 1)) FROM VALUES (1), (2), (1) AS tab(col) | struct<hex(count_min_sketch(col, 0.5, 0.5, 1)):string> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CovPopulation | covar_pop | SELECT covar_pop(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2) | struct<covar_pop(c1, c2):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CovSample | covar_samp | SELECT covar_samp(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2) | struct<covar_samp(c1, c2):double> |

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -362,7 +362,7 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.Min | min | SELECT min(col) FROM VALUES (10), (-1), (20) AS tab(col) | struct<min(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.MinBy | min_by | SELECT min_by(x, y) FROM VALUES (('a', 10)), (('b', 50)), (('c', 20)) AS tab(x, y) | struct<min_by(x, y):string> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Percentile | percentile | SELECT percentile(col, 0.3) FROM VALUES (0), (10) AS tab(col) | struct<percentile(col, 0.3, 1):double> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_count(y, x):bigint> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<count(y, x):bigint> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Skewness | skewness | SELECT skewness(col) FROM VALUES (-10), (-20), (100), (1000) AS tab(col) | struct<skewness(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevPop | stddev_pop | SELECT stddev_pop(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<stddev_pop(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp | std | SELECT std(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<std(col):double> |

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -336,17 +336,17 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitAndAgg | bit_and | SELECT bit_and(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_and(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitOrAgg | bit_or | SELECT bit_or(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_or(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitXorAgg | bit_xor | SELECT bit_xor(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_xor(col):int> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | bool_and | SELECT bool_and(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<min(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | every | SELECT every(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<min(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | any | SELECT any(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | bool_or | SELECT bool_or(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | some | SELECT some(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | bool_and | SELECT bool_and(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<bool_and(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | every | SELECT every(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<every(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | any | SELECT any(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<any(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | bool_or | SELECT bool_or(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<bool_or(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | some | SELECT some(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<some(col):boolean> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectList | array_agg | SELECT array_agg(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_list(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectList | collect_list | SELECT collect_list(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_list(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet | collect_set | SELECT collect_set(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_set(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Corr | corr | SELECT corr(c1, c2) FROM VALUES (3, 2), (3, 3), (6, 4) as tab(c1, c2) | struct<corr(c1, c2):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Count | count | SELECT count(*) FROM VALUES (NULL), (5), (5), (20) AS tab(col) | struct<count(1):bigint> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.CountIf | count_if | SELECT count_if(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col) | struct<count(nullif(((col % 2) = 0), false)):bigint> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.CountIf | count_if | SELECT count_if(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col) | struct<countif(nullif(((col % 2) = 0), false)):bigint> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CountMinSketchAgg | count_min_sketch | SELECT hex(count_min_sketch(col, 0.5d, 0.5d, 1)) FROM VALUES (1), (2), (1) AS tab(col) | struct<hex(count_min_sketch(col, 0.5, 0.5, 1)):string> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CovPopulation | covar_pop | SELECT covar_pop(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2) | struct<covar_pop(c1, c2):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CovSample | covar_samp | SELECT covar_samp(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2) | struct<covar_samp(c1, c2):double> |
@@ -362,7 +362,7 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.Min | min | SELECT min(col) FROM VALUES (10), (-1), (20) AS tab(col) | struct<min(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.MinBy | min_by | SELECT min_by(x, y) FROM VALUES (('a', 10)), (('b', 50)), (('c', 20)) AS tab(x, y) | struct<min_by(x, y):string> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Percentile | percentile | SELECT percentile(col, 0.3) FROM VALUES (0), (10) AS tab(col) | struct<percentile(col, 0.3, 1):double> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<count(y, x):bigint> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_count(y, x):bigint> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Skewness | skewness | SELECT skewness(col) FROM VALUES (-10), (-20), (100), (1000) AS tab(col) | struct<skewness(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevPop | stddev_pop | SELECT stddev_pop(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<stddev_pop(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp | std | SELECT std(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<std(col):double> |

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -336,17 +336,17 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitAndAgg | bit_and | SELECT bit_and(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_and(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitOrAgg | bit_or | SELECT bit_or(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_or(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.BitXorAgg | bit_xor | SELECT bit_xor(col) FROM VALUES (3), (5) AS tab(col) | struct<bit_xor(col):int> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | bool_and | SELECT bool_and(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<bool_and(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | every | SELECT every(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<every(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | any | SELECT any(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<any(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | bool_or | SELECT bool_or(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<bool_or(col):boolean> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | some | SELECT some(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<some(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | bool_and | SELECT bool_and(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<min(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolAnd | every | SELECT every(col) FROM VALUES (true), (true), (true) AS tab(col) | struct<min(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | any | SELECT any(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | bool_or | SELECT bool_or(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.BoolOr | some | SELECT some(col) FROM VALUES (true), (false), (false) AS tab(col) | struct<max(col):boolean> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectList | array_agg | SELECT array_agg(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_list(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectList | collect_list | SELECT collect_list(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_list(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CollectSet | collect_set | SELECT collect_set(col) FROM VALUES (1), (2), (1) AS tab(col) | struct<collect_set(col):array<int>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Corr | corr | SELECT corr(c1, c2) FROM VALUES (3, 2), (3, 3), (6, 4) as tab(c1, c2) | struct<corr(c1, c2):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Count | count | SELECT count(*) FROM VALUES (NULL), (5), (5), (20) AS tab(col) | struct<count(1):bigint> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.CountIf | count_if | SELECT count_if(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col) | struct<countif(nullif(((col % 2) = 0), false)):bigint> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.CountIf | count_if | SELECT count_if(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col) | struct<count(nullif(((col % 2) = 0), false)):bigint> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CountMinSketchAgg | count_min_sketch | SELECT hex(count_min_sketch(col, 0.5d, 0.5d, 1)) FROM VALUES (1), (2), (1) AS tab(col) | struct<hex(count_min_sketch(col, 0.5, 0.5, 1)):string> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CovPopulation | covar_pop | SELECT covar_pop(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2) | struct<covar_pop(c1, c2):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.CovSample | covar_samp | SELECT covar_samp(c1, c2) FROM VALUES (1,1), (2,2), (3,3) AS tab(c1, c2) | struct<covar_samp(c1, c2):double> |
@@ -362,7 +362,7 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.Min | min | SELECT min(col) FROM VALUES (10), (-1), (20) AS tab(col) | struct<min(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.MinBy | min_by | SELECT min_by(x, y) FROM VALUES (('a', 10)), (('b', 50)), (('c', 20)) AS tab(x, y) | struct<min_by(x, y):string> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Percentile | percentile | SELECT percentile(col, 0.3) FROM VALUES (0), (10) AS tab(col) | struct<percentile(col, 0.3, 1):double> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_count(y, x):bigint> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<count(y, x):bigint> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Skewness | skewness | SELECT skewness(col) FROM VALUES (-10), (-20), (100), (1000) AS tab(col) | struct<skewness(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevPop | stddev_pop | SELECT stddev_pop(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<stddev_pop(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp | std | SELECT std(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<std(col):double> |

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -383,7 +383,7 @@ struct<>
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE 1 = 0
 -- !query schema
-struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL	NULL	NULL
 
@@ -391,7 +391,7 @@ NULL	NULL	NULL	NULL	NULL
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE k = 4
 -- !query schema
-struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL	NULL	NULL
 
@@ -399,7 +399,7 @@ NULL	NULL	NULL	NULL	NULL
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE k = 5
 -- !query schema
-struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 false	true	true	false	true
 
@@ -407,7 +407,7 @@ false	true	true	false	true
 -- !query
 SELECT k, every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg GROUP BY k
 -- !query schema
-struct<k:int,every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<k:int,min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 1	false	true	true	false	true
 2	true	true	true	true	true
@@ -419,7 +419,7 @@ struct<k:int,every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean
 -- !query
 SELECT k, every(v) FROM test_agg GROUP BY k HAVING every(v) = false
 -- !query schema
-struct<k:int,every(v):boolean>
+struct<k:int,min(v):boolean>
 -- !query output
 1	false
 3	false
@@ -429,7 +429,7 @@ struct<k:int,every(v):boolean>
 -- !query
 SELECT k, every(v) FROM test_agg GROUP BY k HAVING every(v) IS NULL
 -- !query schema
-struct<k:int,every(v):boolean>
+struct<k:int,min(v):boolean>
 -- !query output
 4	NULL
 
@@ -470,7 +470,7 @@ SELECT every(1)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'every(1)' due to data type mismatch: argument 1 requires boolean type, however, 'min(1)' is of int type.; line 1 pos 7
+cannot resolve 'every(1)' due to data type mismatch: Input to function 'every' should have been boolean, but it's [int].; line 1 pos 7
 
 
 -- !query
@@ -479,7 +479,7 @@ SELECT some(1S)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'some(1S)' due to data type mismatch: argument 1 requires boolean type, however, 'max(1S)' is of smallint type.; line 1 pos 7
+cannot resolve 'some(1S)' due to data type mismatch: Input to function 'some' should have been boolean, but it's [smallint].; line 1 pos 7
 
 
 -- !query
@@ -488,7 +488,7 @@ SELECT any(1L)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'any(1L)' due to data type mismatch: argument 1 requires boolean type, however, 'max(1L)' is of bigint type.; line 1 pos 7
+cannot resolve 'any(1L)' due to data type mismatch: Input to function 'any' should have been boolean, but it's [bigint].; line 1 pos 7
 
 
 -- !query
@@ -497,7 +497,7 @@ SELECT every("true")
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'every('true')' due to data type mismatch: argument 1 requires boolean type, however, 'min('true')' is of string type.; line 1 pos 7
+cannot resolve 'every('true')' due to data type mismatch: Input to function 'every' should have been boolean, but it's [string].; line 1 pos 7
 
 
 -- !query
@@ -506,7 +506,7 @@ SELECT bool_and(1.0)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'bool_and(1.0BD)' due to data type mismatch: argument 1 requires boolean type, however, 'min(1.0BD)' is of decimal(2,1) type.; line 1 pos 7
+cannot resolve 'bool_and(1.0BD)' due to data type mismatch: Input to function 'bool_and' should have been boolean, but it's [decimal(2,1)].; line 1 pos 7
 
 
 -- !query
@@ -515,13 +515,13 @@ SELECT bool_or(1.0D)
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'bool_or(1.0D)' due to data type mismatch: argument 1 requires boolean type, however, 'max(1.0D)' is of double type.; line 1 pos 7
+cannot resolve 'bool_or(1.0D)' due to data type mismatch: Input to function 'bool_or' should have been boolean, but it's [double].; line 1 pos 7
 
 
 -- !query
 SELECT k, v, every(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -538,7 +538,7 @@ struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST 
 -- !query
 SELECT k, v, some(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -555,7 +555,7 @@ struct<k:int,v:boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST R
 -- !query
 SELECT k, v, any(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -572,7 +572,7 @@ struct<k:int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, v, bool_and(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,bool_and(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -589,7 +589,7 @@ struct<k:int,v:boolean,bool_and(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIR
 -- !query
 SELECT k, v, bool_or(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,bool_or(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -716,7 +716,7 @@ struct<histogram_2:array<struct<x:double,y:double>>,histogram_3:array<struct<x:d
 -- !query
 SELECT regr_count(y, x) FROM testRegression
 -- !query schema
-struct<regr_count(y, x):bigint>
+struct<count(y, x):bigint>
 -- !query output
 3
 
@@ -724,7 +724,7 @@ struct<regr_count(y, x):bigint>
 -- !query
 SELECT regr_count(y, x) FROM testRegression WHERE x IS NOT NULL
 -- !query schema
-struct<regr_count(y, x):bigint>
+struct<count(y, x):bigint>
 -- !query output
 3
 
@@ -732,7 +732,7 @@ struct<regr_count(y, x):bigint>
 -- !query
 SELECT k, count(*), regr_count(y, x) FROM testRegression GROUP BY k
 -- !query schema
-struct<k:int,count(1):bigint,regr_count(y, x):bigint>
+struct<k:int,count(1):bigint,count(y, x):bigint>
 -- !query output
 1	1	0
 2	4	3
@@ -741,7 +741,7 @@ struct<k:int,count(1):bigint,regr_count(y, x):bigint>
 -- !query
 SELECT k, count(*) FILTER (WHERE x IS NOT NULL), regr_count(y, x) FROM testRegression GROUP BY k
 -- !query schema
-struct<k:int,count(1) FILTER (WHERE (x IS NOT NULL)):bigint,regr_count(y, x):bigint>
+struct<k:int,count(1) FILTER (WHERE (x IS NOT NULL)):bigint,count(y, x):bigint>
 -- !query output
 1	0	0
 2	3	3

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -383,7 +383,7 @@ struct<>
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE 1 = 0
 -- !query schema
-struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL	NULL	NULL
 
@@ -391,7 +391,7 @@ NULL	NULL	NULL	NULL	NULL
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE k = 4
 -- !query schema
-struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL	NULL	NULL
 
@@ -399,7 +399,7 @@ NULL	NULL	NULL	NULL	NULL
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE k = 5
 -- !query schema
-struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 false	true	true	false	true
 
@@ -407,7 +407,7 @@ false	true	true	false	true
 -- !query
 SELECT k, every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg GROUP BY k
 -- !query schema
-struct<k:int,every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
+struct<k:int,min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
 -- !query output
 1	false	true	true	false	true
 2	true	true	true	true	true
@@ -419,7 +419,7 @@ struct<k:int,every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean
 -- !query
 SELECT k, every(v) FROM test_agg GROUP BY k HAVING every(v) = false
 -- !query schema
-struct<k:int,every(v):boolean>
+struct<k:int,min(v):boolean>
 -- !query output
 1	false
 3	false
@@ -429,7 +429,7 @@ struct<k:int,every(v):boolean>
 -- !query
 SELECT k, every(v) FROM test_agg GROUP BY k HAVING every(v) IS NULL
 -- !query schema
-struct<k:int,every(v):boolean>
+struct<k:int,min(v):boolean>
 -- !query output
 4	NULL
 
@@ -467,61 +467,55 @@ struct<k:int,every:boolean>
 -- !query
 SELECT every(1)
 -- !query schema
-struct<>
+struct<min(1):int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'every(1)' due to data type mismatch: Input to function 'every' should have been boolean, but it's [int].; line 1 pos 7
+1
 
 
 -- !query
 SELECT some(1S)
 -- !query schema
-struct<>
+struct<max(1):smallint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'some(1S)' due to data type mismatch: Input to function 'some' should have been boolean, but it's [smallint].; line 1 pos 7
+1
 
 
 -- !query
 SELECT any(1L)
 -- !query schema
-struct<>
+struct<max(1):bigint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'any(1L)' due to data type mismatch: Input to function 'any' should have been boolean, but it's [bigint].; line 1 pos 7
+1
 
 
 -- !query
 SELECT every("true")
 -- !query schema
-struct<>
+struct<min(true):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'every('true')' due to data type mismatch: Input to function 'every' should have been boolean, but it's [string].; line 1 pos 7
+true
 
 
 -- !query
 SELECT bool_and(1.0)
 -- !query schema
-struct<>
+struct<min(1.0):decimal(2,1)>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'bool_and(1.0BD)' due to data type mismatch: Input to function 'bool_and' should have been boolean, but it's [decimal(2,1)].; line 1 pos 7
+1.0
 
 
 -- !query
 SELECT bool_or(1.0D)
 -- !query schema
-struct<>
+struct<max(1.0):double>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'bool_or(1.0D)' due to data type mismatch: Input to function 'bool_or' should have been boolean, but it's [double].; line 1 pos 7
+1.0
 
 
 -- !query
 SELECT k, v, every(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -538,7 +532,7 @@ struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST 
 -- !query
 SELECT k, v, some(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -555,7 +549,7 @@ struct<k:int,v:boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST R
 -- !query
 SELECT k, v, any(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -572,7 +566,7 @@ struct<k:int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, v, bool_and(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,bool_and(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -589,7 +583,7 @@ struct<k:int,v:boolean,bool_and(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIR
 -- !query
 SELECT k, v, bool_or(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,bool_or(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -716,7 +716,7 @@ struct<histogram_2:array<struct<x:double,y:double>>,histogram_3:array<struct<x:d
 -- !query
 SELECT regr_count(y, x) FROM testRegression
 -- !query schema
-struct<regr_count(y, x):bigint>
+struct<count(y, x):bigint>
 -- !query output
 3
 
@@ -724,7 +724,7 @@ struct<regr_count(y, x):bigint>
 -- !query
 SELECT regr_count(y, x) FROM testRegression WHERE x IS NOT NULL
 -- !query schema
-struct<regr_count(y, x):bigint>
+struct<count(y, x):bigint>
 -- !query output
 3
 
@@ -732,7 +732,7 @@ struct<regr_count(y, x):bigint>
 -- !query
 SELECT k, count(*), regr_count(y, x) FROM testRegression GROUP BY k
 -- !query schema
-struct<k:int,count(1):bigint,regr_count(y, x):bigint>
+struct<k:int,count(1):bigint,count(y, x):bigint>
 -- !query output
 1	1	0
 2	4	3
@@ -741,7 +741,7 @@ struct<k:int,count(1):bigint,regr_count(y, x):bigint>
 -- !query
 SELECT k, count(*) FILTER (WHERE x IS NOT NULL), regr_count(y, x) FROM testRegression GROUP BY k
 -- !query schema
-struct<k:int,count(1) FILTER (WHERE (x IS NOT NULL)):bigint,regr_count(y, x):bigint>
+struct<k:int,count(1) FILTER (WHERE (x IS NOT NULL)):bigint,count(y, x):bigint>
 -- !query output
 1	0	0
 2	3	3

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -383,7 +383,7 @@ struct<>
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE 1 = 0
 -- !query schema
-struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
+struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
 -- !query output
 NULL	NULL	NULL	NULL	NULL
 
@@ -391,7 +391,7 @@ NULL	NULL	NULL	NULL	NULL
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE k = 4
 -- !query schema
-struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
+struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
 -- !query output
 NULL	NULL	NULL	NULL	NULL
 
@@ -399,7 +399,7 @@ NULL	NULL	NULL	NULL	NULL
 -- !query
 SELECT every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg WHERE k = 5
 -- !query schema
-struct<min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
+struct<every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
 -- !query output
 false	true	true	false	true
 
@@ -407,7 +407,7 @@ false	true	true	false	true
 -- !query
 SELECT k, every(v), some(v), any(v), bool_and(v), bool_or(v) FROM test_agg GROUP BY k
 -- !query schema
-struct<k:int,min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):boolean>
+struct<k:int,every(v):boolean,some(v):boolean,any(v):boolean,bool_and(v):boolean,bool_or(v):boolean>
 -- !query output
 1	false	true	true	false	true
 2	true	true	true	true	true
@@ -419,7 +419,7 @@ struct<k:int,min(v):boolean,max(v):boolean,max(v):boolean,min(v):boolean,max(v):
 -- !query
 SELECT k, every(v) FROM test_agg GROUP BY k HAVING every(v) = false
 -- !query schema
-struct<k:int,min(v):boolean>
+struct<k:int,every(v):boolean>
 -- !query output
 1	false
 3	false
@@ -429,7 +429,7 @@ struct<k:int,min(v):boolean>
 -- !query
 SELECT k, every(v) FROM test_agg GROUP BY k HAVING every(v) IS NULL
 -- !query schema
-struct<k:int,min(v):boolean>
+struct<k:int,every(v):boolean>
 -- !query output
 4	NULL
 
@@ -467,55 +467,61 @@ struct<k:int,every:boolean>
 -- !query
 SELECT every(1)
 -- !query schema
-struct<min(1):int>
+struct<>
 -- !query output
-1
+org.apache.spark.sql.AnalysisException
+cannot resolve 'every(1)' due to data type mismatch: argument 1 requires boolean type, however, 'min(1)' is of int type.; line 1 pos 7
 
 
 -- !query
 SELECT some(1S)
 -- !query schema
-struct<max(1):smallint>
+struct<>
 -- !query output
-1
+org.apache.spark.sql.AnalysisException
+cannot resolve 'some(1S)' due to data type mismatch: argument 1 requires boolean type, however, 'max(1S)' is of smallint type.; line 1 pos 7
 
 
 -- !query
 SELECT any(1L)
 -- !query schema
-struct<max(1):bigint>
+struct<>
 -- !query output
-1
+org.apache.spark.sql.AnalysisException
+cannot resolve 'any(1L)' due to data type mismatch: argument 1 requires boolean type, however, 'max(1L)' is of bigint type.; line 1 pos 7
 
 
 -- !query
 SELECT every("true")
 -- !query schema
-struct<min(true):string>
+struct<>
 -- !query output
-true
+org.apache.spark.sql.AnalysisException
+cannot resolve 'every('true')' due to data type mismatch: argument 1 requires boolean type, however, 'min('true')' is of string type.; line 1 pos 7
 
 
 -- !query
 SELECT bool_and(1.0)
 -- !query schema
-struct<min(1.0):decimal(2,1)>
+struct<>
 -- !query output
-1.0
+org.apache.spark.sql.AnalysisException
+cannot resolve 'bool_and(1.0BD)' due to data type mismatch: argument 1 requires boolean type, however, 'min(1.0BD)' is of decimal(2,1) type.; line 1 pos 7
 
 
 -- !query
 SELECT bool_or(1.0D)
 -- !query schema
-struct<max(1.0):double>
+struct<>
 -- !query output
-1.0
+org.apache.spark.sql.AnalysisException
+cannot resolve 'bool_or(1.0D)' due to data type mismatch: argument 1 requires boolean type, however, 'max(1.0D)' is of double type.; line 1 pos 7
 
 
 -- !query
 SELECT k, v, every(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -532,7 +538,7 @@ struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, v, some(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -549,7 +555,7 @@ struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, v, any(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -566,7 +572,7 @@ struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, v, bool_and(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,bool_and(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -583,7 +589,7 @@ struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, v, bool_or(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,bool_or(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -710,7 +716,7 @@ struct<histogram_2:array<struct<x:double,y:double>>,histogram_3:array<struct<x:d
 -- !query
 SELECT regr_count(y, x) FROM testRegression
 -- !query schema
-struct<count(y, x):bigint>
+struct<regr_count(y, x):bigint>
 -- !query output
 3
 
@@ -718,7 +724,7 @@ struct<count(y, x):bigint>
 -- !query
 SELECT regr_count(y, x) FROM testRegression WHERE x IS NOT NULL
 -- !query schema
-struct<count(y, x):bigint>
+struct<regr_count(y, x):bigint>
 -- !query output
 3
 
@@ -726,7 +732,7 @@ struct<count(y, x):bigint>
 -- !query
 SELECT k, count(*), regr_count(y, x) FROM testRegression GROUP BY k
 -- !query schema
-struct<k:int,count(1):bigint,count(y, x):bigint>
+struct<k:int,count(1):bigint,regr_count(y, x):bigint>
 -- !query output
 1	1	0
 2	4	3
@@ -735,7 +741,7 @@ struct<k:int,count(1):bigint,count(y, x):bigint>
 -- !query
 SELECT k, count(*) FILTER (WHERE x IS NOT NULL), regr_count(y, x) FROM testRegression GROUP BY k
 -- !query schema
-struct<k:int,count(1) FILTER (WHERE (x IS NOT NULL)):bigint,count(y, x):bigint>
+struct<k:int,count(1) FILTER (WHERE (x IS NOT NULL)):bigint,regr_count(y, x):bigint>
 -- !query output
 1	0	0
 2	3	3

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/aggregates_part1.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/aggregates_part1.sql.out
@@ -291,7 +291,7 @@ struct<avg(CAST(x AS DOUBLE)):double,var_pop(CAST(x AS DOUBLE)):double>
 -- !query
 SELECT regr_count(b, a) FROM aggtest
 -- !query schema
-struct<regr_count(b, a):bigint>
+struct<count(b, a):bigint>
 -- !query output
 4
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-aggregates_part1.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-aggregates_part1.sql.out
@@ -282,7 +282,7 @@ struct<avg(udf(CAST(x AS DOUBLE))):double,udf(var_pop(CAST(x AS DOUBLE))):double
 -- !query
 SELECT regr_count(b, a) FROM aggtest
 -- !query schema
-struct<regr_count(b, a):bigint>
+struct<count(b, a):bigint>
 -- !query output
 4
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -293,7 +293,7 @@ struct<>
 -- !query
 SELECT udf(every(v)), udf(some(v)), any(v) FROM test_agg WHERE 1 = 0
 -- !query schema
-struct<udf(every(v)):boolean,udf(some(v)):boolean,any(v):boolean>
+struct<udf(min(v)):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL
 
@@ -301,7 +301,7 @@ NULL	NULL	NULL
 -- !query
 SELECT udf(every(udf(v))), some(v), any(v) FROM test_agg WHERE k = 4
 -- !query schema
-struct<udf(every(udf(v))):boolean,some(v):boolean,any(v):boolean>
+struct<udf(min(udf(v))):boolean,max(v):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL
 
@@ -309,7 +309,7 @@ NULL	NULL	NULL
 -- !query
 SELECT every(v), udf(some(v)), any(v) FROM test_agg WHERE k = 5
 -- !query schema
-struct<every(v):boolean,udf(some(v)):boolean,any(v):boolean>
+struct<min(v):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query output
 false	true	true
 
@@ -317,7 +317,7 @@ false	true	true
 -- !query
 SELECT udf(k), every(v), udf(some(v)), any(v) FROM test_agg GROUP BY udf(k)
 -- !query schema
-struct<udf(k):int,every(v):boolean,udf(some(v)):boolean,any(v):boolean>
+struct<udf(k):int,min(v):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query output
 1	false	true	true
 2	true	true	true
@@ -329,7 +329,7 @@ struct<udf(k):int,every(v):boolean,udf(some(v)):boolean,any(v):boolean>
 -- !query
 SELECT udf(k), every(v) FROM test_agg GROUP BY k HAVING every(v) = false
 -- !query schema
-struct<udf(k):int,every(v):boolean>
+struct<udf(k):int,min(v):boolean>
 -- !query output
 1	false
 3	false
@@ -339,7 +339,7 @@ struct<udf(k):int,every(v):boolean>
 -- !query
 SELECT udf(k), udf(every(v)) FROM test_agg GROUP BY udf(k) HAVING every(v) IS NULL
 -- !query schema
-struct<udf(k):int,udf(every(v)):boolean>
+struct<udf(k):int,udf(min(v)):boolean>
 -- !query output
 4	NULL
 
@@ -380,7 +380,7 @@ SELECT every(udf(1))
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'every(CAST(udf(cast(1 as string)) AS INT))' due to data type mismatch: argument 1 requires boolean type, however, 'min(CAST(udf(cast(1 as string)) AS INT))' is of int type.; line 1 pos 7
+cannot resolve 'every(CAST(udf(cast(1 as string)) AS INT))' due to data type mismatch: Input to function 'every' should have been boolean, but it's [int].; line 1 pos 7
 
 
 -- !query
@@ -389,7 +389,7 @@ SELECT some(udf(1S))
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'some(CAST(udf(cast(1 as string)) AS SMALLINT))' due to data type mismatch: argument 1 requires boolean type, however, 'max(CAST(udf(cast(1 as string)) AS SMALLINT))' is of smallint type.; line 1 pos 7
+cannot resolve 'some(CAST(udf(cast(1 as string)) AS SMALLINT))' due to data type mismatch: Input to function 'some' should have been boolean, but it's [smallint].; line 1 pos 7
 
 
 -- !query
@@ -398,7 +398,7 @@ SELECT any(udf(1L))
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'any(CAST(udf(cast(1 as string)) AS BIGINT))' due to data type mismatch: argument 1 requires boolean type, however, 'max(CAST(udf(cast(1 as string)) AS BIGINT))' is of bigint type.; line 1 pos 7
+cannot resolve 'any(CAST(udf(cast(1 as string)) AS BIGINT))' due to data type mismatch: Input to function 'any' should have been boolean, but it's [bigint].; line 1 pos 7
 
 
 -- !query
@@ -407,13 +407,13 @@ SELECT udf(every("true"))
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-cannot resolve 'every('true')' due to data type mismatch: argument 1 requires boolean type, however, 'min('true')' is of string type.; line 1 pos 11
+cannot resolve 'every('true')' due to data type mismatch: Input to function 'every' should have been boolean, but it's [string].; line 1 pos 11
 
 
 -- !query
 SELECT k, v, every(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -430,7 +430,7 @@ struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST 
 -- !query
 SELECT k, udf(udf(v)), some(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,udf(udf(v)):boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,udf(udf(v)):boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -447,7 +447,7 @@ struct<k:int,udf(udf(v)):boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NUL
 -- !query
 SELECT udf(udf(k)), v, any(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<udf(udf(k)):int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<udf(udf(k)):int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -293,7 +293,7 @@ struct<>
 -- !query
 SELECT udf(every(v)), udf(some(v)), any(v) FROM test_agg WHERE 1 = 0
 -- !query schema
-struct<udf(min(v)):boolean,udf(max(v)):boolean,max(v):boolean>
+struct<udf(every(v)):boolean,udf(some(v)):boolean,any(v):boolean>
 -- !query output
 NULL	NULL	NULL
 
@@ -301,7 +301,7 @@ NULL	NULL	NULL
 -- !query
 SELECT udf(every(udf(v))), some(v), any(v) FROM test_agg WHERE k = 4
 -- !query schema
-struct<udf(min(udf(v))):boolean,max(v):boolean,max(v):boolean>
+struct<udf(every(udf(v))):boolean,some(v):boolean,any(v):boolean>
 -- !query output
 NULL	NULL	NULL
 
@@ -309,7 +309,7 @@ NULL	NULL	NULL
 -- !query
 SELECT every(v), udf(some(v)), any(v) FROM test_agg WHERE k = 5
 -- !query schema
-struct<min(v):boolean,udf(max(v)):boolean,max(v):boolean>
+struct<every(v):boolean,udf(some(v)):boolean,any(v):boolean>
 -- !query output
 false	true	true
 
@@ -317,7 +317,7 @@ false	true	true
 -- !query
 SELECT udf(k), every(v), udf(some(v)), any(v) FROM test_agg GROUP BY udf(k)
 -- !query schema
-struct<udf(k):int,min(v):boolean,udf(max(v)):boolean,max(v):boolean>
+struct<udf(k):int,every(v):boolean,udf(some(v)):boolean,any(v):boolean>
 -- !query output
 1	false	true	true
 2	true	true	true
@@ -329,7 +329,7 @@ struct<udf(k):int,min(v):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query
 SELECT udf(k), every(v) FROM test_agg GROUP BY k HAVING every(v) = false
 -- !query schema
-struct<udf(k):int,min(v):boolean>
+struct<udf(k):int,every(v):boolean>
 -- !query output
 1	false
 3	false
@@ -339,7 +339,7 @@ struct<udf(k):int,min(v):boolean>
 -- !query
 SELECT udf(k), udf(every(v)) FROM test_agg GROUP BY udf(k) HAVING every(v) IS NULL
 -- !query schema
-struct<udf(k):int,udf(min(v)):boolean>
+struct<udf(k):int,udf(every(v)):boolean>
 -- !query output
 4	NULL
 
@@ -377,39 +377,43 @@ struct<udf(udf(k)):int,every:boolean>
 -- !query
 SELECT every(udf(1))
 -- !query schema
-struct<min(udf(1)):int>
+struct<>
 -- !query output
-1
+org.apache.spark.sql.AnalysisException
+cannot resolve 'every(CAST(udf(cast(1 as string)) AS INT))' due to data type mismatch: argument 1 requires boolean type, however, 'min(CAST(udf(cast(1 as string)) AS INT))' is of int type.; line 1 pos 7
 
 
 -- !query
 SELECT some(udf(1S))
 -- !query schema
-struct<max(udf(1)):smallint>
+struct<>
 -- !query output
-1
+org.apache.spark.sql.AnalysisException
+cannot resolve 'some(CAST(udf(cast(1 as string)) AS SMALLINT))' due to data type mismatch: argument 1 requires boolean type, however, 'max(CAST(udf(cast(1 as string)) AS SMALLINT))' is of smallint type.; line 1 pos 7
 
 
 -- !query
 SELECT any(udf(1L))
 -- !query schema
-struct<max(udf(1)):bigint>
+struct<>
 -- !query output
-1
+org.apache.spark.sql.AnalysisException
+cannot resolve 'any(CAST(udf(cast(1 as string)) AS BIGINT))' due to data type mismatch: argument 1 requires boolean type, however, 'max(CAST(udf(cast(1 as string)) AS BIGINT))' is of bigint type.; line 1 pos 7
 
 
 -- !query
 SELECT udf(every("true"))
 -- !query schema
-struct<udf(min(true)):string>
+struct<>
 -- !query output
-true
+org.apache.spark.sql.AnalysisException
+cannot resolve 'every('true')' due to data type mismatch: argument 1 requires boolean type, however, 'min('true')' is of string type.; line 1 pos 11
 
 
 -- !query
 SELECT k, v, every(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -426,7 +430,7 @@ struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RA
 -- !query
 SELECT k, udf(udf(v)), some(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,udf(udf(v)):boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,udf(udf(v)):boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -443,7 +447,7 @@ struct<k:int,udf(udf(v)):boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULL
 -- !query
 SELECT udf(udf(k)), v, any(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<udf(udf(k)):int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<udf(udf(k)):int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -293,7 +293,7 @@ struct<>
 -- !query
 SELECT udf(every(v)), udf(some(v)), any(v) FROM test_agg WHERE 1 = 0
 -- !query schema
-struct<udf(every(v)):boolean,udf(some(v)):boolean,any(v):boolean>
+struct<udf(min(v)):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL
 
@@ -301,7 +301,7 @@ NULL	NULL	NULL
 -- !query
 SELECT udf(every(udf(v))), some(v), any(v) FROM test_agg WHERE k = 4
 -- !query schema
-struct<udf(every(udf(v))):boolean,some(v):boolean,any(v):boolean>
+struct<udf(min(udf(v))):boolean,max(v):boolean,max(v):boolean>
 -- !query output
 NULL	NULL	NULL
 
@@ -309,7 +309,7 @@ NULL	NULL	NULL
 -- !query
 SELECT every(v), udf(some(v)), any(v) FROM test_agg WHERE k = 5
 -- !query schema
-struct<every(v):boolean,udf(some(v)):boolean,any(v):boolean>
+struct<min(v):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query output
 false	true	true
 
@@ -317,7 +317,7 @@ false	true	true
 -- !query
 SELECT udf(k), every(v), udf(some(v)), any(v) FROM test_agg GROUP BY udf(k)
 -- !query schema
-struct<udf(k):int,every(v):boolean,udf(some(v)):boolean,any(v):boolean>
+struct<udf(k):int,min(v):boolean,udf(max(v)):boolean,max(v):boolean>
 -- !query output
 1	false	true	true
 2	true	true	true
@@ -329,7 +329,7 @@ struct<udf(k):int,every(v):boolean,udf(some(v)):boolean,any(v):boolean>
 -- !query
 SELECT udf(k), every(v) FROM test_agg GROUP BY k HAVING every(v) = false
 -- !query schema
-struct<udf(k):int,every(v):boolean>
+struct<udf(k):int,min(v):boolean>
 -- !query output
 1	false
 3	false
@@ -339,7 +339,7 @@ struct<udf(k):int,every(v):boolean>
 -- !query
 SELECT udf(k), udf(every(v)) FROM test_agg GROUP BY udf(k) HAVING every(v) IS NULL
 -- !query schema
-struct<udf(k):int,udf(every(v)):boolean>
+struct<udf(k):int,udf(min(v)):boolean>
 -- !query output
 4	NULL
 
@@ -377,43 +377,39 @@ struct<udf(udf(k)):int,every:boolean>
 -- !query
 SELECT every(udf(1))
 -- !query schema
-struct<>
+struct<min(udf(1)):int>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'every(CAST(udf(cast(1 as string)) AS INT))' due to data type mismatch: Input to function 'every' should have been boolean, but it's [int].; line 1 pos 7
+1
 
 
 -- !query
 SELECT some(udf(1S))
 -- !query schema
-struct<>
+struct<max(udf(1)):smallint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'some(CAST(udf(cast(1 as string)) AS SMALLINT))' due to data type mismatch: Input to function 'some' should have been boolean, but it's [smallint].; line 1 pos 7
+1
 
 
 -- !query
 SELECT any(udf(1L))
 -- !query schema
-struct<>
+struct<max(udf(1)):bigint>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'any(CAST(udf(cast(1 as string)) AS BIGINT))' due to data type mismatch: Input to function 'any' should have been boolean, but it's [bigint].; line 1 pos 7
+1
 
 
 -- !query
 SELECT udf(every("true"))
 -- !query schema
-struct<>
+struct<udf(min(true)):string>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'every('true')' due to data type mismatch: Input to function 'every' should have been boolean, but it's [string].; line 1 pos 11
+true
 
 
 -- !query
 SELECT k, v, every(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,v:boolean,min(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	false
@@ -430,7 +426,7 @@ struct<k:int,v:boolean,every(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST 
 -- !query
 SELECT k, udf(udf(v)), some(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<k:int,udf(udf(v)):boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<k:int,udf(udf(v)):boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true
@@ -447,7 +443,7 @@ struct<k:int,udf(udf(v)):boolean,some(v) OVER (PARTITION BY k ORDER BY v ASC NUL
 -- !query
 SELECT udf(udf(k)), v, any(v) OVER (PARTITION BY k ORDER BY v) FROM test_agg
 -- !query schema
-struct<udf(udf(k)):int,v:boolean,any(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
+struct<udf(udf(k)):int,v:boolean,max(v) OVER (PARTITION BY k ORDER BY v ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):boolean>
 -- !query output
 1	false	false
 1	true	true


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark provides `RuntimeReplaceable` to replace function with another function. The last function must be exists in build-in functions, so `RuntimeReplaceable` make Spark could reuse the implement of build-in function.
But `RuntimeReplaceable` not works for aggregate function.


### Why are the changes needed?
Make `RuntimeReplaceable` works for `AggregateFunction`


### Does this PR introduce _any_ user-facing change?
'No'.
This change is for spark developers.


### How was this patch tested?
Exists tests.
