### PR TITLE
[SPARK-38480][K8S] Remove `spark.kubernetes.job.queue` in favor of `spark.kubernetes.driver.podGroupTemplateFile`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1357,15 +1357,6 @@ See the [configuration page](configuration.html) for information on Spark config
   <td>3.3.0</td>
 </tr>
 <tr>
-  <td><code>spark.kubernetes.job.queue</code></td>
-  <td>(none)</td>
-  <td>
-    The name of the queue to which the job is submitted. This info will be stored in configuration
-    and passed to specific feature step.
-  </td>
-  <td>3.3.0</td>
-</tr>
-<tr>
   <td><code>spark.kubernetes.configMap.maxSize</code></td>
   <td><code>1572864</code></td>
   <td>

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -306,13 +306,6 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
-  val KUBERNETES_JOB_QUEUE = ConfigBuilder("spark.kubernetes.job.queue")
-    .doc("The name of the queue to which the job is submitted. This info " +
-      "will be stored in configuration and passed to specific feature step.")
-    .version("3.3.0")
-    .stringConf
-    .createOptional
-
   val KUBERNETES_EXECUTOR_REQUEST_CORES =
     ConfigBuilder("spark.kubernetes.executor.request.cores")
       .doc("Specify the cpu request for each executor pod")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
@@ -32,7 +32,6 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
 
   private lazy val podGroupName = s"${kubernetesConf.appId}-podgroup"
   private lazy val namespace = kubernetesConf.namespace
-  private lazy val queue = kubernetesConf.get(KUBERNETES_JOB_QUEUE)
   private var priorityClassName: Option[String] = None
 
   override def init(config: KubernetesDriverConf): Unit = {
@@ -60,7 +59,6 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
 
     var spec = pg.getSpec
     if (spec == null) spec = new PodGroupSpec
-    queue.foreach(spec.setQueue(_))
     priorityClassName.foreach(spec.setPriorityClassName(_))
     pg.setSpec(spec)
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
@@ -41,16 +41,6 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
     assert(podGroup.getMetadata.getName === s"${kubernetesConf.appId}-podgroup")
   }
 
-  test("SPARK-38818: Support `spark.kubernetes.job.queue`") {
-    val sparkConf = new SparkConf()
-      .set(KUBERNETES_JOB_QUEUE.key, "queue1")
-    val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf)
-    val step = new VolcanoFeatureStep()
-    step.init(kubernetesConf)
-    val podGroup = step.getAdditionalPreKubernetesResources().head.asInstanceOf[PodGroup]
-    assert(podGroup.getSpec.getQueue === "queue1")
-  }
-
   test("SPARK-36061: Executor Pod with Volcano PodGroup") {
     val sparkConf = new SparkConf()
     val kubernetesConf = KubernetesTestConf.createExecutorConf(sparkConf)

--- a/resource-managers/kubernetes/integration-tests/src/test/resources/volcano/queue-driver-podgroup-template.yml
+++ b/resource-managers/kubernetes/integration-tests/src/test/resources/volcano/queue-driver-podgroup-template.yml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+spec:
+  queue: queue

--- a/resource-managers/kubernetes/integration-tests/src/test/resources/volcano/queue0-driver-podgroup-template.yml
+++ b/resource-managers/kubernetes/integration-tests/src/test/resources/volcano/queue0-driver-podgroup-template.yml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+spec:
+  queue: queue0

--- a/resource-managers/kubernetes/integration-tests/src/test/resources/volcano/queue1-driver-podgroup-template.yml
+++ b/resource-managers/kubernetes/integration-tests/src/test/resources/volcano/queue1-driver-podgroup-template.yml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+spec:
+  queue: queue1

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
@@ -200,7 +200,7 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
       groupLoc: Option[String] = None,
       queue: Option[String] = None,
       driverTemplate: Option[String] = None): SparkAppConf = {
-    val conf = kubernetesTestComponents.newSparkAppConf()
+    var conf = kubernetesTestComponents.newSparkAppConf()
       .set(CONTAINER_IMAGE.key, image)
       .set(KUBERNETES_DRIVER_POD_NAME.key, driverPodName)
       .set(s"${KUBERNETES_DRIVER_LABEL_PREFIX}spark-app-locator", appLoc)
@@ -210,7 +210,12 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
       .set(KUBERNETES_SCHEDULER_NAME.key, "volcano")
       .set(KUBERNETES_DRIVER_POD_FEATURE_STEPS.key, VOLCANO_FEATURE_STEP)
       .set(KUBERNETES_EXECUTOR_POD_FEATURE_STEPS.key, VOLCANO_FEATURE_STEP)
-    queue.foreach(conf.set(KUBERNETES_JOB_QUEUE.key, _))
+    queue.foreach { q =>
+      conf = conf.set(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE.key,
+        new File(
+          getClass.getResource(s"/volcano/$q-driver-podgroup-template.yml").getFile
+        ).getAbsolutePath)
+    }
     groupLoc.foreach { locator =>
       conf.set(s"${KUBERNETES_DRIVER_LABEL_PREFIX}spark-group-locator", locator)
       conf.set(s"${KUBERNETES_EXECUTOR_LABEL_PREFIX}spark-group-locator", locator)

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
@@ -200,7 +200,7 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
       groupLoc: Option[String] = None,
       queue: Option[String] = None,
       driverTemplate: Option[String] = None): SparkAppConf = {
-    var conf = kubernetesTestComponents.newSparkAppConf()
+    val conf = kubernetesTestComponents.newSparkAppConf()
       .set(CONTAINER_IMAGE.key, image)
       .set(KUBERNETES_DRIVER_POD_NAME.key, driverPodName)
       .set(s"${KUBERNETES_DRIVER_LABEL_PREFIX}spark-app-locator", appLoc)
@@ -211,7 +211,7 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
       .set(KUBERNETES_DRIVER_POD_FEATURE_STEPS.key, VOLCANO_FEATURE_STEP)
       .set(KUBERNETES_EXECUTOR_POD_FEATURE_STEPS.key, VOLCANO_FEATURE_STEP)
     queue.foreach { q =>
-      conf = conf.set(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE.key,
+      conf.set(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE.key,
         new File(
           getClass.getResource(s"/volcano/$q-driver-podgroup-template.yml").getFile
         ).getAbsolutePath)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `spark.kubernetes.job.queue` in favor of `spark.kubernetes.driver.podGroupTemplateFile` for Apache Spark 3.3.

### Why are the changes needed?

There are several batch execution scheduler options including custom schedulers in K8s environment.
We had better isolate scheduler specific settings instead of introducing a new configuration.

### Does this PR introduce _any_ user-facing change?

No, the previous configuration is not released yet.

### How was this patch tested?

Pass the CIs and K8s IT.

```
[info] KubernetesSuite:
[info] - Run SparkPi with no resources (8 seconds, 548 milliseconds)
[info] - Run SparkPi with no resources & statefulset allocation (8 seconds, 419 milliseconds)
[info] - Run SparkPi with a very long application name. (8 seconds, 360 milliseconds)
[info] - Use SparkLauncher.NO_RESOURCE (8 seconds, 386 milliseconds)
[info] - Run SparkPi with a master URL without a scheme. (8 seconds, 589 milliseconds)
[info] - Run SparkPi with an argument. (8 seconds, 361 milliseconds)
[info] - Run SparkPi with custom labels, annotations, and environment variables. (8 seconds, 363 milliseconds)
[info] - All pods have the same service account by default (8 seconds, 332 milliseconds)
[info] - Run extraJVMOptions check on driver (4 seconds, 331 milliseconds)
[info] - Run SparkRemoteFileTest using a remote data file (8 seconds, 392 milliseconds)
[info] - Verify logging configuration is picked from the provided SPARK_CONF_DIR/log4j2.properties (13 seconds, 915 milliseconds)
[info] - Run SparkPi with env and mount secrets. (18 seconds, 172 milliseconds)
[info] - Run PySpark on simple pi.py example (9 seconds, 368 milliseconds)
[info] - Run PySpark to test a pyfiles example (11 seconds, 489 milliseconds)
[info] - Run PySpark with memory customization (9 seconds, 378 milliseconds)
[info] - Run in client mode. (6 seconds, 296 milliseconds)
[info] - Start pod creation from template (8 seconds, 465 milliseconds)
[info] - SPARK-38398: Schedule pod creation from template (9 seconds, 460 milliseconds)
[info] - Test basic decommissioning (40 seconds, 795 milliseconds)
[info] - Test basic decommissioning with shuffle cleanup (41 seconds, 16 milliseconds)
[info] *** Test still running after 2 minutes, 19 seconds: suite name: KubernetesSuite, test name: Test decommissioning with dynamic allocation & shuffle cleanups.
[info] - Test decommissioning with dynamic allocation & shuffle cleanups (2 minutes, 40 seconds)
[info] - Test decommissioning timeouts (40 seconds, 446 milliseconds)
[info] - SPARK-37576: Rolling decommissioning (1 minute, 5 seconds)
[info] - Run SparkR on simple dataframe.R example (12 seconds, 562 milliseconds)
[info] VolcanoSuite:
[info] - Run SparkPi with no resources (10 seconds, 339 milliseconds)
[info] - Run SparkPi with no resources & statefulset allocation (9 seconds, 346 milliseconds)
[info] - Run SparkPi with a very long application name. (9 seconds, 306 milliseconds)
[info] - Use SparkLauncher.NO_RESOURCE (9 seconds, 361 milliseconds)
[info] - Run SparkPi with a master URL without a scheme. (9 seconds, 344 milliseconds)
[info] - Run SparkPi with an argument. (9 seconds, 421 milliseconds)
[info] - Run SparkPi with custom labels, annotations, and environment variables. (9 seconds, 365 milliseconds)
[info] - All pods have the same service account by default (9 seconds, 337 milliseconds)
[info] - Run extraJVMOptions check on driver (5 seconds, 348 milliseconds)
[info] - Run SparkRemoteFileTest using a remote data file (8 seconds, 310 milliseconds)
[info] - Verify logging configuration is picked from the provided SPARK_CONF_DIR/log4j2.properties (15 seconds, 13 milliseconds)
[info] - Run SparkPi with env and mount secrets. (18 seconds, 466 milliseconds)
[info] - Run PySpark on simple pi.py example (10 seconds, 558 milliseconds)
[info] - Run PySpark to test a pyfiles example (11 seconds, 445 milliseconds)
[info] - Run PySpark with memory customization (10 seconds, 395 milliseconds)
[info] - Run in client mode. (6 seconds, 239 milliseconds)
[info] - Start pod creation from template (10 seconds, 415 milliseconds)
[info] - SPARK-38398: Schedule pod creation from template (9 seconds, 440 milliseconds)
[info] - Test basic decommissioning (42 seconds, 799 milliseconds)
[info] - Test basic decommissioning with shuffle cleanup (42 seconds, 836 milliseconds)
[info] - Test decommissioning with dynamic allocation & shuffle cleanups (2 minutes, 41 seconds)
[info] - Test decommissioning timeouts (42 seconds, 375 milliseconds)
[info] - SPARK-37576: Rolling decommissioning (1 minute, 7 seconds)
[info] - Run SparkR on simple dataframe.R example (12 seconds, 441 milliseconds)
[info] - Run SparkPi with volcano scheduler (10 seconds, 421 milliseconds)
[info] - SPARK-38188: Run SparkPi jobs with 2 queues (only 1 enabled) (13 seconds, 256 milliseconds)
[info] - SPARK-38188: Run SparkPi jobs with 2 queues (all enabled) (16 seconds, 216 milliseconds)
[info] - SPARK-38423: Run SparkPi Jobs with priorityClassName (14 seconds, 264 milliseconds
[info] - SPARK-38423: Run driver job to validate priority order (16 seconds, 325 milliseconds)
[info] Run completed in 28 minutes, 9 seconds.
[info] Total number of tests run: 53
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 53, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 1785 s (29:45), completed Mar 8, 2022 11:15:23 PM
```