### PR TITLE
[SPARK-38356][YARN] Print resolved versions of platform JARs used by Spark

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -447,7 +447,8 @@ private[spark] class Client(
     var destPath = srcPath
     if (force || !compareFs(srcFs, destFs) || "file".equals(srcFs.getScheme)) {
       destPath = new Path(destDir, destName.getOrElse(srcPath.getName()))
-      logInfo(s"Uploading resource $srcPath -> $destPath")
+      val resolvedSrcPath = new Path(Paths.get(srcPath.toUri.getPath).toRealPath().toUri)
+      logInfo(s"Uploading resource $resolvedSrcPath -> $destPath")
       try {
         FileUtil.copy(srcFs, srcPath, destFs, destPath, false, hadoopConf)
       } catch {


### PR DESCRIPTION
… Yarn client

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Resolving symlinks in yarn client to better log the platform jars being used by Spark. Additionally, by using the resolved version, the environment tab contains the specific jars being used rather than the symlink. 


### Why are the changes needed?

Eases the debugging process. 


### Does this PR introduce _any_ user-facing change?
Resolved versions of jars are shown in logs and spark job environment ui. 

### How was this patch tested?
Tested on production environment + existing unit tests
