### PR TITLE
 [SPARK-38344][SHUFFLE] Avoid to submit task when there are no requests to push up in push-based shuffle.

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -118,11 +118,11 @@ private[spark] class ShuffleBlockPusher(conf: SparkConf) extends Logging {
     pushRequests ++= Utils.randomize(requests)
     if (pushRequests.isEmpty) {
       notifyDriverAboutPushCompletion()
+    } else {
+      submitTask(() => {
+        tryPushUpToMax()
+      })
     }
-
-    submitTask(() => {
-      tryPushUpToMax()
-    })
   }
 
   private[shuffle] def tryPushUpToMax(): Unit = {


### PR DESCRIPTION


### What changes were proposed in this pull request?

Avoid to submit task when there are no requests to push up in push-based shuffle.

### Why are the changes needed?
This is a performance improvement to the existing functionality.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA.
Existing unittests.
