### PR TITLE
[WIP][SPARK-38460][SQL] Clean up duplicate codes in `get` method of `ColumnarBatchRow/ColumnarRow/MutableColumnarRow`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
@@ -145,15 +145,18 @@ public final class ColumnarBatchRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
+    // return InternalRow.getReader(ordinal, dataType).apply(this);
     if (dataType instanceof BooleanType) {
       return getBoolean(ordinal);
     } else if (dataType instanceof ByteType) {
       return getByte(ordinal);
     } else if (dataType instanceof ShortType) {
       return getShort(ordinal);
-    } else if (dataType instanceof IntegerType || dataType instanceof YearMonthIntervalType) {
+    } else if (dataType instanceof IntegerType || dataType instanceof DateType ||
+      dataType instanceof YearMonthIntervalType) {
       return getInt(ordinal);
-    } else if (dataType instanceof LongType || dataType instanceof DayTimeIntervalType) {
+    } else if (dataType instanceof LongType || dataType instanceof TimestampType ||
+      dataType instanceof DayTimeIntervalType) {
       return getLong(ordinal);
     } else if (dataType instanceof FloatType) {
       return getFloat(ordinal);
@@ -166,10 +169,6 @@ public final class ColumnarBatchRow extends InternalRow {
     } else if (dataType instanceof DecimalType) {
       DecimalType t = (DecimalType) dataType;
       return getDecimal(ordinal, t.precision(), t.scale());
-    } else if (dataType instanceof DateType) {
-      return getInt(ordinal);
-    } else if (dataType instanceof TimestampType) {
-      return getLong(ordinal);
     } else if (dataType instanceof ArrayType) {
       return getArray(ordinal);
     } else if (dataType instanceof StructType) {

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
@@ -18,6 +18,7 @@ package org.apache.spark.sql.vectorized;
 
 import org.apache.spark.annotation.DeveloperApi;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.InternalRow$;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.CalendarInterval;
@@ -145,39 +146,7 @@ public final class ColumnarBatchRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    // return InternalRow.getReader(ordinal, dataType).apply(this);
-    if (dataType instanceof BooleanType) {
-      return getBoolean(ordinal);
-    } else if (dataType instanceof ByteType) {
-      return getByte(ordinal);
-    } else if (dataType instanceof ShortType) {
-      return getShort(ordinal);
-    } else if (dataType instanceof IntegerType || dataType instanceof DateType ||
-      dataType instanceof YearMonthIntervalType) {
-      return getInt(ordinal);
-    } else if (dataType instanceof LongType || dataType instanceof TimestampType ||
-      dataType instanceof DayTimeIntervalType) {
-      return getLong(ordinal);
-    } else if (dataType instanceof FloatType) {
-      return getFloat(ordinal);
-    } else if (dataType instanceof DoubleType) {
-      return getDouble(ordinal);
-    } else if (dataType instanceof StringType) {
-      return getUTF8String(ordinal);
-    } else if (dataType instanceof BinaryType) {
-      return getBinary(ordinal);
-    } else if (dataType instanceof DecimalType) {
-      DecimalType t = (DecimalType) dataType;
-      return getDecimal(ordinal, t.precision(), t.scale());
-    } else if (dataType instanceof ArrayType) {
-      return getArray(ordinal);
-    } else if (dataType instanceof StructType) {
-      return getStruct(ordinal, ((StructType)dataType).fields().length);
-    } else if (dataType instanceof MapType) {
-      return getMap(ordinal);
-    } else {
-      throw new UnsupportedOperationException("Datatype not supported " + dataType);
-    }
+    return InternalRow$.MODULE$.getReader(ordinal, dataType).apply(this);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
@@ -146,7 +146,7 @@ public final class ColumnarBatchRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    return InternalRow$.MODULE$.getReader(ordinal, dataType).apply(this);
+    return InternalRow$.MODULE$.getGetter(ordinal, dataType).apply(this);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
@@ -18,8 +18,8 @@ package org.apache.spark.sql.vectorized;
 
 import org.apache.spark.annotation.DeveloperApi;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.InternalRow$;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.SpecializedGettersReader;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -146,7 +146,7 @@ public final class ColumnarBatchRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    return InternalRow$.MODULE$.getGetter(ordinal, dataType).apply(this);
+    return SpecializedGettersReader.read(this, ordinal, dataType, false, false);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
@@ -155,7 +155,7 @@ public final class ColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    return InternalRow$.MODULE$.getReader(ordinal, dataType).apply(this);
+    return InternalRow$.MODULE$.getGetter(ordinal, dataType).apply(this);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
@@ -18,8 +18,8 @@ package org.apache.spark.sql.vectorized;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.InternalRow$;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.SpecializedGettersReader;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -155,7 +155,7 @@ public final class ColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    return InternalRow$.MODULE$.getGetter(ordinal, dataType).apply(this);
+    return SpecializedGettersReader.read(this, ordinal, dataType, false, false);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
@@ -18,6 +18,7 @@ package org.apache.spark.sql.vectorized;
 
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.InternalRow$;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.CalendarInterval;
@@ -154,39 +155,7 @@ public final class ColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    // return InternalRow.getReader(ordinal, dataType).apply(this);
-    if (dataType instanceof BooleanType) {
-      return getBoolean(ordinal);
-    } else if (dataType instanceof ByteType) {
-      return getByte(ordinal);
-    } else if (dataType instanceof ShortType) {
-      return getShort(ordinal);
-    } else if (dataType instanceof IntegerType || dataType instanceof DateType ||
-      dataType instanceof YearMonthIntervalType) {
-      return getInt(ordinal);
-    } else if (dataType instanceof LongType || dataType instanceof TimestampType ||
-      dataType instanceof DayTimeIntervalType) {
-      return getLong(ordinal);
-    } else if (dataType instanceof FloatType) {
-      return getFloat(ordinal);
-    } else if (dataType instanceof DoubleType) {
-      return getDouble(ordinal);
-    } else if (dataType instanceof StringType) {
-      return getUTF8String(ordinal);
-    } else if (dataType instanceof BinaryType) {
-      return getBinary(ordinal);
-    } else if (dataType instanceof DecimalType) {
-      DecimalType t = (DecimalType) dataType;
-      return getDecimal(ordinal, t.precision(), t.scale());
-    } else if (dataType instanceof ArrayType) {
-      return getArray(ordinal);
-    } else if (dataType instanceof StructType) {
-      return getStruct(ordinal, ((StructType)dataType).fields().length);
-    } else if (dataType instanceof MapType) {
-      return getMap(ordinal);
-    } else {
-      throw new UnsupportedOperationException("Datatype not supported " + dataType);
-    }
+    return InternalRow$.MODULE$.getReader(ordinal, dataType).apply(this);
   }
 
   @Override

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
@@ -154,15 +154,18 @@ public final class ColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
+    // return InternalRow.getReader(ordinal, dataType).apply(this);
     if (dataType instanceof BooleanType) {
       return getBoolean(ordinal);
     } else if (dataType instanceof ByteType) {
       return getByte(ordinal);
     } else if (dataType instanceof ShortType) {
       return getShort(ordinal);
-    } else if (dataType instanceof IntegerType || dataType instanceof YearMonthIntervalType) {
+    } else if (dataType instanceof IntegerType || dataType instanceof DateType ||
+      dataType instanceof YearMonthIntervalType) {
       return getInt(ordinal);
-    } else if (dataType instanceof LongType || dataType instanceof DayTimeIntervalType) {
+    } else if (dataType instanceof LongType || dataType instanceof TimestampType ||
+      dataType instanceof DayTimeIntervalType) {
       return getLong(ordinal);
     } else if (dataType instanceof FloatType) {
       return getFloat(ordinal);
@@ -175,10 +178,6 @@ public final class ColumnarRow extends InternalRow {
     } else if (dataType instanceof DecimalType) {
       DecimalType t = (DecimalType) dataType;
       return getDecimal(ordinal, t.precision(), t.scale());
-    } else if (dataType instanceof DateType) {
-      return getInt(ordinal);
-    } else if (dataType instanceof TimestampType) {
-      return getLong(ordinal);
     } else if (dataType instanceof ArrayType) {
       return getArray(ordinal);
     } else if (dataType instanceof StructType) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -188,29 +188,4 @@ object InternalRow {
     case _: MapType => (input, v) => input.update(ordinal, v.asInstanceOf[MapData].copy())
     case _ => (input, v) => input.update(ordinal, v)
   }
-
-  /**
-   * Returns a Getter for an `InternalRow` with given data type.
-   */
-  def getGetter(ordinal: Int, dt: DataType): InternalRow => Any = dt match {
-    case BooleanType => row => row.getBoolean(ordinal)
-    case ByteType => row => row.getByte(ordinal)
-    case ShortType => row => row.getShort(ordinal)
-    case IntegerType | DateType | _: YearMonthIntervalType =>
-      row => row.getInt(ordinal)
-    case LongType | TimestampType | _: DayTimeIntervalType =>
-      row => row.getLong(ordinal)
-    case FloatType => row => row.getFloat(ordinal)
-    case DoubleType => row => row.getDouble(ordinal)
-    case StringType => row => row.getUTF8String(ordinal)
-    case BinaryType => row => row.getBinary(ordinal)
-    case DecimalType.Fixed(precision, scale) =>
-      row => row.getDecimal(ordinal, precision, scale)
-    case _: ArrayType => row => row.getArray(ordinal)
-    case struct: StructType =>
-      row => row.getStruct(ordinal, struct.fields.length)
-    case _: MapType => row => row.getMap(ordinal)
-    case otherType =>
-      throw new UnsupportedOperationException(s"Datatype not supported $otherType")
-  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -99,8 +99,6 @@ abstract class InternalRow extends SpecializedGetters with Serializable {
 
 object InternalRow {
 
-  import org.apache.spark.sql.vectorized.ColumnVector
-
   /**
    * This method can be used to construct a [[InternalRow]] with the given values.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -190,7 +190,10 @@ object InternalRow {
     case _ => (input, v) => input.update(ordinal, v)
   }
 
-  def getReader(ordinal: Int, dt: DataType): InternalRow => Any = dt match {
+  /**
+   * Returns a Getter for an `InternalRow` with given data type.
+   */
+  def getGetter(ordinal: Int, dt: DataType): InternalRow => Any = dt match {
     case BooleanType => row => row.getBoolean(ordinal)
     case ByteType => row => row.getByte(ordinal)
     case ShortType => row => row.getShort(ordinal)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/InternalRow.scala
@@ -98,7 +98,6 @@ abstract class InternalRow extends SpecializedGetters with Serializable {
 }
 
 object InternalRow {
-
   /**
    * This method can be used to construct a [[InternalRow]] with the given values.
    */

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -154,15 +154,16 @@ public final class MutableColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
+    // return InternalRow.getReader(ordinal, dataType).apply(this);
     if (dataType instanceof BooleanType) {
       return getBoolean(ordinal);
     } else if (dataType instanceof ByteType) {
       return getByte(ordinal);
     } else if (dataType instanceof ShortType) {
       return getShort(ordinal);
-    } else if (dataType instanceof IntegerType) {
+    } else if (dataType instanceof IntegerType || dataType instanceof DateType) {
       return getInt(ordinal);
-    } else if (dataType instanceof LongType) {
+    } else if (dataType instanceof LongType || dataType instanceof TimestampType) {
       return getLong(ordinal);
     } else if (dataType instanceof FloatType) {
       return getFloat(ordinal);
@@ -175,10 +176,6 @@ public final class MutableColumnarRow extends InternalRow {
     } else if (dataType instanceof DecimalType) {
       DecimalType t = (DecimalType) dataType;
       return getDecimal(ordinal, t.precision(), t.scale());
-    } else if (dataType instanceof DateType) {
-      return getInt(ordinal);
-    } else if (dataType instanceof TimestampType) {
-      return getLong(ordinal);
     } else if (dataType instanceof ArrayType) {
       return getArray(ordinal);
     } else if (dataType instanceof StructType) {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -155,7 +155,7 @@ public final class MutableColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    return InternalRow$.MODULE$.getReader(ordinal, dataType).apply(this);
+    return InternalRow$.MODULE$.getGetter(ordinal, dataType).apply(this);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.vectorized;
 import java.math.BigDecimal;
 
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.InternalRow$;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarArray;
@@ -154,37 +155,7 @@ public final class MutableColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    // return InternalRow.getReader(ordinal, dataType).apply(this);
-    if (dataType instanceof BooleanType) {
-      return getBoolean(ordinal);
-    } else if (dataType instanceof ByteType) {
-      return getByte(ordinal);
-    } else if (dataType instanceof ShortType) {
-      return getShort(ordinal);
-    } else if (dataType instanceof IntegerType || dataType instanceof DateType) {
-      return getInt(ordinal);
-    } else if (dataType instanceof LongType || dataType instanceof TimestampType) {
-      return getLong(ordinal);
-    } else if (dataType instanceof FloatType) {
-      return getFloat(ordinal);
-    } else if (dataType instanceof DoubleType) {
-      return getDouble(ordinal);
-    } else if (dataType instanceof StringType) {
-      return getUTF8String(ordinal);
-    } else if (dataType instanceof BinaryType) {
-      return getBinary(ordinal);
-    } else if (dataType instanceof DecimalType) {
-      DecimalType t = (DecimalType) dataType;
-      return getDecimal(ordinal, t.precision(), t.scale());
-    } else if (dataType instanceof ArrayType) {
-      return getArray(ordinal);
-    } else if (dataType instanceof StructType) {
-      return getStruct(ordinal, ((StructType)dataType).fields().length);
-    } else if (dataType instanceof MapType) {
-      return getMap(ordinal);
-    } else {
-      throw new UnsupportedOperationException("Datatype not supported " + dataType);
-    }
+    return InternalRow$.MODULE$.getReader(ordinal, dataType).apply(this);
   }
 
   @Override

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -20,8 +20,8 @@ package org.apache.spark.sql.execution.vectorized;
 import java.math.BigDecimal;
 
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.InternalRow$;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.SpecializedGettersReader;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -155,7 +155,7 @@ public final class MutableColumnarRow extends InternalRow {
 
   @Override
   public Object get(int ordinal, DataType dataType) {
-    return InternalRow$.MODULE$.getGetter(ordinal, dataType).apply(this);
+    return SpecializedGettersReader.read(this, ordinal, dataType, false, false);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
The logic of the `ColumnarBatchRow.get` is very similar to `ColumnarRow.get` and `MutableColumnarRow.get`.

This PR is changed to make the above 3 methods call `SpecializedGettersReader.read` to clean up duplicate codes.

The `SpecializedGettersReader.read` is also used by `UnsafeArrayData.get`, `UnsafeRow.get` and `ColumnarArray.get` in Spark code.

### Why are the changes needed?
Clean up duplicate codes.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA