### PR TITLE
[SPARK-38171][BUILD][SQL] Upgrade ORC to 1.7.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -219,9 +219,9 @@ objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.7.2//orc-core-1.7.2.jar
-orc-mapreduce/1.7.2//orc-mapreduce-1.7.2.jar
-orc-shims/1.7.2//orc-shims-1.7.2.jar
+orc-core/1.7.3//orc-core-1.7.3.jar
+orc-mapreduce/1.7.3//orc-mapreduce-1.7.3.jar
+orc-shims/1.7.3//orc-shims-1.7.3.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -205,9 +205,9 @@ objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.7.2//orc-core-1.7.2.jar
-orc-mapreduce/1.7.2//orc-mapreduce-1.7.2.jar
-orc-shims/1.7.2//orc-shims-1.7.2.jar
+orc-core/1.7.3//orc-core-1.7.3.jar
+orc-mapreduce/1.7.3//orc-mapreduce-1.7.3.jar
+orc-shims/1.7.3//orc-shims-1.7.3.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>
-    <orc.version>1.7.2</orc.version>
+    <orc.version>1.7.3</orc.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC dependency to 1.7.3.

### Why are the changes needed?

Apache ORC 1.7.3 is the 3rd maintenance release.
- https://orc.apache.org/news/2022/02/09/ORC-1.7.3/
- https://github.com/apache/orc/releases/tag/v1.7.3

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.