### PR TITLE
[SPARK-36649][SQL] Support `Trigger.AvailableNow` on Kafka data source

### DIFF
--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -57,7 +57,7 @@ private[kafka010] class KafkaMicroBatchStream(
     metadataPath: String,
     startingOffsets: KafkaOffsetRangeLimit,
     failOnDataLoss: Boolean)
-  extends SupportsAdmissionControl with ReportsSourceMetrics with MicroBatchStream with Logging {
+  extends SupportsTriggerAvailableNow with ReportsSourceMetrics with MicroBatchStream with Logging {
 
   private[kafka010] val pollTimeoutMs = options.getLong(
     KafkaSourceProvider.CONSUMER_POLL_TIMEOUT,
@@ -81,6 +81,8 @@ private[kafka010] class KafkaMicroBatchStream(
 
   private var latestPartitionOffsets: PartitionOffsetMap = _
 
+  private var allDataForTriggerAvailableNow: PartitionOffsetMap = _
+
   /**
    * Lazily initialize `initialPartitionOffsets` to make sure that `KafkaConsumer.poll` is only
    * called in StreamExecutionThread. Otherwise, interrupting a thread while running
@@ -98,7 +100,7 @@ private[kafka010] class KafkaMicroBatchStream(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
-      maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(super.getDefaultReadLimit)
+      maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable())
     }
   }
 
@@ -113,7 +115,13 @@ private[kafka010] class KafkaMicroBatchStream(
 
   override def latestOffset(start: Offset, readLimit: ReadLimit): Offset = {
     val startPartitionOffsets = start.asInstanceOf[KafkaSourceOffset].partitionToOffsets
-    latestPartitionOffsets = kafkaOffsetReader.fetchLatestOffsets(Some(startPartitionOffsets))
+
+    // Use the pre-fetched list of partition offsets when Trigger.AvailableNow is enabled.
+    latestPartitionOffsets = if (allDataForTriggerAvailableNow != null) {
+      allDataForTriggerAvailableNow
+    } else {
+      kafkaOffsetReader.fetchLatestOffsets(Some(startPartitionOffsets))
+    }
 
     val limits: Seq[ReadLimit] = readLimit match {
       case rows: CompositeReadLimit => rows.getReadLimits
@@ -297,6 +305,11 @@ private[kafka010] class KafkaMicroBatchStream(
     } else {
       logWarning(message + s". $INSTRUCTION_FOR_FAIL_ON_DATA_LOSS_FALSE")
     }
+  }
+
+  override def prepareForTriggerAvailableNow(): Unit = {
+    allDataForTriggerAvailableNow = kafkaOffsetReader.fetchLatestOffsets(
+      Some(getOrCreateInitialPartitionOffsets()))
   }
 }
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -100,9 +100,7 @@ private[kafka010] class KafkaMicroBatchStream(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
-      // Calling ReadLimit.allAvailable() explicitly instead of super.getDefaultReadLimit because
-      // scala compiler bug https://github.com/scala/bug/issues/12523
-      // TODO revert to calling super.getDefaultReadLimit when scala complier bug is fixed
+      // TODO (SPARK-37973) Directly call super.getDefaultReadLimit when scala issue 12523 is fixed
       maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable())
     }
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchStream.scala
@@ -100,6 +100,9 @@ private[kafka010] class KafkaMicroBatchStream(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
+      // Calling ReadLimit.allAvailable() explicitly instead of super.getDefaultReadLimit because
+      // scala compiler bug https://github.com/scala/bug/issues/12523
+      // TODO revert to calling super.getDefaultReadLimit when scala complier bug is fixed
       maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable())
     }
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -134,6 +134,9 @@ private[kafka010] class KafkaSource(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
+      // Calling ReadLimit.allAvailable() explicitly instead of super.getDefaultReadLimit because
+      // scala compiler bug https://github.com/scala/bug/issues/12523
+      // TODO revert to calling super.getDefaultReadLimit when scala complier bug is fixed
       maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable())
     }
   }

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -77,8 +77,7 @@ private[kafka010] class KafkaSource(
     metadataPath: String,
     startingOffsets: KafkaOffsetRangeLimit,
     failOnDataLoss: Boolean)
-  extends SupportsAdmissionControl
-  with SupportsTriggerAvailableNow
+  extends SupportsTriggerAvailableNow
   with Source
   with Logging {
 
@@ -135,7 +134,7 @@ private[kafka010] class KafkaSource(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
-      maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(super.getDefaultReadLimit)
+      maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable() )
     }
   }
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -134,7 +134,7 @@ private[kafka010] class KafkaSource(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
-      maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable() )
+      maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable())
     }
   }
 

--- a/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
+++ b/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSource.scala
@@ -77,9 +77,7 @@ private[kafka010] class KafkaSource(
     metadataPath: String,
     startingOffsets: KafkaOffsetRangeLimit,
     failOnDataLoss: Boolean)
-  extends SupportsTriggerAvailableNow
-  with Source
-  with Logging {
+  extends SupportsTriggerAvailableNow with Source with Logging {
 
   private val sc = sqlContext.sparkContext
 
@@ -134,9 +132,7 @@ private[kafka010] class KafkaSource(
     } else if (minOffsetPerTrigger.isDefined) {
       ReadLimit.minRows(minOffsetPerTrigger.get, maxTriggerDelayMs)
     } else {
-      // Calling ReadLimit.allAvailable() explicitly instead of super.getDefaultReadLimit because
-      // scala compiler bug https://github.com/scala/bug/issues/12523
-      // TODO revert to calling super.getDefaultReadLimit when scala complier bug is fixed
+      // TODO (SPARK-37973) Directly call super.getDefaultReadLimit when scala issue 12523 is fixed
       maxOffsetsPerTrigger.map(ReadLimit.maxRows).getOrElse(ReadLimit.allAvailable())
     }
   }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -217,17 +217,17 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     def startTriggerAvailableNowQuery(): StreamingQuery = {
       reader.writeStream
         .foreachBatch((_: Dataset[Row], _: Long) => {
-          index+=1
+          index += 1
         })
         .trigger(Trigger.AvailableNow)
         .start()
     }
 
-    val q1 = startTriggerAvailableNowQuery()
+    val query = startTriggerAvailableNowQuery()
     try {
-      assert(q1.awaitTermination(streamingTimeout.toMillis))
+      assert(query.awaitTermination(streamingTimeout.toMillis))
     } finally {
-      q1.stop()
+      query.stop()
     }
 
     // should have 3 batches now i.e. 15 / 5 = 3

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -199,9 +199,9 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 5)
 
-    testUtils.sendMessages(topic, (0 until 15).map(x => {
-      "foo-" + x
-    }).toArray, Some(0))
+    testUtils.sendMessages(topic, (0 until 15).map{ case x =>
+      s"foo-$x"
+    }.toArray, Some(0))
 
     val reader = spark
       .readStream
@@ -216,9 +216,9 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     var index: Int = 0
     def startTriggerAvailableNowQuery(): StreamingQuery = {
       reader.writeStream
-        .foreachBatch((df: Dataset[Row], i: Long) => {
+        .foreachBatch{ case (_: Dataset[Row], _: Long) =>
           index+=1
-        })
+        }
         .trigger(Trigger.AvailableNow)
         .start()
     }

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -218,8 +218,6 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
       reader.writeStream
         .foreachBatch((df: Dataset[Row], i: Long) => {
           index+=1
-          df.foreach((f: Row) => {
-          })
         })
         .trigger(Trigger.AvailableNow)
         .start()

--- a/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/external/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -199,7 +199,7 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     val topic = newTopic()
     testUtils.createTopic(topic, partitions = 5)
 
-    testUtils.sendMessages(topic, (0 until 15).map{ case x =>
+    testUtils.sendMessages(topic, (0 until 15).map { case x =>
       s"foo-$x"
     }.toArray, Some(0))
 
@@ -216,9 +216,9 @@ abstract class KafkaMicroBatchSourceSuiteBase extends KafkaSourceSuiteBase {
     var index: Int = 0
     def startTriggerAvailableNowQuery(): StreamingQuery = {
       reader.writeStream
-        .foreachBatch{ case (_: Dataset[Row], _: Long) =>
+        .foreachBatch((_: Dataset[Row], _: Long) => {
           index+=1
-        }
+        })
         .trigger(Trigger.AvailableNow)
         .start()
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
To add support to using the AvailableNow trigger for the KafkaSource

### Why are the changes needed?
To allow users to use the KafkaSource the AvailableNow trigger.  The AvailableNow trigger allows the all the data currently available in the source to be processed in multiple micro batches.

### Does this PR introduce _any_ user-facing change?

Yes, allows users to using the KafkaSource to use the AvailableNow trigger

### How was this patch tested?

Added a test for this.
