### PR TITLE
[SPARK-38118][SQL] Func(wrong data type) in HAVING clause should throw data mismatch error

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -623,7 +623,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
     }
   }
 
-  private def extraHintForAnsiTypeCoercionExpression(plan: LogicalPlan): String = {
+  private[analysis] def extraHintForAnsiTypeCoercionExpression(plan: LogicalPlan): String = {
     if (!SQLConf.get.ansiEnabled) {
       ""
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -645,8 +645,5 @@ case class TempResolvedColumn(child: Expression, nameParts: Seq[String]) extends
   override def dataType: DataType = child.dataType
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
-
-  override def sql: String = {
-    s"${child.sql}"
-  }
+  override def sql: String = child.sql
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -645,4 +645,9 @@ case class TempResolvedColumn(child: Expression, nameParts: Seq[String]) extends
   override def dataType: DataType = child.dataType
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
+
+  override def sql: String = {
+    val childrenSQL = children.map(_.sql).mkString(", ")
+    s"$childrenSQL"
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -647,7 +647,6 @@ case class TempResolvedColumn(child: Expression, nameParts: Seq[String]) extends
     copy(child = newChild)
 
   override def sql: String = {
-    val childrenSQL = children.map(_.sql).mkString(", ")
-    s"$childrenSQL"
+    s"${child.sql}"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4294,31 +4294,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         Row(3, 2, 6) :: Nil)
     }
   }
-
-  test("SPARK-38118: Func(wrong_type) in the HAVING clause should throw data mismatch error") {
-    Seq("mean", "abs").foreach { func =>
-      val e1 = intercept[AnalysisException](
-        sql(
-          s"""
-             |WITH t as (SELECT true c)
-             |SELECT t.c
-             |FROM t
-             |GROUP BY t.c
-             |HAVING ${func}(t.c) > 0d""".stripMargin))
-
-      assert(e1.message.contains(s"cannot resolve '$func(t.c)' due to data type mismatch"))
-
-      val e2 = intercept[AnalysisException](
-        sql(
-          s"""
-             |WITH t as (SELECT true c, false d)
-             |SELECT (t.c AND t.d) c
-             |FROM t
-             |GROUP BY t.c
-             |HAVING ${func}(c) > 0d""".stripMargin))
-      assert(e2.message.contains(s"cannot resolve '$func(t.c)' due to data type mismatch"))
-    }
-  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
```
with t as (select true c)
select t.c
from t
group by t.c
having mean(t.c) > 0
```

This query throws `Column 't.c' does not exist. Did you mean one of the following? [t.c]`

However, mean(boolean) is not a supported function signature, thus error result should be  `cannot resolve 'mean(t.c)' due to data type mismatch: function average requires numeric or interval types, not boolean`

 

This is because

1. The mean(boolean) in HAVING was not marked as resolved in `ResolveFunctions` rule.
2. Thus in `ResolveAggregationFunctions`, the `TempResolvedColumn` as a wrapper in `mean(TempResolvedColumn(t.c))` cannot be removed (only resolved AGG can remove its’s `TempResolvedColumn`).
3. Thus in a later batch rule applying,  `TempResolvedColumn` was reverted and it becomes mean(`t.c`), so mean loses the information about t.c.
4. Thus at the last step, the analyzer can only report t.c not found.

 

mean(boolean) in HAVING is not marked as resolved in {{ResolveFunctions}} rule because 
1. It uses Expression default `resolved` field population code:
```lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess```
2. During the analyzing,  mean(boolean) is mean(TempResolveColumn(boolean), thus childrenResolved is true.
3. however checkInputDataTypes() will be false [Average.scala#L55](https://github.com/apache/spark/blob/74ebef243c18e7a8f32bf90ea75ab6afed9e3132/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala#L55)
4. Thus eventually Average's `resolved`  will be false, but it leads to wrong error message.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve error message so users can better debug their query.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. This will change user-facing error message.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit Test