### PR TITLE
[SPARK-37735][K8S][TESTS][FOLLOWUP] Remove casting to KubernetesConf in tests

### DIFF
--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -222,8 +222,8 @@ class KubernetesConfSuite extends SparkFunSuite {
     val sparkConf = new SparkConf(false)
     val driverConf = KubernetesTestConf.createDriverConf(sparkConf)
     val execConf = KubernetesTestConf.createExecutorConf(sparkConf)
-    assert(driverConf.asInstanceOf[KubernetesConf].appId === KubernetesTestConf.APP_ID)
-    assert(execConf.asInstanceOf[KubernetesConf].appId === KubernetesTestConf.APP_ID)
+    assert(driverConf.appId === KubernetesTestConf.APP_ID)
+    assert(execConf.appId === KubernetesTestConf.APP_ID)
   }
 
   test("SPARK-36566: get app name label") {


### PR DESCRIPTION

### What changes were proposed in this pull request?

Minor simplification:

There is no need to cast
org.apache.spark.deploy.k8s.KubernetesDriverConf/KubernetesExecutorConf to org.apache.spark.deploy.k8s.KubernetesConf in KubernetesConfSuite

Related-to: https://github.com/apache/spark/pull/35015

### Why are the changes needed?

Small simplification of the test code.

### Does this PR introduce _any_ user-facing change?

No!

### How was this patch tested?

Build and test KubernetesConfSuite#test("SPARK-37735: access appId in KubernetesConf") {