### PR TITLE
[SPARK-38237][SQL] Rename back StatefulOpClusteredDistribution to HashClusteredDistribution

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -282,65 +282,65 @@ class DistributionSuite extends SparkFunSuite {
     }
 
     // Validate only HashPartitioning (and HashPartitioning in PartitioningCollection) can satisfy
-    // StatefulOpClusteredDistribution. SinglePartition can also satisfy this distribution when
-    // `_requiredNumPartitions` is 1.
+    // HashClusteredDistribution. SinglePartition can also satisfy this distribution when
+    // `requiredNumPartitions` is Some(1).
     checkSatisfied(
       HashPartitioning(Seq($"a", $"b", $"c"), 10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       true)
 
     checkSatisfied(
       PartitioningCollection(Seq(
         HashPartitioning(Seq($"a", $"b", $"c"), 10),
         RangePartitioning(Seq($"a".asc, $"b".asc, $"c".asc), 10))),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       true)
 
     checkSatisfied(
       SinglePartition,
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 1),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(1)),
       true)
 
     checkSatisfied(
       PartitioningCollection(Seq(
         HashPartitioning(Seq($"a", $"b"), 1),
         SinglePartition)),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 1),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(1)),
       true)
 
     checkSatisfied(
       HashPartitioning(Seq($"a", $"b"), 10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       HashPartitioning(Seq($"a", $"b", $"c"), 5),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       RangePartitioning(Seq($"a".asc, $"b".asc, $"c".asc), 10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       SinglePartition,
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       BroadcastPartitioning(IdentityBroadcastMode),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       RoundRobinPartitioning(10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       UnknownPartitioning(10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -93,7 +93,7 @@ case class FlatMapGroupsWithStateExec(
    * to have the same grouping so that the data are co-lacated on the same task.
    */
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(groupingAttributes, stateInfo.map(_.numPartitions)) ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -185,8 +185,8 @@ case class StreamingSymmetricHashJoinExec(
   val nullRight = new GenericInternalRow(right.output.map(_.withNullability(true)).length)
 
   override def requiredChildDistribution: Seq[Distribution] =
-    StatefulOpClusteredDistribution(leftKeys, getStateInfo.numPartitions) ::
-      StatefulOpClusteredDistribution(rightKeys, getStateInfo.numPartitions) :: Nil
+    HashClusteredDistribution(leftKeys, stateInfo.map(_.numPartitions)) ::
+      HashClusteredDistribution(rightKeys, stateInfo.map(_.numPartitions)) :: Nil
 
   override def output: Seq[Attribute] = joinType match {
     case _: InnerLike => left.output ++ right.output

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -334,7 +334,7 @@ case class StateStoreRestoreExec(
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     if (keyExpressions.isEmpty) {
@@ -496,7 +496,7 @@ case class StateStoreSaveExec(
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     if (keyExpressions.isEmpty) {
@@ -579,7 +579,7 @@ case class SessionWindowStateStoreRestoreExec(
   }
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(keyWithoutSessionExpressions, stateInfo.map(_.numPartitions)) :: Nil
@@ -693,7 +693,7 @@ case class SessionWindowStateStoreSaveExec(
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(keyExpressions, stateInfo.map(_.numPartitions)) :: Nil
@@ -754,7 +754,7 @@ case class StreamingDeduplicateExec(
 
   /** Distribute by grouping attributes */
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(keyExpressions, stateInfo.map(_.numPartitions)) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -571,7 +571,7 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
       CheckNewAnswer((5, 10, 5, 15, 5, 25)))
   }
 
-  test("streaming join should require StatefulOpClusteredDistribution from children") {
+  test("streaming join should require HashClusteredDistribution from children") {
     val input1 = MemoryStream[Int]
     val input2 = MemoryStream[Int]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename back `StatefulOpClusteredDistribution` to `HashClusteredDistribution`. This PR retains the content of the classdoc for stateful operators in `HashClusteredDistribution`, along with new general content of the classdoc.

### Why are the changes needed?

We figured out that in some case `HashClusteredDistribution` is still desirable other than stateful operators; `HashPartitioning` with subset of grouping keys can satisfy `ClusteredDistribution`, which means the cardinality of the subset of grouping keys technically defines the max parallelism. Increasing the number of partitions does not always help to solve the skew of the partitions.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests since this PR just renames a class.