### PR TITLE
[SPARK-38237][SQL][SS] Introduce a new config to require all cluster keys on Aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -407,6 +407,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val REQUIRE_ALL_CLUSTER_KEYS_FOR_AGGREGATE =
+    buildConf("spark.sql.aggregate.requireAllClusterKeys")
+      .internal()
+      .doc("When true, aggregate operator requires all the clustering keys as the hash partition" +
+        " keys from child. This is to avoid data skews which can lead to significant " +
+        "performance regression if shuffles are eliminated.")
+      .version("3.3.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()
     .doc("When true, enable use of radix sort when possible. Radix sort is much faster but " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/DistributionSuite.scala
@@ -282,65 +282,65 @@ class DistributionSuite extends SparkFunSuite {
     }
 
     // Validate only HashPartitioning (and HashPartitioning in PartitioningCollection) can satisfy
-    // StatefulOpClusteredDistribution. SinglePartition can also satisfy this distribution when
-    // `_requiredNumPartitions` is 1.
+    // HashClusteredDistribution. SinglePartition can also satisfy this distribution when
+    // `requiredNumPartitions` is Some(1).
     checkSatisfied(
       HashPartitioning(Seq($"a", $"b", $"c"), 10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       true)
 
     checkSatisfied(
       PartitioningCollection(Seq(
         HashPartitioning(Seq($"a", $"b", $"c"), 10),
         RangePartitioning(Seq($"a".asc, $"b".asc, $"c".asc), 10))),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       true)
 
     checkSatisfied(
       SinglePartition,
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 1),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(1)),
       true)
 
     checkSatisfied(
       PartitioningCollection(Seq(
         HashPartitioning(Seq($"a", $"b"), 1),
         SinglePartition)),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 1),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(1)),
       true)
 
     checkSatisfied(
       HashPartitioning(Seq($"a", $"b"), 10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       HashPartitioning(Seq($"a", $"b", $"c"), 5),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       RangePartitioning(Seq($"a".asc, $"b".asc, $"c".asc), 10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       SinglePartition,
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       BroadcastPartitioning(IdentityBroadcastMode),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       RoundRobinPartitioning(10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
 
     checkSatisfied(
       UnknownPartitioning(10),
-      StatefulOpClusteredDistribution(Seq($"a", $"b", $"c"), 10),
+      HashClusteredDistribution(Seq($"a", $"b", $"c"), Some(10)),
       false)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -93,7 +93,7 @@ case class FlatMapGroupsWithStateExec(
    * to have the same grouping so that the data are co-lacated on the same task.
    */
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(groupingAttributes, stateInfo.map(_.numPartitions)) ::

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -287,6 +287,9 @@ abstract class StreamExecution(
         // Disable cost-based join optimization as we do not want stateful operations
         // to be rearranged
         sparkSessionForStream.conf.set(SQLConf.CBO_ENABLED.key, "false")
+        // Disable any config affecting the required child distribution of stateful operators.
+        // Please read through the NOTE on the classdoc of HashClusteredDistribution for details.
+        sparkSessionForStream.conf.set(SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_AGGREGATE.key, "false")
 
         updateStatusMessage("Initializing sources")
         // force initialization of the logical plan so that the sources can be created

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamingSymmetricHashJoinExec.scala
@@ -185,8 +185,8 @@ case class StreamingSymmetricHashJoinExec(
   val nullRight = new GenericInternalRow(right.output.map(_.withNullability(true)).length)
 
   override def requiredChildDistribution: Seq[Distribution] =
-    StatefulOpClusteredDistribution(leftKeys, getStateInfo.numPartitions) ::
-      StatefulOpClusteredDistribution(rightKeys, getStateInfo.numPartitions) :: Nil
+    HashClusteredDistribution(leftKeys, stateInfo.map(_.numPartitions)) ::
+      HashClusteredDistribution(rightKeys, stateInfo.map(_.numPartitions)) :: Nil
 
   override def output: Seq[Attribute] = joinType match {
     case _: InnerLike => left.output ++ right.output

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -334,7 +334,7 @@ case class StateStoreRestoreExec(
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     if (keyExpressions.isEmpty) {
@@ -496,7 +496,7 @@ case class StateStoreSaveExec(
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     if (keyExpressions.isEmpty) {
@@ -579,7 +579,7 @@ case class SessionWindowStateStoreRestoreExec(
   }
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(keyWithoutSessionExpressions, stateInfo.map(_.numPartitions)) :: Nil
@@ -693,7 +693,7 @@ case class SessionWindowStateStoreSaveExec(
   override def outputPartitioning: Partitioning = child.outputPartitioning
 
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(keyExpressions, stateInfo.map(_.numPartitions)) :: Nil
@@ -754,7 +754,7 @@ case class StreamingDeduplicateExec(
 
   /** Distribute by grouping attributes */
   override def requiredChildDistribution: Seq[Distribution] = {
-    // NOTE: Please read through the NOTE on the classdoc of StatefulOpClusteredDistribution
+    // NOTE: Please read through the NOTE on the classdoc of HashClusteredDistribution
     // before making any changes.
     // TODO(SPARK-38204)
     ClusteredDistribution(keyExpressions, stateInfo.map(_.numPartitions)) :: Nil

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -24,10 +24,12 @@ import scala.util.Random
 import org.scalatest.matchers.must.Matchers.the
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.execution.WholeStageCodegenExec
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
+import org.apache.spark.sql.execution.{InputAdapter, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
-import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
-import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExchangeExec}
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
@@ -1452,6 +1454,57 @@ class DataFrameAggregateSuite extends QueryTest
   test("SPARK-38221: group by stream of complex expressions should not fail") {
     val df = Seq(1).toDF("id").groupBy(Stream($"id" + 1, $"id" + 2): _*).sum("id")
     checkAnswer(df, Row(2, 3, 1))
+  }
+
+  test("SPARK-38237: require all cluster keys for child required distribution") {
+    def partitionExpressionsColumns(expressions: Seq[Expression]): Seq[String] = {
+      expressions.flatMap {
+        case ref: AttributeReference => Some(ref.name)
+      }
+    }
+
+    def isShuffleExecByRequirement(
+        plan: ShuffleExchangeExec,
+        desiredClusterColumns: Seq[String],
+        desiredNumPartitions: Int): Boolean = plan match {
+      case ShuffleExchangeExec(op: HashPartitioning, _, ENSURE_REQUIREMENTS)
+        if partitionExpressionsColumns(op.expressions) === desiredClusterColumns &&
+          op.numPartitions === desiredNumPartitions => true
+
+      case _ => false
+    }
+
+    val df = Seq(("a", 1, 1), ("a", 2, 2), ("b", 1, 3), ("b", 1, 4)).toDF("key1", "key2", "value")
+
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_AGGREGATE.key -> "true") {
+
+      val grouped = df
+        // repartition by sub group keys which satisfies ClusteredDistribution(group keys)
+        .repartition($"key1")
+        .groupBy($"key1", $"key2")
+        .agg(sum($"value"))
+
+      checkAnswer(grouped, Seq(Row("a", 1, 1), Row("a", 2, 2), Row("b", 1, 7)))
+
+      val numPartitions = spark.sqlContext.conf.getConf(SQLConf.SHUFFLE_PARTITIONS)
+
+      val shuffleByRequirement = grouped.queryExecution.executedPlan.flatMap {
+        case a if a.isInstanceOf[BaseAggregateExec] =>
+          a.children.head match {
+            case InputAdapter(s: ShuffleExchangeExec)
+              if isShuffleExecByRequirement(s, Seq("key1", "key2"), numPartitions) => Some(s)
+            case s: ShuffleExchangeExec
+              if isShuffleExecByRequirement(s, Seq("key1", "key2"), numPartitions) => Some(s)
+            case _ => None
+          }
+
+        case _ => None
+      }
+
+      assert(shuffleByRequirement.nonEmpty, "Can't find desired shuffle node from the query plan")
+    }
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -571,7 +571,7 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
       CheckNewAnswer((5, 10, 5, 15, 5, 25)))
   }
 
-  test("streaming join should require StatefulOpClusteredDistribution from children") {
+  test("streaming join should require HashClusteredDistribution from children") {
     val input1 = MemoryStream[Int]
     val input2 = MemoryStream[Int]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to introduce a new config `spark.sql.aggregate.requireAllClusterKeys` (default: false) to force required child distribution of Aggregate to use `HashClusteredDistribution` instead of `ClusteredDistribution`, which effectively requires all cluster keys on output partitioning.
(Technically it requires more strict condition, but this PR takes the easier and less invasive way to implement since it's only effective when the config is enabled.)

This PR also proposes to rename back `StatefulOpClusteredDistribution` to `HashClusteredDistribution`, since it is now being used from batch query as well. This PR retains the content of the classdoc for stateful operators in `HashClusteredDistribution`, along with new general content of the classdoc.

### Why are the changes needed?

We figured out performance issues with aggregate operator in some cases. To explain a simple case, suppose table t1 is hash partitioned by k1, with a small number of partitions and the data is skewed. If we run GROUP BY k1, k2 against the table, Spark doesn't add a shuffle (intended in point of Spark's view) and the query will run super slowly.

We observed the query slowness from mins to hours due to this, so we can't simply say it's a trade off. Since we don't have a good way to automatically deal with the issue, we would like to provide the config to end users to tune by theirselves at least.

### Does this PR introduce _any_ user-facing change?

Yes, users will have a new config to enforce requiring all grouping keys on output partitioning of the child of aggregate.

### How was this patch tested?

New test.