### PR TITLE
[SPARK-38102][CORE] Support custom commitProtocolClass in saveAsNewAPIHadoopDataset

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -339,7 +339,8 @@ class HadoopMapReduceWriteConfigUtil[K, V: ClassTag](conf: SerializableConfigura
 
   override def createCommitter(jobId: Int): HadoopMapReduceCommitProtocol = {
     FileCommitProtocol.instantiate(
-      className = classOf[HadoopMapReduceCommitProtocol].getName,
+      className = getConf.get("mapreduce.sources.commitProtocolClass",
+        classOf[HadoopMapReduceCommitProtocol].getName),
       jobId = jobId.toString,
       outputPath = getConf.get("mapreduce.output.fileoutputformat.outputdir")
     ).asInstanceOf[HadoopMapReduceCommitProtocol]

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -478,7 +478,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
                                  dynamicPartitionOverwrite: Boolean = false)
     extends HadoopMapReduceCommitProtocol(jobId, path, dynamicPartitionOverwrite)
 
-  test ("SPARK-38102 save Hadoop Dataset through new Hadoop API with PathOutputCommitProtocol") {
+  test ("SPARK-38102 save Hadoop Dataset through new Hadoop API with custom commitProtocolClass") {
     sc = new SparkContext("local", "test")
     val randomRDD = sc.parallelize(
       Seq(("key1", "a"), ("key2", "a"), ("key3", "b"), ("key4", "c")), 1)

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -473,6 +473,23 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     assert(new File(tempDir.getPath + "/outputDataset_new/part-r-00000").exists())
   }
 
+  test ("save Hadoop Dataset through new Hadoop API with PathOutputCommitProtocol") {
+    sc = new SparkContext("local", "test")
+    val randomRDD = sc.parallelize(
+      Seq(("key1", "a"), ("key2", "a"), ("key3", "b"), ("key4", "c")), 1)
+    val job = Job.getInstance(sc.hadoopConfiguration)
+    job.setOutputKeyClass(classOf[String])
+    job.setOutputValueClass(classOf[String])
+    job.setOutputFormatClass(classOf[NewTextOutputFormat[String, String]])
+    val jobConfig = job.getConfiguration
+    jobConfig.set("mapreduce.output.fileoutputformat.outputdir",
+      tempDir.getPath + "/outputDataset_new")
+    jobConfig.set("mapreduce.sources.commitProtocolClass",
+      "org.apache.spark.internal.io.cloud.PathOutputCommitProtocol")
+    randomRDD.saveAsNewAPIHadoopDataset(jobConfig)
+    assert(new File(tempDir.getPath + "/outputDataset_new/part-r-00000").exists())
+  }
+
   test("Get input files via old Hadoop API") {
     sc = new SparkContext("local", "test")
     val outDir = new File(tempDir, "output").getAbsolutePath


### PR DESCRIPTION
There is no way to apply spark-hadoop-cloud's commitProtocolClass when using saveAsNewAPIHadoopDataset that are to avoid object storage's problem.

https://spark.apache.org/docs/latest/cloud-integration.html

 

It is needed to support custom commitProtocolClass class when using saveAsNewAPIHadoopDataset by an option. For example,

```
spark.hadoop.mapreduce.sources.commitProtocolClass org.apache.spark.internal.io.cloud.PathOutputCommitProtocol
```

 