### PR TITLE
Add EqualTo handling in generateSQL()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/ExpressionSQLBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/ExpressionSQLBuilder.scala
@@ -48,6 +48,14 @@ class ExpressionSQLBuilder(e: Expression) {
       } else {
         None
       }
+    case EqualTo(left, right) =>
+      val l = generateSQL(left)
+      val r = generateSQL(right)
+      if (l.isDefined && r.isDefined) {
+        Some(s"${l.get} = ${r.get}")
+      } else {
+        None
+      }
     case Not(child) => generateSQL(child).map(v => s"NOT ($v)")
     case CaseWhen(branches, elseValue) =>
       val conditionsSQL = branches.map(_._1).flatMap(generateSQL)


### PR DESCRIPTION
### What changes were proposed in this pull request?
ExpressionSQLBuilder#generateSQL() should handle EqualTo case.
This PR adds the handling of EqualTo.

### Why are the changes needed?
EqualTo is a common case that the builder should process.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.