### PR TITLE
[SPARK-38175][CORE][FOLLOWUP]  Remove `urlPattern` from `HistoryAppStatusStore#replaceLogUrls` method signature

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryAppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryAppStatusStore.scala
@@ -44,9 +44,10 @@ private[spark] class HistoryAppStatusStore(
 
   override def executorList(activeOnly: Boolean): Seq[v1.ExecutorSummary] = {
     val execList = super.executorList(activeOnly)
-    logUrlPattern match {
-      case Some(_) => execList.map(replaceLogUrls)
-      case None => execList
+    if (logUrlPattern.nonEmpty) {
+      execList.map(replaceLogUrls)
+    } else {
+      execList
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryAppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryAppStatusStore.scala
@@ -45,7 +45,7 @@ private[spark] class HistoryAppStatusStore(
   override def executorList(activeOnly: Boolean): Seq[v1.ExecutorSummary] = {
     val execList = super.executorList(activeOnly)
     logUrlPattern match {
-      case Some(pattern) => execList.map(replaceLogUrls(_, pattern))
+      case Some(_) => execList.map(replaceLogUrls)
       case None => execList
     }
   }
@@ -53,12 +53,12 @@ private[spark] class HistoryAppStatusStore(
   override def executorSummary(executorId: String): v1.ExecutorSummary = {
     val execSummary = super.executorSummary(executorId)
     logUrlPattern match {
-      case Some(pattern) => replaceLogUrls(execSummary, pattern)
+      case Some(_) => replaceLogUrls(execSummary)
       case None => execSummary
     }
   }
 
-  private def replaceLogUrls(exec: v1.ExecutorSummary, urlPattern: String): v1.ExecutorSummary = {
+  private def replaceLogUrls(exec: v1.ExecutorSummary): v1.ExecutorSummary = {
     val newLogUrlMap = logUrlHandler.applyPattern(exec.executorLogs, exec.attributes)
     replaceExecutorLogs(exec, newLogUrlMap)
   }

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryAppStatusStore.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryAppStatusStore.scala
@@ -52,9 +52,10 @@ private[spark] class HistoryAppStatusStore(
 
   override def executorSummary(executorId: String): v1.ExecutorSummary = {
     val execSummary = super.executorSummary(executorId)
-    logUrlPattern match {
-      case Some(_) => replaceLogUrls(execSummary)
-      case None => execSummary
+    if (logUrlPattern.nonEmpty) {
+      replaceLogUrls(execSummary)
+    } else {
+      execSummary
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr is a followup of SPARK-38175 to remove `urlPattern` from `HistoryAppStatusStore#replaceLogUrls` method signature


### Why are the changes needed?
Cleanup unused symbol.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GA