### PR TITLE
[SPARK-35173][SQL][PYTHON][FOLLOW-UP] Use DataFrame.sparkSession instead of DataFrame.sql_ctx in withColumns

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3006,7 +3006,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         cols = list(colsMap.values())
 
         return DataFrame(
-            self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(*cols)), self.sql_ctx
+            self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(*cols)),
+            self.sparkSession,
         )
 
     def withColumn(self, colName: str, col: Column) -> "DataFrame":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup for both https://github.com/apache/spark/commit/8853f286371bcc1d44762a0a8ed5bf1a40cdbbd5 and https://github.com/apache/spark/commit/88696ebcb72fd3057b1546831f653b29b7e0abb2. There was a logical conflict here:

We should make it use `DataFrame.sparkSession` instead of `DataFrame.sql_ctx`

https://github.com/apache/spark/runs/5193146096?check_suite_focus=true

```
======================================================================
FAIL: test_with_columns (pyspark.sql.tests.test_dataframe.DataFrameTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/tests/test_dataframe.py", line 484, in test_with_columns
    keys = self.df.withColumns({"key": self.df.key}).select("key").collect()
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 3009, in withColumns
    self._jdf.withColumns(_to_seq(self._sc, col_names), self._jcols(*cols)), self.sql_ctx
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 123, in __init__
    assert not os.environ.get("SPARK_TESTING")  # Sanity check for our internal usage.
AssertionError

```

### Why are the changes needed?

To fix the build, and remove deprecated usage of `SQLContext`.

### Does this PR introduce _any_ user-facing change?

No, it's not released out yet.

### How was this patch tested?

CI should test it out.