### PR TITLE
[SPARK-38086][SQL] Make ArrowColumnVector Extendable

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -28,10 +28,10 @@ import org.apache.spark.unsafe.types.UTF8String;
 /**
  * A column vector backed by Apache Arrow.
  */
-public final class ArrowColumnVector extends ColumnVector {
+public class ArrowColumnVector extends ColumnVector {
 
-  private final ArrowVectorAccessor accessor;
-  private ArrowColumnVector[] childColumns;
+  ArrowVectorAccessor accessor;
+  ArrowColumnVector[] childColumns;
 
   public ValueVector getValueVector() { return accessor.vector; }
 
@@ -130,9 +130,16 @@ public final class ArrowColumnVector extends ColumnVector {
   @Override
   public ArrowColumnVector getChild(int ordinal) { return childColumns[ordinal]; }
 
-  public ArrowColumnVector(ValueVector vector) {
-    super(ArrowUtils.fromArrowField(vector.getField()));
+  ArrowColumnVector(DataType type) {
+     super(type);
+  }
 
+  public ArrowColumnVector(ValueVector vector) {
+    this(ArrowUtils.fromArrowField(vector.getField()));
+    initAccessor(vector);
+  }
+
+  void initAccessor(ValueVector vector) {
     if (vector instanceof BitVector) {
       accessor = new BooleanAccessor((BitVector) vector);
     } else if (vector instanceof TinyIntVector) {
@@ -184,9 +191,9 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private abstract static class ArrowVectorAccessor {
+  abstract static class ArrowVectorAccessor {
 
-    private final ValueVector vector;
+    final ValueVector vector;
 
     ArrowVectorAccessor(ValueVector vector) {
       this.vector = vector;
@@ -254,7 +261,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class BooleanAccessor extends ArrowVectorAccessor {
+  static class BooleanAccessor extends ArrowVectorAccessor {
 
     private final BitVector accessor;
 
@@ -269,7 +276,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class ByteAccessor extends ArrowVectorAccessor {
+  static class ByteAccessor extends ArrowVectorAccessor {
 
     private final TinyIntVector accessor;
 
@@ -284,7 +291,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class ShortAccessor extends ArrowVectorAccessor {
+  static class ShortAccessor extends ArrowVectorAccessor {
 
     private final SmallIntVector accessor;
 
@@ -299,7 +306,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class IntAccessor extends ArrowVectorAccessor {
+  static class IntAccessor extends ArrowVectorAccessor {
 
     private final IntVector accessor;
 
@@ -314,7 +321,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class LongAccessor extends ArrowVectorAccessor {
+  static class LongAccessor extends ArrowVectorAccessor {
 
     private final BigIntVector accessor;
 
@@ -329,7 +336,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class FloatAccessor extends ArrowVectorAccessor {
+  static class FloatAccessor extends ArrowVectorAccessor {
 
     private final Float4Vector accessor;
 
@@ -344,7 +351,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class DoubleAccessor extends ArrowVectorAccessor {
+  static class DoubleAccessor extends ArrowVectorAccessor {
 
     private final Float8Vector accessor;
 
@@ -359,7 +366,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class DecimalAccessor extends ArrowVectorAccessor {
+  static class DecimalAccessor extends ArrowVectorAccessor {
 
     private final DecimalVector accessor;
 
@@ -375,7 +382,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class StringAccessor extends ArrowVectorAccessor {
+  static class StringAccessor extends ArrowVectorAccessor {
 
     private final VarCharVector accessor;
     private final NullableVarCharHolder stringResult = new NullableVarCharHolder();
@@ -398,7 +405,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class BinaryAccessor extends ArrowVectorAccessor {
+  static class BinaryAccessor extends ArrowVectorAccessor {
 
     private final VarBinaryVector accessor;
 
@@ -413,7 +420,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class DateAccessor extends ArrowVectorAccessor {
+  static class DateAccessor extends ArrowVectorAccessor {
 
     private final DateDayVector accessor;
 
@@ -428,7 +435,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class TimestampAccessor extends ArrowVectorAccessor {
+  static class TimestampAccessor extends ArrowVectorAccessor {
 
     private final TimeStampMicroTZVector accessor;
 
@@ -443,7 +450,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class TimestampNTZAccessor extends ArrowVectorAccessor {
+  static class TimestampNTZAccessor extends ArrowVectorAccessor {
 
     private final TimeStampMicroVector accessor;
 
@@ -458,7 +465,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class ArrayAccessor extends ArrowVectorAccessor {
+  static class ArrayAccessor extends ArrowVectorAccessor {
 
     private final ListVector accessor;
     private final ArrowColumnVector arrayData;
@@ -495,14 +502,14 @@ public final class ArrowColumnVector extends ColumnVector {
    * bug in the code.
    *
    */
-  private static class StructAccessor extends ArrowVectorAccessor {
+  static class StructAccessor extends ArrowVectorAccessor {
 
     StructAccessor(StructVector vector) {
       super(vector);
     }
   }
 
-  private static class MapAccessor extends ArrowVectorAccessor {
+  static class MapAccessor extends ArrowVectorAccessor {
     private final MapVector accessor;
     private final ArrowColumnVector keys;
     private final ArrowColumnVector values;
@@ -524,14 +531,14 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class NullAccessor extends ArrowVectorAccessor {
+  static class NullAccessor extends ArrowVectorAccessor {
 
     NullAccessor(NullVector vector) {
       super(vector);
     }
   }
 
-  private static class IntervalYearAccessor extends ArrowVectorAccessor {
+  static class IntervalYearAccessor extends ArrowVectorAccessor {
 
     private final IntervalYearVector accessor;
 
@@ -546,7 +553,7 @@ public final class ArrowColumnVector extends ColumnVector {
     }
   }
 
-  private static class DurationAccessor extends ArrowVectorAccessor {
+  static class DurationAccessor extends ArrowVectorAccessor {
 
     private final DurationVector accessor;
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -21,6 +21,7 @@ import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.*;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
 
+import org.apache.spark.annotation.DeveloperApi;
 import org.apache.spark.sql.util.ArrowUtils;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -28,6 +29,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 /**
  * A column vector backed by Apache Arrow.
  */
+@DeveloperApi
 public class ArrowColumnVector extends ColumnVector {
 
   ArrowVectorAccessor accessor;

--- a/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
@@ -455,7 +455,7 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
     val intVector = columnVector.getValueVector.asInstanceOf[IntVector]
     (0 until 10).foreach { i =>
       assert(columnVector.getInt(i) === i + 1)
-      intVector.get(i) === i + 1
+      assert(intVector.get(i) === i)
     }
 
     columnVector.close()

--- a/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.vectorized
 
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex._
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to make ArrowColumnVector extendable by relaxing access modifier restrictions


### Why are the changes needed?
Some Spark extension libraries need to extend ArrowColumnVector.java.

It is impossible extend ArrowColumnVector class for now because the class is final and the accessors are all private.
Proposing to relax private/final restrictions to make ArrowColumnVector extendable.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests.
