### PR TITLE
[SPARK-38157][SQL] Explicitly set ANSI to false in test timestampNTZ/timestamp.sql and SQLQueryTestSuite to match the expected golden results

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/timestampNTZ/timestamp.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/timestampNTZ/timestamp.sql
@@ -1,1 +1,2 @@
+--SET spark.sql.ansi.enabled = false
 --IMPORT timestamp.sql

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -388,6 +388,7 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
         localSparkSession.conf.set(SQLConf.TIMESTAMP_TYPE.key,
           TimestampTypes.TIMESTAMP_NTZ.toString)
       case _ =>
+        localSparkSession.conf.set(SQLConf.ANSI_ENABLED.key, false)
     }
 
     if (configSet.nonEmpty) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR explicitly sets the ANSI to false in the timestampNTZ/timestamp.sql input itself, and in the `SQLQueryTestSuite` when the input doesn't match with any of `PgSQLTest`, `AnsiTest` or `TimestampNTZTest`. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Without this change, `ThriftServerQueryTestSuite` will fail on timestampNTZ/timestamp.sql, when ANSI is on by default. It is because the timestampNTZ/timestamp.sql should only work with ANSI off according to the golden result file, but ThriftServerQueryTestSuite or the timestamp.sql test doesn't override the default ANSI setting. 
The same goes with the `SQLQueryTestSuite`.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.