### PR TITLE
[SPARK-38094] Enable matching schema column names by field ids

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -805,6 +805,15 @@ object QueryExecutionErrors {
        """.stripMargin.replaceAll("\n", " "))
   }
 
+  def foundDuplicateFieldInFieldIdLookupModeError(
+      requiredId: Int, matchedFields: String): Throwable = {
+    new RuntimeException(
+      s"""
+         |Found duplicate field(s) "$requiredId": $matchedFields
+         |in id mapping mode
+       """.stripMargin.replaceAll("\n", " "))
+  }
+
   def failedToMergeIncompatibleSchemasError(
       left: StructType, right: StructType, e: Throwable): Throwable = {
     new SparkException(s"Failed to merge incompatible schemas $left and $right", e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -948,7 +948,7 @@ object SQLConf {
         " will use field IDs (if present) in the requested Spark schema to look up Parquet" +
         " fields instead of using column names")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val IGNORE_MISSING_PARQUET_FIELD_ID =
     buildConf("spark.sql.parquet.fieldId.ignoreMissing")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -945,8 +945,8 @@ object SQLConf {
 
   val IGNORE_MISSING_PARQUET_FIELD_ID =
     buildConf("spark.sql.parquet.fieldId.ignoreMissing")
-      .doc("When the Parquet file does't have any field IDs but the" +
-        " Spark read schema is using field IDs to read, we will return silently return nulls" +
+      .doc("When the Parquet file doesn't have any field IDs but the" +
+        " Spark read schema is using field IDs to read, we will silently return nulls" +
         "when this flag is enabled, or error otherwise.")
       .booleanConf
       .createWithDefault(false)
@@ -4269,6 +4269,8 @@ class SQLConf extends Serializable with Logging {
   def inferDictAsStruct: Boolean = getConf(SQLConf.INFER_NESTED_DICT_AS_STRUCT)
 
   def parquetFieldIdEnabled: Boolean = getConf(SQLConf.PARQUET_FIELD_ID_ENABLED)
+
+  def ignoreMissingParquetFieldId: Boolean = getConf(SQLConf.IGNORE_MISSING_PARQUET_FIELD_ID)
 
   def useV1Command: Boolean = getConf(SQLConf.LEGACY_USE_V1_COMMAND)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -953,7 +953,7 @@ object SQLConf {
       .createWithDefault(false)
 
   val IGNORE_MISSING_PARQUET_FIELD_ID =
-    buildConf("spark.sql.parquet.fieldId.ignoreMissing")
+    buildConf("spark.sql.parquet.fieldId.read.ignoreMissing")
       .doc("When the Parquet file doesn't have any field IDs but the " +
         "Spark read schema is using field IDs to read, we will silently return nulls " +
         "when this flag is enabled, or error otherwise.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -934,6 +934,23 @@ object SQLConf {
     .intConf
     .createWithDefault(4096)
 
+   val PARQUET_FIELD_ID_ENABLED =
+    buildConf("spark.sql.parquet.fieldId.enabled")
+      .doc("Field ID is a native field of the Parquet schema spec. When enabled, Parquet readers" +
+        " will use field IDs (if present) in the requested Spark schema to look up Parquet" +
+        " fields instead of using column names; Parquet writers will also populate the field Id" +
+        " metadata (if present) in the Spark schema to the Parquet schema.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val IGNORE_MISSING_PARQUET_FIELD_ID =
+    buildConf("spark.sql.parquet.fieldId.ignoreMissing")
+      .doc("When the Parquet file does't have any field IDs but the" +
+        " Spark read schema is using field IDs to read, we will return silently return nulls" +
+        "when this flag is enabled, or error otherwise.")
+      .booleanConf
+      .createWithDefault(false)
+
   val ORC_COMPRESSION = buildConf("spark.sql.orc.compression.codec")
     .doc("Sets the compression codec used when writing ORC files. If either `compression` or " +
       "`orc.compress` is specified in the table-specific options/properties, the precedence " +
@@ -4250,6 +4267,8 @@ class SQLConf extends Serializable with Logging {
   def maxConcurrentOutputFileWriters: Int = getConf(SQLConf.MAX_CONCURRENT_OUTPUT_FILE_WRITERS)
 
   def inferDictAsStruct: Boolean = getConf(SQLConf.INFER_NESTED_DICT_AS_STRUCT)
+
+  def parquetFieldIdEnabled: Boolean = getConf(SQLConf.PARQUET_FIELD_ID_ENABLED)
 
   def useV1Command: Boolean = getConf(SQLConf.LEGACY_USE_V1_COMMAND)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -939,6 +939,7 @@ object SQLConf {
       .doc("Field ID is a native field of the Parquet schema spec. When enabled," +
         " Parquet writers will populate the field Id" +
         " metadata (if present) in the Spark schema to the Parquet schema.")
+      .version("3.3.0")
       .booleanConf
       .createWithDefault(true)
 
@@ -947,6 +948,7 @@ object SQLConf {
       .doc("Field ID is a native field of the Parquet schema spec. When enabled, Parquet readers" +
         " will use field IDs (if present) in the requested Spark schema to look up Parquet" +
         " fields instead of using column names")
+      .version("3.3.0")
       .booleanConf
       .createWithDefault(false)
 
@@ -954,7 +956,8 @@ object SQLConf {
     buildConf("spark.sql.parquet.fieldId.ignoreMissing")
       .doc("When the Parquet file doesn't have any field IDs but the" +
         " Spark read schema is using field IDs to read, we will silently return nulls" +
-        "when this flag is enabled, or error otherwise.")
+        " when this flag is enabled, or error otherwise.")
+      .version("3.3.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -936,27 +936,27 @@ object SQLConf {
 
    val PARQUET_FIELD_ID_WRITE_ENABLED =
     buildConf("spark.sql.parquet.fieldId.write.enabled")
-      .doc("Field ID is a native field of the Parquet schema spec. When enabled," +
-        " Parquet writers will populate the field Id" +
-        " metadata (if present) in the Spark schema to the Parquet schema.")
+      .doc("Field ID is a native field of the Parquet schema spec. When enabled, " +
+        "Parquet writers will populate the field Id " +
+        "metadata (if present) in the Spark schema to the Parquet schema.")
       .version("3.3.0")
       .booleanConf
       .createWithDefault(true)
 
   val PARQUET_FIELD_ID_READ_ENABLED =
     buildConf("spark.sql.parquet.fieldId.read.enabled")
-      .doc("Field ID is a native field of the Parquet schema spec. When enabled, Parquet readers" +
-        " will use field IDs (if present) in the requested Spark schema to look up Parquet" +
-        " fields instead of using column names")
+      .doc("Field ID is a native field of the Parquet schema spec. When enabled, Parquet readers " +
+        "will use field IDs (if present) in the requested Spark schema to look up Parquet " +
+        "fields instead of using column names")
       .version("3.3.0")
       .booleanConf
       .createWithDefault(false)
 
   val IGNORE_MISSING_PARQUET_FIELD_ID =
     buildConf("spark.sql.parquet.fieldId.ignoreMissing")
-      .doc("When the Parquet file doesn't have any field IDs but the" +
-        " Spark read schema is using field IDs to read, we will silently return nulls" +
-        " when this flag is enabled, or error otherwise.")
+      .doc("When the Parquet file doesn't have any field IDs but the " +
+        "Spark read schema is using field IDs to read, we will silently return nulls " +
+        "when this flag is enabled, or error otherwise.")
       .version("3.3.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -934,12 +934,19 @@ object SQLConf {
     .intConf
     .createWithDefault(4096)
 
-   val PARQUET_FIELD_ID_ENABLED =
-    buildConf("spark.sql.parquet.fieldId.enabled")
+   val PARQUET_FIELD_ID_WRITE_ENABLED =
+    buildConf("spark.sql.parquet.fieldId.write.enabled")
+      .doc("Field ID is a native field of the Parquet schema spec. When enabled," +
+        " Parquet writers will populate the field Id" +
+        " metadata (if present) in the Spark schema to the Parquet schema.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val PARQUET_FIELD_ID_READ_ENABLED =
+    buildConf("spark.sql.parquet.fieldId.read.enabled")
       .doc("Field ID is a native field of the Parquet schema spec. When enabled, Parquet readers" +
         " will use field IDs (if present) in the requested Spark schema to look up Parquet" +
-        " fields instead of using column names; Parquet writers will also populate the field Id" +
-        " metadata (if present) in the Spark schema to the Parquet schema.")
+        " fields instead of using column names")
       .booleanConf
       .createWithDefault(true)
 
@@ -4268,7 +4275,9 @@ class SQLConf extends Serializable with Logging {
 
   def inferDictAsStruct: Boolean = getConf(SQLConf.INFER_NESTED_DICT_AS_STRUCT)
 
-  def parquetFieldIdEnabled: Boolean = getConf(SQLConf.PARQUET_FIELD_ID_ENABLED)
+  def parquetFieldIdReadEnabled: Boolean = getConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED)
+
+  def parquetFieldIdWriteEnabled: Boolean = getConf(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED)
 
   def ignoreMissingParquetFieldId: Boolean = getConf(SQLConf.IGNORE_MISSING_PARQUET_FIELD_ID)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -119,6 +119,10 @@ class ParquetFileFormat
       SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
       sparkSession.sessionState.conf.parquetOutputTimestampType.toString)
 
+    conf.set(
+      SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key,
+      sparkSession.sessionState.conf.parquetFieldIdWriteEnabled.toString)
+
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
+import java.io.IOException
 import java.net.URI
 
 import scala.collection.JavaConverters._
@@ -354,6 +355,13 @@ class ParquetFileFormat
         }
       } else {
         logDebug(s"Falling back to parquet-mr")
+
+        if (SQLConf.get.parquetFieldIdEnabled &&
+            ParquetUtils.hasFieldIds(requiredSchema)) {
+          throw new IOException("Parquet-mr reader does not support schema with field IDs." +
+            s" Please choose a different Parquet reader. Read schema: ${requiredSchema.json}")
+        }
+
         // ParquetRecordReader returns InternalRow
         val readSupport = new ParquetReadSupport(
           convertTz,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -356,8 +356,7 @@ class ParquetFileFormat
       } else {
         logDebug(s"Falling back to parquet-mr")
 
-        if (SQLConf.get.parquetFieldIdEnabled &&
-            ParquetUtils.hasFieldIds(requiredSchema)) {
+        if (SQLConf.get.parquetFieldIdReadEnabled && ParquetUtils.hasFieldIds(requiredSchema)) {
           throw new IOException("Parquet-mr reader does not support schema with field IDs." +
             s" Please choose a different Parquet reader. Read schema: ${requiredSchema.json}")
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -358,7 +358,6 @@ class ParquetFileFormat
         }
       } else {
         logDebug(s"Falling back to parquet-mr")
-
         // ParquetRecordReader returns InternalRow
         val readSupport = new ParquetReadSupport(
           convertTz,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import java.io.IOException
 import java.net.URI
 
 import scala.collection.JavaConverters._
@@ -355,11 +354,6 @@ class ParquetFileFormat
         }
       } else {
         logDebug(s"Falling back to parquet-mr")
-
-        if (SQLConf.get.parquetFieldIdReadEnabled && ParquetUtils.hasFieldIds(requiredSchema)) {
-          throw new IOException("Parquet-mr reader does not support schema with field IDs." +
-            s" Please choose a different Parquet reader. Read schema: ${requiredSchema.json}")
-        }
 
         // ParquetRecordReader returns InternalRow
         val readSupport = new ParquetReadSupport(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -451,10 +451,10 @@ object ParquetReadSupport extends Logging {
             clipParquetType(parquetTypes.head, f.dataType, useFieldId, caseSensitive)
           }
         }.getOrElse {
-        // When there is no ID match, we use a fake name to avoid a name match by accident
-        // We need this name to be unique as well, otherwise there will be type conflicts
-        toParquet.convertField(f.copy(name = generateFakeColumnName))
-      }
+          // When there is no ID match, we use a fake name to avoid a name match by accident
+          // We need this name to be unique as well, otherwise there will be type conflicts
+          toParquet.convertField(f.copy(name = generateFakeColumnName))
+        }
     }
 
     if (useFieldId && ParquetUtils.hasFieldIds(structType)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.time.ZoneId
+import java.util
 import java.util.{Locale, Map => JMap, UUID}
 
 import scala.collection.JavaConverters._
@@ -87,7 +88,7 @@ class ParquetReadSupport(
 
     val parquetRequestedSchema = ParquetReadSupport.getRequestedSchema(
       context.getFileSchema, catalystRequestedSchema, conf, enableVectorizedReader)
-    new ReadContext(parquetRequestedSchema, Map.empty[String, String].asJava)
+    new ReadContext(parquetRequestedSchema, new util.HashMap[String, String]())
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetReadSupport.scala
@@ -137,9 +137,11 @@ object ParquetReadSupport extends Logging {
         !containsFieldIds(parquetFileSchema) &&
         ParquetUtils.hasFieldIds(catalystRequestedSchema)) {
       throw new RuntimeException(
+        "Spark read schema expects field Ids, " +
+          "but Parquet file schema doesn't contain any field Ids.\n" +
+        "Please remove the field ids from Spark schema or ignore missing ids by " +
+          "setting `spark.sql.parquet.fieldId.ignoreMissing = true`\n" +
         s"""
-           |Spark read schema expects field Ids, but Parquet file schema doesn't contain field Ids.
-           |
            |Spark read schema:
            |${catalystRequestedSchema.prettyJson}
            |
@@ -181,6 +183,17 @@ object ParquetReadSupport extends Logging {
        """.stripMargin)
 
     parquetRequestedSchema
+  }
+
+  /**
+   * Overloaded method for backward compatibility with
+   * `caseSensitive` default to `true` and `useFieldId` default to `false`
+   */
+  def clipParquetSchema(
+      parquetSchema: MessageType,
+      catalystSchema: StructType,
+      caseSensitive: Boolean = true): MessageType = {
+    clipParquetSchema(parquetSchema, catalystSchema, caseSensitive, useFieldId = false)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -203,10 +203,7 @@ private[parquet] class ParquetRowConverter(
   private[this] val fieldConverters: Array[Converter with HasParentContainerUpdater] = {
     // (SPARK-31116) Use case insensitive map if spark.sql.caseSensitive is false
     // to prevent throwing IllegalArgumentException when searching catalyst type's field index
-    def nameToIndex =
-      catalystType.fields.zipWithIndex.map { case (f, idx) =>
-          (f.name, idx)
-        }.toMap
+    def nameToIndex: Map[String, Int] = catalystType.fieldNames.zipWithIndex.toMap
 
     val catalystFieldIdxByName = if (SQLConf.get.caseSensitiveAnalysis) {
       nameToIndex

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -203,16 +203,42 @@ private[parquet] class ParquetRowConverter(
   private[this] val fieldConverters: Array[Converter with HasParentContainerUpdater] = {
     // (SPARK-31116) Use case insensitive map if spark.sql.caseSensitive is false
     // to prevent throwing IllegalArgumentException when searching catalyst type's field index
-    val catalystFieldNameToIndex = if (SQLConf.get.caseSensitiveAnalysis) {
-      catalystType.fieldNames.zipWithIndex.toMap
+    def nameToIndex =
+      catalystType.fields.zipWithIndex.map { case (f, idx) =>
+          (f.name, idx)
+        }.toMap
+
+    val catalystFieldIdxByName = if (SQLConf.get.caseSensitiveAnalysis) {
+      nameToIndex
     } else {
-      CaseInsensitiveMap(catalystType.fieldNames.zipWithIndex.toMap)
+      CaseInsensitiveMap(nameToIndex)
     }
+
+    // (SPARK-38094) parquet field ids, if exist, should be prioritized for matching
+    val catalystFieldIdxByFieldId =
+      if (SQLConf.get.parquetFieldIdReadEnabled && ParquetUtils.hasFieldIds(catalystType)) {
+        catalystType.fields
+          .zipWithIndex
+          .filter { case (f, _) => ParquetUtils.hasFieldId(f) }
+          .map { case (f, idx) => (ParquetUtils.getFieldId(f), idx) }
+          .toMap
+      } else {
+        Map.empty[Int, Int]
+      }
+
     parquetType.getFields.asScala.map { parquetField =>
-      val fieldIndex = catalystFieldNameToIndex(parquetField.getName)
-      val catalystField = catalystType(fieldIndex)
+      val catalystFieldIndex = Option(parquetField.getId).map { fieldId =>
+        // field has id, try to match by id first before falling back to match by name
+        catalystFieldIdxByFieldId
+          .getOrElse(fieldId.intValue(), catalystFieldIdxByName(parquetField.getName))
+      }.getOrElse {
+        // field doesn't have id, just match by name
+        catalystFieldIdxByName(parquetField.getName)
+      }
+      val catalystField = catalystType(catalystFieldIndex)
       // Converted field value should be set to the `fieldIndex`-th cell of `currentRow`
-      newConverter(parquetField, catalystField.dataType, new RowUpdater(currentRow, fieldIndex))
+      newConverter(parquetField,
+        catalystField.dataType, new RowUpdater(currentRow, catalystFieldIndex))
     }.toArray
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -224,10 +224,9 @@ private[parquet] class ParquetRowConverter(
       }
 
     parquetType.getFields.asScala.map { parquetField =>
-      val catalystFieldIndex = Option(parquetField.getId).map { fieldId =>
+      val catalystFieldIndex = Option(parquetField.getId).flatMap { fieldId =>
         // field has id, try to match by id first before falling back to match by name
-        catalystFieldIdxByFieldId
-          .getOrElse(fieldId.intValue(), catalystFieldIdxByName(parquetField.getName))
+        catalystFieldIdxByFieldId.get(fieldId.intValue())
       }.getOrElse {
         // field doesn't have id, just match by name
         catalystFieldIdxByName(parquetField.getName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -450,7 +450,7 @@ class SparkToParquetSchemaConverter(
     writeLegacyParquetFormat = conf.get(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key).toBoolean,
     outputTimestampType = SQLConf.ParquetOutputTimestampType.withName(
       conf.get(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key)),
-    useFieldId = SQLConf.get.parquetFieldIdWriteEnabled)
+    useFieldId = conf.get(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key).toBoolean)
 
   /**
    * Converts a Spark SQL [[StructType]] to a Parquet [[MessageType]].

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -434,6 +434,8 @@ class ParquetToSparkSchemaConverter(
  *        When set to false, use standard format defined in parquet-format spec.  This argument only
  *        affects Parquet write path.
  * @param outputTimestampType which parquet timestamp type to use when writing.
+ * @param useFieldId whether we should include write field id to Parquet schema. Set this to false
+ *        via `spark.sql.parquet.fieldId.write.enabled = false` to disable writing field ids.
  */
 class SparkToParquetSchemaConverter(
     writeLegacyParquetFormat: Boolean = SQLConf.PARQUET_WRITE_LEGACY_FORMAT.defaultValue.get,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -439,18 +439,18 @@ class SparkToParquetSchemaConverter(
     writeLegacyParquetFormat: Boolean = SQLConf.PARQUET_WRITE_LEGACY_FORMAT.defaultValue.get,
     outputTimestampType: SQLConf.ParquetOutputTimestampType.Value =
       SQLConf.ParquetOutputTimestampType.INT96,
-    useFieldId: Boolean = SQLConf.PARQUET_FIELD_ID_ENABLED.defaultValue.get) {
+    useFieldId: Boolean = SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.defaultValue.get) {
 
   def this(conf: SQLConf) = this(
     writeLegacyParquetFormat = conf.writeLegacyParquetFormat,
     outputTimestampType = conf.parquetOutputTimestampType,
-    useFieldId = conf.parquetFieldIdEnabled)
+    useFieldId = conf.parquetFieldIdWriteEnabled)
 
   def this(conf: Configuration) = this(
     writeLegacyParquetFormat = conf.get(SQLConf.PARQUET_WRITE_LEGACY_FORMAT.key).toBoolean,
     outputTimestampType = SQLConf.ParquetOutputTimestampType.withName(
       conf.get(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key)),
-    useFieldId = SQLConf.get.parquetFieldIdEnabled)
+    useFieldId = SQLConf.get.parquetFieldIdWriteEnabled)
 
   /**
    * Converts a Spark SQL [[StructType]] to a Parquet [[MessageType]].

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -176,7 +176,7 @@ object ParquetUtils {
 
   def getFieldId(field: StructField): Int = {
     require(hasFieldId(field),
-      "The key `parquet.field.id` doesn't exist in the metadata of " + field)
+      s"The key `$FIELD_ID_METADATA_KEY` doesn't exist in the metadata of " + field)
     field.metadata.getLong(FIELD_ID_METADATA_KEY).toInt
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -177,7 +177,13 @@ object ParquetUtils {
   def getFieldId(field: StructField): Int = {
     require(hasFieldId(field),
       s"The key `$FIELD_ID_METADATA_KEY` doesn't exist in the metadata of " + field)
-    Math.toIntExact(field.metadata.getLong(FIELD_ID_METADATA_KEY))
+    try {
+      Math.toIntExact(field.metadata.getLong(FIELD_ID_METADATA_KEY))
+    } catch {
+      case _: ArithmeticException | _: ClassCastException =>
+        throw new IllegalArgumentException(
+          s"The key `$FIELD_ID_METADATA_KEY` must be a 32-bit integer")
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -177,7 +177,7 @@ object ParquetUtils {
   def getFieldId(field: StructField): Int = {
     require(hasFieldId(field),
       s"The key `$FIELD_ID_METADATA_KEY` doesn't exist in the metadata of " + field)
-    field.metadata.getLong(FIELD_ID_METADATA_KEY).toInt
+    Math.toIntExact(field.metadata.getLong(FIELD_ID_METADATA_KEY))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetUtils.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Count, CountStar, Max, Min}
 import org.apache.spark.sql.execution.datasources.AggregatePushDownUtils
 import org.apache.spark.sql.internal.SQLConf.{LegacyBehaviorPolicy, PARQUET_AGGREGATE_PUSHDOWN_ENABLED}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
 
 object ParquetUtils {
   def inferSchema(
@@ -142,6 +142,42 @@ object ParquetUtils {
   private def isSummaryFile(file: Path): Boolean = {
     file.getName == ParquetFileWriter.PARQUET_COMMON_METADATA_FILE ||
       file.getName == ParquetFileWriter.PARQUET_METADATA_FILE
+  }
+
+  /**
+   * A StructField metadata key used to set the field id of a column in the Parquet schema.
+   */
+  val FIELD_ID_METADATA_KEY = "parquet.field.id"
+
+  /**
+   * Whether there exists a field in the schema, whether inner or leaf, has the parquet field
+   * ID metadata.
+   */
+  def hasFieldIds(schema: StructType): Boolean = {
+    def recursiveCheck(schema: DataType): Boolean = {
+      schema match {
+        case st: StructType =>
+          st.exists(field => hasFieldId(field) || recursiveCheck(field.dataType))
+
+        case at: ArrayType => recursiveCheck(at.elementType)
+
+        case mt: MapType => recursiveCheck(mt.keyType) || recursiveCheck(mt.valueType)
+
+        case _ =>
+          // No need to really check primitive types, just to terminate the recursion
+          false
+      }
+    }
+    if (schema.isEmpty) false else recursiveCheck(schema)
+  }
+
+  def hasFieldId(field: StructField): Boolean =
+    field.metadata.contains(FIELD_ID_METADATA_KEY)
+
+  def getFieldId(field: StructField): Int = {
+    require(hasFieldId(field),
+      "The key `parquet.field.id` doesn't exist in the metadata of " + field)
+    field.metadata.getLong(FIELD_ID_METADATA_KEY).toInt
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
@@ -81,6 +81,9 @@ case class ParquetWrite(
 
     conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, sqlConf.parquetOutputTimestampType.toString)
 
+    conf
+      .set(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, sqlConf.parquetFieldIdWriteEnabled.toString)
+
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
@@ -81,8 +81,9 @@ case class ParquetWrite(
 
     conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key, sqlConf.parquetOutputTimestampType.toString)
 
-    conf
-      .set(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key, sqlConf.parquetFieldIdWriteEnabled.toString)
+    conf.set(
+      SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key,
+      sqlConf.parquetFieldIdWriteEnabled.toString)
 
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
@@ -30,6 +30,13 @@ class ParquetFieldIdIOSuite extends QueryTest with ParquetTest with SharedSparkS
   private def withId(id: Int): Metadata =
     new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()
 
+  protected def test(testName: String)(testFun: => Any): Unit = {
+    super.test(testName, ParquetUseDefaultFieldIdConfigs()) {
+      withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
+        testFun
+      }
+    }
+  }
 
   test("Parquet reads infer fields using field ids correctly") {
     withTempDir { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
@@ -156,7 +156,7 @@ class ParquetFieldIdIOSuite extends QueryTest with ParquetTest with SharedSparkS
             spark.read.schema(schema).parquet(dir.getCanonicalPath).collect()
           }.getCause
           assert(cause.isInstanceOf[RuntimeException] &&
-            cause.getMessage.contains("Parquet file schema doesn't contain field Ids"))
+            cause.getMessage.contains("Parquet file schema doesn't contain any field Ids"))
           val expectedValues = (1 to schema.length).map(_ => null)
           withSQLConf(SQLConf.IGNORE_MISSING_PARQUET_FIELD_ID.key -> "true") {
             checkAnswer(
@@ -196,7 +196,7 @@ class ParquetFieldIdIOSuite extends QueryTest with ParquetTest with SharedSparkS
             spark.read.schema(readSchema).parquet(dir.getCanonicalPath).collect()
           }.getCause
           assert(cause.isInstanceOf[RuntimeException] &&
-            cause.getMessage.contains("Parquet file schema doesn't contain field Ids"))
+            cause.getMessage.contains("Parquet file schema doesn't contain any field Ids"))
         }
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, Metadata, MetadataBuilder, StringType, StructType}
+
+class ParquetFieldIdIOSuite extends QueryTest with ParquetTest with SharedSparkSession  {
+
+  private def withId(id: Int): Metadata =
+    new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()
+
+  /**
+   * Field id is supported in OSS vectorized reader at the moment.
+   * parquet-mr support is coming soon.
+   */
+  private def withAllSupportedReaders(code: => Unit): Unit = {
+   withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true")(code)
+  }
+
+  test("general test") {
+    withTempDir { dir =>
+      val readSchema =
+        new StructType().add(
+          "a", StringType, true, withId(0))
+          .add("b", IntegerType, true, withId(1))
+
+      val writeSchema =
+        new StructType()
+          .add("random", IntegerType, true, withId(1))
+          .add("name", StringType, true, withId(0))
+
+      val readData = Seq(Row("text", 100), Row("more", 200))
+      val writeData = Seq(Row(100, "text"), Row(200, "more"))
+      spark.createDataFrame(writeData.asJava, writeSchema)
+        .write.mode("overwrite").parquet(dir.getCanonicalPath)
+
+      withAllSupportedReaders {
+        checkAnswer(spark.read.schema(readSchema).parquet(dir.getCanonicalPath), readData)
+        checkAnswer(spark.read.schema(readSchema).parquet(dir.getCanonicalPath)
+          .where("b < 50"), Seq.empty)
+        checkAnswer(spark.read.schema(readSchema).parquet(dir.getCanonicalPath)
+          .where("a >= 'oh'"), Row("text", 100) :: Nil)
+      }
+
+      // blocked for Parquet-mr reader
+      val e = intercept[SparkException] {
+        withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+          checkAnswer(spark.read.schema(readSchema).parquet(dir.getCanonicalPath), readData)
+        }
+      }
+      val cause = e.getCause
+      assert(cause.isInstanceOf[java.io.IOException] &&
+        cause.getMessage.contains("Parquet-mr reader does not support schema with field IDs."))
+    }
+  }
+
+  test("absence of field ids") {
+    withTempDir { dir =>
+      val readSchema =
+        new StructType()
+          .add("a", IntegerType, true, withId(1))
+          .add("b", StringType, true, withId(2))
+          .add("c", IntegerType, true, withId(3))
+
+      val writeSchema =
+        new StructType()
+          .add("a", IntegerType, true, withId(3))
+          .add("randomName", StringType, true)
+
+      val writeData = Seq(Row(100, "text"), Row(200, "more"))
+
+      spark.createDataFrame(writeData.asJava, writeSchema)
+        .write.mode("overwrite").parquet(dir.getCanonicalPath)
+
+      withAllSupportedReaders {
+        checkAnswer(spark.read.schema(readSchema).parquet(dir.getCanonicalPath),
+          // 3 different cases for the 3 columns to read:
+          //   - a: ID 1 is not found, but there is column with name `a`, still return null
+          //   - b: ID 2 is not found, return null
+          //   - c: ID 3 is found, read it
+          Row(null, null, 100) :: Row(null, null, 200) :: Nil)
+      }
+    }
+  }
+
+  test("multiple id matches") {
+    withTempDir { dir =>
+      val readSchema =
+        new StructType()
+          .add("a", IntegerType, true, withId(1))
+
+      val writeSchema =
+        new StructType()
+          .add("a", IntegerType, true, withId(1))
+          .add("rand1", StringType, true, withId(2))
+          .add("rand2", StringType, true, withId(1))
+
+      val writeData = Seq(Row(100, "text", "txt"), Row(200, "more", "mr"))
+
+      spark.createDataFrame(writeData.asJava, writeSchema)
+        .write.mode("overwrite").parquet(dir.getCanonicalPath)
+
+      withAllSupportedReaders {
+        val cause = intercept[SparkException] {
+          spark.read.schema(readSchema).parquet(dir.getCanonicalPath).collect()
+        }.getCause
+        assert(cause.isInstanceOf[RuntimeException] &&
+          cause.getMessage.contains("Found duplicate field(s)"))
+      }
+    }
+  }
+
+  test("read parquet file without ids") {
+    withTempDir { dir =>
+      val readSchema =
+        new StructType()
+          .add("a", IntegerType, true, withId(1))
+
+      val writeSchema =
+        new StructType()
+          .add("a", IntegerType, true)
+          .add("rand1", StringType, true)
+          .add("rand2", StringType, true)
+
+      val writeData = Seq(Row(100, "text", "txt"), Row(200, "more", "mr"))
+      spark.createDataFrame(writeData.asJava, writeSchema)
+        .write.mode("overwrite").parquet(dir.getCanonicalPath)
+      withAllSupportedReaders {
+        Seq(readSchema, readSchema.add("b", StringType, true)).foreach { schema =>
+          val cause = intercept[SparkException] {
+            spark.read.schema(schema).parquet(dir.getCanonicalPath).collect()
+          }.getCause
+          assert(cause.isInstanceOf[RuntimeException] &&
+            cause.getMessage.contains("Parquet file schema doesn't contain field Ids"))
+          val expectedValues = (1 to schema.length).map(_ => null)
+          withSQLConf(SQLConf.IGNORE_MISSING_PARQUET_FIELD_ID.key -> "true") {
+            checkAnswer(
+              spark.read.schema(schema).parquet(dir.getCanonicalPath),
+              Row(expectedValues: _*) :: Row(expectedValues: _*) :: Nil)
+          }
+        }
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdIOSuite.scala
@@ -30,14 +30,6 @@ class ParquetFieldIdIOSuite extends QueryTest with ParquetTest with SharedSparkS
   private def withId(id: Int): Metadata =
     new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()
 
-  protected def test(testName: String)(testFun: => Any): Unit = {
-    super.test(testName, ParquetUseDefaultFieldIdConfigs()) {
-      withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
-        testFun
-      }
-    }
-  }
-
   test("Parquet reads infer fields using field ids correctly") {
     withTempDir { dir =>
       val readSchema =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdSchemaSuite.scala
@@ -45,8 +45,8 @@ class ParquetFieldIdSchemaSuite extends ParquetSchemaTest {
       val actual = ParquetReadSupport.clipParquetSchema(
         fileSchema,
         catalystSchema,
-        useFieldId = useFieldId,
-        caseSensitive = caseSensitive)
+        caseSensitive = caseSensitive,
+        useFieldId = useFieldId)
 
       // each fake name should be uniquely generated
       val fakeColumnNames = actual.getPaths.asScala.flatten.filter(_.startsWith(FAKE_COLUMN_NAME))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdSchemaSuite.scala
@@ -30,12 +30,6 @@ class ParquetFieldIdSchemaSuite extends ParquetSchemaTest {
   private val UUID_REGEX =
     "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}".r
 
-  protected def test(testName: String)(testFun: => Any): Unit = {
-    withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true") {
-      super.test(testName, ParquetUseDefaultFieldIdConfigs())(testFun)
-    }
-  }
-
   private def withId(id: Int) =
     new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFieldIdSchemaSuite.scala
@@ -1,0 +1,501 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import scala.collection.JavaConverters._
+
+import org.apache.parquet.schema.{MessageType, MessageTypeParser}
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+class ParquetFieldIdSchemaSuite extends ParquetSchemaTest {
+
+  private val FAKE_COLUMN_NAME = "_fake_name_"
+  private val UUID_REGEX =
+    "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}".r
+
+  private def withId(id: Int) =
+    new MetadataBuilder().putLong(ParquetUtils.FIELD_ID_METADATA_KEY, id).build()
+
+  private def testSchemaClipping(
+      testName: String,
+      parquetSchema: String,
+      catalystSchema: StructType,
+      expectedSchema: String,
+      caseSensitive: Boolean = true,
+      useFieldId: Boolean = true): Unit = {
+    test(s"Clipping with field id - $testName") {
+      val fileSchema = MessageTypeParser.parseMessageType(parquetSchema)
+      val actual = ParquetReadSupport.clipParquetSchema(
+        fileSchema,
+        catalystSchema,
+        useFieldId = useFieldId,
+        caseSensitive = caseSensitive)
+
+      // each fake name should be uniquely generated
+      val fakeColumnNames = actual.getPaths.asScala.flatten.filter(_.startsWith(FAKE_COLUMN_NAME))
+      assert(
+        fakeColumnNames.distinct == fakeColumnNames, "Should generate unique fake column names")
+
+      // replace the random part of all fake names with a fixed id generator
+      val ids1 = (1 to 100).iterator
+      val actualNormalized = MessageTypeParser.parseMessageType(
+        UUID_REGEX.replaceAllIn(actual.toString, _ => ids1.next().toString)
+      )
+      val ids2 = (1 to 100).iterator
+      val expectedNormalized = MessageTypeParser.parseMessageType(
+        FAKE_COLUMN_NAME.r.replaceAllIn(expectedSchema, _ => s"$FAKE_COLUMN_NAME${ids2.next()}")
+      )
+
+      try {
+        expectedNormalized.checkContains(actualNormalized)
+        actualNormalized.checkContains(expectedNormalized)
+      } catch { case cause: Throwable =>
+        fail(
+          s"""Expected clipped schema:
+             |$expectedSchema
+             |Actual clipped schema:
+             |$actual
+           """.stripMargin,
+          cause)
+      }
+      checkEqual(actualNormalized, expectedNormalized)
+      // might be redundant but just to have some free tests for the utils
+      assert(ParquetReadSupport.containsFieldIds(fileSchema))
+      assert(ParquetUtils.hasFieldIds(catalystSchema))
+    }
+  }
+
+  private def testSqlToParquet(
+    testName: String,
+    sqlSchema: StructType,
+    parquetSchema: String): Unit = {
+    val converter = new SparkToParquetSchemaConverter(
+      writeLegacyParquetFormat = false,
+      outputTimestampType = SQLConf.ParquetOutputTimestampType.INT96,
+      useFieldId = true)
+
+    test(s"sql => parquet: $testName") {
+      val actual = converter.convert(sqlSchema)
+      val expected = MessageTypeParser.parseMessageType(parquetSchema)
+      checkEqual(actual, expected)
+    }
+  }
+
+  private def checkEqual(actual: MessageType, expected: MessageType): Unit = {
+    actual.checkContains(expected)
+    expected.checkContains(actual)
+    assert(actual.toString == expected.toString,
+      s"""
+         |Schema mismatch.
+         |Expected schema:
+         |${expected.toString}
+         |Actual schema:
+         |${actual.toString}
+         """.stripMargin
+    )
+  }
+
+  test("check hasFieldIds for schema") {
+    val simpleSchemaMissingId = new StructType()
+      .add("f010", DoubleType, nullable = true, withId(7))
+      .add("f012", LongType, nullable = true)
+
+    assert(ParquetUtils.hasFieldIds(simpleSchemaMissingId))
+
+    val f01ElementType = new StructType()
+      .add("f010", DoubleType, nullable = true, withId(7))
+      .add("f012", LongType, nullable = true, withId(8))
+
+    assert(ParquetUtils.hasFieldIds(f01ElementType))
+
+    val f0Type = new StructType()
+      .add("f00", ArrayType(StringType, containsNull = false), nullable = true, withId(2))
+      .add("f01", ArrayType(f01ElementType, containsNull = false), nullable = true)
+
+    assert(ParquetUtils.hasFieldIds(f0Type))
+
+    assert(ParquetUtils.hasFieldIds(
+      new StructType().add("f0", f0Type, nullable = false, withId(1))))
+
+    assert(!ParquetUtils.hasFieldIds(new StructType().add("f0", IntegerType, nullable = true)))
+    assert(!ParquetUtils.hasFieldIds(new StructType()));
+  }
+
+  test("check containsFieldIds for parquet schema") {
+
+    // empty Parquet schema fails too
+    assert(
+      !ParquetReadSupport.containsFieldIds(
+        MessageTypeParser.parseMessageType(
+          """message root {
+             |}
+          """.stripMargin)))
+
+    assert(
+      !ParquetReadSupport.containsFieldIds(
+        MessageTypeParser.parseMessageType(
+          """message root {
+            |  required group f0 {
+            |    optional int32 f00;
+            |  }
+            |}
+          """.stripMargin)))
+
+    assert(
+      ParquetReadSupport.containsFieldIds(
+        MessageTypeParser.parseMessageType(
+          """message root {
+            |  required group f0 = 1 {
+            |    optional int32 f00;
+            |    optional binary f01;
+            |  }
+            |}
+          """.stripMargin)))
+
+    assert(
+      ParquetReadSupport.containsFieldIds(
+        MessageTypeParser.parseMessageType(
+          """message root {
+            |  required group f0 {
+            |    optional int32 f00 = 1;
+            |    optional binary f01;
+            |  }
+            |}
+          """.stripMargin)))
+
+    assert(
+      !ParquetReadSupport.containsFieldIds(
+        MessageTypeParser.parseMessageType(
+          """message spark_schema {
+              |  required group f0 {
+              |    optional group f00 (LIST) {
+              |      repeated group list {
+              |        required binary element (UTF8);
+              |      }
+              |    }
+              |  }
+              |}
+            """.stripMargin)))
+
+    assert(
+      ParquetReadSupport.containsFieldIds(
+        MessageTypeParser.parseMessageType(
+          """message spark_schema {
+            |  required group f0 {
+            |    optional group f00 (LIST) {
+            |      repeated group list = 1 {
+            |        required binary element (UTF8);
+            |      }
+            |    }
+            |  }
+            |}
+            """.stripMargin)))
+  }
+
+  test("ID in Parquet Types is read as null when not set") {
+    val parquetSchemaString =
+      """message root {
+        |  required group f0 {
+        |    optional int32 f00;
+        |  }
+        |}
+      """.stripMargin
+
+    val parquetSchema = MessageTypeParser.parseMessageType(parquetSchemaString)
+    val f0 = parquetSchema.getFields().get(0)
+    assert(f0.getId() == null)
+    assert(f0.asGroupType().getFields.get(0).getId == null)
+  }
+
+  testSqlToParquet(
+    "standard array",
+    sqlSchema = {
+      val f01ElementType = new StructType()
+        .add("f010", DoubleType, nullable = true, withId(7))
+        .add("f012", LongType, nullable = true, withId(9))
+
+      val f0Type = new StructType()
+        .add("f00", ArrayType(StringType, containsNull = false), nullable = true, withId(2))
+        .add("f01", ArrayType(f01ElementType, containsNull = false), nullable = true, withId(5))
+
+      new StructType().add("f0", f0Type, nullable = false, withId(1))
+    },
+    parquetSchema =
+      """message spark_schema {
+        |  required group f0 = 1 {
+        |    optional group f00 (LIST) = 2 {
+        |      repeated group list {
+        |        required binary element (UTF8);
+        |      }
+        |    }
+        |
+        |    optional group f01 (LIST) = 5 {
+        |      repeated group list {
+        |        required group element {
+        |          optional double f010 = 7;
+        |          optional int64 f012 = 9;
+        |        }
+        |      }
+        |    }
+        |  }
+        |}
+      """.stripMargin)
+
+  testSchemaClipping(
+    "simple nested struct",
+
+    parquetSchema =
+      """message root {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |    optional int32 f01 = 3;
+        |  }
+        |}
+      """.stripMargin,
+
+    catalystSchema = {
+      val f0Type = new StructType().add(
+        "g00", IntegerType, nullable = true, withId(2))
+      new StructType()
+        .add("g0", f0Type, nullable = false, withId(1))
+        .add("g1", IntegerType, nullable = true, withId(4))
+    },
+
+    expectedSchema =
+      s"""message spark_schema {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |  optional int32 $FAKE_COLUMN_NAME = 4;
+        |}
+      """.stripMargin)
+
+  testSchemaClipping(
+    "standard array",
+
+    parquetSchema =
+      """message root {
+        |  required group f0 = 1 {
+        |    optional group f00 (LIST) = 2 {
+        |      repeated group list {
+        |        required binary element (UTF8);
+        |      }
+        |    }
+        |
+        |    optional group f01 (LIST) = 5 {
+        |      repeated group list {
+        |        required group element {
+        |          optional int32 f010 = 7;
+        |          optional double f011 = 8;
+        |        }
+        |      }
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+
+    catalystSchema = {
+      val f01ElementType = new StructType()
+        .add("g011", DoubleType, nullable = true, withId(8))
+        .add("g012", LongType, nullable = true, withId(9))
+
+      val f0Type = new StructType()
+        .add("g00", ArrayType(StringType, containsNull = false), nullable = true, withId(2))
+        .add("g01", ArrayType(f01ElementType, containsNull = false), nullable = true, withId(5))
+
+      new StructType().add("g0", f0Type, nullable = false, withId(1))
+    },
+
+    expectedSchema =
+      s"""message spark_schema {
+        |  required group f0 = 1 {
+        |    optional group f00 (LIST) = 2 {
+        |      repeated group list {
+        |        required binary element (UTF8);
+        |      }
+        |    }
+        |
+        |    optional group f01 (LIST) = 5 {
+        |      repeated group list {
+        |        required group element {
+        |          optional double f011 = 8;
+        |          optional int64 $FAKE_COLUMN_NAME = 9;
+        |        }
+        |      }
+        |    }
+        |  }
+        |}
+      """.stripMargin)
+
+  testSchemaClipping(
+    "standard map with complex key",
+
+    parquetSchema =
+      """message root {
+        |  required group f0 (MAP) = 3 {
+        |    repeated group key_value = 1 {
+        |      required group key = 2 {
+        |        required int32 value_f0 = 4;
+        |        required int64 value_f1 = 6;
+        |      }
+        |      required int32 value = 5;
+        |    }
+        |  }
+        |}
+      """.stripMargin,
+
+    catalystSchema = {
+      val keyType =
+        new StructType()
+          .add("value_g1", LongType, nullable = false, withId(6))
+          .add("value_g2", DoubleType, nullable = false, withId(7))
+
+      val f0Type = MapType(keyType, IntegerType, valueContainsNull = false)
+
+      new StructType().add("g0", f0Type, nullable = false, withId(3))
+    },
+
+    expectedSchema =
+      s"""message spark_schema {
+        |  required group f0 (MAP) = 3 {
+        |    repeated group key_value = 1 {
+        |      required group key = 2 {
+        |        required int64 value_f1 = 6;
+        |        required double $FAKE_COLUMN_NAME = 7;
+        |      }
+        |      required int32 value = 5;
+        |    }
+        |  }
+        |}
+      """.stripMargin)
+
+  testSchemaClipping(
+    "won't match field id if structure is different",
+
+    parquetSchema =
+      """message root {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |  optional int32 f1 = 3;
+        |}
+      """.stripMargin,
+
+    catalystSchema = {
+      val f0Type = new StructType()
+        .add("g00", IntegerType, nullable = true, withId(2))
+        // parquet has id 3, but won't use because structure is different
+        .add("g01", IntegerType, nullable = true, withId(3))
+      new StructType()
+        .add("g0", f0Type, nullable = false, withId(1))
+    },
+
+    // note that f1 is not picked up, even though it's Id is 3
+    expectedSchema =
+      s"""message spark_schema {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |    optional int32 $FAKE_COLUMN_NAME = 3;
+        |  }
+        |}
+      """.stripMargin)
+
+  testSchemaClipping(
+    "Complex type with multiple mismatches should work",
+
+    parquetSchema =
+      """message root {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |  optional int32 f1 = 3;
+        |  optional int32 f2 = 4;
+        |}
+      """.stripMargin,
+
+    catalystSchema = {
+      val f0Type = new StructType()
+        .add("g00", IntegerType, nullable = true, withId(2))
+
+      new StructType()
+        .add("g0", f0Type, nullable = false, withId(999))
+        .add("g1", IntegerType, nullable = true, withId(3))
+        .add("g2", IntegerType, nullable = true, withId(888))
+    },
+
+    expectedSchema =
+      s"""message spark_schema {
+        |  required group $FAKE_COLUMN_NAME = 999 {
+        |    optional int32 g00 = 2;
+        |  }
+        |  optional int32 f1 = 3;
+        |  optional int32 $FAKE_COLUMN_NAME = 888;
+        |}
+      """.stripMargin)
+
+  testSchemaClipping(
+    "Should allow fall-back to name matching if id not found",
+
+    parquetSchema =
+      """message root {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |  optional int32 f1 = 3;
+        |  optional int32 f2 = 4;
+        |  required group f4 = 5 {
+        |    optional int32 f40 = 6;
+        |  }
+        |}
+      """.stripMargin,
+
+    catalystSchema = {
+      val f0Type = new StructType()
+        // nested f00 without id should also work
+        .add("f00", IntegerType, nullable = true)
+
+      val f4Type = new StructType()
+        .add("g40", IntegerType, nullable = true, withId(6))
+
+      new StructType()
+        .add("g0", f0Type, nullable = false, withId(1))
+        .add("g1", IntegerType, nullable = true, withId(3))
+        // f2 without id should be matched using name matching
+        .add("f2", IntegerType, nullable = true)
+        // name is not matched
+        .add("g2", IntegerType, nullable = true)
+        // f4 without id will do name matching, but g40 will be matched using id
+        .add("f4", f4Type, nullable = true)
+    },
+
+    expectedSchema =
+      s"""message spark_schema {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |  optional int32 f1 = 3;
+        |  optional int32 f2 = 4;
+        |  optional int32 g2;
+        |  required group f4 = 5 {
+        |    optional int32 f40 = 6;
+        |  }
+        |}
+      """.stripMargin)
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -2257,7 +2257,10 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       caseSensitive: Boolean): Unit = {
     test(s"Clipping - $testName") {
       val actual = ParquetReadSupport.clipParquetSchema(
-        MessageTypeParser.parseMessageType(parquetSchema), catalystSchema, caseSensitive)
+        MessageTypeParser.parseMessageType(parquetSchema),
+        catalystSchema,
+        useFieldId = false,
+        caseSensitive)
 
       try {
         expectedSchema.checkContains(actual)
@@ -2821,7 +2824,10 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       }
       assertThrows[RuntimeException] {
         ParquetReadSupport.clipParquetSchema(
-          MessageTypeParser.parseMessageType(parquetSchema), catalystSchema, caseSensitive = false)
+         MessageTypeParser.parseMessageType(parquetSchema),
+          catalystSchema,
+          useFieldId = false,
+          caseSensitive = false)
       }
     }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaSuite.scala
@@ -2259,8 +2259,8 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
       val actual = ParquetReadSupport.clipParquetSchema(
         MessageTypeParser.parseMessageType(parquetSchema),
         catalystSchema,
-        useFieldId = false,
-        caseSensitive)
+        caseSensitive,
+        useFieldId = false)
 
       try {
         expectedSchema.checkContains(actual)
@@ -2826,8 +2826,8 @@ class ParquetSchemaSuite extends ParquetSchemaTest {
         ParquetReadSupport.clipParquetSchema(
          MessageTypeParser.parseMessageType(parquetSchema),
           catalystSchema,
-          useFieldId = false,
-          caseSensitive = false)
+          caseSensitive = false,
+          useFieldId = false)
       }
     }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -32,8 +32,6 @@ import org.apache.parquet.hadoop.{Footer, ParquetFileReader, ParquetFileWriter, 
 import org.apache.parquet.hadoop.metadata.{BlockMetaData, FileMetaData, ParquetMetadata}
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.schema.MessageType
-import org.scalactic.source.Position
-import org.scalatest.Tag
 
 import org.apache.spark.TestUtils
 import org.apache.spark.sql.DataFrame
@@ -53,30 +51,6 @@ private[sql] trait ParquetTest extends FileBasedDataSourceTest {
   override protected val dataSourceName: String = "parquet"
   override protected val vectorizedReaderEnabledKey: String =
     SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key
-
-  case class ParquetUseDefaultFieldIdConfigs()
-    extends Tag("Use SQLConf default options for setting Parquet field id configs")
-
-  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
-      (implicit pos: Position): Unit = {
-    if (testTags.exists(_.isInstanceOf[ParquetUseDefaultFieldIdConfigs])) {
-      super.test(testName, testTags: _*)(testFun)
-    } else {
-      // grid test with different combination of parquet field id options
-      super.test(testName, testTags: _*) {
-        Seq(true, false).foreach { enableRead =>
-          Seq(true, false).foreach { enableWrite =>
-            withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> enableRead.toString,
-              SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key -> enableWrite.toString) {
-              withClue(s"Field ID read enabled: $enableRead, write enabled: $enableWrite") {
-                testFun
-              }
-            }
-          }
-        }
-      }
-    }
-  }
 
   /**
    * Reads the parquet file at `path`

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetTest.scala
@@ -32,6 +32,8 @@ import org.apache.parquet.hadoop.{Footer, ParquetFileReader, ParquetFileWriter, 
 import org.apache.parquet.hadoop.metadata.{BlockMetaData, FileMetaData, ParquetMetadata}
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.schema.MessageType
+import org.scalactic.source.Position
+import org.scalatest.Tag
 
 import org.apache.spark.TestUtils
 import org.apache.spark.sql.DataFrame
@@ -51,6 +53,30 @@ private[sql] trait ParquetTest extends FileBasedDataSourceTest {
   override protected val dataSourceName: String = "parquet"
   override protected val vectorizedReaderEnabledKey: String =
     SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key
+
+  case class ParquetUseDefaultFieldIdConfigs()
+    extends Tag("Use SQLConf default options for setting Parquet field id configs")
+
+  override protected def test(testName: String, testTags: Tag*)(testFun: => Any)
+      (implicit pos: Position): Unit = {
+    if (testTags.exists(_.isInstanceOf[ParquetUseDefaultFieldIdConfigs])) {
+      super.test(testName, testTags: _*)(testFun)
+    } else {
+      // grid test with different combination of parquet field id options
+      super.test(testName, testTags: _*) {
+        Seq(true, false).foreach { enableRead =>
+          Seq(true, false).foreach { enableWrite =>
+            withSQLConf(SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> enableRead.toString,
+              SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED.key -> enableWrite.toString) {
+              withClue(s"Field ID read enabled: $enableRead, write enabled: $enableWrite") {
+                testFun
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
   /**
    * Reads the parquet file at `path`
@@ -165,9 +191,17 @@ private[sql] trait ParquetTest extends FileBasedDataSourceTest {
 
   def withAllParquetReaders(code: => Unit): Unit = {
     // test the row-based reader
-    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false")(code)
+    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false") {
+      withClue("Parquet-mr reader") {
+        code
+      }
+    }
     // test the vectorized reader
-    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true")(code)
+    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+      withClue("Vectorized reader") {
+        code
+      }
+    }
   }
 
   def withAllParquetWriters(code: => Unit): Unit = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -61,7 +61,13 @@ private[sql] object TestSQLContext {
   val overrideConfs: Map[String, String] =
     Map(
       // Fewer shuffle partitions to speed up testing.
-      SQLConf.SHUFFLE_PARTITIONS.key -> "5")
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+      // Enable parquet read field id for tests to ensure correctness
+      // By default, if Spark schema doesn't contain the `parquet.field.id` metadata,
+      // the underlying matching mechanism should behave exactly like name matching
+      // which is the existing behavior. Therefore, turning this on ensures that we didn't
+      // introduce any regression for such mixed matching mode.
+      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true")
 }
 
 private[sql] class TestSQLSessionStateBuilder(

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -61,7 +61,10 @@ private[sql] object TestSQLContext {
   val overrideConfs: Map[String, String] =
     Map(
       // Fewer shuffle partitions to speed up testing.
-      SQLConf.SHUFFLE_PARTITIONS.key -> "5")
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
+      // Enable parquet read field id for tests to ensure correctness
+      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true"
+    )
 }
 
 private[sql] class TestSQLSessionStateBuilder(

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/TestSQLContext.scala
@@ -61,10 +61,7 @@ private[sql] object TestSQLContext {
   val overrideConfs: Map[String, String] =
     Map(
       // Fewer shuffle partitions to speed up testing.
-      SQLConf.SHUFFLE_PARTITIONS.key -> "5",
-      // Enable parquet read field id for tests to ensure correctness
-      SQLConf.PARQUET_FIELD_ID_READ_ENABLED.key -> "true"
-    )
+      SQLConf.SHUFFLE_PARTITIONS.key -> "5")
 }
 
 private[sql] class TestSQLSessionStateBuilder(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Field Id is a native field in the Parquet schema (https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L398)

After this PR, when the requested schema has field IDs, Parquet readers will first use the field ID to determine which Parquet columns to read if the field ID exists in Spark schema, before falling back to match using column names. 

This PR supports:
- Vectorized reader
- parquet-mr reader

### Why are the changes needed?
It enables matching columns by field id for supported DWs like iceberg and Delta. Specifically, it enables easy conversion from Iceberg (which uses field ids by name) to Delta, and allows `id` mode for Delta [column mapping](https://docs.databricks.com/delta/delta-column-mapping.html)

### Does this PR introduce _any_ user-facing change?
This PR introduces three new configurations:

`spark.sql.parquet.fieldId.write.enabled`: If enabled, Spark will write out native field ids that are stored inside StructField's metadata as `parquet.field.id` to parquet files. This configuration is default to `true`.

`spark.sql.parquet.fieldId.read.enabled`: If enabled, Spark will attempt to read field ids in parquet files and utilize them for matching columns. This configuration is default to `false`, so Spark could maintain its existing behavior by default.

`spark.sql.parquet.fieldId.read.ignoreMissing`: if enabled, Spark will read parquet files that do not have any field ids, while attempting to match the columns by id in Spark schema;  nulls will be returned for spark columns without a match. This configuration is default to `false`, so Spark could alert the user in case field id matching is expected but parquet files do not have any ids.

### How was this patch tested?
Existing tests + new unit tests.