### PR TITLE
[SPARK-38423][K8S][FOLLOWUP] PodGroup spec should not be null

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
@@ -48,6 +48,8 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
         .withName(podGroupName)
         .withNamespace(namespace)
       .endMetadata()
+      .editOrNewSpec()
+      .endSpec()
 
     queue.foreach(podGroup.editOrNewSpec().withQueue(_).endSpec())
 
@@ -58,7 +60,7 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
 
   override def configurePod(pod: SparkPod): SparkPod = {
 
-    priorityClassName = Some(pod.pod.getSpec.getPriorityClassName)
+    priorityClassName = Option(pod.pod.getSpec.getPriorityClassName)
 
     val k8sPodBuilder = new PodBuilder(pod.pod)
       .editMetadata()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of #35639 to prevent `PodGroup` with `null` spec. 

### Why are the changes needed?

First, for `null` value, we should use `Option(null)` to make it `None`. This PR fixes the following.
```
- priorityClassName = Some(pod.pod.getSpec.getPriorityClassName)
+ priorityClassName = Option(pod.pod.getSpec.getPriorityClassName)
```

Second, when `queue` and `priorityClassName` are not given. `PodGroup` is created with `null` spec.
This causes NullPointerException during the test case. This PR fixes it.

### Does this PR introduce _any_ user-facing change?

No. This is not released yet.

### How was this patch tested?

Pass the CIs.