### PR TITLE
[SPARK-38140][SQL] Desc column stats (min, max) for timestamp type is not consistent with the values due to time zone difference

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -656,11 +656,12 @@ object CatalogColumnStat extends Logging {
 
   val VERSION = 2
 
-  private def getTimestampFormatter(
+  def getTimestampFormatter(
       isParsing: Boolean,
+      format: String = "yyyy-MM-dd HH:mm:ss.SSSSSS",
       zoneId: ZoneId = ZoneOffset.UTC): TimestampFormatter = {
     TimestampFormatter(
-      format = "yyyy-MM-dd HH:mm:ss.SSSSSS",
+      format = format,
       zoneId = zoneId,
       isParsing = isParsing)
   }
@@ -695,15 +696,10 @@ object CatalogColumnStat extends Logging {
    * Converts the given value from Catalyst data type to string representation of external
    * data type.
    */
-  def toExternalString(
-      v: Any,
-      colName: String,
-      dataType: DataType,
-      zoneId: ZoneId = ZoneOffset.UTC): String = {
+  def toExternalString(v: Any, colName: String, dataType: DataType): String = {
     val externalValue = dataType match {
       case DateType => DateFormatter().format(v.asInstanceOf[Int])
-      case TimestampType =>
-        getTimestampFormatter(isParsing = false, zoneId).format(v.asInstanceOf[Long])
+      case TimestampType => getTimestampFormatter(isParsing = false).format(v.asInstanceOf[Long])
       case BooleanType | _: IntegralType | FloatType | DoubleType => v
       case _: DecimalType => v.asInstanceOf[Decimal].toJavaBigDecimal
       // This version of Spark does not use min/max for binary/string types so we ignore it.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.catalog
 
 import java.net.URI
-import java.time.ZoneOffset
+import java.time.{ZoneId, ZoneOffset}
 import java.util.Date
 
 import scala.collection.mutable
@@ -656,10 +656,12 @@ object CatalogColumnStat extends Logging {
 
   val VERSION = 2
 
-  private def getTimestampFormatter(isParsing: Boolean): TimestampFormatter = {
+  private def getTimestampFormatter(
+      isParsing: Boolean,
+      zoneId: ZoneId = ZoneOffset.UTC): TimestampFormatter = {
     TimestampFormatter(
       format = "yyyy-MM-dd HH:mm:ss.SSSSSS",
-      zoneId = ZoneOffset.UTC,
+      zoneId = zoneId,
       isParsing = isParsing)
   }
 
@@ -693,10 +695,15 @@ object CatalogColumnStat extends Logging {
    * Converts the given value from Catalyst data type to string representation of external
    * data type.
    */
-  def toExternalString(v: Any, colName: String, dataType: DataType): String = {
+  def toExternalString(
+      v: Any,
+      colName: String,
+      dataType: DataType,
+      zoneId: ZoneId = ZoneOffset.UTC): String = {
     val externalValue = dataType match {
       case DateType => DateFormatter().format(v.asInstanceOf[Int])
-      case TimestampType => getTimestampFormatter(isParsing = false).format(v.asInstanceOf[Long])
+      case TimestampType =>
+        getTimestampFormatter(isParsing = false, zoneId).format(v.asInstanceOf[Long])
       case BooleanType | _: IntegralType | FloatType | DoubleType => v
       case _: DecimalType => v.asInstanceOf[Decimal].toJavaBigDecimal
       // This version of Spark does not use min/max for binary/string types so we ignore it.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -803,8 +803,11 @@ case class DescribeColumnCommand(
         // time zone.
         val internalValue =
           CatalogColumnStat.fromExternalString(valueStr, name, dataType, CatalogColumnStat.VERSION)
-        val timeZoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
-        CatalogColumnStat.toExternalString(internalValue, name, dataType, timeZoneId)
+        val curZoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
+        CatalogColumnStat
+          .getTimestampFormatter(
+            isParsing = false, format = "yyyy-MM-dd HH:mm:ss.SSSSSS Z", zoneId = curZoneId)
+          .format(internalValue.asInstanceOf[Long])
       case _ =>
         valueStr
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -789,21 +789,24 @@ case class DescribeColumnCommand(
       } yield histogramDescription(hist)
       buffer ++= histDesc.getOrElse(Seq(Row("histogram", "NULL")))
     }
-    buffer
+    buffer.toSeq
   }
 
-  private def toZoneAwareExternalString(s: String, name: String, dataType: DataType): String = {
+  private def toZoneAwareExternalString(
+      valueStr: String,
+      name: String,
+      dataType: DataType): String = {
     dataType match {
       case TimestampType =>
         // When writing to metastore, we always format timestamp value in the default UTC time zone.
         // So here we need to first convert to internal value, then format it using the current
         // time zone.
         val internalValue =
-          CatalogColumnStat.fromExternalString(s, name, dataType, CatalogColumnStat.VERSION)
+          CatalogColumnStat.fromExternalString(valueStr, name, dataType, CatalogColumnStat.VERSION)
         val timeZoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
         CatalogColumnStat.toExternalString(internalValue, name, dataType, timeZoneId)
       case _ =>
-        s
+        valueStr
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.DescribeCommandSchema
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIfNeeded, CaseInsensitiveMap, CharVarcharUtils}
+import org.apache.spark.sql.catalyst.util.{escapeSingleQuotedString, quoteIfNeeded, CaseInsensitiveMap, CharVarcharUtils, DateTimeUtils}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.TableIdentifierHelper
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -774,8 +774,10 @@ case class DescribeColumnCommand(
     )
     if (isExtended) {
       // Show column stats when EXTENDED or FORMATTED is specified.
-      buffer += Row("min", cs.flatMap(_.min.map(_.toString)).getOrElse("NULL"))
-      buffer += Row("max", cs.flatMap(_.max.map(_.toString)).getOrElse("NULL"))
+      buffer += Row("min", cs.flatMap(_.min.map(
+        toZoneAwareExternalString(_, field.name, field.dataType))).getOrElse("NULL"))
+      buffer += Row("max", cs.flatMap(_.max.map(
+        toZoneAwareExternalString(_, field.name, field.dataType))).getOrElse("NULL"))
       buffer += Row("num_nulls", cs.flatMap(_.nullCount.map(_.toString)).getOrElse("NULL"))
       buffer += Row("distinct_count",
         cs.flatMap(_.distinctCount.map(_.toString)).getOrElse("NULL"))
@@ -787,7 +789,22 @@ case class DescribeColumnCommand(
       } yield histogramDescription(hist)
       buffer ++= histDesc.getOrElse(Seq(Row("histogram", "NULL")))
     }
-    buffer.toSeq
+    buffer
+  }
+
+  private def toZoneAwareExternalString(s: String, name: String, dataType: DataType): String = {
+    dataType match {
+      case TimestampType =>
+        // When writing to metastore, we always format timestamp value in the default UTC time zone.
+        // So here we need to first convert to internal value, then format it using the current
+        // time zone.
+        val internalValue =
+          CatalogColumnStat.fromExternalString(s, name, dataType, CatalogColumnStat.VERSION)
+        val timeZoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
+        CatalogColumnStat.toExternalString(internalValue, name, dataType, timeZoneId)
+      case _ =>
+        s
+    }
   }
 
   private def histogramDescription(histogram: Histogram): Seq[Row] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogColumnStat
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils}
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{withDefaultTimeZone, UTC}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.TimeZoneUTC
 import org.apache.spark.sql.functions.timestamp_seconds
 import org.apache.spark.sql.internal.SQLConf
@@ -524,12 +525,8 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
     val table = "insert_desc_diff_time_zones"
     val tsCol = "timestamp_typed_col"
 
-    val original = TimeZone.getDefault
-    try {
+    withDefaultTimeZone(UTC) {
       withTable(table) {
-
-        TimeZone.setDefault(DateTimeUtils.TimeZoneUTC)
-
         val minTimestamp = "make_timestamp(2022, 1, 1, 0, 0, 1.123456)"
         val maxTimestamp = "make_timestamp(2022, 1, 3, 0, 0, 2.987654)"
         sql(s"CREATE TABLE $table ($tsCol Timestamp) USING parquet")
@@ -556,8 +553,6 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
           expectedMinTimestamp = "2022-01-01 08:00:01.123456",
           expectedMaxTimestamp = "2022-01-03 08:00:02.987654")
       }
-    } finally {
-      TimeZone.setDefault(original)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StatisticsCollectionSuite.scala
@@ -471,7 +471,7 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
     }
   }
 
-  private def checkDescTimestampColStatsByZone(
+  private def checkDescTimestampColStats(
       tableName: String,
       timestampColumn: String,
       expectedMinTimestamp: String,
@@ -506,7 +506,7 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
           sql(s"INSERT INTO $table VALUES $minTimestamp, $maxTimestamp")
           sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR ALL COLUMNS")
 
-          checkDescTimestampColStatsByZone(
+          checkDescTimestampColStats(
             tableName = table,
             timestampColumn = tsCol,
             expectedMinTimestamp = "2022-01-01 00:00:01.123456 " + offset,
@@ -530,21 +530,21 @@ class StatisticsCollectionSuite extends StatisticsCollectionTestBase with Shared
         sql(s"INSERT INTO $table VALUES $minTimestamp, $maxTimestamp")
         sql(s"ANALYZE TABLE $table COMPUTE STATISTICS FOR ALL COLUMNS")
 
-        checkDescTimestampColStatsByZone(
+        checkDescTimestampColStats(
           tableName = table,
           timestampColumn = tsCol,
           expectedMinTimestamp = "2022-01-01 00:00:01.123456 +0000",
           expectedMaxTimestamp = "2022-01-03 00:00:02.987654 +0000")
 
         TimeZone.setDefault(DateTimeUtils.getTimeZone("PST"))
-        checkDescTimestampColStatsByZone(
+        checkDescTimestampColStats(
           tableName = table,
           timestampColumn = tsCol,
           expectedMinTimestamp = "2021-12-31 16:00:01.123456 -0800",
           expectedMaxTimestamp = "2022-01-02 16:00:02.987654 -0800")
 
         TimeZone.setDefault(DateTimeUtils.getTimeZone("Asia/Hong_Kong"))
-        checkDescTimestampColStatsByZone(
+        checkDescTimestampColStats(
           tableName = table,
           timestampColumn = tsCol,
           expectedMinTimestamp = "2022-01-01 08:00:01.123456 +0800",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently timestamp column's stats (min/max) are stored using UTC time zone in metastore, and when desc its min/max column stats, they are also shown in UTC.
As a result, for users not in UTC, the column stats (shown to users) are not consistent with the actual value, which causes confusion.
Note that it does not affect correctness. But we'd better to remove confusion for users.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make column stats and column value consistent when shown to users.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
As an example:
```
spark-sql> create table tab_ts_master (ts timestamp) using parquet;
spark-sql> insert into tab_ts_master values make_timestamp(2022, 1, 1, 0, 0, 1.123456), make_timestamp(2022, 1, 3, 0, 0, 2.987654);
spark-sql> select * from tab_ts_master;
2022-01-01 00:00:01.123456
2022-01-03 00:00:02.987654
spark-sql> set spark.sql.session.timeZone;
spark.sql.session.timeZone	Asia/Shanghai
spark-sql> analyze table tab_ts_master compute statistics for all columns;
```
Before this change:
```
spark-sql> desc formatted tab_ts_master ts;
col_name	ts
data_type	timestamp
comment	NULL
min	2021-12-31 16:00:01.123456
max	2022-01-02 16:00:02.987654
num_nulls	0
distinct_count	2
avg_col_len	8
max_col_len	8
histogram	NULL
```
The min/max column stats are inconsistent with what the user sees in the column values.


After this change:
```
spark-sql> desc formatted tab_ts ts;
col_name	ts
data_type	timestamp
comment	NULL
min	2022-01-01 00:00:01.123456
max	2022-01-03 00:00:02.987654
num_nulls	0
distinct_count	2
avg_col_len	8
max_col_len	8
histogram	NULL
```
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new unit tests.