### PR TITLE
[SPARK-37979][SQL] Switch to more generic error classes in AES functions

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -93,7 +93,7 @@
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
   "INVALID_PARAMETER_VALUE" : {
-    "message" : [ "Invalid parameter value of '%s' in '%s'. %s" ],
+    "message" : [ "The value of parameter(s) '%s' in %s is invalid: %s" ],
     "sqlState" : "22023"
   },
   "MAP_KEY_DOES_NOT_EXIST" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -74,10 +74,6 @@
   "INTERNAL_ERROR" : {
     "message" : [ "%s" ]
   },
-  "INVALID_AES_KEY_LENGTH" : {
-    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s" ],
-    "sqlState" : "42000"
-  },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s. If necessary set %s to false to bypass this error." ]
   },
@@ -98,6 +94,10 @@
   },
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
+  },
+  "INVALID_PARAMETER_VALUE" : {
+    "message" : [ "Invalid parameter value of '%s' in '%s'. Expected: %s but got: %s" ],
+    "sqlState" : "22023"
   },
   "MAP_KEY_DOES_NOT_EXIST" : {
     "message" : [ "Key %s does not exist. If necessary set %s to false to bypass this error." ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -144,8 +144,8 @@
     "message" : [ "Unrecognized SQL type %s" ],
     "sqlState" : "42000"
   },
-  "UNSUPPORTED_AES_MODE" : {
-    "message" : [ "The AES mode %s with the padding %s is not supported" ],
+  "UNSUPPORTED_MODE" : {
+    "message" : [ "The mode %s is not supported" ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_CHANGE_COLUMN" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -144,10 +144,6 @@
     "message" : [ "Unrecognized SQL type %s" ],
     "sqlState" : "42000"
   },
-  "UNSUPPORTED_MODE" : {
-    "message" : [ "The mode %s is not supported" ],
-    "sqlState" : "0A000"
-  },
   "UNSUPPORTED_CHANGE_COLUMN" : {
     "message" : [ "Please add an implementation for a column change here" ],
     "sqlState" : "0A000"
@@ -158,6 +154,10 @@
   },
   "UNSUPPORTED_LITERAL_TYPE" : {
     "message" : [ "Unsupported literal type %s %s" ],
+    "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_MODE" : {
+    "message" : [ "The mode %s is not supported" ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -149,12 +149,12 @@
     "message" : [ "Unsupported data type %s" ],
     "sqlState" : "0A000"
   },
-  "UNSUPPORTED_LITERAL_TYPE" : {
-    "message" : [ "Unsupported literal type %s %s" ],
+  "UNSUPPORTED_FEATURE" : {
+    "message" : [ "The feature is not supported: %s" ],
     "sqlState" : "0A000"
   },
-  "UNSUPPORTED_MODE" : {
-    "message" : [ "The mode %s is not supported" ],
+  "UNSUPPORTED_LITERAL_TYPE" : {
+    "message" : [ "Unsupported literal type %s %s" ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_SIMPLE_STRING_WITH_NODE_ID" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,7 +1,4 @@
 {
-  "AES_CRYPTO_ERROR" : {
-    "message" : [ "AES crypto operation failed with: %s" ]
-  },
   "AMBIGUOUS_FIELD_NAME" : {
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
     "sqlState" : "42000"
@@ -96,7 +93,7 @@
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
   },
   "INVALID_PARAMETER_VALUE" : {
-    "message" : [ "Invalid parameter value of '%s' in '%s'. Expected: %s but got: %s" ],
+    "message" : [ "Invalid parameter value of '%s' in '%s'. %s" ],
     "sqlState" : "22023"
   },
   "MAP_KEY_DOES_NOT_EXIST" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1909,14 +1909,15 @@ object QueryExecutionErrors {
       errorClass = "INVALID_PARAMETER_VALUE",
       messageParameters = Array(
         "key",
-        "aes_encrypt/aes_decrypt",
+        "the aes_encrypt/aes_decrypt function",
         s"expects a binary value with 16, 24 or 32 bytes, but got ${actualLength.toString} bytes."))
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
     new SparkRuntimeException(
       errorClass = "UNSUPPORTED_FEATURE",
-      messageParameters = Array(s"AES-$mode with the padding $padding"))
+      messageParameters = Array(
+        s"AES-$mode with the padding $padding by the aes_encrypt/aes_decrypt function."))
   }
 
   def aesCryptoError(detailMessage: String): RuntimeException = {
@@ -1924,7 +1925,7 @@ object QueryExecutionErrors {
       errorClass = "INVALID_PARAMETER_VALUE",
       messageParameters = Array(
         "expr, key",
-        "aes_encrypt/aes_decrypt",
+        "the aes_encrypt/aes_decrypt function",
         s"Detail message: $detailMessage"))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1909,7 +1909,8 @@ object QueryExecutionErrors {
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
-    new SparkRuntimeException("UNSUPPORTED_AES_MODE", Array(mode, padding))
+    val errorMsg = s"AES-$mode with the padding $padding"
+    new SparkRuntimeException("UNSUPPORTED_MODE", Array(errorMsg))
   }
 
   def aesCryptoError(detailMessage: String): RuntimeException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1908,7 +1908,9 @@ object QueryExecutionErrors {
     new SparkRuntimeException(
       errorClass = "INVALID_PARAMETER_VALUE",
       messageParameters = Array(
-        "key", "aes_encrypt/aes_decrypt", "16, 24 or 32 bytes", actualLength.toString))
+        "key",
+        "aes_encrypt/aes_decrypt",
+        s"Expected: 16, 24 or 32 but got ${actualLength.toString} bytes."))
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
@@ -1918,7 +1920,12 @@ object QueryExecutionErrors {
   }
 
   def aesCryptoError(detailMessage: String): RuntimeException = {
-    new SparkRuntimeException("AES_CRYPTO_ERROR", Array(detailMessage))
+    new SparkRuntimeException(
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters = Array(
+        "expr, key",
+        "aes_encrypt/aes_decrypt",
+        s"Detail message: $detailMessage"))
   }
 
   def hiveTableWithAnsiIntervalsError(tableName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1910,7 +1910,7 @@ object QueryExecutionErrors {
       messageParameters = Array(
         "key",
         "aes_encrypt/aes_decrypt",
-        s"Expected: 16, 24 or 32 but got ${actualLength.toString} bytes."))
+        s"expects a binary value with 16, 24 or 32 bytes, but got ${actualLength.toString} bytes."))
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1905,12 +1905,16 @@ object QueryExecutionErrors {
   }
 
   def invalidAesKeyLengthError(actualLength: Int): RuntimeException = {
-    new SparkRuntimeException("INVALID_AES_KEY_LENGTH", Array(actualLength.toString))
+    new SparkRuntimeException(
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters = Array(
+        "key", "aes_encrypt/aes_decrypt", "16, 24 or 32 bytes", actualLength.toString))
   }
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
-    val errorMsg = s"AES-$mode with the padding $padding"
-    new SparkRuntimeException("UNSUPPORTED_MODE", Array(errorMsg))
+    new SparkRuntimeException(
+      errorClass = "UNSUPPORTED_MODE",
+      messageParameters = Array(s"AES-$mode with the padding $padding"))
   }
 
   def aesCryptoError(detailMessage: String): RuntimeException = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1915,7 +1915,7 @@ object QueryExecutionErrors {
 
   def aesModeUnsupportedError(mode: String, padding: String): RuntimeException = {
     new SparkRuntimeException(
-      errorClass = "UNSUPPORTED_MODE",
+      errorClass = "UNSUPPORTED_FEATURE",
       messageParameters = Array(s"AES-$mode with the padding $padding"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -97,9 +97,9 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       val e = intercept[SparkException] {
         df.collect
       }.getCause.asInstanceOf[SparkRuntimeException]
-      assert(e.getErrorClass === "UNSUPPORTED_MODE")
+      assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
       assert(e.getSqlState === "0A000")
-      assert(e.getMessage.matches("""The mode AES-\w+ with the padding \w+ is not supported"""))
+      assert(e.getMessage.matches("""The feature is not supported: AES-\w+ with the padding \w+"""))
     }
 
     // Unsupported AES mode and padding in encrypt

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -41,16 +41,17 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
     (df1, df2)
   }
 
-  test("INVALID_AES_KEY_LENGTH: invalid key lengths in AES functions") {
+  test("INVALID_PARAMETER_VALUE: invalid key lengths in AES functions") {
     val (df1, df2) = getAesInputs()
     def checkInvalidKeyLength(df: => DataFrame): Unit = {
       val e = intercept[SparkException] {
         df.collect
       }.getCause.asInstanceOf[SparkRuntimeException]
-      assert(e.getErrorClass === "INVALID_AES_KEY_LENGTH")
-      assert(e.getSqlState === "42000")
+      assert(e.getErrorClass === "INVALID_PARAMETER_VALUE")
+      assert(e.getSqlState === "22023")
       assert(e.getMessage.contains(
-        "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes"))
+        "Invalid parameter value of 'key' in 'aes_encrypt/aes_decrypt'. " +
+        "Expected: 16, 24 or 32 bytes but got:"))
     }
 
     // Encryption failure - invalid key length

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -50,7 +50,7 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       assert(e.getErrorClass === "INVALID_PARAMETER_VALUE")
       assert(e.getSqlState === "22023")
       assert(e.getMessage.contains(
-        "The value of parameter(s) 'key' in aes_encrypt/aes_decrypt is invalid: " +
+        "The value of parameter(s) 'key' in the aes_encrypt/aes_decrypt function is invalid: " +
         "expects a binary value with 16, 24 or 32 bytes, but got"))
     }
 
@@ -84,8 +84,8 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       assert(e.getErrorClass === "INVALID_PARAMETER_VALUE")
       assert(e.getSqlState === "22023")
       assert(e.getMessage.contains(
-        "The value of parameter(s) 'expr, key' in aes_encrypt/aes_decrypt is invalid: " +
-        "Detail message:"))
+        "The value of parameter(s) 'expr, key' in the aes_encrypt/aes_decrypt function " +
+        "is invalid: Detail message:"))
     }
   }
 
@@ -99,7 +99,8 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       }.getCause.asInstanceOf[SparkRuntimeException]
       assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
       assert(e.getSqlState === "0A000")
-      assert(e.getMessage.matches("""The feature is not supported: AES-\w+ with the padding \w+"""))
+      assert(e.getMessage.matches("""The feature is not supported: AES-\w+ with the padding \w+""" +
+        " by the aes_encrypt/aes_decrypt function."))
     }
 
     // Unsupported AES mode and padding in encrypt

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -50,8 +50,8 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       assert(e.getErrorClass === "INVALID_PARAMETER_VALUE")
       assert(e.getSqlState === "22023")
       assert(e.getMessage.contains(
-        "Invalid parameter value of 'key' in 'aes_encrypt/aes_decrypt'. " +
-        "Expected: 16, 24 or 32 but got"))
+        "The value of parameter(s) 'key' in aes_encrypt/aes_decrypt is invalid: " +
+        "expects a binary value with 16, 24 or 32 bytes, but got"))
     }
 
     // Encryption failure - invalid key length
@@ -84,7 +84,7 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       assert(e.getErrorClass === "INVALID_PARAMETER_VALUE")
       assert(e.getSqlState === "22023")
       assert(e.getMessage.contains(
-        "Invalid parameter value of 'expr, key' in 'aes_encrypt/aes_decrypt'. " +
+        "The value of parameter(s) 'expr, key' in aes_encrypt/aes_decrypt is invalid: " +
         "Detail message:"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -71,7 +71,7 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("UNSUPPORTED_AES_MODE: unsupported combinations of AES modes and padding") {
+  test("UNSUPPORTED_MODE: unsupported combinations of AES modes and padding") {
     val key16 = "abcdefghijklmnop"
     val key32 = "abcdefghijklmnop12345678ABCDEFGH"
     val (df1, df2) = getAesInputs()
@@ -79,9 +79,9 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
       val e = intercept[SparkException] {
         df.collect
       }.getCause.asInstanceOf[SparkRuntimeException]
-      assert(e.getErrorClass === "UNSUPPORTED_AES_MODE")
+      assert(e.getErrorClass === "UNSUPPORTED_MODE")
       assert(e.getSqlState === "0A000")
-      assert(e.getMessage.matches("""The AES mode \w+ with the padding \w+ is not supported"""))
+      assert(e.getMessage.matches("""The mode AES-\w+ with the padding \w+ is not supported"""))
     }
 
     // Unsupported AES mode and padding in encrypt


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to switch from specific error classes in the AES functions: `aes_encrypt()/aes_decrypt()` to more generic:
- AES_CRYPTO_ERROR -> INVALID_PARAMETER_VALUE
- INVALID_AES_KEY_LENGTH -> INVALID_PARAMETER_VALUE
- UNSUPPORTED_AES_MODE -> UNSUPPORTED_FEATURE

The new error classes `INVALID_PARAMETER_VALUE` and `UNSUPPORTED_MODE` are made to be re-used from other functions but not only in the AES functions.

### Why are the changes needed?
1.  To prevent unlimited inflation of the set of error classes and as a consequence of that inflation of `error-classes.json`.
2. To establish rules for other sub-tasks of SPARK-37935

### Does this PR introduce _any_ user-facing change?
Yes, but the AES functions `aes_encrypt()`/`aes_decrypt()` haven't released yet.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "test:testOnly *SparkThrowableSuite"
$ build/sbt "test:testOnly *QueryExecutionErrorsSuite"
```