### PR TITLE
[SPARK-38436][PYTHON][TESTS] Fix `test_ceil` to test `ceil`

### DIFF
--- a/python/pyspark/pandas/tests/test_series_datetime.py
+++ b/python/pyspark/pandas/tests/test_series_datetime.py
@@ -264,8 +264,8 @@ class SeriesDateTimeTest(PandasOnSparkTestCase, SQLTestUtils):
         self.check_func(lambda x: x.dt.floor(freq="H"))
 
     def test_ceil(self):
-        self.check_func(lambda x: x.dt.floor(freq="min"))
-        self.check_func(lambda x: x.dt.floor(freq="H"))
+        self.check_func(lambda x: x.dt.ceil(freq="min"))
+        self.check_func(lambda x: x.dt.ceil(freq="H"))
 
     @unittest.skip("Unsupported locale setting")
     def test_month_name(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
We have two functions that are testing the same thing.


### Why are the changes needed?
To test both floor and ceil.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Got the green light.