### PR TITLE
[SPARK-38020][SQL]Clear unnecessary branch switch in VectorizedColumnReader.readBatch

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedColumnReader.java
@@ -218,11 +218,6 @@ public class VectorizedColumnReader {
             dictionaryIds, dictionary);
         }
       } else {
-        if (column.hasDictionary() && readState.offset != 0) {
-          // This batch already has dictionary encoded values but this new page is not. The batch
-          // does not support a mix of dictionary and not so we will decode the dictionary.
-          updater.decodeDictionaryIds(readState.offset, 0, column, dictionaryIds, dictionary);
-        }
         column.setDictionary(null);
         VectorizedValuesReader valuesReader = (VectorizedValuesReader) dataColumn;
         defColumn.readBatch(readState, column, valuesReader, updater);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to clear unnecessary branch switch, we need't decode dictionary when the current page is not dictionary encoded in `VectorizedColumnReader.readBatch`


### Why are the changes needed?
clear unnecessary branch witch for code readability


### Does this PR introduce _any_ user-facing change?
No, code simplification only


### How was this patch tested?
Exists test
