### PR TITLE
[SPARK-38201][K8S] Fix `uploadFileToHadoopCompatibleFS` to use `delSrc` and `overwrite` parameters

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -344,7 +344,7 @@ object KubernetesUtils extends Logging {
       delSrc : Boolean = false,
       overwrite: Boolean = true): Unit = {
     try {
-      fs.copyFromLocalFile(false, true, src, dest)
+      fs.copyFromLocalFile(delSrc, overwrite, src, dest)
     } catch {
       case e: IOException =>
         throw new SparkException(s"Error uploading file ${src.getName}", e)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.deploy.k8s
 
 import java.io.File
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -79,7 +79,7 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
     withTempDir { srcDir =>
       val fileName = "test.txt"
       val srcFile = new File(srcDir, fileName)
-      FileUtils.write(srcFile, "test", Charset.defaultCharset())
+      FileUtils.write(srcFile, "test", StandardCharsets.UTF_8)
       withTempDir { destDir =>
         val src = new Path(srcFile.getAbsolutePath)
         val dest = new Path(destDir.getAbsolutePath, fileName)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
@@ -112,7 +112,6 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
         assert(fs.exists(dest))
         assert(fs.getFileStatus(dest).getLen == secondLength)
 
-
         // Append the file again, upload file delSrc = true and overwrite = true.
         // Upload succeeded, `fileLength` changed and src not exists.
         appendFileAndUpload("append-content", delSrc = true, overwrite = true)

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
@@ -118,7 +118,7 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
         assert(!fs.exists(src))
 
         // Rewrite a new file, upload file with delSrc = true and overwrite = false.
-        // Upload failed because dest exists and src still exists.
+        // Upload failed because dest exists, src still exists.
         FileUtils.write(srcFile, "re-init-content", StandardCharsets.UTF_8, true)
         checkUploadException(delSrc = true, overwrite = false)
         assert(fs.exists(src))

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
@@ -107,8 +107,11 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
         assert(firstLength < secondLength)
 
         // Upload file with delSrc = false and overwrite = false.
-        // Upload failed because dest exists.
+        // Upload failed because dest exists and not changed.
         checkUploadException(delSrc = false, overwrite = false)
+        assert(fs.exists(dest))
+        assert(fs.getFileStatus(dest).getLen == secondLength)
+
 
         // Append the file again, upload file delSrc = true and overwrite = true.
         // Upload succeeded, `fileLength` changed and src not exists.

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesUtilsSuite.scala
@@ -93,7 +93,7 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
         // upload succeeded but `ModificationTime` changed
         KubernetesUtils.invokePrivate(upload(src, dest, fs, false, true))
         val secondUploadTime = fs.getFileStatus(dest).getModificationTime
-        assert(firstUploadTime != secondUploadTime)
+        assert(firstUploadTime < secondUploadTime)
 
         // Scenario 3: delSrc = false and overwrite = false,
         // upload failed because dest exists
@@ -107,7 +107,7 @@ class KubernetesUtilsSuite extends SparkFunSuite with PrivateMethodTester {
         // upload succeeded, `ModificationTime` changed and src not exists.
         KubernetesUtils.invokePrivate(upload(src, dest, fs, true, true))
         val thirdUploadTime = fs.getFileStatus(dest).getModificationTime
-        assert(secondUploadTime != thirdUploadTime)
+        assert(secondUploadTime < thirdUploadTime)
         assert(!fs.exists(src))
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`KubernetesUtils#uploadFileToHadoopCompatibleFS` defines the input parameters `delSrc` and `overwrite`,  but constants(`false` and `true`) are used when invoke `FileSystem.copyFromLocalFile(boolean delSrc, boolean overwrite, Path src, Path dst) `, this pr change to use passed in `delSrc` and `overwrite` when invoke the`copyFromLocalFile` method.


### Why are the changes needed?
Bug fix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA and add new test case