### PR TITLE
[SPARK-38210][DOCS] Improve documentation generation README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,13 +26,20 @@ Read on to learn more about viewing documentation in plain text (i.e., markdown)
 documentation yourself. Why build it yourself? So that you have the docs that correspond to
 whichever version of Spark you currently have checked out of revision control.
 
-## Prerequisites
+## Building documentation
+There are two ways to build Spark documentation, complete and partial. Complete will build a site similar
+to one you can find https://spark.apache.org/documentation.html with all APIs documented and partial
+one can be used to build a language/API specific documentation.
+
+### Prerequisites
 
 The Spark documentation build uses a number of tools to build HTML docs and API docs in Scala, Java,
 Python, R and SQL.
 
-You need to have [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
-[Python](https://docs.python.org/2/using/unix.html#getting-and-installing-the-latest-version-of-python)
+For complete documentation all below tools must be installed **including Optionals**.
+
+You need to have JDK, Scala, [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
+[Python](https://docs.python.org/3.8/using/unix.html#getting-and-installing-the-latest-version-of-python)
 installed. Make sure the `bundle` command is available, if not install the Gem containing it:
 
 ```sh
@@ -66,11 +73,15 @@ $ sudo pip install 'sphinx<3.1.0' mkdocs numpy pydata_sphinx_theme ipython nbsph
 
 ### R API Documentation (Optional)
 
-If you'd like to generate R API documentation, you'll need to [install Pandoc](https://pandoc.org/installing.html)
-and install these libraries:
+If you'd like to generate R API documentation, you'll need to install these packages and libraries:
 
 ```sh
-$ sudo Rscript -e 'install.packages(c("knitr", "devtools", "testthat", "rmarkdown"), repos="https://cloud.r-project.org/")'
+$ sudo apt install libssl-dev libcurl4-openssl-dev pandoc libfontconfig1-dev libharfbuzz-dev \
+          libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libxml2-dev
+```
+
+```sh
+$ sudo Rscript -e 'install.packages(c("curl", "knitr", "devtools", "testthat", "rmarkdown", "markdown", "e1071"), repos="https://cloud.r-project.org/")'
 $ sudo Rscript -e 'devtools::install_version("roxygen2", version = "7.1.2", repos="https://cloud.r-project.org/")'
 $ sudo Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
 $ sudo Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
@@ -89,17 +100,7 @@ you have checked out or downloaded.
 In this directory you will find text files formatted using Markdown, with an ".md" suffix. You can
 read those text files directly if you want. Start with `index.md`.
 
-Execute `SKIP_API=1 bundle exec jekyll build` from the `docs/` directory to compile the site. Compiling the site with
-Jekyll will create a directory called `_site` containing `index.html` as well as the rest of the
-compiled files.
-
-```sh
-$ cd docs
-# Skip generating API docs (which takes a while)
-$ SKIP_API=1 bundle exec jekyll build
-```
-
-You can also generate the default Jekyll build with API Docs as follows:
+You can generate the complete website from the `docs/` directory as follows:
 
 ```sh
 $ bundle exec jekyll build
@@ -111,7 +112,15 @@ $ bundle exec jekyll serve --watch
 $ PRODUCTION=1 bundle exec jekyll build
 ```
 
-## API Docs (Scaladoc, Javadoc, Sphinx, roxygen2, MkDocs)
+You can optionally skip API build (for partial build) as it takes time
+
+```sh
+$ cd docs
+# Skip generating API docs (which takes a while)
+$ SKIP_API=1 bundle exec jekyll build
+```
+
+## Generating individual API Docs (Scaladoc, Javadoc, Sphinx, roxygen2, MkDocs)
 
 You can build just the Spark scaladoc and javadoc by running `./build/sbt unidoc` from the `$SPARK_HOME` directory.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,19 +26,19 @@ Read on to learn more about viewing documentation in plain text (i.e., markdown)
 documentation yourself. Why build it yourself? So that you have the docs that correspond to
 whichever version of Spark you currently have checked out of revision control.
 
-## Building documentation
+## Building Documentation
 There are two ways to build Spark documentation, complete and partial. Complete will build a site similar
-to one you can find https://spark.apache.org/documentation.html with all APIs documented and partial
-one can be used to build a language/API specific documentation.
+to the main documentation site at https://spark.apache.org/documentation.html. Partial documentation build is for 
+a specific language or API, are also possible.
 
 ### Prerequisites
 
 The Spark documentation build uses a number of tools to build HTML docs and API docs in Scala, Java,
 Python, R and SQL.
 
-For complete documentation all below tools must be installed **including Optionals**.
+For complete documentation all tools below must be installed **including Optionals**.
 
-You need to have JDK, Scala, [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
+You need to have the JDK, Scala, [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and
 [Python](https://docs.python.org/3.8/using/unix.html#getting-and-installing-the-latest-version-of-python)
 installed. Make sure the `bundle` command is available, if not install the Gem containing it:
 
@@ -112,14 +112,6 @@ $ bundle exec jekyll serve --watch
 $ PRODUCTION=1 bundle exec jekyll build
 ```
 
-You can optionally skip API build (for partial build) as it takes time
-
-```sh
-$ cd docs
-# Skip generating API docs (which takes a while)
-$ SKIP_API=1 bundle exec jekyll build
-```
-
 ## Generating individual API Docs (Scaladoc, Javadoc, Sphinx, roxygen2, MkDocs)
 
 You can build just the Spark scaladoc and javadoc by running `./build/sbt unidoc` from the `$SPARK_HOME` directory.
@@ -138,6 +130,14 @@ The jekyll plugin also generates the PySpark docs using [Sphinx](http://sphinx-d
 using [roxygen2](https://cran.r-project.org/web/packages/roxygen2/index.html) and SQL docs
 using [MkDocs](https://www.mkdocs.org/).
 
-NOTE: To skip the step of building and copying over the Scala, Java, Python, R and SQL API docs, run `SKIP_API=1
-bundle exec jekyll build`. In addition, `SKIP_SCALADOC=1`, `SKIP_PYTHONDOC=1`, `SKIP_RDOC=1` and `SKIP_SQLDOC=1` can be used
+NOTE: To skip the step of building and copying over the Scala, Java, Python, R and SQL API docs, see below example. 
+In addition, `SKIP_SCALADOC=1`, `SKIP_PYTHONDOC=1`, `SKIP_RDOC=1` and `SKIP_SQLDOC=1` can be used
 to skip a single step of the corresponding language. `SKIP_SCALADOC` indicates skipping both the Scala and Java docs.
+
+For example:
+
+```sh
+$ cd docs
+# Skip generating API docs (which takes a while)
+$ SKIP_API=1 bundle exec jekyll build
+```


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current instructions in README file is not complete and not sufficient to complete site build for testing and validation. 
After number of trial and errors I have managed to build it. In the process I had to install number of additional packages. 
This PR purposes improvements to the documentation to avoid spending similar efforts for contributors.

### Why are the changes needed?
Improve Spark documentation generation procedure

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I have started a docker container:
`docker run --name spark_doc_build_new -p 4000:4000 -it spark_doc_build_image`
 and installed everything as per below
```
apt-get update
apt-get -y install  git nano
apt-get -y install  curl
apt-get -y install  ruby-full
apt-get -y install  python3 pip
apt-get -y install  gnupg

echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" >> /etc/apt/sources.list
apt-key adv --keyserver keyserver.ubuntu.com --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7'
apt-get update

apt-get -y install  r-base
apt-get -y install  pandoc libxml2-dev
apt-get -y install  libcurl4-openssl-dev
apt-get -y install  libssl-dev
apt-get -y install  libfontconfig1-dev libharfbuzz-dev   libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev

Rscript -e 'install.packages(c("curl", "knitr", "devtools", "testthat", "rmarkdown", "markdown", "e1071"), repos="https://cloud.r-project.org/")'
Rscript -e 'devtools::install_version("roxygen2", version = "7.1.2", repos="https://cloud.r-project.org/")'
Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"

echo 'deb http://security.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
apt-get update
apt-get -y install  openjdk-8-jdk
apt-get -y install  scala

git clone https://github.com/apache/spark.git
cd spark/doc

gem install bundler
bundle install
bundle exec jekyll build
```
and checked via jekyll serve from host
`bundle exec jekyll serve --host 0.0.0.0`