### PR TITLE
[SPArK-38294][SQL] DDLUtils.verifyNotReadPath should check target is subDir

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -971,7 +971,7 @@ object DDLUtils extends Logging {
     }
   }
 
-  private def isSameOrSubDir(p1: Path, p2: Path, fs: FileSystem): Boolean = {
+  private def isSubDir(p1: Path, p2: Path, fs: FileSystem): Boolean = {
     val path1 = fs.makeQualified(p1).toString + Path.SEPARATOR
     val path2 = fs.makeQualified(p2).toString + Path.SEPARATOR
     path1.startsWith(path2)
@@ -988,7 +988,7 @@ object DDLUtils extends Logging {
 
     val hadoopConf = SparkSession.getActiveSession.get.sessionState.newHadoopConf()
     val fs = outputPath.getFileSystem(hadoopConf)
-    if (inputPaths.exists(path => isSameOrSubDir(outputPath, path, fs))) {
+    if (inputPaths.exists(path => isSubDir(outputPath, path, fs))) {
       throw QueryCompilationErrors.cannotOverwritePathBeingReadFromError()
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/ddl.scala
@@ -971,6 +971,12 @@ object DDLUtils extends Logging {
     }
   }
 
+  private def isSameOrSubDir(p1: Path, p2: Path, fs: FileSystem): Boolean = {
+    val path1 = fs.makeQualified(p1).toString + Path.SEPARATOR
+    val path2 = fs.makeQualified(p2).toString + Path.SEPARATOR
+    path1.startsWith(path2)
+  }
+
   /**
    * Throws exception if outputPath tries to overwrite inputpath.
    */
@@ -980,7 +986,9 @@ object DDLUtils extends Logging {
         r.location.rootPaths
     }.flatten
 
-    if (inputPaths.contains(outputPath)) {
+    val hadoopConf = SparkSession.getActiveSession.get.sessionState.newHadoopConf()
+    val fs = outputPath.getFileSystem(hadoopConf)
+    if (inputPaths.exists(path => isSameOrSubDir(outputPath, path, fs))) {
       throw QueryCompilationErrors.cannotOverwritePathBeingReadFromError()
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1100,7 +1100,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
 
   test("SPARK-38294: DDLUtils.verifyNotReadPath should check target is subDir") {
     withTempPath { path =>
-      withTable("t1", "t2", "t3", "t4") {
+      withTable("t1", "t2") {
         sql(
           s"""
              |CREATE TABLE t1 (id STRING, dt STRING)
@@ -1111,30 +1111,16 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         sql("INSERT OVERWRITE TABLE t1 PARTITION(dt='2020-09-09') SELECT 10")
         sql("INSERT OVERWRITE TABLE t1 PARTITION(dt='2020-09-10') SELECT 1")
 
-        // non partition table with different path
         sql(
           s"""
              |CREATE TABLE t2 (id STRING)
              |USING PARQUET
-             |LOCATION '${path.getAbsolutePath}/dt=2020-09-08'
+             |LOCATION '${path.getAbsolutePath}/dt=2020-09-09'
             """.stripMargin)
         val e1 = intercept[AnalysisException] {
           sql("INSERT OVERWRITE TABLE t2 SELECT id FROM t1 WHERE dt='2020-09-10'")
         }
         assert(e1.getMessage.contains("Cannot overwrite a path that is also being read from."))
-
-        // non partition table with same path
-        sql(
-          s"""
-             |CREATE TABLE t3 (id string)
-             |USING PARQUET
-             |LOCATION '${path.getAbsolutePath}/dt=2020-09-10'
-            """.stripMargin)
-        sql("INSERT OVERWRITE TABLE t1 PARTITION(dt='2020-09-10') SELECT 1")
-        val e2 = intercept[AnalysisException] {
-          sql("INSERT OVERWRITE TABLE t3 SELECT id FROM t1 WHERE dt='2020-09-10'")
-        }
-        assert(e2.getMessage.contains("Cannot overwrite a path that is also being read from."))
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.util.Locale
 
 import com.google.common.io.Files
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{Path, UnsupportedFileSystemException}
 import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
 
 import org.apache.spark.SparkException
@@ -690,7 +690,7 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
     withTempView("test_insert_table") {
       spark.range(10).selectExpr("id", "id AS str").createOrReplaceTempView("test_insert_table")
 
-      val e = intercept[IllegalArgumentException] {
+      val e = intercept[UnsupportedFileSystemException] {
         sql(
           s"""
              |INSERT OVERWRITE LOCAL DIRECTORY 'abc://a'
@@ -699,7 +699,7 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
            """.stripMargin)
       }.getMessage
 
-      assert(e.contains("Wrong FS: abc://a, expected: file:///"))
+      assert(e.contains("No FileSystem for scheme \"abc\""))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When user define a table A and  table location is another table B 's partition path. If user want to insert data to A table with B table's this partition's data, will directly clean the data under table A's location, an cause B's data loss.
 
```
[info]   Cause: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 14.0 failed 1 times, most recent failure: Lost task 0.0 in stage 14.0 (TID 15) (10.12.190.176 executor driver): org.apache.spark.SparkException: Task failed while writing rows.
[info] 	at org.apache.spark.sql.errors.QueryExecutionErrors$.taskFailedWhileWritingRowsError(QueryExecutionErrors.scala:577)
[info] 	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.executeTask(FileFormatWriter.scala:345)
[info] 	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$write$20(FileFormatWriter.scala:252)
[info] 	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
[info] 	at org.apache.spark.scheduler.Task.run(Task.scala:136)
[info] 	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:507)
[info] 	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1475)
[info] 	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:510)
[info] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[info] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[info] 	at java.lang.Thread.run(Thread.java:748)
[info] Caused by: java.io.FileNotFoundException:
[info] File file:/Users/yi.zhu/Documents/project/Angerszhuuuu/spark/target/tmp/spark-f1c6b035-e585-4c0e-9b83-17ad54e85978/dt=2020-09-10/part-00000-855b7af4-fe2b-4933-807a-6bf40eab11ba.c000.snappy.parquet does not exist
[info]
[info] It is possible the underlying files have been updated. You can explicitly invalidate
[info] the cache in Spark by running 'REFRESH TABLE tableName' command in SQL or by
[info] recreating the Dataset/DataFrame involved.
[info]
[info] 	at org.apache.spark.sql.errors.QueryExecutionErrors$.readCurrentFileNotFoundError(QueryExecutionErrors.scala:583)
[info] 	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.org$apache$spark$sql$execution$datasources$FileScanRDD$$anon$$readCurrentFile(FileScanRDD.scala:212)
[info] 	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.nextIterator(FileScanRDD.scala:270)
[info] 	at org.apache.spark.sql.execution.datasources.FileScanRDD$$anon$1.hasNext(FileScanRDD.scala:116)
[info] 	at org.apache.spark.sql.execution.FileSourceScanExec$$anon$1.hasNext(DataSourceScanExec.scala:548)
[info] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.columnartorow_nextBatch_0$(Unknown Source)
[info] 	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
[info] 	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
[info] 	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.hasNext(WholeStageCodegenExec.scala:760)
[info] 	at org.apache.spark.sql.execution.datasources.FileFormatDataWriter.writeWithIterator(FileFormatDataWriter.scala:91)
[info] 	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$executeTask$1(FileFormatWriter.scala:328)
[info] 	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1509)
[info] 	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.executeTask(FileFormatWriter.scala:335)
[info] 	... 9 more
[info]
```

When verify path, we should check if target path is read path's subdir too

### Why are the changes needed?
Avoid potential data loss.



### Does this PR introduce _any_ user-facing change?
User can't insert overwrite table under read path


### How was this patch tested?
Added UT
