### PR TITLE
[SPARK-38348][BUILD] Upgrade `tink` to 1.6.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -255,7 +255,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.5.0//threeten-extra-1.5.0.jar
-tink/1.6.0//tink-1.6.0.jar
+tink/1.6.1//tink-1.6.1.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -240,7 +240,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.5.0//threeten-extra-1.5.0.jar
-tink/1.6.0//tink-1.6.0.jar
+tink/1.6.1//tink-1.6.1.jar
 transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <bouncycastle.version>1.60</bouncycastle.version>
-    <tink.version>1.6.0</tink.version>
+    <tink.version>1.6.1</tink.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, and ./python/setup.py too.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade `com.google.crypto.tink:tink` from 1.6.0 to 1.6.1

### Why are the changes needed?
The release notes as follows:

- https://github.com/google/tink/releases/tag/v1.6.1

There is a performance optimization related to `AesGcmJce.encrypt` method in version 1.6.1 and this method used by `o.a.s.network.crypto.AuthEngine#challenge` and `o.a.s.network.crypto.AuthEngine#response` methods in Spark:

- [Java: isAndroid() shouldn't cause Exceptions to be created](https://github.com/google/tink/issues/497)

This optimization reduces the delay of `AesGcmJce.encrypt` method by 70%.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GA
- Manual test:

Verify the performance improvement of `AesGcmJce.encrypt` method as follows:

```scala
val valuesPerIteration = 100000
val derivedKeyEncryptingKey: Array[Byte] =
    Array(119, -25, -98, 34, -61, 102, 101, -97, 86, -27, 25, 88, 94, -55, 40, -103)
val ephemeralX25519PublicKey: Array[Byte] =
    Array(-94, 121, -27, 40, -42, -6, 114, 17, -11, 107, 58, -69, -69, -58,
        56, -121, 28, -18, 10, 25, 41, -66, 77, 17, 19, -99, -54, 54, 97, -111, -13, 77)
val aadState: Array[Byte] =
    Array(97, 112, 112, 73, 100, -19, 84, 88, -18, -105, 104, 105, 29, -84,
        94, -110, 84, 38, -109, -85, -55)
val benchmark = new Benchmark("Test AesGcmJceEncrypt", valuesPerIteration, output = output)
benchmark.addCase("Test AesGcmJce encrypt") { _: Int =>
      for (_ <- 0L until valuesPerIteration) {
        new AesGcmJce(derivedKeyEncryptingKey).encrypt(ephemeralX25519PublicKey, aadState)
      }
    }
benchmark.run()
```

**Before**: 5423.0 ns/ per row
**After**: 1538.3 ns /per row

