### PR TITLE
[SPARK-38357][SQL][3.2] Fix StackOverflowError with OR(data filter, partition filter)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -124,7 +124,8 @@ private[sql] object PruneFileSourcePartitions
       val (partitionKeyFilters, dataFilters) =
         getPartitionKeyFiltersAndDataFilters(scan.sparkSession, v2Relation,
           scan.readPartitionSchema, filters, output)
-      // The dataFilters are pushed down only once
+      // if there are only partition filters, or the data filters have not been pushed yet,
+      // trigger push down
       if ((partitionKeyFilters.nonEmpty && dataFilters.isEmpty)
         || (dataFilters.nonEmpty && scan.dataFilters.isEmpty)) {
         val prunedV2Relation =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -59,6 +59,7 @@ private[sql] object PruneFileSourcePartitions
     )
     val extraPartitionFilter =
       dataFilters.flatMap(extractPredicatesWithinOutputSet(_, partitionSet))
+
     (ExpressionSet(partitionFilters ++ extraPartitionFilter), dataFilters)
   }
 
@@ -120,7 +121,6 @@ private[sql] object PruneFileSourcePartitions
     case op @ PhysicalOperation(projects, filters,
         v2Relation @ DataSourceV2ScanRelation(_, scan: FileScan, output))
         if filters.nonEmpty =>
-      val dataSchema = StructType(scan.readSchema().fields.diff(scan.readPartitionSchema.fields))
       val (partitionKeyFilters, dataFilters) =
         getPartitionKeyFiltersAndDataFilters(scan.sparkSession, v2Relation,
           scan.readPartitionSchema, filters, output)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
@@ -118,6 +118,28 @@ class PruneFileSourcePartitionsSuite extends PrunePartitionSuiteBase with Shared
     }
   }
 
+  test("SPARK-38357 data + partition filters with OR") {
+    // Force datasource v2 for parquet
+    withSQLConf((SQLConf.USE_V1_SOURCE_LIST.key, "")) {
+      withTempPath { dir =>
+        spark.range(10).coalesce(1).selectExpr("id", "id % 3 as p")
+          .write.partitionBy("p").parquet(dir.getCanonicalPath)
+        withTempView("tmp") {
+          spark.read.parquet(dir.getCanonicalPath).createOrReplaceTempView("tmp");
+          assertPrunedPartitions("SELECT * FROM tmp WHERE (p = 0 AND id > 0) OR (p = 1 AND id = 2)",
+            2,
+            "((tmp.p = 0) || (tmp.p = 1))")
+          assertPrunedPartitions("SELECT * FROM tmp WHERE p = 0 AND id > 0",
+            1,
+            "(tmp.p = 0)")
+          assertPrunedPartitions("SELECT * FROM tmp WHERE p = 0",
+            1,
+            "(tmp.p = 0)")
+        }
+      }
+   }
+  }
+
   protected def collectPartitionFiltersFn(): PartialFunction[SparkPlan, Seq[Expression]] = {
     case scan: FileSourceScanExec => scan.partitionFilters
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
@@ -118,7 +118,7 @@ class PruneFileSourcePartitionsSuite extends PrunePartitionSuiteBase with Shared
     }
   }
 
-  test("SPARK-38357 data + partition filters with OR") {
+  test("SPARK-38357: data + partition filters with OR") {
     // Force datasource v2 for parquet
     withSQLConf((SQLConf.USE_V1_SOURCE_LIST.key, "")) {
       withTempPath { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitionsSuite.scala
@@ -125,7 +125,7 @@ class PruneFileSourcePartitionsSuite extends PrunePartitionSuiteBase with Shared
         spark.range(10).coalesce(1).selectExpr("id", "id % 3 as p")
           .write.partitionBy("p").parquet(dir.getCanonicalPath)
         withTempView("tmp") {
-          spark.read.parquet(dir.getCanonicalPath).createOrReplaceTempView("tmp");
+          spark.read.parquet(dir.getCanonicalPath).createOrReplaceTempView("tmp")
           assertPrunedPartitions("SELECT * FROM tmp WHERE (p = 0 AND id > 0) OR (p = 1 AND id = 2)",
             2,
             "((tmp.p = 0) || (tmp.p = 1))")


### PR DESCRIPTION


### What changes were proposed in this pull request?
If the filter has OR and contains both data filter and partition filter,
e.g. `p` is partition col and `id` is data col
```
SELECT * FROM tmp WHERE (p = 0 AND id > 0) OR (p = 1 AND id = 2)
```
Spark throws StackOverflowError


### Why are the changes needed?
bug fixing


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new UT