### PR TITLE
[SPARK-37953][SQL] Improve the implement of `UnevaluableAggregate`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.DeclarativeAggregate
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.{BinaryLike, LeafLike, QuaternaryLike, TernaryLike, TreeNode, UnaryLike}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern, UNEVALUABLE_AGGREGATE}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
@@ -391,6 +391,10 @@ trait RuntimeReplaceable extends UnaryExpression with Unevaluable {
 trait UnevaluableAggregate extends DeclarativeAggregate {
 
   override def nullable: Boolean = true
+
+  def evaluableAggregateFunction: DeclarativeAggregate
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNEVALUABLE_AGGREGATE)
 
   override lazy val aggBufferAttributes =
     throw QueryExecutionErrors.evaluateUnevaluableAggregateUnsupportedError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ImplicitCastInputTypes, UnevaluableAggregate}
-import org.apache.spark.sql.catalyst.trees.TreePattern.{COUNT_IF, TreePattern}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ImplicitCastInputTypes, Literal, NullIf, UnevaluableAggregate}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.types.{AbstractDataType, BooleanType, DataType, LongType}
 
@@ -45,11 +44,12 @@ case class CountIf(predicate: Expression) extends UnevaluableAggregate with Impl
 
   override def nullable: Boolean = false
 
+  override def evaluableAggregateFunction: DeclarativeAggregate =
+    Count(new NullIf(predicate, Literal.FalseLiteral))
+
   override def dataType: DataType = LongType
 
   override def inputTypes: Seq[AbstractDataType] = Seq(BooleanType)
-
-  final override val nodePatterns: Seq[TreePattern] = Seq(COUNT_IF)
 
   override def checkInputDataTypes(): TypeCheckResult = predicate.dataType match {
     case BooleanType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RegrCount.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/RegrCount.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ImplicitCastInputTypes, UnevaluableAggregate}
 import org.apache.spark.sql.catalyst.trees.BinaryLike
-import org.apache.spark.sql.catalyst.trees.TreePattern.{REGR_COUNT, TreePattern}
 import org.apache.spark.sql.types.{AbstractDataType, DataType, LongType, NumericType}
 
 @ExpressionDescription(
@@ -44,11 +43,11 @@ case class RegrCount(left: Expression, right: Expression)
 
   override def nullable: Boolean = false
 
+  override def evaluableAggregateFunction: DeclarativeAggregate = Count(Seq(left, right))
+
   override def dataType: DataType = LongType
 
   override def inputTypes: Seq[AbstractDataType] = Seq(NumericType, NumericType)
-
-  final override val nodePatterns: Seq[TreePattern] = Seq(REGR_COUNT)
 
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): RegrCount =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/UnevaluableAggs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/UnevaluableAggs.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.TreePattern.{BOOL_AGG, TreePattern}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.types._
 
@@ -31,8 +30,6 @@ abstract class UnevaluableBooleanAggBase(arg: Expression)
   override def dataType: DataType = BooleanType
 
   override def inputTypes: Seq[AbstractDataType] = Seq(BooleanType)
-
-  final override val nodePatterns: Seq[TreePattern] = Seq(BOOL_AGG)
 
   override def checkInputDataTypes(): TypeCheckResult = {
     arg.dataType match {
@@ -58,6 +55,7 @@ abstract class UnevaluableBooleanAggBase(arg: Expression)
   group = "agg_funcs",
   since = "3.0.0")
 case class BoolAnd(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
+  override def evaluableAggregateFunction: DeclarativeAggregate = Min(arg)
   override def nodeName: String = getTagValue(FunctionRegistry.FUNC_ALIAS).getOrElse("bool_and")
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(arg = newChild)
@@ -77,6 +75,7 @@ case class BoolAnd(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
   group = "agg_funcs",
   since = "3.0.0")
 case class BoolOr(arg: Expression) extends UnevaluableBooleanAggBase(arg) {
+  override def evaluableAggregateFunction: DeclarativeAggregate = Max(arg)
   override def nodeName: String = getTagValue(FunctionRegistry.FUNC_ALIAS).getOrElse("bool_or")
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(arg = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable
+
 import org.apache.spark.sql.catalyst.CurrentUserContext.CURRENT_USER
 import org.apache.spark.sql.catalyst.expressions.{UnevaluableAggregate, _}
-import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.TreePattern._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -33,13 +33,11 @@ object TreePattern extends Enumeration  {
   val GROUPING_ANALYTICS: Value = Value
   val BINARY_ARITHMETIC: Value = Value
   val BINARY_COMPARISON: Value = Value
-  val BOOL_AGG: Value = Value
   val CASE_WHEN: Value = Value
   val CAST: Value = Value
   val COALESCE: Value = Value
   val CONCAT: Value = Value
   val COUNT: Value = Value
-  val COUNT_IF: Value = Value
   val CREATE_NAMED_STRUCT: Value = Value
   val CURRENT_LIKE: Value = Value
   val DESERIALIZE_TO_OBJECT: Value = Value
@@ -74,7 +72,7 @@ object TreePattern extends Enumeration  {
   val PIVOT: Value = Value
   val PLAN_EXPRESSION: Value = Value
   val PYTHON_UDF: Value = Value
-  val REGR_COUNT: Value = Value
+  val UNEVALUABLE_AGGREGATE: Value = Value
   val RUNTIME_REPLACEABLE: Value = Value
   val SCALAR_SUBQUERY: Value = Value
   val SCALA_UDF: Value = Value


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark provides `UnevaluableAggregate` to replace function with another function which must be exists in build-in functions, so `UnevaluableAggregate` make Spark could reuse the implement of build-in function.
However, the sub classes of `UnevaluableAggregate` looks cumbersome.


### Why are the changes needed?
Improve the implement of `UnevaluableAggregate`.


### Does this PR introduce _any_ user-facing change?
Yes. Users will see the.change of `UnevaluableAggregate`.


### How was this patch tested?
Exists test.
