### PR TITLE
[SPARK-38104][SQL] Migrate parsing errors of window into the new error framework

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -118,15 +118,18 @@ object QueryParsingErrors {
   }
 
   def repetitiveWindowDefinitionError(name: String, ctx: WindowClauseContext): Throwable = {
-    new ParseException(s"The definition of window '$name' is repetitive", ctx)
+    new ParseException("INVALID_SQL_SYNTAX",
+      Array(s"The definition of window '$name' is repetitive."), ctx)
   }
 
   def invalidWindowReferenceError(name: String, ctx: WindowClauseContext): Throwable = {
-    new ParseException(s"Window reference '$name' is not a window specification", ctx)
+    new ParseException("INVALID_SQL_SYNTAX",
+      Array(s"Window reference '$name' is not a window specification."), ctx)
   }
 
   def cannotResolveWindowReferenceError(name: String, ctx: WindowClauseContext): Throwable = {
-    new ParseException(s"Cannot resolve window reference '$name'", ctx)
+    new ParseException("INVALID_SQL_SYNTAX",
+      Array(s"Cannot resolve window reference '$name'."), ctx)
   }
 
   def naturalCrossJoinUnsupportedError(ctx: RelationContext): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -898,7 +898,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The definition of window 'w' is repetitive(line 8, pos 0)
+Invalid SQL syntax: The definition of window 'w' is repetitive.(line 8, pos 0)
 
 == SQL ==
 SELECT

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -124,4 +124,49 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |--------------^^^
           |""".stripMargin)
   }
+
+  test("SPARK:38104: INVALID_SQL_SYNTAX - redefine window") {
+    validateParsingError(
+      sqlText = "SELECT min(a) OVER win FROM t1 WINDOW win AS win, win AS win2",
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """
+          |Invalid SQL syntax: The definition of window 'win' is repetitive.(line 1, pos 31)
+          |
+          |== SQL ==
+          |SELECT min(a) OVER win FROM t1 WINDOW win AS win, win AS win2
+          |-------------------------------^^^
+          |""".stripMargin)
+  }
+
+  test("SPARK:38104: INVALID_SQL_SYNTAX- invalid window reference") {
+    validateParsingError(
+      sqlText = "SELECT min(a) OVER win FROM t1 WINDOW win AS win",
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """
+          |Invalid SQL syntax: Window reference 'win' is not a window specification.(line 1, pos 31)
+          |
+          |== SQL ==
+          |SELECT min(a) OVER win FROM t1 WINDOW win AS win
+          |-------------------------------^^^
+          |""".stripMargin)
+  }
+
+  test("SPARK:38104: INVALID_SQL_SYNTAX - window reference cannot be resolved") {
+    validateParsingError(
+      sqlText = "SELECT min(a) OVER win FROM t1 WINDOW win AS win2",
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """
+          |Invalid SQL syntax: Cannot resolve window reference 'win2'.(line 1, pos 31)
+          |
+          |== SQL ==
+          |SELECT min(a) OVER win FROM t1 WINDOW win AS win2
+          |-------------------------------^^^
+          |""".stripMargin)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -86,7 +86,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-35789: INVALID_SQL_SYNTAX - LATERAL can only be used with subquery") {
+  test("INVALID_SQL_SYNTAX: LATERAL can only be used with subquery") {
     Seq(
       "SELECT * FROM t1, LATERAL t2" -> 26,
       "SELECT * FROM t1 JOIN LATERAL t2" -> 30,
@@ -125,7 +125,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin)
   }
 
-  test("SPARK:38104: INVALID_SQL_SYNTAX - redefine window") {
+  test("INVALID_SQL_SYNTAX: redefine window") {
     validateParsingError(
       sqlText = "SELECT min(a) OVER win FROM t1 WINDOW win AS win, win AS win2",
       errorClass = "INVALID_SQL_SYNTAX",
@@ -140,7 +140,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin)
   }
 
-  test("SPARK:38104: INVALID_SQL_SYNTAX- invalid window reference") {
+  test("INVALID_SQL_SYNTAX: invalid window reference") {
     validateParsingError(
       sqlText = "SELECT min(a) OVER win FROM t1 WINDOW win AS win",
       errorClass = "INVALID_SQL_SYNTAX",
@@ -155,7 +155,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin)
   }
 
-  test("SPARK:38104: INVALID_SQL_SYNTAX - window reference cannot be resolved") {
+  test("INVALID_SQL_SYNTAX: window reference cannot be resolved") {
     validateParsingError(
       sqlText = "SELECT min(a) OVER win FROM t1 WINDOW win AS win2",
       errorClass = "INVALID_SQL_SYNTAX",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, I migrated parsing errors of window listed below into the new error framework.
- repetitiveWindowDefinitionError
- invalidWindowReferenceError
- cannotResolveWindowReferenceError

### Why are the changes needed?
Porting the parsing errors of window into the new error framework should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
Yes, it changes the error message.

### How was this patch tested?
`$ build/sbt "test:testOnly *QueryParsingErrorsSuite"`