### PR TITLE
[SPARK-37970][SS] Introduce AcceptsLatestSeenOffset to indicate latest seen offset to streaming source

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/AcceptsLatestSeenOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/AcceptsLatestSeenOffset.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.streaming;
+
+/**
+ * Indicates that the source accepts latest seen offset, which requires streaming execution
+ * to provide the latest seen offset when restarting the streaming query from checkpoint.
+ *
+ * Note that this interface aims to only support DSv2 streaming sources. Spark may throw error
+ * if the interface is implemented along with DSv1 streaming sources.
+ *
+ * The callback method will be called once per run.
+ */
+public interface AcceptsLatestSeenOffset extends SparkDataStream {
+  /**
+   * Callback method to receive the latest seen offset information from streaming execution.
+   * The method will be called only when the streaming query is restarted from checkpoint.
+   *
+   * @param offset The offset which was latest seen in the previous run.
+   */
+  void setLatestSeenOffset(Offset offset);
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/AcceptsLatestSeenOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/streaming/AcceptsLatestSeenOffset.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.read.streaming;
 
 /**
- * Indicates that the source accepts latest seen offset, which requires streaming execution
+ * Indicates that the source accepts the latest seen offset, which requires streaming execution
  * to provide the latest seen offset when restarting the streaming query from checkpoint.
  *
  * Note that this interface aims to only support DSv2 streaming sources. Spark may throw error

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AcceptsLatestSeenOffsetHandler.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/AcceptsLatestSeenOffsetHandler.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.sql.connector.read.streaming.{AcceptsLatestSeenOffset, SparkDataStream}
+
+/**
+ * This feeds "latest seen offset" to the sources that implement AcceptsLatestSeenOffset.
+ */
+object AcceptsLatestSeenOffsetHandler {
+  def setLatestSeenOffsetOnSources(
+      offsets: Option[OffsetSeq],
+      sources: Seq[SparkDataStream]): Unit = {
+    assertNoAcceptsLatestSeenOffsetWithDataSourceV1(sources)
+
+    offsets.map(_.toStreamProgress(sources)) match {
+      case Some(streamProgress) =>
+        streamProgress.foreach {
+          case (src: AcceptsLatestSeenOffset, offset) =>
+            src.setLatestSeenOffset(offset)
+
+          case _ => // no-op
+        }
+      case _ => // no-op
+    }
+  }
+
+  private def assertNoAcceptsLatestSeenOffsetWithDataSourceV1(
+      sources: Seq[SparkDataStream]): Unit = {
+    val unsupportedSources = sources
+      .filter(_.isInstanceOf[AcceptsLatestSeenOffset])
+      .filter(_.isInstanceOf[Source])
+
+    if (unsupportedSources.nonEmpty) {
+      throw new UnsupportedOperationException(
+        "AcceptsLatestSeenOffset is not supported with DSv1 streaming source: " +
+          unsupportedSources)
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -212,6 +212,8 @@ class MicroBatchExecution(
         reportTimeTaken("triggerExecution") {
           // We'll do this initialization only once every start / restart
           if (currentBatchId < 0) {
+            AcceptsLatestSeenOffsetHandler.setLatestSeenOffsetOnSources(
+              offsetLog.getLatest().map(_._2), sources)
             populateStartOffsets(sparkSessionForStream)
             logInfo(s"Stream started from $committedOffsets")
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousExecution.scala
@@ -163,6 +163,10 @@ class ContinuousExecution(
   private def runContinuous(sparkSessionForQuery: SparkSession): Unit = {
     val offsets = getStartOffsets(sparkSessionForQuery)
 
+    if (currentBatchId > 0) {
+      AcceptsLatestSeenOffsetHandler.setLatestSeenOffsetOnSources(Some(offsets), sources)
+    }
+
     val withNewSources: LogicalPlan = logicalPlan transform {
       case relation: StreamingDataSourceV2Relation =>
         val loggedOffset = offsets.offsets(0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/AcceptsLatestSeenOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/AcceptsLatestSeenOffsetSuite.scala
@@ -247,10 +247,8 @@ class AcceptsLatestSeenOffsetSuite extends StreamTest with BeforeAndAfter {
     }
 
     override def initialOffset: streaming.Offset = {
-      if (assertInitialOffsetIsCalledAfterLatestOffsetSeen) {
-        if (latestSeenOffset == null) {
-          fail("Expected the latest seen offset to be set.")
-        }
+      if (assertInitialOffsetIsCalledAfterLatestOffsetSeen && latestSeenOffset == null) {
+        fail("Expected the latest seen offset to be set.")
       }
       super.initialOffset
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/AcceptsLatestSeenOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/AcceptsLatestSeenOffsetSuite.scala
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.plans.logical.Range
+import org.apache.spark.sql.connector.read.streaming
+import org.apache.spark.sql.connector.read.streaming.{AcceptsLatestSeenOffset, SparkDataStream}
+import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.execution.streaming.sources.{ContinuousMemoryStream, ContinuousMemoryStreamOffset}
+import org.apache.spark.sql.types.{LongType, StructType}
+
+class AcceptsLatestSeenOffsetSuite extends StreamTest with BeforeAndAfter {
+
+  import testImplicits._
+
+  after {
+    sqlContext.streams.active.foreach(_.stop())
+  }
+
+  test("DataSource V1 source with micro-batch is not supported") {
+    val testSource = new TestSource(spark)
+    val df = testSource.toDF()
+
+    /** Add data to this test source by incrementing its available offset */
+    def addData(numNewRows: Int): StreamAction = new AddData {
+      override def addData(
+          query: Option[StreamExecution]): (SparkDataStream, streaming.Offset) = {
+        testSource.incrementAvailableOffset(numNewRows)
+        (testSource, testSource.getOffset.get)
+      }
+    }
+
+    addData(10)
+    val query = df.writeStream.format("console").start()
+    val exc = intercept[StreamingQueryException] {
+      query.processAllAvailable()
+    }
+    assert(exc.getMessage.contains(
+      "AcceptsLatestSeenOffset is not supported with DSv1 streaming source"))
+  }
+
+  test("DataSource V2 source with micro-batch") {
+    val inputData = new TestMemoryStream[Long](0, spark.sqlContext)
+    val df = inputData.toDF().select("value")
+
+    /** Add data to this test source by incrementing its available offset */
+    def addData(values: Array[Long]): StreamAction = new AddData {
+      override def addData(
+          query: Option[StreamExecution]): (SparkDataStream, streaming.Offset) = {
+        (inputData, inputData.addData(values))
+      }
+    }
+
+    testStream(df)(
+      StartStream(),
+      addData((1L to 10L).toArray),
+      ProcessAllAvailable(),
+      Execute("latest seen offset should be null") { _ =>
+        // this verifies that the callback method is not called for the new query
+        assert(inputData.latestSeenOffset === null)
+      },
+      StopStream,
+
+      StartStream(),
+      addData((11L to 20L).toArray),
+      ProcessAllAvailable(),
+      Execute("latest seen offset should be 0") { _ =>
+        assert(inputData.latestSeenOffset === LongOffset(0))
+      },
+      StopStream,
+
+      Execute("mark last batch as incomplete") { q =>
+        // Delete the last committed batch from the commit log to signify that the last batch
+        // (a no-data batch) did not complete and has to be re-executed on restart.
+        val commit = q.commitLog.getLatest().map(_._1).getOrElse(-1L)
+        q.commitLog.purgeAfter(commit - 1)
+      },
+      StartStream(),
+      addData((21L to 30L).toArray),
+      ProcessAllAvailable(),
+      Execute("latest seen offset should be 1") { _ =>
+        assert(inputData.latestSeenOffset === LongOffset(1))
+      }
+    )
+  }
+
+  test("DataSource V2 source with micro-batch - rollback of microbatch 0") {
+    //  Test case: when the query is restarted, we expect the execution to call `latestSeenOffset`
+    //  first. Later as part of the execution, execution may call `initialOffset` if the previous
+    //  run of the query had no committed batches.
+    val inputData = new TestMemoryStream[Long](0, spark.sqlContext)
+    val df = inputData.toDF().select("value")
+
+    /** Add data to this test source by incrementing its available offset */
+    def addData(values: Array[Long]): StreamAction = new AddData {
+      override def addData(
+        query: Option[StreamExecution]): (SparkDataStream, streaming.Offset) = {
+        (inputData, inputData.addData(values))
+      }
+    }
+
+    testStream(df)(
+      StartStream(),
+      addData((1L to 10L).toArray),
+      ProcessAllAvailable(),
+      Execute("latest seen offset should be null") { _ =>
+        // this verifies that the callback method is not called for the new query
+        assert(inputData.latestSeenOffset === null)
+      },
+      StopStream,
+
+      Execute("mark last batch as incomplete") { q =>
+        // Delete the last committed batch from the commit log to signify that the last batch
+        // (a no-data batch) did not complete and has to be re-executed on restart.
+        val commit = q.commitLog.getLatest().map(_._1).getOrElse(-1L)
+        q.commitLog.purgeAfter(commit - 1)
+      },
+
+      Execute("reset flag initial offset called flag") { q =>
+        inputData.assertInitialOffsetIsCalledAfterLatestOffsetSeen = true
+      },
+      StartStream(),
+      addData((11L to 20L).toArray),
+      ProcessAllAvailable(),
+      Execute("latest seen offset should be 0") { _ =>
+        assert(inputData.latestSeenOffset === LongOffset(0))
+      },
+      StopStream
+    )
+  }
+
+  test("DataSource V2 source with continuous mode") {
+    val inputData = new TestContinuousMemoryStream[Long](0, spark.sqlContext, 1)
+    val df = inputData.toDF().select("value")
+
+    /** Add data to this test source by incrementing its available offset */
+    def addData(values: Array[Long]): StreamAction = new AddData {
+      override def addData(
+          query: Option[StreamExecution]): (SparkDataStream, streaming.Offset) = {
+        (inputData, inputData.addData(values))
+      }
+    }
+
+    testStream(df)(
+      StartStream(trigger = Trigger.Continuous("1 hour")),
+      addData((1L to 10L).toArray),
+      AwaitEpoch(0),
+      Execute { _ =>
+        assert(inputData.latestSeenOffset === null)
+      },
+      IncrementEpoch(),
+      StopStream,
+
+      StartStream(trigger = Trigger.Continuous("1 hour")),
+      addData((11L to 20L).toArray),
+      AwaitEpoch(2),
+      Execute { _ =>
+        assert(inputData.latestSeenOffset === ContinuousMemoryStreamOffset(Map(0 -> 10)))
+      },
+      IncrementEpoch(),
+      StopStream,
+
+      StartStream(trigger = Trigger.Continuous("1 hour")),
+      addData((21L to 30L).toArray),
+      AwaitEpoch(3),
+      Execute { _ =>
+        assert(inputData.latestSeenOffset === ContinuousMemoryStreamOffset(Map(0 -> 20)))
+      }
+    )
+  }
+
+  class TestSource(spark: SparkSession) extends Source with AcceptsLatestSeenOffset {
+
+    @volatile var currentOffset = 0L
+
+    override def getOffset: Option[Offset] = {
+      if (currentOffset <= 0) None else Some(LongOffset(currentOffset))
+    }
+
+    override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
+      if (currentOffset == 0) currentOffset = getOffsetValue(end)
+      val plan = Range(
+        start.map(getOffsetValue).getOrElse(0L) + 1L, getOffsetValue(end) + 1L, 1, None,
+        isStreaming = true)
+      Dataset.ofRows(spark, plan)
+    }
+
+    def incrementAvailableOffset(numNewRows: Int): Unit = {
+      currentOffset = currentOffset + numNewRows
+    }
+
+    override def setLatestSeenOffset(offset: streaming.Offset): Unit = {
+      assert(false, "This method should not be called!")
+    }
+
+    def reset(): Unit = {
+      currentOffset = 0L
+    }
+
+    def toDF(): DataFrame = Dataset.ofRows(spark, StreamingExecutionRelation(this, spark))
+    override def schema: StructType = new StructType().add("value", LongType)
+    override def stop(): Unit = {}
+    private def getOffsetValue(offset: Offset): Long = {
+      offset match {
+        case s: SerializedOffset => LongOffset(s).offset
+        case l: LongOffset => l.offset
+        case _ => throw new IllegalArgumentException("incorrect offset type: " + offset)
+      }
+    }
+  }
+
+  class TestMemoryStream[A : Encoder](
+      _id: Int,
+      _sqlContext: SQLContext,
+      _numPartitions: Option[Int] = None)
+    extends MemoryStream[A](_id, _sqlContext, _numPartitions)
+    with AcceptsLatestSeenOffset {
+
+    @volatile var latestSeenOffset: streaming.Offset = null
+
+    // Flag to assert the sequence of calls in following scenario:
+    //  When the query is restarted, we expect the execution to call `latestSeenOffset` first.
+    //  Later as part of the execution, execution may call `initialOffset` if the previous
+    //  run of the query had no committed batches.
+    @volatile var assertInitialOffsetIsCalledAfterLatestOffsetSeen: Boolean = false
+
+    override def setLatestSeenOffset(offset: streaming.Offset): Unit = {
+      latestSeenOffset = offset
+    }
+
+    override def initialOffset: streaming.Offset = {
+      if (assertInitialOffsetIsCalledAfterLatestOffsetSeen) {
+        if (latestSeenOffset == null) {
+          fail("Expected the latest seen offset to be set.")
+        }
+      }
+      super.initialOffset
+    }
+  }
+
+  class TestContinuousMemoryStream[A : Encoder](
+      _id: Int,
+      _sqlContext: SQLContext,
+      _numPartitions: Int = 2)
+    extends ContinuousMemoryStream[A](_id, _sqlContext, _numPartitions)
+    with AcceptsLatestSeenOffset {
+
+    @volatile var latestSeenOffset: streaming.Offset = _
+
+    override def setLatestSeenOffset(offset: streaming.Offset): Unit = {
+      latestSeenOffset = offset
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces a new interface on streaming data source `AcceptsLatestSeenOffset`, which notifies Spark to provide latest seen offset to the sources implementing the interface at every restart of the query. Spark will provide the latest seen offset before fetching the offset or data.

Worth noting that the interface only support DSv2 streaming sources; the usage of DSv1 streaming source is limited to internal and it has different method call flow, so we would like to focus on DSv2. Spark will throw error if the DSv1 streaming source implements the interface.

### Why are the changes needed?

This could be useful for the source if source needs to prepare based on the latest seen offset before fetching anything. More specifically, we found this very useful and handy for the data source which needs to track the offset by itself, since the external storage does not provide the offset for the latest available data.

### Does this PR introduce _any_ user-facing change?

No, the change is limited to the data source developers.

### How was this patch tested?

New unit tests.