### PR TITLE
[SPARK-38133][SQL] UnsafeRow should treat TIMESTAMP_NTZ as mutable and fixed width

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -90,7 +90,8 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
           FloatType,
           DoubleType,
           DateType,
-          TimestampType
+          TimestampType,
+          TimestampNTZType
         })));
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
@@ -187,7 +187,7 @@ sealed trait BufferSetterGetterUtils {
               row.setNullAt(ordinal)
             }
 
-        case TimestampType =>
+        case TimestampType | TimestampNTZType =>
           (row: InternalRow, ordinal: Int, value: Any) =>
             if (value != null) {
               row.setLong(ordinal, value.asInstanceOf[Long])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
@@ -187,7 +187,7 @@ sealed trait BufferSetterGetterUtils {
               row.setNullAt(ordinal)
             }
 
-        case TimestampType | TimestampNTZType =>
+        case TimestampType =>
           (row: InternalRow, ordinal: Int, value: Any) =>
             if (value != null) {
               row.setLong(ordinal, value.asInstanceOf[Long])

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -343,11 +343,10 @@ class DataFramePivotSuite extends QueryTest with SharedSparkSession {
     checkAnswer(actual, Row(Array(2.5), Array(3.0)))
   }
 
-  test("isfixedlength issue") {
+  test("SPARK-38133: Grouping by TIMESTAMP_NTZ should not corrupt results") {
     checkAnswer(
       courseSales.withColumn("ts", $"year".cast("string").cast("timestamp_ntz"))
         .groupBy("ts")
-        // pivot with extra columns to trigger optimization
         .pivot("course", Seq("dotNET", "Java"))
         .agg(sum($"earnings"))
         .select("ts", "dotNET", "Java"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFramePivotSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import java.time.LocalDateTime
 import java.util.Locale
 
 import org.apache.spark.sql.catalyst.expressions.aggregate.PivotFirst
@@ -340,5 +341,18 @@ class DataFramePivotSuite extends QueryTest with SharedSparkSession {
       .groupBy().pivot("type", Seq("a", "b")).agg(
         percentile_approx(col("value"), array(lit(0.5)), lit(10000)))
     checkAnswer(actual, Row(Array(2.5), Array(3.0)))
+  }
+
+  test("isfixedlength issue") {
+    checkAnswer(
+      courseSales.withColumn("ts", $"year".cast("string").cast("timestamp_ntz"))
+        .groupBy("ts")
+        // pivot with extra columns to trigger optimization
+        .pivot("course", Seq("dotNET", "Java"))
+        .agg(sum($"earnings"))
+        .select("ts", "dotNET", "Java"),
+      Row(LocalDateTime.of(2012, 1, 1, 0, 0, 0, 0), 15000.0, 20000.0) ::
+        Row(LocalDateTime.of(2013, 1, 1, 0, 0, 0, 0), 48000.0, 30000.0) :: Nil
+    )
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -896,7 +896,10 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
     // UnsafeRow.mutableFieldTypes.asScala.toSeq will trigger SortAggregate to use
     // UnsafeRow as the aggregation buffer. While, dataTypes will trigger
     // SortAggregate to use a safe row as the aggregation buffer.
-    Seq(dataTypes, UnsafeRow.mutableFieldTypes.asScala.toSeq).foreach { dataTypes =>
+    // udaf cannot yet handle TimestampNTZType
+    val mutableFieldTypes = UnsafeRow.mutableFieldTypes
+      .asScala.filterNot(_.isInstanceOf[TimestampNTZType]).toSeq
+    Seq(dataTypes, mutableFieldTypes).foreach { dataTypes =>
       val fields = dataTypes.zipWithIndex.map { case (dataType, index) =>
         StructField(s"col$index", dataType, nullable = true)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add TimestampNTZType to UnsafeRow's list of mutable fields.

### Why are the changes needed?

Assume this data:
```
create or replace temp view v1 as
select * from values
  (1, timestamp_ntz'2012-01-01 00:00:00', 10000),
  (2, timestamp_ntz'2012-01-01 00:00:00', 20000),
  (1, timestamp_ntz'2012-01-01 00:00:00', 5000),
  (1, timestamp_ntz'2013-01-01 00:00:00', 48000),
  (2, timestamp_ntz'2013-01-01 00:00:00', 30000)
  as data(a, b, c);
```
The following query produces incorrect results:
```
select *
from v1
pivot (
  sum(c)
  for a in (1, 2)
);
```
The timestamp_ntz values are corrupted:
```
2012-01-01 19:05:19.476736	15000	20000
2013-01-01 19:05:19.476736	48000	30000
```
Because `UnsafeRow.isFixedLength` returns `false` for data type `TimestampNTZType`, `GenerateUnsafeRowJoiner` generates code for the `TIMESTAMP_NTZ` field as though it was a variable length field (it adds an offset to the Long value, thus corrupting the timestamp value).

By adding `TimestampNTZType` to `UnsafeRow`'s list of mutable fields, `UnsafeRow.isFixedLength` returns `true`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit test.
