### PR TITLE
[SPARK-37936][SQL] Use error classes in the parsing errors of intervals

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -85,15 +85,15 @@
   "INVALID_FROM_TO_UNIT_VALUE" : {
     "message" : [ "The value of from-to unit must be a string" ]
   },
+  "INVALID_INPUT_SYNTAX_FOR_NUMERIC_TYPE" : {
+    "message" : [ "invalid input syntax for type numeric: %s. To return NULL instead, use 'try_cast'. If necessary set %s to false to bypass this error." ],
+    "sqlState" : "42000"
+  },
   "INVALID_INTERVAL_FORM" : {
     "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s" ]
   },
   "INVALID_INTERVAL_LITERAL" : {
     "message" : [ "at least one time unit should be given for interval literal" ]
-  },
-  "INVALID_INPUT_SYNTAX_FOR_NUMERIC_TYPE" : {
-    "message" : [ "invalid input syntax for type numeric: %s. To return NULL instead, use 'try_cast'. If necessary set %s to false to bypass this error." ],
-    "sqlState" : "42000"
   },
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -165,9 +165,6 @@
     "message" : [ "The feature is not supported: %s" ],
     "sqlState" : "0A000"
   },
-  "UNSUPPORTED_FROM_TO_INTERVAL" : {
-    "message" : [ "Intervals FROM %s TO %s are not supported." ]
-  },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -165,6 +165,9 @@
     "message" : [ "The feature is not supported: %s" ],
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_FROM_TO_INTERVAL" : {
+    "message" : [ "Intervals FROM %s TO %s are not supported." ]
+  },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -82,6 +82,15 @@
     "message" : [ "The fraction of sec must be zero. Valid range is [0, 60]. If necessary set %s to false to bypass this error. " ],
     "sqlState" : "22023"
   },
+  "INVALID_FROM_TO_UNIT_VALUE" : {
+    "message" : [ "The value of from-to unit must be a string" ]
+  },
+  "INVALID_INTERVAL_FORM" : {
+    "message" : [ "Can only use numbers in the interval value part for multiple unit value pairs interval form, but got invalid value: %s" ]
+  },
+  "INVALID_INTERVAL_LITERAL" : {
+    "message" : [ "at least one time unit should be given for interval literal" ]
+  },
   "INVALID_INPUT_SYNTAX_FOR_NUMERIC_TYPE" : {
     "message" : [ "invalid input syntax for type numeric: %s. To return NULL instead, use 'try_cast'. If necessary set %s to false to bypass this error." ],
     "sqlState" : "42000"
@@ -111,6 +120,12 @@
     "message" : [ "Unknown static partition column: %s" ],
     "sqlState" : "42000"
   },
+  "MIXED_INTERVAL_UNITS" : {
+    "message" : [ "Cannot mix year-month and day-time fields: %s" ]
+  },
+  "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL" : {
+    "message" : [ "Can only have a single from-to unit in the interval literal syntax" ]
+  },
   "NON_LITERAL_PIVOT_VALUES" : {
     "message" : [ "Literal expressions required for pivot values, found '%s'" ],
     "sqlState" : "42000"
@@ -137,6 +152,9 @@
   },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
+  },
+  "UNSUPPORTED_FROM_TO_INTERVAL" : {
+    "message" : [ "Intervals FROM %s TO %s are not supported." ]
   },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -153,9 +153,6 @@
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]
   },
-  "UNSUPPORTED_FROM_TO_INTERVAL" : {
-    "message" : [ "Intervals FROM %s TO %s are not supported." ]
-  },
   "UNRECOGNIZED_SQL_TYPE" : {
     "message" : [ "Unrecognized SQL type %s" ],
     "sqlState" : "42000"
@@ -167,6 +164,9 @@
   "UNSUPPORTED_FEATURE" : {
     "message" : [ "The feature is not supported: %s" ],
     "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_FROM_TO_INTERVAL" : {
+    "message" : [ "Intervals FROM %s TO %s are not supported." ]
   },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -212,6 +212,7 @@ object QueryParsingErrors {
       messageParameters = Array(s"Intervals FROM $from TO $to are not supported."),
       ctx)
   }
+
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -207,9 +207,12 @@ object QueryParsingErrors {
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array(s"Intervals FROM $from TO $to are not supported."),
+      ctx)
   }
-
+  Array(s"IF NOT EXISTS for the table '$tableName' by INSERT INTO.")
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -207,7 +207,7 @@ object QueryParsingErrors {
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
+    new ParseException(s"UNSUPPORTED_FEATURE", Array.empty, ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -209,7 +209,7 @@ object QueryParsingErrors {
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(
       errorClass = "UNSUPPORTED_FEATURE",
-      messageParameters = Array(s"Intervals FROM $from TO $to are not supported"),
+      messageParameters = Array(s"Intervals FROM $from TO $to are not supported."),
       ctx)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -208,8 +208,8 @@ object QueryParsingErrors {
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      errorClass = "UNSUPPORTED_FEATURE",
-      messageParameters = Array(s"Intervals FROM $from TO $to are not supported."),
+      errorClass = s"UNSUPPORTED_FEATURE",
+      messageParameters = Array(s"Intervals FROM $from TO $to are not supported"),
       ctx)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -207,7 +207,7 @@ object QueryParsingErrors {
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"UNSUPPORTED_FEATURE", Array.empty, ctx)
+    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -190,31 +190,31 @@ object QueryParsingErrors {
   }
 
   def moreThanOneFromToUnitInIntervalLiteralError(ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL", Array.empty, ctx)
+    new ParseException("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL", Array.empty, ctx)
   }
 
   def invalidIntervalLiteralError(ctx: IntervalContext): Throwable = {
-    new ParseException(s"INVALID_INTERVAL_LITERAL", Array.empty, ctx)
+    new ParseException("INVALID_INTERVAL_LITERAL", Array.empty, ctx)
   }
 
   def invalidIntervalFormError(value: String, ctx: MultiUnitsIntervalContext): Throwable = {
-    new ParseException(s"INVALID_INTERVAL_FORM", Array(value), ctx)
+    new ParseException("INVALID_INTERVAL_FORM", Array(value), ctx)
   }
 
   def invalidFromToUnitValueError(ctx: IntervalValueContext): Throwable = {
-    new ParseException(s"INVALID_FROM_TO_UNIT_VALUE", Array.empty, ctx)
+    new ParseException("INVALID_FROM_TO_UNIT_VALUE", Array.empty, ctx)
   }
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      errorClass = s"UNSUPPORTED_FEATURE",
+      errorClass = "UNSUPPORTED_FEATURE",
       messageParameters = Array(s"Intervals FROM $from TO $to are not supported"),
       ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
+    new ParseException("MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }
 
   def dataTypeUnsupportedError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -190,29 +190,28 @@ object QueryParsingErrors {
   }
 
   def moreThanOneFromToUnitInIntervalLiteralError(ctx: ParserRuleContext): Throwable = {
-    new ParseException("Can only have a single from-to unit in the interval literal syntax", ctx)
+    new ParseException(s"MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL", Array.empty, ctx)
   }
 
   def invalidIntervalLiteralError(ctx: IntervalContext): Throwable = {
-    new ParseException("at least one time unit should be given for interval literal", ctx)
+    new ParseException(s"INVALID_INTERVAL_LITERAL", Array.empty, ctx)
   }
 
   def invalidIntervalFormError(value: String, ctx: MultiUnitsIntervalContext): Throwable = {
-    new ParseException("Can only use numbers in the interval value part for" +
-      s" multiple unit value pairs interval form, but got invalid value: $value", ctx)
+    new ParseException(s"INVALID_INTERVAL_FORM", Array(value), ctx)
   }
 
   def invalidFromToUnitValueError(ctx: IntervalValueContext): Throwable = {
-    new ParseException("The value of from-to unit must be a string", ctx)
+    new ParseException(s"INVALID_FROM_TO_UNIT_VALUE", Array.empty, ctx)
   }
 
   def fromToIntervalUnsupportedError(
       from: String, to: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"Intervals FROM $from TO $to are not supported.", ctx)
+    new ParseException(s"UNSUPPORTED_FROM_TO_INTERVAL", Array(from, to), ctx)
   }
 
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"Cannot mix year-month and day-time fields: $literal", ctx)
+    new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }
 
   def dataTypeUnsupportedError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -212,7 +212,6 @@ object QueryParsingErrors {
       messageParameters = Array(s"Intervals FROM $from TO $to are not supported."),
       ctx)
   }
-  Array(s"IF NOT EXISTS for the table '$tableName' by INSERT INTO.")
   def mixedIntervalUnitsError(literal: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(s"MIXED_INTERVAL_UNITS", Array(literal), ctx)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -836,10 +836,6 @@ class ExpressionParserSuite extends AnalysisTest {
       }
     }
 
-    // Unknown FROM TO intervals
-    intercept("interval '10' month to second",
-      "Intervals FROM month TO second are not supported.")
-
     // Composed intervals.
     checkIntervals(
       "10 years 3 months", Literal.create(Period.of(10, 3, 0), YearMonthIntervalType()))

--- a/sql/core/src/test/resources/sql-tests/inputs/interval.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/interval.sql
@@ -167,7 +167,8 @@ SELECT interval '2 weeks 2 days 1 hour 3 minutes 2 seconds 100 millisecond 200 m
 select interval;
 select interval 1 fake_unit;
 select interval 1 year to month;
-select interval '1' year to second;
+-- SPARK-37936: moving this query test into 'QueryParsingErrorsSuite'
+-- select interval '1' year to second;
 select interval '10-9' year to month '2-1' year to month;
 select interval '10-9' year to month '12:11:10' hour to second;
 select interval '1 15:11' day to minute '12:11:10' hour to second;

--- a/sql/core/src/test/resources/sql-tests/inputs/interval.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/interval.sql
@@ -167,8 +167,7 @@ SELECT interval '2 weeks 2 days 1 hour 3 minutes 2 seconds 100 millisecond 200 m
 select interval;
 select interval 1 fake_unit;
 select interval 1 year to month;
--- SPARK-37936: moving this query test into 'QueryParsingErrorsSuite'
--- select interval '1' year to second;
+select interval '1' year to second;
 select interval '10-9' year to month '2-1' year to month;
 select interval '10-9' year to month '12:11:10' hour to second;
 select interval '1 15:11' day to minute '12:11:10' hour to second;

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1213,7 +1213,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Intervals FROM year TO second are not supported.(line 1, pos 16)
+The feature is not supported: Intervals FROM year TO second are not supported(line 1, pos 16)
 
 == SQL ==
 select interval '1' year to second

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1213,7 +1213,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The feature is not supported: Intervals FROM year TO second are not supported(line 1, pos 16)
+The feature is not supported: Intervals FROM year TO second are not supported.(line 1, pos 16)
 
 == SQL ==
 select interval '1' year to second

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1206,7 +1206,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Intervals FROM year TO second are not supported.(line 1, pos 16)
+The feature is not supported: Intervals FROM year TO second are not supported(line 1, pos 16)
 
 == SQL ==
 select interval '1' year to second

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1206,7 +1206,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The feature is not supported: Intervals FROM year TO second are not supported(line 1, pos 16)
+The feature is not supported: Intervals FROM year TO second are not supported.(line 1, pos 16)
 
 == SQL ==
 select interval '1' year to second

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -116,7 +116,16 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
   // Moved from ExpressionParserSuite
   test("UNSUPPORTED_FEATURE: Unsupported month to second interval") {
     val e = intercept[ParseException] {
-      spark.sql("SELECT interval '10' month to second)")
+      spark.sql("SELECT interval '10' month to second")
+    }
+    assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
+    assert(e.getSqlState === "0A000")
+    assert(e.getMessage.contains("The feature is not supported"))
+  }
+  // Moved from Interval.sql
+  test("UNSUPPORTED_FEATURE: Unsupported month to second interval") {
+    val e = intercept[ParseException] {
+      spark.sql("select interval '1' year to second")
     }
     assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
     assert(e.getSqlState === "0A000")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -105,14 +105,23 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       "The value of from-to unit must be a string"))
   }
 
-  test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
+  test("UNSUPPORTED_FEATURE: Unsupported from-to interval") {
     val e = intercept[ParseException] {
       spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)")
     }
-    assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
-    assert(e.getMessage.contains("are not supported."))
+    assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
+    assert(e.getSqlState === "0A000")
+    assert(e.getMessage.contains("The feature is not supported"))
   }
-
+  // Moved from ExpressionParserSuite
+  test("UNSUPPORTED_FEATURE: Unsupported month to second interval") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT interval '10' month to second)")
+    }
+    assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
+    assert(e.getSqlState === "0A000")
+    assert(e.getMessage.contains("The feature is not supported"))
+  }
   test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
     val e = intercept[ParseException] {
       spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -78,4 +78,57 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
         message = "Invalid SQL syntax: LATERAL can only be used with subquery.")
     }
   }
+  test("MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL: from-to unit in the interval literal") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL 1 to 3 year to month AS col")
+    }
+    assert(e.getErrorClass === "MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL")
+    assert(e.getMessage.contains(
+      "Can only have a single from-to unit in the interval literal syntax"))
+  }
+
+  test("INVALID_INTERVAL_LITERAL: invalid interval literal") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL DAY")
+    }
+    assert(e.getErrorClass === "INVALID_INTERVAL_LITERAL")
+    assert(e.getMessage.contains(
+      "at least one time unit should be given for interval literal"))
+  }
+
+  test("INVALID_FROM_TO_UNIT_VALUE: value of from-to unit must be a string") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL -2021 YEAR TO MONTH")
+    }
+    assert(e.getErrorClass === "INVALID_FROM_TO_UNIT_VALUE")
+    assert(e.getMessage.contains(
+      "The value of from-to unit must be a string"))
+  }
+
+  test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)")
+    }
+    assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
+    assert(e.getMessage.matches(
+      """Intervals FROM \w+ TO \w+ are not supported"""))
+  }
+
+  test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR")
+    }
+    assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
+    assert(e.getMessage.contains(
+      "Cannot mix year-month and day-time fields"))
+  }
+
+  test("INVALID_INTERVAL_FORM: invalid interval form") {
+    val e = intercept[ParseException] {
+      spark.sql("SELECT INTERVAL '1 DAY 2' HOUR")
+    }
+    assert(e.getErrorClass === "INVALID_INTERVAL_FORM")
+    assert(e.getMessage.contains(
+      "numbers in the interval value part for multiple unit value pairs interval form"))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -111,7 +111,8 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     }
     assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
     assert(e.getSqlState === "0A000")
-    assert(e.getMessage.contains("The feature is not supported"))
+    assert(e.getMessage.contains(
+      "The feature is not supported: Intervals FROM year TO day are not supported"))
   }
 
   // Moved from ExpressionParserSuite
@@ -121,7 +122,8 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     }
     assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
     assert(e.getSqlState === "0A000")
-    assert(e.getMessage.contains("The feature is not supported"))
+    assert(e.getMessage.contains(
+      "The feature is not supported: Intervals FROM month TO second are not supported"))
   }
 
   test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
@@ -129,7 +131,6 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR")
     }
     assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
-
     assert(e.getMessage.contains(
       "Cannot mix year-month and day-time fields"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -105,13 +105,12 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       "The value of from-to unit must be a string"))
   }
 
-  test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
+  test("UNSUPPORTED_FEATURE: Unsupported from-to interval") {
     val e = intercept[ParseException] {
       spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)")
     }
-    assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
-    assert(e.getMessage.matches(
-      """Intervals FROM year TO day are not supported"""))
+    assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
+    assert(e.getMessage.contains("The feature is not supported"))
   }
 
   test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -113,6 +113,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     assert(e.getSqlState === "0A000")
     assert(e.getMessage.contains("The feature is not supported"))
   }
+
   // Moved from ExpressionParserSuite
   test("UNSUPPORTED_FEATURE: Unsupported month to second interval") {
     val e = intercept[ParseException] {
@@ -122,15 +123,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     assert(e.getSqlState === "0A000")
     assert(e.getMessage.contains("The feature is not supported"))
   }
-  // Moved from Interval.sql
-  test("UNSUPPORTED_FEATURE: Unsupported month to second interval") {
-    val e = intercept[ParseException] {
-      spark.sql("select interval '1' year to second")
-    }
-    assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
-    assert(e.getSqlState === "0A000")
-    assert(e.getMessage.contains("The feature is not supported"))
-  }
+
   test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {
     val e = intercept[ParseException] {
       spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR")

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -105,12 +105,12 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       "The value of from-to unit must be a string"))
   }
 
-  test("UNSUPPORTED_FEATURE: Unsupported from-to interval") {
+  test("UNSUPPORTED_FROM_TO_INTERVAL: Unsupported from-to interval") {
     val e = intercept[ParseException] {
       spark.sql("SELECT extract(MONTH FROM INTERVAL '2021-11' YEAR TO DAY)")
     }
-    assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
-    assert(e.getMessage.contains("The feature is not supported"))
+    assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
+    assert(e.getMessage.contains("are not supported."))
   }
 
   test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -119,6 +119,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       spark.sql("SELECT INTERVAL 1 MONTH 2 HOUR")
     }
     assert(e.getErrorClass === "MIXED_INTERVAL_UNITS")
+
     assert(e.getMessage.contains(
       "Cannot mix year-month and day-time fields"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -111,7 +111,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     }
     assert(e.getErrorClass === "UNSUPPORTED_FROM_TO_INTERVAL")
     assert(e.getMessage.matches(
-      """Intervals FROM \w+ TO \w+ are not supported"""))
+      """Intervals FROM year TO day are not supported"""))
   }
 
   test("MIXED_INTERVAL_UNITS: Cannot mix year-month and day-time fields") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, We propose to throw ParseException from below methods with the error classes:
- moreThanOneFromToUnitInIntervalLiteralError() - MORE_THAN_ONE_FROM_TO_UNIT_IN_INTERVAL_LITERAL
- invalidIntervalLiteralError() - INVALID_INTERVAL_LITERAL
- invalidIntervalFormError() - INVALID_INTERVAL_FORM
- invalidFromToUnitValueError() - INVALID_FROM_TO_UNIT_VALUE
- fromToIntervalUnsupportedError() - UNSUPPORTED_FROM_TO_INTERVAL
- mixedIntervalUnitsError() - MIXED_INTERVAL_UNITS

New error classes are added to error-classes.json.

New test suite QueryParsingErrorsSuite for checking the errors has been created.

### Why are the changes needed?
Please refer [SPARK-37935: Migrate onto error classes](https://issues.apache.org/jira/browse/SPARK-37935).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New tests are added to QueryParsingErrorsSuite.