### PR TITLE
[SPARK-38241][K8S][TESTS] Close KubernetesClient in K8S integrations tests

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/KubeConfigBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/KubeConfigBackend.scala
@@ -60,6 +60,9 @@ private[spark] class KubeConfigBackend(var context: String)
   }
 
   override def cleanUp(): Unit = {
+    if (defaultClient != null) {
+      defaultClient.close()
+    }
     super.cleanUp()
   }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/MinikubeTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/MinikubeTestBackend.scala
@@ -34,6 +34,9 @@ private[spark] object MinikubeTestBackend extends IntegrationTestBackend {
   }
 
   override def cleanUp(): Unit = {
+    if (defaultClient != null) {
+      defaultClient.close()
+    }
     super.cleanUp()
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?

Close org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend#getKubernetesClient in the `cleanUp()` of the backend implementations.

### Why are the changes needed?

It is a good practice to cleanup resources at the end of the tests, so they do not leak and affect other tests.

Recently I've noticed the following in the output:
```
===== POSSIBLE THREAD LEAK IN SUITE o.a.s.deploy.k8s.integrationtest.VolcanoSuite, threads: OkHttp [https://192.168.49.2:8443/.](https://192.168.49.2:8443/).. (daemon=false), scala-execution-context-global-26 (daemon=true), OkHttp ConnectionPool (daemon=true), scala-execution-context-global-24 (daemon=true), Okio Watchdog (daemon=true), scala-execution-context-global-23 (daemon=true), scala-execution-context-global-21 (daemon=true), scala-execution-context-global-22 (daemon=true), OkHttp WebSocket [https://192.168.49.2:8443/.](https://192.168.49.2:8443/).. (daemon=false), scala-execution-context-global-25 (daemon=true), scala-execution-context-global-20 (daemon=true) =====
```


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Run the IT tests
