### PR TITLE
[SPARK-38321][SQL][TESTS] Fix BooleanSimplificationSuite under ANSI

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -138,8 +138,8 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper with
       'a > 1 && 'b > 3 && 'c > 1)
 
     checkCondition(
-      ('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0 && (('a > 1 || 'b > 3) && 'c > 1)),
-      ('a > 1 || 'b > 3) && 'd > 0 && 'c > 1)
+      ('a > 1 || 'b > 3) && (('a > 1 || 'b > 3) && 'd > 0L && (('a > 1 || 'b > 3) && 'c > 1)),
+      ('a > 1 || 'b > 3) && 'd > 0L && 'c > 1)
 
     checkCondition(
       'a > 1 && 'b > 2 && 'a > 1 && 'c > 3,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes BooleanSimplificationSuite under ANSI mode. Change the test case to be a long type to avoid casting difference in ANSI on/off.

### Why are the changes needed?
To set up a new GA job to run tests with ANSI mode before 3.3.0 release.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test locally with both ANSI on and off, both passed.