### PR TITLE
[SPARK-38003][SQL] LookupFunctions rule should only look up functions from the scalar function registry

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1557,17 +1557,18 @@ class SessionCatalog(
    */
   def lookupBuiltinOrTempFunction(name: String): Option[ExpressionInfo] = {
     FunctionRegistry.builtinOperators.get(name.toLowerCase(Locale.ROOT)).orElse {
-      synchronized(
-        lookupTempFuncWithViewContext(name, isBuiltinFunction, functionRegistry.lookupFunction))
+      synchronized(lookupTempFuncWithViewContext(
+        name, FunctionRegistry.builtin.functionExists, functionRegistry.lookupFunction))
     }
   }
 
   /**
-   * Look up the `ExpressionInfo` of the given table function by name if it's a
-   * built-in or temp function.
+   * Look up the `ExpressionInfo` of the given function by name if it's a built-in or
+   * temp table function.
    */
   def lookupBuiltinOrTempTableFunction(name: String): Option[ExpressionInfo] = synchronized {
-    lookupTempFuncWithViewContext(name, isBuiltinFunction, tableFunctionRegistry.lookupFunction)
+    lookupTempFuncWithViewContext(
+      name, TableFunctionRegistry.builtin.functionExists, tableFunctionRegistry.lookupFunction)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -1553,16 +1553,21 @@ class SessionCatalog(
 
   /**
    * Look up the `ExpressionInfo` of the given function by name if it's a built-in or temp function.
-   * This supports both scalar and table functions.
+   * This only supports scalar functions.
    */
   def lookupBuiltinOrTempFunction(name: String): Option[ExpressionInfo] = {
     FunctionRegistry.builtinOperators.get(name.toLowerCase(Locale.ROOT)).orElse {
-      def lookup(ident: FunctionIdentifier): Option[ExpressionInfo] = {
-        functionRegistry.lookupFunction(ident).orElse(
-          tableFunctionRegistry.lookupFunction(ident))
-      }
-      synchronized(lookupTempFuncWithViewContext(name, isBuiltinFunction, lookup))
+      synchronized(
+        lookupTempFuncWithViewContext(name, isBuiltinFunction, functionRegistry.lookupFunction))
     }
+  }
+
+  /**
+   * Look up the `ExpressionInfo` of the given table function by name if it's a
+   * built-in or temp function.
+   */
+  def lookupBuiltinOrTempTableFunction(name: String): Option[ExpressionInfo] = synchronized {
+    lookupTempFuncWithViewContext(name, isBuiltinFunction, tableFunctionRegistry.lookupFunction)
   }
 
   /**
@@ -1709,7 +1714,9 @@ class SessionCatalog(
    */
   def lookupFunctionInfo(name: FunctionIdentifier): ExpressionInfo = synchronized {
     if (name.database.isEmpty) {
-      lookupBuiltinOrTempFunction(name.funcName).getOrElse(lookupPersistentFunction(name))
+      lookupBuiltinOrTempFunction(name.funcName)
+        .orElse(lookupBuiltinOrTempTableFunction(name.funcName))
+        .getOrElse(lookupPersistentFunction(name))
     } else {
       lookupPersistentFunction(name)
     }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
@@ -374,7 +374,7 @@ SELECT range(1, 100) OVER () FROM empsalary
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-Undefined function: 'range'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.; line 1 pos 7
+Undefined function: range. This function is neither a built-in/temporary function, nor a persistent function that is qualified as spark_catalog.default.range.; line 1 pos 7
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates the Analyzer rule `LookupFunctions` to only use scalar function registry instead of using both scalar function and table function registries, since currently LookupFunctions only handles scalar functions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make the error message consistent when a scalar function does not exist.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing unit tests.
