### PR TITLE
[SPARK-38318][SQL] Skip view cyclic reference check if view is stored as logical plan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -614,7 +614,11 @@ object ViewHelper extends SQLConfHelper with Logging {
     }.getOrElse(false)
     if (replace && uncache) {
       logDebug(s"Try to uncache ${name.quotedString} before replacing.")
-      checkCyclicViewReference(analyzedPlan, Seq(name), name)
+      if (!conf.storeAnalyzedPlanForView) {
+        // Skip cyclic check because when stored analyzed plan for view, the depended
+        // view is already converted to the underlying tables. So no cyclic views.
+        checkCyclicViewReference(analyzedPlan, Seq(name), name)
+      }
       CommandUtils.uncacheTableOrView(session, name.quotedString)
     }
     if (!conf.storeAnalyzedPlanForView && originalText.nonEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -612,16 +612,17 @@ object ViewHelper extends SQLConfHelper with Logging {
     val uncache = getRawTempView(name.table).map { r =>
       needsToUncache(r, aliasedPlan)
     }.getOrElse(false)
+    val storeAnalyzedPlanForView = conf.storeAnalyzedPlanForView || originalText.isEmpty
     if (replace && uncache) {
       logDebug(s"Try to uncache ${name.quotedString} before replacing.")
-      if (!conf.storeAnalyzedPlanForView && originalText.nonEmpty) {
+      if (!storeAnalyzedPlanForView) {
         // Skip cyclic check because when stored analyzed plan for view, the depended
         // view is already converted to the underlying tables. So no cyclic views.
         checkCyclicViewReference(analyzedPlan, Seq(name), name)
       }
       CommandUtils.uncacheTableOrView(session, name.quotedString)
     }
-    if (!conf.storeAnalyzedPlanForView && originalText.nonEmpty) {
+    if (!storeAnalyzedPlanForView) {
       TemporaryViewRelation(
         prepareTemporaryView(
           name,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/views.scala
@@ -614,7 +614,7 @@ object ViewHelper extends SQLConfHelper with Logging {
     }.getOrElse(false)
     if (replace && uncache) {
       logDebug(s"Try to uncache ${name.quotedString} before replacing.")
-      if (!conf.storeAnalyzedPlanForView) {
+      if (!conf.storeAnalyzedPlanForView && originalText.nonEmpty) {
         // Skip cyclic check because when stored analyzed plan for view, the depended
         // view is already converted to the underlying tables. So no cyclic views.
         checkCyclicViewReference(analyzedPlan, Seq(name), name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -409,7 +409,7 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
 
 abstract class TempViewTestSuite extends SQLViewTestSuite {
 
-  def createDatasetView(df: DataFrame, viewName: String): Unit
+  def createOrReplaceDatasetView(df: DataFrame, viewName: String): Unit
 
   test("SPARK-37202: temp view should capture the function registered by catalog API") {
     val funcName = "tempFunc"
@@ -443,15 +443,15 @@ abstract class TempViewTestSuite extends SQLViewTestSuite {
     val viewName = formattedViewName("v")
     withSQLConf(STORE_ANALYZED_PLAN_FOR_VIEW.key -> "false") {
       withView(viewName) {
-        createDatasetView(sql("SELECT 1"), "v")
-        createDatasetView(sql(s"SELECT * FROM $viewName"), "v")
+        createOrReplaceDatasetView(sql("SELECT 1"), "v")
+        createOrReplaceDatasetView(sql(s"SELECT * FROM $viewName"), "v")
         checkViewOutput(viewName, Seq(Row(1)))
       }
     }
     withSQLConf(STORE_ANALYZED_PLAN_FOR_VIEW.key -> "true") {
       withView(viewName) {
-        createDatasetView(sql("SELECT 1"), "v")
-        createDatasetView(sql(s"SELECT * FROM $viewName"), "v")
+        createOrReplaceDatasetView(sql("SELECT 1"), "v")
+        createOrReplaceDatasetView(sql(s"SELECT * FROM $viewName"), "v")
         checkViewOutput(viewName, Seq(Row(1)))
 
         createView("v", "SELECT 2", replace = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -38,7 +38,7 @@ abstract class SQLViewTestSuite extends QueryTest with SQLTestUtils {
   import testImplicits._
 
   protected def viewTypeString: String
-  def formattedViewName(viewName: String): String
+  protected def formattedViewName(viewName: String): String
   protected def tableIdentifier(viewName: String): TableIdentifier
 
   def createView(
@@ -457,7 +457,7 @@ abstract class TempViewTestSuite extends SQLViewTestSuite {
 
 class LocalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
   override protected def viewTypeString: String = "TEMPORARY VIEW"
-  override def formattedViewName(viewName: String): String = viewName
+  override protected def formattedViewName(viewName: String): String = viewName
   override protected def tableIdentifier(viewName: String): TableIdentifier = {
     TableIdentifier(viewName)
   }
@@ -469,7 +469,7 @@ class LocalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
 class GlobalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
   private def db: String = spark.sharedState.globalTempViewManager.database
   override protected def viewTypeString: String = "GLOBAL TEMPORARY VIEW"
-  override def formattedViewName(viewName: String): String = {
+  override protected def formattedViewName(viewName: String): String = {
     s"$db.$viewName"
   }
   override protected def tableIdentifier(viewName: String): TableIdentifier = {
@@ -497,7 +497,7 @@ class OneTableCatalog extends InMemoryCatalog {
 class PersistedViewTestSuite extends SQLViewTestSuite with SharedSparkSession {
   private def db: String = "default"
   override protected def viewTypeString: String = "VIEW"
-  override def formattedViewName(viewName: String): String = s"$db.$viewName"
+  override protected def formattedViewName(viewName: String): String = s"$db.$viewName"
   override protected def tableIdentifier(viewName: String): TableIdentifier = {
     TableIdentifier(viewName, Some(db))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -468,7 +468,7 @@ class LocalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession {
   override protected def tableIdentifier(viewName: String): TableIdentifier = {
     TableIdentifier(viewName)
   }
-  override def createDatasetView(df: DataFrame, viewName: String): Unit = {
+  override def createOrReplaceDatasetView(df: DataFrame, viewName: String): Unit = {
     df.createOrReplaceTempView(viewName)
   }
 }
@@ -482,7 +482,7 @@ class GlobalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession 
   override protected def tableIdentifier(viewName: String): TableIdentifier = {
     TableIdentifier(viewName, Some(db))
   }
-  override def createDatasetView(df: DataFrame, viewName: String): Unit = {
+  override def createOrReplaceDatasetView(df: DataFrame, viewName: String): Unit = {
     df.createOrReplaceGlobalTempView(viewName)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -439,8 +439,15 @@ abstract class TempViewTestSuite extends SQLViewTestSuite {
     }
   }
 
-  test("back compatibility: skip cyclic reference check when storeAnalyzedPlan = true") {
+  test("back compatibility: skip cyclic reference check if view is stored as logical plan") {
     val viewName = formattedViewName("v")
+    withSQLConf(STORE_ANALYZED_PLAN_FOR_VIEW.key -> "false") {
+      withView(viewName) {
+        createDatasetView(sql("SELECT 1"), "v")
+        createDatasetView(sql(s"SELECT * FROM $viewName"), "v")
+        checkViewOutput(viewName, Seq(Row(1)))
+      }
+    }
     withSQLConf(STORE_ANALYZED_PLAN_FOR_VIEW.key -> "true") {
       withView(viewName) {
         createDatasetView(sql("SELECT 1"), "v")


### PR DESCRIPTION
### What changes were proposed in this pull request?
In 3.2, we unified the representation of dataset view and SQL view, i.e., we wrap both
of them with `View`. This causes a regression that below case works in 3.1 but failed in 3.2
```sql
sql("select 1").createOrReplaceTempView("v")
sql("select * from v").createOrReplaceTempView("v")
-- in 3.1 it works well, and select will output 1
-- in 3.2 it failed with error: "AnalysisException: Recursive view v detected (cycle: v -> v)"
```
The root cause is in 3.1 we actually never did view cyclic check for dataset view. Because they
are wrapped by `SubqueryAlias` instead of `View`
In this PR, we want to skip the cyclic check if the view is stored as a logical plan.
i.e., `storeAnalyzedPlanForView = true` or view is created by Dataset API.

### Why are the changes needed?
fix regression


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
newly added ut
