### PR TITLE
[SPARK-38312][CORE] Use error class in GraphiteSink

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -43,6 +43,12 @@
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
   },
+  "GRAPHITE_SINK_INVALID_PROTOCOL" : {
+    "message" : [ "Invalid Graphite protocol: %s" ]
+  },
+  "GRAPHITE_SINK_PROPERTY_MISSING" : {
+    "message" : [ "Graphite sink requires '%s' property." ]
+  },
   "GROUPING_COLUMN_MISMATCH" : {
     "message" : [ "Column of grouping (%s) can't be found in grouping columns %s" ],
     "sqlState" : "42000"

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -315,4 +315,14 @@ object SparkCoreErrors {
   def failToGetNonShuffleBlockError(blockId: BlockId, e: Throwable): Throwable = {
     new SparkException(s"Failed to get block $blockId, which is not a shuffle block", e)
   }
+
+  def graphiteSinkInvalidProtocolError(invalidProtocol: String): Throwable = {
+    new SparkException(errorClass = "GRAPHITE_SINK_INVALID_PROTOCOL",
+      messageParameters = Array(invalidProtocol), cause = null)
+  }
+
+  def graphiteSinkPropertyMissingError(missingProperty: String): Throwable = {
+    new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
+      messageParameters = Array(missingProperty), cause = null)
+  }
 }

--- a/core/src/main/scala/org/apache/spark/metrics/sink/GraphiteSink.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/GraphiteSink.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 import com.codahale.metrics.{Metric, MetricFilter, MetricRegistry}
 import com.codahale.metrics.graphite.{Graphite, GraphiteReporter, GraphiteUDP}
 
-import org.apache.spark.SparkException
+import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.metrics.MetricsSystem
 
 private[spark] class GraphiteSink(
@@ -43,13 +43,11 @@ private[spark] class GraphiteSink(
   def propertyToOption(prop: String): Option[String] = Option(property.getProperty(prop))
 
   if (!propertyToOption(GRAPHITE_KEY_HOST).isDefined) {
-    throw new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
-      messageParameters = Array("host"), cause = null)
+    throw SparkCoreErrors.graphiteSinkPropertyMissingError("host")
   }
 
   if (!propertyToOption(GRAPHITE_KEY_PORT).isDefined) {
-    throw new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
-      messageParameters = Array("port"), cause = null)
+    throw SparkCoreErrors.graphiteSinkPropertyMissingError("port")
   }
 
   val host = propertyToOption(GRAPHITE_KEY_HOST).get
@@ -72,8 +70,7 @@ private[spark] class GraphiteSink(
   val graphite = propertyToOption(GRAPHITE_KEY_PROTOCOL).map(_.toLowerCase(Locale.ROOT)) match {
     case Some("udp") => new GraphiteUDP(host, port)
     case Some("tcp") | None => new Graphite(host, port)
-    case Some(p) => throw new SparkException(errorClass = "GRAPHITE_SINK_INVALID_PROTOCOL",
-      messageParameters = Array(p), cause = null)
+    case Some(p) => throw SparkCoreErrors.graphiteSinkInvalidProtocolError(p)
   }
 
   val filter = propertyToOption(GRAPHITE_KEY_REGEX) match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change is to refactor exceptions thrown in GraphiteSink to use error class framework.

### Why are the changes needed?
This is to follow the error class framework.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added unit tests.