### PR TITLE
[SPARK-37932][SQL] Fix view bug when using join in duplicate views

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1200,6 +1200,11 @@ class Analyzer(override val catalogManager: CatalogManager)
                 val newRelation = multi.newInstance()
                 newRelation.copyTagsFrom(multi)
                 newRelation
+              case view @ View(_, _, child: LogicalPlan) =>
+                val newChild = child.mapExpressions {
+                  case alias: Alias => alias.newInstance()
+                }
+                view.copy(view.desc, view.isTempView, newChild)
             }).orElse {
               val table = CatalogV2Util.loadTable(catalog, ident, timeTravelSpec)
               val loaded = createRelation(catalog, ident, table, u.options, u.isStreaming)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1204,7 +1204,7 @@ class Analyzer(override val catalogManager: CatalogManager)
                 val newChild = child.mapExpressions {
                   case alias: Alias => alias.newInstance()
                 }
-                view.copy(view.desc, view.isTempView, newChild)
+                view.withNewChildren(Seq(newChild))
             }).orElse {
               val table = CatalogV2Util.loadTable(catalog, ident, timeTravelSpec)
               val loaded = createRelation(catalog, ident, table, u.options, u.isStreaming)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -904,19 +904,21 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
     }
   }
 
-  test("SPARK-37932: view join view self with having filter") {
+  test("SPARK-37932: view join with same view") {
     withTable("t") {
       withView("v1") {
-        Seq((2, "test2"), (3, "test3"), (1, "test1")).toDF("id", "name")
+        Seq((1, "test1"), (2, "test2"), (1, "test2")).toDF("id", "name")
           .write.format("parquet").saveAsTable("t")
         sql("CREATE VIEW v1 (id, name) AS SELECT id, name FROM t")
 
-        sql("""SELECT l1.id FROM v1 l1
-              | INNER JOIN (
-              |   SELECT id FROM v1
-              |   GROUP BY id HAVING COUNT(DISTINCT name) > 1
-              | ) l2 ON l1.id = l2.id GROUP BY l1.name, l1.id;
-        """.stripMargin)
+        checkAnswer(
+          sql("""SELECT l1.id FROM v1 l1
+                |INNER JOIN (
+                |   SELECT id FROM v1
+                |   GROUP BY id HAVING COUNT(DISTINCT name) > 1
+                | ) l2 ON l1.id = l2.id GROUP BY l1.name, l1.id;
+                |""".stripMargin),
+          Seq(Row(1), Row(1)))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -903,4 +903,21 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  test("SPARK-37932: view join view self with having filter") {
+    withTable("t") {
+      withView("v1") {
+        Seq((2, "test2"), (3, "test3"), (1, "test1")).toDF("id", "name")
+          .write.format("parquet").saveAsTable("t")
+        sql("CREATE VIEW v1 (id, name) AS SELECT id, name FROM t")
+
+        sql("""SELECT l1.id FROM v1 l1
+              | INNER JOIN (
+              |   SELECT id FROM v1
+              |   GROUP BY id HAVING COUNT(DISTINCT name) > 1
+              | ) l2 ON l1.id = l2.id GROUP BY l1.name, l1.id;
+        """.stripMargin)
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When the join with duplicate view like
```
SELECT l1.idFROM v1 l1
 INNER JOIN (
   SELECT id FROM v1
   GROUP BY id  HAVING COUNT(DISTINCT name) > 1
 ) l2
 ON l1.id = l2.id
 GROUP BY l1.name, l1.id;
```
The error stack is:
```
Resolved attribute(s) name#26 missing from id#31,name#32 in operator !Aggregate [id#31], [id#31, count(distinct name#26) AS count(distinct name#26)#33L]. Attribute(s) with the same name appear in the operation: name. Please check if the right attribute(s) are used.;
Aggregate [name#26, id#25], [id#25]
+- Join Inner, (id#25 = id#31)
   :- SubqueryAlias l1
   :  +- SubqueryAlias spark_catalog.default.v1
   :     +- View (`default`.`v1`, [id#25,name#26])
   :        +- Project [cast(id#20 as int) AS id#25, cast(name#21 as string) AS name#26]
   :           +- Project [id#20, name#21]
   :              +- SubqueryAlias spark_catalog.default.t
   :                 +- Relation default.t[id#20,name#21] parquet
   +- SubqueryAlias l2
      +- Project [id#31]
         +- Filter (count(distinct name#26)#33L > cast(1 as bigint))
            +- !Aggregate [id#31], [id#31, count(distinct name#26) AS count(distinct name#26)#33L]
               +- SubqueryAlias spark_catalog.default.v1
                  +- View (`default`.`v1`, [id#31,name#32])
                     +- Project [cast(id#27 as int) AS id#31, cast(name#28 as string) AS name#32]
                        +- Project [id#27, name#28]
                           +- SubqueryAlias spark_catalog.default.t
                              +- Relation default.t[id#27,name#28] parquet
```
Spark will consider the two views to be duplicates, which will cause the query to fail. We can add new aliases to attributes in the view to avoid two views from being considered duplicates.

Optimization plan after this change：
```
Aggregate [name#26, id#25], [id#25]
+- Join Inner, (id#25 = id#27)
   :- SubqueryAlias l1
   :  +- SubqueryAlias spark_catalog.default.v1
   :     +- View (`default`.`v1`, [id#25,name#26])
   :        +- Project [cast(id#20 as int) AS id#25, cast(name#21 as string) AS name#26]
   :           +- Project [id#20, name#21]
   :              +- SubqueryAlias spark_catalog.default.t
   :                 +- Relation default.t[id#20,name#21] parquet
   +- SubqueryAlias l2
      +- Project [id#27]
         +- Filter (count(distinct name#28)#33L > cast(1 as bigint))
            +- Aggregate [id#27], [id#27, count(distinct name#28) AS count(distinct name#28)#33L]
               +- SubqueryAlias spark_catalog.default.v1
                  +- View (`default`.`v1`, [id#27,name#28])
                     +- Project [cast(id#29 as int) AS id#27, cast(name#30 as string) AS name#28]
                        +- Project [id#29, name#30]
                           +- SubqueryAlias spark_catalog.default.t
                              +- Relation default.t[id#29,name#30] parquet
```
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix bug when using join in duplicate views.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. When we join with duplicate view, the query would be successful.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add new UT