### PR TITLE
[SPARK-37991][SQL][TESTS] Improve test case logic by replacing it with a test utility function

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -341,11 +341,8 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
   // --------------------------------------------------------------------------
 
   test("basic create and list partitions") {
-    val catalog = newEmptyCatalog()
-    catalog.createDatabase(newDb("mydb"), ignoreIfExists = false)
-    catalog.createTable(newTable("tbl", "mydb"), ignoreIfExists = false)
-    catalog.createPartitions("mydb", "tbl", Seq(part1, part2), ignoreIfExists = false)
-    assert(catalogPartitionsEqual(catalog, "mydb", "tbl", Seq(part1, part2)))
+    val catalog = newBasicCatalog()
+    assert(catalogPartitionsEqual(catalog, "db2", "tbl2", Seq(part1, part2)))
   }
 
   test("create partitions when database/table does not exist") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves test case "**basic create and list partitions**" inside `ExternalCatalogSuite.scala` by replacing set up code with a test utility function from the same suite: `newBasicCatalog()`

### Why are the changes needed?
Code reduction and simplification

### Does this PR introduce any user-facing change?
No

### How was this patch tested?

`build/sbt -v -d "test:testOnly *CatalogSuite"`