### PR TITLE
[SPARK-38077][SQL] Fix binary compatibility issue with isDeterministic flag

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -254,6 +254,8 @@ case class StaticInvoke(
     returnNullable: Boolean = true,
     isDeterministic: Boolean = true) extends InvokeLike {
 
+  // This additional constructor is added to keep binary compatibility after the addition of the
+  // above `isDeterministic` parameter. See SPARK-38077 for more detail.
   def this(
       staticObject: Class[_],
       dataType: DataType,
@@ -384,6 +386,8 @@ case class Invoke(
     returnNullable : Boolean = true,
     isDeterministic: Boolean = true) extends InvokeLike {
 
+  // This additional constructor is added to keep binary compatibility after the addition of the
+  // above `isDeterministic` parameter. See SPARK-38077 for more detail.
   def this(
       targetObject: Expression,
       functionName: String,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -254,6 +254,18 @@ case class StaticInvoke(
     returnNullable: Boolean = true,
     isDeterministic: Boolean = true) extends InvokeLike {
 
+  def this(
+      staticObject: Class[_],
+      dataType: DataType,
+      functionName: String,
+      arguments: Seq[Expression],
+      inputTypes: Seq[AbstractDataType],
+      propagateNull: Boolean,
+      returnNullable: Boolean) = {
+    this(staticObject, dataType, functionName, arguments, inputTypes,
+      propagateNull, returnNullable, true)
+  }
+
   val objectName = staticObject.getName.stripSuffix("$")
   val cls = if (staticObject.getName == objectName) {
     staticObject
@@ -321,6 +333,20 @@ case class StaticInvoke(
     copy(arguments = newChildren)
 }
 
+object StaticInvoke {
+  def apply(
+      staticObject: Class[_],
+      dataType: DataType,
+      functionName: String,
+      arguments: Seq[Expression],
+      inputTypes: Seq[AbstractDataType],
+      propagateNull: Boolean,
+      returnNullable: Boolean): StaticInvoke = {
+    StaticInvoke(staticObject, dataType, functionName, arguments, inputTypes, propagateNull,
+      returnNullable, true)
+  }
+}
+
 /**
  * Calls the specified function on an object, optionally passing arguments.  If the `targetObject`
  * expression evaluates to null then null will be returned.
@@ -357,6 +383,18 @@ case class Invoke(
     propagateNull: Boolean = true,
     returnNullable : Boolean = true,
     isDeterministic: Boolean = true) extends InvokeLike {
+
+  def this(
+      targetObject: Expression,
+      functionName: String,
+      dataType: DataType,
+      arguments: Seq[Expression],
+      methodInputTypes: Seq[AbstractDataType],
+      propagateNull: Boolean,
+      returnNullable : Boolean) = {
+    this(targetObject, functionName, dataType, arguments, methodInputTypes, propagateNull,
+      returnNullable, true)
+  }
 
   lazy val argClasses = ScalaReflection.expressionJavaClasses(arguments)
 
@@ -471,6 +509,19 @@ case class Invoke(
     copy(targetObject = newChildren.head, arguments = newChildren.tail)
 }
 
+object Invoke {
+  def apply(
+      targetObject: Expression,
+      functionName: String,
+      dataType: DataType,
+      arguments: Seq[Expression],
+      methodInputTypes: Seq[AbstractDataType],
+      propagateNull: Boolean,
+      returnNullable : Boolean): Invoke = {
+    Invoke(targetObject, functionName, dataType, arguments, methodInputTypes,
+      propagateNull, returnNullable, true)
+  }
+}
 object NewInstance {
   def apply(
       cls: Class[_],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This fixes a binary compatibility issue caused by SPARK-37957 with the introduction of the additional `isDeterministic` which defaults to true.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Adding method parameters with default value will break binary compatibility (see [here](https://github.com/jatcwang/binary-compatibility-guide#dont-adding-parameters-with-default-values-to-methods)). Even though Spark doesn't strictly guarantee it, it is still better to avoid. In this case, the compatibility of [frameless](https://github.com/typelevel/frameless) is broken when it wants to work with multiple Spark versions (e.g., 3.2.0 and 3.2.1).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Now it requires users to call `setDeterministic` after initializing `Invoke` and `StaticInvoke` if they want to mark the methods as non-deterministic.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing tests.