### PR TITLE
[SPARK-38417][CORE] Remove `Experimental` from `RDD.cleanShuffleDependencies` API

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -1746,7 +1746,6 @@ abstract class RDD[T: ClassTag](
   }
 
   /**
-   * :: Experimental ::
    * Removes an RDD's shuffles and it's non-persisted ancestors.
    * When running without a shuffle service, cleaning up shuffle files enables downscaling.
    * If you use the RDD after this call, you should checkpoint and materialize it first.
@@ -1755,7 +1754,6 @@ abstract class RDD[T: ClassTag](
    *   * Tuning the driver GC to be more aggressive, so the regular context cleaner is triggered
    *   * Setting an appropriate TTL for shuffle files to be auto cleaned
    */
-  @Experimental
   @DeveloperApi
   @Since("3.1.0")
   def cleanShuffleDependencies(blocking: Boolean = false): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Experimental` from `RDD.cleanShuffleDependencies` API at Apache Spark 3.3.

### Why are the changes needed?

This API has been used since Apache Spark 3.1.0.

### Does this PR introduce _any_ user-facing change?

No. This has been used for a long time in 3.1.1 ~ 3.2.1 since April 7, 2020.
- https://spark.apache.org/docs/3.1.1/api/scala/org/apache/spark/rdd/RDD.html#cleanShuffleDependencies(blocking:Boolean):Unit

### How was this patch tested?

Manual review because this is a human-oriented doc change.