### PR TITLE
[SPARK-38261][INFRA] Add missing R packages from base image

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -533,7 +533,7 @@ jobs:
         python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8'
         apt-get update -y
         apt-get install -y ruby ruby-dev
-        Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'roxygen2'), repos='https://cloud.r-project.org/')"
+        Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'e1071', 'roxygen2'), repos='https://cloud.r-project.org/')"
         Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
         Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
         gem install bundler


### PR DESCRIPTION
Current GitHub workflow job **Linters, licenses, dependencies and documentation generation** is missing R packages to complete Documentation and API build.

**Build and test** -  is not failing as these packages are installed on the base image.

We need to keep them in-sync IMO with the base image for easy switch back to ubuntu runner when ready.

Reference: [**The base image**](https://hub.docker.com/layers/dongjoon/apache-spark-github-action-image/20220207/images/sha256-af09d172ff8e2cbd71df9a1bc5384a47578c4a4cc293786c539333cafaf4a7ce?context=explore)


### What changes were proposed in this pull request?
Adding missing packages to the workflow file 


### Why are the changes needed?
To make them inline with the base image config and make the job task **complete** for standalone execution (i.e. without this image)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GitHub builds and in the local Docker containers
