### PR TITLE
[SPARK-37985][SQL] Fix flaky test for SPARK-37578

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -933,6 +933,7 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
             statusStore.executionsList().last.metricValues != null)
         }
 
+        spark.sparkContext.listenerBus.waitUntilEmpty()
         assert(bytesWritten.sum == 246)
         assert(recordsWritten.sum == 20)
       } finally {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SQLAppStatusListenerSuite.scala
@@ -906,11 +906,14 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
       val statusStore = spark.sharedState.statusStore
       val oldCount = statusStore.executionsCount()
 
+      val numPartitions = 2
+      var finishedTask = 0
       val bytesWritten = new ArrayBuffer[Long]()
       val recordsWritten = new ArrayBuffer[Long]()
 
       val bytesWrittenListener = new SparkListener() {
         override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = {
+          finishedTask += 1
           bytesWritten += taskEnd.taskMetrics.outputMetrics.bytesWritten
           recordsWritten += taskEnd.taskMetrics.outputMetrics.recordsWritten
         }
@@ -919,7 +922,8 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
 
       try {
         val cls = classOf[CustomMetricsDataSource].getName
-        spark.range(0, 10, 1, 2).select('id as 'i, -'id as 'j).write.format(cls)
+        spark.range(0, 10, 1, numPartitions)
+          .select('id as 'i, -'id as 'j).write.format(cls)
           .option("path", dir.getCanonicalPath).mode("append").save()
 
         // Wait until the new execution is started and being tracked.
@@ -931,6 +935,11 @@ class SQLAppStatusListenerSuite extends SharedSparkSession with JsonTestUtils
         eventually(timeout(10.seconds), interval(10.milliseconds)) {
           assert(statusStore.executionsList().nonEmpty &&
             statusStore.executionsList().last.metricValues != null)
+        }
+
+        // Wait for bytesWrittenListener receive all TaskEnd event log.
+        eventually(timeout(10.seconds), interval(10.milliseconds)) {
+          assert(finishedTask == numPartitions)
         }
 
         assert(bytesWritten.sum == 246)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In SQL test `SPARK-37578: Update output metrics from Datasource v2`
Execution's metric value is not null seem only can promise the execution is not still running.
But can't promise bytesWrittenListener have received all TaskEnd event, cause test failed.


### Why are the changes needed?
Fix flaky test


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existed UT
