### PR TITLE
[SPARK-38156][SQL] Support CREATE EXTERNAL TABLE LIKE syntax

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -139,7 +139,7 @@ statement
     | createTableHeader ('(' colTypeList ')')? tableProvider?
         createTableClauses
         (AS? query)?                                                   #createTable
-    | CREATE TABLE (IF NOT EXISTS)? target=tableIdentifier
+    | CREATE EXTERNAL? TABLE (IF NOT EXISTS)? target=tableIdentifier
         LIKE source=tableIdentifier
         (tableProvider |
         rowFormat |

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -671,6 +671,9 @@ class SparkSqlAstBuilder extends AstBuilder {
     val location = visitLocationSpecList(ctx.locationSpec())
     val serdeInfo = getSerdeInfo(
       ctx.rowFormat.asScala.toSeq, ctx.createFileFormat.asScala.toSeq, ctx)
+    if (ctx.EXTERNAL() != null && location.isEmpty) {
+      operationNotAllowed(s"CREATE EXTERNAL TABLE LIKE without the LOCATION clause", ctx)
+    }
     if (provider.isDefined && serdeInfo.isDefined) {
       operationNotAllowed(s"CREATE TABLE LIKE ... USING ... ${serdeInfo.get.describe}", ctx)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -476,4 +476,9 @@ class SparkSqlParserSuite extends AnalysisTest {
         "reserved")
     }
   }
+
+  test("CREATE TABLE LIKE COMMAND should reject external table without location spec") {
+    intercept("create external table target like source",
+      "CREATE EXTERNAL TABLE LIKE without the LOCATION clause")
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support `CREATE EXTERNAL TABLE LIKE` syntax.


### Why are the changes needed?
For making the SQL API more consistent and ergonomic for users.


### Does this PR introduce _any_ user-facing change?
Before: only `CREATE TABLE a LIKE b LOCATION path` is supported.
After: Both `CREATE TABLE a LIKE b LOCATION path` and `CREATE EXTERNAL TABLE a LIKE b LOCATION path`


### How was this patch tested?
New UTs.
