### PR TITLE
 [SPARK-38428][SHUFFLE] Check the FetchShuffleBlocks message only once to improve iteration in external shuffle service

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -512,14 +512,14 @@ public class ExternalBlockHandler extends RpcHandler
       mapIds = msg.mapIds;
       reduceIds = msg.reduceIds;
       batchFetchEnabled = msg.batchFetchEnabled;
-    }
-
-    @Override
-    public boolean hasNext() {
       // mapIds.length must equal to reduceIds.length, and the passed in FetchShuffleBlocks
       // must have non-empty mapIds and reduceIds, see the checking logic in
       // OneForOneBlockFetcher.
       assert(mapIds.length != 0 && mapIds.length == reduceIds.length);
+    }
+
+    @Override
+    public boolean hasNext() {
       return mapIdx < mapIds.length && reduceIdx < reduceIds[mapIdx].length;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, the FetchShuffleBlocks is checked in each element of a ShuffleManagedBufferIterator, which is unnecessary and it only needs to be checked once in the ShuffleManagedBufferIterator constructor.

### Why are the changes needed?
To improve performance.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unittests.