### PR TITLE
[SPARK-38081][K8S][TESTS] Support `cloud`-backend in K8s IT with SBT

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -649,7 +649,7 @@ object KubernetesIntegrationTests {
           "-t", imageTag.getOrElse("dev"),
           "-p", s"$bindingsDir/python/Dockerfile",
           "-R", s"$bindingsDir/R/Dockerfile") ++
-          (if (deployMode == Some("docker-for-desktop")) Seq.empty else Seq("-m")) ++
+          (if (deployMode != Some("minikube")) Seq.empty else Seq("-m")) ++
           extraOptions :+
           "build"
         val ec = Process(cmd).!

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -623,6 +623,7 @@ object KubernetesIntegrationTests {
 
   val dockerBuild = TaskKey[Unit]("docker-imgs", "Build the docker images for ITs.")
   val runITs = TaskKey[Unit]("run-its", "Only run ITs, skip image build.")
+  val imageRepo = sys.props.getOrElse("spark.kubernetes.test.imageRepo", "docker.io/kubespark")
   val imageTag = sys.props.get("spark.kubernetes.test.imageTag")
   val namespace = sys.props.get("spark.kubernetes.test.namespace")
   val deployMode = sys.props.get("spark.kubernetes.test.deployMode")
@@ -646,6 +647,7 @@ object KubernetesIntegrationTests {
           Seq("-f", s"$dockerFile")
         }
         val cmd = Seq(dockerTool,
+          "-r", imageRepo,
           "-t", imageTag.getOrElse("dev"),
           "-p", s"$bindingsDir/python/Dockerfile",
           "-R", s"$bindingsDir/R/Dockerfile") ++
@@ -655,6 +657,13 @@ object KubernetesIntegrationTests {
         val ec = Process(cmd).!
         if (ec != 0) {
           throw new IllegalStateException(s"Process '${cmd.mkString(" ")}' exited with $ec.")
+        }
+        if (deployMode == Some("cloud")) {
+          val cmd = Seq(dockerTool, "-r", imageRepo, "-t", imageTag.getOrElse("dev"), "push")
+          val ret = Process(cmd).!
+          if (ret != 0) {
+            throw new IllegalStateException(s"Process '${cmd.mkString(" ")}' exited with $ret.")
+          }
         }
       }
       shouldBuildImage = true

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -677,6 +677,7 @@ object KubernetesIntegrationTests {
     (Test / test) := (Test / test).dependsOn(dockerBuild).value,
     (Test / javaOptions) ++= Seq(
       s"-Dspark.kubernetes.test.deployMode=${deployMode.getOrElse("minikube")}",
+      s"-Dspark.kubernetes.test.imageRepo=${imageRepo}",
       s"-Dspark.kubernetes.test.imageTag=${imageTag.getOrElse("dev")}",
       s"-Dspark.kubernetes.test.unpackSparkDir=$sparkHome"
     ),

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -187,7 +187,7 @@ to the wrapper scripts and using the wrapper scripts will simply set these appro
   <tr>
     <td><code>spark.kubernetes.test.master</code></td>
     <td>
-      When using the <code>cloud-url</code> backend must be specified to indicate the K8S master URL to communicate 
+      When using the <code>cloud</code> backend must be specified to indicate the K8S master URL to communicate
       with.
     </td>
     <td></td>

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.launcher.SparkLauncher
 private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
 
   import BasicTestsSuite._
-  import KubernetesSuite.k8sTestTag
+  import KubernetesSuite.{k8sTestTag, localTestTag}
   import KubernetesSuite.{TIMEOUT, INTERVAL}
 
   test("Run SparkPi with no resources", k8sTestTag) {
@@ -116,7 +116,7 @@ private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
       expectedJVMValue = Seq("(spark.test.foo,spark.test.bar)"))
   }
 
-  test("Run SparkRemoteFileTest using a remote data file", k8sTestTag) {
+  test("Run SparkRemoteFileTest using a remote data file", k8sTestTag, localTestTag) {
     assert(sys.props.contains("spark.test.home"), "spark.test.home is not set!")
     TestUtils.withHttpServer(sys.props("spark.test.home")) { baseURL =>
       sparkAppConf.set("spark.files", baseURL.toString +

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -595,6 +595,7 @@ class KubernetesSuite extends SparkFunSuite
 
 private[spark] object KubernetesSuite {
   val k8sTestTag = Tag("k8s")
+  val localTestTag = Tag("local")
   val rTestTag = Tag("r")
   val MinikubeTag = Tag("minikube")
   val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPi"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to
- Support `cloud` backend in K8s IT with SBT (Image building/pushing/testing)
- Add a new K8s test tag, `local`, and apply it to a test case using local HTTP server.

### Why are the changes needed?

To run K8s IT in the cloud environment more easily.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually test like the following.
```
$ build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests -Dtest.exclude.tags=minikube,local -Dspark.kubernetes.test.deployMode=cloud -Dspark.kubernetes.test.master=k8s://....eks.amazonaws.com -Dspark.kubernetes.test.namespace=spark-cloud-test -Dspark.kubernetes.test.imageRepo=... -Dspark.kubernetes.test.imageTag=2022-02-01 "kubernetes-integration-tests/test"

...
[info] KubernetesSuite:
[info] - Run SparkPi with no resources (26 seconds, 678 milliseconds)
[info] - Run SparkPi with no resources & statefulset allocation (18 seconds, 617 milliseconds)
[info] - Run SparkPi with a very long application name. (17 seconds, 205 milliseconds)
[info] - Use SparkLauncher.NO_RESOURCE (17 seconds, 555 milliseconds)
[info] - Run SparkPi with a master URL without a scheme. (17 seconds, 478 milliseconds)
[info] - Run SparkPi with an argument. (17 seconds, 518 milliseconds)
[info] - Run SparkPi with custom labels, annotations, and environment variables. (17 seconds, 648 milliseconds)
[info] - All pods have the same service account by default (17 seconds, 800 milliseconds)
[info] - Run extraJVMOptions check on driver (11 seconds, 141 milliseconds)
[info] - Verify logging configuration is picked from the provided SPARK_CONF_DIR/log4j2.properties (25 seconds, 608 milliseconds)
[info] - Run SparkPi with env and mount secrets. (27 seconds, 114 milliseconds)
[info] - Run PySpark on simple pi.py example (42 seconds, 929 milliseconds)
[info] - Run PySpark to test a pyfiles example (19 seconds, 914 milliseconds)
[info] - Run PySpark with memory customization (16 seconds, 985 milliseconds)
[info] - Run in client mode. (10 seconds, 42 milliseconds)
[info] - Start pod creation from template (16 seconds, 207 milliseconds)
[info] - Test basic decommissioning (49 seconds, 519 milliseconds)
[info] - Test basic decommissioning with shuffle cleanup (49 seconds, 472 milliseconds)
[info] - Test decommissioning with dynamic allocation & shuffle cleanups (2 minutes, 49 seconds)
[info] - Test decommissioning timeouts (50 seconds, 423 milliseconds)
[info] - SPARK-37576: Rolling decommissioning (1 minute, 13 seconds)
[info] - Run SparkR on simple dataframe.R example (51 seconds, 712 milliseconds)
[info] Run completed in 15 minutes, 50 seconds.
[info] Total number of tests run: 22
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 22, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 1920 s (32:00), completed Jan 31, 2022 11:56:38 PM
```