### PR TITLE
[SPARK-38281][SQL][Tests] Fix AnalysisSuite under ANSI mode

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -221,7 +221,9 @@ class AnalysisSuite extends AnalysisTest with Matchers {
     val pl = plan.asInstanceOf[Project].projectList
 
     assert(pl(0).dataType == DoubleType)
-    assert(pl(1).dataType == DoubleType)
+    if (!SQLConf.get.ansiEnabled) {
+      assert(pl(1).dataType == DoubleType)
+    }
     assert(pl(2).dataType == DoubleType)
     assert(pl(3).dataType == DoubleType)
     assert(pl(4).dataType == DoubleType)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the org.apache.spark.sql.catalyst.analysis.AnalysisSuite under ANSI mode.
With ANSI on, there won't be a type cast on string a / string b. Make the cast assertion only when ANSI is off.

### Why are the changes needed?
To set up a new GA job to run tests with ANSI mode before 3.3.0 release.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test locally with both ANSI on and off, both passed.
