### PR TITLE
[SPARK-38443][SS][DOC] Document config STREAMING_SESSION_WINDOW_MERGE_SESSIONS_IN_LOCAL_PARTITION

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1225,6 +1225,12 @@ Note that there are some restrictions when you use session window in streaming q
 
 For batch query, global window (only having `session_window` in grouping key) is supported.
 
+Due to implementation details of session window in streaming query, for each input row in same session,
+it will be assigned initial session window and then merged into real session after shuffling. If the RPS
+of input rows is high and there are too many rows in same session in a batch, the output of shuffle write
+might be significant. For such case, you can enable `spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition`
+to sort and merge session in local partition prior to shuffle.
+
 ##### Conditions for watermarking to clean aggregation state
 {:.no_toc}
 

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1226,8 +1226,8 @@ Note that there are some restrictions when you use session window in streaming q
 For batch query, global window (only having `session_window` in grouping key) is supported.
 
 Due to implementation details of session window in streaming query, for each input row in same session,
-it will be assigned initial session window and then merged into real session after shuffling. If the RPS
-of input rows is high and there are too many rows in same session in a batch, the output of shuffle write
+it will be assigned initial session window and then merged into real session after shuffling. If the input
+rate is high and there are too many rows in same session in a batch, the output of shuffle write
 might be significant. For such case, you can enable `spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition`
 to sort and merge session in local partition prior to shuffle.
 

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -1225,11 +1225,12 @@ Note that there are some restrictions when you use session window in streaming q
 
 For batch query, global window (only having `session_window` in grouping key) is supported.
 
-Due to implementation details of session window in streaming query, for each input row in same session,
-it will be assigned initial session window and then merged into real session after shuffling. If the input
-rate is high and there are too many rows in same session in a batch, the output of shuffle write
-might be significant. For such case, you can enable `spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition`
-to sort and merge session in local partition prior to shuffle.
+By default, Spark does not perform partial aggregation for session window aggregation, since it requires additional
+sort in local partitions before grouping. It works better for the case there are only few number of input rows in
+same group key for each local partition, but for the case there are numerous input rows having same group key in
+local partition, doing partial aggregation can still increase the performance significantly despite additional sort.
+
+You can enable `spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition` to indicate Spark to perform partial aggregation.
 
 ##### Conditions for watermarking to clean aggregation state
 {:.no_toc}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1720,7 +1720,6 @@ object SQLConf {
 
   val STREAMING_SESSION_WINDOW_MERGE_SESSIONS_IN_LOCAL_PARTITION =
     buildConf("spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition")
-      .internal()
       .doc("When true, streaming session window sorts and merge sessions in local partition " +
         "prior to shuffle. This is to reduce the rows to shuffle, but only beneficial when " +
         "there're lots of rows in a batch being assigned to same sessions.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This proposes to document the config `spark.sql.streaming.sessionWindow.merge.sessions.in.local.partition` in structured streaming guide.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We have use case the customer faces issue on large shuffle write in session window. Users are hardly to know what is the issue and cannot find related document. The config is hidden, although it is useful for such case. We should document it so end users can find it easily.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, documented a config in user-facing guide.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Basically doc change.