### PR TITLE
[SPARK-38202][CORE] Ignore jar download failures in Executor.run()

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -965,15 +965,20 @@ private[spark] class Executor(
           .getOrElse(-1L)
         if (currentTimeStamp < timestamp) {
           logInfo(s"Fetching $name with timestamp $timestamp")
-          // Fetch file with useCache mode, close cache for local mode.
-          Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
-            hadoopConf, timestamp, useCache = !isLocal)
-          currentJars(name) = timestamp
-          // Add it to our class loader
-          val url = new File(SparkFiles.getRootDirectory(), localName).toURI.toURL
-          if (!urlClassLoader.getURLs().contains(url)) {
-            logInfo(s"Adding $url to class loader")
-            urlClassLoader.addURL(url)
+          try {
+            // Fetch file with useCache mode, close cache for local mode.
+            Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
+              hadoopConf, timestamp, useCache = !isLocal)
+            currentJars(name) = timestamp
+            // Add it to our class loader
+            val url = new File(SparkFiles.getRootDirectory(), localName).toURI.toURL
+            if (!urlClassLoader.getURLs().contains(url)) {
+              logInfo(s"Adding $url to class loader")
+              urlClassLoader.addURL(url)
+            }
+          } catch {
+            case NonFatal(_) =>
+              logWarning(s"Failed to fetch $name during dependency update")
           }
         }
       }

--- a/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ExecutorSuite.scala
@@ -262,6 +262,13 @@ class ExecutorSuite extends SparkFunSuite
     }
   }
 
+  test("Invalid URL in addedJars") {
+    sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
+    sc.addJar("http://invalid/library.jar")
+    val ans = sc.range(0, 10).count()
+    assert(ans == 10)
+  }
+
   test("Heartbeat should drop zero accumulator updates") {
     heartbeatZeroAccumulatorUpdateTest(true)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change is to ignore failures in jar download when updating jar dependencies in Executor.run().

### Why are the changes needed?
Currently when a user adds a jar with an invalid URL into SparkContext, all subsequent query executions will fail when trying to download that jar, even when the query has nothing to do with the jar dependency. This change is to fix that by ignoring the failure when downloading the jar.

### Does this PR introduce _any_ user-facing change?
Yes. After this change, users will be able to run queries even there are invalid URLs in SparkContext.addedJars.

### How was this patch tested?
Added a unit test.