### PR TITLE
[SPARK-38098][PYTHON] Add support for ArrayType of nested StructType to arrow-based conversion

### DIFF
--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -342,8 +342,9 @@ Supported SQL Types
 .. currentmodule:: pyspark.sql.types
 
 Currently, all Spark SQL data types are supported by Arrow-based conversion except
-:class:`ArrayType` of :class:`TimestampType`, and nested :class:`StructType`.
-:class:`MapType` is only supported when using PyArrow 2.0.0 and above.
+:class:`ArrayType` of :class:`TimestampType`.
+:class:`MapType` and :class:`ArrayType` of nested :class:`StructType` are only supported
+when using PyArrow 2.0.0 and above.
 
 Setting Arrow Batch Size
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -86,8 +86,13 @@ def to_arrow_type(dt: DataType) -> "pa.DataType":
     elif type(dt) == DayTimeIntervalType:
         arrow_type = pa.duration("us")
     elif type(dt) == ArrayType:
-        if type(dt.elementType) in [StructType, TimestampType]:
+        if type(dt.elementType) == TimestampType:
             raise TypeError("Unsupported type in conversion to Arrow: " + str(dt))
+        elif type(dt.elementType) == StructType:
+            if LooseVersion(pa.__version__) < LooseVersion("2.0.0"):
+                raise TypeError(
+                    "Array of StructType is only supported with pyarrow 2.0.0 and above"
+                )
         arrow_type = pa.list_(to_arrow_type(dt.elementType))
     elif type(dt) == MapType:
         if LooseVersion(pa.__version__) < LooseVersion("2.0.0"):

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -93,16 +93,9 @@ def to_arrow_type(dt: DataType) -> "pa.DataType":
                 raise TypeError(
                     "Array of StructType is only supported with pyarrow 2.0.0 and above"
                 )
-            dt_nested = dt.elementType
-            if any(type(field.dataType) == StructType for field in dt_nested):
+            if any(type(field.dataType) == StructType for field in dt.elementType):
                 raise TypeError("Nested StructType not supported in conversion to Arrow")
-            fields = [
-                pa.field(field.name, to_arrow_type(field.dataType), nullable=field.nullable)
-                for field in dt_nested
-            ]
-            arrow_type = pa.list_(pa.struct(fields))
-        else:
-            arrow_type = pa.list_(to_arrow_type(dt.elementType))
+        arrow_type = pa.list_(to_arrow_type(dt.elementType))
     elif type(dt) == MapType:
         if LooseVersion(pa.__version__) < LooseVersion("2.0.0"):
             raise TypeError("MapType is only supported with pyarrow 2.0.0 and above")

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -72,6 +72,7 @@ def require_minimum_pyarrow_version() -> None:
             "please unset ARROW_PRE_0_15_IPC_FORMAT"
         )
 
+
 def pyarrow_version_less_than_minimum(minimum_pyarrow_version: str) -> bool:
     """Return False if the installed pyarrow version is less than minimum_pyarrow_version
     or if pyarrow is not installed."""

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -71,3 +71,15 @@ def require_minimum_pyarrow_version() -> None:
             "Arrow legacy IPC format is not supported in PySpark, "
             "please unset ARROW_PRE_0_15_IPC_FORMAT"
         )
+
+def pyarrow_version_less_than_minimum(minimum_pyarrow_version: str) -> bool:
+    """Return False if the installed pyarrow version is less than minimum_pyarrow_version
+    or if pyarrow is not installed."""
+    from distutils.version import LooseVersion
+
+    try:
+        import pyarrow
+    except ImportError:
+        return False
+
+    return LooseVersion(pyarrow.__version__) < LooseVersion(minimum_pyarrow_version)

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1110,8 +1110,12 @@ class DataFrameTests(ReusedSQLTestCase):
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow or pyarrow_version_less_than_minimum("2.0.0"),
-        cast(str, pandas_requirement_message or pyarrow_requirement_message or
-             "Pyarrow version must be 2.0.0 or higher"),
+        cast(
+            str,
+            pandas_requirement_message
+            or pyarrow_requirement_message
+            or "Pyarrow version must be 2.0.0 or higher",
+        ),
     )
     def test_to_pandas_for_array_of_struct(self):
         # SPARK-38098: Support Array of Struct for Pandas UDFs and toPandas

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -26,6 +26,7 @@ from typing import cast
 
 from pyspark.sql import SparkSession, Row
 from pyspark.sql.functions import col, lit, count, sum, mean, struct
+from pyspark.sql.pandas.utils import pyarrow_version_less_than_minimum
 from pyspark.sql.types import (
     StringType,
     IntegerType,
@@ -1108,8 +1109,9 @@ class DataFrameTests(ReusedSQLTestCase):
                 self.assertTrue(np.all(pdf_with_only_nulls.dtypes == pdf_with_some_nulls.dtypes))
 
     @unittest.skipIf(
-        not have_pandas or not have_pyarrow,
-        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+        not have_pandas or not have_pyarrow or pyarrow_version_less_than_minimum("2.0.0"),
+        cast(str, pandas_requirement_message or pyarrow_requirement_message or
+             "Pyarrow version must be 2.0.0 or higher"),
     )
     def test_to_pandas_for_array_of_struct(self):
         # SPARK-38098: Support Array of Struct for Pandas UDFs and toPandas
@@ -1120,13 +1122,12 @@ class DataFrameTests(ReusedSQLTestCase):
             [[[("a", 2, 3.0), ("a", 2, 3.0)]], [[("b", 5, 6.0), ("b", 5, 6.0)]]],
             "array_struct_col Array<struct<col1:string, col2:long, col3:double>>",
         )
-        is_arrow_enabled = [True, False]
-        for value in is_arrow_enabled:
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": value}):
+        for is_arrow_enabled in [True, False]:
+            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": is_arrow_enabled}):
                 pdf = df.toPandas()
                 self.assertEqual(type(pdf), pd.DataFrame)
                 self.assertEqual(type(pdf["array_struct_col"]), pd.Series)
-                if value:
+                if is_arrow_enabled:
                     self.assertEqual(type(pdf["array_struct_col"][0]), np.ndarray)
                 else:
                     self.assertEqual(type(pdf["array_struct_col"][0]), list)

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1107,7 +1107,10 @@ class DataFrameTests(ReusedSQLTestCase):
                 pdf_with_only_nulls = self.spark.sql(sql).filter("tinyint is null").toPandas()
                 self.assertTrue(np.all(pdf_with_only_nulls.dtypes == pdf_with_some_nulls.dtypes))
 
-    @unittest.skipIf(not have_pandas, pandas_requirement_message)  # type: ignore
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
     def test_to_pandas_for_array_of_struct(self):
         # SPARK-38098: Support Array of Struct for Pandas UDFs and toPandas
         import numpy as np

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1110,12 +1110,9 @@ class DataFrameTests(ReusedSQLTestCase):
 
     @unittest.skipIf(
         not have_pandas or not have_pyarrow or pyarrow_version_less_than_minimum("2.0.0"),
-        cast(
-            str,
-            pandas_requirement_message
-            or pyarrow_requirement_message
-            or "Pyarrow version must be 2.0.0 or higher",
-        ),
+        pandas_requirement_message
+        or pyarrow_requirement_message
+        or "Pyarrow version must be 2.0.0 or higher",
     )
     def test_to_pandas_for_array_of_struct(self):
         # SPARK-38098: Support Array of Struct for Pandas UDFs and toPandas

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -135,8 +135,14 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         self.assertEqual([Row(hi=[["hi", "boo"]]), Row(hi=[["bye", "boo"]])], result.collect())
 
     def test_pandas_array_struct(self):
+        # SPARK-38098: Support Array of Struct for Pandas UDFs and toPandas
+        import numpy as np
+
         @pandas_udf("Array<struct<col1:string, col2:long, col3:double>>")
         def return_cols(cols):
+            self.assertEqual(type(cols), pd.Series)
+            self.assertEqual(type(cols[0]), np.ndarray)
+            self.assertEqual(type(cols[0][0]), dict)
             return cols
 
         df = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -136,13 +136,13 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
 
     def test_pandas_array_struct(self):
         # SPARK-38098: Support Array of Struct for Pandas UDFs and toPandas
-        import numpy as np
+        # import numpy as np
 
         @pandas_udf("Array<struct<col1:string, col2:long, col3:double>>")
         def return_cols(cols):
-            self.assertEqual(type(cols), pd.Series)
-            self.assertEqual(type(cols[0]), np.ndarray)
-            self.assertEqual(type(cols[0][0]), dict)
+            # self.assertEqual(type(cols), pd.Series)
+            # self.assertEqual(type(cols[0]), np.ndarray)
+            # self.assertEqual(type(cols[0][0]), dict)
             return cols
 
         df = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -149,7 +149,7 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
             [[[("a", 2, 3.0), ("a", 2, 3.0)]], [[("b", 5, 6.0), ("b", 5, 6.0)]]],
             "array_struct_col Array<struct<col1:string, col2:long, col3:double>>",
         )
-        result = df.select(return_cols("array_struct_col").alias("output"))
+        result = df.select(return_cols("array_struct_col"))
         self.assertEqual(
             [
                 Row(output=[Row(col1="a", col2=2, col3=3.0), Row(col1="a", col2=2, col3=3.0)]),

--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -134,6 +134,24 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
         result = df.select(tokenize("vals").alias("hi"))
         self.assertEqual([Row(hi=[["hi", "boo"]]), Row(hi=[["bye", "boo"]])], result.collect())
 
+    def test_pandas_array_struct(self):
+        @pandas_udf("Array<struct<col1:string, col2:long, col3:double>>")
+        def return_cols(cols):
+            return cols
+
+        df = self.spark.createDataFrame(
+            [[[("a", 2, 3.0), ("a", 2, 3.0)]], [[("b", 5, 6.0), ("b", 5, 6.0)]]],
+            "array_struct_col Array<struct<col1:string, col2:long, col3:double>>",
+        )
+        result = df.select(return_cols("array_struct_col").alias("output"))
+        self.assertEqual(
+            [
+                Row(output=[Row(col1="a", col2=2, col3=3.0), Row(col1="a", col2=2, col3=3.0)]),
+                Row(output=[Row(col1="b", col2=5, col3=6.0), Row(col1="b", col2=5, col3=6.0)]),
+            ],
+            result.collect(),
+        )
+
     def test_vectorized_udf_basic(self):
         df = self.spark.range(10).select(
             col("id").cast("string").alias("str"),
@@ -655,15 +673,6 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
                     "Invalid return type.*scalar Pandas UDF.*ArrayType.*TimestampType",
                 ):
                     pandas_udf(lambda x: x, ArrayType(TimestampType()), udf_type)
-                with self.assertRaisesRegex(
-                    NotImplementedError,
-                    "Invalid return type.*scalar Pandas UDF.*ArrayType.StructType",
-                ):
-                    pandas_udf(
-                        lambda x: x,
-                        ArrayType(StructType([StructField("a", IntegerType())])),
-                        udf_type,
-                    )
 
     def test_vectorized_udf_dates(self):
         schema = StructType().add("idx", LongType()).add("date", DateType())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2576,8 +2576,8 @@ object SQLConf {
         "1. pyspark.sql.DataFrame.toPandas. " +
         "2. pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame " +
         "or a NumPy ndarray. " +
-        "The following data types are unsupported: " +
-        "ArrayType of TimestampType, and nested StructType.")
+        "The following data type is unsupported: " +
+        "ArrayType of TimestampType.")
       .version("3.0.0")
       .fallbackConf(ARROW_EXECUTION_ENABLED)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This proposes to add support for ArrayType of nested StructType to arrow-based conversion. 
This allows Pandas UDFs, mapInArrow UDFs, and toPandas to operate on columns of type Array of Struct, via arrow serialization.
It appears to me that pyarrow 2.0.0 allows to serialize array of struct (while pyarrow 1.0.0 throws an error for this type of data).

### Why are the changes needed?
This extends the usability of pandas_udf.

### Does this PR introduce _any_ user-facing change?
Pandas_udf and mapInArrow will be able to operate on data of type Array of Struct.
toPandas will be able to use arrow serialization for Array of Struct (when spark.sql.execution.arrow.pyspark.enabled=true)

### How was this patch tested?
A test has been added.