### PR TITLE
[SPARK-38142][SQL][TESTS] Move `ArrowColumnVectorSuite` to `org.apache.spark.sql.vectorized`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.execution.vectorized
+package org.apache.spark.sql.vectorized
 
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex._
@@ -23,7 +23,6 @@ import org.apache.arrow.vector.complex._
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.ArrowUtils
-import org.apache.spark.sql.vectorized.ArrowColumnVector
 import org.apache.spark.unsafe.types.UTF8String
 
 class ArrowColumnVectorSuite extends SparkFunSuite {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to move `ArrowColumnVectorSuite` to `org.apache.spark.sql.vectorized` so that the package names match


### Why are the changes needed?
Currently `ArrowColumnVector` is under `org.apache.spark.sql.vectorized`. However, `ArrowColumnVectorSuite` is under `org.apache.spark.sql.execution.vectorized`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
