### PR TITLE
[SPARK-38160][SQL] Shuffle by rand could lead to incorrect answers when ShuffleFetchFailed happend

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/MapPartitionsRDD.scala
@@ -35,13 +35,17 @@ import org.apache.spark.{Partition, TaskContext}
  * @param isOrderSensitive whether or not the function is order-sensitive. If it's order
  *                         sensitive, it may return totally different result when the input order
  *                         is changed. Mostly stateful functions are order-sensitive.
+ * @param isPartitionKeyIndeterminate whether or not the partition key is indeterminate.
+ *                                    If not, it may return different result event though
+ *                                    [[org.apache.spark.Partitioner]] is deterministic.
  */
 private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     var prev: RDD[T],
     f: (TaskContext, Int, Iterator[T]) => Iterator[U],  // (TaskContext, partition index, iterator)
     preservesPartitioning: Boolean = false,
     isFromBarrier: Boolean = false,
-    isOrderSensitive: Boolean = false)
+    isOrderSensitive: Boolean = false,
+    isPartitionKeyIndeterminate: Boolean = false)
   extends RDD[U](prev) {
 
   override val partitioner = if (preservesPartitioning) firstParent[T].partitioner else None
@@ -60,7 +64,8 @@ private[spark] class MapPartitionsRDD[U: ClassTag, T: ClassTag](
     isFromBarrier || dependencies.exists(_.rdd.isBarrier())
 
   override protected def getOutputDeterministicLevel = {
-    if (isOrderSensitive && prev.outputDeterministicLevel == DeterministicLevel.UNORDERED) {
+    if (isPartitionKeyIndeterminate ||
+      (isOrderSensitive && prev.outputDeterministicLevel == DeterministicLevel.UNORDERED)) {
       DeterministicLevel.INDETERMINATE
     } else {
       super.getOutputDeterministicLevel

--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -867,16 +867,21 @@ abstract class RDD[T: ClassTag](
    * @param isOrderSensitive whether or not the function is order-sensitive. If it's order
    *                         sensitive, it may return totally different result when the input order
    *                         is changed. Mostly stateful functions are order-sensitive.
+   * @param isPartitionKeyIndeterminate whether or not the partition key is indeterminate.
+   *                                    If not, it may return different result event though
+   *                                    [[org.apache.spark.Partitioner]] is deterministic.
    */
   private[spark] def mapPartitionsWithIndexInternal[U: ClassTag](
       f: (Int, Iterator[T]) => Iterator[U],
       preservesPartitioning: Boolean = false,
-      isOrderSensitive: Boolean = false): RDD[U] = withScope {
+      isOrderSensitive: Boolean = false,
+      isPartitionKeyIndeterminate: Boolean = false): RDD[U] = withScope {
     new MapPartitionsRDD(
       this,
       (_: TaskContext, index: Int, iter: Iterator[T]) => f(index, iter),
       preservesPartitioning = preservesPartitioning,
-      isOrderSensitive = isOrderSensitive)
+      isOrderSensitive = isOrderSensitive,
+      isPartitionKeyIndeterminate = isPartitionKeyIndeterminate)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -64,7 +64,7 @@ case class CollectLimitExec(limit: Int, child: SparkPlan) extends LimitExec {
         new ShuffledRowRDD(
           ShuffleExchangeExec.prepareShuffleDependency(
             locallyLimited,
-            child.output,
+            child,
             SinglePartition,
             serializer,
             writeMetrics),
@@ -233,7 +233,7 @@ case class TakeOrderedAndProjectExec(
         new ShuffledRowRDD(
           ShuffleExchangeExec.prepareShuffleDependency(
             localTopK,
-            child.output,
+            child,
             SinglePartition,
             serializer,
             writeMetrics),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When we do shuffle on indeterminate expressions such as `rand`, and ShuffleFetchFailed happend, we may get incorrent result since it only retries failed map tasks.

To illustrate this, suppose we have a dataset with two columns `(range(1, 5) as a, rand() as b)`, we shuffle by `b` using two map tasks and two reduce tasks.
<img width="630" alt="image" src="https://user-images.githubusercontent.com/1312321/153171110-13887a78-565f-4cdf-afda-bb9053ea7ef0.png">

**When there is a fetch failed and we need to rerun map task 2,  the generated partitions maybe different compared with last attempt, and finally we get a duplicate record with a = 4**
<img width="610" alt="image" src="https://user-images.githubusercontent.com/1312321/153172262-bf5e2c81-8db6-4b01-8b70-8f284b54b09d.png">
 
This is very similary to the bug in Repartition+Shuffle, which is fixed by https://github.com/apache/spark/pull/22112. 
This PR try to fix this by reuse current machenism.


### Why are the changes needed?
Fix data inconsistent issue.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added UT
