### PR TITLE
[MINOR] Remove unnecessary null check for exception cause

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -82,8 +82,8 @@ public interface ErrorHandler {
       // If it is a FileNotFoundException originating from the client while pushing the shuffle
       // blocks to the server, even then there is no need to retry. We will still log this
       // exception once which helps with debugging.
-      if (t.getCause() != null && (t.getCause() instanceof ConnectException ||
-          t.getCause() instanceof FileNotFoundException)) {
+      if (t.getCause() instanceof ConnectException ||
+          t.getCause() instanceof FileNotFoundException) {
         return false;
       }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockTransferor.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RetryingBlockTransferor.java
@@ -191,7 +191,7 @@ public class RetryingBlockTransferor {
    */
   private synchronized boolean shouldRetry(Throwable e) {
     boolean isIOException = e instanceof IOException
-      || (e.getCause() != null && e.getCause() instanceof IOException);
+      || e.getCause() instanceof IOException;
     boolean hasRemainingRetries = retryCount < maxRetries;
     return isIOException && hasRemainingRetries && errorHandler.shouldRetryError(e);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In two classes under common/network-shuffle, we check whether t.getCause() is null before instanceof check.
The null check is not needed since null pointer wouldn't pass instanceof check.

### Why are the changes needed?
This PR simplifies the code by dropping unnecessary null check.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test suite.