### PR TITLE
[SPARK-37536][SQL] Allow for API user to disable Shuffle on Local Mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3521,6 +3521,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val LOCAL_MODE_SHUFFLE_ENABLED =
+    buildConf("spark.sql.localMode.shuffle.enabled")
+      .doc("When false, will disable shuffling plans, when running in local mode. " +
+        "It will improve the JVM's performance, by avoiding unnecessary " +
+        "shuffling, since there is only one process.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -653,7 +653,7 @@ class EnsureRequirementsSuite extends SharedSparkSession {
       outputPartitioning = HashPartitioning(exprB :: exprC :: Nil, 5))
     val smjExec1 = SortMergeJoinExec(
       exprA :: exprB :: Nil, exprC :: exprB :: Nil, Inner, None, plan1, plan2)
-    new EnsureRequirements(disableShuffle = false).apply(smjExec1) match {
+    new EnsureRequirements(disableShuffle = true).apply(smjExec1) match {
       case SortMergeJoinExec(leftKeys, rightKeys, _, _,
       SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _),
       SortExec(_, _, DummySparkPlan(_, _, _: HashPartitioning, _, _), _), _) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce a new API configuration flag to disable shuffling when running in running mode - allows for substantial performance while running Spark embedded. This flag, will not be accounted for cluster mode.

### Why are the changes needed?
We have been using Spark on local mode, as a small embedded, in-memory SQL DB for microservices.

Spark's powerful SQL features, and flexibility enables developers to build efficient data querying solutions. Due to the nature of our solution dealing with small datasets, which required to be queried through SQL, on very low latencies, we found the embedded approach a very good model.

We found through experimentation, that Spark on local mode, would gain significant performance improvements (on average between 20-30%) by disabling the shuffling on aggregation operations - ShuffleExchangeExec.

### Does this PR introduce _any_ user-facing change?
This PR will expose a SQL configuration, which should be documented for the corresponding release. This will provide users, the option to disable Shuffling plans while running locally. If it's runnng on cluster node, this flag will not be effective.
This change would represent a public change against the latest master branch.


### How was this patch tested?
Unit tests were added (included in the PR), and bench tests were done locally to validate the performance of the new dataset API 
