### PR TITLE
[SPARK-38482][SQL] Migrate legacy.keepCommandOutputSchema related to KeepLegacyOutputs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/KeepLegacyOutputs.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.analysis
 
-import org.apache.spark.sql.catalyst.plans.logical.{DescribeNamespace, LogicalPlan, ShowNamespaces, ShowTableProperties, ShowTables}
+import org.apache.spark.sql.catalyst.plans.logical.{DescribeNamespace, LogicalPlan, ShowNamespaces, ShowTableExtended, ShowTableProperties, ShowTables, ShowViews}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.COMMAND
 import org.apache.spark.sql.internal.SQLConf
@@ -33,6 +33,14 @@ object KeepLegacyOutputs extends Rule[LogicalPlan] {
       plan.resolveOperatorsUpWithPruning(
         _.containsPattern(COMMAND)) {
         case s: ShowTables =>
+          assert(s.output.length == 3)
+          val newOutput = s.output.head.withName("database") +: s.output.tail
+          s.copy(output = newOutput)
+        case s: ShowTableExtended =>
+          assert(s.output.length == 4)
+          val newOutput = s.output.head.withName("database") +: s.output.tail
+          s.copy(output = newOutput)
+        case s: ShowViews =>
           assert(s.output.length == 3)
           val newOutput = s.output.head.withName("database") +: s.output.tail
           s.copy(output = newOutput)

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -227,14 +227,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         pattern,
         partitionSpec @ (None | Some(UnresolvedPartitionSpec(_, _))),
         output) =>
-      val newOutput = if (conf.getConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA)) {
-        assert(output.length == 4)
-        output.head.withName("database") +: output.tail
-      } else {
-        output
-      }
       val tablePartitionSpec = partitionSpec.map(_.asInstanceOf[UnresolvedPartitionSpec].spec)
-      ShowTablesCommand(Some(db), Some(pattern), newOutput, true, tablePartitionSpec)
+      ShowTablesCommand(Some(db), Some(pattern), output, true, tablePartitionSpec)
 
     // ANALYZE TABLE works on permanent views if the views are cached.
     case AnalyzeTable(ResolvedV1TableOrViewIdentifier(ident), partitionSpec, noScan) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowTablesSuite.scala
@@ -136,18 +136,18 @@ trait ShowTablesSuiteBase extends command.ShowTablesSuiteBase with command.Tests
     assert(msg.matches("(Database|Namespace) 'unknown' not found"))
   }
 
-  test("[SPARK-2222] keep the legacy output schema") {
+  test("SPARK-38482 keep the legacy output schema") {
     Seq(true, false).foreach { keepLegacySchema =>
       withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> keepLegacySchema.toString) {
-        withNamespaceAndTable("ns1", "tbl") { tbl =>
+        withNamespaceAndTable("ns", "tbl") { tbl =>
           spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing ")
 
           val extended = sql(s"SHOW TABLE EXTENDED LIKE '$tbl'")
           val schema = extended.schema.fieldNames.toSeq.head
           if (keepLegacySchema) {
-            assert(schema === Seq("database"))
+            assert(schema === "database")
           } else {
-            assert(schema === Seq("namespace"))
+            assert(schema === "namespace")
           }
         }
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -287,18 +287,18 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
     assert(r === new Path(s"$workingDir/kv1.txt"))
   }
 
-  test("[SPARK-2222] keep the legacy output schema") {
+  test("SPARK-38482 keep the legacy output schema") {
     Seq(true, false).foreach { keepLegacySchema =>
       withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> keepLegacySchema.toString) {
         withView("v1") {
-          spark.sql(s"CREATE VIEW v1 AS SELECT 1 AS id ")
+          spark.sql("CREATE VIEW v1 AS SELECT 1 AS id ")
 
-          val views = sql(s"SHOW VIEWS")
+          val views = sql("SHOW VIEWS")
           val schema = views.schema.fieldNames.toSeq.head
           if (keepLegacySchema) {
-            assert(schema === Seq("database"))
+            assert(schema === "database")
           } else {
-            assert(schema === Seq("namespace"))
+            assert(schema === "namespace")
           }
         }
       }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveCommandSuite.scala
@@ -286,4 +286,22 @@ class HiveCommandSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
       FsConstants.LOCAL_FS_URI, workingDir, new Path("kv1.txt"))
     assert(r === new Path(s"$workingDir/kv1.txt"))
   }
+
+  test("[SPARK-2222] keep the legacy output schema") {
+    Seq(true, false).foreach { keepLegacySchema =>
+      withSQLConf(SQLConf.LEGACY_KEEP_COMMAND_OUTPUT_SCHEMA.key -> keepLegacySchema.toString) {
+        withView("v1") {
+          spark.sql(s"CREATE VIEW v1 AS SELECT 1 AS id ")
+
+          val views = sql(s"SHOW VIEWS")
+          val schema = views.schema.fieldNames.toSeq.head
+          if (keepLegacySchema) {
+            assert(schema === Seq("database"))
+          } else {
+            assert(schema === Seq("namespace"))
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr aims to migrate legacy.keepCommandOutputSchema related to KeepLegacyOutputs

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It's been a while since we introduced the v2 commands, and it seems reasonable to use v2 commands by default.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests