### PR TITLE
[SPARK-37989][SQL] Push down limit through Aggregate if it is group only

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1363,6 +1363,17 @@ case class Distinct(child: LogicalPlan) extends UnaryNode {
 }
 
 /**
+ * Returns a new logical plan that partially dedups input rows.
+ */
+case class PartialDistinct(child: LogicalPlan) extends UnaryNode {
+  override def maxRows: Option[Long] = child.maxRows
+  override def output: Seq[Attribute] = child.output
+  final override val nodePatterns: Seq[TreePattern] = Seq(DISTINCT_LIKE)
+  override protected def withNewChildInternal(newChild: LogicalPlan): PartialDistinct =
+    copy(child = newChild)
+}
+
+/**
  * A base interface for [[RepartitionByExpression]] and [[Repartition]]
  */
 abstract class RepartitionOperation extends UnaryNode {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1337,6 +1337,11 @@ object QueryCompilationErrors {
       "Cannot use a mixture of aggregate function and group aggregate pandas UDF")
   }
 
+  def failedToPlanPartialDistinct(): Throwable = {
+    new AnalysisException(
+      "Failed to plan PartialDistinct. Please report your query to Spark user mailing list")
+  }
+
   def ambiguousAttributesInSelfJoinError(
       ambiguousAttrs: Seq[AttributeReference]): Throwable = {
     new AnalysisException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -577,6 +577,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
               if aggExpressions.forall(_.isInstanceOf[AggregateExpression]) =>
             Seq(AggUtils.planPartialAggregations(
               groupingExpressions,
+              groupingExpressions.map(_.toAttribute),
               aggExpressions.map(_.asInstanceOf[AggregateExpression]),
               resultExpressions,
               planLater(child)))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -108,7 +108,7 @@ object AggUtils {
 
     createAggregate(
       requiredChildDistributionExpressions = None,
-      groupingExpressions = groupingAttributes,
+      groupingExpressions = groupingExpressions,
       aggregateExpressions = partialAggregateExpressions,
       aggregateAttributes = partialAggregateAttributes,
       initialInputBufferOffset = 0,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -94,11 +94,11 @@ object AggUtils {
 
   def planPartialAggregations(
       groupingExpressions: Seq[NamedExpression],
+      groupingAttributes: Seq[Attribute],
       aggregateExpressions: Seq[AggregateExpression],
       resultExpressions: Seq[NamedExpression],
       child: SparkPlan): SparkPlan = {
 
-    val groupingAttributes = groupingExpressions.map(_.toAttribute)
     val partialAggregateExpressions = aggregateExpressions.map(_.copy(mode = Partial))
     val partialAggregateAttributes =
       partialAggregateExpressions.flatMap(_.aggregateFunction.aggBufferAttributes)
@@ -108,7 +108,7 @@ object AggUtils {
 
     createAggregate(
       requiredChildDistributionExpressions = None,
-      groupingExpressions = groupingExpressions,
+      groupingExpressions = groupingAttributes,
       aggregateExpressions = partialAggregateExpressions,
       aggregateAttributes = partialAggregateAttributes,
       initialInputBufferOffset = 0,
@@ -126,8 +126,8 @@ object AggUtils {
     // 1. Create an Aggregate Operator for partial aggregations.
 
     val groupingAttributes = groupingExpressions.map(_.toAttribute)
-    val partialAggregate =
-      planPartialAggregations(groupingExpressions, aggregateExpressions, resultExpressions, child)
+    val partialAggregate = planPartialAggregations(groupingExpressions, groupingAttributes,
+      aggregateExpressions, resultExpressions, child)
 
     // If we have session window expression in aggregation, we add MergingSessionExec to
     // merge sessions with calculating aggregation values.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr add a new logical plan(`PartialDistinct`) to support partially deduplicate input rows and use it push down limit through Aggregate if it is group only.

For example:
```scala
spark.range(10000L).write.saveAsTable("t1")
spark.sql("SELECT DISTINCT * FROM t1 LIMIT 5").explain(true)
```

Before this pr:
```
== Optimized Logical Plan ==
GlobalLimit 5
+- LocalLimit 5
   +- Aggregate [id#3L], [id#3L]
      +- Relation default.t1[id#3L] parquet
```

After this pr:
```
== Optimized Logical Plan ==
GlobalLimit 5
+- LocalLimit 5
   +- Aggregate [id#3L], [id#3L]
      +- LocalLimit 5
         +- PartialDistinct
            +- Relation default.t1[id#3L] parquet
```

`PartialDistinct` has other use cases.

Use cases | Example query | Benefited queries
-- | -- | --
Partially deduplicate the right side of left semi/anti join | `SELECT  * FROM a WHERE id IN (SELECT id FROM b)` | q10, q14a, q14b, q16, q23a, q23b, q35, q69, q94 , q95
Push down partially deduplicate through join | `SELECT DISTINCT * FROM a JOIN b ON a.id = b.id` | q37, q38, q82, q87


### Why are the changes needed?

Improve query performance by reduce shuffle data.
Before this PR | After this PR
--- | ---
![image](https://user-images.githubusercontent.com/5399861/151117530-40a50695-14d1-405f-8604-4ed067382c6b.png) | ![image](https://user-images.githubusercontent.com/5399861/151117473-d5534ee2-c581-42a1-b863-4c73be62d25f.png)





### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test:
```scala
import org.apache.spark.benchmark.Benchmark
import org.apache.spark.sql.catalyst.optimizer.LimitPushDown
val numRows = 1024 * 1024 * 1000

spark.sql(s"CREATE TABLE t1 using parquet AS SELECT id AS a, id % ($numRows div 100) AS b, id % ($numRows div 100000) AS c, id % ($numRows div 100000000) AS d, 1 AS e FROM range(1, ${numRows}L, 1, 5)")

Seq("a", "b", "c", "d", "e").foreach { col =>
  val benchmark = new Benchmark(s"Push down limit through Aggregate for column $col", numRows, minNumIters = 1)
  Seq(10, 500, 5000).foreach { limitNumber =>
    Seq(LimitPushDown.ruleName, "").foreach { execludedRules =>
      benchmark.addCase(s"Query with limit $limitNumber and push down ${if (execludedRules.length > 0) "disabled" else "enabled"}") { _ =>
        withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key -> execludedRules) {
          spark.sql(s"SELECT distinct $col FROM t1 LIMIT $limitNumber").write.format("noop").mode("Overwrite").save()
        }
      }
    }
  }
  benchmark.run()
}
```

```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_281-b09 on Mac OS X 10.15.7
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Push down limit through Aggregate for column a:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
Query with limit 10 and push down disabled             660955         660955           0          1.6         630.3       1.0X
Query with limit 10 and push down enabled              226576         226576           0          4.6         216.1       2.9X
Query with limit 500 and push down disabled            607825         607825           0          1.7         579.7       1.1X
Query with limit 500 and push down enabled             226541         226541           0          4.6         216.0       2.9X
Query with limit 5000 and push down disabled           656318         656318           0          1.6         625.9       1.0X
Query with limit 5000 and push down enabled            209951         209951           0          5.0         200.2       3.1X

Push down limit through Aggregate for column b:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
Query with limit 10 and push down disabled             488007         488007           0          2.1         465.4       1.0X
Query with limit 10 and push down enabled              185569         185569           0          5.7         177.0       2.6X
Query with limit 500 and push down disabled            448877         448877           0          2.3         428.1       1.1X
Query with limit 500 and push down enabled             176152         176152           0          6.0         168.0       2.8X
Query with limit 5000 and push down disabled           488315         488315           0          2.1         465.7       1.0X
Query with limit 5000 and push down enabled            203667         203667           0          5.1         194.2       2.4X

Push down limit through Aggregate for column c:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
Query with limit 10 and push down disabled              29690          29690           0         35.3          28.3       1.0X
Query with limit 10 and push down enabled               28573          28573           0         36.7          27.2       1.0X
Query with limit 500 and push down disabled             32982          32982           0         31.8          31.5       0.9X
Query with limit 500 and push down enabled              27068          27068           0         38.7          25.8       1.1X
Query with limit 5000 and push down disabled            28202          28202           0         37.2          26.9       1.1X
Query with limit 5000 and push down enabled             27972          27972           0         37.5          26.7       1.1X

Push down limit through Aggregate for column d:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
Query with limit 10 and push down disabled              17116          17116           0         61.3          16.3       1.0X
Query with limit 10 and push down enabled               18308          18308           0         57.3          17.5       0.9X
Query with limit 500 and push down disabled             16998          16998           0         61.7          16.2       1.0X
Query with limit 500 and push down enabled              18278          18278           0         57.4          17.4       0.9X
Query with limit 5000 and push down disabled            17302          17302           0         60.6          16.5       1.0X
Query with limit 5000 and push down enabled             17342          17342           0         60.5          16.5       1.0X

Push down limit through Aggregate for column e:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------
Query with limit 10 and push down disabled              16508          16508           0         63.5          15.7       1.0X
Query with limit 10 and push down enabled               16567          16567           0         63.3          15.8       1.0X
Query with limit 500 and push down disabled             16888          16888           0         62.1          16.1       1.0X
Query with limit 500 and push down enabled              16802          16802           0         62.4          16.0       1.0X
Query with limit 5000 and push down disabled            17139          17139           0         61.2          16.3       1.0X
Query with limit 5000 and push down enabled             16988          16988           0         61.7          16.2       1.0X
```