### PR TITLE
[SPARK-37188][PYTHON] Respect user input layout kwargs in plot.hist

### DIFF
--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 from typing import TYPE_CHECKING, Union
 
 import pandas as pd
@@ -109,7 +110,11 @@ def plot_histogram(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
             )
         )
 
-    fig = go.Figure(data=bars, layout=go.Layout(barmode="stack"))
+    layout_keys = inspect.signature(go.Layout).parameters.keys()
+    layout_kwargs = {k: v for k, v in kwargs.items() if k in layout_keys}
+
+    fig = go.Figure(data=bars, layout=go.Layout(**layout_kwargs))
+    fig["layout"]["barmode"] = "stack"
     fig["layout"]["xaxis"]["title"] = "value"
     fig["layout"]["yaxis"]["title"] = "count"
     return fig

--- a/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/plot/test_frame_plot_plotly.py
@@ -186,6 +186,13 @@ class DataFramePlotPlotlyTest(PandasOnSparkTestCase, TestUtils):
         # )
         # check_pie_plot(psdf1)
 
+    def test_hist_layout_kwargs(self):
+        s = ps.Series([1, 3, 2])
+        plt = s.plot.hist(title="Title", foo="xxx")
+        self.assertEqual(plt.layout.barmode, "stack")
+        self.assertEqual(plt.layout.title.text, "Title")
+        self.assertFalse(hasattr(plt.layout, "foo"))
+
     def test_hist_plot(self):
         def check_hist_plot(psdf):
             bins = np.array([1.0, 5.9, 10.8, 15.7, 20.6, 25.5, 30.4, 35.3, 40.2, 45.1, 50.0])


### PR DESCRIPTION
### What changes were proposed in this pull request?

```
s = ps.Series([1, 3, 2])
plt = s.plot.hist(title="Title")
```

Before this patch:
![image](https://user-images.githubusercontent.com/1736354/150648238-0fc08e19-f4e3-43dc-9378-fe5810bc4df3.png)

After this patch (with title):
![image](https://user-images.githubusercontent.com/1736354/150648232-39daf7a6-1527-4cb0-ae45-ec7fd6704a1f.png)

### Why are the changes needed?
pyspark.pandas histogram accepts the title option but does not add a title to the plot

### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
- UT passed
- Manual test