### PR TITLE
[SPARK-37941][SQL] Use error classes in the compilation errors of casting

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -137,6 +137,15 @@
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
   },
+  "UP_CAST_FAILURE": {
+    "message" : [ "Cannot up cast %s from %s to %s.\nThe type path of the target object is: %s.\nYou can either add an explicit cast to the input data or choose a higher precision type of the field in the target object" ]
+  },
+  "UP_CAST_UNSUPPORTED_ABSTRACT_DATA_TYPE": {
+    "message" : [ "UpCast only support DecimalType as AbstractDataType yet, but got: %s" ]
+  },
+  "UP_CAST_AS_ATTRIBUTE_UNSUPPORTED": {
+    "message" : [ "Cannot up cast %s from %s to %s as it may truncate" ]
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -137,15 +137,6 @@
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
   },
-  "UP_CAST_FAILURE": {
-    "message" : [ "Cannot up cast %s from %s to %s.\nThe type path of the target object is:\n%sYou can either add an explicit cast to the input data or choose a higher precision type of the field in the target object" ]
-  },
-  "UP_CAST_UNSUPPORTED_ABSTRACT_DATA_TYPE": {
-    "message" : [ "UpCast only support DecimalType as AbstractDataType yet, but got: %s" ]
-  },
-  "UP_CAST_AS_ATTRIBUTE_UNSUPPORTED": {
-    "message" : [ "Cannot up cast %s from %s to %s as it may truncate" ]
-  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
   },
@@ -175,6 +166,15 @@
   "UNSUPPORTED_TRANSACTION_BY_JDBC_SERVER" : {
     "message" : [ "The target JDBC server does not support transaction and can only support ALTER TABLE with a single action." ],
     "sqlState" : "0A000"
+  },
+  "UP_CAST_AS_ATTRIBUTE_UNSUPPORTED" : {
+    "message" : [ "Cannot up cast %s from %s to %s as it may truncate" ]
+  },
+  "UP_CAST_FAILURE" : {
+    "message" : [ "Cannot up cast %s from %s to %s.\nThe type path of the target object is:\n%sYou can either add an explicit cast to the input data or choose a higher precision type of the field in the target object" ]
+  },
+  "UP_CAST_UNSUPPORTED_ABSTRACT_DATA_TYPE" : {
+    "message" : [ "UpCast only support DecimalType as AbstractDataType yet, but got: %s" ]
   },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -138,7 +138,7 @@
     "sqlState" : "22023"
   },
   "UP_CAST_FAILURE": {
-    "message" : [ "Cannot up cast %s from %s to %s.\nThe type path of the target object is: %s.\nYou can either add an explicit cast to the input data or choose a higher precision type of the field in the target object" ]
+    "message" : [ "Cannot up cast %s from %s to %s.\nThe type path of the target object is:\n%sYou can either add an explicit cast to the input data or choose a higher precision type of the field in the target object" ]
   },
   "UP_CAST_UNSUPPORTED_ABSTRACT_DATA_TYPE": {
     "message" : [ "UpCast only support DecimalType as AbstractDataType yet, but got: %s" ]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -158,16 +158,21 @@ object QueryCompilationErrors {
   def upCastFailureError(
       fromStr: String, from: Expression, to: DataType, walkedTypePath: Seq[String]): Throwable = {
     new AnalysisException(
-      s"Cannot up cast $fromStr from " +
-        s"${from.dataType.catalogString} to ${to.catalogString}.\n" +
-        s"The type path of the target object is:\n" + walkedTypePath.mkString("", "\n", "\n") +
-        "You can either add an explicit cast to the input data or choose a higher precision " +
-        "type of the field in the target object")
+      errorClass = "UP_CAST_FAILURE",
+      messageParameters = Array(
+        fromStr,
+        from.dataType.catalogString,
+        to.catalogString,
+        walkedTypePath.mkString("", "\n", "\n")
+      )
+    )
   }
 
   def unsupportedAbstractDataTypeForUpCastError(gotType: AbstractDataType): Throwable = {
     new AnalysisException(
-      s"UpCast only support DecimalType as AbstractDataType yet, but got: $gotType")
+      errorClass = "UP_CAST_UNSUPPORTED_ABSTRACT_DATA_TYPE",
+      messageParameters = Array(gotType.toString)
+    )
   }
 
   def outerScopeFailureForNewInstanceError(className: String): Throwable = {
@@ -417,9 +422,13 @@ object QueryCompilationErrors {
 
   def cannotUpCastAsAttributeError(
       fromAttr: Attribute, toAttr: Attribute): Throwable = {
-    new AnalysisException(s"Cannot up cast ${fromAttr.sql} from " +
-      s"${fromAttr.dataType.catalogString} to ${toAttr.dataType.catalogString} " +
-      "as it may truncate")
+    new AnalysisException(
+      errorClass = "UP_CAST_AS_ATTRIBUTE_UNSUPPORTED",
+      messageParameters = Array(
+        fromAttr.sql,
+        fromAttr.dataType.catalogString,
+        toAttr.dataType.catalogString)
+    )
   }
 
   def functionUndefinedError(name: FunctionIdentifier): Throwable = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Migrate the following errors in QueryCompilationErrors onto use error classes:
upCastFailureError
unsupportedAbstractDataTypeForUpCastError
cannotUpCastAsAttributeError

### Why are the changes needed?
Porting casting errors to new error framework.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing UT.
