### PR TITLE
[SPARK-38100][SQL] Remove unused private method in `Decimal`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -251,9 +251,6 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def toByte: Byte = toLong.toByte
 
-  private def overflowException(dataType: String) =
-    throw QueryExecutionErrors.castingCauseOverflowError(this, dataType)
-
   /**
    * @return the Byte value that is equal to the rounded decimal.
    * @throws ArithmeticException if the decimal is too big to fit in Byte type.


### PR DESCRIPTION
### What changes were proposed in this pull request?
There is an unused `private` method `overflowException` in `org.apache.spark.sql.types.Decimal`, this method add by SPARK-28741 and  the relevant invocations are replaced by `QueryExecutionErrors.castingCauseOverflowError` directly after SPARK-35060. So this pr remove this unused method.


### Why are the changes needed?
Remove unused method.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA