### PR TITLE
[SPARK-38051][R][DOCS] Update `Roxygen` reference to 7.1.2

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -60,7 +60,7 @@ Collate:
     'types.R'
     'utils.R'
     'window.R'
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 NeedsCompilation: no
 Encoding: UTF-8

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,12 +55,12 @@ and install these libraries:
 
 ```sh
 $ sudo Rscript -e 'install.packages(c("knitr", "devtools", "testthat", "rmarkdown"), repos="https://cloud.r-project.org/")'
-$ sudo Rscript -e 'devtools::install_version("roxygen2", version = "7.1.1", repos="https://cloud.r-project.org/")'
+$ sudo Rscript -e 'devtools::install_version("roxygen2", version = "7.1.2", repos="https://cloud.r-project.org/")'
 $ sudo Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
 $ sudo Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
 ```
 
-Note: Other versions of roxygen2 might work in SparkR documentation generation but `RoxygenNote` field in `$SPARK_HOME/R/pkg/DESCRIPTION` is 7.1.1, which is updated if the version is mismatched.
+Note: Other versions of roxygen2 might work in SparkR documentation generation but `RoxygenNote` field in `$SPARK_HOME/R/pkg/DESCRIPTION` is 7.1.2, which is updated if the version is mismatched.
 
 ### API Documentation
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Roxygen` reference to 7.1.2 for Apache Spark 3.3.0.

### Why are the changes needed?

`Roxygen2` was 7.1.2 since 2021-09-08. So, this touches `R/pkg/DESCRIPTION` file when we build with `-Psparkr`. This PR removes this annoying situation by removing this version mismatch.
- https://cran.r-project.org/web/packages/roxygen2/index.html

```
$ build/sbt -Psparkr compile
$ git diff
diff --git a/R/pkg/DESCRIPTION b/R/pkg/DESCRIPTION
index 6b85bb758a..d147ff2b34 100644
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -60,7 +60,7 @@ Collate:
     'types.R'
     'utils.R'
     'window.R'
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 NeedsCompilation: no
 Encoding: UTF-8
```

We have been using `7.1.2` already for testing.
```
$ docker run -it --rm dongjoon/apache-spark-github-action-image:20211228 Rscript -e 'installed.packages()' | grep roxygen2 | grep site-library
roxygen2    "roxygen2"    "/usr/local/lib/R/site-library" "7.1.2"
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.