### PR TITLE
[SPARK-38163][SQL] Preserve the error class of `SparkThrowable` while constructing of function builder

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.GuardedBy
 import scala.collection.mutable
 import scala.reflect.ClassTag
 
+import org.apache.spark.SparkThrowable
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.FunctionIdentifier
@@ -129,7 +130,11 @@ object FunctionRegistryBase {
         } catch {
           // the exception is an invocation exception. To get a meaningful message, we need the
           // cause.
-          case e: Exception => throw new AnalysisException(e.getCause.getMessage)
+          case e: Exception =>
+            throw e.getCause match {
+              case ae: SparkThrowable => ae
+              case _ => new AnalysisException(e.getCause.getMessage)
+            }
         }
       } else {
         // Otherwise, find a constructor method that matches the number of arguments, and use that.

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -111,4 +111,13 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
         "grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup")
     }
   }
+
+  test("ILLEGAL_SUBSTRING: the argument_index of string format is invalid") {
+    val e = intercept[AnalysisException] {
+      sql("select format_string('%0$s', 'Hello')")
+    }
+    assert(e.errorClass === Some("ILLEGAL_SUBSTRING"))
+    assert(e.message ===
+      "The argument_index of string format cannot contain position 0$.")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to propagate `SparkThrowable` to user space AS IS in constructing of function builder. This allows to preserve the error class, for instance.

### Why are the changes needed?
This fixes the issues portrayed by the example below:
```scala
scala> try { sql("select format_string('%0$s', 'Hello')") } catch { case e: org.apache.spark.sql.AnalysisException => println(e.getErrorClass) }
null
``` 
The expected error should be `ILLEGAL_SUBSTRING`. It sets at https://github.com/apache/spark/blob/899d3bb44d7c72dc0179545189ac8170bde993a8/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala#L71.

### Does this PR introduce _any_ user-facing change?
Yes, the PR changes exceptions that can be handles by users.

After the changes:
```scala
scala> try { sql("select format_string('%0$s', 'Hello')") } catch { case e: org.apache.spark.sql.AnalysisException => println(e.getErrorClass) }
ILLEGAL_SUBSTRING
```

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *QueryCompilationErrorsSuite"
```