### PR TITLE
[SPARK-38135][K8S] Introduce job sheduling related configurations

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -23,6 +23,7 @@ import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{PYSPARK_DRIVER_PYTHON, PYSPARK_PYTHON}
 import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.network.util.ByteUnit
 
 private[spark] object Config extends Logging {
 
@@ -674,6 +675,42 @@ private[spark] object Config extends Logging {
       .intConf
       .checkValue(value => value > 0, "Maximum number of pending pods should be a positive integer")
       .createWithDefault(Int.MaxValue)
+
+  val KUBERNETES_JOB_QUEUE = ConfigBuilder("spark.kubernetes.job.queue")
+    .doc("The name of the queue to which the job is submitted. This info " +
+      "will be stored in configuration and passed to specified feature step.")
+    .version("3.3.0")
+    .stringConf
+    .createWithDefault("default")
+
+  val KUBERNETES_JOB_MIN_CPU = ConfigBuilder("spark.kubernetes.job.minCPU")
+    .doc("The minimum CPU for running the job. This info " +
+      "will be stored in configuration and passed to specified feature step.")
+    .version("3.3.0")
+    .doubleConf
+    .createWithDefault(2.0)
+
+  val KUBERNETES_JOB_MIN_MEMORY = ConfigBuilder("spark.kubernetes.job.minMemory")
+    .doc("The minimum memory for running the job, in MiB unless otherwise specified. This info " +
+      "will be stored in configuration and passed to specified feature step.")
+    .version("3.3.0")
+    .bytesConf(ByteUnit.MiB)
+    .createWithDefaultString("3g")
+
+  val KUBERNETES_JOB_MIN_MEMBER = ConfigBuilder("spark.kubernetes.job.minMember")
+    .doc("The minimum number of pods running in a job. This info " +
+      "will be stored in configuration and passed to specified feature step.")
+    .version("3.3.0")
+    .intConf
+    .checkValue(value => value > 0, "The minimum number should be a positive integer")
+    .createWithDefault(1)
+
+  val KUBERNETES_JOB_PRIORITY_CLASS_NAME = ConfigBuilder("spark.kubernetes.job.priorityClassName")
+    .doc("The priority of the running job. This info " +
+      "will be stored in configuration and passed to specified feature step.")
+    .version("3.3.0")
+    .stringConf
+    .createOptional
 
   val KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label."
   val KUBERNETES_DRIVER_ANNOTATION_PREFIX = "spark.kubernetes.driver.annotation."


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch inroduces 5 scheduling related configurations:
- `spark.kubernetes.job.queue`: The name of the queue to which the job is submitted.
- `spark.kubernetes.job.minCPU`: The minimum CPU for running the job.
- `spark.kubernetes.job.minMemory`: The minimum memory for running the job, in MiB unless otherwise specified.
- `spark.kubernetes.job.minMember`: The minimum number of pods running in a job.
- `spark.kubernetes.job.priorityClassName`: The priority of the running job.

These info will be stored in configuration and passed to specified feature step, such as it will be used by Yunikorn/Volcano feature step.


### Why are the changes needed?
This PR help user integrate Spark with Volcano Scheduler to enable minResource/queue/priority support.

See also: [SPARK-36057](https://issues.apache.org/jira/browse/SPARK-36057)

### Does this PR introduce _any_ user-facing change?
Yes, configuration added.


### How was this patch tested?
CI passed
