### PR TITLE
[SPARK-38441][PYTHON] Support string and bool `regex` in `Series.replace`

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4318,6 +4318,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Replace values given in to_replace with value.
         Values of the Series are replaced with other values dynamically.
 
+        .. note:: The API supports pattern matching (and replacement) on the whole string only,
+            which is different from pandas'.
+
         Parameters
         ----------
         to_replace : str, list, tuple, dict, Series, int, float, or None
@@ -4358,6 +4361,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             Whether to interpret to_replace and/or value as regular expressions.
             If this is True then to_replace must be a string.
             Alternatively, this could be a regular expression in which case to_replace must be None.
+
 
         Returns
         -------

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4494,6 +4494,17 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4     bar
         5     new
         dtype: object
+
+        Only supports pattern matching (and replacement) on the whole string
+
+        >>> psser.replace('ba', 'xx', regex=True)
+        0     xx
+        1    foo
+        2     xx
+        3    abc
+        4     xx
+        5    zoo
+        dtype: object
         """
         if isinstance(regex, str):
             if to_replace is not None:
@@ -4501,7 +4512,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             to_replace = regex
             regex = True
         elif not isinstance(regex, bool):
-            raise NotImplementedError("regex of %s type is supported" % type(regex).__name__)
+            raise NotImplementedError("'regex' of %s type is not supported" % type(regex).__name__)
         elif regex is True:
             assert isinstance(
                 to_replace, str

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4318,7 +4318,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Replace values given in to_replace with value.
         Values of the Series are replaced with other values dynamically.
 
-        .. note:: The API supports pattern matching (and replacement) on the whole string only,
+        .. note:: For partial pattern matching, the replacement is against the whole string,
             which is different from pandas'.
 
         Parameters
@@ -4495,7 +4495,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         5     new
         dtype: object
 
-        Only supports pattern matching (and replacement) on the whole string
+        For partial pattern matching, the replacement is against the whole string
 
         >>> psser.replace('ba', 'xx', regex=True)
         0     xx

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4307,12 +4307,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         """
         return self.index
 
-    # TODO: 'regex', 'method' parameter
+    # TODO: introduce 'method', 'limit', 'in_place'; fully support 'regex'
     def replace(
         self,
         to_replace: Optional[Union[Any, List, Tuple, Dict]] = None,
         value: Optional[Union[List, Tuple]] = None,
-        regex: bool = False,
+        regex: Union[str, bool] = False,
     ) -> "Series":
         """
         Replace values given in to_replace with value.
@@ -4353,6 +4353,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             For a DataFrame a dict of values can be used to specify which value to use
             for each column (columns not in the dict will not be filled).
             Regular expressions, strings and lists or dicts of such objects are also allowed.
+
+        regex: bool or str, default False
+            Whether to interpret to_replace and/or value as regular expressions.
+            If this is True then to_replace must be a string.
+            Alternatively, this could be a regular expression in which case to_replace must be None.
 
         Returns
         -------
@@ -4464,13 +4469,36 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 weight      1.0
                 length      0.3
         dtype: float64
+
+        Regular expression `to_replace`
+
+        >>> psser = ps.Series(['bat', 'foo', 'bait', 'abc', 'bar', 'zoo'])
+        >>> psser.replace(to_replace=r'^ba.$', value='new', regex=True)
+        0     new
+        1     foo
+        2    bait
+        3     abc
+        4     new
+        5     zoo
+        dtype: object
         """
+        if isinstance(regex, str):
+            if to_replace is not None:
+                raise ValueError("'to_replace' must be 'None' if 'regex' is not a bool")
+            to_replace = regex
+            regex = True
+        elif not isinstance(regex, bool):
+            raise NotImplementedError("regex of %s type is supported" % type(regex).__name__)
+        elif regex is True:
+            assert isinstance(
+                to_replace, str
+            ), "If 'regex' is True then 'to_replace' must be a string"
+
         if to_replace is None:
             return self.fillna(method="ffill")
         if not isinstance(to_replace, (str, list, tuple, dict, int, float)):
             raise TypeError("'to_replace' should be one of str, list, tuple, dict, int, float")
-        if regex:
-            raise NotImplementedError("replace currently not support for regex")
+
         to_replace = list(to_replace) if isinstance(to_replace, tuple) else to_replace
         value = list(value) if isinstance(value, tuple) else value
         if isinstance(to_replace, list) and isinstance(value, list):
@@ -4499,10 +4527,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                         current = current.when(cond, value)
                 current = current.otherwise(self.spark.column)
         else:
-            cond = self.spark.column.isin(to_replace)
-            # to_replace may be a scalar
-            if np.array(pd.isna(to_replace)).any():
-                cond = cond | F.isnan(self.spark.column) | self.spark.column.isNull()
+            if regex:
+                # to_replace must be a string
+                cond = self.spark.column.rlike(to_replace)
+            else:
+                cond = self.spark.column.isin(to_replace)
+                # to_replace may be a scalar
+                if np.array(pd.isna(to_replace)).any():
+                    cond = cond | F.isnan(self.spark.column) | self.spark.column.isNull()
             current = F.when(cond, value).otherwise(self.spark.column)
 
         return self._with_new_scol(current)  # TODO: dtype?

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4484,11 +4484,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         >>> psser.replace(value='new', regex=r'^.oo$')
         0     bat
-        1     foo
+        1     new
         2    bait
         3     abc
         4     bar
-        5     zoo
+        5     new
         dtype: object
         """
         if isinstance(regex, str):

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4481,6 +4481,15 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4     new
         5     zoo
         dtype: object
+
+        >>> psser.replace(value='new', regex=r'^.oo$')
+        0     bat
+        1     foo
+        2    bait
+        3     abc
+        4     bar
+        5     zoo
+        dtype: object
         """
         if isinstance(regex, str):
             if to_replace is not None:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -4319,7 +4319,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Values of the Series are replaced with other values dynamically.
 
         .. note:: For partial pattern matching, the replacement is against the whole string,
-            which is different from pandas'.
+            which is different from pandas'. That's by the nature of underlying Spark API.
 
         Parameters
         ----------

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1744,6 +1744,10 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(
             psser.replace(regex=r"^.oo$", value="new"), pser.replace(regex=r"^.oo$", value="new")
         )
+        self.assert_eq(
+            (psser + "o").replace(regex=r"^.ooo$", value="new"),
+            (pser + "o").replace(regex=r"^.ooo$", value="new"),
+        )
 
         msg = "'to_replace' should be one of str, list, tuple, dict, int, float"
         with self.assertRaisesRegex(TypeError, msg):

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1757,6 +1757,10 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         msg = "If 'regex' is True then 'to_replace' must be a string"
         with self.assertRaisesRegex(AssertionError, msg):
             psser.replace(["bat", "foo", "bait"], regex=True)
+        unsupported_regex = [r"^.oo$", r"^ba.$"]
+        msg = "'regex' of %s type is not supported" % type(unsupported_regex).__name__
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            psser.replace(regex=unsupported_regex, value="new")
 
     def test_xs(self):
         midx = pd.MultiIndex(

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1724,7 +1724,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
     def test_replace(self):
         pser = pd.Series([10, 20, 15, 30, np.nan], name="x")
-        psser = ps.Series(pser)
+        psser = ps.from_pandas(pser)
 
         self.assert_eq(psser.replace(), pser.replace())
         self.assert_eq(psser.replace({}), pser.replace({}))
@@ -1735,15 +1735,28 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.replace([10, 15], [45, 50]), pser.replace([10, 15], [45, 50]))
         self.assert_eq(psser.replace((10, 15), (45, 50)), pser.replace((10, 15), (45, 50)))
 
+        pser = pd.Series(["bat", "foo", "bait", "abc", "bar", "zoo"])
+        psser = ps.from_pandas(pser)
+        self.assert_eq(
+            psser.replace(to_replace=r"^ba.$", value="new", regex=True),
+            pser.replace(to_replace=r"^ba.$", value="new", regex=True),
+        )
+        self.assert_eq(
+            psser.replace(regex=r"^.oo$", value="new"), pser.replace(regex=r"^.oo$", value="new")
+        )
+
         msg = "'to_replace' should be one of str, list, tuple, dict, int, float"
         with self.assertRaisesRegex(TypeError, msg):
             psser.replace(ps.range(5))
         msg = "Replacement lists must match in length. Expecting 3 got 2"
         with self.assertRaisesRegex(ValueError, msg):
-            psser.replace([10, 20, 30], [1, 2])
-        msg = "replace currently not support for regex"
-        with self.assertRaisesRegex(NotImplementedError, msg):
-            psser.replace(r"^1.$", regex=True)
+            psser.replace(["bat", "foo", "bait"], ["a", "b"])
+        msg = "'to_replace' must be 'None' if 'regex' is not a bool"
+        with self.assertRaisesRegex(ValueError, msg):
+            psser.replace(to_replace="foo", regex=r"^.oo$")
+        msg = "If 'regex' is True then 'to_replace' must be a string"
+        with self.assertRaisesRegex(AssertionError, msg):
+            psser.replace(["bat", "foo", "bait"], regex=True)
 
     def test_xs(self):
         midx = pd.MultiIndex(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support string and bool `regex` in Series.replace


### Why are the changes needed?
To reach parity with pandas API.


### Does this PR introduce _any_ user-facing change?
Yes. String and bool `regex` are supported for `Series.replace`.
```py
# bool `regex`
        >>> psser = ps.Series(['bat', 'foo', 'bait', 'abc', 'bar', 'zoo'])
        >>> psser.replace(to_replace=r'^ba.$', value='new', regex=True)
        0     new
        1     foo
        2    bait
        3     abc
        4     new
        5     zoo
        dtype: object

# string `regex`
        >>> psser.replace(value='new', regex=r'^.oo$')
        0     bat
        1     new
        2    bait
        3     abc
        4     bar
        5     new
        dtype: object
```

### How was this patch tested?
Unit test.
