### PR TITLE
[SPARK-37916][SPARK-37713][K8S] Revert "Assign namespace to executor configmap"

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -29,7 +29,7 @@ import io.fabric8.kubernetes.api.model.{ConfigMap, ConfigMapBuilder, KeyToPath}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.k8s.{Config, Constants, KubernetesUtils}
-import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNSNAME_MAX_LENGTH, KUBERNETES_NAMESPACE}
+import org.apache.spark.deploy.k8s.Config.KUBERNETES_DNSNAME_MAX_LENGTH
 import org.apache.spark.deploy.k8s.Constants.ENV_SPARK_CONF_DIR
 import org.apache.spark.internal.Logging
 
@@ -89,12 +89,9 @@ private[spark] object KubernetesClientUtils extends Logging {
    */
   def buildConfigMap(configMapName: String, confFileMap: Map[String, String],
       withLabels: Map[String, String] = Map()): ConfigMap = {
-    val configMapNameSpace =
-      confFileMap.getOrElse(KUBERNETES_NAMESPACE.key, KUBERNETES_NAMESPACE.defaultValueString)
     new ConfigMapBuilder()
       .withNewMetadata()
         .withName(configMapName)
-        .withNamespace(configMapNameSpace)
         .withLabels(withLabels.asJava)
         .endMetadata()
       .withImmutable(true)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesClusterSchedulerBackend.scala
@@ -76,10 +76,8 @@ private[spark] class KubernetesClusterSchedulerBackend(
 
   private def setUpExecutorConfigMap(driverPod: Option[Pod]): Unit = {
     val configMapName = KubernetesClientUtils.configMapNameExecutor
-    val resolvedExecutorProperties =
-      Map(KUBERNETES_NAMESPACE.key -> conf.get(KUBERNETES_NAMESPACE))
     val confFilesMap = KubernetesClientUtils
-      .buildSparkConfDirFilesMap(configMapName, conf, resolvedExecutorProperties)
+      .buildSparkConfDirFilesMap(configMapName, conf, Map.empty)
     val labels =
       Map(SPARK_APP_ID_LABEL -> applicationId(), SPARK_ROLE_LABEL -> SPARK_POD_EXECUTOR_ROLE)
     val configMap = KubernetesClientUtils.buildConfigMap(configMapName, confFilesMap, labels)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -20,11 +20,7 @@ package org.apache.spark.deploy.k8s.submit
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.util.UUID
 
-import scala.collection.JavaConverters._
-
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
@@ -79,28 +75,5 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     val expectedOutput = Map("testConf.1" -> "test123456", "testConf.2" -> "test123456",
       "testConf.3" -> "test123456")
     assert(output === expectedOutput)
-  }
-
-  test("verify that configmap built as expected") {
-    val configMapName = s"configmap-name-${UUID.randomUUID.toString}"
-    val configMapNameSpace = s"configmap-namespace-${UUID.randomUUID.toString}"
-    val properties = Map(Config.KUBERNETES_NAMESPACE.key -> configMapNameSpace)
-    val sparkConf =
-      testSetup(properties.map(f => f._1 -> f._2.getBytes(StandardCharsets.UTF_8)))
-    val confFileMap =
-      KubernetesClientUtils.buildSparkConfDirFilesMap(configMapName, sparkConf, properties)
-    val outputConfigMap =
-      KubernetesClientUtils.buildConfigMap(configMapName, confFileMap, properties)
-    val expectedConfigMap =
-      new ConfigMapBuilder()
-        .withNewMetadata()
-          .withName(configMapName)
-          .withNamespace(configMapNameSpace)
-          .withLabels(properties.asJava)
-        .endMetadata()
-        .withImmutable(true)
-        .addToData(confFileMap.asJava)
-        .build()
-    assert(outputConfigMap === expectedConfigMap)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This reverts commit c4a9772f741836cdb399e35a45b3b5df48d9eea6 which was merged in https://github.com/apache/spark/pull/34983 .

### Why are the changes needed?
Before this revert, there are two expected behaviors:
1. **Can't submit application with specified namespace**
the driver pod would be stuck in `ContainerCreating` due to `MountVolume.SetUp failed for volume "spark-conf-volume-driver" : configmap "spark-drv-ed33d87e8b2eb017-conf-map" not found`, because the configFileMap doesn't contains namespace info in driver side.

2. **`configFileMap` doesn't allow `namespace` key as confimap.data** (but kubernetes doesn't have this limit).

The configmap of executor is still set correctly after revert this patch (the original PR solved case):
```scala
    // Create configmap in ns2 namespace
    val builder2 = new ConfigMapBuilder()
      .withNewMetadata()
        // We don't specify ns2 in here like `.withNamespace("ns2")`
        .withName("configmap2")
      .endMetadata()
      .addToData("testkey", "testvalue")
      .build()
    val configMap2 = client.inNamespace("ns2").resource(builder2).createOrReplace()
    // the namespace is still set to ns2 as expected.
    assert(configMap2.getMetadata.getNamespace === "ns2")
```
That is even if we don't need to explicitly set the namespace for configmap.metadata, it will set correctly. That means we don't need the original PR.

### Does this PR introduce _any_ user-facing change?
NO


### How was this patch tested?
- Manual test passed
```
bin/spark-submit  \
    --master k8s://https://127.0.0.1:49963  \
    --deploy-mode cluster  \
    --conf spark.executor.instances=1  \
    # with non-default namespace
    --conf spark.kubernetes.namespace=spark \
    --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark-sa  \
    --conf spark.kubernetes.container.image=spark:latest  \
    --class org.apache.spark.examples.SparkPi  \
    --name spark-pi  \
    local:///opt/spark/examples/jars/spark-examples_2.12-3.3.0-SNAPSHOT.jar
```
- existing UT
- Manaully run spark on K8S integration test.