### PR TITLE
[SPARK-38126][SQL][TESTS] Check the whole message of error classes

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -37,7 +37,7 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     val msg1 = intercept[AnalysisException] {
       sql("select 'value1' as a, 1L as b").as[StringIntClass]
     }.message
-    assert(msg1 ==
+    assert(msg1 ===
       s"""
          |Cannot up cast b from bigint to int.
          |The type path of the target object is:
@@ -51,7 +51,7 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
         " named_struct('a', 'value1', 'b', cast(1.0 as decimal(38,18))) as b")
         .as[ComplexClass]
     }.message
-    assert(msg2 ==
+    assert(msg2 ===
       s"""
          |Cannot up cast b.`b` from decimal(38,18) to bigint.
          |The type path of the target object is:
@@ -72,9 +72,8 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
 
       Dataset.ofRows(spark, plan)
     }.message
-    assert(msg.contains("The feature is not supported: " +
+    assert(msg.matches("The feature is not supported: " +
       "UpCast only support DecimalType as AbstractDataType yet," +
-      " but got: org.apache.spark.sql.types.NumericType"))
+      """ but got: org.apache.spark.sql.types.NumericType\$\@\w+"""))
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -57,6 +57,20 @@ class QueryExecutionErrorsSuite extends QueryTest with SharedSparkSession {
 
     // Encryption failure - invalid key length
     checkInvalidKeyLength(df1.selectExpr("aes_encrypt(value, '12345678901234567')"))
+    checkInvalidKeyLength(df1.selectExpr("aes_encrypt(value, binary('123456789012345'))"))
+    checkInvalidKeyLength(df1.selectExpr("aes_encrypt(value, binary(''))"))
+
+    // Decryption failure - invalid key length
+    Seq("value16", "value24", "value32").foreach { colName =>
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), '12345678901234567')"))
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), binary('123456789012345'))"))
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), '')"))
+      checkInvalidKeyLength(df2.selectExpr(
+        s"aes_decrypt(unbase64($colName), binary(''))"))
+    }
   }
 
   test("INVALID_PARAMETER_VALUE: AES decrypt failure - key mismatch") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -32,7 +32,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     }
     assert(e.getErrorClass === errorClass)
     assert(e.getSqlState === sqlState)
-    assert(e.getMessage.contains(message))
+    assert(e.getMessage === message)
   }
 
   test("UNSUPPORTED_FEATURE: LATERAL join with NATURAL join not supported") {
@@ -40,7 +40,14 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlText = "SELECT * FROM t1 NATURAL JOIN LATERAL (SELECT c1 + c2 AS c2)",
       errorClass = "UNSUPPORTED_FEATURE",
       sqlState = "0A000",
-      message = "The feature is not supported: LATERAL join with NATURAL join.")
+      message =
+        """
+          |The feature is not supported: LATERAL join with NATURAL join.(line 1, pos 14)
+          |
+          |== SQL ==
+          |SELECT * FROM t1 NATURAL JOIN LATERAL (SELECT c1 + c2 AS c2)
+          |--------------^^^
+          |""".stripMargin)
   }
 
   test("UNSUPPORTED_FEATURE: LATERAL join with USING join not supported") {
@@ -48,11 +55,19 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlText = "SELECT * FROM t1 JOIN LATERAL (SELECT c1 + c2 AS c2) USING (c2)",
       errorClass = "UNSUPPORTED_FEATURE",
       sqlState = "0A000",
-      message = "The feature is not supported: LATERAL join with USING join.")
+      message =
+        """
+          |The feature is not supported: LATERAL join with USING join.(line 1, pos 14)
+          |
+          |== SQL ==
+          |SELECT * FROM t1 JOIN LATERAL (SELECT c1 + c2 AS c2) USING (c2)
+          |--------------^^^
+          |""".stripMargin)
   }
 
   test("UNSUPPORTED_FEATURE: Unsupported LATERAL join type") {
-    Seq(("RIGHT OUTER", "RightOuter"),
+    Seq(
+      ("RIGHT OUTER", "RightOuter"),
       ("FULL OUTER", "FullOuter"),
       ("LEFT SEMI", "LeftSemi"),
       ("LEFT ANTI", "LeftAnti")).foreach { pair =>
@@ -60,22 +75,38 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
         sqlText = s"SELECT * FROM t1 ${pair._1} JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3",
         errorClass = "UNSUPPORTED_FEATURE",
         sqlState = "0A000",
-        message = s"The feature is not supported: LATERAL join type '${pair._2}'.")
+        message =
+          s"""
+            |The feature is not supported: LATERAL join type '${pair._2}'.(line 1, pos 14)
+            |
+            |== SQL ==
+            |SELECT * FROM t1 ${pair._1} JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3
+            |--------------^^^
+            |""".stripMargin)
     }
   }
 
   test("SPARK-35789: INVALID_SQL_SYNTAX - LATERAL can only be used with subquery") {
-    Seq("SELECT * FROM t1, LATERAL t2",
-      "SELECT * FROM t1 JOIN LATERAL t2",
-      "SELECT * FROM t1, LATERAL (t2 JOIN t3)",
-      "SELECT * FROM t1, LATERAL (LATERAL t2)",
-      "SELECT * FROM t1, LATERAL VALUES (0, 1)",
-      "SELECT * FROM t1, LATERAL RANGE(0, 1)").foreach { sqlText =>
+    Seq(
+      "SELECT * FROM t1, LATERAL t2" -> 26,
+      "SELECT * FROM t1 JOIN LATERAL t2" -> 30,
+      "SELECT * FROM t1, LATERAL (t2 JOIN t3)" -> 26,
+      "SELECT * FROM t1, LATERAL (LATERAL t2)" -> 26,
+      "SELECT * FROM t1, LATERAL VALUES (0, 1)" -> 26,
+      "SELECT * FROM t1, LATERAL RANGE(0, 1)" -> 26
+    ).foreach { case (sqlText, pos) =>
       validateParsingError(
         sqlText = sqlText,
         errorClass = "INVALID_SQL_SYNTAX",
         sqlState = "42000",
-        message = "Invalid SQL syntax: LATERAL can only be used with subquery.")
+        message =
+          s"""
+            |Invalid SQL syntax: LATERAL can only be used with subquery.(line 1, pos $pos)
+            |
+            |== SQL ==
+            |$sqlText
+            |${"-" * pos}^^^
+            |""".stripMargin)
     }
   }
 
@@ -84,6 +115,13 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlText = "SELECT * FROM a NATURAL CROSS JOIN b",
       errorClass = "UNSUPPORTED_FEATURE",
       sqlState = "0A000",
-      message = "The feature is not supported: NATURAL CROSS JOIN.")
+      message =
+        """
+          |The feature is not supported: NATURAL CROSS JOIN.(line 1, pos 14)
+          |
+          |== SQL ==
+          |SELECT * FROM a NATURAL CROSS JOIN b
+          |--------------^^^
+          |""".stripMargin)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check the whole error messages of error classes in the test suites `Query.*ErrorsSuite`.

### Why are the changes needed?
1. To catch changes in error classes.
2. To improve test coverage.
3. Set user expectations from Spark's errors.
4. The checks can be considered as documentation of error messages in tests.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *QueryParsingErrorsSuite"
$ build/sbt "test:testOnly *QueryCompilationErrorsSuite"
$ build/sbt "test:testOnly *QueryCompilationErrorsDSv2Suite"
$ build/sbt "test:testOnly *QueryExecutionErrorsSuite"
```