### PR TITLE
[WIP][SPARK-37946][SQL] Use error classes in the execution errors related to partitions

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -167,5 +167,89 @@
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"
+  },
+  "UNABLE_TO_DELETE_PARTITION_PATH" : {
+    "message" : [ "Unable to delete partition path %s" ],
+    "sqlState" : "42000"
+  },
+  "UNABLE_TO_CREATE_PARTITION_PATH" : {
+    "message" : [ "Unable to create partition path %s" ],
+    "sqlState" : "42000"
+  },
+  "UNABLE_TO_RENAME_PARTITION_PATH" : {
+    "message" : [ "Unable to rename partition path %s" ],
+    "sqlState" : "42000"
+  },
+  "NOT_A_DATA_SOURCE_RDD_PARTITION" : {
+    "message" : [ "[BUG] Not a DataSourceRDDPartition: %s" ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_CLEAR_PARTITION_DIRECTORY" : {
+    "message" : [ "Unable to clear partition directory %s prior to writing to it" ],
+    "sqlState" : "42000"
+  },
+  "FAILED_TO_CAST_VALUE_TO_DATATYPE_FOR_PARTITION_COLUMN" : {
+    "message" : [ "Failed to cast value %s to %s for partition column %s" ],
+    "sqlState" : "42000"
+  },
+  "UNSUPPORTED_PARTITION_TRANSFORM" : {
+    "message" : [ "SessionCatalog does not support partition transform: %s" ],
+    "sqlState" : "0A000"
+  },
+  "CANNOT_CREATE_JDBC_TABLE_WITH_PARTITIONS" : {
+    "message" : [ "Cannot create JDBC table with partition" ],
+    "sqlState" : "0A000"
+  },
+  "REQUESTED_PARTITIONS_MISMATCH_TABLE_PARTITIONS" : {
+    "message" : [ "Requested partitioning does not match the %s table:\\nRequested partitions: %s\\nTable partitions: %s" ],
+    "sqlState" : "42000"
+  },
+  "DYNAMIC_PARTITION_KEY_NOT_AMONG_WRITTEN_PARTITION_PATHS" : {
+    "message" : [ "Dynamic partition key %s is not among written partition paths." ],
+    "sqlState" : "42000"
+  },
+  "CANNOT_REMOVE_PARTITION_DIR" : {
+    "message" : [ "Cannot remove partition directory '%s'" ],
+    "sqlState" : "42000"
+  },
+  "ALTER_TABLE_WITH_DROP_PARTITION_AND_PURGE_UNSUPPORTED" : {
+    "message" : [ "ALTER TABLE ... DROP PARTITION ... PURGE" ],
+    "sqlState" : "0A000"
+  },
+  "INVALID_PARTITION_FILTER" : {
+    "message" : [ "Partition filter cannot have both `\"` and `'` characters" ],
+    "sqlState" : "0A000"
+  },
+  "GET_PARTITION_METADATA_BY_FILTER" : {
+    "message" : [ "Caught Hive MetaException attempting to get partition metadata by filter from Hive.You can set the Spark configuration setting %s to true to work around this problem, however this will result in degraded performance. Please report a bug: https://issues.apache.org/jira/browse/SPARK" ],
+    "sqlState" : "42000"
+  },
+  "ILLEGAL_LOCATION_CLAUSE_FOR_VIEW_PARTITION" : {
+    "message" : [ "LOCATION clause illegal for view partition" ],
+    "sqlState" : "42000"
+  },
+  "PARTITION_COLUMN_NOT_FOUND_IN_SCHEMA" : {
+    "message" : [ "Partition column %s not found in schema %s" ],
+    "sqlState" : "22023"
+  },
+  "CANNOT_ADD_MULTI_PARTITIONS_ON_NONATOMIC_PARTITION_TABLE" : {
+    "message" : [ "Nonatomic partition table %s can not add multiple partitions." ],
+    "sqlState" : "0A000"
+  },
+  "CANNOT_DROP_MULTI_PARTITIONS_ON_NONATOMIC_PARTITION_TABLE" : {
+    "message" : [ "%s source does not support user-specified schema." ],
+    "sqlState" : "0A000"
+  },
+  "TRUNCATE_MULTI_PARTITION_UNSUPPORTED" : {
+    "message" : [ "The table %s does not support truncation of multiple partition." ],
+    "sqlState" : "0A000"
+  },
+  "DYNAMIC_PARTITION_OVERWRITE_UNSUPPORTED_BY_TABLE" : {
+    "message" : [ "Table does not support dynamic partition overwrite: %s" ],
+    "sqlState" : "0A000"
+  },
+  "WRITE_PARTITION_EXCEED_CONFIG_SIZE_WHEN_DYNAMIC_PARTITION" : {
+    "message" : [ "Number of dynamic partitions created is %s, which is more than %s. To solve this try to set %s to at least %s." ],
+    "sqlState" : "22000"
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -422,7 +422,7 @@ object QueryExecutionErrors {
   }
 
   def unableToDeletePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to delete partition path $partitionPath", e)
+    new SparkException("UNABLE_TO_DELETE_PARTITION_PATH", Array(partitionPath), e)
   }
 
   def unableToDropTableAsFailedToDeleteDirectoryError(
@@ -438,11 +438,11 @@ object QueryExecutionErrors {
   }
 
   def unableToCreatePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to create partition path $partitionPath", e)
+    new SparkException("UNABLE_TO_CREATE_PARTITION_PATH", Array(partitionPath), e)
   }
 
   def unableToRenamePartitionPathError(oldPartPath: Path, e: IOException): Throwable = {
-    new SparkException(s"Unable to rename partition path $oldPartPath", e)
+    new SparkException("UNABLE_TO_RENAME_PARTITION_PATH", Array(oldPartPath), e)
   }
 
   def methodNotImplementedError(methodName: String): Throwable = {
@@ -499,7 +499,7 @@ object QueryExecutionErrors {
   }
 
   def notADatasourceRDDPartitionError(split: Partition): Throwable = {
-    new SparkException(s"[BUG] Not a DataSourceRDDPartition: $split")
+    new SparkException("NOT_A_DATA_SOURCE_RDD_PARTITION", Array(split), null)
   }
 
   def dataPathNotSpecifiedError(): Throwable = {
@@ -607,13 +607,13 @@ object QueryExecutionErrors {
   }
 
   def cannotClearPartitionDirectoryError(path: Path): Throwable = {
-    new IOException(s"Unable to clear partition directory $path prior to writing to it")
+    new SparkException("CANNOT_CLEAR_PARTITION_DIRECTORY", Array(path), null)
   }
 
   def failedToCastValueToDataTypeForPartitionColumnError(
       value: String, dataType: DataType, columnName: String): Throwable = {
-    new RuntimeException(s"Failed to cast value `$value` to " +
-      s"`$dataType` for partition column `$columnName`")
+    new SparkException("FAILED_TO_CAST_VALUE_TO_DATATYPE_FOR_PARTITION_COLUMN"
+      , Array(value, dataType, columnName), null)
   }
 
   def endOfStreamError(): Throwable = {
@@ -668,8 +668,7 @@ object QueryExecutionErrors {
   }
 
   def unsupportedPartitionTransformError(transform: Transform): Throwable = {
-    new UnsupportedOperationException(
-      s"SessionCatalog does not support partition transform: $transform")
+    new SparkException("UNSUPPORTED_PARTITION_TRANSFORM", Array(transform), null)
   }
 
   def missingDatabaseLocationError(): Throwable = {
@@ -708,7 +707,7 @@ object QueryExecutionErrors {
   }
 
   def cannotCreateJDBCTableWithPartitionsError(): Throwable = {
-    new UnsupportedOperationException("Cannot create JDBC table with partition")
+    new SparkException("CANNOT_CREATE_JDBC_TABLE_WITH_PARTITIONS", Array.empty, null)
   }
 
   def unsupportedUserSpecifiedSchemaError(): Throwable = {
@@ -1354,19 +1353,20 @@ object QueryExecutionErrors {
   def requestedPartitionsMismatchTablePartitionsError(
       table: CatalogTable, partition: Map[String, Option[String]]): Throwable = {
     new SparkException(
-      s"""
-         |Requested partitioning does not match the ${table.identifier.table} table:
-         |Requested partitions: ${partition.keys.mkString(",")}
-         |Table partitions: ${table.partitionColumnNames.mkString(",")}
-       """.stripMargin)
+       "REQUESTED_PARTITIONS_MISMATCH_TABLE_PARTITIONS",
+       Array(table.identifier.table,
+         partition.keys.mkString(","),
+         table.partitionColumnNames.mkString(",")
+       ),
+       null)
   }
 
   def dynamicPartitionKeyNotAmongWrittenPartitionPathsError(key: String): Throwable = {
-    new SparkException(s"Dynamic partition key $key is not among written partition paths.")
+    new SparkException("DYNAMIC_PARTITION_KEY_NOT_AMONG_WRITTEN_PARTITION_PATHS", Array(key), null)
   }
 
   def cannotRemovePartitionDirError(partitionPath: Path): Throwable = {
-    new RuntimeException(s"Cannot remove partition directory '$partitionPath'")
+    new SparkException("CANNOT_REMOVE_PARTITION_DIR", Array(partitionPath), null)
   }
 
   def cannotCreateStagingDirError(message: String, e: IOException): Throwable = {
@@ -1399,23 +1399,16 @@ object QueryExecutionErrors {
   }
 
   def alterTableWithDropPartitionAndPurgeUnsupportedError(): Throwable = {
-    new UnsupportedOperationException("ALTER TABLE ... DROP PARTITION ... PURGE")
+    new SparkException("ALTER_TABLE_WITH_DROP_PARTITION_AND_PURGE_UNSUPPORTED", Array.empty, null)
   }
 
   def invalidPartitionFilterError(): Throwable = {
-    new UnsupportedOperationException(
-      """Partition filter cannot have both `"` and `'` characters""")
+    new SparkException("INVALID_PARTITION_FILTER", Array.empty, null)
   }
 
   def getPartitionMetadataByFilterError(e: InvocationTargetException): Throwable = {
-    new RuntimeException(
-      s"""
-         |Caught Hive MetaException attempting to get partition metadata by filter
-         |from Hive. You can set the Spark configuration setting
-         |${SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ON_EXCEPTION.key} to true to work
-         |around this problem, however this will result in degraded performance. Please
-         |report a bug: https://issues.apache.org/jira/browse/SPARK
-       """.stripMargin.replaceAll("\n", " "), e)
+     new SparkException("GET_PARTITION_METADATA_BY_FILTER",
+       Array(SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FALLBACK_ON_EXCEPTION.key), e)
   }
 
   def unsupportedHiveMetastoreVersionError(version: String, key: String): Throwable = {
@@ -1441,7 +1434,7 @@ object QueryExecutionErrors {
   }
 
   def illegalLocationClauseForViewPartitionError(): Throwable = {
-    new SparkException("LOCATION clause illegal for view partition")
+    new SparkException("ILLEGAL_LOCATION_CLAUSE_FOR_VIEW_PARTITION", Array.empty, null)
   }
 
   def renamePathAsExistsPathError(srcPath: Path, dstPath: Path): Throwable = {
@@ -1484,7 +1477,7 @@ object QueryExecutionErrors {
   }
 
   def partitionColumnNotFoundInSchemaError(col: String, schema: StructType): Throwable = {
-    new RuntimeException(s"Partition column $col not found in schema $schema")
+    new SparkException("PARTITION_COLUMN_NOT_FOUND_IN_SCHEMA", Array(col, schema), null)
   }
 
   def stateNotDefinedOrAlreadyRemovedError(): Throwable = {
@@ -1699,8 +1692,9 @@ object QueryExecutionErrors {
   }
 
   def cannotAddMultiPartitionsOnNonatomicPartitionTableError(tableName: String): Throwable = {
-    new UnsupportedOperationException(
-      s"Nonatomic partition table $tableName can not add multiple partitions.")
+    new SparkException(
+      "CANNOT_ADD_MULTI_PARTITIONS_ON_NONATOMIC_PARTITION_TABLE",
+      Array(tableName), null)
   }
 
   def userSpecifiedSchemaUnsupportedByDataSourceError(provider: TableProvider): Throwable = {
@@ -1709,13 +1703,13 @@ object QueryExecutionErrors {
   }
 
   def cannotDropMultiPartitionsOnNonatomicPartitionTableError(tableName: String): Throwable = {
-    new UnsupportedOperationException(
-      s"Nonatomic partition table $tableName can not drop multiple partitions.")
+    new SparkException(
+      "CANNOT_DROP_MULTI_PARTITIONS_ON_NONATOMIC_PARTITION_TABLE",
+      Array(tableName), null)
   }
 
   def truncateMultiPartitionUnsupportedError(tableName: String): Throwable = {
-    new UnsupportedOperationException(
-      s"The table $tableName does not support truncation of multiple partition.")
+    new SparkException("TRUNCATE_MULTI_PARTITION_UNSUPPORTED", Array(tableName), null)
   }
 
   def overwriteTableByUnsupportedExpressionError(table: Table): Throwable = {
@@ -1723,7 +1717,7 @@ object QueryExecutionErrors {
   }
 
   def dynamicPartitionOverwriteUnsupportedByTableError(table: Table): Throwable = {
-    new SparkException(s"Table does not support dynamic partition overwrite: $table")
+    new SparkException("DYNAMIC_PARTITION_OVERWRITE_UNSUPPORTED_BY_TABLE", Array(table), null)
   }
 
   def failedMergingSchemaError(schema: StructType, e: SparkException): Throwable = {
@@ -1942,10 +1936,8 @@ object QueryExecutionErrors {
       maxDynamicPartitions: Int,
       maxDynamicPartitionsKey: String): Throwable = {
     new SparkException(
-      s"Number of dynamic partitions created is $numWrittenParts" +
-        s", which is more than $maxDynamicPartitions" +
-        s". To solve this try to set $maxDynamicPartitionsKey" +
-        s" to at least $numWrittenParts.")
+      "WRITE_PARTITION_EXCEED_CONFIG_SIZE_WHEN_DYNAMIC_PARTITION",
+      Array(numWrittenParts, maxDynamicPartitions, maxDynamicPartitionsKey, numWrittenParts), null)
   }
 
   def invalidNumberFormatError(input: UTF8String, format: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -422,7 +422,7 @@ object QueryExecutionErrors {
   }
 
   def unableToDeletePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException("UNABLE_TO_DELETE_PARTITION_PATH", Array(partitionPath), e)
+    new SparkException("UNABLE_TO_DELETE_PARTITION_PATH", Array(partitionPath.toString), e)
   }
 
   def unableToDropTableAsFailedToDeleteDirectoryError(
@@ -438,11 +438,11 @@ object QueryExecutionErrors {
   }
 
   def unableToCreatePartitionPathError(partitionPath: Path, e: IOException): Throwable = {
-    new SparkException("UNABLE_TO_CREATE_PARTITION_PATH", Array(partitionPath), e)
+    new SparkException("UNABLE_TO_CREATE_PARTITION_PATH", Array(partitionPath.toString), e)
   }
 
   def unableToRenamePartitionPathError(oldPartPath: Path, e: IOException): Throwable = {
-    new SparkException("UNABLE_TO_RENAME_PARTITION_PATH", Array(oldPartPath), e)
+    new SparkException("UNABLE_TO_RENAME_PARTITION_PATH", Array(oldPartPath.toString), e)
   }
 
   def methodNotImplementedError(methodName: String): Throwable = {
@@ -499,7 +499,7 @@ object QueryExecutionErrors {
   }
 
   def notADatasourceRDDPartitionError(split: Partition): Throwable = {
-    new SparkException("NOT_A_DATA_SOURCE_RDD_PARTITION", Array(split), null)
+    new SparkException("NOT_A_DATA_SOURCE_RDD_PARTITION", Array(split.toString), null)
   }
 
   def dataPathNotSpecifiedError(): Throwable = {
@@ -607,13 +607,13 @@ object QueryExecutionErrors {
   }
 
   def cannotClearPartitionDirectoryError(path: Path): Throwable = {
-    new SparkException("CANNOT_CLEAR_PARTITION_DIRECTORY", Array(path), null)
+    new SparkException("CANNOT_CLEAR_PARTITION_DIRECTORY", Array(path.toString), null)
   }
 
   def failedToCastValueToDataTypeForPartitionColumnError(
       value: String, dataType: DataType, columnName: String): Throwable = {
     new SparkException("FAILED_TO_CAST_VALUE_TO_DATATYPE_FOR_PARTITION_COLUMN"
-      , Array(value, dataType, columnName), null)
+      , Array(value, dataType.toString, columnName), null)
   }
 
   def endOfStreamError(): Throwable = {
@@ -668,7 +668,7 @@ object QueryExecutionErrors {
   }
 
   def unsupportedPartitionTransformError(transform: Transform): Throwable = {
-    new SparkException("UNSUPPORTED_PARTITION_TRANSFORM", Array(transform), null)
+    new SparkException("UNSUPPORTED_PARTITION_TRANSFORM", Array(transform.toString), null)
   }
 
   def missingDatabaseLocationError(): Throwable = {
@@ -1366,7 +1366,7 @@ object QueryExecutionErrors {
   }
 
   def cannotRemovePartitionDirError(partitionPath: Path): Throwable = {
-    new SparkException("CANNOT_REMOVE_PARTITION_DIR", Array(partitionPath), null)
+    new SparkException("CANNOT_REMOVE_PARTITION_DIR", Array(partitionPath.toString), null)
   }
 
   def cannotCreateStagingDirError(message: String, e: IOException): Throwable = {
@@ -1477,7 +1477,7 @@ object QueryExecutionErrors {
   }
 
   def partitionColumnNotFoundInSchemaError(col: String, schema: StructType): Throwable = {
-    new SparkException("PARTITION_COLUMN_NOT_FOUND_IN_SCHEMA", Array(col, schema), null)
+    new SparkException("PARTITION_COLUMN_NOT_FOUND_IN_SCHEMA", Array(col, schema.toString), null)
   }
 
   def stateNotDefinedOrAlreadyRemovedError(): Throwable = {
@@ -1717,7 +1717,8 @@ object QueryExecutionErrors {
   }
 
   def dynamicPartitionOverwriteUnsupportedByTableError(table: Table): Throwable = {
-    new SparkException("DYNAMIC_PARTITION_OVERWRITE_UNSUPPORTED_BY_TABLE", Array(table), null)
+    new SparkException("DYNAMIC_PARTITION_OVERWRITE_UNSUPPORTED_BY_TABLE",
+      Array(table.toString), null)
   }
 
   def failedMergingSchemaError(schema: StructType, e: SparkException): Throwable = {
@@ -1937,7 +1938,8 @@ object QueryExecutionErrors {
       maxDynamicPartitionsKey: String): Throwable = {
     new SparkException(
       "WRITE_PARTITION_EXCEED_CONFIG_SIZE_WHEN_DYNAMIC_PARTITION",
-      Array(numWrittenParts, maxDynamicPartitions, maxDynamicPartitionsKey, numWrittenParts), null)
+      Array(numWrittenParts.toString, maxDynamicPartitions.toString,
+        maxDynamicPartitionsKey, numWrittenParts.toString), null)
   }
 
   def invalidNumberFormatError(input: UTF8String, format: String): Throwable = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use error classes defined in `error-classes.json` in the execution errors related to partitions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To use the new error framework.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
TBD