### PR TITLE
[SPARK-38425][K8S] Avoid possible errors due to incorrect file size or type supplied in hadoop conf

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -122,7 +122,7 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
     }
   }
 
-  private[submit] def loadSparkConfDirFiles(confFiles: Seq[File]): Map[String, String] = {
+  private def loadSparkConfDirFiles(confFiles: Seq[File]): Map[String, String] = {
     val maxSize = conf.get(Config.CONFIG_MAP_MAXSIZE)
     var truncatedMapSize: Long = 0
     val truncatedMap = mutable.HashMap[String, String]()

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -20,15 +20,15 @@ import java.io.File
 import java.nio.charset.{MalformedInputException, StandardCharsets}
 
 import scala.collection.JavaConverters._
-import com.google.common.io.Files
+import scala.collection.mutable
+import scala.io.{Codec, Source}
 
+import com.google.common.io.Files
 import io.fabric8.kubernetes.api.model._
+
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
-
-import scala.collection.mutable
-import scala.io.{Codec, Source}
 
 /**
  * Mounts the Hadoop configuration - either a pre-defined config map, or a local configuration

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStep.scala
@@ -18,7 +18,9 @@ package org.apache.spark.deploy.k8s.features
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesUtils, SparkPod}
+import io.fabric8.kubernetes.api.model.{ConfigMapBuilder, ContainerBuilder, HasMetadata, KeyToPathBuilder, PodBuilder, VolumeBuilder}
+
+import org.apache.spark.deploy.k8s.{Config, KubernetesConf, KubernetesUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.submit.KubernetesClientUtils
@@ -53,7 +55,7 @@ private[spark] class HadoopConfDriverFeatureStep(conf: KubernetesConf)
     original.transform { case pod if hasHadoopConf =>
       val confVolume = if (confDir.isDefined) {
         val keyPaths = confFilesMap.map {
-          case (fileName: String, _:String) =>
+          case (fileName: String, _: String) =>
             new KeyToPathBuilder()
               .withKey(fileName)
               .withPath(fileName)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -126,7 +126,7 @@ private[spark] object KubernetesClientUtils extends Logging {
     }
   }
 
-  private[submit] def loadHadoopConfDirFiles(
+  def loadHadoopConfDirFiles(
       confDir: Option[String],
       maxSize: Long): Map[String, String] = {
     if (confDir.isDefined) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip mount files in hadoop conf if they are binary or very large to fit the configMap's max size.

### Why are the changes needed?
Config map cannot hold binary files and there is also a limit on how much data a configMap can hold.
And spark conf limit has been done in [SPARK-32221].

### Does this PR introduce _any_ user-facing change?
yes, in simple words avoids possible errors due to negligence (for example, placing a large file or a binary file in SPARK_CONF_DIR) and thus improves user experience.


### How was this patch tested?
Actually testing in k8s cluster and existing tests.