### PR TITLE
[SPARK-38291][BUILD][TESTS] Upgrade `postgresql` from 42.3.0 to 42.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1181,7 +1181,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.0</version>
+        <version>42.3.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Postgresql 42.3.0 to 42.3.3
[Postgresql changelog 42.3.3](https://jdbc.postgresql.org/documentation/changelog.html#version_42.3.3)

### Why are the changes needed?
[CVE-2022-21724](https://nvd.nist.gov/vuln/detail/CVE-2022-21724)
and 
[Arbitrary File Write Vulnerability](https://github.com/advisories/GHSA-673j-qm5f-xpv8)

By upgrading postgresql from 42.3.0 to 42.3.3 we will resolve these issues. 


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
All test must pass. 