### PR TITLE
[SPARK-38297][PYTHON] Explicitly cast the return value at DataFrame.to_numpy in POS

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -582,7 +582,7 @@ class Frame(object, metaclass=ABCMeta):
             "`to_numpy` loads all data into the driver's memory. "
             "It should only be used if the resulting NumPy ndarray is expected to be small."
         )
-        return self._to_pandas().values
+        return cast(np.ndarray, self._to_pandas().values)
 
     @property
     def values(self) -> np.ndarray:


### PR DESCRIPTION
### What changes were proposed in this pull request?

MyPy build currently fails as below:

```
starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/pandas/generic.py:585: error: Incompatible return value type (got "Union[ndarray[Any, Any], ExtensionArray]", expected "ndarray[Any, Any]")  [return-value]
Found 1 error in 1 file (checked 324 source files)
1
```

https://github.com/apache/spark/runs/5298261168?check_suite_focus=true

I tried to reproduce in my local by matching NumPy and MyPy versions but failed. So I decided to work around the problem first by explicitly casting to make MyPy happy.

### Why are the changes needed?

To make the build pass.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should verify if it's fixed.