### PR TITLE
[SPARK-32165][SQL] SessionState leaks SparkListener with multiple SparkSession

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SharedState.scala
@@ -113,6 +113,9 @@ private[sql] class SharedState(
     val kvStore = sparkContext.statusStore.store.asInstanceOf[ElementTrackingStore]
     val listener = new SQLAppStatusListener(conf, kvStore, live = true)
     sparkContext.listenerBus.addToStatusQueue(listener)
+    sparkContext.cleaner.foreach { cleaner =>
+      cleaner.registerSparkListenerForCleanup(this, listener)
+    }
     val statusStore = new SQLAppStatusStore(kvStore, Some(listener))
     sparkContext.ui.foreach(new SQLTab(statusStore, _))
     statusStore


### PR DESCRIPTION
### What changes were proposed in this pull request?
The memory leak of `ExecutionListenerBus` was fixed in https://github.com/apache/spark/commit/4d90c5dc0efcf77ef6735000ee7016428c57077b by automatically cleaning it up when the `SparkSession` is GC'ed.
This is a similar fix for the memory leak of `SQLAppStatusListener` that occurs when a new `SessionState` is touched.  The memory leak is automatically cleaned up when the `SharedState` is GC'ed.


### Why are the changes needed?
The memory leak causes OOM in spark applications like Spark Thrift Server that creates many sessions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
A test has been added to the PR
