### PR TITLE
[SPARK-37987][SS][TESTS] Print out which exception was thrown in schema validation unit test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -778,7 +778,10 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
         AddData(inputData, 21),
         ExpectFailure[SparkException] { e =>
           val stateSchemaExc = findStateSchemaNotCompatible(e)
-          assert(stateSchemaExc.isDefined)
+          assert(
+            stateSchemaExc.isDefined,
+            s"${classOf[StateSchemaNotCompatible].getSimpleName} " +
+              s"was not found in:\n${Utils.exceptionString(e)}")
           val msg = stateSchemaExc.get.getMessage
           assert(msg.contains("Provided schema doesn't match to the schema for existing state"))
           // other verifications are presented in StateStoreSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves the `assert` message by showing full stack trace from the exception thrown on the flaky test `StreamingAggregationSuite.changing schema of state when restarting query - state format version 1` in order to debug further why it fails.

### Why are the changes needed?

To debug the cause of flakiness.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.