### PR TITLE
[SPARK-38287][BUILD][SQL][TESTS] Upgrade `h2` from 2.0.204 to 2.1.210 in /sql/core

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -153,7 +153,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.0.204</version>
+      <version>2.1.210</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bump h2 from 2.0.204 to 2.1.210 in /sql/core

### Why are the changes needed?
[Arbitrary code execution in H2 Console](https://github.com/advisories/GHSA-45hx-wfhj-473x)
and   
[CVE-2021-42392](https://nvd.nist.gov/vuln/detail/CVE-2021-42392)
 
### Does this PR introduce _any_ user-facing change?
Some users use remote security scanners and this is one of the issues that comes up. How this can do some damage with spark is highly uncertain. but let's remove the uncertainty that any user may have.


### How was this patch tested?
All test must pass.
