### PR TITLE
[SPARK-37998][K8S][TESTS] Use `rbac.authorization.k8s.io/v1` instead of `v1beta1`

### DIFF
--- a/resource-managers/kubernetes/integration-tests/dev/spark-rbac.yaml
+++ b/resource-managers/kubernetes/integration-tests/dev/spark-rbac.yaml
@@ -26,7 +26,7 @@ metadata:
   name: spark-sa
   namespace: spark
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: spark-role
@@ -38,7 +38,7 @@ rules:
   verbs:
   - "*"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: spark-role-binding


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before this patch:
```bash
$ k apply -f  resource-managers/kubernetes/integration-tests/dev/spark-rbac.yaml
namespace/spark created
serviceaccount/spark-sa created
unable to recognize "resource-managers/kubernetes/integration-tests/dev/spark-rbac.yaml": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1"
unable to recognize "resource-managers/kubernetes/integration-tests/dev/spark-rbac.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
```

This patch bumps rbac to v1 to fix api no matches error in latest minikube setup k8s.

### Why are the changes needed?

Current spark-rbac.yaml would be failed to create rbac when setup k8s using minikube latest version.

As note from kubernetes:
- The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.
- Migrate manifests and API clients to use the rbac.authorization.k8s.io/v1 API version, available since v1.8.

We'd better using rbac `v1` in here to aovid apply failed on kuberentes v1.22+.

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```bash
$ k apply -f spark-rbac.yaml
namespace/spark unchanged
serviceaccount/spark-sa unchanged
clusterrole.rbac.authorization.k8s.io/spark-role created
clusterrolebinding.rbac.authorization.k8s.io/spark-role-binding created
```