### PR TITLE
[SPARK-38431][SQL]Support to delete matched rows from jdbc tables

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -22,10 +22,12 @@ import java.time.{Instant, LocalDate}
 import java.util
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 import scala.util.control.NonFatal
+
 import org.apache.spark.TaskContext
 import org.apache.spark.executor.InputMetrics
 import org.apache.spark.internal.Logging

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -425,4 +425,19 @@ class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
       assert(m.contains("\"TABLEENGINENAME\" not found"))
     }
   }
+
+  test("DELETE FROM TABLE WHERE Clause") {
+    sql("insert into h2.test.people values('tony', 1)")
+    sql("insert into h2.test.people values('any', 2)")
+    sql("insert into h2.test.people values('gina', 3)")
+    val preCount = sql("select * from h2.test.people").count()
+    sql("delete from h2.test.people where id = 1")
+    val aftCount = sql("select * from h2.test.people").count()
+    assert((aftCount + 1) == preCount)
+    sql("insert into h2.test.people values('an', 4)")
+    val preCount1 = sql("select * from h2.test.people").count()
+    sql("delete from h2.test.people where id > 3")
+    val aftCount1 = sql("select * from h2.test.people").count()
+    assert(aftCount1 < preCount1)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support to delete matched rows from jdbc tables，when execute the following sql
`delete from db.table where ...`

related issue: https://issues.apache.org/jira/browse/SPARK-38431

### Why are the changes needed?
when access rdbms，`delete from table where ...` is not supported.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new testing
