### PR TITLE
[SPARK-38222][SQL] Expose Node Description attribute in SQL Rest API

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/SqlResource.scala
@@ -128,7 +128,8 @@ private[v1] class SqlResource extends BaseAppResource {
       val wholeStageCodegenId = nodeIdAndWSCGIdMap.get(node.id).flatten
       val metrics =
         node.metrics.flatMap(m => getMetric(metricValues, m.accumulatorId, m.name.trim))
-      Node(nodeId = node.id, nodeName = node.name.trim, wholeStageCodegenId, metrics)
+      Node(nodeId = node.id, nodeName = node.name.trim,
+        nodeDesc = node.desc, wholeStageCodegenId, metrics)
     }
 
     nodes.sortBy(_.nodeId).reverse

--- a/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
+++ b/sql/core/src/main/scala/org/apache/spark/status/api/v1/sql/api.scala
@@ -36,6 +36,7 @@ class ExecutionData private[spark] (
 case class Node private[spark](
     nodeId: Long,
     nodeName: String,
+    nodeDesc: String,
     wholeStageCodegenId: Option[Long] = None,
     metrics: Seq[Metric])
 

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceSuite.scala
@@ -39,15 +39,19 @@ object SqlResourceSuite {
   val PLAN_DESCRIPTION = "== Physical Plan ==\nCollectLimit (3)\n+- * Filter (2)\n +- Scan text..."
   val DESCRIPTION = "csv at MyDataFrames.scala:57"
 
+  val TEST_NODE_DESC_0 = "test_node_desc_0"
+  val TEST_NODE_DESC_1 = "test_node_desc_1"
+  val TEST_NODE_DESC_2 = "test_node_desc_2"
+
   val nodeIdAndWSCGIdMap: Map[Long, Option[Long]] = Map(1L -> Some(1L))
 
-  val filterNode = new SparkPlanGraphNode(1, FILTER, "",
+  val filterNode = new SparkPlanGraphNode(1, FILTER, TEST_NODE_DESC_1,
     metrics = Seq(SQLPlanMetric(NUMBER_OF_OUTPUT_ROWS, 1, "")))
   val nodes: Seq[SparkPlanGraphNode] = Seq(
-    new SparkPlanGraphCluster(0, WHOLE_STAGE_CODEGEN_1, "",
+    new SparkPlanGraphCluster(0, WHOLE_STAGE_CODEGEN_1, TEST_NODE_DESC_0,
       nodes = ArrayBuffer(filterNode),
       metrics = Seq(SQLPlanMetric(DURATION, 0, ""))),
-    new SparkPlanGraphNode(2, SCAN_TEXT, "",
+    new SparkPlanGraphNode(2, SCAN_TEXT, TEST_NODE_DESC_2,
       metrics = Seq(
       SQLPlanMetric(METADATA_TIME, 2, ""),
       SQLPlanMetric(NUMBER_OF_FILES_READ, 3, ""),
@@ -97,12 +101,12 @@ object SqlResourceSuite {
     )
   }
 
-  private def getNodes(): Seq[Node] = {
-    val node = Node(0, WHOLE_STAGE_CODEGEN_1,
+  private def getExpectedNodes(): Seq[Node] = {
+    val node = Node(0, WHOLE_STAGE_CODEGEN_1, TEST_NODE_DESC_0,
       wholeStageCodegenId = None, metrics = Seq(Metric(DURATION, "0 ms")))
-    val node2 = Node(1, FILTER,
+    val node2 = Node(1, FILTER, TEST_NODE_DESC_1,
       wholeStageCodegenId = Some(1), metrics = Seq(Metric(NUMBER_OF_OUTPUT_ROWS, "1")))
-    val node3 = Node(2, SCAN_TEXT, wholeStageCodegenId = None,
+    val node3 = Node(2, SCAN_TEXT, TEST_NODE_DESC_2, wholeStageCodegenId = None,
       metrics = Seq(Metric(METADATA_TIME, "2 ms"),
         Metric(NUMBER_OF_FILES_READ, "1"),
         Metric(NUMBER_OF_OUTPUT_ROWS, "1"),
@@ -113,8 +117,8 @@ object SqlResourceSuite {
   }
 
   private def getExpectedNodesWhenWholeStageCodegenIsOff(): Seq[Node] = {
-    val node = Node(1, FILTER, metrics = Seq(Metric(NUMBER_OF_OUTPUT_ROWS, "1")))
-    val node2 = Node(2, SCAN_TEXT,
+    val node = Node(1, FILTER, TEST_NODE_DESC_1, metrics = Seq(Metric(NUMBER_OF_OUTPUT_ROWS, "1")))
+    val node2 = Node(2, SCAN_TEXT, TEST_NODE_DESC_2,
       metrics = Seq(Metric(METADATA_TIME, "2 ms"),
         Metric(NUMBER_OF_FILES_READ, "1"),
         Metric(NUMBER_OF_OUTPUT_ROWS, "1"),
@@ -168,7 +172,7 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
         sqlExecutionUIData, SparkPlanGraph(nodes, edges), true, false)
     verifyExpectedExecutionData(
       executionData,
-      nodes = getNodes(),
+      nodes = getExpectedNodes(),
       edges,
       planDescription = "")
   }
@@ -179,7 +183,7 @@ class SqlResourceSuite extends SparkFunSuite with PrivateMethodTester {
         sqlExecutionUIData, SparkPlanGraph(nodes, edges), true, true)
     verifyExpectedExecutionData(
       executionData,
-      nodes = getNodes(),
+      nodes = getExpectedNodes(),
       edges = edges,
       planDescription = PLAN_DESCRIPTION)
   }

--- a/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/status/api/v1/sql/SqlResourceWithActualMetricsSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.status.api.v1.sql
 import java.net.URL
 import java.text.SimpleDateFormat
 
+import org.apache.commons.lang3.StringUtils
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods
 
@@ -97,6 +98,8 @@ class SqlResourceWithActualMetricsSuite
       s"Expected failedJobIds should be empty but actual: ${executionData.failedJobIds}")
     assert(executionData.nodes.nonEmpty, "Expected nodes should not be empty}")
     executionData.nodes.filterNot(node => excludedNodes.contains(node.nodeName)).foreach { node =>
+      assert(StringUtils.isNotBlank(node.nodeName))
+      assert(StringUtils.isNotBlank(node.nodeDesc))
       assert(node.metrics.nonEmpty, "Expected metrics of nodes should not be empty")
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, SQL public Rest API does not expose `node description` and it is useful to have more details at query level such as:
```
- Join Operators(BHJ, SMJ, SHJ) => when correlating join operator with join type and which leg is built for BHJ. 
- HashAggregate => aggregated keys and agg functions
- Providing alignment with SparkUI DAG visualization (per node/operator) under sql page (nodeDesc is shown 
   when user comes on the operator on UI)
- List can be extended for other operators.
```
Current Sample Json Result:
```
{
    "nodeId" : 14,
    "nodeName" : "BroadcastHashJoin",
    "wholeStageCodegenId" : 3,
    "metrics" : [ {
          "name" : "number of output rows",
          "value" : {
        "amount" : "2"
          }
    }
},
...
{
    "nodeId" : 8,
    "nodeName" : "HashAggregate",
    "wholeStageCodegenId" : 4,
    "metrics" : [ {
      "name" : "spill size",
      "value" : {
        "amount" : "0.0"
      }
    }
} 
```
New Sample Json Result:
```
{
    "nodeId" : 14,
    "nodeName" : "BroadcastHashJoin",
    "nodeDesc" : "BroadcastHashJoin [id#4], [id#24], Inner, BuildLeft, false",
    "wholeStageCodegenId" : 3,
    "metrics" : [ {
          "name" : "number of output rows",
          "value" : {
        "amount" : "2"
          }
    }
},
...
{
    "nodeId" : 8,
    "nodeName" : "HashAggregate",
    "nodeDesc" : "HashAggregate(keys=[name#5, age#6, salary#18], functions=[avg(cast(age#6 as bigint)), avg(salary#18)])",
    "wholeStageCodegenId" : 4,
    "metrics" : [ {
      "name" : "spill size",
      "value" : {
        "amount" : "0.0"
      }
    }
} 
```

### Why are the changes needed?
It is useful to have more details  at query level such as:
- join type, 
- which leg is built for BHJ, 
- aggregated keys, 
- agg functions 
- Providing alignment with SparkUI DAG visualization (per node/operator) under sql page etc.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add more coverage to existing UTs
