### PR TITLE
[SPARK-38387][PYTHON] Support `na_action` and Series input correspondence in `Series.map`

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -606,7 +606,11 @@ class Index(IndexOpsMixin):
                     "If the mapper is a dictionary, its values must be of the same type"
                 )
 
-        return Index(self.to_series().map(mapper, na_action)).rename(self.name)
+        return Index(
+            self.to_series().pandas_on_spark.transform_batch(
+                lambda pser: pser.map(mapper, na_action)
+            )
+        ).rename(self.name)
 
     @property
     def values(self) -> np.ndarray:

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -606,11 +606,7 @@ class Index(IndexOpsMixin):
                     "If the mapper is a dictionary, its values must be of the same type"
                 )
 
-        return Index(
-            self.to_series().pandas_on_spark.transform_batch(
-                lambda pser: pser.map(mapper, na_action)
-            )
-        ).rename(self.name)
+        return Index(self.to_series().map(mapper, na_action)).rename(self.name)
 
     @property
     def values(self) -> np.ndarray:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -976,7 +976,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             return sdf.select(F.covar_samp(*sdf.columns)).head(1)[0][0]
 
-    # TODO: NaN and None
+    # TODO: NaN and None when ``arg`` is an empty dict
     def map(
         self, arg: Union[Dict, Callable[[Any], Any], pd.Series], na_action: Optional[str] = None
     ) -> "Series":
@@ -993,10 +993,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         Parameters
         ----------
-        arg : function, dict, or pd.Series
+        arg : function, dict or pd.Series
             Mapping correspondence.
         na_action :
-            If ‘ignore’, propagate NA values, without passing them to the mapping correspondence.
+            If `ignore`, propagate NA values, without passing them to the mapping correspondence.
 
         Returns
         -------

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -977,6 +977,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             return sdf.select(F.covar_samp(*sdf.columns)).head(1)[0][0]
 
     # TODO: NaN and None when ``arg`` is an empty dict
+    # TODO: Support ps.Series ``arg``
     def map(
         self, arg: Union[Dict, Callable[[Any], Any], pd.Series], na_action: Optional[str] = None
     ) -> "Series":
@@ -1031,6 +1032,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         value (e.g. ``defaultdict``):
 
         >>> s.map({'cat': 'kitten', 'dog': 'puppy'})
+        0    kitten
+        1     puppy
+        2      None
+        3      None
+        dtype: object
+
+        It also accepts a pandas Series:
+
+        >>> pser = pd.Series(['kitten', 'puppy'], index=['cat', 'dog'])
+        >>> s.map(pser)
         0    kitten
         1     puppy
         2      None

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1059,7 +1059,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3    I am a rabbit
         dtype: object
         """
-        if isinstance(arg, dict):
+        if isinstance(arg, (dict, pd.Series)):
             is_start = True
             # In case dictionary is empty.
             current = F.when(SF.lit(False), SF.lit(None).cast(self.spark.data_type))

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1171,7 +1171,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.map(d), pser.map(d))
 
         # series correspondence
-        pser_to_apply = pd.Series(["one", "two", "three", "four"])
+        pser_to_apply = pd.Series(["one", "two", "four"], index=["cat", "dog", "rabbit"])
         self.assert_eq(psser.map(pser_to_apply), pser.map(pser_to_apply))
         self.assert_eq(psser.map(pser_to_apply, na_action="ignore"), pser.map(pser_to_apply, na_action="ignore"))
 

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1163,7 +1163,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         psser = ps.from_pandas(pser)
 
         # dict correspondence
-        # Currently Koalas doesn't return NaN as pandas does.
+        # Currently pandas API on Spark doesn't return NaN as pandas does.
         self.assert_eq(psser.map({}), pser.map({}).replace({pd.np.nan: None}))
 
         d = defaultdict(lambda: "abc")

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1184,6 +1184,13 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             pser.map(lambda x: x.upper(), na_action="ignore"),
         )
 
+        def to_upper(string) -> str:
+            return string.upper() if string else ""
+
+        self.assert_eq(
+            psser.map(to_upper), pser.map(to_upper),
+        )
+
         def tomorrow(date) -> datetime:
             return date + timedelta(days=1)
 

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1164,7 +1164,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
         # dict correspondence
         # Currently pandas API on Spark doesn't return NaN as pandas does.
-        self.assert_eq(psser.map({}), pser.map({}).replace({pd.np.nan: None}))
+        self.assert_eq(psser.map({}), pser.map({}).replace({np.nan: None}))
 
         d = defaultdict(lambda: "abc")
         self.assertTrue("abc" in repr(psser.map(d)))

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1173,7 +1173,10 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         # series correspondence
         pser_to_apply = pd.Series(["one", "two", "four"], index=["cat", "dog", "rabbit"])
         self.assert_eq(psser.map(pser_to_apply), pser.map(pser_to_apply))
-        self.assert_eq(psser.map(pser_to_apply, na_action="ignore"), pser.map(pser_to_apply, na_action="ignore"))
+        self.assert_eq(
+            psser.map(pser_to_apply, na_action="ignore"),
+            pser.map(pser_to_apply, na_action="ignore"),
+        )
 
         # function correspondence
         self.assert_eq(

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1161,12 +1161,25 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
     def test_map(self):
         pser = pd.Series(["cat", "dog", None, "rabbit"])
         psser = ps.from_pandas(pser)
+
+        # dict correspondence
         # Currently Koalas doesn't return NaN as pandas does.
         self.assert_eq(psser.map({}), pser.map({}).replace({pd.np.nan: None}))
 
         d = defaultdict(lambda: "abc")
         self.assertTrue("abc" in repr(psser.map(d)))
         self.assert_eq(psser.map(d), pser.map(d))
+
+        # series correspondence
+        pser_to_apply = pd.Series(["one", "two", "three", "four"])
+        self.assert_eq(psser.map(pser_to_apply), pser.map(pser_to_apply))
+        self.assert_eq(psser.map(pser_to_apply, na_action="ignore"), pser.map(pser_to_apply, na_action="ignore"))
+
+        # function correspondence
+        self.assert_eq(
+            psser.map(lambda x: x.upper(), na_action="ignore"),
+            pser.map(lambda x: x.upper(), na_action="ignore"),
+        )
 
         def tomorrow(date) -> datetime:
             return date + timedelta(days=1)

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1187,9 +1187,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         def to_upper(string) -> str:
             return string.upper() if string else ""
 
-        self.assert_eq(
-            psser.map(to_upper), pser.map(to_upper),
-        )
+        self.assert_eq(psser.map(to_upper), pser.map(to_upper))
 
         def tomorrow(date) -> datetime:
             return date + timedelta(days=1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support `na_action` and Series input correspondence in `Series.map`


### Why are the changes needed?
To reach parity to pandas API.

Note that `na_action` is supported in older pandas:
```py
>>> import pandas as pd
>>> pd.__version__
'1.0.0'
>>> pser = pd.Series(['a', 'b', None])
>>> pser.map(lambda x : x.upper(), na_action='ignore')
0       A
1       B
2    None
dtype: object
```

### Does this PR introduce _any_ user-facing change?
Yes. `na_action`, Series input correspondence are supported now:
```py
>>> psser = ps.Series(['cat', 'dog', None, 'rabbit'])

# na_action support
>>> psser.map(lambda x : x.upper(), na_action="ignore")
0       CAT                                                                     
1       DOG
2      None
3    RABBIT
dtype: object

# Series input correspondence support
>>> pser_to_apply = pd.Series(["one", "two", "four"], index=["cat", "dog", "rabbit"])
>>> psser.map(pser_to_apply)
0     one
1     two
2    None
3    four
dtype: object
```

### How was this patch tested?
Unit tests.
