### PR TITLE
[MINOR][DOCS][3.2] Fixed closing tags in running-on-kubernetes.md

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1289,7 +1289,7 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.executor.scheduler.name<code></td>
+  <td><code>spark.kubernetes.executor.scheduler.name</code></td>
   <td>(none)</td>
   <td>
 	Specify the scheduler name for each executor pod.


### PR DESCRIPTION


### What changes were proposed in this pull request?
Per [feedback](https://github.com/apache/spark/pull/35561#issuecomment-1043663966) on #35561 from @dongjoon-hyun, I'm back porting fixes from `master` to `branch-3.2` since there was a conflict. From original PR:

> Several `<code>` elements in running-on-kubernetes.md had typos in their closing tags, causing rendering issues on the HTML site. Example of rendering issue:
> 
> https://spark.apache.org/docs/3.2.1/running-on-kubernetes.html#configuration
>
> This PR fixes those typos and resolves the rendering issue.

### Why are the changes needed?

Changes from #35561 were in conflict with `branch-3.2`. From original PR:

> The typo fixes allows the HTML site to render the article correctly.


### Does this PR introduce _any_ user-facing change?
From original PR: 

> Yes, currently the site shows several headers and closing tags as plain text:
> https://spark.apache.org/docs/3.2.1/running-on-kubernetes.html#configuration
> 
> This PR allows those headers to be correctly rendered and no longer shows the table's closing tags.


### How was this patch tested?
No tests were added. I did a local build of the site per the instructions and confirmed the HTML renders correctly.
