### PR TITLE
[SPARK-37865][SQL][3.0]Fix union bug when the first child of union has duplicate columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1342,6 +1342,14 @@ class Analyzer(
           }
         }
         u.copy(children = newChildren)
+      case u @ Union(children)
+          // the first child of union has duplicate attributes
+          if children.head.output.distinct.length < children.head.output.length =>
+        val projectList = children.head.output.map { attr =>
+          Alias(attr, attr.name)()
+        }
+        val newChildren = Project(projectList, children.head) +: children.tail
+        u.copy(children = newChildren)
 
       // When resolve `SortOrder`s in Sort based on child, don't report errors as
       // we still have chance to resolve it based on its descendants

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1015,4 +1015,50 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       checkAnalysis(plan, expect)
     }
   }
+
+  test("SPARK-37865: Add alias when the first child of union has duplicate attributes") {
+    val table1 = LocalRelation(
+      AttributeReference("a", IntegerType)(),
+      AttributeReference("b", IntegerType)())
+    val table2 = LocalRelation(
+      AttributeReference("a", IntegerType)(),
+      AttributeReference("b", IntegerType)())
+
+    // only the first child of union has duplicate attributes
+    val left1 = Project(Seq(table1.output(0), table1.output(0)), table1)
+    val right1 = Project(Seq(table2.output(0), table2.output(1)), table2)
+
+    val union1 = Union(left1 :: right1 :: Nil)
+    val analyzed1 = caseSensitiveAnalyzer.execute(union1)
+    val expectedLeft1 = Project(
+      Seq(
+        Alias(table1.output(0), table1.output(0).name)(),
+        Alias(table1.output(0), table1.output(0).name)()),
+      left1)
+    val expected1 = Union(expectedLeft1 :: right1 :: Nil)
+    comparePlans(analyzed1, expected1)
+
+    // only the second child of union has duplicate attributes
+    val left2 = Project(Seq(table1.output(0), table1.output(1)), table1)
+    val right2 = Project(Seq(table2.output(0), table2.output(0)), table2)
+
+    val union2 = Union(left2 :: right2 :: Nil)
+    val analyzed2 = caseSensitiveAnalyzer.execute(union2)
+    val expected2 = Union(left2 :: right2 :: Nil)
+    comparePlans(analyzed2, expected2)
+
+    // both sides of union has duplicate attributes
+    val left3 = Project(Seq(table1.output(0), table1.output(0)), table1)
+    val right3 = Project(Seq(table2.output(1), table2.output(1)), table2)
+
+    val union3 = Union(left3 :: right3 :: Nil)
+    val analyzed3 = caseSensitiveAnalyzer.execute(union3)
+    val expectedLeft3 = Project(
+      Seq(
+        Alias(table1.output(0), table1.output(0).name)(),
+        Alias(table1.output(0), table1.output(0).name)()),
+      left3)
+    val expected3 = Union(expectedLeft3 :: right3 :: Nil)
+    comparePlans(analyzed3, expected3)
+  }
 }


### PR DESCRIPTION
This is the backport PR replated to #35168.

### What changes were proposed in this pull request?

When the first child of Union has duplicate columns like select a, a from t1 union select a, b from t2, spark only use the first column to aggregate the results, which would make the results incorrect, and this behavior is inconsistent with other engines like PostgreSQL, MySQL. **We could alias the attribute of the first child of union to resolve this, or you could argue that this is the feature of Spark SQL**.

sample query:
select
a,
a
from values (1, 1), (1, 2) as t1(a, b)
UNION ALL
SELECT
c,
d
from values (2, 3), (2, 3) as t2(c, d)

result is   (1, 1), (1, 1), (3, 3), (3, 3) 
expected (1, 1), (1, 1), (2, 3), (2, 3)

---

select
a,
a
from values (1, 1), (1, 2) as t1(a, b)
UNION
SELECT
c,
d
from values (2, 3), (2, 3) as t2(c, d)

result is  (1, 1), (2, 2)
expected (1, 1), (2, 3)


### Why are the changes needed?

It is possibly a bug.


### Does this PR introduce _any_ user-facing change?
 
Yes. When we union with the first child has duplicate columns, the result would be different.


### How was this patch tested?

Add new UT.
