### PR TITLE
[SPARK-37988][PYTHON] Fix confused warning for `black` version mismatched

### DIFF
--- a/dev/reformat-python
+++ b/dev/reformat-python
@@ -28,4 +28,10 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+RUNNING_BLACK_VERSION=$(python -c "import black;print(black.__version__)")
+if [ "$BLACK_VERSION" != "$RUNNING_BLACK_VERSION" ]; then
+    echo "The required version '$BLACK_VERSION' does not match the running version '$RUNNING_BLACK_VERSION', Please re-install Black, for example, via 'pip install black==$BLACK_VERSION'."
+    exit 1
+fi
+
 $BLACK_BUILD --config dev/pyproject.toml python/pyspark dev


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a friendly error message for `black` version mismatched.

### Why are the changes needed?
Before this patch:
```bash
$ dev/reformat-python
Oh no! 💥 💔 💥 The required version `21.12b0` does not match the running version `21.7b0`!
```

The developer might confused by this warnning before taking a look on dev/reformat code.

After this patch:
```bash
$ dev/reformat-python
The required version '21.12b0' does not match the running version '21.7b0', Please re-install Black, for example, via 'pip install black==21.12b0'.
```

### Does this PR introduce _any_ user-facing change?
No, dev only


### How was this patch tested?
Manually test
