### PR TITLE
[SPARK-38146][SQL] Call `setLong` rather than `update` on aggregation buffer when aggregating a TIMESTAMP_NTZ column with a UDAF

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/udaf.scala
@@ -83,7 +83,7 @@ sealed trait BufferSetterGetterUtils {
           (row: InternalRow, ordinal: Int) =>
             if (row.isNullAt(ordinal)) null else row.getInt(ordinal)
 
-        case TimestampType =>
+        case TimestampType | TimestampNTZType =>
           (row: InternalRow, ordinal: Int) =>
             if (row.isNullAt(ordinal)) null else row.getLong(ordinal)
 
@@ -187,7 +187,7 @@ sealed trait BufferSetterGetterUtils {
               row.setNullAt(ordinal)
             }
 
-        case TimestampType =>
+        case TimestampType | TimestampNTZType =>
           (row: InternalRow, ordinal: Int, value: Any) =>
             if (value != null) {
               row.setLong(ordinal, value.asInstanceOf[Long])

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/AggregationQuerySuite.scala
@@ -896,10 +896,7 @@ abstract class AggregationQuerySuite extends QueryTest with SQLTestUtils with Te
     // UnsafeRow.mutableFieldTypes.asScala.toSeq will trigger SortAggregate to use
     // UnsafeRow as the aggregation buffer. While, dataTypes will trigger
     // SortAggregate to use a safe row as the aggregation buffer.
-    // udaf cannot yet handle TimestampNTZType
-    val mutableFieldTypes = UnsafeRow.mutableFieldTypes
-      .asScala.filterNot(_.isInstanceOf[TimestampNTZType]).toSeq
-    Seq(dataTypes, mutableFieldTypes).foreach { dataTypes =>
+    Seq(dataTypes, UnsafeRow.mutableFieldTypes.asScala.toSeq).foreach { dataTypes =>
       val fields = dataTypes.zipWithIndex.map { case (dataType, index) =>
         StructField(s"col$index", dataType, nullable = true)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change BufferSetterGetterUtils to use `InternalRow.setLong` for TIMESTAMP_NTZ values rather then `InternalRow.update`.

### Why are the changes needed?

When a query aggregates a TIMESTAMP_NTZ column using a UDAF that extends `UserDefinedAggregateFunction`, Spark will use `TungstenAggregationIterator`, which creates an `UnsafeRow` for the low-level aggregation buffer.

However, the wrapper of that buffer (`MutableAggregationBufferImpl`) fails to properly set up a field setter function for the TIMESTAMP_NTZ column, so it attempts to call `UnsafeRow.update` on the underlying buffer. The UnsafeRow instance throws `java.lang.UnsupportedOperationException`:

```
Caused by: java.lang.UnsupportedOperationException
  at org.apache.spark.sql.catalyst.expressions.UnsafeRow.update(UnsafeRow.java:218)
  at org.apache.spark.sql.execution.aggregate.BufferSetterGetterUtils.$anonfun$createSetters$15(udaf.scala:217)
  at org.apache.spark.sql.execution.aggregate.BufferSetterGetterUtils.$anonfun$createSetters$15$adapted(udaf.scala:215)
  at org.apache.spark.sql.execution.aggregate.MutableAggregationBufferImpl.update(udaf.scala:272)
  at MyAverage$.initialize(<console>:52)
  at org.apache.spark.sql.execution.aggregate.ScalaUDAF.initialize(udaf.scala:450)

```
See the Jira (SPARK-38146) for a full reproduction example.

Before the fix for SPARK-38133, `UnsafeRow` did not consider TIMESTAMP_NTZ as mutable or fixed size, so Spark would use `SortBasedAggregationIterator`, which would created a `GenericInternalRow` for the underlying buffer rather than an `UnsafeRow` instance. Therefore, before SPARK-38133, a UDAF could aggegrate a TIMESTAMP_NTZ column.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Turned back on testing of TIMESTAMP_NTZ in the unit test "udaf with all data types" in `HashAggregationQuerySuite`.