### PR TITLE
[SPARK-38089][CORE][TESTS] Show the root cause exception in `TestUtils.assertExceptionMsg`

### DIFF
--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -263,7 +263,8 @@ private[spark] object TestUtils {
       contains = contain(e, msg)
     }
     assert(contains,
-      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg")
+      s"Exception tree doesn't contain the expected exception ${typeMsg}with message: $msg\n" +
+        Utils.exceptionString(e))
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve assertion failure message in `TestUtils.assertExceptionMsg` to print out the exception tree in which it was searching (upon failure).

### Why are the changes needed?
`TestUtils.assertExceptionMsg` is great, but when the assertion _doesn't_ match, it can be challenging to tell why, because the exception tree that was searched isn't printed. Only way I could find to fix it up was to run things in a debugger and check the exception tree. This makes it easier to tell what went wrong just from the assertion failure message.

### Does this PR introduce _any_ user-facing change?
No. Easier for devs to see why their test failed.

### How was this patch tested?
Used extensively while writing the tests for PR #34009. It was very useful!

For example, let's say I had a typo in the assertion for the test case `AvroSuite.SPARK-34133: Writing user provided schema respects case sensitivity for field matching`. The failure would look like:
```
java.lang.AssertionError: assertion failed: Exception tree doesn't contain the expected exception of type
org.apache.spark.sql.avro.IncompatibleSchemaException with message: Cannot find field "FOO" in Avro schema
	at scala.Predef$.assert(Predef.scala:223)
	at org.apache.spark.TestUtils$.assertExceptionMsg(TestUtils.scala:269)
	at org.apache.spark.sql.avro.AvroSuite.$anonfun$new$175(AvroSuite.scala:1409)
	...
```
So I know that I'm wrong, but I can't tell _why_. Now, after the change:
```
java.lang.AssertionError: assertion failed: Exception tree doesn't contain the expected exception of type
org.apache.spark.sql.avro.IncompatibleSchemaException with message: Cannot find field "FOO" in Avro schema
org.apache.spark.sql.avro.IncompatibleSchemaException: Cannot find field 'FOO' in Avro schema
	at org.apache.spark.sql.avro.AvroUtils$AvroSchemaHelper.$anonfun$validateNoExtraCatalystFields$1(AvroUtils.scala:265)
	at org.apache.spark.sql.avro.AvroUtils$AvroSchemaHelper.$anonfun$validateNoExtraCatalystFields$1$adapted(AvroUtils.scala:258)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at org.apache.spark.sql.avro.AvroUtils$AvroSchemaHelper.validateNoExtraCatalystFields(AvroUtils.scala:258)
	...

	at scala.Predef$.assert(Predef.scala:223)
	at org.apache.spark.TestUtils$.assertExceptionMsg(TestUtils.scala:266)
	at org.apache.spark.sql.avro.AvroSuite.$anonfun$new$175(AvroSuite.scala:1409)
	...
```
I can easily see that I used the wrong type of quotes. Much better!