### PR TITLE
[SPARK-38183][PYTHON][FOLLOWUP] Check the ANSI conf properly when creating pandas-on-Spark session

### DIFF
--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -474,7 +474,7 @@ def default_session() -> SparkSession:
     # the behavior of pandas API on Spark follows pandas, not SQL.
     if is_testing():
         spark.conf.set("spark.sql.ansi.enabled", False)  # type: ignore[arg-type]
-    if spark.conf.get("spark.sql.ansi.enabled"):
+    if spark.conf.get("spark.sql.ansi.enabled") == "true":
         log_advice(
             "The config 'spark.sql.ansi.enabled' is set to True. "
             "This can cause unexpected behavior "


### PR DESCRIPTION
### What changes were proposed in this pull request?

This followup for https://github.com/apache/spark/pull/35488 proposes to fix ANSI conf check properly in `python/pyspark/pandas/utils.py`.



### Why are the changes needed?

So far, the condition `if spark.conf.get("spark.sql.ansi.enabled"):` always went True, since `spark.conf.get("spark.sql.ansi.enabled")` returns `"true"` or `"false"` instead of `True` or `False`.

So, it's always show the warning message although the ANSI mode is not enabled.

We might need to check the returned string properly so that we can only show the warning message when the `"spark.sql.ansi.enabled"` is actually set as True.

### Does this PR introduce _any_ user-facing change?

Now users see warning message when only `"spark.sql.ansi.enabled"` is set as True.


### How was this patch tested?

Manually test, and the existing tests are should be passed.
