### PR TITLE
[SPARK-38342][CORE] Clean up deprecated api usage of Ivy

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -1456,9 +1456,9 @@ private[spark] object SparkSubmitUtils extends Logging {
           throw new RuntimeException(rr.getAllProblemMessages.toString)
         }
         // retrieve all resolved dependencies
+        retrieveOptions.setDestArtifactPattern(packagesDirectory.getAbsolutePath + File.separator +
+          "[organization]_[artifact]-[revision](-[classifier]).[ext]")
         ivy.retrieve(rr.getModuleDescriptor.getModuleRevisionId,
-          packagesDirectory.getAbsolutePath + File.separator +
-            "[organization]_[artifact]-[revision](-[classifier]).[ext]",
           retrieveOptions.setConfs(Array(ivyConfName)))
         resolveDependencyPaths(rr.getArtifacts.toArray, packagesDirectory)
       } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `Ivy.retrieve(ModuleRevisionId, RetrieveOptions)` instead of  deprecated `Ivy.retrieve(ModuleRevisionId, String, RetrieveOptions)` to  clean up deprecation compilation warning.

The refactor way refer to the Implementation of  `RetrieveEngine#retrieve` method as follows:

```java
    @Deprecated
    public int retrieve(ModuleRevisionId mrid, String destFilePattern, RetrieveOptions options)
            throws IOException {
        RetrieveOptions retrieveOptions = new RetrieveOptions(options);
        retrieveOptions.setDestArtifactPattern(destFilePattern);

        RetrieveReport result = retrieve(mrid, retrieveOptions);
        return result.getNbrArtifactsCopied();
    }
```

### Why are the changes needed?
Clean up deprecated api usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA