### PR TITLE
[SPARK-38355][PYTHON][TESTS] Use `mkstemp` instead of `mktemp`

### DIFF
--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -259,7 +259,7 @@ class TestUtils:
     @contextmanager
     def temp_file(self):
         with self.temp_dir() as tmp:
-            yield tempfile.mktemp(dir=tmp)
+            yield tempfile.mkstemp(dir=tmp)[1]
 
 
 class ComparisonTestBase(PandasOnSparkTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?
To change from `mktemp` to `mkstemp`. 

### Why are the changes needed?
Pandas API on Spark use `mktemp` in test. 
`mktemp` "THIS FUNCTION IS UNSAFE AND SHOULD NOT BE USED.  The file name may
refer to a file that did not exist at some point, but by the time
you get around to creating it, someone else may have beaten you to
the punch."

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Got the green light.