### PR TITLE
[SPARK-38278][PYTHON] Add SparkContext.addArchive in PySpark

### DIFF
--- a/python/docs/source/reference/pyspark.rst
+++ b/python/docs/source/reference/pyspark.rst
@@ -53,6 +53,7 @@ Spark Context APIs
 
     SparkContext.PACKAGE_EXTENSIONS
     SparkContext.accumulator
+    SparkContext.addArchive
     SparkContext.addFile
     SparkContext.addPyFile
     SparkContext.applicationId

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1294,10 +1294,10 @@ class SparkContext:
         Notes
         -----
         A path can be added only once. Subsequent additions of the same path are ignored.
+        This API is experimental.
 
         Examples
         --------
-
         Creates a zipped file that contains a text file written '100'.
 
         >>> import zipfile
@@ -1310,7 +1310,8 @@ class SparkContext:
         ...     zipped.write(path, os.path.basename(path))
         >>> sc.addArchive(zip_path)
 
-        Read '100' as an integer and process with the data in the RDD.
+        Reads the '100' as an integer in the zipped file, and processes
+        it with the data in the RDD.
 
         >>> def func(iterator):
         ...    with open("%s/test.txt" % SparkFiles.get("test.zip")) as f:
@@ -1318,10 +1319,6 @@ class SparkContext:
         ...        return [x * int(v) for x in iterator]
         >>> sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
         [100, 200, 300, 400]
-
-        Notes
-        -----
-        This API is experimental.
         """
         self._jsc.sc().addArchive(path)
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -1278,6 +1278,53 @@ class SparkContext:
 
         importlib.invalidate_caches()
 
+    def addArchive(self, path: str) -> None:
+        """
+        Add an archive to be downloaded with this Spark job on every node.
+        The `path` passed can be either a local file, a file in HDFS
+        (or other Hadoop-supported filesystems), or an HTTP, HTTPS or
+        FTP URI.
+
+        To access the file in Spark jobs, use :meth:`SparkFiles.get` with the
+        filename to find its download/unpacked location. The given path should
+        be one of .zip, .tar, .tar.gz, .tgz and .jar.
+
+        .. versionadded:: 3.3.0
+
+        Notes
+        -----
+        A path can be added only once. Subsequent additions of the same path are ignored.
+
+        Examples
+        --------
+
+        Creates a zipped file that contains a text file written '100'.
+
+        >>> import zipfile
+        >>> from pyspark import SparkFiles
+        >>> path = os.path.join(tempdir, "test.txt")
+        >>> zip_path = os.path.join(tempdir, "test.zip")
+        >>> with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipped:
+        ...     with open(path, "w") as f:
+        ...         _ = f.write("100")
+        ...     zipped.write(path, os.path.basename(path))
+        >>> sc.addArchive(zip_path)
+
+        Read '100' as an integer and process with the data in the RDD.
+
+        >>> def func(iterator):
+        ...    with open("%s/test.txt" % SparkFiles.get("test.zip")) as f:
+        ...        v = int(f.readline())
+        ...        return [x * int(v) for x in iterator]
+        >>> sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
+        [100, 200, 300, 400]
+
+        Notes
+        -----
+        This API is experimental.
+        """
+        self._jsc.sc().addArchive(path)
+
     def setCheckpointDir(self, dirName: str) -> None:
         """
         Set the directory under which RDDs are going to be checkpointed. The


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `SparkContext.addArchive` in PySpark side that's added in https://github.com/apache/spark/pull/30486.

### Why are the changes needed?

To have the same API parity with the Scala side.

### Does this PR introduce _any_ user-facing change?

Yes, this PR exposes an API (`SparkContext.addArchive`) that exists in Scala side.

### How was this patch tested?

Doctest was added.