### PR TITLE
[SPARK-38080][TESTS][SS]Flaky test: StreamingQueryManagerSuite: 'awaitAnyTermination with timeout and resetTerminated'

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -201,9 +201,13 @@ class StreamingQueryManagerSuite extends StreamTest {
 
       // After that query is stopped, awaitAnyTerm should throw exception
       eventually(Timeout(streamingTimeout)) { require(!q3.isActive) } // wait for query to stop
+      // When `isActive` becomes `false`, `StreamingQueryManager` may not receive the error yet.
+      // Hence, call `stop` to wait until the thread of `q3` exits so that we can ensure
+      // `StreamingQueryManager` has already received the error.
+      q3.stop()
       testAwaitAnyTermination(
         ExpectException[SparkException],
-        awaitTimeout = 2.second,
+        awaitTimeout = 100.milliseconds,
         testBehaviorFor = 4.seconds)
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a flaky test.

### Why are the changes needed?

`StreamingQueryManagerSuite: 'awaitAnyTermination with timeout and resetTerminated'` is a flaky test.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

- The flaky test can be reproduced by adding a `Thread.sleep(100)` in https://github.com/apache/spark/blob/v3.2.1/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala#L346
- Using the above reproduction to verify the PR. 