### PR TITLE
[SPARK-37947][SQL] Extract generator from GeneratorOuter expression contained by a Generate operator.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2812,8 +2812,7 @@ class Analyzer(override val catalogManager: CatalogManager)
           p
         }
 
-      case g @ Generate(GeneratorOuter(generator), _, _, _, _, _)
-          if generator.resolved =>
+      case g @ Generate(GeneratorOuter(generator), _, _, _, _, _) =>
         g.copy(generator = generator,
           outer = true
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2812,6 +2812,12 @@ class Analyzer(override val catalogManager: CatalogManager)
           p
         }
 
+      case g @ Generate(GeneratorOuter(generator), _, _, _, _, _)
+          if generator.resolved =>
+        g.copy(generator = generator,
+          outer = true
+        )
+
       case g: Generate => g
 
       case p if p.expressions.exists(hasGenerator) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2813,9 +2813,7 @@ class Analyzer(override val catalogManager: CatalogManager)
         }
 
       case g @ Generate(GeneratorOuter(generator), _, _, _, _, _) =>
-        g.copy(generator = generator,
-          outer = true
-        )
+        g.copy(generator = generator, outer = true)
 
       case g: Generate => g
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -304,24 +304,22 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
   }
 
   test("lateral view <func>_outer()") {
+    checkAnswer(
+      sql("select * from values 1, 2 lateral view explode_outer(array()) a as b"),
+      Row(1, null) :: Row(2, null) :: Nil)
+
     withTempView("t1") {
       sql(
         """select * from values
-          |(0, array(1), array(struct(0, 1), struct(3, 4))),
-          |(1, array(4, 5), array(struct(6, 7))),
-          |(2, array(), array()),
-          |(3, null, null)
-          |tbl(id, arr1, arr2)
+          |array(struct(0, 1), struct(3, 4)),
+          |array(struct(6, 7)),
+          |array(),
+          |null
+          |as tbl(arr)
          """.stripMargin).createOrReplaceTempView("t1")
-
       checkAnswer(
-        sql("select id, c3 from t1 lateral view explode_outer(arr1) as c3"),
-        Row(0, 1) :: Row(1, 4) :: Row(1, 5) :: Row(2, null) :: Row(3, null) :: Nil)
-
-      checkAnswer(
-        sql("select id, f1, f2 from t1 lateral view inline_outer(arr2) as f1, f2"),
-        Row(0, 0, 1) :: Row(0, 3, 4) :: Row(1, 6, 7) ::
-          Row(2, null, null) :: Row(3, null, null) :: Nil)
+        sql("select f1, f2 from t1 lateral view inline_outer(arr) as f1, f2"),
+        Row(0, 1) :: Row(3, 4) :: Row(6, 7) :: Row(null, null) :: Row(null, null) :: Nil)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GeneratorFunctionSuite.scala
@@ -363,6 +363,10 @@ class GeneratorFunctionSuite extends QueryTest with SharedSparkSession {
       sql("select * from values 1, 2 lateral view explode_outer(array()) a as b"),
       Row(1, null) :: Row(2, null) :: Nil)
 
+    checkAnswer(
+      sql("select * from values 1, 2 lateral view outer explode_outer(array()) a as b"),
+      Row(1, null) :: Row(2, null) :: Nil)
+
     withTempView("t1") {
       sql(
         """select * from values


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the ExtractGenerator rule to extract a generator from a GeneratorOuter expression contained by a Generate operator.

### Why are the changes needed?

This works:

```
select * from values 1, 2 lateral view outer explode(array()) as b;
```

But this does not work:

```
select * from values 1, 2 lateral view explode_outer(array()) as b;
```

It produces the error:

```
Error in query: Column 'b' does not exist. Did you mean one of the following? [col1]; line 1 pos 26;
```

This is because the parser directly creates a Generate operator with the (as of yet unresolved) generator function. Later, the ResolveFunctions rule converts the unresolved function to a resolved generator wrapped by a GeneratorOuter expression. Although the ExtractGenerator rule will extract the generator function from a GeneratorOuter, it doesn't work if the GeneratorOuter is an expression in a Generate operator. Because the generator is not extracted, the ResolveGenerator rule fails to match on the Generate operator, and therefore fails to turn the generator's output expressions into attributes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Existing unit tests.
- New unit test.
