### PR TITLE
[SPARK-38125][BUILD][SQL] Use static factory methods instead of the deprecated `Byte/Short/Integer/Long` constructors

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -190,8 +190,8 @@
             <property name="message" value="Avoid using Object.toStringHelper. Use ToStringBuilder instead." />
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="new Integer\("/>
-            <property name="message" value="Use static factory 'valueOf(int)' or 'parseInt(String)' instead of the deprecated constructors." />
+            <property name="format" value="new (java\.lang\.)?(Byte|Integer|Long|Short)\("/>
+            <property name="message" value="Use static factory 'valueOf' or 'parseXXX' instead of the deprecated constructors." />
         </module>
         <module name="IllegalImport">
             <property name="illegalPkgs" value="org.apache.log4j" />

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -189,6 +189,10 @@
             <property name="format" value="Objects\.toStringHelper"/>
             <property name="message" value="Avoid using Object.toStringHelper. Use ToStringBuilder instead." />
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="new Integer\("/>
+            <property name="message" value="Use static factory 'valueOf(int)' or 'parseInt(String)' instead of the deprecated constructors." />
+        </module>
         <module name="IllegalImport">
             <property name="illegalPkgs" value="org.apache.log4j" />
         </module>

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -325,8 +325,8 @@ This file is divided into 3 sections:
   </check>
 
   <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
-    <parameters><parameter name="regex">new Integer\(</parameter></parameters>
-    <customMessage>Use static factory 'valueOf(int)' or 'parseInt(String)' instead of the deprecated constructors.</customMessage>
+    <parameters><parameter name="regex">new (java\.lang\.)?(Byte|Integer|Long|Short)\(</parameter></parameters>
+    <customMessage>Use static factory 'valueOf' or 'parseXXX' instead of the deprecated constructors.</customMessage>
   </check>
 
   <!-- SPARK-16877: Avoid Java annotations -->

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -324,6 +324,11 @@ This file is divided into 3 sections:
     <customMessage>Omit braces in case clauses.</customMessage>
   </check>
 
+  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">new Integer\(</parameter></parameters>
+    <customMessage>Use static factory 'valueOf(int)' or 'parseInt(String)' instead of the deprecated constructors.</customMessage>
+  </check>
+
   <!-- SPARK-16877: Avoid Java annotations -->
   <check level="error" class="org.scalastyle.scalariform.OverrideJavaChecker" enabled="true"></check>
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDatasetSuite.java
@@ -279,7 +279,7 @@ public class JavaDatasetSuite implements Serializable {
     Assert.assertTrue(prevState.isUpdated());
     Assert.assertFalse(prevState.isRemoved());
     Assert.assertTrue(prevState.exists());
-    Assert.assertEquals(new Integer(9), prevState.get());
+    Assert.assertEquals(Integer.valueOf(9), prevState.get());
     Assert.assertEquals(0L, prevState.getCurrentProcessingTimeMs());
     Assert.assertEquals(1000L, prevState.getCurrentWatermarkMs());
     Assert.assertEquals(Optional.of(1500L), prevState.getTimeoutTimestampMs());
@@ -289,7 +289,7 @@ public class JavaDatasetSuite implements Serializable {
     Assert.assertTrue(prevState.isUpdated());
     Assert.assertFalse(prevState.isRemoved());
     Assert.assertTrue(prevState.exists());
-    Assert.assertEquals(new Integer(18), prevState.get());
+    Assert.assertEquals(Integer.valueOf(18), prevState.get());
 
     prevState = TestGroupState.create(
       Optional.of(9), GroupStateTimeout.EventTimeTimeout(), 0L, Optional.of(1000L), true);

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -469,7 +469,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
       if (i == 0) {
         assert(zone === "Z")
       } else {
-        assert(zone === String.format("%+03d:00", new Integer(i)))
+        assert(zone === String.format("%+03d:00", Integer.valueOf(i)))
       }
     }
     val e2 = intercept[ParseException](sql("set time zone interval 19 hours"))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
@@ -138,7 +138,7 @@ private[thriftserver] trait ReflectedCompositeService { this: AbstractService =>
         serviceStartCount += 1
       }
       // Emulating `AbstractService.start`
-      val startTime = Long.valueOf(System.currentTimeMillis())
+      val startTime = java.lang.Long.valueOf(System.currentTimeMillis())
       setAncestorField(this, 3, "startTime", startTime)
       invoke(classOf[AbstractService], this, "ensureCurrentState", classOf[STATE] -> STATE.INITED)
       invoke(classOf[AbstractService], this, "changeState", classOf[STATE] -> STATE.STARTED)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
@@ -138,7 +138,7 @@ private[thriftserver] trait ReflectedCompositeService { this: AbstractService =>
         serviceStartCount += 1
       }
       // Emulating `AbstractService.start`
-      val startTime = new java.lang.Long(System.currentTimeMillis())
+      val startTime = Long.valueOf(System.currentTimeMillis())
       setAncestorField(this, 3, "startTime", startTime)
       invoke(classOf[AbstractService], this, "ensureCurrentState", classOf[STATE] -> STATE.INITED)
       invoke(classOf[AbstractService], this, "changeState", classOf[STATE] -> STATE.STARTED)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIService.scala
@@ -147,7 +147,7 @@ private[thriftserver] trait ReflectedCompositeService { this: AbstractService =>
       case NonFatal(e) =>
       logError(s"Error starting services $getName", e)
       invoke(classOf[CompositeService], this, "stop",
-        classOf[Int] -> new Integer(serviceStartCount))
+        classOf[Int] -> Integer.valueOf(serviceStartCount))
       throw HiveThriftServerErrors.failedToStartServiceError(getName, e)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use static factor methods instead of the deprecated `Integer` constructors and add Java/Scala linter rules to enforce new styles.

### Why are the changes needed?

`Byte/Short/Integer/Long` constructors are deprecated in Java 9.
- https://docs.oracle.com/javase/9/docs/api/java/lang/Byte.html#Byte-byte-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Byte.html#Byte-java.lang.String-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Short.html#Short-short-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Short.html#Short-java.lang.String-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-int-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-java.lang.String-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Long.html#Long-long-
- https://docs.oracle.com/javase/9/docs/api/java/lang/Long.html#Long-java.lang.String-

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the newly added Scalastyle and Java Checkstyle.