### PR TITLE
[SPARK-38418][PYSPARK] Add PySpark `cleanShuffleDependencies` developer API

### DIFF
--- a/python/docs/source/reference/pyspark.rst
+++ b/python/docs/source/reference/pyspark.rst
@@ -112,6 +112,7 @@ RDD APIs
     RDD.cache
     RDD.cartesian
     RDD.checkpoint
+    RDD.cleanShuffleDependencies
     RDD.coalesce
     RDD.cogroup
     RDD.collect

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -465,6 +465,21 @@ class RDD(Generic[T_co]):
 
         return checkpointFile.get() if checkpointFile.isDefined() else None
 
+    def cleanShuffleDependencies(self, blocking: bool = False) -> None:
+        """
+        Removes an RDD's shuffles and it's non-persisted ancestors.
+
+        When running without a shuffle service, cleaning up shuffle files enables downscaling.
+        If you use the RDD after this call, you should checkpoint and materialize it first.
+
+        .. versionadded:: 3.3.0
+
+        Notes
+        -----
+        This API is a developer API.
+        """
+        self._jrdd.rdd().cleanShuffleDependencies(blocking)
+
     def map(self: "RDD[T]", f: Callable[[T], U], preservesPartitioning: bool = False) -> "RDD[U]":
         """
         Return a new RDD by applying a function to each element of this RDD.

--- a/python/pyspark/rdd.py
+++ b/python/pyspark/rdd.py
@@ -474,6 +474,11 @@ class RDD(Generic[T_co]):
 
         .. versionadded:: 3.3.0
 
+        Parameters
+        ----------
+        blocking : bool, optional
+           block on shuffle cleanup tasks. Disabled by default.
+
         Notes
         -----
         This API is a developer API.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `cleanShuffleDependencies` developer API to PySpark RDD like Scala.

### Why are the changes needed?

This API has been documented and used since Apache Spark 3.1.0 and we removed `Experimental` tag at Apache Spark 3.3.0 via SPARK-38417.
- https://spark.apache.org/docs/latest/api/scala/org/apache/spark/rdd/RDD.html#cleanShuffleDependencies(blocking:Boolean):Unit

This is required for a feature parity in PySpark 3.3.0.


### Does this PR introduce _any_ user-facing change?

Yes, but this is a new API addition.

### How was this patch tested?

Pass the CIs.