### PR TITLE
[MINOR][DOCS] Fix minor typos at nulls_option in Window Functions

### DIFF
--- a/docs/sql-ref-syntax-qry-select-window.md
+++ b/docs/sql-ref-syntax-qry-select-window.md
@@ -52,7 +52,7 @@ window_function [ nulls_option ] OVER
 
 * **nulls_option**
 
-    Specifies whether or not to skip null values when evaluating the window function. `RESECT NULLS` means not skipping null values, while `IGNORE NULLS` means skipping. If not specified, the default is `RESECT NULLS`.
+    Specifies whether or not to skip null values when evaluating the window function. `RESPECT NULLS` means not skipping null values, while `IGNORE NULLS` means skipping. If not specified, the default is `RESPECT NULLS`.
 
     **Syntax:**
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a typo: `RESECT` -> `RESPECT`.

### Why are the changes needed?

`RESECT` isn't a valid term here

### Does this PR introduce _any_ user-facing change?
Yes, the typos in the docs are corrected.

### How was this patch tested?
inspection via the Github UI