### PR TITLE
[SPARK-38248][CORE][DSTREAM][PYTHON][SQL] Add `@nowarn` to suppress warnings related to `java.io.Serializable` interface

### DIFF
--- a/core/src/main/scala/org/apache/spark/Partitioner.scala
+++ b/core/src/main/scala/org/apache/spark/Partitioner.scala
@@ -19,6 +19,7 @@ package org.apache.spark
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.math.log10
@@ -250,6 +251,7 @@ class RangePartitioner[K : Ordering : ClassTag, V](
     result
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     val sfactory = SparkEnv.get.serializer
@@ -268,6 +270,7 @@ class RangePartitioner[K : Ordering : ClassTag, V](
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     val sfactory = SparkEnv.get.serializer

--- a/core/src/main/scala/org/apache/spark/SerializableWritable.scala
+++ b/core/src/main/scala/org/apache/spark/SerializableWritable.scala
@@ -19,6 +19,8 @@ package org.apache.spark
 
 import java.io._
 
+import scala.annotation.nowarn
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.ObjectWritable
 import org.apache.hadoop.io.Writable
@@ -33,11 +35,13 @@ class SerializableWritable[T <: Writable](@transient var t: T) extends Serializa
 
   override def toString: String = t.toString
 
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.defaultWriteObject()
     new ObjectWritable(t).write(out)
   }
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
     val ow = new ObjectWritable()

--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -19,6 +19,8 @@ package org.apache.spark
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
+
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
@@ -194,9 +196,11 @@ case class ExceptionFailure(
  */
 private[spark] class ThrowableSerializationWrapper(var exception: Throwable) extends
     Serializable with Logging {
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = {
     out.writeObject(exception)
   }
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = {
     try {
       exception = in.readObject().asInstanceOf[Throwable]

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRDD.scala
@@ -22,6 +22,7 @@ import java.net._
 import java.nio.charset.StandardCharsets
 import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 
+import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
@@ -750,6 +751,7 @@ private[spark] class PythonBroadcast(@transient var path: String) extends Serial
   /**
    * Read data from disks, then copy it to `out`
    */
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.writeLong(broadcastId)
     val in = new FileInputStream(new File(path))
@@ -763,6 +765,7 @@ private[spark] class PythonBroadcast(@transient var path: String) extends Serial
   /**
    * Write data into disk and map it to a broadcast block.
    */
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = {
     broadcastId = in.readLong()
     val blockId = BroadcastBlockId(broadcastId, "python")

--- a/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
+++ b/core/src/main/scala/org/apache/spark/broadcast/TorrentBroadcast.scala
@@ -219,6 +219,7 @@ private[spark] class TorrentBroadcast[T: ClassTag](obj: T, id: Long)
   }
 
   /** Used by the JVM when serializing this object. */
+  @scala.annotation.nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     assertValid()
     out.defaultWriteObject()

--- a/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ApplicationInfo.scala
@@ -52,6 +52,7 @@ private[spark] class ApplicationInfo(
 
   init()
 
+  @scala.annotation.nowarn
   private def readObject(in: java.io.ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
     init()

--- a/core/src/main/scala/org/apache/spark/deploy/master/DriverInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/DriverInfo.scala
@@ -41,6 +41,7 @@ private[deploy] class DriverInfo(
 
   init()
 
+  @scala.annotation.nowarn
   private def readObject(in: java.io.ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
     init()

--- a/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/WorkerInfo.scala
@@ -87,6 +87,7 @@ private[spark] class WorkerInfo(
     }
   }
 
+  @scala.annotation.nowarn
   private def readObject(in: java.io.ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
     init()

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -36,6 +36,7 @@ class CartesianPartition(
   var s2 = rdd2.partitions(s2Index)
   override val index: Int = idx
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent split at the time of task serialization

--- a/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoGroupedRDD.scala
@@ -40,6 +40,7 @@ private[spark] case class NarrowCoGroupSplitDep(
     var split: Partition
   ) extends Serializable {
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent split at the time of task serialization

--- a/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CoalescedRDD.scala
@@ -40,6 +40,7 @@ private[spark] case class CoalescedRDDPartition(
     @transient preferredLocation: Option[String] = None) extends Partition {
   var parents: Seq[Partition] = parentsIndices.map(rdd.partitions(_))
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent partition at the time of task serialization

--- a/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelCollectionRDD.scala
@@ -19,6 +19,7 @@ package org.apache.spark.rdd
 
 import java.io._
 
+import scala.annotation.nowarn
 import scala.collection.Map
 import scala.collection.immutable.NumericRange
 import scala.collection.mutable.ArrayBuffer
@@ -46,6 +47,7 @@ private[spark] class ParallelCollectionPartition[T: ClassTag](
 
   override def index: Int = slice
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
 
@@ -65,6 +67,7 @@ private[spark] class ParallelCollectionPartition[T: ClassTag](
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
 

--- a/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/PartitionerAwareUnionRDD.scala
@@ -39,6 +39,7 @@ class PartitionerAwareUnionRDDPartition(
 
   override def equals(other: Any): Boolean = super.equals(other)
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent partition at the time of task serialization

--- a/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/UnionRDD.scala
@@ -51,6 +51,7 @@ private[spark] class UnionPartition[T: ClassTag](
 
   override val index: Int = idx
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent split at the time of task serialization

--- a/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ZippedPartitionsRDD.scala
@@ -34,6 +34,7 @@ private[spark] class ZippedPartitionsPartition(
   var partitionValues = rdds.map(rdd => rdd.partitions(idx))
   def partitions: Seq[Partition] = partitionValues
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent split at the time of task serialization

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -24,6 +24,7 @@ import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.annotation.Nullable
 
+import scala.annotation.nowarn
 import scala.concurrent.{Future, Promise}
 import scala.reflect.ClassTag
 import scala.util.{DynamicVariable, Failure, Success, Try}
@@ -538,12 +539,14 @@ private[netty] class NettyRpcEndpointRef(
   override def address: RpcAddress =
     if (endpointAddress.rpcAddress != null) endpointAddress.rpcAddress else null
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = {
     in.defaultReadObject()
     nettyEnv = NettyRpcEnv.currentEnv.value
     client = NettyRpcEnv.currentClient.value
   }
 
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = {
     out.defaultWriteObject()
   }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerId.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerId.scala
@@ -85,6 +85,7 @@ class BlockManagerId private (
     topologyInfo_ = if (isTopologyInfoAvailable) Option(in.readUTF()) else None
   }
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def readResolve(): Object = BlockManagerId.getCachedBlockManagerId(this)
 

--- a/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
+++ b/core/src/main/scala/org/apache/spark/storage/StorageLevel.scala
@@ -112,6 +112,7 @@ class StorageLevel private(
     _replication = in.readByte()
   }
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def readResolve(): Object = StorageLevel.getCachedStorageLevel(this)
 

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -188,6 +188,7 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
   }
 
   // Called by Java when deserializing an object
+  @scala.annotation.nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
     if (atDriverSide) {

--- a/core/src/main/scala/org/apache/spark/util/SerializableBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableBuffer.scala
@@ -21,6 +21,8 @@ import java.io.{EOFException, IOException, ObjectInputStream, ObjectOutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 
+import scala.annotation.nowarn
+
 /**
  * A wrapper around a java.nio.ByteBuffer that is serializable through Java serialization, to make
  * it easier to pass ByteBuffers in case class messages.
@@ -29,6 +31,7 @@ private[spark]
 class SerializableBuffer(@transient var buffer: ByteBuffer) extends Serializable {
   def value: ByteBuffer = buffer
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     val length = in.readInt()
     buffer = ByteBuffer.allocate(length)
@@ -44,6 +47,7 @@ class SerializableBuffer(@transient var buffer: ByteBuffer) extends Serializable
     buffer.rewind() // Allow us to read it later
   }
 
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.writeInt(buffer.limit())
     if (Channels.newChannel(out).write(buffer) != buffer.limit()) {

--- a/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableConfiguration.scala
@@ -18,6 +18,8 @@ package org.apache.spark.util
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
+
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.annotation.{DeveloperApi, Unstable}
@@ -29,11 +31,13 @@ import org.apache.spark.annotation.{DeveloperApi, Unstable}
  */
 @DeveloperApi @Unstable
 class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.defaultWriteObject()
     value.write(out)
   }
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     value = new Configuration(false)
     value.readFields(in)

--- a/core/src/main/scala/org/apache/spark/util/SerializableJobConf.scala
+++ b/core/src/main/scala/org/apache/spark/util/SerializableJobConf.scala
@@ -19,15 +19,19 @@ package org.apache.spark.util
 
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
+
 import org.apache.hadoop.mapred.JobConf
 
 private[spark]
 class SerializableJobConf(@transient var value: JobConf) extends Serializable {
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     out.defaultWriteObject()
     value.write(out)
   }
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     value = new JobConf(false)
     value.readFields(in)

--- a/core/src/test/scala/org/apache/spark/FailureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FailureSuite.scala
@@ -276,6 +276,7 @@ class NonSerializableUserException extends RuntimeException {
 }
 
 class NonDeserializableUserException extends RuntimeException {
+  @scala.annotation.nowarn
   private def readObject(in: ObjectInputStream): Unit = {
     throw new IOException("Intentional exception during deserialization.")
   }

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.rdd
 import java.io.{File, IOException, ObjectInputStream, ObjectOutputStream}
 import java.lang.management.ManagementFactory
 
+import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.concurrent.duration._
@@ -1096,10 +1097,12 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
 
   test("task serialization exception should not hang scheduler") {
     class BadSerializable extends Serializable {
+      @nowarn
       @throws(classOf[IOException])
       private def writeObject(out: ObjectOutputStream): Unit =
         throw new KryoException("Bad serialization")
 
+      @nowarn
       @throws(classOf[IOException])
       private def readObject(in: ObjectInputStream): Unit = {}
     }

--- a/core/src/test/scala/org/apache/spark/scheduler/NotSerializableFakeTask.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/NotSerializableFakeTask.scala
@@ -19,6 +19,8 @@ package org.apache.spark.scheduler
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
+
 import org.apache.spark.TaskContext
 
 /**
@@ -30,6 +32,7 @@ private[spark] class NotSerializableFakeTask(myId: Int, stageId: Int)
   override def runTask(context: TaskContext): Array[Byte] = Array.empty[Byte]
   override def preferredLocations: Seq[TaskLocation] = Seq[TaskLocation]()
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(out: ObjectOutputStream): Unit = {
     if (stageId == 0) {
@@ -37,6 +40,7 @@ private[spark] class NotSerializableFakeTask(myId: Int, stageId: Int)
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(in: ObjectInputStream): Unit = {}
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -300,6 +300,7 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
 }
 
 private class UndeserializableException extends Exception {
+  @scala.annotation.nowarn
   private def readObject(in: ObjectInputStream): Unit = {
     // scalastyle:off throwerror
     throw new NoClassDefFoundError()

--- a/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/SerializationDebuggerSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.serializer
 import java.io._
 
 import scala.annotation.meta.param
+import scala.annotation.nowarn
 
 import org.scalatest.BeforeAndAfterEach
 
@@ -186,6 +187,7 @@ class SerializationDebuggerSuite extends SparkFunSuite with BeforeAndAfterEach {
   test("improveException with error in debugger") {
     // Object that throws exception in the SerializationDebugger
     val o = new SerializableClass1 {
+      @nowarn
       private def writeReplace(): Object = {
         throw new Exception()
       }
@@ -218,6 +220,7 @@ class SerializableSubclass(val objectField: Object) extends SerializableClass1
 class SerializableClassWithWriteObject(val objectField: Object) extends Serializable {
   val serializableObjectField = new SerializableClass1
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = {
     oos.defaultWriteObject()
@@ -227,6 +230,7 @@ class SerializableClassWithWriteObject(val objectField: Object) extends Serializ
 
 class SerializableClassWithWriteReplace(@(transient @param) replacementFieldObject: Object)
   extends Serializable {
+  @nowarn
   private def writeReplace(): Object = {
     replacementFieldObject
   }
@@ -234,6 +238,7 @@ class SerializableClassWithWriteReplace(@(transient @param) replacementFieldObje
 
 
 class SerializableClassWithRecursiveWriteReplace extends Serializable {
+  @nowarn
   private def writeReplace(): Object = {
     new SerializableClassWithRecursiveWriteReplace
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateOrdering.scala
@@ -192,6 +192,7 @@ class LazilyGeneratedOrdering(val ordering: Seq[SortOrder])
     generatedOrdering.compare(a, b)
   }
 
+  @scala.annotation.nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     in.defaultReadObject()
     generatedOrdering = GenerateOrdering.generate(ordering)

--- a/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/DStreamGraph.scala
@@ -19,6 +19,7 @@ package org.apache.spark.streaming
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 import scala.collection.parallel.immutable.ParVector
 
@@ -179,6 +180,7 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
     inputStreams.map(_.rememberDuration).filter(_ != null).maxBy(_.milliseconds)
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     logDebug("DStreamGraph.writeObject used")
@@ -191,6 +193,7 @@ final private[streaming] class DStreamGraph extends Serializable with Logging {
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     logDebug("DStreamGraph.readObject used")

--- a/streaming/src/main/scala/org/apache/spark/streaming/api/python/PythonDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/api/python/PythonDStream.scala
@@ -21,6 +21,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import java.lang.reflect.Proxy
 import java.util.{ArrayList => JArrayList, List => JList}
 
+import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 import scala.language.existentials
 
@@ -97,12 +98,14 @@ private[python] class TransformFunction(@transient var pfunc: PythonTransformFun
     resultRDD
   }
 
+  @nowarn
   private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
     val bytes = PythonTransformFunctionSerializer.serialize(pfunc)
     out.writeInt(bytes.length)
     out.write(bytes)
   }
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
     val length = in.readInt()
     val bytes = new Array[Byte](length)

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStream.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming.dstream
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
 import scala.collection.mutable.HashMap
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -509,6 +510,7 @@ abstract class DStream[T: ClassTag] (
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     logDebug(s"${this.getClass().getSimpleName}.writeObject used")
@@ -532,6 +534,7 @@ abstract class DStream[T: ClassTag] (
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     logDebug(s"${this.getClass().getSimpleName}.readObject used")

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala
@@ -19,6 +19,7 @@ package org.apache.spark.streaming.dstream
 
 import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
 import scala.collection.mutable.HashMap
 import scala.reflect.ClassTag
 
@@ -123,6 +124,7 @@ class DStreamCheckpointData[T: ClassTag](dstream: DStream[T])
       currentCheckpointFiles.mkString("\n") + "\n]"
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     logDebug(this.getClass().getSimpleName + ".writeObject used")
@@ -146,6 +148,7 @@ class DStreamCheckpointData[T: ClassTag](dstream: DStream[T])
     }
   }
 
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     logDebug(this.getClass().getSimpleName + ".readObject used")

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/FileInputDStream.scala
@@ -310,6 +310,7 @@ class FileInputDStream[K, V, F <: NewInputFormat[K, V]](
     _fs = null
   }
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     logDebug(this.getClass().getSimpleName + ".readObject used")

--- a/streaming/src/main/scala/org/apache/spark/streaming/dstream/QueueInputDStream.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/dstream/QueueInputDStream.scala
@@ -19,6 +19,7 @@ package org.apache.spark.streaming.dstream
 
 import java.io.{NotSerializableException, ObjectInputStream, ObjectOutputStream}
 
+import scala.annotation.nowarn
 import scala.collection.mutable.{ArrayBuffer, Queue}
 import scala.reflect.ClassTag
 
@@ -37,11 +38,13 @@ class QueueInputDStream[T: ClassTag](
 
   override def stop(): Unit = { }
 
+  @nowarn
   private def readObject(in: ObjectInputStream): Unit = {
     throw new NotSerializableException("queueStream doesn't support checkpointing. " +
       "Please don't use queueStream when checkpointing is enabled.")
   }
 
+  @nowarn
   private def writeObject(oos: ObjectOutputStream): Unit = {
     logWarning("queueStream doesn't support checkpointing")
   }

--- a/streaming/src/main/scala/org/apache/spark/streaming/rdd/MapWithStateRDD.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/rdd/MapWithStateRDD.scala
@@ -98,6 +98,7 @@ private[streaming] class MapWithStateRDDPartition(
     case _ => false
   }
 
+  @scala.annotation.nowarn
   @throws(classOf[IOException])
   private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
     // Update the reference to parent split at the time of task serialization

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/RateController.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/RateController.scala
@@ -54,6 +54,7 @@ private[streaming] abstract class RateController(val streamUID: Int, rateEstimat
     rateLimit = new AtomicLong(-1L)
   }
 
+  @scala.annotation.nowarn
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     ois.defaultReadObject()
     init()

--- a/streaming/src/main/scala/org/apache/spark/streaming/util/StateMap.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/util/StateMap.scala
@@ -19,6 +19,7 @@ package org.apache.spark.streaming.util
 
 import java.io._
 
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
 
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
@@ -312,12 +313,14 @@ private[streaming] class OpenHashMapBasedStateMap[K, S](
     parentStateMap = newParentSessionStore
   }
 
+  @nowarn
   private def writeObject(outputStream: ObjectOutputStream): Unit = {
     // Write all the non-transient fields, especially class tags, etc.
     outputStream.defaultWriteObject()
     writeObjectInternal(outputStream)
   }
 
+  @nowarn
   private def readObject(inputStream: ObjectInputStream): Unit = {
     // Read the non-transient fields, especially class tags, etc.
     inputStream.defaultReadObject()

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -20,6 +20,7 @@ package org.apache.spark.streaming
 import java.io.{IOException, ObjectInputStream}
 import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 
+import scala.annotation.nowarn
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
@@ -101,6 +102,7 @@ class TestOutputStream[T: ClassTag](
   }, false) {
 
   // This is to clear the output buffer every it is read from a checkpoint
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     ois.defaultReadObject()
@@ -125,6 +127,7 @@ class TestOutputStreamWithPartitions[T: ClassTag](
   }, false) {
 
   // This is to clear the output buffer every it is read from a checkpoint
+  @nowarn
   @throws(classOf[IOException])
   private def readObject(ois: ObjectInputStream): Unit = Utils.tryOrIOException {
     ois.defaultReadObject()


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are 5 api related to `java.io.Serializable` interface:

- private void writeObject(java.io.ObjectOutputStream out) throws IOException
- private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException;
- private void readObjectNoData() throws ObjectStreamException;
- ANY-ACCESS-MODIFIER Object writeReplace() throws ObjectStreamException;
- ANY-ACCESS-MODIFIER Object readResolve() throws ObjectStreamException;

And the implementations of these methods is mistaken for unused in Spark code, for example Intellij identify them as `Declaration is never used` and in we enabled the compilation options related to `unused`, there will also be relevant compilation warning log.

So this pr add `@nowarn` for this method to suppress related warnings, the added rules are as follows:

- If it has one instance in a file, it uses it without importing (@scala.annotation.nowarn)
- If it has more than one instances, it imports


### Why are the changes needed?
Suppress unwanted warnings



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA