### PR TITLE
[SPARK-38296][SQL] Support error class AnalysisExceptions in FunctionRegistry

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -179,6 +179,9 @@
   "UNSUPPORTED_OPERATION" : {
     "message" : [ "The operation is not supported: %s" ]
   },
+  "WINDOW_PARAMETER_TYPE_ERROR" : {
+    "message" : [ "Invalid Window Parameter: The parameter(s) %s must be of type %s" ]
+  },
   "WRITING_JOB_ABORTED" : {
     "message" : [ "Writing job aborted" ],
     "sqlState" : "40000"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -17,11 +17,13 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import java.util.Locale
 import java.lang.reflect.InvocationTargetException
+import java.util.Locale
 import javax.annotation.concurrent.GuardedBy
+
 import scala.collection.mutable
 import scala.reflect.ClassTag
+
 import org.apache.spark.SparkThrowable
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -154,10 +154,10 @@ object FunctionRegistryBase {
           // the exception is an invocation exception. To get a meaningful message, we need the
           // cause.
           case e: InvocationTargetException =>
-            e.getCause match {
+            e.getCause() match {
               // Propagate Error Class AnalysisExceptions
-              case a: AnalysisException if a.getErrorClass().nonEmpty => throw a
-              case a: Exception => throw new AnalysisException(a.getCause.getMessage)
+              case a: AnalysisException if (a.getErrorClass() != null) => throw a
+              case e: Exception => throw new AnalysisException(e.getMessage)
             }
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1536,8 +1536,11 @@ object QueryCompilationErrors {
   }
 
   def invalidLiteralForWindowDurationError(): Throwable = {
-    new AnalysisException("The duration and time inputs to window must be " +
-      "an integer, long or string literal.")
+    new AnalysisException(
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters = Array("Duration/Time", "window function", "The duration and time " +
+        "inputs to window must be an integer, long or string literal.")
+    )
   }
 
   def noSuchStructFieldInGivenFieldsError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1538,9 +1538,11 @@ object QueryCompilationErrors {
   def invalidLiteralForWindowDurationError(): Throwable = {
     new AnalysisException(
       errorClass = "INVALID_PARAMETER_VALUE",
-      messageParameters = Array("Duration/Time", "window function", "The duration and time " +
-        "inputs to window must be an integer, long or string literal.")
-    )
+      messageParameters = Array(
+        "Duration/Time",
+        "window function",
+        "The duration and time " +
+          "inputs to window must be an integer, long or string literal."))
   }
 
   def noSuchStructFieldInGivenFieldsError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1537,12 +1537,10 @@ object QueryCompilationErrors {
 
   def invalidLiteralForWindowDurationError(): Throwable = {
     new AnalysisException(
-      errorClass = "INVALID_PARAMETER_VALUE",
+      errorClass = "WINDOW_PARAMETER_TYPE_ERROR",
       messageParameters = Array(
         "Duration/Time",
-        "window function",
-        "The duration and time " +
-          "inputs to window must be an integer, long or string literal."))
+        "Integer, Long, String"))
   }
 
   def noSuchStructFieldInGivenFieldsError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -183,10 +183,10 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     val e = intercept[AnalysisException] {
       sql("SELECT * FROM df GROUP BY id, WINDOW(time1, NULL, '5 minutes') ORDER BY id")
     }
-    assert(e.errorClass === Some("INVALID_PARAMETER_VALUE"))
+    assert(e.errorClass === Some("WINDOW_PARAMETER_TYPE_ERROR"))
     assert(
       e.message ===
-        "The value of parameter(s) 'Duration/Time' in window function is invalid: " +
-          "The duration and time inputs to window must be an integer, long or string literal.")
+        "Invalid Window Parameter: The parameter(s) " +
+          "Duration/Time must be of type Integer, Long, String")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -169,7 +169,8 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
       "Pandas UDF aggregate expressions don't support pivot.")
   }
 
-  test("INVALID_PARAMETER_VALUE: Invalid value for duration/time inputs to time/session window") {
+  test("WINDOW_PARAMETER_TYPE_ERROR: " +
+    "Invalid value for duration/time inputs to time/session window") {
     val df = Seq(
       (1, "2020-10-10 01:00:00", "2010-09-09 03:00:00"),
       (2, "2019-08-08 07:30:20", "2022-01-01 01:00:20"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -174,8 +174,8 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
       (1, "2020-10-10 01:00:00", "2010-09-09 03:00:00"),
       (2, "2019-08-08 07:30:20", "2022-01-01 01:00:20"),
       (2, "2021-04-04 04:44:44", "2021-06-06 06:36:36"),
-      (1, "1995-05-05 05:55:55", "1999-09-09 02:22:22")
-    ).toDF("id", "time1", "time2")
+      (1, "1995-05-05 05:55:55", "1999-09-09 02:22:22"))
+      .toDF("id", "time1", "time2")
       .withColumn("time1", to_timestamp(col("time1")))
       .withColumn("time2", to_timestamp(col("time2")))
     df.createOrReplaceTempView("df")
@@ -184,8 +184,9 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
       sql("SELECT * FROM df GROUP BY id, WINDOW(time1, NULL, '5 minutes') ORDER BY id")
     }
     assert(e.errorClass === Some("INVALID_PARAMETER_VALUE"))
-    assert(e.message ===
-      "The value of parameter(s) 'Duration/Time' in window function is invalid: " +
-        "The duration and time inputs to window must be an integer, long or string literal.")
+    assert(
+      e.message ===
+        "The value of parameter(s) 'Duration/Time' in window function is invalid: " +
+          "The duration and time inputs to window must be an integer, long or string literal.")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

#### Migrate invalidLiteralForWindowDurationError to error classes. This error will now throw AnalysisException with error class INVALID_PARAMETER_VALUE.

#### Update error handling logic in FunctionRegistry.scala to propagate the error class AnalysisExceptions.
- Without this change, if invalidLiteralForWindowDurationError is migrated to error classes, the error will continue to spit out the old non error class AnalysisException (UT will fail). I'm proposing this PR separately from the other Window Compilation Error migrations to keep the larger PR more tightly scoped.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
This is part of the ongoing effort to migrate errors to error classes.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test in [QueryCompilationErrorsSuite.scala](https://github.com/andrewfmurphy/spark/commit/7ee0a648a46c213c77378495442fac400f344690#diff-1fd98ab15bfc9b8068b37cc5cfbc3376ee63ca2d18600a502db3012d24915424).
