### PR TITLE
[WIP][SPARK-38432][SQL] Reactor framework so as JDBC dialect could compile filter by self way

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysFalse.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysFalse.java
@@ -20,6 +20,7 @@ package org.apache.spark.sql.connector.expressions.filter;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
@@ -46,5 +47,5 @@ public final class AlwaysFalse extends Filter {
   public String toString() { return "FALSE"; }
 
   @Override
-  public NamedReference[] references() { return EMPTY_REFERENCE; }
+  public Expression[] references() { return EMPTY_EXPRESSION; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysTrue.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/AlwaysTrue.java
@@ -20,6 +20,7 @@ package org.apache.spark.sql.connector.expressions.filter;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
@@ -46,5 +47,5 @@ public final class AlwaysTrue extends Filter {
   public String toString() { return "TRUE"; }
 
   @Override
-  public NamedReference[] references() { return EMPTY_REFERENCE; }
+  public Expression[] references() { return EMPTY_EXPRESSION; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/BinaryComparison.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/BinaryComparison.java
@@ -20,8 +20,7 @@ package org.apache.spark.sql.connector.expressions.filter;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * Base class for {@link EqualNullSafe}, {@link EqualTo}, {@link GreaterThan},
@@ -31,16 +30,16 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
  */
 @Evolving
 abstract class BinaryComparison extends Filter {
-  protected final NamedReference column;
-  protected final Literal<?> value;
+  protected final Expression column;
+  protected final Expression value;
 
-  protected BinaryComparison(NamedReference column, Literal<?> value) {
+  protected BinaryComparison(Expression column, Expression value) {
     this.column = column;
     this.value = value;
   }
 
-  public NamedReference column() { return column; }
-  public Literal<?> value() { return value; }
+  public Expression column() { return column; }
+  public Expression value() { return value; }
 
   @Override
   public boolean equals(Object o) {
@@ -56,5 +55,5 @@ abstract class BinaryComparison extends Filter {
   }
 
   @Override
-  public NamedReference[] references() { return new NamedReference[] { column }; }
+  public Expression[] references() { return new Expression[] { column }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualNullSafe.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualNullSafe.java
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * Performs equality comparison, similar to {@link EqualTo}. However, this differs from
@@ -31,7 +30,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class EqualNullSafe extends BinaryComparison {
 
-  public EqualNullSafe(NamedReference column, Literal<?> value) {
+  public EqualNullSafe(Expression column, Expression value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualTo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/EqualTo.java
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to a value
@@ -30,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class EqualTo extends BinaryComparison {
 
-  public EqualTo(NamedReference column, Literal<?> value) {
+  public EqualTo(Expression column, Expression value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Filter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/Filter.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.expressions.Expression;
-import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * Filter base class
@@ -31,10 +30,10 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public abstract class Filter implements Expression, Serializable {
 
-  protected static final NamedReference[] EMPTY_REFERENCE = new NamedReference[0];
+  protected static final Expression[] EMPTY_EXPRESSION = new Expression[0];
 
   /**
    * Returns list of columns that are referenced by this filter.
    */
-  public abstract NamedReference[] references();
+  public abstract Expression[] references();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThan.java
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to a value
@@ -30,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class GreaterThan extends BinaryComparison {
 
-  public GreaterThan(NamedReference column, Literal<?> value) {
+  public GreaterThan(Expression column, Expression value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThanOrEqual.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/GreaterThanOrEqual.java
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to a value
@@ -30,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class GreaterThanOrEqual extends BinaryComparison {
 
-  public GreaterThanOrEqual(NamedReference column, Literal<?> value) {
+  public GreaterThanOrEqual(Expression column, Expression value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/In.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/In.java
@@ -22,8 +22,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to one of the
@@ -34,15 +34,15 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class In extends Filter {
   static final int MAX_LEN_TO_PRINT = 50;
-  private final NamedReference column;
+  private final Expression column;
   private final Literal<?>[] values;
 
-  public In(NamedReference column, Literal<?>[] values) {
+  public In(Expression column, Literal<?>[] values) {
     this.column = column;
     this.values = values;
   }
 
-  public NamedReference column() { return column; }
+  public Expression column() { return column; }
   public Literal<?>[] values() { return values; }
 
   @Override
@@ -72,5 +72,5 @@ public final class In extends Filter {
   }
 
   @Override
-  public NamedReference[] references() { return new NamedReference[] { column }; }
+  public Expression[] references() { return new Expression[] { column }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNotNull.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNotNull.java
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector.expressions.filter;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to a non-null value.
@@ -29,13 +29,13 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
  */
 @Evolving
 public final class IsNotNull extends Filter {
-  private final NamedReference column;
+  private final Expression column;
 
-  public IsNotNull(NamedReference column) {
+  public IsNotNull(Expression column) {
     this.column = column;
   }
 
-  public NamedReference column() { return column; }
+  public Expression column() { return column; }
 
   @Override
   public String toString() { return column.describe() + " IS NOT NULL"; }
@@ -54,5 +54,5 @@ public final class IsNotNull extends Filter {
   }
 
   @Override
-  public NamedReference[] references() { return new NamedReference[] { column }; }
+  public Expression[] references() { return new Expression[] { column }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNull.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/IsNull.java
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector.expressions.filter;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to null.
@@ -29,13 +29,13 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
  */
 @Evolving
 public final class IsNull extends Filter {
-  private final NamedReference column;
+  private final Expression column;
 
-  public IsNull(NamedReference column) {
+  public IsNull(Expression column) {
     this.column = column;
   }
 
-  public NamedReference column() { return column; }
+  public Expression column() { return column; }
 
   @Override
   public String toString() { return column.describe() + " IS NULL"; }
@@ -54,5 +54,5 @@ public final class IsNull extends Filter {
   }
 
   @Override
-  public NamedReference[] references() { return new NamedReference[] { column }; }
+  public Expression[] references() { return new Expression[] { column }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThan.java
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to a value
@@ -30,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class LessThan extends BinaryComparison {
 
-  public LessThan(NamedReference column, Literal<?> value) {
+  public LessThan(Expression column, Expression value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThanOrEqual.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/LessThanOrEqual.java
@@ -18,8 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.Literal;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 
 /**
  * A filter that evaluates to {@code true} iff the {@code column} evaluates to a value
@@ -30,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.NamedReference;
 @Evolving
 public final class LessThanOrEqual extends BinaryComparison {
 
-  public LessThanOrEqual(NamedReference column, Literal<?> value) {
+  public LessThanOrEqual(Expression column, Expression value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringContains.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringContains.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 @Evolving
 public final class StringContains extends StringPredicate {
 
-  public StringContains(NamedReference column, UTF8String value) {
+  public StringContains(Expression column, UTF8String value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringEndsWith.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringEndsWith.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 @Evolving
 public final class StringEndsWith extends StringPredicate {
 
-  public StringEndsWith(NamedReference column, UTF8String value) {
+  public StringEndsWith(Expression column, UTF8String value) {
     super(column, value);
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringPredicate.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringPredicate.java
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector.expressions.filter;
 import java.util.Objects;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -31,15 +31,15 @@ import org.apache.spark.unsafe.types.UTF8String;
  */
 @Evolving
 abstract class StringPredicate extends Filter {
-  protected final NamedReference column;
+  protected final Expression column;
   protected final UTF8String value;
 
-  protected StringPredicate(NamedReference column, UTF8String value) {
+  protected StringPredicate(Expression column, UTF8String value) {
     this.column = column;
     this.value = value;
   }
 
-  public NamedReference column() { return column; }
+  public Expression column() { return column; }
   public UTF8String value() { return value; }
 
   @Override
@@ -56,5 +56,5 @@ abstract class StringPredicate extends Filter {
   }
 
   @Override
-  public NamedReference[] references() { return new NamedReference[] { column }; }
+  public Expression[] references() { return new Expression[] { column }; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringStartsWith.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/filter/StringStartsWith.java
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.connector.expressions.filter;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 @Evolving
 public final class StringStartsWith extends StringPredicate {
 
-  public StringStartsWith(NamedReference column, UTF8String value) {
+  public StringStartsWith(Expression column, UTF8String value) {
     super(column, value);
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -27,17 +27,17 @@ import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, DynamicPruning, EmptyRow, Expression, Literal, NamedExpression, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.catalyst.util.toPrettySQL
+import org.apache.spark.sql.catalyst.util.{toPrettySQL, V2ExpressionBuilder}
 import org.apache.spark.sql.connector.catalog.{Identifier, StagingTableCatalog, SupportsNamespaces, SupportsPartitionManagement, SupportsWrite, Table, TableCapability, TableCatalog}
 import org.apache.spark.sql.connector.catalog.index.SupportsIndex
-import org.apache.spark.sql.connector.expressions.{FieldReference, Literal => V2Literal, LiteralValue}
+import org.apache.spark.sql.connector.expressions.{Expression => V2Expression, FieldReference, Literal => V2Literal, LiteralValue}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse => V2AlwaysFalse, AlwaysTrue => V2AlwaysTrue, And => V2And, EqualNullSafe => V2EqualNullSafe, EqualTo => V2EqualTo, Filter => V2Filter, GreaterThan => V2GreaterThan, GreaterThanOrEqual => V2GreaterThanOrEqual, In => V2In, IsNotNull => V2IsNotNull, IsNull => V2IsNull, LessThan => V2LessThan, LessThanOrEqual => V2LessThanOrEqual, Not => V2Not, Or => V2Or, StringContains => V2StringContains, StringEndsWith => V2StringEndsWith, StringStartsWith => V2StringStartsWith}
 import org.apache.spark.sql.connector.read.LocalScan
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.connector.write.V1Write
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.{FilterExec, LeafExecNode, LocalTableScanExec, ProjectExec, RowDataSourceScanExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, PushableColumn, PushableColumnBase}
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, PushableColumn, PushableColumnAndNestedColumn, PushableColumnBase, PushableColumnWithoutNestedColumn}
 import org.apache.spark.sql.execution.streaming.continuous.{WriteToContinuousDataSource, WriteToContinuousDataSourceExec}
 import org.apache.spark.sql.internal.StaticSQLConf.WAREHOUSE_PATH
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
@@ -472,64 +472,46 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
 private[sql] object DataSourceV2Strategy {
 
   private def translateLeafNodeFilterV2(
-      predicate: Expression,
-      pushableColumn: PushableColumnBase): Option[V2Filter] = predicate match {
-    case expressions.EqualTo(pushableColumn(name), Literal(v, t)) =>
-      Some(new V2EqualTo(FieldReference(name), LiteralValue(v, t)))
-    case expressions.EqualTo(Literal(v, t), pushableColumn(name)) =>
-      Some(new V2EqualTo(FieldReference(name), LiteralValue(v, t)))
+      predicate: Expression): Option[V2Filter] = predicate match {
+    case expressions.EqualTo(PushableExpression(expr1), PushableExpression(expr2)) =>
+      Some(new V2EqualTo(expr1, expr2))
+    case expressions.EqualNullSafe(PushableExpression(expr1), PushableExpression(expr2)) =>
+      Some(new V2EqualNullSafe(expr1, expr2))
+    case expressions.GreaterThan(PushableExpression(expr1), PushableExpression(expr2)) =>
+      Some(new V2GreaterThan(expr1, expr2))
+    case expressions.LessThan(PushableExpression(expr1), PushableExpression(expr2)) =>
+      Some(new V2LessThan(expr1, expr2))
+    case expressions.GreaterThanOrEqual(PushableExpression(expr1), PushableExpression(expr2)) =>
+      Some(new V2GreaterThanOrEqual(expr1, expr2))
+    case expressions.LessThanOrEqual(PushableExpression(expr1), PushableExpression(expr2)) =>
+      Some(new V2LessThanOrEqual(expr1, expr2))
 
-    case expressions.EqualNullSafe(pushableColumn(name), Literal(v, t)) =>
-      Some(new V2EqualNullSafe(FieldReference(name), LiteralValue(v, t)))
-    case expressions.EqualNullSafe(Literal(v, t), pushableColumn(name)) =>
-      Some(new V2EqualNullSafe(FieldReference(name), LiteralValue(v, t)))
-
-    case expressions.GreaterThan(pushableColumn(name), Literal(v, t)) =>
-      Some(new V2GreaterThan(FieldReference(name), LiteralValue(v, t)))
-    case expressions.GreaterThan(Literal(v, t), pushableColumn(name)) =>
-      Some(new V2LessThan(FieldReference(name), LiteralValue(v, t)))
-
-    case expressions.LessThan(pushableColumn(name), Literal(v, t)) =>
-      Some(new V2LessThan(FieldReference(name), LiteralValue(v, t)))
-    case expressions.LessThan(Literal(v, t), pushableColumn(name)) =>
-      Some(new V2GreaterThan(FieldReference(name), LiteralValue(v, t)))
-
-    case expressions.GreaterThanOrEqual(pushableColumn(name), Literal(v, t)) =>
-      Some(new V2GreaterThanOrEqual(FieldReference(name), LiteralValue(v, t)))
-    case expressions.GreaterThanOrEqual(Literal(v, t), pushableColumn(name)) =>
-      Some(new V2LessThanOrEqual(FieldReference(name), LiteralValue(v, t)))
-
-    case expressions.LessThanOrEqual(pushableColumn(name), Literal(v, t)) =>
-      Some(new V2LessThanOrEqual(FieldReference(name), LiteralValue(v, t)))
-    case expressions.LessThanOrEqual(Literal(v, t), pushableColumn(name)) =>
-      Some(new V2GreaterThanOrEqual(FieldReference(name), LiteralValue(v, t)))
-
-    case in @ expressions.InSet(pushableColumn(name), set) =>
+    case in @ expressions.InSet(PushableExpression(expr), set) =>
       val values: Array[V2Literal[_]] =
         set.toSeq.map(elem => LiteralValue(elem, in.dataType)).toArray
-      Some(new V2In(FieldReference(name), values))
+      Some(new V2In(expr, values))
 
     // Because we only convert In to InSet in Optimizer when there are more than certain
     // items. So it is possible we still get an In expression here that needs to be pushed
     // down.
-    case in @ expressions.In(pushableColumn(name), list) if list.forall(_.isInstanceOf[Literal]) =>
+    case in @ expressions.In(PushableExpression(expr), list)
+      if list.forall(_.isInstanceOf[Literal]) =>
       val hSet = list.map(_.eval(EmptyRow))
-      Some(new V2In(FieldReference(name),
-        hSet.toArray.map(LiteralValue(_, in.value.dataType))))
+      Some(new V2In(expr, hSet.toArray.map(LiteralValue(_, in.value.dataType))))
 
-    case expressions.IsNull(pushableColumn(name)) =>
-      Some(new V2IsNull(FieldReference(name)))
-    case expressions.IsNotNull(pushableColumn(name)) =>
-      Some(new V2IsNotNull(FieldReference(name)))
+    case expressions.IsNull(PushableExpression(expr)) =>
+      Some(new V2IsNull(expr))
+    case expressions.IsNotNull(PushableExpression(expr)) =>
+      Some(new V2IsNotNull(expr))
 
-    case expressions.StartsWith(pushableColumn(name), Literal(v: UTF8String, StringType)) =>
-      Some(new V2StringStartsWith(FieldReference(name), v))
+    case expressions.StartsWith(PushableExpression(expr), Literal(v: UTF8String, StringType)) =>
+      Some(new V2StringStartsWith(expr, v))
 
-    case expressions.EndsWith(pushableColumn(name), Literal(v: UTF8String, StringType)) =>
-      Some(new V2StringEndsWith(FieldReference(name), v))
+    case expressions.EndsWith(PushableExpression(expr), Literal(v: UTF8String, StringType)) =>
+      Some(new V2StringEndsWith(expr, v))
 
-    case expressions.Contains(pushableColumn(name), Literal(v: UTF8String, StringType)) =>
-      Some(new V2StringContains(FieldReference(name), v))
+    case expressions.Contains(PushableExpression(expr), Literal(v: UTF8String, StringType)) =>
+      Some(new V2StringContains(expr, v))
 
     case expressions.Literal(true, BooleanType) =>
       Some(new V2AlwaysTrue)
@@ -537,8 +519,8 @@ private[sql] object DataSourceV2Strategy {
     case expressions.Literal(false, BooleanType) =>
       Some(new V2AlwaysFalse)
 
-    case e @ pushableColumn(name) if e.dataType.isInstanceOf[BooleanType] =>
-      Some(new V2EqualTo(FieldReference(name), LiteralValue(true, BooleanType)))
+    case e @ PushableExpression(expr) if e.dataType.isInstanceOf[BooleanType] =>
+      Some(new V2EqualTo(expr, LiteralValue(true, BooleanType)))
 
     case _ => None
   }
@@ -599,8 +581,7 @@ private[sql] object DataSourceV2Strategy {
           .map(new V2Not(_))
 
       case other =>
-        val filter = translateLeafNodeFilterV2(
-          other, PushableColumn(nestedPredicatePushdownEnabled))
+        val filter = translateLeafNodeFilterV2(other)
         if (filter.isDefined && translatedFilterToExpr.isDefined) {
           translatedFilterToExpr.get(filter.get) = predicate
         }
@@ -624,5 +605,15 @@ private[sql] object DataSourceV2Strategy {
         translatedFilterToExpr.getOrElse(other,
           throw new IllegalStateException("Failed to rebuild Expression for filter: " + filter))
     }
+  }
+}
+
+/**
+ * Get the expression of DS V2 to represent catalyst expression that can be pushed down.
+ */
+object PushableExpression {
+  def unapply(e: Expression): Option[V2Expression] = e match {
+    case PushableColumnAndNestedColumn(name) => Some(FieldReference(name))
+    case _ => new V2ExpressionBuilder(e).build()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark DS V2 could push down filters into JDBC source. However, only the most basic form of filter is supported.
On the other hand, some JDBC source could not compile the filters by themselves way.

This PR reactor the framework so as JDBC dialect could compile expression by self way.
First, The framework translate catalyst expressions to DS V2 filters.
Second, The JDBC dialect could compile DS V2 filters to different SQL syntax.


### Why are the changes needed?
Make  the framework be more common use.


### Does this PR introduce _any_ user-facing change?
'No'.
The feature is not released.


### How was this patch tested?
Exists tests.
