### PR TITLE
[SPARK-38144][CORE] Remove unused `spark.storage.safetyFraction` config

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -364,11 +364,6 @@ package object config {
     .doubleConf
     .createWithDefault(0.6)
 
-  private[spark] val STORAGE_SAFETY_FRACTION = ConfigBuilder("spark.storage.safetyFraction")
-    .version("1.1.0")
-    .doubleConf
-    .createWithDefault(0.9)
-
   private[spark] val STORAGE_UNROLL_MEMORY_THRESHOLD =
     ConfigBuilder("spark.storage.unrollMemoryThreshold")
       .doc("Initial memory to request before unrolling any block")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the unused `spark.storage.safetyFraction`.

### Why are the changes needed?

Apache Spark 3.0.0 deleted `StaticMemoryManager` and its `spark.storage.safetyFraction` usage via 
SPARK-26539.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.