### PR TITLE
[MINOR][SQL] Remove redundant array creation in UnsafeRow

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -80,7 +80,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
   static {
     mutableFieldTypes = Collections.unmodifiableSet(
       new HashSet<>(
-        Arrays.asList(new DataType[] {
+        Arrays.asList(
           NullType,
           BooleanType,
           ByteType,
@@ -92,7 +92,7 @@ public final class UnsafeRow extends InternalRow implements Externalizable, Kryo
           DateType,
           TimestampType,
           TimestampNTZType
-        })));
+        )));
   }
 
   public static boolean isFixedLength(DataType dt) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`j.u.Arrays.asList` is a varargs api, this pr remove the redundant array creation to simplify the code.


### Why are the changes needed?
Code simplification.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA