### PR TITLE
[SPARK-38062][CORE] Avoid resolving placeholder hostname for FallbackStorage in BlockManagerDecommissioner

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -136,9 +136,9 @@ private[storage] class BlockManagerDecommissioner(
                 if (bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo).size < blocks.size) {
                   logWarning(s"Skipping block $shuffleBlockInfo, block deleted.")
                 } else if (fallbackStorage.isDefined
-                  // Confirm peer is not the fallback BM ID because then fallbackStorage would
-                  // already have been used in the try-block above and there's no point trying again
-                  && peer != FallbackStorage.FALLBACK_BLOCK_MANAGER_ID) {
+                    // Confirm peer is not the fallback BM ID because fallbackStorage would already
+                    // have been used in the try-block above so there's no point trying again
+                    && peer != FallbackStorage.FALLBACK_BLOCK_MANAGER_ID) {
                   fallbackStorage.foreach(_.copy(shuffleBlockInfo, bm))
                 } else {
                   logError(s"Error occurred during migrating $shuffleBlockInfo", e)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -19,9 +19,11 @@ package org.apache.spark.storage
 
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
+
 import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
@@ -29,8 +31,6 @@ import org.apache.spark.internal.config
 import org.apache.spark.shuffle.ShuffleBlockInfo
 import org.apache.spark.storage.BlockManagerMessages.ReplicateBlock
 import org.apache.spark.util.ThreadUtils
-
-import java.nio.file.Paths
 
 /**
  * Class to handle block manager decommissioning retries.
@@ -149,7 +149,6 @@ private[storage] class BlockManagerDecommissioner(
                 keepRunning = false
             }
           }
-          Paths.get("").toString
           if (keepRunning) {
             numMigratedShuffles.incrementAndGet()
           } else {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -19,11 +19,9 @@ package org.apache.spark.storage
 
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.control.NonFatal
-
 import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
@@ -31,6 +29,8 @@ import org.apache.spark.internal.config
 import org.apache.spark.shuffle.ShuffleBlockInfo
 import org.apache.spark.storage.BlockManagerMessages.ReplicateBlock
 import org.apache.spark.util.ThreadUtils
+
+import java.nio.file.Paths
 
 /**
  * Class to handle block manager decommissioning retries.
@@ -149,6 +149,7 @@ private[storage] class BlockManagerDecommissioner(
                 keepRunning = false
             }
           }
+          Paths.get("").toString
           if (keepRunning) {
             numMigratedShuffles.incrementAndGet()
           } else {

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -109,17 +109,21 @@ private[storage] class BlockManagerDecommissioner(
               s"to $peer ($retryCount / $maxReplicationFailuresForDecommission)")
             // Migrate the components of the blocks.
             try {
-              blocks.foreach { case (blockId, buffer) =>
-                logDebug(s"Migrating sub-block ${blockId}")
-                bm.blockTransferService.uploadBlockSync(
-                  peer.host,
-                  peer.port,
-                  peer.executorId,
-                  blockId,
-                  buffer,
-                  StorageLevel.DISK_ONLY,
-                  null) // class tag, we don't need for shuffle
-                logDebug(s"Migrated sub-block $blockId")
+              if (fallbackStorage.isDefined && peer == FallbackStorage.FALLBACK_BLOCK_MANAGER_ID) {
+                fallbackStorage.foreach(_.copy(shuffleBlockInfo, bm))
+              } else {
+                blocks.foreach { case (blockId, buffer) =>
+                  logDebug(s"Migrating sub-block ${blockId}")
+                  bm.blockTransferService.uploadBlockSync(
+                    peer.host,
+                    peer.port,
+                    peer.executorId,
+                    blockId,
+                    buffer,
+                    StorageLevel.DISK_ONLY,
+                    null) // class tag, we don't need for shuffle
+                  logDebug(s"Migrated sub-block $blockId")
+                }
               }
               logInfo(s"Migrated $shuffleBlockInfo to $peer")
             } catch {
@@ -131,7 +135,10 @@ private[storage] class BlockManagerDecommissioner(
                 // driver a no longer referenced RDD with shuffle files.
                 if (bm.migratableResolver.getMigrationBlocks(shuffleBlockInfo).size < blocks.size) {
                   logWarning(s"Skipping block $shuffleBlockInfo, block deleted.")
-                } else if (fallbackStorage.isDefined) {
+                } else if (fallbackStorage.isDefined
+                  // Confirm peer is not the fallback BM ID because then fallbackStorage would
+                  // already have been used in the try-block above and there's no point trying again
+                  && peer != FallbackStorage.FALLBACK_BLOCK_MANAGER_ID) {
                   fallbackStorage.foreach(_.copy(shuffleBlockInfo, bm))
                 } else {
                   logError(s"Error occurred during migrating $shuffleBlockInfo", e)

--- a/pom.xml
+++ b/pom.xml
@@ -3410,7 +3410,6 @@
           <skipTestSources>${scalafmt.skip}</skipTestSources>
           <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
           <onlyChangedFiles>true</onlyChangedFiles>
-          <branch>amaster</branch>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3410,6 +3410,7 @@
           <skipTestSources>${scalafmt.skip}</skipTestSources>
           <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->
           <onlyChangedFiles>true</onlyChangedFiles>
+          <branch>amaster</branch>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This updates `BlockManagerDecommissioner` to avoid treating "remote", the placeholder hostname used by `FALLBACK_BLOCK_MANAGER_ID`, as a valid hostname and attempting to perform a network transfer to it. If the `peer` it encounters matches the fallback block manager ID, it now goes directly to accessing `fallbackStorage`, instead of first attempting to treat it like a valid block manager ID.

In addition, this reverts the changes from SPARK-37318, which should no longer be necessary now that the underlying issue is resolved.

### Why are the changes needed?
See SPARK-38062 for a much more detailed explanation. The gist of it is that:
- Attempting to resolve "remote" can behave unexpectedly in some DNS environments. This can cause failures of the `FallbackStorageSuite` tests, but also could potentially cause issues in a production deployment.
- SPARK-37318 "fixes" the tests by skipping them if such a DNS environment is detected, but this has the obvious drawback of disabling the tests, and doesn't address the problem for production environments.
- Even if resolving "remote" does quickly fail, as the current code expects, it is semantically wrong -- we should not treat this placeholder as a valid hostname.

### Does this PR introduce _any_ user-facing change?
`FallbackStorage` may be resolved slightly quicker, as it removes an unnecessary lookup step, but it should be negligible in most environments. No other user-facing changes.

### How was this patch tested?
The DNS environment in which unit tests are run in an automated fashion at my company means that we experience an issue very similar to what is described in SPARK-37318. Without this patch, tests in `FallbackStorageSuite` consistently fail, exceeding their timeouts. With this patch, the tests consistently (and quickly!) succeed.