### PR TITLE
[SPARK-38002][BUILD] Upgrade ZSTD-JNI to 1.5.2-1

### DIFF
--- a/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk11-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.11.0-1027-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            517            518           1          0.0       51679.1       1.0X
-Compression 10000 times at level 2 without buffer pool            828            829           1          0.0       82770.5       0.6X
-Compression 10000 times at level 3 without buffer pool           1031           1035           6          0.0      103117.5       0.5X
-Compression 10000 times at level 1 with buffer pool               474            475           1          0.0       47377.9       1.1X
-Compression 10000 times at level 2 with buffer pool               544            545           1          0.0       54382.9       1.0X
-Compression 10000 times at level 3 with buffer pool               728            732           5          0.0       72791.2       0.7X
+Compression 10000 times at level 1 without buffer pool            584            604          15          0.0       58407.5       1.0X
+Compression 10000 times at level 2 without buffer pool            654            665          11          0.0       65444.9       0.9X
+Compression 10000 times at level 3 without buffer pool            907            916           8          0.0       90677.0       0.6X
+Compression 10000 times at level 1 with buffer pool               674            686          11          0.0       67437.9       0.9X
+Compression 10000 times at level 2 with buffer pool               759            769          10          0.0       75916.2       0.8X
+Compression 10000 times at level 3 with buffer pool              1006           1017          16          0.0      100600.2       0.6X
 
-OpenJDK 64-Bit Server VM 11.0.13+8-LTS on Linux 5.11.0-1022-azure
-Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.11.0-1027-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           1097           1097           1          0.0      109654.6       1.0X
-Decompression 10000 times from level 2 without buffer pool           1097           1097           0          0.0      109695.5       1.0X
-Decompression 10000 times from level 3 without buffer pool           1093           1093           1          0.0      109309.2       1.0X
-Decompression 10000 times from level 1 with buffer pool               854            855           1          0.0       85422.5       1.3X
-Decompression 10000 times from level 2 with buffer pool               853            853           0          0.0       85287.9       1.3X
-Decompression 10000 times from level 3 with buffer pool               854            854           0          0.0       85417.9       1.3X
+Decompression 10000 times from level 1 without buffer pool            693            698           9          0.0       69257.4       1.0X
+Decompression 10000 times from level 2 without buffer pool            699            707           7          0.0       69857.8       1.0X
+Decompression 10000 times from level 3 without buffer pool            689            697           7          0.0       68858.9       1.0X
+Decompression 10000 times from level 1 with buffer pool               450            476          37          0.0       45005.9       1.5X
+Decompression 10000 times from level 2 with buffer pool               527            550          26          0.0       52653.2       1.3X
+Decompression 10000 times from level 3 with buffer pool               452            513          43          0.0       45201.4       1.5X
 
 

--- a/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-jdk17-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.11.0-1027-azure
 Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool           2930           2953          33          0.0      293038.2       1.0X
-Compression 10000 times at level 2 without buffer pool           1846           2728        1248          0.0      184565.8       1.6X
-Compression 10000 times at level 3 without buffer pool           2109           2110           2          0.0      210881.8       1.4X
-Compression 10000 times at level 1 with buffer pool              1466           1479          19          0.0      146569.0       2.0X
-Compression 10000 times at level 2 with buffer pool              1570           1584          20          0.0      156976.5       1.9X
-Compression 10000 times at level 3 with buffer pool              1845           1852          10          0.0      184465.3       1.6X
+Compression 10000 times at level 1 without buffer pool           2380           2426          65          0.0      238014.5       1.0X
+Compression 10000 times at level 2 without buffer pool           1532           2271        1045          0.0      153222.7       1.6X
+Compression 10000 times at level 3 without buffer pool           1746           1757          15          0.0      174619.0       1.4X
+Compression 10000 times at level 1 with buffer pool              1177           1178           2          0.0      117681.3       2.0X
+Compression 10000 times at level 2 with buffer pool              1267           1273           8          0.0      126719.0       1.9X
+Compression 10000 times at level 3 with buffer pool              1517           1603         122          0.0      151729.8       1.6X
 
-OpenJDK 64-Bit Server VM 17.0.1+12-LTS on Linux 5.11.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.11.0-1027-azure
 Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool           2852           2887          49          0.0      285224.2       1.0X
-Decompression 10000 times from level 2 without buffer pool           2903           2908           7          0.0      290287.1       1.0X
-Decompression 10000 times from level 3 without buffer pool           2846           2858          18          0.0      284558.0       1.0X
-Decompression 10000 times from level 1 with buffer pool              2637           2647          14          0.0      263714.3       1.1X
-Decompression 10000 times from level 2 with buffer pool              2619           2629          14          0.0      261915.2       1.1X
-Decompression 10000 times from level 3 with buffer pool              2640           2652          17          0.0      263976.7       1.1X
+Decompression 10000 times from level 1 without buffer pool           2241           2271          42          0.0      224123.2       1.0X
+Decompression 10000 times from level 2 without buffer pool           2210           2253          62          0.0      220980.7       1.0X
+Decompression 10000 times from level 3 without buffer pool           2220           2228          12          0.0      221964.2       1.0X
+Decompression 10000 times from level 1 with buffer pool              1987           1995          12          0.0      198705.4       1.1X
+Decompression 10000 times from level 2 with buffer pool              1966           1968           4          0.0      196572.3       1.1X
+Decompression 10000 times from level 3 with buffer pool              1983           1991          11          0.0      198277.7       1.1X
 
 

--- a/core/benchmarks/ZStandardBenchmark-results.txt
+++ b/core/benchmarks/ZStandardBenchmark-results.txt
@@ -2,26 +2,26 @@
 Benchmark ZStandardCompressionCodec
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.11.0-1027-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Compression 10000 times at level 1 without buffer pool            398            523         144          0.0       39785.2       1.0X
-Compression 10000 times at level 2 without buffer pool            452            457           5          0.0       45210.8       0.9X
-Compression 10000 times at level 3 without buffer pool            634            650          15          0.0       63405.8       0.6X
-Compression 10000 times at level 1 with buffer pool               329            334           4          0.0       32851.3       1.2X
-Compression 10000 times at level 2 with buffer pool               384            393           7          0.0       38421.9       1.0X
-Compression 10000 times at level 3 with buffer pool               561            570           7          0.0       56070.4       0.7X
+Compression 10000 times at level 1 without buffer pool            633            774         122          0.0       63315.3       1.0X
+Compression 10000 times at level 2 without buffer pool            748            749           2          0.0       74771.7       0.8X
+Compression 10000 times at level 3 without buffer pool            945            949           7          0.0       94461.5       0.7X
+Compression 10000 times at level 1 with buffer pool               287            289           2          0.0       28703.6       2.2X
+Compression 10000 times at level 2 with buffer pool               336            342           3          0.0       33641.3       1.9X
+Compression 10000 times at level 3 with buffer pool               517            528           8          0.0       51747.9       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_312-b07 on Linux 5.11.0-1022-azure
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.11.0-1027-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Benchmark ZStandardCompressionCodec:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------
-Decompression 10000 times from level 1 without buffer pool            686            686           0          0.0       68582.6       1.0X
-Decompression 10000 times from level 2 without buffer pool            683            686           3          0.0       68270.5       1.0X
-Decompression 10000 times from level 3 without buffer pool            687            690           4          0.0       68653.8       1.0X
-Decompression 10000 times from level 1 with buffer pool               495            497           3          0.0       49467.7       1.4X
-Decompression 10000 times from level 2 with buffer pool               438            467          26          0.0       43839.3       1.6X
-Decompression 10000 times from level 3 with buffer pool               495            496           1          0.0       49474.0       1.4X
+Decompression 10000 times from level 1 without buffer pool            683            689           9          0.0       68294.8       1.0X
+Decompression 10000 times from level 2 without buffer pool            684            685           1          0.0       68441.8       1.0X
+Decompression 10000 times from level 3 without buffer pool            684            685           1          0.0       68446.7       1.0X
+Decompression 10000 times from level 1 with buffer pool               494            495           2          0.0       49362.5       1.4X
+Decompression 10000 times from level 2 with buffer pool               493            495           2          0.0       49330.7       1.4X
+Decompression 10000 times from level 3 with buffer pool               494            497           5          0.0       49359.8       1.4X
 
 

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -268,4 +268,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.5.1-1//zstd-jni-1.5.1-1.jar
+zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -252,4 +252,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.5.1-1//zstd-jni-1.5.1-1.jar
+zstd-jni/1.5.2-1//zstd-jni-1.5.2-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -773,7 +773,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.1-1</version>
+        <version>1.5.2-1</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ZSTD-JNI to 1.5.2-1.

### Why are the changes needed?

This will bring the following improvements.
- https://github.com/luben/zstd-jni/commit/1cc38de0153dd83ccd465b115c72573fe7d97930 (Reducing synchronization in RecyclingBufferPool)
- https://github.com/luben/zstd-jni/commit/16b841192635a02292a172c28fde57a425479eab (Import Zstd v1.5.2)
- https://github.com/luben/zstd-jni/commit/fb16a195367d1fb6a1ed699f36fbd38b67a853b0 (Remove redundant reset)
- https://github.com/luben/zstd-jni/commit/13711375c88ccc2291c4077f35be98552e6898be (Expose the default compression level)
- https://github.com/luben/zstd-jni/commit/1e7ea4d4ec144ad2cd52a3f26ab02eb9938c9943 (Remove the tag on some tests that was added for)
- https://github.com/luben/zstd-jni/commit/d786f6e6c157a289f7282d3a0116f3840d1e1f69 (Mark deprecated APIs with deprecated annotation.)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.