### PR TITLE
[SPARK-38271] PoissonSampler may output more rows than MaxRows

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1347,6 +1347,8 @@ case class Sample(
   }
 
   override def maxRows: Option[Long] = {
+    // when withReplacement is true, PoissonSampler is applied in SampleExec,
+    // which can not guarantee the number of output rows less than or equal to child.maxRows.
     if (withReplacement) None else child.maxRows
   }
   override def output: Seq[Attribute] = child.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1348,7 +1348,7 @@ case class Sample(
 
   override def maxRows: Option[Long] = {
     // when withReplacement is true, PoissonSampler is applied in SampleExec,
-    // which can not guarantee the number of output rows less than or equal to child.maxRows.
+    // which may output more rows than child.maxRows.
     if (withReplacement) None else child.maxRows
   }
   override def output: Seq[Attribute] = child.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1346,7 +1346,9 @@ case class Sample(
       s"Sampling fraction ($fraction) must be on interval [0, 1] without replacement")
   }
 
-  override def maxRows: Option[Long] = child.maxRows
+  override def maxRows: Option[Long] = {
+    if (withReplacement) None else child.maxRows
+  }
   override def output: Seq[Attribute] = child.output
 
   override protected def withNewChildInternal(newChild: LogicalPlan): Sample =


### PR DESCRIPTION
### What changes were proposed in this pull request?
when `replacement=true`, `Sample.maxRows` returns `None`


### Why are the changes needed?
the underlying impl of `SampleExec` can not guarantee that its number of output rows <= `Sample.maxRows`

```
scala> val df = spark.range(0, 1000)
df: org.apache.spark.sql.Dataset[Long] = [id: bigint]

scala> df.count
res0: Long = 1000

scala> df.sample(true, 0.999999, 10).count
res1: Long = 1004
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing testsuites