### PR TITLE
[SPARK-37918][SQL]instance sessionBuilder with specified construct

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -1148,6 +1148,7 @@ object SparkSession extends Logging {
     conf.get(CATALOG_IMPLEMENTATION) match {
       case "hive" => HIVE_SESSION_STATE_BUILDER_CLASS_NAME
       case "in-memory" => classOf[SessionStateBuilder].getCanonicalName
+      case other => other
     }
   }
 
@@ -1167,11 +1168,10 @@ object SparkSession extends Logging {
       className: String,
       sparkSession: SparkSession): SessionState = {
     try {
-      // invoke new [Hive]SessionStateBuilder(
-      //   SparkSession,
-      //   Option[SessionState])
+      // Instance the sessionStateBuilder with specified
+      // construct, build-in [Hive]SessionStateBuilder or custom SessionStateBuilder
       val clazz = Utils.classForName(className)
-      val ctor = clazz.getConstructors.head
+      val ctor = clazz.getConstructor(classOf[SparkSession], classOf[Option[SessionState]])
       ctor.newInstance(sparkSession, None).asInstanceOf[BaseSessionStateBuilder].build()
     } catch {
       case NonFatal(e) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Currently, Spark SQL support that a developer can modify the builder by providing custom versions of components, so we should instance sessionBuilder with specified construct.

### Why are the changes needed?
Fix potential issue.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add ut
