### PR TITLE
[SPARK-38184][SQL][DOCS] Fix malformatted ExpressionDescription of decode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2418,12 +2418,12 @@ object Decode {
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
-            |_FUNC_(bin, charset) - Decodes the first argument using the second argument character set.
-            |
-            |_FUNC_(expr, search, result [, search, result ] ... [, default]) - Decode compares expr
-            |  to each search value one by one. If expr is equal to a search, returns the corresponding result.
-            |  If no match is found, then Oracle returns default. If default is omitted, returns null.
-          """,
+    _FUNC_(bin, charset) - Decodes the first argument using the second argument character set.
+
+    _FUNC_(expr, search, result [, search, result ] ... [, default]) - Decode compares expr
+      to each search value one by one. If expr is equal to a search, returns the corresponding result.
+      If no match is found, then Oracle returns default. If default is omitted, returns null.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(encode('abc', 'utf-8'), 'utf-8');


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix malformatted ExpressionDescription of decode.


### Why are the changes needed?
Currently, https://spark.apache.org/docs/latest/api/sql/#decode is malformed because its ExpressionDescription uses the pipe symbol.

### Does this PR introduce _any_ user-facing change?
Doc change only.

### How was this patch tested?
Manual test.

Updated HTML looks as below:
![image](https://user-images.githubusercontent.com/47337188/153554869-b2b16250-6a9a-4f84-9774-96c0894edcd7.png)
