### PR TITLE
[MINOR][DOCS] fix default value of history server

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -357,7 +357,7 @@ Security options for the Spark History Server are covered more detail in the
   </tr>
   <tr>
     <td>spark.history.custom.executor.log.url.applyIncompleteApplication</td>
-    <td>false</td>
+    <td>true</td>
     <td>
         Specifies whether to apply custom spark executor log URL to incomplete applications as well.
         If executor logs for running applications should be provided as origin log URLs, set this to `false`.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Alignment between the documentation and the code.

### Why are the changes needed?

The [actual default value ](https://github.com/apache/spark/blame/master/core/src/main/scala/org/apache/spark/internal/config/History.scala#L198) for `spark.history.custom.executor.log.url.applyIncompleteApplication` is `true` and not `false` as stated in the documentation. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
N/A


