### PR TITLE
[SPARK-37923][SQL][FOLLOWUP] Rename MultipleBucketTransformsError in QueryExecutionErrors to multipleBucketTransformsError

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogV2Implicits.scala
@@ -60,7 +60,7 @@ private[sql] object CatalogV2Implicits {
           identityCols += col
 
         case BucketTransform(numBuckets, col, sortCol) =>
-          if (bucketSpec.nonEmpty) throw QueryExecutionErrors.MultipleBucketTransformsError
+          if (bucketSpec.nonEmpty) throw QueryExecutionErrors.multipleBucketTransformsError
           if (sortCol.isEmpty) {
             bucketSpec = Some(BucketSpec(numBuckets, col.map(_.fieldNames.mkString(".")), Nil))
           } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1951,7 +1951,7 @@ object QueryExecutionErrors {
       s"The input string '$input' does not match the given number format: '$format'")
   }
 
-  def MultipleBucketTransformsError(): Throwable = {
+  def multipleBucketTransformsError(): Throwable = {
     new UnsupportedOperationException("Multiple bucket transforms are not supported.")
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-37923 defines `QueryExecutionErrors.MultipleBucketTransformsError`,  but the function name should start with lowercase letter, to this method rename `MultipleBucketTransformsError` to `multipleBucketTransformsError`.



### Why are the changes needed?
function name should start with lowercase letter.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA