### PR TITLE
[SPARK-38247][SQL] Unify the output of df.explain and "explain " if plan is command

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -541,7 +541,8 @@ class Dataset[T] private[sql](
     // of evaluation of the Dataset. So just output QueryExecution's query plans here.
 
     // scalastyle:off println
-    println(queryExecution.explainString(ExplainMode.fromString(mode)))
+    println(sparkSession.sessionState.executePlan(queryExecution.logical,
+      CommandExecutionMode.SKIP).explainString(ExplainMode.fromString(mode)))
     // scalastyle:on println
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -522,6 +522,13 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
         "== Analyzed Logical Plan ==\nCreateViewCommand")
     }
   }
+
+  test("SPARK-38247: Unify the output of df.explain and \"explain \" if plan is command") {
+    checkKeywordsNotExistsInExplain(
+      sql("show tables"),
+      ExtendedMode,
+      "CommandResult")
+  }
 }
 
 class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuite {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This pr aims to unify the out of df.explain and "explain" sql if plan is a command

- unify the out of df.explain and "explain" sql if plan is a command
- Make the output of explain unambiguous if plan is a command
 

Lets say have a query like "show tables", we want to explain it -> sql("show tables").explain("extended")

**Before this pr:**
```
== Parsed Logical Plan ==
'ShowTables [namespace#62, tableName#63, isTemporary#64]
+- 'UnresolvedNamespace
== Analyzed Logical Plan ==
namespace: string, tableName: string, isTemporary: boolean
ShowTablesCommand default, [namespace#62, tableName#63, isTemporary#64], false
== Optimized Logical Plan ==
CommandResult [namespace#62, tableName#63, isTemporary#64], Execute ShowTablesCommand, [[default,lt,false], [default,people,false], [default,person,false], [default,rt,false], [default,t,false], [default,t1,false], [default,t10086,false], [default,txtsource,false]]
   +- ShowTablesCommand default, [namespace#62, tableName#63, isTemporary#64], false
== Physical Plan ==
CommandResult [namespace#62, tableName#63, isTemporary#64]
   +- Execute ShowTablesCommand
         +- ShowTablesCommand default, [namespace#62, tableName#63, isTemporary#64], false 
```
**After this pr:**
```
== Parsed Logical Plan ==
'ShowTables [namespace#0, tableName#1, isTemporary#2]
+- 'UnresolvedNamespace
== Analyzed Logical Plan ==
namespace: string, tableName: string, isTemporary: boolean
ShowTables [namespace#0, tableName#1, isTemporary#2]
+- ResolvedNamespace V2SessionCatalog(spark_catalog), [default]
== Optimized Logical Plan ==
ShowTables [namespace#0, tableName#1, isTemporary#2]
+- ResolvedNamespace V2SessionCatalog(spark_catalog), [default]
== Physical Plan ==
ShowTables [namespace#0, tableName#1, isTemporary#2], V2SessionCatalog(spark_catalog), [default] 
```

### Why are the changes needed?
Make the output of `df.explain` unambiguous

### Does this PR introduce _any_ user-facing change?
Yes, improve the out of `df.explain`


### How was this patch tested?
add test
