### PR TITLE
[SPARK-38007][K8S][DOCS] Update K8s doc to recommend K8s 1.20+

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,8 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A runnable distribution of Spark 2.3 or above.
-* A running Kubernetes cluster at version >= 1.6 with access configured to it using
+* A running Kubernetes cluster at version >= 1.20 with access configured to it using
 [kubectl](https://kubernetes.io/docs/user-guide/prereqs/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s `Prerequisites` doc to recommend K8s 1.20+ and to remove `Spark 2.3`.

### Why are the changes needed?

The AS-IS document is outdated because it's written 4 years ago.
- kubernetes-client 4.1.1 dropped K8s 1.6 and 1.7 support. (https://github.com/fabric8io/kubernetes-client)
- kubernetes-client 5.8.0 dropped K8s 1.9 support. (https://github.com/fabric8io/kubernetes-client)
- EKS also makes the following EOLs (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
  - 1.16 (September 27, 2021)
  - 1.17 (November 2, 2021)
  - 1.18 (March 31, 2022)
  - 1.19 (April, 2022)
- MKS has the similar status (https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)



### Does this PR introduce _any_ user-facing change?

No. This is a documentation change.

### How was this patch tested?

Manual.