### PR TITLE
[SPARK-38179][SQL] Improve `WritableColumnVector` to better support null struct

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -216,7 +216,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * the struct type, and each child vector is responsible to store the data for its corresponding
    * struct field.
    */
-  public final ColumnarRow getStruct(int rowId) {
+  public ColumnarRow getStruct(int rowId) {
     if (isNullAt(rowId)) return null;
     return new ColumnarRow(this, rowId);
   }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnVector.java
@@ -288,7 +288,7 @@ public abstract class ColumnVector implements AutoCloseable {
    * is a long type vector, containing all the microsecond values of all the interval values in this
    * vector.
    */
-  public final CalendarInterval getInterval(int rowId) {
+  public CalendarInterval getInterval(int rowId) {
     if (isNullAt(rowId)) return null;
     final int months = getChild(0).getInt(rowId);
     final int days = getChild(1).getInt(rowId);

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -66,9 +66,10 @@ public final class OffHeapColumnVector extends WritableColumnVector {
 
   // Only set if type is Struct.
   //
-  // A slot 'structOffsetData[i]' is only defined iff 'nulls[i]' is NOT set. If defined,
+  // A slot 'structOffsetData[i]' should only be set and used iff 'nulls[i]' is NOT set. If set,
   // 'structOffsetData[i] = j' indicates that for struct at slot 'i', its offset in the child
-  // vectors is 'j'.
+  // vectors is 'j'. For those slots that are not set, their values are undefined and should never
+  // be used.
   //
   // This is useful since we don't want to materialize null structs.
   private long structOffsetData;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -581,7 +581,7 @@ public final class OffHeapColumnVector extends WritableColumnVector {
           Platform.reallocateMemory(offsetData, oldCapacity * 4L, newCapacity * 4L);
     } else if (isStruct()) {
       this.structOffsetData =
-        Platform.reallocateMemory(structOffsetData, oldCapacity * 4L, newCapacity * 4L);
+          Platform.reallocateMemory(structOffsetData, oldCapacity * 4L, newCapacity * 4L);
     } else if (type instanceof ByteType || type instanceof BooleanType) {
       this.data = Platform.reallocateMemory(data, oldCapacity, newCapacity);
     } else if (type instanceof ShortType) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -137,7 +137,7 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   @Override
   public boolean isNullAt(int rowId) {
-    return isAllNull || nulls[rowId] == 1;
+    return nulls[rowId] == 1;
   }
 
   //

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OnHeapColumnVector.java
@@ -75,9 +75,10 @@ public final class OnHeapColumnVector extends WritableColumnVector {
 
   // Only set if type is Struct.
   //
-  // A slot 'structOffsets[i]' is only defined iff 'nulls[i]' is NOT set. If defined,
-  // 'structOffsets[i] = j' indicates that for struct at slot 'i', its offset in the child vectors
-  // is 'j'.
+  // A slot 'structOffsets[i]' should only be set and used iff 'nulls[i]' is NOT set. If set,
+  // 'structOffsets[i] = j' indicates that for struct at slot 'i', its offset in the child
+  // vectors is 'j'. For those slots that are not set, their values are undefined and should never
+  // be used.
   //
   // This is useful since we don't want to materialize null structs.
   private int[] structOffsets;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -53,7 +53,7 @@ public abstract class WritableColumnVector extends ColumnVector {
    * Resets this column for writing. The currently stored values are no longer accessible.
    */
   public void reset() {
-    if (isConstant || isAllNull) return;
+    if (isConstant) return;
 
     if (childColumns != null) {
       for (WritableColumnVector c: childColumns) {
@@ -81,10 +81,6 @@ public abstract class WritableColumnVector extends ColumnVector {
       dictionaryIds = null;
     }
     dictionary = null;
-  }
-
-  public void reserveAdditional(int additionalCapacity) {
-    reserve(elementsAppended + additionalCapacity);
   }
 
   public void reserve(int requiredCapacity) {
@@ -121,7 +117,7 @@ public abstract class WritableColumnVector extends ColumnVector {
 
   @Override
   public boolean hasNull() {
-    return isAllNull || numNulls > 0;
+    return numNulls > 0;
   }
 
   @Override
@@ -733,46 +729,9 @@ public abstract class WritableColumnVector extends ColumnVector {
   public WritableColumnVector getChild(int ordinal) { return childColumns[ordinal]; }
 
   /**
-   * Returns the number of child vectors.
-   */
-  public int getNumChildren() {
-    return childColumns.length;
-  }
-
-  /**
-   * Returns the elements appended. This is useful
-   */
-  public final int getElementsAppended() { return elementsAppended; }
-
-  /**
-   * Increment number of elements appended by 'num'.
-   *
-   * This is useful when one wants to the 'putXXX' API to add new elements to the vector, but
-   * still want to keep count of how many elements have been added (since the 'putXXX' APIs don't
-   * increment count).
-   */
-  public final void addElementsAppended(int num) {
-    elementsAppended += num;
-  }
-
-  /**
    * Marks this column as being constant.
    */
   public final void setIsConstant() { isConstant = true; }
-
-  /**
-   * Marks this column only contains null values.
-   */
-  public final void setAllNull() {
-    isAllNull = true;
-  }
-
-  /**
-   * Whether this column only contains null values.
-   */
-  public final boolean isAllNull() {
-    return isAllNull;
-  }
 
   /**
    * Maximum number of rows that can be stored in this column.
@@ -795,12 +754,6 @@ public abstract class WritableColumnVector extends ColumnVector {
    * across resets.
    */
   protected boolean isConstant;
-
-  /**
-   * True if this column only contains nulls. Comparing to 'isConstant' above, this doesn't require
-   * any allocation of space.
-   */
-  protected boolean isAllNull;
 
   /**
    * Default size of each array length value. This grows as necessary.

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -684,8 +684,8 @@ public abstract class WritableColumnVector extends ColumnVector {
       }
     } else {
       putNotNull(elementsAppended);
+      putStruct(elementsAppended, elementsAppended);
     }
-    putStruct(elementsAppended, elementsAppended);
     elementsAppended++;
     return elementsAppended;
   }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -725,6 +725,11 @@ public abstract class WritableColumnVector extends ColumnVector {
    */
   public abstract int getStructOffset(int rowId);
 
+  /**
+   * Returns the elements appended.
+   */
+  public final int getElementsAppended() { return elementsAppended; }
+
   @Override
   public WritableColumnVector getChild(int ordinal) { return childColumns[ordinal]; }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
@@ -374,8 +374,10 @@ class ColumnVectorSuite extends SparkFunSuite with BeforeAndAfterEach {
     val c2 = testVector.getChild(1)
     c1.putInt(0, 123)
     c2.putDouble(0, 3.45)
+    testVector.putStruct(0, 0)
     c1.putInt(1, 456)
     c2.putDouble(1, 5.67)
+    testVector.putStruct(1, 1)
 
     assert(testVector.getStruct(0).get(0, IntegerType) === 123)
     assert(testVector.getStruct(0).get(1, DoubleType) === 3.45)
@@ -581,6 +583,7 @@ class ColumnVectorSuite extends SparkFunSuite with BeforeAndAfterEach {
       val column = v.getChild(0)
       (0 until 10).foreach { i =>
         column.putInt(i, i)
+        v.putStruct(i, i)
       }
       (0 until 10).foreach { i =>
         val row = v.getStruct(i)
@@ -596,6 +599,7 @@ class ColumnVectorSuite extends SparkFunSuite with BeforeAndAfterEach {
       val column = v.getChild(0)
       (0 until 10).foreach { i =>
         column.putLong(i, i)
+        v.putStruct(i, i)
       }
       (0 until 10).foreach { i =>
         val row = v.getStruct(i)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchSuite.scala
@@ -1018,12 +1018,16 @@ class ColumnarBatchSuite extends SparkFunSuite {
 
       c1.putInt(0, 123)
       c2.putDouble(0, 3.45)
+      column.putStruct(0, 0)
 
       column.putNull(1)
       assert(column.getStruct(1) == null)
 
       c1.putInt(2, 456)
       c2.putDouble(2, 5.67)
+      c1.putInt(1, 456)
+      c2.putDouble(1, 5.67)
+      column.putStruct(2, 1)
 
       val s = column.getStruct(0)
       assert(s.getInt(0) == 123)
@@ -1079,6 +1083,7 @@ class ColumnarBatchSuite extends SparkFunSuite {
       (0 until 6).foreach { i =>
         c0.putInt(i, i)
         c1.putLong(i, i * 10)
+        data.putStruct(i, i)
       }
       // Arrays in column: [(0, 0), (1, 10)], [(1, 10), (2, 20), (3, 30)],
       // [(4, 40), (5, 50)]
@@ -1115,6 +1120,10 @@ class ColumnarBatchSuite extends SparkFunSuite {
       c1.putArray(1, 2, 1)
       c1.putArray(2, 3, 3)
 
+      column.putStruct(0, 0)
+      column.putStruct(1, 1)
+      column.putStruct(2, 2)
+
       assert(column.getStruct(0).getInt(0) === 0)
       assert(column.getStruct(0).getArray(1).toIntArray() === Array(0, 1))
       assert(column.getStruct(1).getInt(0) === 1)
@@ -1135,6 +1144,9 @@ class ColumnarBatchSuite extends SparkFunSuite {
       c0.putInt(0, 0)
       c0.putInt(1, 1)
       c0.putInt(2, 2)
+      column.putStruct(0, 0)
+      column.putStruct(1, 1)
+      column.putStruct(2, 2)
       val c1c0 = c1.getChild(0)
       val c1c1 = c1.getChild(1)
       // Structs in c1: (7, 70), (8, 80), (9, 90)
@@ -1144,6 +1156,9 @@ class ColumnarBatchSuite extends SparkFunSuite {
       c1c1.putInt(0, 70)
       c1c1.putInt(1, 80)
       c1c1.putInt(2, 90)
+      c1.putStruct(0, 0)
+      c1.putStruct(1, 1)
+      c1.putStruct(2, 2)
 
       assert(column.getStruct(0).getInt(0) === 0)
       assert(column.getStruct(0).getStruct(1, 2).toSeq(subSchema) === Seq(7, 70))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This changes `WritableColumnVector` to better support null structs, by avoiding allocating space in child vectors when an element is null.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently, for a `WritableColumnVector` whose type is struct, Spark needs to allocate space in all child vectors even if an element is null. This is not very space efficient. 

In addition, this doesn't work well with the ongoing Parquet vectorized support for complex types, since when creating the child column vectors for a struct, we don't yet have the information of which slot is for null struct (Parquet packs values contiguously instead of having null slots).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Shouldn't be, since `WritableColumnVector` is Spark internal API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Updated `ColumnVectorSuite` and `ColumnarBatchSuite` to reflect the new changes.