### PR TITLE
[SPARK-36059][K8S][FOLLOWUP] Support `spark.kubernetes.scheduler.name`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1332,7 +1332,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.3.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.executor.scheduler.name<code></td>
+  <td><code>spark.kubernetes.executor.scheduler.name</code></td>
   <td>(none)</td>
   <td>
 	Specify the scheduler name for each executor pod.
@@ -1340,10 +1340,19 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.driver.scheduler.name<code></td>
+  <td><code>spark.kubernetes.driver.scheduler.name</code></td>
   <td>(none)</td>
   <td>
     Specify the scheduler name for driver pod.
+  </td>
+  <td>3.3.0</td>
+</tr>
+<tr>
+  <td><code>spark.kubernetes.scheduler.name</code></td>
+  <td>(none)</td>
+  <td>
+    Specify the scheduler name for driver and executor pods. If `spark.kubernetes.driver.scheduler.name` or
+    `spark.kubernetes.executor.scheduler.name` is set, will override this.
   </td>
   <td>3.3.0</td>
 </tr>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -283,6 +283,15 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
+  val KUBERNETES_SCHEDULER_NAME =
+    ConfigBuilder("spark.kubernetes.scheduler.name")
+      .doc("Specify the scheduler name for driver and executor pod, if " +
+        s"`${KUBERNETES_DRIVER_SCHEDULER_NAME.key}` or `${KUBERNETES_DRIVER_SCHEDULER_NAME.key}` " +
+        "is set, will replace this.")
+      .version("3.3.0")
+      .stringConf
+      .createOptional
+
   val KUBERNETES_EXECUTOR_REQUEST_CORES =
     ConfigBuilder("spark.kubernetes.executor.request.cores")
       .doc("Specify the cpu request for each executor pod")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -285,9 +285,9 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_SCHEDULER_NAME =
     ConfigBuilder("spark.kubernetes.scheduler.name")
-      .doc("Specify the scheduler name for driver and executor pod, if " +
-        s"`${KUBERNETES_DRIVER_SCHEDULER_NAME.key}` or `${KUBERNETES_DRIVER_SCHEDULER_NAME.key}` " +
-        "is set, will replace this.")
+      .doc("Specify the scheduler name for driver and executor pods. if " +
+        s"`${KUBERNETES_DRIVER_SCHEDULER_NAME.key}` or " +
+        s"`${KUBERNETES_EXECUTOR_SCHEDULER_NAME.key}` is set, will override this.")
       .version("3.3.0")
       .stringConf
       .createOptional

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -285,7 +285,7 @@ private[spark] object Config extends Logging {
 
   val KUBERNETES_SCHEDULER_NAME =
     ConfigBuilder("spark.kubernetes.scheduler.name")
-      .doc("Specify the scheduler name for driver and executor pods. if " +
+      .doc("Specify the scheduler name for driver and executor pods. If " +
         s"`${KUBERNETES_DRIVER_SCHEDULER_NAME.key}` or " +
         s"`${KUBERNETES_EXECUTOR_SCHEDULER_NAME.key}` is set, will override this.")
       .version("3.3.0")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -136,7 +136,9 @@ private[spark] class KubernetesDriverConf(
     KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, KUBERNETES_DRIVER_VOLUMES_PREFIX)
   }
 
-  override def schedulerName: String = get(KUBERNETES_DRIVER_SCHEDULER_NAME).getOrElse("")
+  override def schedulerName: String = {
+    get(KUBERNETES_DRIVER_SCHEDULER_NAME).getOrElse(get(KUBERNETES_SCHEDULER_NAME).getOrElse(""))
+  }
 }
 
 private[spark] class KubernetesExecutorConf(
@@ -195,7 +197,9 @@ private[spark] class KubernetesExecutorConf(
     KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, KUBERNETES_EXECUTOR_VOLUMES_PREFIX)
   }
 
-  override def schedulerName: String = get(KUBERNETES_EXECUTOR_SCHEDULER_NAME).getOrElse("")
+  override def schedulerName: String = {
+    get(KUBERNETES_EXECUTOR_SCHEDULER_NAME).getOrElse(get(KUBERNETES_SCHEDULER_NAME).getOrElse(""))
+  }
 
   private def checkExecutorEnvKey(key: String): Boolean = {
     // Pattern for matching an executorEnv key, which meets certain naming rules.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -42,7 +42,7 @@ private[spark] abstract class KubernetesConf(val sparkConf: SparkConf) {
   def secretEnvNamesToKeyRefs: Map[String, String]
   def secretNamesToMountPaths: Map[String, String]
   def volumes: Seq[KubernetesVolumeSpec]
-  def schedulerName: String
+  def schedulerName: Option[String]
   def appId: String
 
   def appName: String = get("spark.app.name", "spark")
@@ -136,8 +136,8 @@ private[spark] class KubernetesDriverConf(
     KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, KUBERNETES_DRIVER_VOLUMES_PREFIX)
   }
 
-  override def schedulerName: String = {
-    get(KUBERNETES_DRIVER_SCHEDULER_NAME).getOrElse(get(KUBERNETES_SCHEDULER_NAME).getOrElse(""))
+  override def schedulerName: Option[String] = {
+    Option(get(KUBERNETES_DRIVER_SCHEDULER_NAME).getOrElse(get(KUBERNETES_SCHEDULER_NAME).orNull))
   }
 }
 
@@ -197,8 +197,8 @@ private[spark] class KubernetesExecutorConf(
     KubernetesVolumeUtils.parseVolumesWithPrefix(sparkConf, KUBERNETES_EXECUTOR_VOLUMES_PREFIX)
   }
 
-  override def schedulerName: String = {
-    get(KUBERNETES_EXECUTOR_SCHEDULER_NAME).getOrElse(get(KUBERNETES_SCHEDULER_NAME).getOrElse(""))
+  override def schedulerName: Option[String] = {
+    Option(get(KUBERNETES_EXECUTOR_SCHEDULER_NAME).getOrElse(get(KUBERNETES_SCHEDULER_NAME).orNull))
   }
 
   private def checkExecutorEnvKey(key: String): Boolean = {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicDriverFeatureStep.scala
@@ -152,7 +152,7 @@ private[spark] class BasicDriverFeatureStep(conf: KubernetesDriverConf)
         .endSpec()
       .build()
 
-    conf.get(KUBERNETES_DRIVER_SCHEDULER_NAME)
+    conf.schedulerName
       .foreach(driverPod.getSpec.setSchedulerName)
 
     SparkPod(driverPod, driverContainer)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -299,7 +299,7 @@ private[spark] class BasicExecutorFeatureStep(
         .endSpec()
       .build()
     }
-    kubernetesConf.get(KUBERNETES_EXECUTOR_SCHEDULER_NAME)
+    kubernetesConf.schedulerName
       .foreach(executorPod.getSpec.setSchedulerName)
 
     SparkPod(executorPod, containerWithLifecycle)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -206,10 +206,17 @@ class KubernetesConfSuite extends SparkFunSuite {
   test("SPARK-36059: Set driver.scheduler and executor.scheduler") {
     val sparkConf = new SparkConf(false)
     val execUnsetConf = KubernetesTestConf.createExecutorConf(sparkConf)
-    val driverUnsetConf = KubernetesTestConf.createExecutorConf(sparkConf)
+    val driverUnsetConf = KubernetesTestConf.createDriverConf(sparkConf)
     assert(execUnsetConf.schedulerName === "")
     assert(driverUnsetConf.schedulerName === "")
 
+    sparkConf.set(KUBERNETES_SCHEDULER_NAME, "sameScheduler")
+    val execCommonConf = KubernetesTestConf.createExecutorConf(sparkConf)
+    assert(execCommonConf.schedulerName === "sameScheduler")
+    val driverCommonConf = KubernetesTestConf.createDriverConf(sparkConf)
+    assert(driverCommonConf.schedulerName === "sameScheduler")
+
+    assert(sparkConf.get(KUBERNETES_SCHEDULER_NAME) === Some("sameScheduler"))
     sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "driverScheduler")
     sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "executorScheduler")
     val execConf = KubernetesTestConf.createExecutorConf(sparkConf)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -215,13 +215,13 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === Some("sameScheduler"))
     assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === Some("sameScheduler"))
 
-    // Overwrite by driver/executor side scheduler when ""
+    // Override by driver/executor side scheduler when ""
     sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "")
     sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "")
     assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === Some(""))
     assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === Some(""))
 
-    // Overwrite by driver/executor side scheduler when set
+    // Override by driver/executor side scheduler when set
     sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "driverScheduler")
     sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "executorScheduler")
     val execConf = KubernetesTestConf.createExecutorConf(sparkConf)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -210,12 +210,20 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(execUnsetConf.schedulerName === "")
     assert(driverUnsetConf.schedulerName === "")
 
+    assert(sparkConf.get(KUBERNETES_DRIVER_SCHEDULER_NAME) === None)
+    assert(sparkConf.get(KUBERNETES_EXECUTOR_SCHEDULER_NAME) === None)
+    // Set to KUBERNETES_SCHEDULER_NAME when  KUBERNETES_[DRIVER/EXECUTOR]_SCHEDULER_NAME is None
     sparkConf.set(KUBERNETES_SCHEDULER_NAME, "sameScheduler")
-    val execCommonConf = KubernetesTestConf.createExecutorConf(sparkConf)
-    assert(execCommonConf.schedulerName === "sameScheduler")
-    val driverCommonConf = KubernetesTestConf.createDriverConf(sparkConf)
-    assert(driverCommonConf.schedulerName === "sameScheduler")
+    assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === "sameScheduler")
+    assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === "sameScheduler")
 
+    // Set to KUBERNETES_SCHEDULER_NAME when KUBERNETES_[DRIVER/EXECUTOR]_SCHEDULER_NAME is ""
+    sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "")
+    sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "")
+    assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === "sameScheduler")
+    assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === "sameScheduler")
+
+    // scheduler name is override by driver/executor scheduler name
     assert(sparkConf.get(KUBERNETES_SCHEDULER_NAME) === Some("sameScheduler"))
     sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "driverScheduler")
     sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "executorScheduler")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -207,30 +207,27 @@ class KubernetesConfSuite extends SparkFunSuite {
     val sparkConf = new SparkConf(false)
     val execUnsetConf = KubernetesTestConf.createExecutorConf(sparkConf)
     val driverUnsetConf = KubernetesTestConf.createDriverConf(sparkConf)
-    assert(execUnsetConf.schedulerName === "")
-    assert(driverUnsetConf.schedulerName === "")
+    assert(execUnsetConf.schedulerName === None)
+    assert(driverUnsetConf.schedulerName === None)
 
-    assert(sparkConf.get(KUBERNETES_DRIVER_SCHEDULER_NAME) === None)
-    assert(sparkConf.get(KUBERNETES_EXECUTOR_SCHEDULER_NAME) === None)
-    // Set to KUBERNETES_SCHEDULER_NAME when  KUBERNETES_[DRIVER/EXECUTOR]_SCHEDULER_NAME is None
     sparkConf.set(KUBERNETES_SCHEDULER_NAME, "sameScheduler")
-    assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === "sameScheduler")
-    assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === "sameScheduler")
+    // Use KUBERNETES_SCHEDULER_NAME when is NOT set
+    assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === Some("sameScheduler"))
+    assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === Some("sameScheduler"))
 
-    // Set to KUBERNETES_SCHEDULER_NAME when KUBERNETES_[DRIVER/EXECUTOR]_SCHEDULER_NAME is ""
+    // Overwrite by driver/executor side scheduler when ""
     sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "")
     sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "")
-    assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === "sameScheduler")
-    assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === "sameScheduler")
+    assert(KubernetesTestConf.createDriverConf(sparkConf).schedulerName === Some(""))
+    assert(KubernetesTestConf.createExecutorConf(sparkConf).schedulerName === Some(""))
 
-    // scheduler name is override by driver/executor scheduler name
-    assert(sparkConf.get(KUBERNETES_SCHEDULER_NAME) === Some("sameScheduler"))
+    // Overwrite by driver/executor side scheduler when set
     sparkConf.set(KUBERNETES_DRIVER_SCHEDULER_NAME, "driverScheduler")
     sparkConf.set(KUBERNETES_EXECUTOR_SCHEDULER_NAME, "executorScheduler")
     val execConf = KubernetesTestConf.createExecutorConf(sparkConf)
-    assert(execConf.schedulerName === "executorScheduler")
+    assert(execConf.schedulerName === Some("executorScheduler"))
     val driverConf = KubernetesTestConf.createDriverConf(sparkConf)
-    assert(driverConf.schedulerName === "driverScheduler")
+    assert(driverConf.schedulerName === Some("driverScheduler"))
   }
 
   test("SPARK-37735: access appId in KubernetesConf") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodBuilderSuite.scala
@@ -53,6 +53,14 @@ abstract class PodBuilderSuite extends SparkFunSuite {
     verify(client, never()).pods()
   }
 
+  test("SPARK-36059: set custom scheduler") {
+    val client = mockKubernetesClient()
+    val sparkConf = baseConf.clone().set(templateFileConf.key, "template-file.yaml")
+      .set(Config.KUBERNETES_SCHEDULER_NAME.key, "custom")
+    val pod = buildPod(sparkConf, client)
+    assert(pod.pod.getSpec.getSchedulerName === "custom")
+  }
+
   test("load pod template if specified") {
     val client = mockKubernetesClient()
     val sparkConf = baseConf.clone().set(templateFileConf.key, "template-file.yaml")

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/PodBuilderSuite.scala
@@ -36,6 +36,8 @@ abstract class PodBuilderSuite extends SparkFunSuite {
 
   protected def templateFileConf: ConfigEntry[_]
 
+  protected def roleSpecificSchedulerNameConf: ConfigEntry[_]
+
   protected def userFeatureStepsConf: ConfigEntry[_]
 
   protected def userFeatureStepWithExpectedAnnotation: (String, String)
@@ -55,10 +57,16 @@ abstract class PodBuilderSuite extends SparkFunSuite {
 
   test("SPARK-36059: set custom scheduler") {
     val client = mockKubernetesClient()
-    val sparkConf = baseConf.clone().set(templateFileConf.key, "template-file.yaml")
+    val conf1 = baseConf.clone().set(templateFileConf.key, "template-file.yaml")
       .set(Config.KUBERNETES_SCHEDULER_NAME.key, "custom")
-    val pod = buildPod(sparkConf, client)
-    assert(pod.pod.getSpec.getSchedulerName === "custom")
+    val pod1 = buildPod(conf1, client)
+    assert(pod1.pod.getSpec.getSchedulerName === "custom")
+
+    val conf2 = baseConf.clone().set(templateFileConf.key, "template-file.yaml")
+      .set(Config.KUBERNETES_SCHEDULER_NAME.key, "custom")
+      .set(roleSpecificSchedulerNameConf.key, "rolescheduler")
+    val pod2 = buildPod(conf2, client)
+    assert(pod2.pod.getSpec.getSchedulerName === "rolescheduler")
   }
 
   test("load pod template if specified") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesDriverBuilderSuite.scala
@@ -34,6 +34,10 @@ class KubernetesDriverBuilderSuite extends PodBuilderSuite {
     Config.KUBERNETES_DRIVER_PODTEMPLATE_FILE
   }
 
+  override protected def roleSpecificSchedulerNameConf: ConfigEntry[_] = {
+    Config.KUBERNETES_DRIVER_SCHEDULER_NAME
+  }
+
   override protected def userFeatureStepsConf: ConfigEntry[_] = {
     Config.KUBERNETES_DRIVER_POD_FEATURE_STEPS
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBuilderSuite.scala
@@ -33,6 +33,10 @@ class KubernetesExecutorBuilderSuite extends PodBuilderSuite {
     Config.KUBERNETES_EXECUTOR_PODTEMPLATE_FILE
   }
 
+  override protected def roleSpecificSchedulerNameConf: ConfigEntry[_] = {
+    Config.KUBERNETES_EXECUTOR_SCHEDULER_NAME
+  }
+
   override protected def userFeatureStepsConf: ConfigEntry[_] = {
     Config.KUBERNETES_EXECUTOR_POD_FEATURE_STEPS
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `spark.kubernetes.scheduler.name` to support specify driver and executor scheduler togerther.

### Why are the changes needed?
Before this patch, we have to specify two configuration for driver and executor:
```
spark.kubernetes.executor.scheduler.name='volcano'
spark.kubernetes.driver.scheduler.name='volcano'
```

After this patch, we can specify executor and driver scheduler name by one configuration
```
spark.kubernetes.scheduler.name='volcano'
```


### Does this PR introduce _any_ user-facing change?
Yes, a configuration added.


### How was this patch tested?
UT
