### PR TITLE
[SPARK-38054][SQL] Supports list namespaces in JDBC v2 MySQL dialect

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1944,4 +1944,16 @@ object QueryExecutionErrors {
   def MultipleBucketTransformsError(): Throwable = {
     new UnsupportedOperationException("Multiple bucket transforms are not supported.")
   }
+
+  def unsupportedCreateNamespaceCommentError(): Throwable = {
+    new SQLFeatureNotSupportedException("Create namespace comment is not supported")
+  }
+
+  def unsupportedRemoveNamespaceCommentError(): Throwable = {
+    new SQLFeatureNotSupportedException("Remove namespace comment is not supported")
+  }
+
+  def unsupportedDropNamespaceRestrictError(): Throwable = {
+    new SQLFeatureNotSupportedException("Drop namespace restrict is not supported")
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -979,7 +979,7 @@ object JdbcUtils extends Logging with SQLConfHelper {
       namespace: String,
       comment: String): Unit = {
     val dialect = JdbcDialects.get(options.url)
-    dialect.createSchemaWithComment(conn, options, namespace, comment)
+    dialect.createSchema(conn, options, namespace, comment)
   }
 
   def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -990,12 +990,12 @@ object JdbcUtils extends Logging with SQLConfHelper {
 
   def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {
     val dialect = JdbcDialects.get(options.url)
-    dialect.namespacesExists(conn, options, namespace)
+    dialect.schemasExists(conn, options, namespace)
   }
 
   def listNamespaces(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
     val dialect = JdbcDialects.get(options.url)
-    dialect.listNamespaces(conn, options)
+    dialect.listSchemas(conn, options)
   }
 
   def createNamespaceComment(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -978,8 +978,14 @@ object JdbcUtils extends Logging with SQLConfHelper {
       options: JDBCOptions,
       namespace: String,
       comment: String): Unit = {
-    val dialect = JdbcDialects.get(options.url)
-    dialect.createSchema(conn, options, namespace, comment)
+    val statement = conn.createStatement
+    try {
+      statement.setQueryTimeout(options.queryTimeout)
+      val dialect = JdbcDialects.get(options.url)
+      dialect.createSchema(statement, namespace, comment)
+    } finally {
+      statement.close()
+    }
   }
 
   def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -979,10 +979,13 @@ object JdbcUtils extends Logging with SQLConfHelper {
       namespace: String,
       comment: String): Unit = {
     val dialect = JdbcDialects.get(options.url)
-    executeStatement(conn, options, s"CREATE SCHEMA ${dialect.quoteIdentifier(namespace)}")
-    if (comment.nonEmpty) {
-      executeStatement(conn, options, dialect.getSchemaCommentQuery(namespace, comment))
+    val schemaCommentQuery = if (comment.isEmpty) {
+      comment
+    } else {
+      dialect.getSchemaCommentQuery(namespace, comment)
     }
+    executeStatement(conn, options, s"CREATE SCHEMA ${dialect.quoteIdentifier(namespace)}")
+    if (comment.nonEmpty) executeStatement(conn, options, schemaCommentQuery)
   }
 
   def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -971,57 +971,57 @@ object JdbcUtils extends Logging with SQLConfHelper {
   }
 
   /**
-   * Creates a namespace.
+   * Creates a schema.
    */
-  def createNamespace(
+  def createSchema(
       conn: Connection,
       options: JDBCOptions,
-      namespace: String,
+      schema: String,
       comment: String): Unit = {
     val statement = conn.createStatement
     try {
       statement.setQueryTimeout(options.queryTimeout)
       val dialect = JdbcDialects.get(options.url)
-      dialect.createSchema(statement, namespace, comment)
+      dialect.createSchema(statement, schema, comment)
     } finally {
       statement.close()
     }
   }
 
-  def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {
+  def schemaExists(conn: Connection, options: JDBCOptions, schema: String): Boolean = {
     val dialect = JdbcDialects.get(options.url)
-    dialect.schemasExists(conn, options, namespace)
+    dialect.schemasExists(conn, options, schema)
   }
 
-  def listNamespaces(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
+  def listSchemas(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
     val dialect = JdbcDialects.get(options.url)
     dialect.listSchemas(conn, options)
   }
 
-  def alterNamespaceComment(
+  def alterSchemaComment(
       conn: Connection,
       options: JDBCOptions,
-      namespace: String,
+      schema: String,
       comment: String): Unit = {
     val dialect = JdbcDialects.get(options.url)
-    executeStatement(conn, options, dialect.getSchemaCommentQuery(namespace, comment))
+    executeStatement(conn, options, dialect.getSchemaCommentQuery(schema, comment))
   }
 
-  def removeNamespaceComment(
+  def removeSchemaComment(
       conn: Connection,
       options: JDBCOptions,
-      namespace: String): Unit = {
+      schema: String): Unit = {
     val dialect = JdbcDialects.get(options.url)
-    executeStatement(conn, options, dialect.removeSchemaCommentQuery(namespace))
+    executeStatement(conn, options, dialect.removeSchemaCommentQuery(schema))
   }
 
   /**
-   * Drops a namespace from the JDBC database.
+   * Drops a schema from the JDBC database.
    */
-  def dropNamespace(
-      conn: Connection, options: JDBCOptions, namespace: String, cascade: Boolean): Unit = {
+  def dropSchema(
+      conn: Connection, options: JDBCOptions, schema: String, cascade: Boolean): Unit = {
     val dialect = JdbcDialects.get(options.url)
-    executeStatement(conn, options, dialect.dropSchema(namespace, cascade))
+    executeStatement(conn, options, dialect.dropSchema(schema, cascade))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -978,28 +978,8 @@ object JdbcUtils extends Logging with SQLConfHelper {
       options: JDBCOptions,
       namespace: String,
       comment: String): Unit = {
-    val metaData = conn.getMetaData
-    if (!metaData.supportsTransactions) {
-      throw QueryExecutionErrors.transactionUnsupportedByJdbcServerError()
-    } else {
-      conn.setAutoCommit(false)
-      val statement = conn.createStatement
-      try {
-        statement.setQueryTimeout(options.queryTimeout)
-        val dialect = JdbcDialects.get(options.url)
-        for (sql <- dialect.createSchemaWithComment(namespace, comment)) {
-          statement.executeUpdate(sql)
-        }
-        conn.commit()
-      } catch {
-        case e: Exception =>
-          if (conn != null) conn.rollback()
-          throw e
-      } finally {
-        statement.close()
-        conn.setAutoCommit(true)
-      }
-    }
+    val dialect = JdbcDialects.get(options.url)
+    dialect.createSchemaWithComment(conn, options, namespace, comment)
   }
 
   def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -979,13 +979,10 @@ object JdbcUtils extends Logging with SQLConfHelper {
       namespace: String,
       comment: String): Unit = {
     val dialect = JdbcDialects.get(options.url)
-    val schemaCommentQuery = if (comment.isEmpty) {
-      comment
-    } else {
-      dialect.getSchemaCommentQuery(namespace, comment)
-    }
     executeStatement(conn, options, s"CREATE SCHEMA ${dialect.quoteIdentifier(namespace)}")
-    if (comment.nonEmpty) executeStatement(conn, options, schemaCommentQuery)
+    if (comment.nonEmpty) {
+      executeStatement(conn, options, dialect.getSchemaCommentQuery(namespace, comment))
+    }
   }
 
   def namespaceExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -978,30 +978,26 @@ object JdbcUtils extends Logging with SQLConfHelper {
       options: JDBCOptions,
       namespace: String,
       comment: String): Unit = {
-    val dialect = JdbcDialects.get(options.url)
-    if (comment.isEmpty) {
-      executeStatement(conn, options, s"CREATE SCHEMA ${dialect.quoteIdentifier(namespace)}")
+    val metaData = conn.getMetaData
+    if (!metaData.supportsTransactions) {
+      throw QueryExecutionErrors.transactionUnsupportedByJdbcServerError()
     } else {
-      val metaData = conn.getMetaData
-      if (!metaData.supportsTransactions) {
-        throw QueryExecutionErrors.transactionUnsupportedByJdbcServerError()
-      } else {
-        conn.setAutoCommit(false)
-        val statement = conn.createStatement
-        try {
-          statement.setQueryTimeout(options.queryTimeout)
-          for (sql <- dialect.createSchemaWithComment(namespace, comment)) {
-            statement.executeUpdate(sql)
-          }
-          conn.commit()
-        } catch {
-          case e: Exception =>
-            if (conn != null) conn.rollback()
-            throw e
-        } finally {
-          statement.close()
-          conn.setAutoCommit(true)
+      conn.setAutoCommit(false)
+      val statement = conn.createStatement
+      try {
+        statement.setQueryTimeout(options.queryTimeout)
+        val dialect = JdbcDialects.get(options.url)
+        for (sql <- dialect.createSchemaWithComment(namespace, comment)) {
+          statement.executeUpdate(sql)
         }
+        conn.commit()
+      } catch {
+        case e: Exception =>
+          if (conn != null) conn.rollback()
+          throw e
+      } finally {
+        statement.close()
+        conn.setAutoCommit(true)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -245,7 +245,7 @@ class JDBCTableCatalog extends TableCatalog with SupportsNamespaces with Logging
             if (set.property() == SupportsNamespaces.PROP_COMMENT) {
               JdbcUtils.withConnection(options) { conn =>
                 JdbcUtils.classifyException(s"Failed create comment on name space: $db", dialect) {
-                  JdbcUtils.createNamespaceComment(conn, options, db, set.value)
+                  JdbcUtils.alterNamespaceComment(conn, options, db, set.value)
                 }
               }
             } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalog.scala
@@ -172,14 +172,14 @@ class JDBCTableCatalog extends TableCatalog with SupportsNamespaces with Logging
   override def namespaceExists(namespace: Array[String]): Boolean = namespace match {
     case Array(db) =>
       JdbcUtils.withConnection(options) { conn =>
-        JdbcUtils.namespaceExists(conn, options, db)
+        JdbcUtils.schemaExists(conn, options, db)
       }
     case _ => false
   }
 
   override def listNamespaces(): Array[Array[String]] = {
     JdbcUtils.withConnection(options) { conn =>
-      JdbcUtils.listNamespaces(conn, options)
+      JdbcUtils.listSchemas(conn, options)
     }
   }
 
@@ -226,7 +226,7 @@ class JDBCTableCatalog extends TableCatalog with SupportsNamespaces with Logging
       }
       JdbcUtils.withConnection(options) { conn =>
         JdbcUtils.classifyException(s"Failed create name space: $db", dialect) {
-          JdbcUtils.createNamespace(conn, options, db, comment)
+          JdbcUtils.createSchema(conn, options, db, comment)
         }
       }
 
@@ -245,7 +245,7 @@ class JDBCTableCatalog extends TableCatalog with SupportsNamespaces with Logging
             if (set.property() == SupportsNamespaces.PROP_COMMENT) {
               JdbcUtils.withConnection(options) { conn =>
                 JdbcUtils.classifyException(s"Failed create comment on name space: $db", dialect) {
-                  JdbcUtils.alterNamespaceComment(conn, options, db, set.value)
+                  JdbcUtils.alterSchemaComment(conn, options, db, set.value)
                 }
               }
             } else {
@@ -256,7 +256,7 @@ class JDBCTableCatalog extends TableCatalog with SupportsNamespaces with Logging
             if (unset.property() == SupportsNamespaces.PROP_COMMENT) {
               JdbcUtils.withConnection(options) { conn =>
                 JdbcUtils.classifyException(s"Failed remove comment on name space: $db", dialect) {
-                  JdbcUtils.removeNamespaceComment(conn, options, db)
+                  JdbcUtils.removeSchemaComment(conn, options, db)
                 }
               }
             } else {
@@ -278,7 +278,7 @@ class JDBCTableCatalog extends TableCatalog with SupportsNamespaces with Logging
     case Array(db) if namespaceExists(namespace) =>
       JdbcUtils.withConnection(options) { conn =>
         JdbcUtils.classifyException(s"Failed drop name space: $db", dialect) {
-          JdbcUtils.dropNamespace(conn, options, db, cascade)
+          JdbcUtils.dropSchema(conn, options, db, cascade)
           true
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -230,12 +230,12 @@ abstract class JdbcDialect extends Serializable with Logging{
   }
 
   /**
-   * Check namespace exists or not.
+   * Check schema exists or not.
    */
-  def namespacesExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {
-    val rs = conn.getMetaData.getSchemas(null, namespace)
+  def schemasExists(conn: Connection, options: JDBCOptions, schema: String): Boolean = {
+    val rs = conn.getMetaData.getSchemas(null, schema)
     while (rs.next()) {
-      if (rs.getString(1) == namespace) return true;
+      if (rs.getString(1) == schema) return true;
     }
     false
   }
@@ -243,7 +243,7 @@ abstract class JdbcDialect extends Serializable with Logging{
   /**
    * Lists all the schemas in this table.
    */
-  def listNamespaces(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
+  def listSchemas(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
     val schemaBuilder = ArrayBuilder.make[Array[String]]
     val rs = conn.getMetaData.getSchemas()
     while (rs.next()) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -232,7 +232,7 @@ abstract class JdbcDialect extends Serializable with Logging{
   /**
    * Create schema with comment.
    */
-  def createSchemaWithComment(
+  def createSchema(
       conn: Connection, options: JDBCOptions, schema: String, comment: String): Unit = {
     val statement = conn.createStatement
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -234,6 +234,7 @@ abstract class JdbcDialect extends Serializable with Logging{
    */
   def createSchema(statement: Statement, schema: String, comment: String): Unit = {
     val schemaCommentQuery = if (comment.nonEmpty) {
+      // We generate comment query here so that it can fail earlier without creating the schema.
       getSchemaCommentQuery(schema, comment)
     } else {
       comment

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, Date, Timestamp}
+import java.sql.{Connection, Date, Statement, Timestamp}
 import java.time.{Instant, LocalDate}
 import java.util
 
@@ -232,22 +232,15 @@ abstract class JdbcDialect extends Serializable with Logging{
   /**
    * Create schema with comment.
    */
-  def createSchema(
-      conn: Connection, options: JDBCOptions, schema: String, comment: String): Unit = {
-    val statement = conn.createStatement
-    try {
-      statement.setQueryTimeout(options.queryTimeout)
-      val schemaCommentQuery = if (comment.nonEmpty) {
-        getSchemaCommentQuery(schema, comment)
-      } else {
-        comment
-      }
-      statement.executeUpdate(s"CREATE SCHEMA ${quoteIdentifier(schema)}")
-      if (comment.nonEmpty) {
-        statement.executeUpdate(schemaCommentQuery)
-      }
-    } finally {
-      statement.close()
+  def createSchema(statement: Statement, schema: String, comment: String): Unit = {
+    val schemaCommentQuery = if (comment.nonEmpty) {
+      getSchemaCommentQuery(schema, comment)
+    } else {
+      comment
+    }
+    statement.executeUpdate(s"CREATE SCHEMA ${quoteIdentifier(schema)}")
+    if (comment.nonEmpty) {
+      statement.executeUpdate(schemaCommentQuery)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -235,7 +235,7 @@ abstract class JdbcDialect extends Serializable with Logging{
   def createSchemaWithComment(schema: String, comment: String): Array[String] = {
     val clauses = ArrayBuilder.make[String]
     clauses += s"CREATE SCHEMA ${quoteIdentifier(schema)}"
-    clauses += getSchemaCommentQuery(schema, comment)
+    if (comment.nonEmpty) clauses += getSchemaCommentQuery(schema, comment)
     clauses.result()
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -230,7 +230,7 @@ abstract class JdbcDialect extends Serializable with Logging{
   }
 
   /**
-   * Create schema with comment.
+   * Create schema with an optional comment. Empty string means no comment.
    */
   def createSchema(
       conn: Connection, options: JDBCOptions, schema: String, comment: String): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -230,6 +230,29 @@ abstract class JdbcDialect extends Serializable with Logging{
   }
 
   /**
+   * Check namespace exists or not.
+   */
+  def namespacesExists(conn: Connection, options: JDBCOptions, namespace: String): Boolean = {
+    val rs = conn.getMetaData.getSchemas(null, namespace)
+    while (rs.next()) {
+      if (rs.getString(1) == namespace) return true;
+    }
+    false
+  }
+
+  /**
+   * Lists all the schemas in this table.
+   */
+  def listNamespaces(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
+    val schemaBuilder = ArrayBuilder.make[Array[String]]
+    val rs = conn.getMetaData.getSchemas()
+    while (rs.next()) {
+      schemaBuilder += Array(rs.getString(1))
+    }
+    schemaBuilder.result
+  }
+
+  /**
    * Return Some[true] iff `TRUNCATE TABLE` causes cascading default.
    * Some[true] : TRUNCATE TABLE causes cascading.
    * Some[false] : TRUNCATE TABLE does not cause cascading.

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -230,6 +230,16 @@ abstract class JdbcDialect extends Serializable with Logging{
   }
 
   /**
+   * Create schema with comment.
+   */
+  def createSchemaWithComment(schema: String, comment: String): Array[String] = {
+    val clauses = ArrayBuilder.make[String]
+    clauses += s"CREATE SCHEMA ${quoteIdentifier(schema)}"
+    clauses += getSchemaCommentQuery(schema, comment)
+    clauses.result()
+  }
+
+  /**
    * Check schema exists or not.
    */
   def schemasExists(conn: Connection, options: JDBCOptions, schema: String): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -21,6 +21,8 @@ import java.sql.{Connection, SQLException, Types}
 import java.util
 import java.util.Locale
 
+import scala.collection.mutable.ArrayBuilder
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NoSuchIndexException}
@@ -74,6 +76,26 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
 
   override def quoteIdentifier(colName: String): String = {
     s"`$colName`"
+  }
+
+  override def namespacesExists(
+      conn: Connection, options: JDBCOptions, namespace: String): Boolean = {
+    listNamespaces(conn, options).exists(_.head == namespace)
+  }
+
+  override def listNamespaces(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
+    val schemaBuilder = ArrayBuilder.make[Array[String]]
+    try {
+      JdbcUtils.executeQuery(conn, options, "SHOW SCHEMAS") { rs =>
+        while (rs.next()) {
+          schemaBuilder += Array(rs.getString("Database"))
+        }
+      }
+    } catch {
+      case _: Exception =>
+        logWarning("Cannot show schemas.")
+    }
+    schemaBuilder.result
   }
 
   override def getTableExistsQuery(table: String): String = {
@@ -134,6 +156,14 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
     case _ => JdbcUtils.getCommonJDBCType(dt)
   }
 
+  override def getSchemaCommentQuery(schema: String, comment: String): String = {
+    throw QueryExecutionErrors.unsupportedCreateNamespaceCommentError()
+  }
+
+  override def removeSchemaCommentQuery(schema: String): String = {
+    throw QueryExecutionErrors.unsupportedRemoveNamespaceCommentError()
+  }
+
   // CREATE INDEX syntax
   // https://dev.mysql.com/doc/refman/8.0/en/create-index.html
   override def createIndex(
@@ -175,26 +205,27 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
     val sql = s"SHOW INDEXES FROM $tableName"
     var indexMap: Map[String, TableIndex] = Map()
     try {
-      val rs = JdbcUtils.executeQuery(conn, options, sql)
-      while (rs.next()) {
-        val indexName = rs.getString("key_name")
-        val colName = rs.getString("column_name")
-        val indexType = rs.getString("index_type")
-        val indexComment = rs.getString("Index_comment")
-        if (indexMap.contains(indexName)) {
-          val index = indexMap.get(indexName).get
-          val newIndex = new TableIndex(indexName, indexType,
-            index.columns() :+ FieldReference(colName),
-            index.columnProperties, index.properties)
-          indexMap += (indexName -> newIndex)
-        } else {
-          // The only property we are building here is `COMMENT` because it's the only one
-          // we can get from `SHOW INDEXES`.
-          val properties = new util.Properties();
-          if (indexComment.nonEmpty) properties.put("COMMENT", indexComment)
-          val index = new TableIndex(indexName, indexType, Array(FieldReference(colName)),
-            new util.HashMap[NamedReference, util.Properties](), properties)
-          indexMap += (indexName -> index)
+      JdbcUtils.executeQuery(conn, options, sql) { rs =>
+        while (rs.next()) {
+          val indexName = rs.getString("key_name")
+          val colName = rs.getString("column_name")
+          val indexType = rs.getString("index_type")
+          val indexComment = rs.getString("Index_comment")
+          if (indexMap.contains(indexName)) {
+            val index = indexMap.get(indexName).get
+            val newIndex = new TableIndex(indexName, indexType,
+              index.columns() :+ FieldReference(colName),
+              index.columnProperties, index.properties)
+            indexMap += (indexName -> newIndex)
+          } else {
+            // The only property we are building here is `COMMENT` because it's the only one
+            // we can get from `SHOW INDEXES`.
+            val properties = new util.Properties();
+            if (indexComment.nonEmpty) properties.put("COMMENT", indexComment)
+            val index = new TableIndex(indexName, indexType, Array(FieldReference(colName)),
+              new util.HashMap[NamedReference, util.Properties](), properties)
+            indexMap += (indexName -> index)
+          }
         }
       }
     } catch {
@@ -217,6 +248,14 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
         }
       case unsupported: UnsupportedOperationException => throw unsupported
       case _ => super.classifyException(message, e)
+    }
+  }
+
+  override def dropSchema(schema: String, cascade: Boolean): String = {
+    if (cascade) {
+      s"DROP SCHEMA ${quoteIdentifier(schema)}"
+    } else {
+      throw QueryExecutionErrors.unsupportedDropNamespaceRestrictError()
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -78,12 +78,11 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
     s"`$colName`"
   }
 
-  override def namespacesExists(
-      conn: Connection, options: JDBCOptions, namespace: String): Boolean = {
-    listNamespaces(conn, options).exists(_.head == namespace)
+  override def schemasExists(conn: Connection, options: JDBCOptions, schema: String): Boolean = {
+    listSchemas(conn, options).exists(_.head == schema)
   }
 
-  override def listNamespaces(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
+  override def listSchemas(conn: Connection, options: JDBCOptions): Array[Array[String]] = {
     val schemaBuilder = ArrayBuilder.make[Array[String]]
     try {
       JdbcUtils.executeQuery(conn, options, "SHOW SCHEMAS") { rs =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, `JDBCTableCatalog.scala` query namespaces show below.
```
      val schemaBuilder = ArrayBuilder.make[Array[String]]
      val rs = conn.getMetaData.getSchemas()
      while (rs.next()) {
        schemaBuilder += Array(rs.getString(1))
      }
      schemaBuilder.result
```

But the code cannot get any information when using MySQL JDBC driver.
This PR uses `SHOW SCHEMAS` to query namespaces of MySQL.
This PR also fix other issues below:

- Release the docker tests in `MySQLNamespaceSuite.scala`.
- Because MySQL doesn't support create comment of schema, let's throws `SQLFeatureNotSupportedException`.
- Because MySQL doesn't support `DROP SCHEMA` in `RESTRICT` mode, let's throws `SQLFeatureNotSupportedException`.
- Reactor `JdbcUtils.executeQuery` to avoid `java.sql.SQLException: Operation not allowed after ResultSet closed`.


### Why are the changes needed?
MySQL dialect supports query namespaces.


### Does this PR introduce _any_ user-facing change?
'Yes'.
Some API changed.


### How was this patch tested?
New tests.
