### PR TITLE
[SPARK-38240][SQL][FOLLOW-UP] Make RuntimeReplaceableAggregate as an add-on of AggregateFunction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -344,9 +344,10 @@ object FunctionRegistry {
   //     will be replaced by the actual expression at the end of analysis. See `Left` as an example.
   //   - The function can be implemented by combining some existing expressions. We can use
   //     `RuntimeReplaceable` to define the combination. See `ParseToDate` as an example.
-  //     We can also inherit the analysis behavior from the replacement expression, by
-  //     mixing `InheritAnalysisRules`. See `TryAdd` as an example.
-  //   - Similarly, we can use `RuntimeReplaceableAggregate` to implement new aggregate functions.
+  //     To inherit the analysis behavior from the replacement expression
+  //     mix-in `InheritAnalysisRules` with `RuntimeReplaceable`. See `TryAdd` as an example.
+  //   - For `AggregateFunction`, `RuntimeReplaceableAggregate` should be mixed-in. See
+  //     `CountIf` as an example.
   //
   // Sometimes, multiple functions share the same/similar expression replacement logic and it's
   // tedious to create many similar `RuntimeReplaceable` expressions. We can use `ExpressionBuilder`

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -390,17 +390,17 @@ trait InheritAnalysisRules extends UnaryLike[Expression] { self: RuntimeReplacea
 }
 
 /**
- * An aggregate expression that gets rewritten (currently by the optimizer) into a
+ * An add-on of [[AggregateFunction]]. This gets rewritten (currently by the optimizer) into a
  * different aggregate expression for evaluation. This is mainly used to provide compatibility
  * with other databases. For example, we use this to support every, any/some aggregates by rewriting
  * them with Min and Max respectively.
  */
-abstract class RuntimeReplaceableAggregate extends AggregateFunction with RuntimeReplaceable {
-  def aggBufferSchema: StructType = throw new IllegalStateException(
+trait RuntimeReplaceableAggregate extends RuntimeReplaceable { self: AggregateFunction =>
+  override def aggBufferSchema: StructType = throw new IllegalStateException(
     "RuntimeReplaceableAggregate.aggBufferSchema should not be called")
-  def aggBufferAttributes: Seq[AttributeReference] = throw new IllegalStateException(
+  override def aggBufferAttributes: Seq[AttributeReference] = throw new IllegalStateException(
     "RuntimeReplaceableAggregate.aggBufferAttributes should not be called")
-  def inputAggBufferAttributes: Seq[AttributeReference] = throw new IllegalStateException(
+  override def inputAggBufferAttributes: Seq[AttributeReference] = throw new IllegalStateException(
     "RuntimeReplaceableAggregate.inputAggBufferAttributes should not be called")
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
@@ -34,8 +34,7 @@ import org.apache.spark.sql.types.{AbstractDataType, BooleanType}
   """,
   group = "agg_funcs",
   since = "3.0.0")
-case class CountIf(
-    child: Expression)
+case class CountIf(child: Expression)
   extends AggregateFunction
   with RuntimeReplaceableAggregate
   with ImplicitCastInputTypes

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
@@ -34,8 +34,12 @@ import org.apache.spark.sql.types.{AbstractDataType, BooleanType}
   """,
   group = "agg_funcs",
   since = "3.0.0")
-case class CountIf(child: Expression) extends RuntimeReplaceableAggregate
-  with ImplicitCastInputTypes with UnaryLike[Expression] {
+case class CountIf(
+    child: Expression)
+  extends AggregateFunction
+  with RuntimeReplaceableAggregate
+  with ImplicitCastInputTypes
+  with UnaryLike[Expression] {
   override lazy val replacement: Expression = Count(new NullIf(child, Literal.FalseLiteral))
   override def nodeName: String = "count_if"
   override def inputTypes: Seq[AbstractDataType] = Seq(BooleanType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/boolAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/boolAggregates.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types._
   """,
   group = "agg_funcs",
   since = "3.0.0")
-case class BoolAnd(child: Expression) extends RuntimeReplaceableAggregate
+case class BoolAnd(child: Expression) extends AggregateFunction with RuntimeReplaceableAggregate
   with ImplicitCastInputTypes with UnaryLike[Expression] {
   override lazy val replacement: Expression = Min(child)
   override def nodeName: String = "bool_and"
@@ -56,7 +56,7 @@ case class BoolAnd(child: Expression) extends RuntimeReplaceableAggregate
   """,
   group = "agg_funcs",
   since = "3.0.0")
-case class BoolOr(child: Expression) extends RuntimeReplaceableAggregate
+case class BoolOr(child: Expression) extends AggregateFunction with RuntimeReplaceableAggregate
   with ImplicitCastInputTypes with UnaryLike[Expression] {
   override lazy val replacement: Expression = Max(child)
   override def nodeName: String = "bool_or"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
@@ -36,8 +36,13 @@ import org.apache.spark.sql.types.{AbstractDataType, NumericType}
   """,
   group = "agg_funcs",
   since = "3.3.0")
-case class RegrCount(left: Expression, right: Expression)
-  extends RuntimeReplaceableAggregate with ImplicitCastInputTypes with BinaryLike[Expression] {
+case class RegrCount(
+    left: Expression,
+    right: Expression)
+  extends AggregateFunction
+  with RuntimeReplaceableAggregate
+  with ImplicitCastInputTypes
+  with BinaryLike[Expression] {
   override lazy val replacement: Expression = Count(Seq(left, right))
   override def nodeName: String = "regr_count"
   override def inputTypes: Seq[AbstractDataType] = Seq(NumericType, NumericType)
@@ -65,8 +70,13 @@ case class RegrCount(left: Expression, right: Expression)
   group = "agg_funcs",
   since = "3.3.0")
 // scalastyle:on line.size.limit
-case class RegrAvgX(left: Expression, right: Expression)
-  extends RuntimeReplaceableAggregate with ImplicitCastInputTypes with BinaryLike[Expression] {
+case class RegrAvgX(
+    left: Expression,
+    right: Expression)
+  extends AggregateFunction
+  with RuntimeReplaceableAggregate
+  with ImplicitCastInputTypes
+  with BinaryLike[Expression] {
   override lazy val replacement: Expression =
     Average(If(And(IsNotNull(left), IsNotNull(right)), right, Literal.create(null, right.dataType)))
   override def nodeName: String = "regr_avgx"
@@ -95,8 +105,13 @@ case class RegrAvgX(left: Expression, right: Expression)
   group = "agg_funcs",
   since = "3.3.0")
 // scalastyle:on line.size.limit
-case class RegrAvgY(left: Expression, right: Expression)
-  extends RuntimeReplaceableAggregate with ImplicitCastInputTypes with BinaryLike[Expression] {
+case class RegrAvgY(
+    left: Expression,
+    right: Expression)
+  extends AggregateFunction
+  with RuntimeReplaceableAggregate
+  with ImplicitCastInputTypes
+  with BinaryLike[Expression] {
   override lazy val replacement: Expression =
     Average(If(And(IsNotNull(left), IsNotNull(right)), left, Literal.create(null, left.dataType)))
   override def nodeName: String = "regr_avgy"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
@@ -36,9 +36,7 @@ import org.apache.spark.sql.types.{AbstractDataType, NumericType}
   """,
   group = "agg_funcs",
   since = "3.3.0")
-case class RegrCount(
-    left: Expression,
-    right: Expression)
+case class RegrCount(left: Expression, right: Expression)
   extends AggregateFunction
   with RuntimeReplaceableAggregate
   with ImplicitCastInputTypes


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/35534 (https://github.com/apache/spark/pull/35534#discussion_r809708015) that proposes to make `RuntimeReplaceableAggregate` as an add-on of `AggregateFunction`. 

Now, `ReplaceableAggregateFunction` is a mix-in for `AggregateFunction` that makes the expression can be replaced runtime.

### Why are the changes needed?

To make the hierarchy of class similar.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

I tested that it compiles fine. CI in this PR will test it out.
