### PR TITLE
[SPARK-36424][SQL][FOLLOWUP] The strategy of Eliminate Limits batch should be fixedPoint

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEOptimizer.scala
@@ -40,7 +40,7 @@ class AQEOptimizer(conf: SQLConf) extends RuleExecutor[LogicalPlan] {
       ConvertToLocalRelation,
       UpdateAttributeNullability),
     Batch("Dynamic Join Selection", Once, DynamicJoinSelection),
-    Batch("Eliminate Limits", Once, EliminateLimits)
+    Batch("Eliminate Limits", fixedPoint, EliminateLimits)
   )
 
   final override protected def batches: Seq[Batch] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2243,6 +2243,15 @@ class AdaptiveQueryExecSuite
           """.stripMargin)
         assert(findTopLevelLimit(origin2).size == 1)
         assert(findTopLevelLimit(adaptive2).isEmpty)
+
+        // The strategy of Eliminate Limits batch should be fixedPoint
+        val (origin3, adaptive3) = runAdaptiveAndVerifyResult(
+          """
+            |SELECT * FROM (SELECT c1 + c2 FROM (SELECT DISTINCT * FROM v LIMIT 10086)) LIMIT 20
+          """.stripMargin
+        )
+        assert(findTopLevelLimit(origin3).size == 1)
+        assert(findTopLevelLimit(adaptive3).isEmpty)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr change the strategy of `Eliminate Limits` batch from Once to fixedPoint in AQEOptimizer.

### Why are the changes needed?

Fix bug. Otherwise check batch idempotence will fail:
```scala
spark.range(10).write.saveAsTable("t1")
spark.table("t1").distinct().limit(10086).selectExpr("cast(id as string)").limit(20).collect()
```

```
Once strategy's idempotence is broken for batch Eliminate Limits
!GlobalLimit 20                                                                                     Project [cast(id#3L as string) AS id#6]
!+- LocalLimit 20                                                                                   +- LogicalQueryStage Aggregate [id#3L], [id#3L], HashAggregate(keys=[id#3L], functions=[])
!   +- Project [cast(id#3L as string) AS id#6]                                                      
!      +- LogicalQueryStage Aggregate [id#3L], [id#3L], HashAggregate(keys=[id#3L], functions=[])   
  
```

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Unit test.