### PR TITLE
[SPARK-37769][SQL][FOLLOWUP] Add UTF8String import in FileScanRDD.scala

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileScanRDD.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.execution.datasources.FileFormat._
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.NextIterator
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the import missing. Logical conflict between https://github.com/apache/spark/pull/35068 and https://github.com/apache/spark/pull/35055.

### Why are the changes needed?

To fix up the complication.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI should test it out in compliation.