### PR TITLE
[SPARK-38350][SQL] Make the table name output of V1/V2 "desc extended table" consistent

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -289,7 +289,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
       if (partitionSpec.nonEmpty) {
         throw QueryCompilationErrors.describeDoesNotSupportPartitionForV2TablesError()
       }
-      DescribeTableExec(output, r.table, isExtended) :: Nil
+      DescribeTableExec(output, r, isExtended) :: Nil
 
     case DescribeColumn(_: ResolvedTable, column, isExtended, output) =>
       column match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -120,13 +120,13 @@ class DataSourceV2SQLSuite
   }
 
   test("DescribeTable extended using v2 catalog") {
-    spark.sql("CREATE TABLE testcat.table_name (id bigint, data string)" +
+    spark.sql("CREATE TABLE testcat.default.table_name (id bigint, data string)" +
       " USING foo" +
       " PARTITIONED BY (id)" +
       " TBLPROPERTIES ('bar'='baz')" +
       " COMMENT 'this is a test table'" +
       " LOCATION 'file:/tmp/testcat/table_name'")
-    val descriptionDf = spark.sql("DESCRIBE TABLE EXTENDED testcat.table_name")
+    val descriptionDf = spark.sql("DESCRIBE TABLE EXTENDED testcat.default.table_name")
     assert(descriptionDf.schema.map(field => (field.name, field.dataType))
       === Seq(
         ("col_name", StringType),
@@ -146,7 +146,9 @@ class DataSourceV2SQLSuite
       Array("_partition", "string", "Partition key used to store the row"),
       Array("", "", ""),
       Array("# Detailed Table Information", "", ""),
-      Array("Name", "testcat.table_name", ""),
+      Array("Catalog", "testcat", ""),
+      Array("Database", "default", ""),
+      Array("Table", "table_name", ""),
       Array("Comment", "this is a test table", ""),
       Array("Location", "file:/tmp/testcat/table_name", ""),
       Array("Provider", "foo", ""),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The V1 "DESC TABLE EXTENDED" command contains info of "Database" and "Table", which can be used by external tools like DBT: https://github.com/apache/spark/pull/17394

However, the V2 version contains only one field "name" representing "catalog.database.table". External tools can't recognize it. 
Also, it is weird to have different command outputs from the same command.

This PR is to make the database/table name output of V1/V2 "desc extended table" consistent. For the output of V2 tables, this PR also shows the catalog name in the output.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Make the database/table name output of V1/V2 "desc extended table" consistent so that it can be parsed by external tools like DBT.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it changes the database/table name output of V2 "desc extended table" so that it becomes consistent with V1 tables.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT