### PR TITLE
[SPARK-38479][PYTHON] Add `Series.duplicated` to indicate duplicate Series values

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -183,6 +183,7 @@ Reindexing / Selection / Label manipulation
    Series.drop
    Series.droplevel
    Series.drop_duplicates
+   Series.duplicated
    Series.equals
    Series.add_prefix
    Series.add_suffix

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -59,7 +59,6 @@ class MissingPandasLikeSeries:
 
     # Properties we won't support.
     array = common.array(_unsupported_property)
-    duplicated = common.duplicated(_unsupported_property)
     nbytes = _unsupported_property(
         "nbytes",
         reason="'nbytes' requires to compute whole dataset. You can calculate manually it, "

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1673,8 +1673,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         See Also
         --------
-        Index.drop_duplicates : Equivalent method on pandas.Index.
-        DataFrame.duplicated : Equivalent method on pandas.DataFrame.
+        Index.drop_duplicates : Remove duplicate values from Index.
+        DataFrame.duplicated : Equivalent method on DataFrame.
         Series.drop_duplicates : Remove duplicate values from Series.
 
         Examples

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1655,6 +1655,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         Series. Either all duplicates, all except the first or all except the
         last occurrence of duplicates can be indicated.
 
+        .. versionadded:: 3.4.0
+
         Parameters
         ----------
         keep : {'first', 'last', False}, default 'first'

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1647,7 +1647,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     tolist = to_list
 
-    def duplicated(self, keep: str = "first") -> "Series":
+    def duplicated(self, keep: Union[bool, str] = "first") -> "Series":
         """
         Indicate duplicate Series values.
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1722,7 +1722,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         4     True
         dtype: bool
         """
-        return self._psdf[[self.name]].duplicated(keep=keep)
+        return self._psdf[[self.name]].duplicated(keep=keep).rename(self.name)
 
     def drop_duplicates(
         self, keep: Union[bool, str] = "first", inplace: bool = False

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1673,7 +1673,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
         See Also
         --------
-        Index.duplicated : Equivalent method on pandas.Index.
+        Index.drop_duplicates : Equivalent method on pandas.Index.
         DataFrame.duplicated : Equivalent method on pandas.DataFrame.
         Series.drop_duplicates : Remove duplicate values from Series.
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1647,6 +1647,83 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
 
     tolist = to_list
 
+    def duplicated(self, keep: str = "first") -> "Series":
+        """
+        Indicate duplicate Series values.
+
+        Duplicated values are indicated as ``True`` values in the resulting
+        Series. Either all duplicates, all except the first or all except the
+        last occurrence of duplicates can be indicated.
+
+        Parameters
+        ----------
+        keep : {'first', 'last', False}, default 'first'
+            Method to handle marking duplicates:
+            - 'first' : Mark duplicates as ``True`` except for the first
+              occurrence.
+            - 'last' : Mark duplicates as ``True`` except for the last
+              occurrence.
+            - ``False`` : Mark all duplicates as ``True``.
+
+        Returns
+        -------
+        Series
+            Series indicating whether each value has occurred in the
+            preceding values
+
+        See Also
+        --------
+        Index.duplicated : Equivalent method on pandas.Index.
+        DataFrame.duplicated : Equivalent method on pandas.DataFrame.
+        Series.drop_duplicates : Remove duplicate values from Series.
+
+        Examples
+        --------
+        By default, for each set of duplicated values, the first occurrence is
+        set on False and all others on True:
+
+        >>> animals = ps.Series(['lama', 'cow', 'lama', 'beetle', 'lama'])
+        >>> animals.duplicated().sort_index()
+        0    False
+        1    False
+        2     True
+        3    False
+        4     True
+        dtype: bool
+
+        which is equivalent to
+
+        >>> animals.duplicated(keep='first').sort_index()
+        0    False
+        1    False
+        2     True
+        3    False
+        4     True
+        dtype: bool
+
+        By using 'last', the last occurrence of each set of duplicated values
+        is set on False and all others on True:
+
+        >>> animals.duplicated(keep='last').sort_index()
+        0     True
+        1    False
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        By setting keep on ``False``, all duplicates are True:
+
+        >>> animals.duplicated(keep=False).sort_index()
+        0     True
+        1    False
+        2     True
+        3    False
+        4     True
+        dtype: bool
+        """
+        return self._psdf[[self.name]].duplicated(keep=keep)
+
     def drop_duplicates(
         self, keep: Union[bool, str] = "first", inplace: bool = False
     ) -> Optional["Series"]:

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -421,6 +421,10 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assert_eq(psser.duplicated(keep="last").sort_index(), pser.duplicated(keep="last"))
             self.assert_eq(psser.duplicated(keep=False).sort_index(), pser.duplicated(keep=False))
 
+        pser = pd.Series([1, 2, 1, 2, 3], name="numbers")
+        psser = ps.from_pandas(pser)
+        self.assert_eq((psser + 1).duplicated(), (pser + 1).duplicated())
+
     def test_drop_duplicates(self):
         pdf = pd.DataFrame({"animal": ["lama", "cow", "lama", "beetle", "lama", "hippo"]})
         psdf = ps.from_pandas(pdf)

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -399,6 +399,14 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             )
             self.assert_eq(psser.isin([1, 5, 0, None]), expected)
 
+    def test_duplicated(self):
+        pser = pd.Series(["beetle", "lama", "cow", "lama", "beetle", "lama"], name="animal")
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.duplicated().sort_index(), pser.duplicated())
+        self.assert_eq(psser.duplicated(keep="first").sort_index(), pser.duplicated(keep="first"))
+        self.assert_eq(psser.duplicated(keep="last").sort_index(), pser.duplicated(keep="last"))
+        self.assert_eq(psser.duplicated(keep=False).sort_index(), pser.duplicated(keep=False))
+
     def test_drop_duplicates(self):
         pdf = pd.DataFrame({"animal": ["lama", "cow", "lama", "beetle", "lama", "hippo"]})
         psdf = ps.from_pandas(pdf)

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -400,12 +400,26 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assert_eq(psser.isin([1, 5, 0, None]), expected)
 
     def test_duplicated(self):
-        pser = pd.Series(["beetle", "lama", "cow", "lama", "beetle", "lama"], name="animal")
-        psser = ps.from_pandas(pser)
-        self.assert_eq(psser.duplicated().sort_index(), pser.duplicated())
-        self.assert_eq(psser.duplicated(keep="first").sort_index(), pser.duplicated(keep="first"))
-        self.assert_eq(psser.duplicated(keep="last").sort_index(), pser.duplicated(keep="last"))
-        self.assert_eq(psser.duplicated(keep=False).sort_index(), pser.duplicated(keep=False))
+        for pser in [
+            pd.Series(["beetle", None, "beetle", None, "lama", "beetle"], name="objects"),
+            pd.Series([1, np.nan, 1, np.nan], name="numbers"),
+            pd.Series(
+                [
+                    pd.Timestamp("2022-01-01"),
+                    pd.Timestamp("2022-02-02"),
+                    pd.Timestamp("2022-01-01"),
+                    pd.Timestamp("2022-02-02"),
+                ],
+                name="times",
+            ),
+        ]:
+            psser = ps.from_pandas(pser)
+            self.assert_eq(psser.duplicated().sort_index(), pser.duplicated())
+            self.assert_eq(
+                psser.duplicated(keep="first").sort_index(), pser.duplicated(keep="first")
+            )
+            self.assert_eq(psser.duplicated(keep="last").sort_index(), pser.duplicated(keep="last"))
+            self.assert_eq(psser.duplicated(keep=False).sort_index(), pser.duplicated(keep=False))
 
     def test_drop_duplicates(self):
         pdf = pd.DataFrame({"animal": ["lama", "cow", "lama", "beetle", "lama", "hippo"]})

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -423,7 +423,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
         pser = pd.Series([1, 2, 1, 2, 3], name="numbers")
         psser = ps.from_pandas(pser)
-        self.assert_eq((psser + 1).duplicated(), (pser + 1).duplicated())
+        self.assert_eq((psser + 1).duplicated().sort_index(), (pser + 1).duplicated())
 
     def test_drop_duplicates(self):
         pdf = pd.DataFrame({"animal": ["lama", "cow", "lama", "beetle", "lama", "hippo"]})


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `Series.duplicated` to indicate duplicate Series values.


### Why are the changes needed?
To reach parity with pandas API.


### Does this PR introduce _any_ user-facing change?
Yes, `Series.duplicated` is supported now.
```py
        >>> animals = ps.Series(['lama', 'cow', 'lama', 'beetle', 'lama'])
        >>> animals.duplicated().sort_index()
        0    False
        1    False
        2     True
        3    False
        4     True
        dtype: bool

        >>> animals.duplicated(keep='last').sort_index()
        0     True
        1    False
        2     True
        3    False
        4    False
        dtype: bool

        >>> animals.duplicated(keep=False).sort_index()
        0     True
        1    False
        2     True
        3    False
        4     True
        dtype: bool
```

### How was this patch tested?
Unit tests.
