### PR TITLE
[SPARK-38274][BUILD] Upgarde `JUnit4` to `4.13.2` and upgrade corresponding `junit-interface` to `0.13.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.novocode</groupId>
+      <groupId>com.github.sbt</groupId>
       <artifactId>junit-interface</artifactId>
       <scope>test</scope>
     </dependency>
@@ -1128,7 +1128,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1144,9 +1144,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.novocode</groupId>
+        <groupId>com.github.sbt</groupId>
         <artifactId>junit-interface</artifactId>
-        <version>0.11</version>
+        <version>0.13.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1227,7 +1227,7 @@ object TestSettings {
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-W", "120", "300"),
     (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // Enable Junit testing.
-    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
+    libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % "test",
     // `parallelExecutionInTest` controls whether test suites belonging to the same SBT project
     // can run in parallel with one another. It does NOT control whether tests execute in parallel
     // within the same JVM (which is controlled by `testForkedParallel`) or whether test cases


### PR DESCRIPTION
### What changes were proposed in this pull request?
The main change of this pr as follows:

- Upgarde `Junit4` to `4.13.2`: https://github.com/junit-team/junit4/blob/HEAD/doc/ReleaseNotes4.13.2.md
- Change  `junit-interface` groupId from `com.novocode` to  `com.github.sbt` due to the organization name has changed to "com.github.sbt" in 0.12 and upgrade `junit-interface` version to `0.13.3` refer to [https://github.com/sbt/junit-interface/#setup](https://github.com/sbt/junit-interface/#setup)

### Why are the changes needed?
Upgarde test framework.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA