### PR TITLE
[SPARK-38238][SQL]Contains Join for Spark SQL

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -263,7 +263,7 @@ object ExtractContainsJoin
 
 object ExtractContainsPattern extends Logging {
 
-  def concatChildren(concat: Concat): Seq[Expression] = {
+  def concatChildren(concat: Concat): mutable.ArrayBuffer[Expression] = {
     val stack = mutable.Stack[Expression](concat)
     val buf = mutable.ArrayBuffer[Expression]()
     while (!stack.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -263,7 +263,7 @@ object ExtractContainsJoin
 
 object ExtractContainsPattern extends Logging {
 
-  def concatChildren(concat: Concat): mutable.ArrayBuffer[Expression] = {
+  def concatChildren(concat: Concat): Seq[Expression] = {
     val stack = mutable.Stack[Expression](concat)
     val buf = mutable.ArrayBuffer[Expression]()
     while (!stack.isEmpty) {
@@ -272,7 +272,7 @@ object ExtractContainsPattern extends Logging {
         case e => buf += e
       }
     }
-    buf
+    buf.toSeq
   }
 
   def unapply(expr: Expression): Option[Expression] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3529,14 +3529,14 @@ object SQLConf {
       "the planner will use contains join operator (instead of BNL) for string match queries.")
     .version("3.3.0")
     .booleanConf
-    .createWithDefault(true)
+    .createWithDefault(false)
 
   val CONTAINS_JOIN_THRESHOLD = buildConf("spark.sql.containsJoinThreshold")
     .doc("Configures the maximum size in bytes for a string relation that will be broadcast to " +
       "all worker nodes when performing contains join.")
     .version("3.3.0")
     .bytesConf(ByteUnit.BYTE)
-    .createWithDefaultString("50MB")
+    .createWithDefaultString("10MB")
 
   /**
    * Holds information about keys that have been deprecated.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3523,6 +3523,21 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val CONTAINS_JOIN_ENABLED = buildConf("spark.sql.planner.containsJoin.enabled")
+    .internal()
+    .doc(s"When true and '${ADAPTIVE_EXECUTION_ENABLED.key}' is true, " +
+      "the planner will use contains join operator (instead of BNL) for string match queries.")
+    .version("3.3.0")
+    .booleanConf
+    .createWithDefault(true)
+
+  val CONTAINS_JOIN_THRESHOLD = buildConf("spark.sql.containsJoinThreshold")
+    .doc("Configures the maximum size in bytes for a string relation that will be broadcast to " +
+      "all worker nodes when performing contains join.")
+    .version("3.3.0")
+    .bytesConf(ByteUnit.BYTE)
+    .createWithDefaultString("50MB")
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -4254,6 +4269,10 @@ class SQLConf extends Serializable with Logging {
   def inferDictAsStruct: Boolean = getConf(SQLConf.INFER_NESTED_DICT_AS_STRUCT)
 
   def useV1Command: Boolean = getConf(SQLConf.LEGACY_USE_V1_COMMAND)
+
+  def containsJoinEnabled: Boolean = getConf(CONTAINS_JOIN_ENABLED)
+
+  def containsJoinThreshold: Long = getConf(CONTAINS_JOIN_THRESHOLD)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ExtractContainsJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/planning/ExtractContainsJoinSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.planning
+
+import org.apache.spark.sql.catalyst.analysis.TestRelations
+import org.apache.spark.sql.catalyst.dsl.expressions.upper
+import org.apache.spark.sql.catalyst.expressions.{Concat, Like, Literal}
+import org.apache.spark.sql.catalyst.optimizer.BuildRight
+import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, JoinHint}
+import org.apache.spark.sql.internal.SQLConf
+
+class ExtractContainsJoinSuite extends PlanTest {
+
+  private val relation = TestRelations.testRelation2
+
+  test("SPARK-38238: extract contains pattern") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.CONTAINS_JOIN_ENABLED.key -> "true") {
+      // c1 LIKE concat('%' || upper(c1) || ' ' || '%')
+      // upper(c1#741) LIKE concat(concat(concat(concat(% , upper(c1#785)),  ), %)
+      val input1 = Concat(
+        Seq(
+          Concat(Seq(Concat(Seq(Literal("%"), upper(relation.output(1)))), Literal(" "))),
+          Literal("%")))
+      // c1 || ' '
+      val output1 = Concat(Seq(upper(relation.output(1)), Literal(" ")))
+
+      // concat(concat(concat(concat(% , upper(TITLE#831)),  ), %))
+      val input2 =
+        Concat(
+          Seq(
+            Concat(
+              Seq(
+                Concat(Seq(
+                  Concat(Seq(Concat(Seq(Literal("%"), Literal(" "))), upper(relation.output(1)))),
+                  Literal(" "))),
+                Literal("%")))))
+      val output2 =
+        Concat(Seq(Literal(" "), upper(relation.output(1)), Literal(" ")))
+
+      val inputAndExpects = Array((input1, output1), (input2, output2))
+      val leftExpr = upper(relation.output(0))
+      inputAndExpects.foreach { case (e1, e2) =>
+        val join = Join(relation, relation, Inner, Some(new Like(leftExpr, e1)), JoinHint.NONE)
+
+        val ExtractContainsJoin(_, leftKey, rightKey, _, _, buildSide, _, _, _) = join
+        assert(leftKey == leftExpr)
+        assert(rightKey == e2)
+        assert(buildSide == BuildRight)
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -280,6 +280,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
           None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 
+      case ExtractContainsJoin(joinType, leftExpr, rightExpr, left, right, buildSide,
+      checkWildcards, conditions, hint)
+        if canBroadcastTokenTree(left, right, buildSide, hint, conf) =>
+        Seq(joins.BroadcastContainsJoinExec(leftExpr, rightExpr,
+          planLater(left), planLater(right), buildSide, joinType, checkWildcards, conditions))
+
       // If it is not an equi-join, we first look at the join hints w.r.t. the following order:
       //   1. broadcast hint: pick broadcast nested loop join. If both sides have the broadcast
       //      hints, choose the smaller side (based on stats) to broadcast for inner and full joins,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastContainsJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastContainsJoinExec.scala
@@ -1,0 +1,590 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.{SparkException, TaskContext}
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.codegen.Block.BlockHelper
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.physical.{BroadcastDistribution, Distribution, UnspecifiedDistribution}
+import org.apache.spark.sql.execution.{CodegenSupport, SparkPlan}
+import org.apache.spark.sql.execution.metric.SQLMetrics
+
+@DeveloperApi
+case class BroadcastContainsJoinExec(
+    leftKey: Expression,
+    rightKey: Expression,
+    left: SparkPlan,
+    right: SparkPlan,
+    buildSide: BuildSide,
+    joinType: JoinType,
+    checkWildcards: Boolean,
+    condition: Option[Expression])
+    extends BaseJoinExec
+    with CodegenSupport {
+
+  override def leftKeys: Seq[Expression] = Seq(leftKey)
+
+  override def rightKeys: Seq[Expression] = Seq(rightKey)
+
+  override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
+    "emptyInputRows" -> SQLMetrics.createMetric(sparkContext, "number of empty input rows"))
+
+  val numOutputRows = longMetric("numOutputRows")
+  val emptyInputRows = longMetric("emptyInputRows")
+
+  /** BuildRight means the right relation <=> the broadcast relation. */
+  val (streamedPlan, streamedKeys, buildPlan, buildKeys) = buildSide match {
+    case BuildRight => (left, leftKeys, right, rightKeys)
+    case BuildLeft => (right, rightKeys, left, leftKeys)
+  }
+
+  @transient protected lazy val buildBoundKeys = bindReferences(buildKeys, buildPlan.output)
+
+  @transient protected lazy val streamedBoundKeys =
+    bindReferences(streamedKeys, streamedPlan.output)
+
+  override def requiredChildDistribution: Seq[Distribution] = {
+    // TODO support isNullAwareAntiJoin parameter
+    val isNullAwareAntiJoin = false
+    val mode = TokenTreeBroadcastMode(buildBoundKeys, checkWildcards, isNullAwareAntiJoin)
+    buildSide match {
+      case BuildLeft =>
+        BroadcastDistribution(mode) :: UnspecifiedDistribution :: Nil
+      case BuildRight =>
+        UnspecifiedDistribution :: BroadcastDistribution(mode) :: Nil
+    }
+  }
+
+  private[this] def genResultProjection: UnsafeProjection = joinType match {
+    case LeftExistence(j) =>
+      UnsafeProjection.create(output, output)
+    case other =>
+      // Always put the stream side on left to simplify implementation
+      // both of left and right side could be null
+      UnsafeProjection
+        .create(output, (streamedPlan.output ++ buildPlan.output).map(_.withNullability(true)))
+  }
+
+  override def output: Seq[Attribute] = {
+    joinType match {
+      case _: InnerLike =>
+        left.output ++ right.output
+      case LeftOuter =>
+        left.output ++ right.output.map(_.withNullability(true))
+      case RightOuter =>
+        left.output.map(_.withNullability(true)) ++ right.output
+      case FullOuter =>
+        left.output.map(_.withNullability(true)) ++ right.output.map(_.withNullability(true))
+      case LeftExistence(_) =>
+        left.output
+      case x =>
+        throw new IllegalArgumentException(
+          s"BroadcastContainsJoin should not take $x as the JoinType")
+    }
+  }
+
+  @transient private lazy val boundCondition = {
+    if (condition.isDefined) {
+      Predicate.create(condition.get, streamedPlan.output ++ buildPlan.output).eval _
+    } else { (r: InternalRow) =>
+      true
+    }
+  }
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    val broadcastRelation = buildPlan.executeBroadcast[TreeRelation]()
+    val resultRdd = streamedPlan.execute().mapPartitionsInternal { streamedIter =>
+      val startTS = System.currentTimeMillis()
+      logInfo("Start read broadcast relation")
+      val relation = broadcastRelation.value
+      logInfo(s"Got broadcast relation in ${System.currentTimeMillis() - startTS} ms")
+      TaskContext.get().taskMetrics().incPeakExecutionMemory(relation.estimatedSize)
+      join(streamedIter, relation)
+    }
+    resultRdd.mapPartitionsWithIndexInternal { (index, iter) =>
+      val resultProj = genResultProjection
+      resultProj.initialize(index)
+      iter.map { r =>
+        numOutputRows += 1
+        resultProj(r)
+      }
+    }
+  }
+
+  def join(input: Iterator[InternalRow], relation: TreeRelation): Iterator[InternalRow] = {
+    (joinType, buildSide) match {
+      case (_: InnerLike, _) =>
+        innerJoin(input, relation)
+      case (LeftOuter, BuildRight) | (RightOuter, BuildLeft) =>
+        outerJoin(input, relation)
+      case (LeftSemi, BuildRight) =>
+        semiJoin(input, relation)
+      case (LeftAnti, BuildRight) =>
+        antiJoin(input, relation)
+      case _ =>
+        throw new SparkException(
+          s"Not supported joinType:${joinType} with " +
+            s"buildSide:${buildSide} for ContainsJoin")
+    }
+  }
+
+  /**
+   * The implementation for InnerJoin.
+   */
+  private def innerJoin(
+      streamedIter: Iterator[InternalRow],
+      relation: TreeRelation): Iterator[InternalRow] = {
+    val streamedKeysGenerator = UnsafeProjection.create(streamedBoundKeys)
+
+    streamedIter.flatMap { streamedRow =>
+      val key = streamedKeysGenerator(streamedRow).getUTF8String(0)
+      if (key != null) {
+        val streamedKeyValue = key.toString
+        relation.tree
+          .doMatch(streamedKeyValue)
+          .map(new JoinedRow(streamedRow, _))
+          .filterNot(condition.isDefined && !boundCondition(_))
+      } else {
+        emptyInputRows += 1
+        Set[InternalRow]()
+      }
+    }
+  }
+
+  /**
+   * The implementation for these joins:
+   *
+   *   LeftOuter with BuildRight
+   *   RightOuter with BuildLeft
+   */
+  private def outerJoin(
+      streamedIter: Iterator[InternalRow],
+      relation: TreeRelation): Iterator[InternalRow] = {
+
+    val streamedKeysGenerator = UnsafeProjection.create(streamedBoundKeys)
+
+    val nulls = new GenericInternalRow(buildPlan.output.size)
+    streamedIter.flatMap { streamedRow =>
+      val key = streamedKeysGenerator(streamedRow).getUTF8String(0)
+      if (key != null) {
+        val streamedKeyValue = key.toString
+        val matchedRows = relation.tree
+          .doMatch(streamedKeyValue)
+          .map(new JoinedRow(streamedRow, _))
+          .filterNot(condition.isDefined && !boundCondition(_))
+        if (matchedRows.size == 0) {
+          Set(new JoinedRow(streamedRow, nulls))
+        } else {
+          matchedRows
+        }
+      } else {
+        emptyInputRows += 1
+        // outer join will return streamedRow and null
+        Set(new JoinedRow(streamedRow, nulls))
+      }
+    }
+  }
+
+  private def semiJoin(
+      streamedIter: Iterator[InternalRow],
+      relation: TreeRelation): Iterator[InternalRow] = {
+    if (relation.rowNumber == 0) {
+      return Iterator.empty
+    }
+
+    val streamedKeysGenerator = UnsafeProjection.create(streamedBoundKeys)
+    val joinedRow = new JoinedRow
+
+    streamedIter.filter { streamedRow =>
+      val key = streamedKeysGenerator(streamedRow).getUTF8String(0)
+      if (key == null) {
+        false
+      } else {
+        val streamedKeyValue = key.toString
+        val matchedRows = relation.tree.doMatch(streamedKeyValue)
+        matchedRows.nonEmpty && (condition.isEmpty || matchedRows.exists { row =>
+          boundCondition(joinedRow(streamedRow, row))
+        })
+      }
+    }
+  }
+
+  private def antiJoin(
+      streamedIter: Iterator[InternalRow],
+      relation: TreeRelation): Iterator[InternalRow] = {
+    // If the right side is empty, AntiJoin simply returns the left side.
+    if (relation.rowNumber == 0) {
+      return streamedIter
+    }
+
+    val streamedKeysGenerator = UnsafeProjection.create(streamedBoundKeys)
+    val joinedRow = new JoinedRow
+
+    streamedIter.filter { streamedRow =>
+      val key = streamedKeysGenerator(streamedRow).getUTF8String(0)
+      if (key == null) {
+        true
+      } else {
+        val streamedKeyValue = key.toString
+        val matchedRows = relation.tree.doMatch(streamedKeyValue)
+        matchedRows.isEmpty || (condition.isDefined && !matchedRows.exists { row =>
+          boundCondition(joinedRow(streamedRow, row))
+        })
+      }
+    }
+  }
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    streamedPlan.asInstanceOf[CodegenSupport].inputRDDs()
+  }
+
+  override def doProduce(ctx: CodegenContext): String = {
+    streamedPlan.asInstanceOf[CodegenSupport].produce(ctx, this)
+  }
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+    joinType match {
+      case _: InnerLike => codegenInner(ctx, input)
+      case LeftOuter | RightOuter => codegenOuter(ctx, input)
+      case LeftSemi => codegenSemi(ctx, input)
+      case LeftAnti => codegenAnti(ctx, input)
+      case x =>
+        throw new IllegalArgumentException(s"Contains join should not take $x as the JoinType")
+    }
+  }
+
+  // If the streaming side needs to copy result, this join plan needs to copy too. Otherwise,
+  // this join plan only needs to copy result if it may output multiple rows for one input.
+  override def needCopyResult: Boolean =
+    streamedPlan.asInstanceOf[CodegenSupport].needCopyResult
+
+  def prepareBroadcast(ctx: CodegenContext): (String, Long, Int) = {
+    // create a name for TreeRelation
+    val broadcastRelation = buildPlan.executeBroadcast[TreeRelation]()
+    val broadcast = ctx.addReferenceObj("broadcast", broadcastRelation)
+    val clsName = TreeRelation.getClass.getName.stripSuffix("$")
+
+    // Inline mutable state since not many join operations in a task
+    val treeTerm = ctx.addMutableState(
+      DoubleArrayTrieTree.getClass.getName.stripSuffix("$"),
+      "tokenTree",
+      v => s"""
+              | $v = (($clsName) $broadcast.value()).tree();
+              | incPeakExecutionMemory((($clsName) $broadcast.value()).estimatedSize());
+       """.stripMargin,
+      forceInline = true)
+    (treeTerm, broadcastRelation.value.estimatedSize, broadcastRelation.value.rowNumber)
+  }
+
+  /**
+   * Returns the code for generating join key for stream side, and expression of whether the key
+   * has any null in it or not.
+   */
+  protected def genStreamSideJoinKey(
+      ctx: CodegenContext,
+      input: Seq[ExprCode]): (ExprCode, String) = {
+    ctx.currentVars = input
+    // generate the join key as UnsafeRow
+    val ev = GenerateUnsafeProjection.createCode(ctx, streamedBoundKeys)
+    (ev, s"${ev.value}.anyNull()")
+  }
+
+  /**
+   * Generates the code for variable of build side.
+   */
+  private def genBuildSideVars(ctx: CodegenContext, matched: String): Seq[ExprCode] = {
+    ctx.currentVars = null
+    ctx.INPUT_ROW = matched
+    buildPlan.output.zipWithIndex.map { case (a, i) =>
+      val ev = BoundReference(i, a.dataType, a.nullable).genCode(ctx)
+      if (joinType.isInstanceOf[InnerLike]) {
+        ev
+      } else {
+        // the variables are needed even there is no matched rows
+        val isNull = ctx.freshName("isNull")
+        val value = ctx.freshName("value")
+        val javaType = CodeGenerator.javaType(a.dataType)
+        val code = code"""
+                         |boolean $isNull = true;
+                         |$javaType $value = ${CodeGenerator.defaultValue(a.dataType)};
+                         |if ($matched != null) {
+                         |  ${ev.code}
+                         |  $isNull = ${ev.isNull};
+                         |  $value = ${ev.value};
+                         |}
+         """.stripMargin
+        ExprCode(code, JavaCode.isNullVariable(isNull), JavaCode.variable(value, a.dataType))
+      }
+    }
+  }
+
+  /**
+   * Generate the (non-equi) condition used to filter joined rows. This is used in Inner, Left Semi
+   * and Left Anti joins.
+   */
+  protected def getJoinCondition(
+      ctx: CodegenContext,
+      input: Seq[ExprCode]): (String, String, Seq[ExprCode]) = {
+    val matched = ctx.freshName("matched")
+    val buildVars = genBuildSideVars(ctx, matched)
+    val checkCondition = if (condition.isDefined) {
+      val expr = condition.get
+      // evaluate the variables from build side that used by condition
+      val eval = evaluateRequiredVariables(buildPlan.output, buildVars, expr.references)
+      // filter the output via condition
+      ctx.currentVars = input ++ buildVars
+      val ev =
+        BindReferences.bindReference(expr, streamedPlan.output ++ buildPlan.output).genCode(ctx)
+      val skipRow = s"${ev.isNull} || !${ev.value}"
+      s"""
+         |$eval
+         |${ev.code}
+         |if (!($skipRow))
+       """.stripMargin
+    } else {
+      ""
+    }
+    (matched, checkCondition, buildVars)
+  }
+
+  /**
+   * Generates the code for Inner join.
+   */
+  protected def codegenInner(ctx: CodegenContext, input: Seq[ExprCode]): String = {
+    val (tokenTreeTerm, _, rowNumber) = prepareBroadcast(ctx)
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val (matched, checkCondition, buildVars) = getJoinCondition(ctx, input)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+
+    val resultVars = buildSide match {
+      case BuildLeft => buildVars ++ input
+      case BuildRight => input ++ buildVars
+    }
+
+    if (rowNumber == 0) {
+      """
+        |// If TreeRelation is empty, tree inner join simply returns nothing.
+      """.stripMargin
+    } else {
+      val matches = ctx.freshName("matches")
+      val joinedRow = ctx.freshName("joinedRow")
+      val arrayBufferCls = classOf[ArrayBuffer[InternalRow]].getName
+      val iteratorCls = classOf[Iterator[InternalRow]].getName
+
+      s"""
+         |// generate join key for stream side
+         |${keyEv.code}
+         |if(${keyEv.value}.getUTF8String(0) != null) {
+         |  // Assume streamedBoundKeys only has one string expression
+         |  String streamedKeyValue = ${keyEv.value}.getUTF8String(0).toString();
+         |  // find matches from TokenTree
+         |  $arrayBufferCls $matches = $anyNull ? null : $tokenTreeTerm.doMatch(streamedKeyValue);
+         |  if ($matches != null) {
+         |    $iteratorCls it = $matches.iterator();
+         |    while (it.hasNext()) {
+         |      InternalRow $matched = (InternalRow) it.next();
+         |      InternalRow $joinedRow = new JoinedRow(${keyEv.value}, $matched);
+         |      $checkCondition {
+         |        $numOutput.add(1);
+         |        ${consume(ctx, resultVars)}
+         |      }
+         |    }
+         |  }
+         |}
+     """.stripMargin
+    }
+  }
+
+  /**
+   * Generates the code for left or right outer join.
+   */
+  protected def codegenOuter(ctx: CodegenContext, input: Seq[ExprCode]): String = {
+    val (tokenTreeTerm, _, _) = prepareBroadcast(ctx)
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val matched = ctx.freshName("matched")
+    val buildVars = genBuildSideVars(ctx, matched)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+
+    // filter the output via condition
+    val conditionPassed = ctx.freshName("conditionPassed")
+    val checkCondition = if (condition.isDefined) {
+      val expr = condition.get
+      // evaluate the variables from build side that used by condition
+      val eval = evaluateRequiredVariables(buildPlan.output, buildVars, expr.references)
+      ctx.currentVars = input ++ buildVars
+      val ev =
+        BindReferences.bindReference(expr, streamedPlan.output ++ buildPlan.output).genCode(ctx)
+      s"""
+         |boolean $conditionPassed = true;
+         |${eval.trim}
+         |if ($matched != null) {
+         |  ${ev.code}
+         |  $conditionPassed = !${ev.isNull} && ${ev.value};
+         |}
+       """.stripMargin
+    } else {
+      s"final boolean $conditionPassed = true;"
+    }
+
+    val resultVars = buildSide match {
+      case BuildLeft => buildVars ++ input
+      case BuildRight => input ++ buildVars
+    }
+
+    val matches = ctx.freshName("matches")
+    val joinedRow = ctx.freshName("joinedRow")
+    val arrayBufferCls = classOf[ArrayBuffer[InternalRow]].getName
+    val iteratorCls = classOf[Iterator[InternalRow]].getName
+    val found = ctx.freshName("found")
+
+    s"""
+       |// generate join key for stream side
+       |${keyEv.code}
+       |
+       |// find matches from TokenTree
+       |$arrayBufferCls $matches = $anyNull || ${keyEv.value}.getUTF8String(0) == null ? null :
+       |        $tokenTreeTerm.doMatch(${keyEv.value}.getUTF8String(0).toString());
+       |boolean $found = false;
+       |$iteratorCls it = $matches == null ? null : $matches.iterator();
+       |// the last iteration of this loop is to emit an empty row if there is no matched rows.
+       |while (it != null && it.hasNext() || !$found) {
+       |  InternalRow $matched = it !=null && it.hasNext() ? (InternalRow) it.next() : null;
+       |  InternalRow $joinedRow = new JoinedRow(${keyEv.value}, $matched);
+       |  ${checkCondition.trim}
+       |  if ($conditionPassed) {
+       |    $found = true;
+       |    $numOutput.add(1);
+       |    ${consume(ctx, resultVars)}
+       |  }
+       |}
+       """.stripMargin
+  }
+
+  /**
+   * Generates the code for left semi join.
+   */
+  protected def codegenSemi(ctx: CodegenContext, input: Seq[ExprCode]): String = {
+    val (tokenTreeTerm, _, rowNumber) = prepareBroadcast(ctx)
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val (matched, checkCondition, _) = getJoinCondition(ctx, input)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+
+    if (rowNumber == 0) {
+      """
+        |// If TreeRelation is empty, tree semi join simply returns nothing.
+      """.stripMargin
+    } else {
+      val matches = ctx.freshName("matches")
+      val joinedRow = ctx.freshName("joinedRow")
+      val arrayBufferCls = classOf[ArrayBuffer[InternalRow]].getName
+      val iteratorCls = classOf[Iterator[InternalRow]].getName
+      val found = ctx.freshName("found")
+
+      s"""
+         |// generate join key for stream side
+         |${keyEv.code}
+         |if(${keyEv.value}.getUTF8String(0) != null) {
+         |  // find matches from TokenTree
+         |  String streamedKeyValue = ${keyEv.value}.getUTF8String(0).toString();
+         |  $arrayBufferCls $matches = $anyNull ? null : $tokenTreeTerm.doMatch(streamedKeyValue);
+         |  if ($matches != null) {
+         |    $iteratorCls it = $matches.iterator();
+         |    boolean $found = false;
+         |    while (!$found && it.hasNext()) {
+         |      InternalRow $matched = (InternalRow) it.next();
+         |      InternalRow $joinedRow = new JoinedRow(${keyEv.value}, $matched);
+         |      $checkCondition {
+         |        $found = true;
+         |      }
+         |    }
+         |    if ($found) {
+         |      $numOutput.add(1);
+         |      ${consume(ctx, input)}
+         |    }
+         |  }
+         |}
+       """.stripMargin
+    }
+  }
+
+  /**
+   * Generates the code for anti join.
+   */
+  protected def codegenAnti(ctx: CodegenContext, input: Seq[ExprCode]): String = {
+    val (tokenTreeTerm, _, rowNumber) = prepareBroadcast(ctx)
+    val numOutput = metricTerm(ctx, "numOutputRows")
+    if (rowNumber == 0) {
+      return s"""
+                |// If TreeRelation is empty, tree anti join simply returns the stream side.
+                |$numOutput.add(1);
+                |${consume(ctx, input)}
+              """.stripMargin
+    }
+
+    val (keyEv, anyNull) = genStreamSideJoinKey(ctx, input)
+    val (matched, checkCondition, _) = getJoinCondition(ctx, input)
+
+    val matches = ctx.freshName("matches")
+    val joinedRow = ctx.freshName("joinedRow")
+    val arrayBufferCls = classOf[ArrayBuffer[InternalRow]].getName
+    val iteratorCls = classOf[Iterator[InternalRow]].getName
+    val found = ctx.freshName("found")
+    s"""
+       |boolean $found = false;
+       |// generate join key for stream side
+       |${keyEv.code}
+       |if(${keyEv.value}.getUTF8String(0) != null) {
+       |  // Check if the TokenTree exists.
+       |  String streamedKeyValue = ${keyEv.value}.getUTF8String(0).toString();
+       |  $arrayBufferCls $matches = $anyNull ? null : $tokenTreeTerm.doMatch(streamedKeyValue);
+       |  if ($matches != null) {
+       |    $iteratorCls it = $matches.iterator();
+       |    // Evaluate the condition.
+       |    while (!$found && it.hasNext()) {
+       |      InternalRow $matched = (InternalRow) it.next();
+       |      InternalRow $joinedRow = new JoinedRow(${keyEv.value}, $matched);
+       |      $checkCondition {
+       |        $found = true;
+       |      }
+       |    }
+       |  }
+       |}
+       |
+       |if (!$found) {
+       |  $numOutput.add(1);
+       |  ${consume(ctx, input)}
+       |}
+       """.stripMargin
+  }
+
+  override protected def withNewChildrenInternal(
+      newLeft: SparkPlan,
+      newRight: SparkPlan): SparkPlan = {
+    copy(left = newLeft, right = newRight)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/TreeRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/TreeRelation.scala
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import java.io.{Externalizable, ObjectInput, ObjectOutput}
+
+import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
+
+import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
+import com.esotericsoftware.kryo.io.{Input, Output}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Expression, UnsafeProjection}
+import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
+import org.apache.spark.sql.execution.joins.TokenNode.EMPTY_CHAR
+import org.apache.spark.util.{KnownSizeEstimation, SizeEstimator}
+
+/**
+ * This tree does not support null value.
+ *
+ * @param key
+ * @param children
+ * @param valuesRef
+ * @tparam V
+ */
+case class TokenNode[V](
+    var key: Char,
+    var children: HashMap[Char, TokenNode[V]] = HashMap[Char, TokenNode[V]](),
+    var valuesRef: ArrayBuffer[V] = null) {
+
+  // for serializer
+  def this() = {
+    this(EMPTY_CHAR)
+  }
+
+  def debugString: String = {
+    debugString("")
+  }
+
+  def debugString(ident: String): String = {
+    val valueRefString =
+      if (valuesRef != null) {
+        s" --> ${valuesRef.mkString("(", ", ", ")")}"
+      } else {
+        ""
+      }
+    val childString =
+      if (children.size > 0) {
+        children
+          .map(tup => tup._2.debugString(ident + "  "))
+          .mkString("\n", "\n", "")
+      } else {
+        ""
+      }
+
+    s"${ident}Node{ $key$valueRefString }${childString}"
+  }
+}
+
+object TokenNode {
+  var EMPTY_CHAR: Char = _
+}
+
+case class DoubleArrayTrieTree[V](
+    var dict: HashMap[Char, Int],
+    var base: Array[Int],
+    var check: Array[Int],
+    var leafMapping: HashMap[Int, ArrayBuffer[V]])
+    extends Externalizable
+    with KryoSerializable
+    with Logging {
+
+  def this() = {
+    this(HashMap[Char, Int](), Array[Int](0), Array[Int](0), HashMap[Int, ArrayBuffer[V]]())
+  }
+
+  def debugString: String = {
+    val sortedDict = dict.toArray.sortBy(_._2)
+    val dictString =
+      s"""${sortedDict.map(_._2).mkString("[", "\t", "]")}
+         |${sortedDict.map(_._1).mkString("[", "\t", "]")}""".stripMargin
+    s"""Dict:
+       |${dictString}
+       |Base:   ${base.mkString("[", "\t", "]")}
+       |Check:  ${check.mkString("[", "\t", "]")}
+       |Leaf:   $leafMapping
+       |""".stripMargin
+  }
+
+  def doMatch(input: String): ArrayBuffer[V] = {
+    val matchedSet = HashSet[Int]()
+    val res = ArrayBuffer[V]()
+    var i = 0
+    val len = input.length
+    while (i < len) {
+      var j = i
+      var stopped = false
+      var pos = 0
+
+      while (j < len && !stopped) {
+        if (dict.contains(input(j))) {
+          val newPos = pos + Math.abs(base(pos)) + dict(input(j))
+          if (newPos >= base.length || base(newPos) == 0 || check(newPos) != pos) {
+            stopped = true
+          } else {
+            if (base(newPos) < 0 && !matchedSet.contains(newPos)) {
+              res ++= leafMapping(newPos)
+              matchedSet += newPos
+            }
+            j = j + 1
+            pos = newPos
+          }
+        } else {
+          i = j
+          stopped = true
+        }
+      }
+      i = i + 1
+    }
+    res
+  }
+
+  override def hashCode(): Int = {
+    dict.hashCode() + 31 * (31 + base.hashCode()) + 31 * (31 + check.hashCode())
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: DoubleArrayTrieTree[_] =>
+      dict.size == that.dict.size && (dict.keySet -- that.dict.keySet).isEmpty &&
+        (base diff that.base).isEmpty && (check diff that.check).isEmpty &&
+        leafMapping.size == that.leafMapping.size &&
+        (leafMapping.keySet -- that.leafMapping.keySet).isEmpty
+
+    case _ => false
+  }
+
+  override def writeExternal(out: ObjectOutput): Unit = {
+    out.writeInt(dict.size)
+    val dictArray = dict.toArray
+    dictArray.map(_._1).foreach(out.writeChar(_))
+    dictArray.map(_._2).foreach(out.writeInt(_))
+    out.writeInt(base.length)
+    base.foreach(out.writeInt(_))
+    check.foreach(out.writeInt(_))
+
+    val leafArray = leafMapping.toArray
+    out.writeInt(leafArray.size)
+    leafArray.map(_._1).foreach(out.writeInt(_))
+    leafArray
+      .map(_._2)
+      .foreach(buf => {
+        out.writeInt(buf.size)
+        buf.foreach(out.writeObject(_))
+      })
+  }
+
+  override def readExternal(in: ObjectInput): Unit = {
+    val dictSize = in.readInt()
+    val dictKeys = Array.fill(dictSize)(in.readChar())
+    val dictValues = Array.fill(dictSize)(in.readInt())
+    dict = HashMap[Char, Int]() ++ dictKeys.zip(dictValues).toMap
+    val baseSize = in.readInt()
+    base = Array.fill(baseSize)(in.readInt())
+    check = Array.fill(baseSize)(in.readInt())
+    val leafSize = in.readInt()
+    val leafMappingKeys = Array.fill(leafSize)(in.readInt())
+    val leafMappingValues: Array[ArrayBuffer[V]] = Array.fill(leafSize)({
+      val buf = new ArrayBuffer[V]()
+      Range(0, in.readInt()).foreach(_ => buf += in.readObject().asInstanceOf[V])
+      buf
+    })
+    leafMapping = HashMap[Int, ArrayBuffer[V]]() ++ leafMappingKeys.zip(leafMappingValues).toMap
+  }
+
+  override def write(kryo: Kryo, out: Output): Unit = {
+    out.writeInt(dict.size)
+    val dictArray = dict.toArray
+    dictArray.map(_._1).foreach(out.writeChar(_))
+    dictArray.map(_._2).foreach(out.writeInt(_))
+    out.writeInt(base.length)
+    base.foreach(out.writeInt(_))
+    check.foreach(out.writeInt(_))
+
+    val leafArray = leafMapping.toArray
+    out.writeInt(leafArray.size)
+    leafArray.map(_._1).foreach(out.writeInt(_))
+    leafArray
+      .map(_._2)
+      .foreach(buf => {
+        out.writeInt(buf.size)
+        buf.foreach(kryo.writeClassAndObject(out, _))
+      })
+  }
+
+  override def read(kryo: Kryo, in: Input): Unit = {
+    val dictSize = in.readInt()
+    val dictKeys = Array.fill(dictSize)(in.readChar())
+    val dictValues = Array.fill(dictSize)(in.readInt())
+    dict = HashMap[Char, Int]() ++ dictKeys.zip(dictValues).toMap
+    val baseSize = in.readInt()
+    base = Array.fill(baseSize)(in.readInt())
+    check = Array.fill(baseSize)(in.readInt())
+    val leafSize = in.readInt()
+    val leafMappingKeys = Array.fill(leafSize)(in.readInt())
+    val leafMappingValues: Array[ArrayBuffer[V]] = Array.fill(leafSize)({
+      val buf = new ArrayBuffer[V]()
+      Range(0, in.readInt()).foreach(_ => buf += kryo.readClassAndObject(in).asInstanceOf[V])
+      buf
+    })
+    leafMapping = HashMap[Int, ArrayBuffer[V]]() ++ leafMappingKeys.zip(leafMappingValues).toMap
+  }
+}
+
+class DoubleArrayTreeBuilder[V] extends Logging {
+
+  val header = new TokenNode[V](EMPTY_CHAR)
+
+  def compile(input: String, value: V): DoubleArrayTreeBuilder[V] = {
+    var curNode = header
+    var i = 0
+    val len = input.length
+    while (i < len) {
+      val ch = input(i)
+      curNode = curNode.children.getOrElseUpdate(ch, TokenNode(ch))
+      i += 1
+    }
+
+    if (curNode.valuesRef == null) {
+      curNode.valuesRef = ArrayBuffer[V]()
+    }
+    curNode.valuesRef += value
+    this
+  }
+
+  /**
+   * encode all chars into a array
+   */
+  def encodeChars[V](header: TokenNode[V]): HashMap[Char, Int] = {
+    val charMapping = HashMap[Char, Int]()
+    val buf = ArrayBuffer[TokenNode[V]](header)
+    while (buf.nonEmpty) {
+      val node = buf.last
+      buf.remove(buf.length - 1)
+      buf ++= node.children.values
+
+      if (node != header && !charMapping.contains(node.key)) {
+        charMapping += node.key -> charMapping.size
+      }
+    }
+    charMapping
+  }
+
+  def builder(): DoubleArrayTrieTree[V] = {
+    val startTime = System.currentTimeMillis()
+    val charMapping = encodeChars(header)
+    var base = Array.fill(charMapping.size * 2)(0)
+    var check = Array.fill(charMapping.size * 2)(0)
+    var nextCheckPos = 0
+    val leafMapping = HashMap[Int, ArrayBuffer[V]]()
+
+    val buf = ArrayBuffer[(Int, TokenNode[V])](0 -> header)
+    base(0) = 1
+
+    def resize(newSize: Int): Unit = {
+      val len = Math.min(base.length, newSize)
+      logInfo(s"Increase double array tree size from ${base.length} to ${newSize}")
+      val newBase = new Array[Int](newSize)
+      Array.copy(base, 0, newBase, 0, len)
+      base = newBase
+      val newCheck = new Array[Int](newSize)
+      Array.copy(check, 0, newCheck, 0, len)
+      check = newCheck
+    }
+
+    while (buf.nonEmpty) {
+      val (position, node) = buf.head
+      buf.remove(0)
+      // select i which will not conflicts with current bases
+      val idToChild = node.children.map { case (key, child) => charMapping(key) -> child }
+      var i = Math.max(nextCheckPos - position, 0)
+      var conflict = true
+      var conflictPosNum = 0
+      while (conflict) {
+        conflict = false
+        i = i + 1
+        if (base(i) == 0) {
+          conflictPosNum = conflictPosNum + 1
+        }
+        for (id <- idToChild.keySet if !conflict) {
+          // Resize if needed
+          if (position + i + id >= base.length) {
+            resize(base.length * 2)
+
+          }
+          if (base(position + i + id) != 0) {
+            conflict = true
+          }
+        }
+      }
+      if (1.0 * i / node.children.size > 1) {
+        nextCheckPos = position + i
+      }
+
+      base(position) = i * base(position) // keep leaf flag(1 or -1)
+      idToChild.foreach { case (id, child) =>
+        val childPosition = position + i + id
+        if (child.valuesRef == null) {
+          base(childPosition) = 1
+        } else {
+          base(childPosition) = -1
+          leafMapping += childPosition -> child.valuesRef
+        }
+        check(childPosition) = position
+        if (child.children.nonEmpty) {
+          // add next level nodes
+          buf += childPosition -> child
+        }
+      }
+      logDebug(s"""AddNode [${{ node.children.map(_._1).mkString(", ") }}]
+                  |Index\t${Range(0, base.length).mkString("\t")}
+                  |Base\t${base.mkString("\t")}
+                  |Check\t${check.mkString("\t")}
+                  |""".stripMargin)
+    }
+
+    var j = base.length
+    while (base(j - 1) == 0) { // base(0) always == 1
+      j = j - 1
+    }
+    resize(j)
+    logDebug(
+      s"Build DoubleArrayTrieTree from trieTree in ${System.currentTimeMillis() - startTime} ms")
+    DoubleArrayTrieTree(charMapping, base, check, leafMapping)
+  }
+}
+
+/**
+ * TODO Here can be optimized in broadcast in executor size PR.
+ * @param tree
+ * @param estimatedSize
+ * @param rowNumber
+ */
+case class TreeRelation(
+    tree: DoubleArrayTrieTree[InternalRow],
+    estimatedSize: Long,
+    rowNumber: Int)
+    extends KnownSizeEstimation
+    with Serializable
+
+case class TokenTreeBroadcastMode(
+    key: Seq[Expression],
+    checkWildcards: Boolean,
+    isNullAware: Boolean = false)
+    extends BroadcastMode
+    with Logging {
+
+  override def transform(rows: Array[InternalRow]): Option[TreeRelation] = {
+    transform(rows.iterator, Some(rows.length))
+  }
+
+  override def transform(
+      rows: Iterator[InternalRow],
+      sizeHint: Option[Long]): Option[TreeRelation] = {
+    val buildStart = System.currentTimeMillis()
+    val keyGenerator = UnsafeProjection.create(canonicalized.key)
+
+    var rowNumber: Int = 0
+    var validRelation = true
+    val rowAndPatterns = rows
+      .filter(keyGenerator(_).getUTF8String(0) != null)
+      .map(row => {
+        rowNumber = rowNumber + 1
+        val patternKey = keyGenerator(row).getString(0)
+        if (checkWildcards) {
+          if (patternKey.contains('%') || patternKey.contains('_')) {
+            validRelation = false
+          }
+        }
+        row -> patternKey
+      })
+      .toArray
+
+    if (validRelation) {
+      val builder =
+        rowAndPatterns.foldLeft(new DoubleArrayTreeBuilder[InternalRow]()) { (builder, tup) =>
+          builder.compile(tup._2, tup._1)
+        }
+
+      val dat = builder.builder()
+      val elapsedTime = System.currentTimeMillis() - buildStart
+      val estimatedSize = SizeEstimator.estimate(dat)
+      logInfo(
+        s"Build contains join trie tree(${estimatedSize} Bytes)" +
+          s" in $elapsedTime ms, origin rows number: ${rowNumber}")
+      Some(TreeRelation(dat, estimatedSize, rowNumber))
+    } else {
+      None
+    }
+  }
+
+  override lazy val canonicalized: TokenTreeBroadcastMode = {
+    this.copy(key = key.map(_.canonicalized))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/TreeRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/TreeRelation.scala
@@ -127,7 +127,6 @@ case class DoubleArrayTrieTree[V](
             pos = newPos
           }
         } else {
-          i = j
           stopped = true
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastContainsJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/joins/BroadcastContainsJoinSuite.scala
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import java.io.{
+  ByteArrayInputStream,
+  ByteArrayOutputStream,
+  ObjectInputStream,
+  ObjectOutputStream
+}
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class BroadcastContainsJoinSuite
+    extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+
+  import testImplicits._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Seq[(Int, String, String)](
+      (-21, null, "left-null"),
+      (20, "key0", "left-0"),
+      (21, "key1", "left-1"),
+      (22, "key2", "left-2"))
+      .toDF("id", "key", "value")
+      .createOrReplaceTempView("t1")
+
+    Seq[(Int, String, String)](
+      (-31, null, "right-null"),
+      (30, "key0", "right-0"),
+      (31, "key1", "right-1"),
+      (33, "key3", "right-3"))
+      .toDF("id", "key", "value")
+      .createOrReplaceTempView("t2")
+
+    Seq[(Int, String, String)](
+      (-31, null, "right-null"),
+      (30, "k%0", "right-0"),
+      (31, "k_y1", "right-1"),
+      (33, "key3", "right-3"))
+      .toDF("id", "key", "value")
+      .createOrReplaceTempView("t3")
+  }
+
+  def testWithCodegen(f: => Unit): Unit = {
+    Seq("false", "true").map { codegenEnabled =>
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> codegenEnabled) {
+        f
+      }
+    }
+  }
+
+  def findTopLevelBroadcastContainsJoin(plan: SparkPlan): Seq[BroadcastContainsJoinExec] = {
+    collect(plan) { case j: BroadcastContainsJoinExec => j }
+  }
+
+  def findTopLevelBroadcastNestedLoopJoin(plan: SparkPlan): Seq[BroadcastNestedLoopJoinExec] = {
+    collect(plan) { case j: BroadcastNestedLoopJoinExec => j }
+  }
+
+  def verifyBroadcastContainsJoinNumber(
+      query: String,
+      expected: Seq[Row],
+      canBroadcast: Boolean,
+      joinNumber: Int): Unit = testWithCodegen {
+    withSQLConf(SQLConf.CONTAINS_JOIN_ENABLED.key -> "false") {
+      val df = sql(query)
+      checkAnswer(df, expected)
+      val plan = df.queryExecution.executedPlan
+      assert(findTopLevelBroadcastNestedLoopJoin(plan).size == joinNumber)
+      assert(findTopLevelBroadcastContainsJoin(plan).size == 0)
+    }
+    withSQLConf(SQLConf.CONTAINS_JOIN_ENABLED.key -> "true") {
+      val df = sql(query)
+      checkAnswer(df, expected)
+      val plan = df.queryExecution.executedPlan
+      if (canBroadcast) {
+        assert(findTopLevelBroadcastNestedLoopJoin(plan).size == 0)
+        assert(findTopLevelBroadcastContainsJoin(plan).size == joinNumber)
+      } else {
+        assert(findTopLevelBroadcastNestedLoopJoin(plan).size == joinNumber)
+        assert(findTopLevelBroadcastContainsJoin(plan).size == 0)
+      }
+    }
+  }
+
+  def verifyBroadcastContainsJoinNumber(
+      query: String,
+      expectedDF: DataFrame,
+      canBroadcast: Boolean,
+      joinNumber: Int): Unit = {
+    verifyBroadcastContainsJoinNumber(query, expectedDF.collect(), canBroadcast, joinNumber)
+  }
+
+  test("SPARK-38238: Build token tree") {
+    val dat =
+      new DoubleArrayTreeBuilder[Long]()
+        .compile("cat", 5)
+        .compile("deep", 7)
+        .compile("do", 17)
+        // same key but different values
+        .compile("dog", 99)
+        .compile("dog", 18)
+        // exactly the same value
+        .compile("dogs", 21)
+        .compile("dogs", 21)
+        .builder()
+
+    assert(dat.doMatch("I love beautiful girls") === ArrayBuffer())
+    assert(dat.doMatch("I do very good") === ArrayBuffer(17))
+    assert(dat.doMatch("A lovely dogs and a annoying dogs") === ArrayBuffer(17, 99, 18, 21, 21))
+    assert(dat.doMatch("I love cats and dogs") === ArrayBuffer(5, 17, 99, 18, 21, 21))
+
+    val os = new ByteArrayOutputStream()
+    val out = new ObjectOutputStream(os)
+    dat.writeExternal(out)
+    out.flush()
+    val in = new ObjectInputStream(new ByteArrayInputStream(os.toByteArray))
+    val serDeDat = new DoubleArrayTrieTree()
+    serDeDat.readExternal(in)
+    assert(dat == serDeDat)
+
+    val dat2 =
+      new DoubleArrayTreeBuilder[Long]()
+        .compile("abcd", 1)
+        .compile("bce", 2)
+        .builder()
+
+    assert(dat2.doMatch("abcdabcabcababcabcda") === ArrayBuffer(1))
+  }
+
+  test("SPARK-38238: contains join patterns") {
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2) */ t1.*, t2.*
+         |FROM t1 join t2
+         |ON upper(t1.key) like concat('%', upper(t2.key), '%')
+         |""".stripMargin,
+      Seq(
+        Row(20, "key0", "left-0", 30, "key0", "right-0"),
+        Row(21, "key1", "left-1", 31, "key1", "right-1")),
+      true,
+      1)
+
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2) */ t1.*, t2.*
+         |FROM t1 join t2
+         |ON position(lower(concat(t2.key, t2.value)), lower(t1.key)) > 0
+         |""".stripMargin,
+      Seq.empty[(Int, String, Int, String)].toDF(),
+      true,
+      1)
+
+    Seq((" how old is she ", "gap"), (" how old is she ", "thorn"))
+      .toDF("keyword", "source")
+      .createOrReplaceTempView("thorntest")
+    // scalastyle:off
+    val text =
+      "Thanks for getting back to me . Won’t let me either I’ll have another go tomorrow" +
+        " might have to wait for package to be delivered ?? Oh my god how dreadful !!! " +
+        "Very lucky it wasn’t her face . How old is she ? Bless hope it doesn’t scar" +
+        " her for life .. if there’s any probs I’ll message you thanks for trying ."
+    // scalastyle:on
+    Seq(text)
+      .toDF("msg_body_txt")
+      .createOrReplaceTempView("msg")
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT msg_body_txt, keyword
+         |FROM msg a
+         |JOIN thorntest t
+         |ON (POSITION(lower(t.keyword), lower(a.msg_body_txt)) > 0)
+         |""".stripMargin,
+      Seq(Row(text, " how old is she "), Row(text, " how old is she ")),
+      true,
+      1)
+  }
+
+  test("SPARK-38238: test BroadcastContainsJoin inner join") {
+    // Use hint because subPlan.stats.sizeInBytes is very large.
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2)*/ t1.key as key1,
+         |       t1.value as value1,
+         |       t2.key as key2,
+         |       t2.value as value2
+         |FROM t1
+         |JOIN t2
+         |ON t1.key like concat('%' || t2.key || '%')
+         |AND length(t1.value) - length(t2.value) < 1
+         |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+         |""".stripMargin,
+      Seq(Row("key0", "left-0", "key0", "right-0")),
+      true,
+      1)
+
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2)*/ t1.key as key1,
+         |       t1.value as value1,
+         |       t2.key as key2,
+         |       t2.value as value2
+         |FROM t1
+         |JOIN t2
+         |ON t1.key like concat('%' || t2.key || '%')
+         |AND length(t1.value) - length(t2.value) > 1
+         |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+         |""".stripMargin,
+      Seq.empty[(String, String, String, String)].toDF(),
+      true,
+      1)
+
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2)*/ t1.key
+         |FROM t1
+         |JOIN t2
+         |ON t1.key like concat('%' || ' ' || t2.key || ' ' || '%')
+         |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+         |""".stripMargin,
+      Seq.empty[(String)].toDF(),
+      true,
+      1)
+  }
+
+  def unSupportedContainsPattern(query: String): Unit = {
+    withSQLConf(
+      SQLConf.CONTAINS_JOIN_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      val df = sql(query)
+      df.collect()
+      val plan = df.queryExecution.executedPlan
+      assert(findTopLevelBroadcastContainsJoin(plan).size == 0)
+    }
+  }
+
+  test("SPARK-38238: extract contains pattern") {
+    // Use hint because subPlan.stats.sizeInBytes is very large
+    unSupportedContainsPattern(s"""SELECT /*+ BROADCAST(t2)*/ t1.key as key1,
+                                  |       t1.value as value1,
+                                  |       t2.key as key2,
+                                  |       t2.value as value2
+                                  |FROM t1
+                                  |JOIN t2
+                                  |ON t1.key like concat('%' || t2.key || '%' || t2.value || '%')
+                                  |AND length(t1.value) - length(t2.value) < 1
+                                  |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+                                  |""".stripMargin)
+    unSupportedContainsPattern(s"""SELECT /*+ BROADCAST(t2)*/ t1.key as key1,
+                                  |       t1.value as value1,
+                                  |       t2.key as key2,
+                                  |       t2.value as value2
+                                  |FROM t1
+                                  |JOIN t2
+                                  |ON t1.key like concat('%' || t2.key || '_' || t2.value || '%')
+                                  |AND length(t1.value) - length(t2.value) < 1
+                                  |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+                                  |""".stripMargin)
+  }
+
+  test(
+    "SPARK-38238: Fall back to NLJ if broadcast relation is in like expression " +
+      "and contains % or _ is unsupported") {
+    unSupportedContainsPattern(s"""SELECT /*+ BROADCAST(t3)*/ t1.key as key1,
+                                  |       t1.value as value1,
+                                  |       t3.key as key2,
+                                  |       t3.value as value2
+                                  |FROM t1
+                                  |JOIN t3
+                                  |ON t1.key like concat('%' || t3.key || '%')
+                                  |""".stripMargin)
+  }
+
+  test("SPARK-38238: Donot fall back to NLJ for position expression") {
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t3)*/ t1.key as key1,
+         |       t1.value as value1,
+         |       t3.key as key2,
+         |       t3.value as value2
+         |FROM t1
+         |JOIN t3
+         |ON position(t3.key, t1.key) > 0
+         |""".stripMargin,
+      Seq.empty[(String)].toDF(),
+      true,
+      1)
+  }
+
+  test("SPARK-38238: test BroadcastContainsJoin outer/semi/anti join") {
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT *
+         |FROM t1
+         |LEFT JOIN t2
+         |ON t1.key like concat('%' || t2.key || '%')
+         |AND length(t1.value) - length(t2.value) < 1
+         |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+         |""".stripMargin,
+      Seq(
+        Row(-21, null, "left-null", null, null, null),
+        Row(20, "key0", "left-0", 30, "key0", "right-0"),
+        Row(22, "key2", "left-2", null, null, null)),
+      true,
+      1)
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT *
+         |FROM t1
+         |RIGHT JOIN t2
+         |ON t1.key like concat('%' || t2.key || '%')
+         |AND length(t1.value) - length(t2.value) < 1
+         |WHERE t2.value in ('right-null', 'right-0', 'right-3')
+         |""".stripMargin,
+      Seq(
+        Row(null, null, null, -31, null, "right-null"),
+        Row(20, "key0", "left-0", 30, "key0", "right-0"),
+        Row(null, null, null, 33, "key3", "right-3")),
+      false,
+      1)
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT *
+         |FROM t1
+         |RIGHT JOIN t2
+         |ON t2.key like concat('%' || t1.key || '%')
+         |AND length(t1.value) - length(t2.value) < 1
+         |WHERE t2.value in ('right-null', 'right-0', 'right-3')
+         |""".stripMargin,
+      Seq(
+        Row(null, null, null, -31, null, "right-null"),
+        Row(20, "key0", "left-0", 30, "key0", "right-0"),
+        Row(null, null, null, 33, "key3", "right-3")),
+      true,
+      1)
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2)*/ t1.*
+         |FROM t1
+         |SEMI JOIN t2
+         |ON t1.key like concat('%' || t2.key || '%')
+         |AND length(t1.value) - length(t2.value) < 1
+         |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+         |""".stripMargin,
+      Seq(Row(20, "key0", "left-0")),
+      true,
+      1)
+    verifyBroadcastContainsJoinNumber(
+      s"""SELECT /*+ BROADCAST(t2)*/ t1.*
+         |FROM t1
+         |ANTI JOIN t2
+         |ON t1.key like concat('%' || t2.key || '%')
+         |AND length(t1.value) - length(t2.value) < 1
+         |WHERE t1.value in ('left-null', 'left-0', 'left-2')
+         |""".stripMargin,
+      Seq(Row(-21, null, "left-null"), Row(22, "key2", "left-2")),
+      true,
+      1)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Try to optimize the string contains join query which could run for a long time. 
For example:
```sql
SELECT a.text, b.pattern
FROM fact_table a
JOIN patterns b
ON a.text like concat('%', b.pattern, '%');
```
Or
```sql
SELECT a.text, b.pattern
FROM fact_table a
JOIN patterns b
ON position(b.pattern, a.text) > 0;
```
The query will go from **O(M * N * m * n)** to **O(M * m * max(n))**
M = number of records in the fact table
N = number of records in the patterns table
m = row length of the fact table
n = row length of the patterns table

### Why are the changes needed?

Before this change, if we want to match many patterns  for each row of the fact table, it could run a very long time.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Added UTs
