### PR TITLE
[SPARK-37903][PYTHON][FOLLOW-UP] Raise ValueError with no return function

### DIFF
--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -64,7 +64,7 @@ class TypeHintTests(unittest.TestCase):
             infer_return_type(f)
 
         self.assertRaisesRegex(
-            TypeError, "A return value is required for the input function", try_infer_return_type
+            ValueError, "A return value is required for the input function", try_infer_return_type
         )
 
         def try_infer_return_type():

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -63,7 +63,9 @@ class TypeHintTests(unittest.TestCase):
 
             infer_return_type(f)
 
-        self.assertRaisesRegex(TypeError, "Unsupported callable", try_infer_return_type)
+        self.assertRaisesRegex(
+            TypeError, "A return value is required for the input function", try_infer_return_type
+        )
 
         def try_infer_return_type():
             def f() -> None:
@@ -71,7 +73,9 @@ class TypeHintTests(unittest.TestCase):
 
             infer_return_type(f)
 
-        self.assertRaisesRegex(TypeError, "not understood", try_infer_return_type)
+        self.assertRaisesRegex(
+            TypeError, "Type <class 'NoneType'> was not understood", try_infer_return_type
+        )
 
     def test_infer_schema_from_pandas_instances(self):
         def func() -> pd.Series[int]:

--- a/python/pyspark/pandas/tests/test_typedef.py
+++ b/python/pyspark/pandas/tests/test_typedef.py
@@ -56,6 +56,23 @@ from pyspark import pandas as ps
 
 
 class TypeHintTests(unittest.TestCase):
+    def test_infer_schema_with_no_return(self):
+        def try_infer_return_type():
+            def f():
+                pass
+
+            infer_return_type(f)
+
+        self.assertRaisesRegex(TypeError, "Unsupported callable", try_infer_return_type)
+
+        def try_infer_return_type():
+            def f() -> None:
+                pass
+
+            infer_return_type(f)
+
+        self.assertRaisesRegex(TypeError, "not understood", try_infer_return_type)
+
     def test_infer_schema_from_pandas_instances(self):
         def func() -> pd.Series[int]:
             pass

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -559,6 +559,9 @@ def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarTyp
 
     tpe = get_type_hints(f).get("return", None)
 
+    if tpe is None:
+        raise TypeError("Unsupported callable")
+
     if hasattr(tpe, "__origin__") and issubclass(tpe.__origin__, SeriesType):
         tpe = tpe.__args__[0]
         if issubclass(tpe, NameTypeHolder):

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -560,7 +560,7 @@ def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarTyp
     tpe = get_type_hints(f).get("return", None)
 
     if tpe is None:
-        raise TypeError("A return value is required for the input function")
+        raise ValueError("A return value is required for the input function")
 
     if hasattr(tpe, "__origin__") and issubclass(tpe.__origin__, SeriesType):
         tpe = tpe.__args__[0]

--- a/python/pyspark/pandas/typedef/typehints.py
+++ b/python/pyspark/pandas/typedef/typehints.py
@@ -560,7 +560,7 @@ def infer_return_type(f: Callable) -> Union[SeriesType, DataFrameType, ScalarTyp
     tpe = get_type_hints(f).get("return", None)
 
     if tpe is None:
-        raise TypeError("Unsupported callable")
+        raise TypeError("A return value is required for the input function")
 
     if hasattr(tpe, "__origin__") and issubclass(tpe.__origin__, SeriesType):
         tpe = tpe.__args__[0]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Raise ValueError with no return function

### Why are the changes needed?
This PR is a follow-up of https://github.com/apache/spark/pull/35200
Currently, with the function with no return, `infer_return_type` will return `ScalarType[DoubleType]` as default. We should raise exception for this case.

### Does this PR introduce _any_ user-facing change?
Yes, 
Before this PR
```python
>>> from pyspark.pandas.typedef.typehints import infer_return_type
>>> def f():
...     pass
... 
>>> infer_return_type(f)
ScalarType[DoubleType]
```

after this PR user will take an exception when infer return type of function with no return.
```python-traceback
>>> from pyspark.pandas.typedef.typehints import infer_return_type
>>> def f():
...     pass
... 
>>> infer_return_type(f)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/u02/spark/python/pyspark/pandas/typedef/typehints.py", line 563, in infer_return_type
    raise ValueError("A return value is required for the input function")
ValueError: A return value is required for the input function

```

### How was this patch tested?
unit test
