### PR TITLE
[SPARK-38065][SQL] Improve the performance of DS V2 aggregate push-down

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -52,7 +52,7 @@ public interface SupportsPushDownAggregates extends ScanBuilder {
    *
    * @return true if enable aggregation push-down, false otherwise.
    */
-  boolean enablePushAggregation();
+  default boolean enablePushAggregation() { return false; }
 
   /**
    * Whether the datasource support complete aggregation push-down. Spark will do grouping again

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -52,7 +52,7 @@ public interface SupportsPushDownAggregates extends ScanBuilder {
    *
    * @return true if enable aggregation push-down, false otherwise.
    */
-  default boolean enablePushAggregation() { return false; }
+  default boolean enablePushAggregation() { return true; }
 
   /**
    * Whether the datasource support complete aggregation push-down. Spark will do grouping again

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -48,6 +48,13 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 public interface SupportsPushDownAggregates extends ScanBuilder {
 
   /**
+   * Whether enable aggregation push-down.
+   *
+   * @return true if enable aggregation push-down, false otherwise.
+   */
+  boolean enablePushAggregation();
+
+  /**
    * Whether the datasource support complete aggregation push-down. Spark will do grouping again
    * if this method returns false.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -95,7 +95,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         case ScanOperation(project, filters, sHolder: ScanBuilderHolder)
           if filters.isEmpty && project.forall(_.isInstanceOf[AttributeReference]) =>
           sHolder.builder match {
-            case r: SupportsPushDownAggregates =>
+            case r: SupportsPushDownAggregates if r.enablePushAggregation() =>
               val aggExprToOutputOrdinal = mutable.HashMap.empty[Expression, Int]
               val aggregates = collectAggregates(resultExpressions, aggExprToOutputOrdinal)
               val normalizedAggregates = DataSourceStrategy.normalizeExprs(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -72,6 +72,8 @@ case class JDBCScanBuilder(
 
   private var pushedGroupByCols: Option[Array[String]] = None
 
+  override val enablePushAggregation: Boolean = jdbcOptions.pushDownAggregate
+
   override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
     lazy val fieldNames = aggregation.groupByColumns()(0).fieldNames()
     jdbcOptions.numPartitions.map(_ == 1).getOrElse(true) ||
@@ -80,8 +82,6 @@ case class JDBCScanBuilder(
   }
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {
-    if (!jdbcOptions.pushDownAggregate) return false
-
     val dialect = JdbcDialects.get(jdbcOptions.url)
     val compiledAggs = aggregation.aggregateExpressions.flatMap(dialect.compileAggregate)
     if (compiledAggs.length != aggregation.aggregateExpressions.length) return false

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -72,7 +72,7 @@ case class JDBCScanBuilder(
 
   private var pushedGroupByCols: Option[Array[String]] = None
 
-  override val enablePushAggregation: Boolean = jdbcOptions.pushDownAggregate
+  override def enablePushAggregation(): Boolean = jdbcOptions.pushDownAggregate
 
   override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
     lazy val fieldNames = aggregation.groupByColumns()(0).fieldNames()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -73,11 +73,10 @@ case class OrcScanBuilder(
     }
   }
 
-  override def pushAggregation(aggregation: Aggregation): Boolean = {
-    if (!sparkSession.sessionState.conf.orcAggregatePushDown) {
-      return false
-    }
+  override val enablePushAggregation: Boolean =
+    sparkSession.sessionState.conf.orcAggregatePushDown
 
+  override def pushAggregation(aggregation: Aggregation): Boolean = {
     AggregatePushDownUtils.getSchemaForPushedAggregation(
       aggregation,
       schema,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/orc/OrcScanBuilder.scala
@@ -73,7 +73,7 @@ case class OrcScanBuilder(
     }
   }
 
-  override val enablePushAggregation: Boolean =
+  override def enablePushAggregation(): Boolean =
     sparkSession.sessionState.conf.orcAggregatePushDown
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -86,7 +86,7 @@ case class ParquetScanBuilder(
   // All filters that can be converted to Parquet are pushed down.
   override def pushedFilters(): Array[Filter] = pushedParquetFilters
 
-  override val enablePushAggregation: Boolean =
+  override def enablePushAggregation(): Boolean =
     sparkSession.sessionState.conf.parquetAggregatePushDown
 
   override def pushAggregation(aggregation: Aggregation): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetScanBuilder.scala
@@ -86,11 +86,10 @@ case class ParquetScanBuilder(
   // All filters that can be converted to Parquet are pushed down.
   override def pushedFilters(): Array[Filter] = pushedParquetFilters
 
-  override def pushAggregation(aggregation: Aggregation): Boolean = {
-    if (!sparkSession.sessionState.conf.parquetAggregatePushDown) {
-      return false
-    }
+  override val enablePushAggregation: Boolean =
+    sparkSession.sessionState.conf.parquetAggregatePushDown
 
+  override def pushAggregation(aggregation: Aggregation): Boolean = {
     AggregatePushDownUtils.getSchemaForPushedAggregation(
       aggregation,
       schema,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, the build-in scan builder that implement `SupportsPushDownAggregates` has itself's config to control aggregate push-down.
We can advance the judgement of the config which controls aggregate push-down.


### Why are the changes needed?
Improve the performance of DS V2 aggregate push-down.


### Does this PR introduce _any_ user-facing change?
'Yes'. This PR add a API `enablePushAggregation` in `SupportsPushDownAggregates`.


### How was this patch tested?
Exists tests.
