### PR TITLE
[SPARK-38452][K8S][TESTS] Support pyDockerfile and rDockerfile in SBT K8s IT

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -646,16 +646,21 @@ object KubernetesIntegrationTests {
         val javaImageTag = sys.props.get("spark.kubernetes.test.javaImageTag")
         val dockerFile = sys.props.getOrElse("spark.kubernetes.test.dockerFile",
             s"$sparkHome/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile.java17")
+        val pyDockerFile = sys.props.getOrElse("spark.kubernetes.test.pyDockerFile",
+            s"$bindingsDir/python/Dockerfile")
+        val rDockerFile = sys.props.getOrElse("spark.kubernetes.test.rDockerFile",
+          s"$bindingsDir/R/Dockerfile")
         val extraOptions = if (javaImageTag.isDefined) {
           Seq("-b", s"java_image_tag=$javaImageTag")
         } else {
           Seq("-f", s"$dockerFile")
         }
+
         val cmd = Seq(dockerTool,
           "-r", imageRepo,
           "-t", imageTag.getOrElse("dev"),
-          "-p", s"$bindingsDir/python/Dockerfile",
-          "-R", s"$bindingsDir/R/Dockerfile") ++
+          "-p", pyDockerFile,
+          "-R", rDockerFile) ++
           (if (deployMode != Some("minikube")) Seq.empty else Seq("-m")) ++
           extraOptions :+
           "build"

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -655,7 +655,6 @@ object KubernetesIntegrationTests {
         } else {
           Seq("-f", s"$dockerFile")
         }
-
         val cmd = Seq(dockerTool,
           "-r", imageRepo,
           "-t", imageTag.getOrElse("dev"),

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -649,7 +649,7 @@ object KubernetesIntegrationTests {
         val pyDockerFile = sys.props.getOrElse("spark.kubernetes.test.pyDockerFile",
             s"$bindingsDir/python/Dockerfile")
         val rDockerFile = sys.props.getOrElse("spark.kubernetes.test.rDockerFile",
-          s"$bindingsDir/R/Dockerfile")
+            s"$bindingsDir/R/Dockerfile")
         val extraOptions = if (javaImageTag.isDefined) {
           Seq("-b", s"java_image_tag=$javaImageTag")
         } else {

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -288,6 +288,16 @@ The following is an example to rerun tests with the pre-built image.
         -Dspark.kubernetes.test.imageTag=2022-03-06 \
         'kubernetes-integration-tests/runIts'
 
+You can also specify your specific dockerfile to build JVM/Python/R based image to test:
+
+    build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests \
+        -Dtest.exclude.tags=minikube \
+        -Dspark.kubernetes.test.deployMode=docker-desktop \
+        -Dspark.kubernetes.test.DockerFile=/path/to/Dockerfile \
+        -Dspark.kubernetes.test.pyDockerFile=/path/to/Dockerfile.py \
+        -Dspark.kubernetes.test.rDockerFile=/path/to/Dockerfile.r \
+        'kubernetes-integration-tests/test'
+
 In addition, you can run a single test selectively.
 
     build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests \

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -300,7 +300,8 @@ You can also specify your specific dockerfile to build JVM/Python/R based image 
     build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests \
         -Dtest.exclude.tags=minikube \
         -Dspark.kubernetes.test.deployMode=docker-desktop \
-        -Dspark.kubernetes.test.DockerFile=/path/to/Dockerfile \
-        -Dspark.kubernetes.test.pyDockerFile=/path/to/Dockerfile.py \
-        -Dspark.kubernetes.test.rDockerFile=/path/to/Dockerfile.r \
+        -Dspark.kubernetes.test.imageTag=2022-03-06 \
+        -Dspark.kubernetes.test.dockerFile=/path/to/Dockerfile \
+        -Dspark.kubernetes.test.pyDockerFile=/path/to/py/Dockerfile \
+        -Dspark.kubernetes.test.rDockerFile=/path/to/r/Dockerfile \
         'kubernetes-integration-tests/test'

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -288,7 +288,14 @@ The following is an example to rerun tests with the pre-built image.
         -Dspark.kubernetes.test.imageTag=2022-03-06 \
         'kubernetes-integration-tests/runIts'
 
-You can also specify your specific dockerfile to build JVM/Python/R based image to test:
+In addition, you can run a single test selectively.
+
+    build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests \
+        -Dspark.kubernetes.test.deployMode=docker-desktop \
+        -Dspark.kubernetes.test.imageTag=2022-03-06 \
+        'kubernetes-integration-tests/testOnly -- -z "Run SparkPi with a very long application name"'
+
+You can also specify your specific dockerfile to build JVM/Python/R based image to test.
 
     build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests \
         -Dtest.exclude.tags=minikube \
@@ -297,10 +304,3 @@ You can also specify your specific dockerfile to build JVM/Python/R based image 
         -Dspark.kubernetes.test.pyDockerFile=/path/to/Dockerfile.py \
         -Dspark.kubernetes.test.rDockerFile=/path/to/Dockerfile.r \
         'kubernetes-integration-tests/test'
-
-In addition, you can run a single test selectively.
-
-    build/sbt -Psparkr -Pkubernetes -Pkubernetes-integration-tests \
-        -Dspark.kubernetes.test.deployMode=docker-desktop \
-        -Dspark.kubernetes.test.imageTag=2022-03-06 \
-        'kubernetes-integration-tests/testOnly -- -z "Run SparkPi with a very long application name"'


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support pyDockerfile and rDockerfile in SBT K8s IT

### Why are the changes needed?
Enable users to specify `pyDockerfile` and `rDockerfile` separately.


### Does this PR introduce _any_ user-facing change?
No, test only


### How was this patch tested?
```
build/sbt -Pkubernetes -Pkubernetes-integration-tests \
-Dtest.exclude.tags=minikube  -Dspark.kubernetes.test.deployMode=docker-desktop \
-Dspark.kubernetes.test.pyDockerFile=/Users/yikun/code/Dockerfile.py \
-Dspark.kubernetes.test.rDockerFile=/Users/yikun/code/Dockerfile.r \
-Dspark.kubernetes.test.DockerFile=/Users/yikun/code/Dockerfile "kubernetes-integration-tests/test"
```