### PR TITLE
[SPARK-38400][PYTHON] Enable Series.rename to change index labels

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1087,7 +1087,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def name(self, name: Name) -> None:
         self.rename(name, inplace=True)
 
-    # TODO: Currently, changing index labels taking dictionary is not supported.
+    # TODO: Currently, changing index labels taking dictionary/Series is not supported.
     def rename(
         self, index: Optional[Union[Name, Callable[[Any], Any]]] = None, **kwargs: Any
     ) -> "Series":

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1087,16 +1087,16 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
     def name(self, name: Name) -> None:
         self.rename(name, inplace=True)
 
-    # TODO: Functionality and documentation should be matched. Currently, changing index labels
-    # taking dictionary and function to change index are not supported.
-    def rename(self, index: Optional[Name] = None, **kwargs: Any) -> "Series":
+    # TODO: Currently, changing index labels taking dictionary is not supported.
+    def rename(self, index: Optional[Union[Name, Callable[[Any], Any]]] = None, **kwargs: Any) -> "Series":
         """
-        Alter Series name.
+        Alter Series index labels or name.
 
         Parameters
         ----------
-        index : scalar
-            Scalar will alter the ``Series.name`` attribute.
+        index : scalar or function, optional
+            Functions are transformations to apply to the index.
+            Scalar will alter the Series.name attribute.
 
         inplace : bool, default False
             Whether to return a new Series. If True then value of copy is
@@ -1105,7 +1105,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Returns
         -------
         Series
-            Series with name altered.
+            Series with index labels or name altered.
 
         Examples
         --------
@@ -1122,9 +1122,26 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         1    2
         2    3
         Name: my_name, dtype: int64
+
+        >>> s.rename(lambda x: x ** 2)  # function, changes labels
+        0    1
+        1    2
+        4    3
+        dtype: int64
         """
         if index is None:
             pass
+        if callable(index):
+            if kwargs.get("inplace", False):
+                raise ValueError("inplace True is not supported yet for a function 'index'")
+            frame = self.to_frame()
+            new_index_name = verify_temp_column_name(frame, "__index_name__")
+            frame[new_index_name] = self.index.map(index)
+            frame.set_index(new_index_name, inplace=True)
+            frame.index.name = self.index.name
+            return first_series(frame).rename(self.name)
+        elif isinstance(index, dict):
+            raise ValueError("dict 'index' is not supported yet")
         elif not is_hashable(index):
             raise TypeError("Series.name must be a hashable type")
         elif not isinstance(index, tuple):

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1088,7 +1088,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         self.rename(name, inplace=True)
 
     # TODO: Currently, changing index labels taking dictionary is not supported.
-    def rename(self, index: Optional[Union[Name, Callable[[Any], Any]]] = None, **kwargs: Any) -> "Series":
+    def rename(
+        self, index: Optional[Union[Name, Callable[[Any], Any]]] = None, **kwargs: Any
+    ) -> "Series":
         """
         Alter Series index labels or name.
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1142,8 +1142,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             frame.set_index(new_index_name, inplace=True)
             frame.index.name = self.index.name
             return first_series(frame).rename(self.name)
-        elif isinstance(index, dict):
-            raise ValueError("dict 'index' is not supported yet")
+        elif isinstance(index, (pd.Series, dict)):
+            raise ValueError("'index' of %s type is not supported yet" % type(index).__name__)
         elif not is_hashable(index):
             raise TypeError("Series.name must be a hashable type")
         elif not isinstance(index, tuple):

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -179,6 +179,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         psser = ps.from_pandas(pser)
 
         self.assert_eq(psser.rename("y"), pser.rename("y"))
+        self.assert_eq(psser.rename(("y", "z")), pser.rename(("y", "z")))
         self.assertEqual(psser.name, "x")  # no mutation
         self.assert_eq(psser.rename(), pser.rename())
 
@@ -200,6 +201,14 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         expected_error_message = "inplace True is not supported yet for a function 'index'"
         with self.assertRaisesRegex(ValueError, expected_error_message):
             psser.rename(lambda x: x ** 2, inplace=True)
+
+        unsupported_index_inputs = (pd.Series([2, 3, 4, 5, 6, 7, 8]), {0: "zero", 1: "one"})
+        for index in unsupported_index_inputs:
+            expected_error_message = (
+                "'index' of %s type is not supported yet" % type(index).__name__
+            )
+            with self.assertRaisesRegex(ValueError, expected_error_message):
+                psser.rename(index)
 
         # Series index
         # pser = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -194,8 +194,12 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             psser.rename(["0", "1"])
 
         # Function index
-        res = psser.rename(lambda x: x ** 2)
-        self.assert_eq(res, pser.rename(lambda x: x ** 2))
+        self.assert_eq(psser.rename(lambda x: x ** 2), pser.rename(lambda x: x ** 2))
+        self.assert_eq((psser + 1).rename(lambda x: x ** 2), (pser + 1).rename(lambda x: x ** 2))
+
+        expected_error_message = "inplace True is not supported yet for a function 'index'"
+        with self.assertRaisesRegex(ValueError, expected_error_message):
+            psser.rename(lambda x: x ** 2, inplace=True)
 
         # Series index
         # pser = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -193,13 +193,13 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         with self.assertRaisesRegex(TypeError, expected_error_message):
             psser.rename(["0", "1"])
 
+        # Function index
+        res = psser.rename(lambda x: x ** 2)
+        self.assert_eq(res, pser.rename(lambda x: x ** 2))
+
         # Series index
         # pser = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')
         # psser = ps.from_pandas(s)
-
-        # TODO: index
-        # res = psser.rename(lambda x: x ** 2)
-        # self.assert_eq(res, pser.rename(lambda x: x ** 2))
 
         # res = psser.rename(pser)
         # self.assert_eq(res, pser.rename(pser))

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -179,7 +179,6 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         psser = ps.from_pandas(pser)
 
         self.assert_eq(psser.rename("y"), pser.rename("y"))
-        self.assert_eq(psser.rename(("y", "z")), pser.rename(("y", "z")))
         self.assertEqual(psser.name, "x")  # no mutation
         self.assert_eq(psser.rename(), pser.rename())
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable Series.rename to change index labels, with function `index` input.


### Why are the changes needed?
To reach parity with pandas.

### Does this PR introduce _any_ user-facing change?
Yes. Using function `index` input to change index labels of Series is supported as below:
```py
>>> s = ps.Series([1, 2, 3])
>>> s.rename(lambda x: x ** 2)
0    1
1    2
4    3
dtype: int64
```

### How was this patch tested?
Unit test.
