### PR TITLE
[SPARK-38230][SQL] InsertIntoHadoopFsRelationCommand unnecessarily fetches details of partitions in most cases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3523,6 +3523,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val HAS_CUSTOM_PARTITION_LOCATIONS =
+    buildConf("spark.sql.hasCustomPartitionLocations")
+      .internal()
+      .doc("Insert into hdfs will fetch partitions' details(e.g. createTime,sd,parameters...), " +
+        "when target table does not have custom partition locations, you can set it to false, " +
+        "it will just fetch partitions' name and reduce requests of hive metastore.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -4254,6 +4264,8 @@ class SQLConf extends Serializable with Logging {
   def inferDictAsStruct: Boolean = getConf(SQLConf.INFER_NESTED_DICT_AS_STRUCT)
 
   def useV1Command: Boolean = getConf(SQLConf.LEGACY_USE_V1_COMMAND)
+
+  def hasCustomPartitionLocations: Boolean = getConf(SQLConf.HAS_CUSTOM_PARTITION_LOCATIONS)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -92,16 +92,30 @@ case class InsertIntoHadoopFsRelationCommand(
 
     var initialMatchingPartitions: Seq[TablePartitionSpec] = Nil
     var customPartitionLocations: Map[TablePartitionSpec, String] = Map.empty
-    var matchingPartitions: Seq[CatalogTablePartition] = Seq.empty
 
     // When partitions are tracked by the catalog, compute all custom partition locations that
     // may be relevant to the insertion job.
     if (partitionsTrackedByCatalog) {
-      matchingPartitions = sparkSession.sessionState.catalog.listPartitions(
-        catalogTable.get.identifier, Some(staticPartitions))
-      initialMatchingPartitions = matchingPartitions.map(_.spec)
-      customPartitionLocations = getCustomPartitionLocations(
-        fs, catalogTable.get, qualifiedOutputPath, matchingPartitions)
+      if (sparkSession.sessionState.conf.hasCustomPartitionLocations) {
+        val matchingPartitions = sparkSession.sessionState.catalog.listPartitions(
+          catalogTable.get.identifier, Some(staticPartitions))
+        initialMatchingPartitions = matchingPartitions.map(_.spec)
+        customPartitionLocations = getCustomPartitionLocations(
+          fs, catalogTable.get, qualifiedOutputPath, matchingPartitions)
+      } else {
+        val partitionNames = sparkSession.sessionState.catalog.listPartitionNames(
+          catalogTable.get.identifier, Some(staticPartitions))
+        initialMatchingPartitions = partitionNames.map(str => {
+          val parts = str.split("/")
+          parts.map(part => {
+            val kvs = part.split("=")
+            if (kvs.length != 2) {
+              throw new IllegalArgumentException("fetched error part: " + part)
+            }
+            (kvs(0), kvs(1))
+          }).toMap
+        })
+      }
     }
 
     val jobId = java.util.UUID.randomUUID().toString
@@ -119,7 +133,7 @@ case class InsertIntoHadoopFsRelationCommand(
         case (SaveMode.ErrorIfExists, true) =>
           throw QueryCompilationErrors.outputPathAlreadyExistsError(qualifiedOutputPath)
         case (SaveMode.Overwrite, true) =>
-          if (ifPartitionNotExists && matchingPartitions.nonEmpty) {
+          if (ifPartitionNotExists && initialMatchingPartitions.nonEmpty) {
             false
           } else if (dynamicPartitionOverwrite) {
             // For dynamic partition overwrite, do not delete partition directories ahead.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a spark conf in order to just fetch partitions' name instead of fetching partitions' details. This can reduce requests on hive metastore.

### Why are the changes needed?
1. method `listPartitions` is order to get locations of partitions and compute custom partition locations(variable `customPartitionLocations`), but in most cases we do not have custom partition locations.
2. method `listPartitionNames` just fetchs partitions' name, it can reduce requests on hive metastore db.

### Does this PR introduce _any_ user-facing change?
Yes, we should config "spark.sql.hasCustomPartitionLocations = false"

### How was this patch tested?
1. recompile InsertIntoHadoopFsRelationCommand.scala
2. update spark-sql_2.12-3.0.2.jar
3. run insert into cases
