### PR TITLE
[MINOR][DOCS] Fixed closing tags in running-on-kubernetes.md

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1141,7 +1141,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td><code>spark.kubernetes.memoryOverheadFactor</code></td>
   <td><code>0.1</code></td>
   <td>
-    This sets the Memory Overhead Factor that will allocate memory to non-JVM memory, which includes off-heap memory allocations, non-JVM tasks, various systems processes, and <code>tmpfs</code>-based local directories when <code>spark.kubernetes.local.dirs.tmpfs<code> is <code>true</code>. For JVM-based jobs this value will default to 0.10 and 0.40 for non-JVM jobs.
+    This sets the Memory Overhead Factor that will allocate memory to non-JVM memory, which includes off-heap memory allocations, non-JVM tasks, various systems processes, and <code>tmpfs</code>-based local directories when <code>spark.kubernetes.local.dirs.tmpfs</code> is <code>true</code>. For JVM-based jobs this value will default to 0.10 and 0.40 for non-JVM jobs.
     This is done as non-JVM tasks need more non-JVM heap space and such tasks commonly fail with "Memory Overhead Exceeded" errors. This preempts this error with a higher default.
   </td>
   <td>2.4.0</td>
@@ -1314,7 +1314,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.executor.decommmissionLabel<code></td>
+  <td><code>spark.kubernetes.executor.decommmissionLabel</code></td>
   <td>(none)</td>
   <td>
     Label to be applied to pods which are exiting or being decommissioned. Intended for use
@@ -1323,7 +1323,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.3.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.executor.decommmissionLabelValue<code></td>
+  <td><code>spark.kubernetes.executor.decommmissionLabelValue</code></td>
   <td>(none)</td>
   <td>
     Value to be applied with the label when


### PR DESCRIPTION
*This contribution is my original work and I license the work to the project under the project’s open source license.*

### What changes were proposed in this pull request?
Several `<code>` elements in `running-on-kubernetes.md` had typos in their closing tags, causing rendering issues on the HTML site. Example of rendering issue:

https://spark.apache.org/docs/3.2.1/running-on-kubernetes.html#configuration

This PR fixes those typos and resolves the rendering issue.

### Why are the changes needed?
The typo fixes allows the HTML site to render the article correctly.

### Does this PR introduce _any_ user-facing change?
Yes, currently the site shows several headers and closing tags as plain text:
https://spark.apache.org/docs/3.2.1/running-on-kubernetes.html#configuration

This PR allows those headers to be correctly rendered and no longer shows the table's closing tags.


### How was this patch tested?
No tests were added. I did a local build of the site per the instructions and confirmed the HTML renders correctly.
