### PR TITLE
[SPARK-38481][SQL] Substitute Java overflow exception from `TIMESTAMPADD` by Spark exception

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -25,6 +25,10 @@
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
+  "DATETIME_OVERFLOW" : {
+    "message" : [ "The '%s' function overflows the input '%s' timestamp by %s %s." ],
+    "sqlState" : "22008"
+  },
   "DIVIDE_BY_ZERO" : {
     "message" : [ "divide by zero. To return NULL instead, use 'try_divide'. If necessary set %s to false (except for ANSI interval type) to bypass this error." ],
     "sqlState" : "22012"

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -26,7 +26,7 @@
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
   "DATETIME_OVERFLOW" : {
-    "message" : [ "The '%s' function overflows the input '%s' timestamp by %s %s." ],
+    "message" : [ "Datetime operation overflow: %s." ],
     "sqlState" : "22008"
   },
   "DIVIDE_BY_ZERO" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -1201,9 +1201,9 @@ object DateTimeUtils {
       case _: scala.MatchError =>
         throw QueryExecutionErrors.invalidUnitInTimestampAdd(unit)
       case _: ArithmeticException | _: DateTimeException =>
-        throw QueryExecutionErrors.datetimeOverflowError("timestampadd", micros, quantity, unit)
+        throw QueryExecutionErrors.timestampAddOverflowError(micros, quantity, unit)
       case e: Throwable =>
-        throw new IllegalStateException(s"Failure of 'timestampadd': ${e.getMessage}")
+        throw new IllegalStateException(s"Failure of 'timestampAdd': ${e.getMessage}")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -1174,29 +1174,36 @@ object DateTimeUtils {
    * @return A timestamp value, expressed in microseconds since 1970-01-01 00:00:00Z.
    */
   def timestampAdd(unit: String, quantity: Int, micros: Long, zoneId: ZoneId): Long = {
-    unit.toUpperCase(Locale.ROOT) match {
-      case "MICROSECOND" =>
-        timestampAddDayTime(micros, quantity, zoneId)
-      case "MILLISECOND" =>
-        timestampAddDayTime(micros, quantity * MICROS_PER_MILLIS, zoneId)
-      case "SECOND" =>
-        timestampAddDayTime(micros, quantity * MICROS_PER_SECOND, zoneId)
-      case "MINUTE" =>
-        timestampAddDayTime(micros, quantity * MICROS_PER_MINUTE, zoneId)
-      case "HOUR" =>
-        timestampAddDayTime(micros, quantity * MICROS_PER_HOUR, zoneId)
-      case "DAY" | "DAYOFYEAR" =>
-        timestampAddDayTime(micros, quantity * MICROS_PER_DAY, zoneId)
-      case "WEEK" =>
-        timestampAddDayTime(micros, quantity * MICROS_PER_DAY * DAYS_PER_WEEK, zoneId)
-      case "MONTH" =>
-        timestampAddMonths(micros, quantity, zoneId)
-      case "QUARTER" =>
-        timestampAddMonths(micros, quantity * 3, zoneId)
-      case "YEAR" =>
-        timestampAddMonths(micros, quantity * MONTHS_PER_YEAR, zoneId)
-      case _ =>
+    try {
+      unit.toUpperCase(Locale.ROOT) match {
+        case "MICROSECOND" =>
+          timestampAddDayTime(micros, quantity, zoneId)
+        case "MILLISECOND" =>
+          timestampAddDayTime(micros, quantity * MICROS_PER_MILLIS, zoneId)
+        case "SECOND" =>
+          timestampAddDayTime(micros, quantity * MICROS_PER_SECOND, zoneId)
+        case "MINUTE" =>
+          timestampAddDayTime(micros, quantity * MICROS_PER_MINUTE, zoneId)
+        case "HOUR" =>
+          timestampAddDayTime(micros, quantity * MICROS_PER_HOUR, zoneId)
+        case "DAY" | "DAYOFYEAR" =>
+          timestampAddDayTime(micros, quantity * MICROS_PER_DAY, zoneId)
+        case "WEEK" =>
+          timestampAddDayTime(micros, quantity * MICROS_PER_DAY * DAYS_PER_WEEK, zoneId)
+        case "MONTH" =>
+          timestampAddMonths(micros, quantity, zoneId)
+        case "QUARTER" =>
+          timestampAddMonths(micros, quantity * 3, zoneId)
+        case "YEAR" =>
+          timestampAddMonths(micros, quantity * MONTHS_PER_YEAR, zoneId)
+      }
+    } catch {
+      case _: scala.MatchError =>
         throw QueryExecutionErrors.invalidUnitInTimestampAdd(unit)
+      case _: ArithmeticException | _: DateTimeException =>
+        throw QueryExecutionErrors.datetimeOverflowError("timestampadd", micros, quantity, unit)
+      case e: Throwable =>
+        throw new IllegalStateException(s"Failure of 'timestampadd': ${e.getMessage}")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1998,14 +1998,9 @@ object QueryExecutionErrors {
       messageParameters = Array("unit", "timestampdiff", unit))
   }
 
-  def datetimeOverflowError(
-      func: String,
-      micros: Long,
-      amount: Int,
-      unit: String): ArithmeticException = {
-    val instant = DateTimeUtils.microsToInstant(micros).toString
+  def timestampAddOverflowError(micros: Long, amount: Int, unit: String): ArithmeticException = {
     new SparkArithmeticException(
       errorClass = "DATETIME_OVERFLOW",
-      messageParameters = Array(func, instant, amount.toString, unit))
+      messageParameters = Array(s"add $amount $unit to '${DateTimeUtils.microsToInstant(micros)}'"))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.{DomainJoin, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
 import org.apache.spark.sql.catalyst.trees.TreeNode
-import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, FailFastMode}
+import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, DateTimeUtils, FailFastMode}
 import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Identifier, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.expressions.Transform
@@ -1996,5 +1996,16 @@ object QueryExecutionErrors {
     new SparkIllegalArgumentException(
       errorClass = "INVALID_PARAMETER_VALUE",
       messageParameters = Array("unit", "timestampdiff", unit))
+  }
+
+  def datetimeOverflowError(
+      func: String,
+      micros: Long,
+      amount: Int,
+      unit: String): ArithmeticException = {
+    val instant = DateTimeUtils.microsToInstant(micros).toString
+    new SparkArithmeticException(
+      errorClass = "DATETIME_OVERFLOW",
+      messageParameters = Array(func, instant, amount.toString, unit))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -291,7 +291,7 @@ class QueryExecutionErrorsSuite extends QueryTest
     }
     assert(e.getErrorClass === "DATETIME_OVERFLOW")
     assert(e.getSqlState === "22008")
-    assert(e.getMessage === "The 'timestampadd' function overflows " +
-      "the input '2022-03-09T09:02:03Z' timestamp by 1000000 YEAR.")
+    assert(e.getMessage ===
+      "Datetime operation overflow: add 1000000 YEAR to '2022-03-09T09:02:03Z'.")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.errors
 
 import java.sql.Timestamp
 
-import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.orc.OrcTest
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
@@ -283,5 +283,15 @@ class QueryExecutionErrorsSuite extends QueryTest
           "Unable to convert timestamp of Orc to data type 'timestamp_ntz'")
       }
     }
+  }
+
+  test("DATETIME_OVERFLOW: timestampadd() overflows its input timestamp") {
+    val e = intercept[SparkArithmeticException] {
+      sql("select timestampadd(YEAR, 1000000, timestamp'2022-03-09 01:02:03')").collect()
+    }
+    assert(e.getErrorClass === "DATETIME_OVERFLOW")
+    assert(e.getSqlState === "22008")
+    assert(e.getMessage === "The 'timestampadd' function overflows " +
+      "the input '2022-03-09T09:02:03Z' timestamp by 1000000 YEAR.")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to throw `SparkArithmeticException` from the datetime function: `timestampadd()` and from its aliases `date_add()`/`dateadd()` with the error class `DATETIME_OVERFLOW` in the case when internal arithmetic or datetime overflow occurs.  The new error classes are added to `error-classes.json`.

### Why are the changes needed?
Porting the functions to new error framework should improve user experience with Spark SQL.

Before the changes:
```sql
spark-sql> select timestampadd(YEAR, 1000000, timestamp'2022-03-09 01:02:03');
java.lang.ArithmeticException: long overflow
	at java.lang.Math.multiplyExact(Math.java:892) ~[?:1.8.0_292]
```

After:
```sql
spark-sql> select timestampadd(YEAR, 1000000, timestamp'2022-03-09 01:02:03');
org.apache.spark.SparkArithmeticException: The 'timestampadd' function overflows the input '2022-03-08T22:02:03Z' timestamp by 1000000 YEAR.
```

### Does this PR introduce _any_ user-facing change?
Yes, but the datetime functions `timestampadd()` and its aliases `dateadd()`/`date_add()` haven't released yet.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "test:testOnly *SparkThrowableSuite"
```
and new test:
```
$ build/sbt "test:testOnly *QueryExecutionErrorsSuite"
```