### PR TITLE
[SPARK-38033][SS] The structured streaming processing cannot be started b…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -301,7 +301,7 @@ class MicroBatchExecution(
               s"If the latest offset is $latestBatchId, the latest commit is ${latestBatchId - 2}" +
               s" and offset ${latestBatchId - 1} doesn't exist. You can try to remove the offset" +
               s" $latestBatchId and start over. If your query aims end-to-end exactly once" +
-              s" semantic, and you can also remove the output from the batch ${latestBatchId - 1}" +
+              s" semantic, you need to also remove the output from the batch ${latestBatchId - 1}" +
               " manually if possible before starting.")
             throw new IllegalStateException(s"batch ${latestBatchId - 1} doesn't exist")
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -302,7 +302,7 @@ class MicroBatchExecution(
               s" and offset ${latestBatchId - 1} doesn't exist. You can try to remove the offset" +
               s" $latestBatchId and start over. If your query aims end-to-end exactly once" +
               s" semantic, and you can also remove the output from the batch ${latestBatchId - 1}" +
-              s" manually if possible before starting.")
+              " manually if possible before starting.")
             throw new IllegalStateException(s"batch ${latestBatchId - 1} doesn't exist")
           }
           committedOffsets = secondLatestOffsets.toStreamProgress(sources)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -282,7 +282,27 @@ class MicroBatchExecution(
         /* Initialize committed offsets to a committed batch, which at this
          * is the second latest batch id in the offset log. */
         if (latestBatchId != 0) {
+          /* SPARK-38033: In some unexpected cases, commit and offset are inconsistent,
+            * and offset is not written into HDFS continuously, as follows:
+            *
+            * commits
+            * /tmp/streaming_xxxxxxxx/commits/113256
+            * /tmp/streaming_xxxxxxxx/commits/113257
+            * offsets
+            * /tmp/streaming_xxxxxxxx/offsets/113257
+            * /tmp/streaming_xxxxxxxx/offsets/113259
+            *
+            * When we start the streaming program, batch ${latestBatchId - 1} is 113258,
+            * but offsets 113258 doesn't exist, an exception will be thrown,resulting in
+            * the program cannot be started. As an improvement, we could probably do some
+            * simply analysis and give better error message. */
           val secondLatestOffsets = offsetLog.get(latestBatchId - 1).getOrElse {
+            logError(s"Please check the checkpoint, batch ${latestBatchId - 1} doesn't exist. " +
+              s"If the latest offset is $latestBatchId, the latest commit is ${latestBatchId - 2}" +
+              s" and offset ${latestBatchId - 1} doesn't exist. You can try to remove the offset" +
+              s" $latestBatchId and start over. If your query aims end-to-end exactly once" +
+              s" semantic, and you can may want to also remove the output from the batch" +
+              s" ${latestBatchId - 1} manually if possible before starting.")
             throw new IllegalStateException(s"batch ${latestBatchId - 1} doesn't exist")
           }
           committedOffsets = secondLatestOffsets.toStreamProgress(sources)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -301,8 +301,8 @@ class MicroBatchExecution(
               s"If the latest offset is $latestBatchId, the latest commit is ${latestBatchId - 2}" +
               s" and offset ${latestBatchId - 1} doesn't exist. You can try to remove the offset" +
               s" $latestBatchId and start over. If your query aims end-to-end exactly once" +
-              s" semantic, and you can may want to also remove the output from the batch" +
-              s" ${latestBatchId - 1} manually if possible before starting.")
+              s" semantic, and you can also remove the output from the batch ${latestBatchId - 1}" +
+              s" manually if possible before starting.")
             throw new IllegalStateException(s"batch ${latestBatchId - 1} doesn't exist")
           }
           committedOffsets = secondLatestOffsets.toStreamProgress(sources)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

The code of method: populateStartOffsets in class: org.apache.spark.sql.execution.streaming.MicroBatchExecution is modified.

### Why are the changes needed?

In some unexpected cases, commit and offset are inconsistent, and offset is not written into HDFS continuously, as follows:

            commits
            /tmp/streaming_xxxxxxxx/commits/113256
            /tmp/streaming_xxxxxxxx/commits/113257

            offsets
            /tmp/streaming_xxxxxxxx/offsets/113257
            /tmp/streaming_xxxxxxxx/offsets/113259
           
When we start the streaming program, batch ${latestBatchId - 1} is 113258, but offsets 113258 doesn't exist, an exception will be thrown, resulting in the program cannot be started. As an improvement, Spark doesn‘t need to repair itself, but we could probably do some simply analysis and give better error message.

### Does this PR introduce _any_ user-facing change?

Yes.
An error message is logged if the exception is thrown.

### How was this patch tested?

Existing tests, just add an error massage