### PR TITLE
[SPARK-38040][BUILD] Enable binary compatibility check for APIs in Catalyst, KVStore and Avro modules

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -66,6 +66,12 @@ object MimaExcludes {
     ProblemFilters.exclude[Problem]("org.apache.spark.sql.catalyst.*"),
     ProblemFilters.exclude[Problem]("org.apache.spark.sql.execution.*"),
     ProblemFilters.exclude[Problem]("org.apache.spark.sql.internal.*"),
+    ProblemFilters.exclude[Problem]("org.apache.spark.sql.errors.*"),
+    // DSv2 catalog and expression APIs are unstable yet. We should enable this back.
+    ProblemFilters.exclude[Problem]("org.apache.spark.sql.connector.catalog.*"),
+    ProblemFilters.exclude[Problem]("org.apache.spark.sql.connector.expressions.*"),
+    // Avro source implementation is internal.
+    ProblemFilters.exclude[Problem]("org.apache.spark.sql.v2.avro.*"),
 
     // [SPARK-34848][CORE] Add duration to TaskMetricDistributions
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.TaskMetricDistributions.this"),

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -376,8 +376,8 @@ object SparkBuild extends PomBuild {
 
   val mimaProjects = allProjects.filterNot { x =>
     Seq(
-      spark, hive, hiveThriftServer, catalyst, repl, networkCommon, networkShuffle, networkYarn,
-      unsafe, tags, tokenProviderKafka010, sqlKafka010, kvstore, avro
+      spark, hive, hiveThriftServer, repl, networkCommon, networkShuffle, networkYarn,
+      unsafe, tags, tokenProviderKafka010, sqlKafka010
     ).contains(x)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

We don't currently run binary compatibility check in below modules:

```
[info] spark-parent: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-network-common: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-tags: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-unsafe: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-network-shuffle: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-kvstore: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-tools: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-token-provider-kafka-0-10: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-streaming-kafka-0-10-assembly: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-catalyst: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-repl: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-avro: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-sql-kafka-0-10: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-hive: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-assembly: mimaPreviousArtifacts not set, not analyzing binary compatibility
[info] spark-examples: mimaPreviousArtifacts not set, not analyzing binary compatibility
```

However, there are some APIs under these modules. For example, https://github.com/apache/spark/blob/master/external/avro/src/main/scala/org/apache/spark/sql/avro/functions.scala for Avro,  https://github.com/apache/spark/tree/master/common/kvstore/src/main/java/org/apache/spark/util/kvstore for KVStore (to be API), and https://github.com/apache/spark/tree/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector for Catalyst

### Why are the changes needed?

To detect binary compatibility.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested via running `dev/mima`.