### PR TITLE
[SPARK-38047][K8S] Add `OUTLIER_NO_FALLBACK` executor roll policy

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -147,7 +147,8 @@ private[spark] object Config extends Logging {
       .createWithDefault(0)
 
   object ExecutorRollPolicy extends Enumeration {
-    val ID, ADD_TIME, TOTAL_GC_TIME, TOTAL_DURATION, AVERAGE_DURATION, FAILED_TASKS, OUTLIER = Value
+    val ID, ADD_TIME, TOTAL_GC_TIME, TOTAL_DURATION, AVERAGE_DURATION, FAILED_TASKS,
+    OUTLIER, OUTLIER_OR_TOTAL_DURATION = Value
   }
 
   val EXECUTOR_ROLL_POLICY =
@@ -165,7 +166,9 @@ private[spark] object Config extends Logging {
         "OUTLIER policy chooses an executor with outstanding statistics which is bigger than" +
         "at least two standard deviation from the mean in average task time, " +
         "total task time, total task GC time, and the number of failed tasks if exists. " +
-        "If there is no outlier, it works like TOTAL_DURATION policy.")
+        "If there is no outlier then no executor will be rolled." +
+        "OUTLIER_OR_TOTAL_DURATION policy picks an outlier using the OUTLIER policy above. " +
+        "If there is no outlier it works like TOTAL_DURATION policy.")
       .version("3.3.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
@@ -181,16 +184,6 @@ private[spark] object Config extends Logging {
       .intConf
       .checkValue(_ >= 0, "The minimum number of tasks should be non-negative.")
       .createWithDefault(0)
-
-  val EXECUTOR_ROLL_OUTLIERS_ONLY =
-    ConfigBuilder("spark.kubernetes.executor.onlyRollOutliers")
-      .doc("Only roll an executor if it is an outlier. An outlier is defined to be at least two " +
-        "standard deviation outside of the mean. If no outlier is found then no executor will " +
-        "be rolled."
-      )
-      .version("3.3.0")
-      .booleanConf
-      .createWithDefault(false)
 
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -182,6 +182,16 @@ private[spark] object Config extends Logging {
       .checkValue(_ >= 0, "The minimum number of tasks should be non-negative.")
       .createWithDefault(0)
 
+  val EXECUTOR_ROLL_OUTLIERS_ONLY =
+    ConfigBuilder("spark.kubernetes.executor.onlyRollOutliers")
+      .doc("Only roll an executor if it is an outlier. An outlier is defined to be at least two " +
+        "standard deviation outside of the mean. If no outlier is found then no executor will " +
+        "be rolled."
+      )
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val KUBERNETES_AUTH_DRIVER_CONF_PREFIX = "spark.kubernetes.authenticate.driver"
   val KUBERNETES_AUTH_EXECUTOR_CONF_PREFIX = "spark.kubernetes.authenticate.executor"
   val KUBERNETES_AUTH_DRIVER_MOUNTED_CONF_PREFIX = "spark.kubernetes.authenticate.driver.mounted"

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -148,7 +148,7 @@ private[spark] object Config extends Logging {
 
   object ExecutorRollPolicy extends Enumeration {
     val ID, ADD_TIME, TOTAL_GC_TIME, TOTAL_DURATION, AVERAGE_DURATION, FAILED_TASKS,
-    OUTLIER, OUTLIER_OR_TOTAL_DURATION = Value
+      OUTLIER, OUTLIER_NO_FALLBACK = Value
   }
 
   val EXECUTOR_ROLL_POLICY =
@@ -166,9 +166,9 @@ private[spark] object Config extends Logging {
         "OUTLIER policy chooses an executor with outstanding statistics which is bigger than" +
         "at least two standard deviation from the mean in average task time, " +
         "total task time, total task GC time, and the number of failed tasks if exists. " +
-        "If there is no outlier then no executor will be rolled." +
-        "OUTLIER_OR_TOTAL_DURATION policy picks an outlier using the OUTLIER policy above. " +
-        "If there is no outlier it works like TOTAL_DURATION policy.")
+        "If there is no outlier it works like TOTAL_DURATION policy. " +
+        "OUTLIER_NO_FALLBACK policy picks an outlier using the OUTLIER policy above. " +
+        "If there is no outlier then no executor will be rolled.")
       .version("3.3.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPlugin.scala
@@ -134,9 +134,7 @@ class ExecutorRollDriverPlugin extends DriverPlugin with Logging {
    * Since we will choose only first item, the duplication is okay.
    */
   private def outliersFromMultipleDimensions(listWithoutDriver: Seq[v1.ExecutorSummary]) =
-    outliers(
-      listWithoutDriver.filter(_.totalTasks > 0),
-      e => e.totalDuration / e.totalTasks) ++
+    outliers(listWithoutDriver.filter(_.totalTasks > 0), e => e.totalDuration / e.totalTasks) ++
       outliers(listWithoutDriver, e => e.totalDuration) ++
       outliers(listWithoutDriver, e => e.totalGCTime) ++
       outliers(listWithoutDriver, e => e.failedTasks)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPluginSuite.scala
@@ -132,9 +132,7 @@ class ExecutorRollPluginSuite extends SparkFunSuite with PrivateMethodTester {
   }
 
   test("A one-item executor list") {
-    ExecutorRollPolicy.values
-      .filter(_ != ExecutorRollPolicy.OUTLIER)
-      .foreach { value =>
+    ExecutorRollPolicy.values.filter(_ != ExecutorRollPolicy.OUTLIER_NO_FALLBACK).foreach { value =>
       assertEquals(
         Some(execWithSmallestID.id),
         plugin.invokePrivate(_choose(Seq(execWithSmallestID), value)))
@@ -174,53 +172,10 @@ class ExecutorRollPluginSuite extends SparkFunSuite with PrivateMethodTester {
       plugin.invokePrivate(_choose(list, ExecutorRollPolicy.AVERAGE_DURATION)))
   }
 
-  test("Policy: OUTLIER_OR_TOTAL_DURATION - Use TOTAL_DURATION if there is no outlier") {
+  test("Policy: OUTLIER - Work like TOTAL_DURATION if there is no outlier") {
     assertEquals(
       plugin.invokePrivate(_choose(list, ExecutorRollPolicy.TOTAL_DURATION)),
-      plugin.invokePrivate(_choose(list, ExecutorRollPolicy.OUTLIER_OR_TOTAL_DURATION)))
-  }
-
-  test("Policy: OUTLIER_OR_TOTAL_DURATION - Detect an average task duration outlier") {
-    val outlier = new ExecutorSummary("9999", "host:port", true, 1,
-      0, 0, 1, 0, 0,
-      3, 0, 1, 300,
-      20, 0, 0,
-      0, false, 0, new Date(1639300001000L),
-      Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
-      false, Set())
-    assertEquals(
-      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.AVERAGE_DURATION)),
-      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER_OR_TOTAL_DURATION)))
-  }
-
-  test("Policy: OUTLIER_OR_TOTAL_DURATION - Detect a total task duration outlier") {
-    val outlier = new ExecutorSummary("9999", "host:port", true, 1,
-      0, 0, 1, 0, 0,
-      3, 0, 1000, 1000,
-      0, 0, 0,
-      0, false, 0, new Date(1639300001000L),
-      Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
-      false, Set())
-    assertEquals(
-      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.TOTAL_DURATION)),
-      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER_OR_TOTAL_DURATION)))
-  }
-
-  test("Policy: OUTLIER_OR_TOTAL_DURATION - Detect a total GC time outlier") {
-    val outlier = new ExecutorSummary("9999", "host:port", true, 1,
-      0, 0, 1, 0, 0,
-      3, 0, 1, 100,
-      1000, 0, 0,
-      0, false, 0, new Date(1639300001000L),
-      Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
-      false, Set())
-    assertEquals(
-      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.TOTAL_GC_TIME)),
-      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER_OR_TOTAL_DURATION)))
-  }
-
-  test("Policy: OUTLIER - Return None if not outliers") {
-    assertEquals(None, plugin.invokePrivate(_choose(list, ExecutorRollPolicy.OUTLIER)))
+      plugin.invokePrivate(_choose(list, ExecutorRollPolicy.OUTLIER)))
   }
 
   test("Policy: OUTLIER - Detect an average task duration outlier") {
@@ -260,5 +215,48 @@ class ExecutorRollPluginSuite extends SparkFunSuite with PrivateMethodTester {
     assertEquals(
       plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.TOTAL_GC_TIME)),
       plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER)))
+  }
+
+  test("Policy: OUTLIER_NO_FALLBACK - Return None if there are no outliers") {
+    assertEquals(None, plugin.invokePrivate(_choose(list, ExecutorRollPolicy.OUTLIER_NO_FALLBACK)))
+  }
+
+  test("Policy: OUTLIER_NO_FALLBACK - Detect an average task duration outlier") {
+    val outlier = new ExecutorSummary("9999", "host:port", true, 1,
+      0, 0, 1, 0, 0,
+      3, 0, 1, 300,
+      20, 0, 0,
+      0, false, 0, new Date(1639300001000L),
+      Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+      false, Set())
+    assertEquals(
+      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.AVERAGE_DURATION)),
+      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER_NO_FALLBACK)))
+  }
+
+  test("Policy: OUTLIER_NO_FALLBACK - Detect a total task duration outlier") {
+    val outlier = new ExecutorSummary("9999", "host:port", true, 1,
+      0, 0, 1, 0, 0,
+      3, 0, 1000, 1000,
+      0, 0, 0,
+      0, false, 0, new Date(1639300001000L),
+      Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+      false, Set())
+    assertEquals(
+      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.TOTAL_DURATION)),
+      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER_NO_FALLBACK)))
+  }
+
+  test("Policy: OUTLIER_NO_FALLBACK - Detect a total GC time outlier") {
+    val outlier = new ExecutorSummary("9999", "host:port", true, 1,
+      0, 0, 1, 0, 0,
+      3, 0, 1, 100,
+      1000, 0, 0,
+      0, false, 0, new Date(1639300001000L),
+      Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+      false, Set())
+    assertEquals(
+      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.TOTAL_GC_TIME)),
+      plugin.invokePrivate(_choose(list :+ outlier, ExecutorRollPolicy.OUTLIER_NO_FALLBACK)))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new executor roll policy which allows users to skip rolling in cases where there are no outlier executors.

### Why are the changes needed?

As currently implemented an executor is always rolled every `spark.kubernetes.executor.rollInterval` interval. In environments where starting of executors can introduce latencies it may be desirable for users to have the option to determine if rolling should only happen when outliers are found.

### Does this PR introduce _any_ user-facing change?

No, this is an additional option being added to a new feature in Apache Spark 3.3.

### How was this patch tested?

Pass the CIs with the newly added test cases.