### PR TITLE
[SPARK-38385][SQL] Improve error messages of empty statement and <EOF> in ParseException

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -133,7 +133,7 @@
   },
   "PARSE_EMPTY_STATEMENT" : {
     "message" : [ "Syntax error, unexpected empty statement" ],
-    "sqlState": "42000"
+    "sqlState" : "42000"
   },
   "PARSE_INPUT_MISMATCHED" : {
     "message" : [ "Syntax error at or near %s" ],

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -131,6 +131,10 @@
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
     "sqlState" : "42000"
   },
+  "PARSE_EMPTY_STATEMENT" : {
+    "message" : [ "Syntax error, unexpected empty statement" ],
+    "sqlState": "42000"
+  },
   "PARSE_INPUT_MISMATCHED" : {
     "message" : [ "Syntax error at or near %s" ],
     "sqlState" : "42000"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -289,7 +289,12 @@ class ParseException(
   }
 
   def withCommand(cmd: String): ParseException = {
-    new ParseException(Option(cmd), message, start, stop, errorClass, messageParameters)
+    // PARSE_EMPTY_STATEMENT error class overrides the PARSE_INPUT_MISMATCHED when cmd is empty
+    if (cmd.trim().isEmpty && errorClass.isDefined && errorClass.get == "PARSE_INPUT_MISMATCHED") {
+      new ParseException(Option(cmd), start, stop, "PARSE_EMPTY_STATEMENT", Array[String]())
+    } else {
+      new ParseException(Option(cmd), message, start, stop, errorClass, messageParameters)
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SparkParserErrorStrategy.scala
@@ -60,6 +60,11 @@ class SparkRecognitionException(
  * message framework to these exceptions.
  */
 class SparkParserErrorStrategy() extends DefaultErrorStrategy {
+  private val userWordDict : Map[String, String] = Map("'<EOF>'" -> "end of input")
+  private def getUserFacingLanguage(input: String) = {
+    userWordDict.getOrElse(input, input)
+  }
+
   override def reportInputMismatch(recognizer: Parser, e: InputMismatchException): Unit = {
     // Keep the original error message in ANTLR
     val msg = "mismatched input " +
@@ -70,7 +75,7 @@ class SparkParserErrorStrategy() extends DefaultErrorStrategy {
     val exceptionWithErrorClass = new SparkRecognitionException(
       e,
       "PARSE_INPUT_MISMATCHED",
-      Array(getTokenErrorDisplay(e.getOffendingToken)))
+      Array(getUserFacingLanguage(getTokenErrorDisplay(e.getOffendingToken))))
     recognizer.notifyErrorListeners(e.getOffendingToken, msg, exceptionWithErrorClass)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
@@ -98,6 +98,21 @@ class ErrorParserSuite extends AnalysisTest {
       "Syntax error at or near", "^^^")
   }
 
+  test("empty input") {
+    val expectedErrMsg = SparkThrowableHelper.getMessage("PARSE_EMPTY_STATEMENT", Array[String]())
+    intercept("", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
+    intercept("   ", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
+    intercept(" \n", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
+  }
+
+  test("jargon token substitute to user-facing language") {
+    // '<EOF>' -> end of input
+    intercept("select count(*", "PARSE_INPUT_MISMATCHED",
+      1, 14, 14, "Syntax error at or near end of input")
+    intercept("select 1 as a from", "PARSE_INPUT_MISMATCHED",
+      1, 18, 18, "Syntax error at or near end of input")
+  }
+
   test("semantic errors") {
     intercept("select *\nfrom r\norder by q\ncluster by q", 3, 0, 11,
       "Combination of ORDER BY/SORT BY/DISTRIBUTE BY/CLUSTER BY is not supported",

--- a/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
@@ -168,7 +168,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-Syntax error at or near '<EOF>'(line 1, pos 19)
+Syntax error at or near end of input(line 1, pos 19)
 
 == SQL ==
 SHOW TABLE EXTENDED


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR handles case 2 and 3 mentioned in https://issues.apache.org/jira/browse/SPARK-38385.
Specifically,
1. For empty query, output a specific error message ‘syntax error, unexpected SQL statement’
    * Before
        ```
        ParseException: 
        mismatched input '<EOF>' expecting {'(', 'CONVERT', 'COPY', 'OPTIMIZE', 'RESTORE', 'ADD', 'ALTER', 'ANALYZE', 'CACHE', 'CLEAR', 'COMMENT', 'COMMIT', 'CREATE', 'DELETE', 'DESC', 'DESCRIBE', 'DFS', 'DROP', 'EXPLAIN', 'EXPORT', 'FROM', 'GRANT', 'IMPORT', 'INSERT', 'LIST', 'LOAD', 'LOCK', 'MAP', 'MERGE', 'MSCK', 'REDUCE', 'REFRESH', 'REPLACE', 'RESET', 'REVOKE', 'ROLLBACK', 'SELECT', 'SET', 'SHOW', 'START', 'TABLE', 'TRUNCATE', 'UNCACHE', 'UNLOCK', 'UPDATE', 'USE', 'VALUES', 'WITH'}(line 1, pos 0)
        
        == SQL ==
        
        ^^^ 
        ```
    * After
        ```
        ParseException: 
        syntax error, unexpected SQL statement(line 1, pos 0)
        
        == SQL ==
        
        ^^^
        ```

2. For the faulty token '\<EOF\>'., substitute it to a readable string ‘end of input’.
    * Before
        ```
        ParseException: 
        mismatched input '<EOF>' expecting {'APPLY', 'CALLED', 'CHANGES', 'CLONE', 'COLLECT', 'CONTAINS', 'CONVERT', 'COPY', 'COPY_OPTIONS', 'CREDENTIAL', 'CREDENTIALS', 'DEEP', 'DEFINER', 'DELTA', 'DETERMINISTIC', 'ENCRYPTION', 'EXPECT', 'FAIL', 'FILES',… (omit long message) 'TRIM', 'TRUE', 'TRUNCATE', 'TRY_CAST', 'TYPE', 'UNARCHIVE', 'UNBOUNDED', 'UNCACHE', 'UNION', 'UNIQUE', 'UNKNOWN', 'UNLOCK', 'UNSET', 'UPDATE', 'USE', 'USER', 'USING', 'VALUES', 'VERSION', 'VIEW', 'VIEWS', 'WHEN', 'WHERE', 'WINDOW', 'WITH', 'WITHIN', 'YEAR', 'ZONE', IDENTIFIER, BACKQUOTED_IDENTIFIER}(line 1, pos 11)
        
        == SQL ==
        select 1  (
        -----------^^^ 
        ```
    * After
        ```
        ParseException: 
        syntax error at or near end of input(line 1, pos 11)
        
        == SQL ==
        select 1  (
        -----------^^^
        ```


#### Changes in code
* error-class.json
    Define a new type of error `PARSE_EMPTY_STATEMENT`
    ```json
      "PARSE_EMPTY_STATEMENT" : {
        "message" : [ "Syntax error, unexpected empty statement" ],
        "sqlState" : "42000"
      },
    ```

* ParserDriver.scala
    Let the `PARSE_EMPTY_STATEMENT` error class overrides the `PARSE_INPUT_MISMATCHED` when cmd (the SQL) is empty. That way, the error messages for empty queries would be "unexpected empty statement".

* SparkParserErrorStrategy.scala
    Define a new dictionary from the input jargon words to user-facing words. In the current mismatch input error, substitute the token to user-facing language. That way, there would be no '\<EOF\>'.

* test suites
    Add two more testcases testing the above cases.

### Why are the changes needed?
https://issues.apache.org/jira/browse/SPARK-38384 The description states the reason for the change.
TLDR, the error messages of ParseException directly coming from ANTLR are not user-friendly and we want to improve it.


### Does this PR introduce _any_ user-facing change?
If the error messages change are considered as user-facing change, then yes.
The changes in the error message:
1.  For empty query, output a specific error message ‘syntax error, unexpected SQL statement’
2. For the faulty token '\<EOF\>'., substitute it to a readable string ‘end of input’.

Example cases are listed in the top of this PR description.

### How was this patch tested?
Unit tests.
