### PR TITLE
[SPARK-38260][BUILD][CORE] Remove `commons-net` dependency in `hadoop-3` profile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -251,10 +251,6 @@
       <artifactId>RoaringBitmap</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-net</groupId>
-      <artifactId>commons-net</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-xml_${scala.binary.version}</artifactId>
     </dependency>

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -49,7 +49,6 @@ commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
-commons-net/3.1//commons-net-3.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.9//commons-text-1.9.jar
 compress-lzf/1.0.3//compress-lzf-1.0.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -804,11 +804,6 @@
         <version>0.9.23</version>
       </dependency>
       <dependency>
-        <groupId>commons-net</groupId>
-        <artifactId>commons-net</artifactId>
-        <version>3.1</version>
-      </dependency>
-      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>4.1.73.Final</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
[SPARK-1189](https://github.com/apache/spark/pull/33/files)  introduces maven dependence on `commons-net`, and `org.apache.commons.net.util.Base64` is used in `SparkSaslServer`,  but `SparkSaslServer` has changed to use `io.netty.handler.codec.base64.Base64` and there is no explicit dependency on `commons-net` in Spark code, so this pr removed this dependency.

After this pr Spark with `hadoop-3` profile no longer need `commons-net`, but Spark with `hadoop-2` still need it due to `hadoop-2.7.4` use `commons-net` directly.

### Why are the changes needed?
Remove unnecessary maven dependency.




### Does this PR introduce _any_ user-facing change?
`commons-net` jar no longer exists in Spark-Client with hadoop-3.x 




### How was this patch tested?
Pass GA
