### PR TITLE
[SPARK-38458][SQL] Fix always false condition in `LogDivertAppender#initLayout`

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
@@ -267,7 +267,7 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
       Appender ap = entry.getValue();
       if (ap.getClass().equals(ConsoleAppender.class)) {
         Layout l = ap.getLayout();
-        if (l.getClass().equals(StringLayout.class)) {
+        if (l instanceof StringLayout) {
           layout = (StringLayout) l;
           break;
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`initLayout` method in `LogDivertAppender` as follows:

```java
private static StringLayout initLayout(OperationLog.LoggingLevel loggingMode) {
   ...
    for (Map.Entry<String, Appender> entry : appenders.entrySet()) {
      Appender ap = entry.getValue();
      if (ap.getClass().equals(ConsoleAppender.class)) {
        Layout l = ap.getLayout();
        if (l.getClass().equals(StringLayout.class)) {
          layout = (StringLayout) l;
          break;
        }
      }
    }
    return getLayout(isVerbose, layout);
  } 
```

`l.getClass().equals(StringLayout.class)` in above method is always return `false` because `StringLayout` is an interface, for example, `JsonLayout` is an implementation of `StringLayout`, but `JsonLayout.class.equals(StringLayout.class)` will return false.

This pr change to use `instanceof` to fix the issue.


### Why are the changes needed?
Bug fix


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA