### PR TITLE
[SPARK-37936][SQL] Use error classes in the parsing errors of intervals

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -175,7 +175,7 @@
     "message" : [ "at least one time unit should be given for interval literal" ]
   },
   "INVALID_INTERVAL_FORM" : {
-    "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. %s" ]
+    "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. " ]
   },
   "INVALID_FROM_TO_UNIT_VALUE" : {
     "message" : [ "The value of from-to unit must be a string" ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -181,7 +181,7 @@
     "message" : [ "The value of from-to unit must be a string" ]
   },
   "UNSUPPORTED_FROM_TO_INTERVAL" : {
-    "message" : [ "Intervals FROM %s TO %s are not supported. %s" ]
+    "message" : [ "Intervals FROM %s TO %s are not supported. " ]
   },
   "MIXED_INTERVAL_UNITS" : {
     "message" : [ "Cannot mix year-month and day-time fields: %s" ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -167,5 +167,23 @@
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"
+  },
+  "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL" : {
+    "message" : [ "Can only have a single from-to unit in the interval literal syntax" ]
+  },
+  "INVALID_INTERVAL_LITERAL" : {
+    "message" : ["at least one time unit should be given for interval literal"]
+  },
+  "INVALID_INTERVAL_FORM" : {
+    "message" : ["Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. %s"]
+  },
+  "INVALID_FROM_TO_UNIT_VALUE" : {
+    "message" : ["The value of from-to unit must be a string"]
+  },
+  "UNSUPPORTED_FROM_TO_INTERVAL" : {
+    "message" : ["Intervals FROM %s TO %s are not supported. %s"]
+  },
+  "MIXED_INTERVAL_UNITS" : {
+    "message" : ["Cannot mix year-month and day-time fields: %s"]
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,4 +1,7 @@
 {
+  "AES_CRYPTO_ERROR" : {
+    "message" : [ "AES crypto operation failed with: %s" ]
+  },
   "AMBIGUOUS_FIELD_NAME" : {
     "message" : [ "Field name %s is ambiguous and has %s matching fields in the struct." ],
     "sqlState" : "42000"
@@ -71,6 +74,10 @@
   "INTERNAL_ERROR" : {
     "message" : [ "%s" ]
   },
+  "INVALID_AES_KEY_LENGTH" : {
+    "message" : [ "The key length of aes_encrypt/aes_decrypt should be one of 16, 24 or 32 bytes, but got: %s" ],
+    "sqlState" : "42000"
+  },
   "INVALID_ARRAY_INDEX" : {
     "message" : [ "Invalid index: %s, numElements: %s. If necessary set %s to false to bypass this error." ]
   },
@@ -85,9 +92,18 @@
     "message" : [ "The fraction of sec must be zero. Valid range is [0, 60]. If necessary set %s to false to bypass this error. " ],
     "sqlState" : "22023"
   },
+  "INVALID_FROM_TO_UNIT_VALUE" : {
+    "message" : [ "The value of from-to unit must be a string" ]
+  },
   "INVALID_INPUT_SYNTAX_FOR_NUMERIC_TYPE" : {
     "message" : [ "invalid input syntax for type numeric: %s. To return NULL instead, use 'try_cast'. If necessary set %s to false to bypass this error." ],
     "sqlState" : "42000"
+  },
+  "INVALID_INTERVAL_FORM" : {
+    "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. " ]
+  },
+  "INVALID_INTERVAL_LITERAL" : {
+    "message" : [ "at least one time unit should be given for interval literal" ]
   },
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
@@ -109,6 +125,12 @@
   "MISSING_STATIC_PARTITION_COLUMN" : {
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
+  },
+  "MIXED_INTERVAL_UNITS" : {
+    "message" : [ "Cannot mix year-month and day-time fields: %s" ]
+  },
+  "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL" : {
+    "message" : [ "Can only have a single from-to unit in the interval literal syntax" ]
   },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
@@ -141,6 +163,10 @@
     "message" : [ "Unrecognized SQL type %s" ],
     "sqlState" : "42000"
   },
+  "UNSUPPORTED_AES_MODE" : {
+    "message" : [ "The AES mode %s with the padding %s is not supported" ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_CHANGE_COLUMN" : {
     "message" : [ "Please add an implementation for a column change here" ],
     "sqlState" : "0A000"
@@ -152,6 +178,9 @@
   "UNSUPPORTED_FEATURE" : {
     "message" : [ "The feature is not supported: %s" ],
     "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_FROM_TO_INTERVAL" : {
+    "message" : [ "Intervals FROM %s TO %s are not supported. " ]
   },
   "UNSUPPORTED_LITERAL_TYPE" : {
     "message" : [ "Unsupported literal type %s %s" ],
@@ -167,23 +196,5 @@
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"
-  },
-  "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL" : {
-    "message" : [ "Can only have a single from-to unit in the interval literal syntax" ]
-  },
-  "INVALID_INTERVAL_LITERAL" : {
-    "message" : [ "at least one time unit should be given for interval literal" ]
-  },
-  "INVALID_INTERVAL_FORM" : {
-    "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. " ]
-  },
-  "INVALID_FROM_TO_UNIT_VALUE" : {
-    "message" : [ "The value of from-to unit must be a string" ]
-  },
-  "UNSUPPORTED_FROM_TO_INTERVAL" : {
-    "message" : [ "Intervals FROM %s TO %s are not supported. " ]
-  },
-  "MIXED_INTERVAL_UNITS" : {
-    "message" : [ "Cannot mix year-month and day-time fields: %s" ]
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -172,18 +172,18 @@
     "message" : [ "Can only have a single from-to unit in the interval literal syntax" ]
   },
   "INVALID_INTERVAL_LITERAL" : {
-    "message" : ["at least one time unit should be given for interval literal"]
+    "message" : [ "at least one time unit should be given for interval literal" ]
   },
   "INVALID_INTERVAL_FORM" : {
-    "message" : ["Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. %s"]
+    "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s. %s" ]
   },
   "INVALID_FROM_TO_UNIT_VALUE" : {
-    "message" : ["The value of from-to unit must be a string"]
+    "message" : [ "The value of from-to unit must be a string" ]
   },
   "UNSUPPORTED_FROM_TO_INTERVAL" : {
-    "message" : ["Intervals FROM %s TO %s are not supported. %s"]
+    "message" : [ "Intervals FROM %s TO %s are not supported. %s" ]
   },
   "MIXED_INTERVAL_UNITS" : {
-    "message" : ["Cannot mix year-month and day-time fields: %s"]
+    "message" : [ "Cannot mix year-month and day-time fields: %s" ]
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -190,28 +190,28 @@ object QueryParsingErrors {
   }
 
   def moreThanOneFromToUnitInIntervalLiteralError(ctx: ParserRuleContext): Throwable = {
-    new ParseException("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL", ctx)
+    new ParseException(s"MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL ", ctx)
   }
 
   def invalidIntervalLiteralError(ctx: IntervalContext): Throwable = {
-    new ParseException("INVALID_INTERVAL_LITERAL", ctx)
+    new ParseException(s"INVALID_INTERVAL_LITERAL ", ctx)
   }
 
   def invalidIntervalFormError(value: String, ctx: MultiUnitsIntervalContext): Throwable = {
-    new ParseException("INVALID_INTERVAL_FORM", Array(value), ctx)
+    new ParseException(s"INVALID_INTERVAL_FORM ", Array(value), ctx)
   }
 
   def invalidFromToUnitValueError(ctx: IntervalValueContext): Throwable = {
-    new ParseException("INVALID_FROM_TO_UNIT_VALUE", ctx)
+    new ParseException(s"INVALID_FROM_TO_UNIT_VALUE ", ctx)
   }
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException("UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
+    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL ", Array(from, to), ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
+    new ParseException(s"MIXED_INTERVAL_UNITS ", Array(literal), ctx)
   }
 
   def dataTypeUnsupportedError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -190,29 +190,28 @@ object QueryParsingErrors {
   }
 
   def moreThanOneFromToUnitInIntervalLiteralError(ctx: ParserRuleContext): Throwable = {
-    new ParseException("Can only have a single from-to unit in the interval literal syntax", ctx)
+    new ParseException("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL", ctx)
   }
 
   def invalidIntervalLiteralError(ctx: IntervalContext): Throwable = {
-    new ParseException("at least one time unit should be given for interval literal", ctx)
+    new ParseException("INVALID_INTERVAL_LITERAL", ctx)
   }
 
   def invalidIntervalFormError(value: String, ctx: MultiUnitsIntervalContext): Throwable = {
-    new ParseException("Can only use numbers in the interval value part for" +
-      s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
+    new ParseException("INVALID_INTERVAL_FORM", Array(value), ctx)
   }
 
   def invalidFromToUnitValueError(ctx: IntervalValueContext): Throwable = {
-    new ParseException("The value of from-to unit must be a string", ctx)
+    new ParseException("INVALID_FROM_TO_UNIT_VALUE", ctx)
   }
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+    new ParseException("UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"Cannot mix year-month and day-time fields: $literal", ctx)
+    new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }
 
   def dataTypeUnsupportedError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -190,28 +190,28 @@ object QueryParsingErrors {
   }
 
   def moreThanOneFromToUnitInIntervalLiteralError(ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL ", ctx)
+    new ParseException(s"MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL", ctx)
   }
 
   def invalidIntervalLiteralError(ctx: IntervalContext): Throwable = {
-    new ParseException(s"INVALID_INTERVAL_LITERAL ", ctx)
+    new ParseException(s"INVALID_INTERVAL_LITERAL", ctx)
   }
 
   def invalidIntervalFormError(value: String, ctx: MultiUnitsIntervalContext): Throwable = {
-    new ParseException(s"INVALID_INTERVAL_FORM ", Array(value), ctx)
+    new ParseException(s"INVALID_INTERVAL_FORM", Array(value), ctx)
   }
 
   def invalidFromToUnitValueError(ctx: IntervalValueContext): Throwable = {
-    new ParseException(s"INVALID_FROM_TO_UNIT_VALUE ", ctx)
+    new ParseException(s"INVALID_FROM_TO_UNIT_VALUE", ctx)
   }
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL ", Array(from, to), ctx)
+    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"MIXED_INTERVAL_UNITS ", Array(literal), ctx)
+    new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }
 
   def dataTypeUnsupportedError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -17,12 +17,11 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSparkSession
 
 class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
-    import testImplicits._
 
     test("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL: from-to unit in the interval literal") {
         val e = intercept[ParseException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -22,58 +22,57 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSparkSession
 
 class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
-
-    test("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL: from-to unit in the interval literal") {
-        val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL 1 to 3 year to month AS col").collect()
-        }.getCause.asInstanceOf[ParseException]
-        assert(e.getErrorClass === "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL")
-        assert(e.getMessage.contains(
-            "Can only have a single from-to unit in the interval literal syntax"))
-    }
-
-    test("INVALID_INTERVAL_LITERAL: invalid interval literal") {
-        val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL DAY").collect()
-        }.getCause.asInstanceOf[ParseException]
-        assert(e.getErrorClass === "INVALID_INTERVAL_LITERAL")
-        assert(e.getMessage.contains(
-            "at least one time unit should be given for interval literal"))
-    }
+  test("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL: from-to unit in the interval literal") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL 1 to 3 year to month AS col").collect()
+    }.getCause.asInstanceOf[ParseException]
+    assert(e.getErrorClass === "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL")
+    assert(e.getMessage.contains(
+      "Can only have a single from-to unit in the interval literal syntax"))
+  }
+  
+  test("INVALID_INTERVAL_LITERAL: invalid interval literal") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL DAY").collect()
+    }.getCause.asInstanceOf[ParseException]
+    assert(e.getErrorClass === "INVALID_INTERVAL_LITERAL")
+    assert(e.getMessage.contains(
+      "at least one time unit should be given for interval literal"))
+  }
 
     test("INVALID_INTERVAL_FORM: invalid interval form") {
-        val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect()
-        }.getCause.asInstanceOf[ParseException]
-        assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
-        assert(e.getMessage.contains(
-            "numbers in the interval value part for multiple unit value pairs interval form"))
+      val e = intercept[ParseException] {
+        spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect()
+      }.getCause.asInstanceOf[ParseException]
+      assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
+      assert(e.getMessage.contains(
+        "numbers in the interval value part for multiple unit value pairs interval form"))
     }
 
     test("INVALID_FROM_TO_UNIT_VALUE: value of from-to unit must be a string") {
-        val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect()
-        }.getCause.asInstanceOf[ParseException]
-        assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
-        assert(e.getMessage.contains(
-            "The value of from-to unit must be a string"))
+      val e = intercept[ParseException] {
+        spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect()
+      }.getCause.asInstanceOf[ParseException]
+      assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
+      assert(e.getMessage.contains(
+        "The value of from-to unit must be a string"))
     }
 
     test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
-        val e = intercept[ParseException] {
-            spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect()
-        }.getCause.asInstanceOf[ParseException]
-        assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
-        assert(e.getMessage.contains(
-            "Intervals FROM YEAR TO DAY are not supported."))
+      val e = intercept[ParseException] {
+        spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect()
+      }.getCause.asInstanceOf[ParseException]
+      assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
+      assert(e.getMessage.contains(
+        "Intervals FROM YEAR TO DAY are not supported."))
     }
 
     test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
-        val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect()
-        }.getCause.asInstanceOf[ParseException]
-        assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
-        assert(e.getMessage.contains(
-            "Cannot mix year-month and day-time fields"))
+      val e = intercept[ParseException] {
+        spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect()
+      }.getCause.asInstanceOf[ParseException]
+      assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
+      assert(e.getMessage.contains(
+        "Cannot mix year-month and day-time fields"))
     }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.errors
+
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
+    import testImplicits._
+
+    test("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL: from-to unit in the interval literal") {
+        val e = intercept[ParseException] {
+            spark.sql("SELECT INTERVAL 1 to 3 year to month AS col").collect
+        }.getCause.asInstanceOf[ParseException]
+        assert(e.getErrorClass === "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL")
+        assert(e.getMessage.contains(
+            "Can only have a single from-to unit in the interval literal syntax"))
+    }
+
+    test("INVALID_INTERVAL_LITERAL: invalid interval literal") {
+        val e = intercept[ParseException] {
+            spark.sql("SELECT INTERVAL  DAY").collect
+        }.getCause.asInstanceOf[ParseException]
+        assert(e.getErrorClass === "INVALID_INTERVAL_LITERAL")
+        assert(e.getMessage.contains(
+            "at least one time unit should be given for interval literal"))
+    }
+
+    test("INVALID_INTERVAL_FORM: invalid interval form") {
+        val e = intercept[ParseException] {
+            spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect
+        }.getCause.asInstanceOf[ParseException]
+        assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
+        assert(e.getMessage.contains(
+            "numbers in the interval value part for multiple unit value pairs interval form"))
+    }
+
+    test("INVALID_FROM_TO_UNIT_VALUE: value of from-to unit must be a string") {
+        val e = intercept[ParseException] {
+            spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect
+        }.getCause.asInstanceOf[ParseException]
+        assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
+        assert(e.getMessage.contains(
+            "The value of from-to unit must be a string"))
+    }
+
+    test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
+        val e = intercept[ParseException] {
+            spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect
+        }.getCause.asInstanceOf[ParseException]
+        assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
+        assert(e.getMessage.contains(
+            "Intervals FROM YEAR TO DAY are not supported."))
+    }
+
+    test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
+        val e = intercept[ParseException] {
+            spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect
+        }.getCause.asInstanceOf[ParseException]
+        assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
+        assert(e.getMessage.contains(
+            "Cannot mix year-month and day-time fields"))
+    }
+
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -77,6 +77,4 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
         assert(e.getMessage.contains(
             "Cannot mix year-month and day-time fields"))
     }
-
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -25,7 +25,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
 
     test("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL: from-to unit in the interval literal") {
         val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL 1 to 3 year to month AS col").collect
+            spark.sql("SELECT INTERVAL 1 to 3 year to month AS col").collect()
         }.getCause.asInstanceOf[ParseException]
         assert(e.getErrorClass === "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL")
         assert(e.getMessage.contains(
@@ -34,7 +34,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
 
     test("INVALID_INTERVAL_LITERAL: invalid interval literal") {
         val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL  DAY").collect
+            spark.sql("SELECT INTERVAL DAY").collect()
         }.getCause.asInstanceOf[ParseException]
         assert(e.getErrorClass === "INVALID_INTERVAL_LITERAL")
         assert(e.getMessage.contains(
@@ -43,7 +43,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
 
     test("INVALID_INTERVAL_FORM: invalid interval form") {
         val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect
+            spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect()
         }.getCause.asInstanceOf[ParseException]
         assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
         assert(e.getMessage.contains(
@@ -52,7 +52,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
 
     test("INVALID_FROM_TO_UNIT_VALUE: value of from-to unit must be a string") {
         val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect
+            spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect()
         }.getCause.asInstanceOf[ParseException]
         assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
         assert(e.getMessage.contains(
@@ -61,7 +61,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
 
     test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
         val e = intercept[ParseException] {
-            spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect
+            spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect()
         }.getCause.asInstanceOf[ParseException]
         assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
         assert(e.getMessage.contains(
@@ -70,7 +70,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
 
     test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
         val e = intercept[ParseException] {
-            spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect
+            spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect()
         }.getCause.asInstanceOf[ParseException]
         assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
         assert(e.getMessage.contains(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -30,7 +30,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
     assert(e.getMessage.contains(
       "Can only have a single from-to unit in the interval literal syntax"))
   }
-  
+
   test("INVALID_INTERVAL_LITERAL: invalid interval literal") {
     val e = intercept[ParseException] {
       spark.sql("SELECT INTERVAL DAY").collect()
@@ -40,39 +40,39 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession{
       "at least one time unit should be given for interval literal"))
   }
 
-    test("INVALID_INTERVAL_FORM: invalid interval form") {
-      val e = intercept[ParseException] {
-        spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect()
-      }.getCause.asInstanceOf[ParseException]
-      assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
-      assert(e.getMessage.contains(
-        "numbers in the interval value part for multiple unit value pairs interval form"))
-    }
+  test("INVALID_FROM_TO_UNIT_VALUE: value of from-to unit must be a string") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect()
+    }.getCause.asInstanceOf[ParseException]
+    assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
+    assert(e.getMessage.contains(
+      "The value of from-to unit must be a string"))
+  }
 
-    test("INVALID_FROM_TO_UNIT_VALUE: value of from-to unit must be a string") {
-      val e = intercept[ParseException] {
-        spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH").collect()
-      }.getCause.asInstanceOf[ParseException]
-      assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
-      assert(e.getMessage.contains(
-        "The value of from-to unit must be a string"))
-    }
+  test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect()
+    }.getCause.asInstanceOf[ParseException]
+    assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
+    assert(e.getMessage.contains(
+      "Intervals FROM YEAR TO DAY are not supported."))
+  }
 
-    test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
-      val e = intercept[ParseException] {
-        spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)").collect()
-      }.getCause.asInstanceOf[ParseException]
-      assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
-      assert(e.getMessage.contains(
-        "Intervals FROM YEAR TO DAY are not supported."))
-    }
+  test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect()
+    }.getCause.asInstanceOf[ParseException]
+    assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
+    assert(e.getMessage.contains(
+      "Cannot mix year-month and day-time fields"))
+  }
 
-    test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
-      val e = intercept[ParseException] {
-        spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR").collect()
-      }.getCause.asInstanceOf[ParseException]
-      assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
-      assert(e.getMessage.contains(
-        "Cannot mix year-month and day-time fields"))
-    }
+  test("INVALID_INTERVAL_FORM: invalid interval form") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL '1 DAY 2' HOUR").collect()
+    }.getCause.asInstanceOf[ParseException]
+    assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
+    assert(e.getMessage.contains(
+      "numbers in the interval value part for multiple unit value pairs interval form"))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the PR, We propose to throw ParseException from below methodswith the error classes:

1. moreThanOneFromToUnitInIntervalLiteralError
2. invalidIntervalLiteralError
3. invalidIntervalFormError
4. invalidFromToUnitValueError
5. fromToIntervalUnsupportedError
6. mixedIntervalUnitsError

MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL - moreThanOneFromToUnitInIntervalLiteralError
INVALID_INTERVAL_LITERAL - invalidIntervalLiteralError
INVALID_INTERVAL_FORM - invalidIntervalFormError
INVALID_FROM_TO_UNIT_VALUE - invalidFromToUnitValueError
UNSUPPORTED_FROM_TO_INTERVAL - fromToIntervalUnsupportedError
MIXED_INTERVAL_UNITS - mixedIntervalUnitsError

New error classes are added to error-classes.json.

New test suite QueryParsingErrorsSuite  for checking the errors has been created.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Please refer SPARK-37935 - Migrate onto error classes

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
By running new test suite:
build/sbt "test:testOnly *QueryParsingErrorsSuite"