### PR TITLE
[SPARK-38391][SQL] Datasource v2 supports partial topN push-down

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -25,7 +25,7 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
  * push down aggregates.
  * <p>
  * If the data source can't fully complete the grouping work, then
- * {@link #supportCompletePushDown(Aggregation)} should return false, and Spark will group the data
+ * {@link #supportCompleteAggregationPushDown(Aggregation)} should return false, and Spark will group the data
  * source output again. For queries like "SELECT min(value) AS m FROM t GROUP BY key", after
  * pushing down the aggregate to the data source, the data source can still output data with
  * duplicated keys, which is OK as Spark will do GROUP BY key again. The final query plan can be
@@ -54,7 +54,7 @@ public interface SupportsPushDownAggregates extends ScanBuilder {
    * @param aggregation Aggregation in SQL statement.
    * @return true if the aggregation can be pushed down to datasource completely, false otherwise.
    */
-  default boolean supportCompletePushDown(Aggregation aggregation) { return false; }
+  default boolean supportCompleteAggregationPushDown(Aggregation aggregation) { return false; }
 
   /**
    * Pushes down Aggregation to datasource. The order of the datasource scan output columns should

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -25,11 +25,11 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
  * push down aggregates.
  * <p>
  * If the data source can't fully complete the grouping work, then
- * {@link #supportCompleteAggregationPushDown(Aggregation)} should return false, and Spark will
- * group the data source output again.
- * For queries like "SELECT min(value) AS m FROM t GROUP BY key", after pushing down the aggregate
- * to the data source, the data source can still output data with duplicated keys, which is OK as
- * Spark will do GROUP BY key again. The final query plan can be something like this:
+ * {@link #supportCompletePushDown(Aggregation)} should return false, and Spark will group the data
+ * source output again. For queries like "SELECT min(value) AS m FROM t GROUP BY key", after
+ * pushing down the aggregate to the data source, the data source can still output data with
+ * duplicated keys, which is OK as Spark will do GROUP BY key again. The final query plan can be
+ * something like this:
  * <pre>
  *   Aggregate [key#1], [min(min_value#2) AS m#3]
  *     +- RelationV2[key#1, min_value#2]
@@ -54,7 +54,7 @@ public interface SupportsPushDownAggregates extends ScanBuilder {
    * @param aggregation Aggregation in SQL statement.
    * @return true if the aggregation can be pushed down to datasource completely, false otherwise.
    */
-  default boolean supportCompleteAggregationPushDown(Aggregation aggregation) { return false; }
+  default boolean supportCompletePushDown(Aggregation aggregation) { return false; }
 
   /**
    * Pushes down Aggregation to datasource. The order of the datasource scan output columns should

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownAggregates.java
@@ -25,11 +25,11 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
  * push down aggregates.
  * <p>
  * If the data source can't fully complete the grouping work, then
- * {@link #supportCompleteAggregationPushDown(Aggregation)} should return false, and Spark will group the data
- * source output again. For queries like "SELECT min(value) AS m FROM t GROUP BY key", after
- * pushing down the aggregate to the data source, the data source can still output data with
- * duplicated keys, which is OK as Spark will do GROUP BY key again. The final query plan can be
- * something like this:
+ * {@link #supportCompleteAggregationPushDown(Aggregation)} should return false, and Spark will
+ * group the data source output again.
+ * For queries like "SELECT min(value) AS m FROM t GROUP BY key", after pushing down the aggregate
+ * to the data source, the data source can still output data with duplicated keys, which is OK as
+ * Spark will do GROUP BY key again. The final query plan can be something like this:
  * <pre>
  *   Aggregate [key#1], [min(min_value#2) AS m#3]
  *     +- RelationV2[key#1, min_value#2]

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -32,15 +32,14 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 public interface SupportsPushDownTopN extends ScanBuilder {
 
     /**
-     * Whether the datasource support complete sort push-down. Spark will do sort again
-     * if this method returns false.
-     *
-     * @return true if the sort can be pushed down to datasource completely, false otherwise.
-     */
-    default boolean supportCompleteSortPushDown() { return false; }
-
-    /**
      * Pushes down top N to the data source.
      */
     boolean pushTopN(SortOrder[] orders, int limit);
+
+    /**
+     * Whether the datasource partial push down sort. Spark will do sort again if returns true.
+     *
+     * @return true if sort be pushed down to datasource partially, false otherwise.
+     */
+    default boolean isPartiallyPushed() { return true; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -37,7 +37,8 @@ public interface SupportsPushDownTopN extends ScanBuilder {
     boolean pushTopN(SortOrder[] orders, int limit);
 
     /**
-     * Whether the datasource partial push down sort. Spark will do sort again if returns true.
+     * Whether the top N is partially pushed or not. If it returns true, then Spark will do top N again.
+     * This method will only be called when `pushTopN` returns true.
      *
      * @return true if sort be pushed down to datasource partially, false otherwise.
      */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -37,8 +37,8 @@ public interface SupportsPushDownTopN extends ScanBuilder {
     boolean pushTopN(SortOrder[] orders, int limit);
 
     /**
-     * Whether the top N is partially pushed or not. If it returns true, then Spark will do top N again.
-     * This method will only be called when `pushTopN` returns true.
+     * Whether the top N is partially pushed or not. If it returns true, then Spark will do top N
+     * again. This method will only be called when `pushTopN` returns true.
      */
     default boolean isPartiallyPushed() { return true; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -38,7 +38,7 @@ public interface SupportsPushDownTopN extends ScanBuilder {
 
     /**
      * Whether the top N is partially pushed or not. If it returns true, then Spark will do top N
-     * again. This method will only be called when `pushTopN` returns true.
+     * again. This method will only be called when {@link #pushTopN} returns true.
      */
     default boolean isPartiallyPushed() { return true; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -32,6 +32,14 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 public interface SupportsPushDownTopN extends ScanBuilder {
 
     /**
+     * Whether the datasource support complete sort push-down. Spark will do sort again
+     * if this method returns false.
+     *
+     * @return true if the sort can be pushed down to datasource completely, false otherwise.
+     */
+    default boolean supportCompleteSortPushDown() { return false; }
+
+    /**
      * Pushes down top N to the data source.
      */
     boolean pushTopN(SortOrder[] orders, int limit);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -39,8 +39,6 @@ public interface SupportsPushDownTopN extends ScanBuilder {
     /**
      * Whether the top N is partially pushed or not. If it returns true, then Spark will do top N again.
      * This method will only be called when `pushTopN` returns true.
-     *
-     * @return true if sort be pushed down to datasource partially, false otherwise.
      */
     default boolean isPartiallyPushed() { return true; }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -129,11 +129,13 @@ object PushDownUtils extends PredicateHelper {
   /**
    * Pushes down top N to the data source Scan
    */
-  def pushTopN(scanBuilder: ScanBuilder, order: Array[SortOrder], limit: Int): Boolean = {
+  def pushTopN(
+      scanBuilder: ScanBuilder,
+      order: Array[SortOrder], limit: Int): Tuple2[Boolean, Boolean] = {
     scanBuilder match {
       case s: SupportsPushDownTopN =>
-        s.pushTopN(order, limit)
-      case _ => false
+        Tuple2(s.pushTopN(order, limit), s.isPartiallyPushed)
+      case _ => Tuple2(false, false)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -131,10 +131,11 @@ object PushDownUtils extends PredicateHelper {
    */
   def pushTopN(
       scanBuilder: ScanBuilder,
-      order: Array[SortOrder], limit: Int): Tuple2[Boolean, Boolean] = {
+      order: Array[SortOrder], limit: Int): (Boolean, Boolean) = {
     scanBuilder match {
       case s: SupportsPushDownTopN =>
-        Tuple2(s.pushTopN(order, limit), s.isPartiallyPushed)
+        val isPushed = s.pushTopN(order, limit)
+        (isPushed, s.isPartiallyPushed)
       case _ => Tuple2(false, false)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -131,7 +131,8 @@ object PushDownUtils extends PredicateHelper {
    */
   def pushTopN(
       scanBuilder: ScanBuilder,
-      order: Array[SortOrder], limit: Int): (Boolean, Boolean) = {
+      order: Array[SortOrder],
+      limit: Int): (Boolean, Boolean) = {
     scanBuilder match {
       case s: SupportsPushDownTopN =>
         val isPushed = s.pushTopN(order, limit)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -134,9 +134,8 @@ object PushDownUtils extends PredicateHelper {
       order: Array[SortOrder],
       limit: Int): (Boolean, Boolean) = {
     scanBuilder match {
-      case s: SupportsPushDownTopN =>
-        val isPushed = s.pushTopN(order, limit)
-        (isPushed, s.isPartiallyPushed)
+      case s: SupportsPushDownTopN if s.pushTopN(order, limit) =>
+        (true, s.isPartiallyPushed)
       case _ => (false, false)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -136,7 +136,7 @@ object PushDownUtils extends PredicateHelper {
       case s: SupportsPushDownTopN =>
         val isPushed = s.pushTopN(order, limit)
         (isPushed, s.isPartiallyPushed)
-      case _ => Tuple2(false, false)
+      case _ => (false, false)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, GeneralAggregateFunc, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, V1Scan}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownTopN, V1Scan}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, LongType, StructType, YearMonthIntervalType}
@@ -385,7 +385,11 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
         if (topNPushed) {
           sHolder.pushedLimit = Some(limit)
           sHolder.sortOrders = orders
-          operation
+          sHolder.builder match {
+            case s: SupportsPushDownTopN if s.supportCompleteSortPushDown() =>
+              operation
+            case _ => s
+          }
         } else {
           s
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -374,7 +374,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
         sHolder.pushedLimit = Some(limit)
       }
       operation
-    case sort @ Sort(order, _, operation @ ScanOperation(project, filter, sHolder: ScanBuilderHolder))
+    case s @ Sort(order, _, operation @ ScanOperation(project, filter, sHolder: ScanBuilderHolder))
         if filter.isEmpty && CollapseProject.canCollapseExpressions(
           order, project, alwaysInline = true) =>
       val aliasMap = getAliasMap(project)
@@ -387,15 +387,15 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
           sHolder.pushedLimit = Some(limit)
           sHolder.sortOrders = orders
           if (isPartiallyPushed) {
-            sort
+            s
           } else {
             operation
           }
         } else {
-          sort
+          s
         }
       } else {
-        sort
+        s
       }
     case p: Project =>
       val newChild = pushDownLimit(p.child, limit)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.expressions.{SortOrder => V2SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.{Aggregation, Avg, Count, GeneralAggregateFunc, Sum}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, SupportsPushDownTopN, V1Scan}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownFilters, V1Scan}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.{DataType, DayTimeIntervalType, LongType, StructType, YearMonthIntervalType}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -72,7 +72,7 @@ case class JDBCScanBuilder(
 
   private var pushedGroupByCols: Option[Array[String]] = None
 
-  override def supportCompletePushDown(aggregation: Aggregation): Boolean = {
+  override def supportCompleteAggregationPushDown(aggregation: Aggregation): Boolean = {
     lazy val fieldNames = aggregation.groupByColumns()(0).fieldNames()
     jdbcOptions.numPartitions.map(_ == 1).getOrElse(true) ||
       (aggregation.groupByColumns().length == 1 && fieldNames.length == 1 &&
@@ -135,6 +135,10 @@ case class JDBCScanBuilder(
       return true
     }
     false
+  }
+
+  override def supportCompleteSortPushDown(): Boolean = {
+    jdbcOptions.numPartitions.map(_ == 1).getOrElse(true)
   }
 
   override def pushTopN(orders: Array[SortOrder], limit: Int): Boolean = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently , Spark supports push down topN completely . But for some data source (e.g. JDBC ) that have multiple partition , we should preserve partial push down topN.


### Why are the changes needed?
Make behavior of sort pushdown correctly.


### Does this PR introduce _any_ user-facing change?
'No'. Just change the inner implement.


### How was this patch tested?
New tests.
