### PR TITLE
[SPARK-38484][PYTHON] Move usage logging instrumentation util functions from pandas module to pyspark.util module

### DIFF
--- a/python/pyspark/instrumentation_utils.py
+++ b/python/pyspark/instrumentation_utils.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import functools
+import inspect
+import threading
+import importlib
+import time
+from types import ModuleType
+from typing import Tuple, Union, List, Callable, Any, Type
+
+
+__all__: List[str] = []
+
+_local = threading.local()
+
+
+def _wrap_function(class_name: str, function_name: str, func: Callable, logger: Any) -> Callable:
+
+    signature = inspect.signature(func)
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if hasattr(_local, "logging") and _local.logging:
+            # no need to log since this should be internal call.
+            return func(*args, **kwargs)
+        _local.logging = True
+        try:
+            start = time.perf_counter()
+            try:
+                res = func(*args, **kwargs)
+                logger.log_success(
+                    class_name, function_name, time.perf_counter() - start, signature
+                )
+                return res
+            except Exception as ex:
+                logger.log_failure(
+                    class_name, function_name, ex, time.perf_counter() - start, signature
+                )
+                raise
+        finally:
+            _local.logging = False
+
+    return wrapper
+
+
+def _wrap_property(class_name: str, property_name: str, prop: Any, logger: Any) -> Any:
+    @property  # type: ignore[misc]
+    def wrapper(self: Any) -> Any:
+        if hasattr(_local, "logging") and _local.logging:
+            # no need to log since this should be internal call.
+            return prop.fget(self)
+        _local.logging = True
+        try:
+            start = time.perf_counter()
+            try:
+                res = prop.fget(self)
+                logger.log_success(class_name, property_name, time.perf_counter() - start)
+                return res
+            except Exception as ex:
+                logger.log_failure(class_name, property_name, ex, time.perf_counter() - start)
+                raise
+        finally:
+            _local.logging = False
+
+    wrapper.__doc__ = prop.__doc__
+
+    if prop.fset is not None:
+        wrapper = wrapper.setter(  # type: ignore[attr-defined]
+            _wrap_function(class_name, prop.fset.__name__, prop.fset, logger)
+        )
+
+    return wrapper
+
+
+def _wrap_missing_function(
+    class_name: str, function_name: str, func: Callable, original: Any, logger: Any
+) -> Any:
+
+    if not hasattr(original, function_name):
+        return func
+
+    signature = inspect.signature(getattr(original, function_name))
+
+    is_deprecated = func.__name__ == "deprecated_function"
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        finally:
+            logger.log_missing(class_name, function_name, is_deprecated, signature)
+
+    return wrapper
+
+
+def _wrap_missing_property(class_name: str, property_name: str, prop: Any, logger: Any) -> Any:
+
+    is_deprecated = prop.fget.__name__ == "deprecated_property"
+
+    @property  # type: ignore[misc]
+    def wrapper(self: Any) -> Any:
+        try:
+            return prop.fget(self)
+        finally:
+            logger.log_missing(class_name, property_name, is_deprecated)
+
+    return wrapper
+
+
+def _attach(
+    logger_module: Union[str, ModuleType],
+    modules: List[ModuleType],
+    classes: List[Type[Any]],
+    missings: List[Tuple[Type[Any], Type[Any]]],
+) -> None:
+    if isinstance(logger_module, str):
+        logger_module = importlib.import_module(logger_module)
+
+    logger = getattr(logger_module, "get_logger")()
+
+    special_functions = set(
+        [
+            "__init__",
+            "__repr__",
+            "__str__",
+            "_repr_html_",
+            "__len__",
+            "__getitem__",
+            "__setitem__",
+            "__getattr__",
+            "__enter__",
+            "__exit__",
+        ]
+    )
+
+    # Modules
+    for target_module in modules:
+        target_name = target_module.__name__.split(".")[-1]
+        for name in getattr(target_module, "__all__"):
+            func = getattr(target_module, name)
+            if not inspect.isfunction(func):
+                continue
+            setattr(target_module, name, _wrap_function(target_name, name, func, logger))
+
+    # Classes
+    for target_class in classes:
+        for name, func in inspect.getmembers(target_class, inspect.isfunction):
+            if name.startswith("_") and name not in special_functions:
+                continue
+            setattr(target_class, name, _wrap_function(target_class.__name__, name, func, logger))
+
+        for name, prop in inspect.getmembers(target_class, lambda o: isinstance(o, property)):
+            if name.startswith("_"):
+                continue
+            setattr(target_class, name, _wrap_property(target_class.__name__, name, prop, logger))
+
+    # Missings
+    for original, missing in missings:
+        for name, func in inspect.getmembers(missing, inspect.isfunction):
+            setattr(
+                missing,
+                name,
+                _wrap_missing_function(original.__name__, name, func, original, logger),
+            )
+
+        for name, prop in inspect.getmembers(missing, lambda o: isinstance(o, property)):
+            setattr(missing, name, _wrap_missing_property(original.__name__, name, prop, logger))

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -55,7 +55,7 @@ from pyspark.pandas.spark.accessors import (
 )
 from pyspark.pandas.strings import StringMethods
 from pyspark.pandas.window import Expanding, ExpandingGroupby, Rolling, RollingGroupby
-from pyspark.util import _attach
+from pyspark.instrumentation_utils import _attach
 
 
 def attach(logger_module: Union[str, ModuleType]) -> None:

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-import functools
-import threading
 from types import ModuleType
 from typing import Union
 

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -16,10 +16,7 @@
 #
 
 import functools
-import importlib
-import inspect
 import threading
-import time
 from types import ModuleType
 from typing import Union
 
@@ -60,6 +57,7 @@ from pyspark.pandas.spark.accessors import (
 )
 from pyspark.pandas.strings import StringMethods
 from pyspark.pandas.window import Expanding, ExpandingGroupby, Rolling, RollingGroupby
+from pyspark.util import _attach
 
 
 def attach(logger_module: Union[str, ModuleType]) -> None:
@@ -76,10 +74,6 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
     --------
     usage_logger : the reference implementation of the usage logger.
     """
-    if isinstance(logger_module, str):
-        logger_module = importlib.import_module(logger_module)
-
-    logger = getattr(logger_module, "get_logger")()
 
     modules = [config, namespace]
     classes = [
@@ -116,44 +110,7 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
     sql_formatter._CAPTURE_SCOPES = 4
     modules.append(sql_formatter)
 
-    # Modules
-    for target_module in modules:
-        target_name = target_module.__name__.split(".")[-1]
-        for name in getattr(target_module, "__all__"):
-            func = getattr(target_module, name)
-            if not inspect.isfunction(func):
-                continue
-            setattr(target_module, name, _wrap_function(target_name, name, func, logger))
-
-    special_functions = set(
-        [
-            "__init__",
-            "__repr__",
-            "__str__",
-            "_repr_html_",
-            "__len__",
-            "__getitem__",
-            "__setitem__",
-            "__getattr__",
-            "__enter__",
-            "__exit__",
-        ]
-    )
-
-    # Classes
-    for target_class in classes:
-        for name, func in inspect.getmembers(target_class, inspect.isfunction):
-            if name.startswith("_") and name not in special_functions:
-                continue
-            setattr(target_class, name, _wrap_function(target_class.__name__, name, func, logger))
-
-        for name, prop in inspect.getmembers(target_class, lambda o: isinstance(o, property)):
-            if name.startswith("_"):
-                continue
-            setattr(target_class, name, _wrap_property(target_class.__name__, name, prop, logger))
-
-    # Missings
-    for original, missing in [
+    missings = [
         (pd.DataFrame, _MissingPandasLikeDataFrame),
         (pd.Series, MissingPandasLikeSeries),
         (pd.Index, MissingPandasLikeIndex),
@@ -165,105 +122,6 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         (pd.core.window.Rolling, MissingPandasLikeRolling),
         (pd.core.window.ExpandingGroupby, MissingPandasLikeExpandingGroupby),
         (pd.core.window.RollingGroupby, MissingPandasLikeRollingGroupby),
-    ]:
-        for name, func in inspect.getmembers(missing, inspect.isfunction):
-            setattr(
-                missing,
-                name,
-                _wrap_missing_function(original.__name__, name, func, original, logger),
-            )
+    ]
 
-        for name, prop in inspect.getmembers(missing, lambda o: isinstance(o, property)):
-            setattr(missing, name, _wrap_missing_property(original.__name__, name, prop, logger))
-
-
-_local = threading.local()
-
-
-def _wrap_function(class_name, function_name, func, logger):
-
-    signature = inspect.signature(func)
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if hasattr(_local, "logging") and _local.logging:
-            # no need to log since this should be internal call.
-            return func(*args, **kwargs)
-        _local.logging = True
-        try:
-            start = time.perf_counter()
-            try:
-                res = func(*args, **kwargs)
-                logger.log_success(
-                    class_name, function_name, time.perf_counter() - start, signature
-                )
-                return res
-            except Exception as ex:
-                logger.log_failure(
-                    class_name, function_name, ex, time.perf_counter() - start, signature
-                )
-                raise
-        finally:
-            _local.logging = False
-
-    return wrapper
-
-
-def _wrap_property(class_name, property_name, prop, logger):
-    @property
-    def wrapper(self):
-        if hasattr(_local, "logging") and _local.logging:
-            # no need to log since this should be internal call.
-            return prop.fget(self)
-        _local.logging = True
-        try:
-            start = time.perf_counter()
-            try:
-                res = prop.fget(self)
-                logger.log_success(class_name, property_name, time.perf_counter() - start)
-                return res
-            except Exception as ex:
-                logger.log_failure(class_name, property_name, ex, time.perf_counter() - start)
-                raise
-        finally:
-            _local.logging = False
-
-    wrapper.__doc__ = prop.__doc__
-
-    if prop.fset is not None:
-        wrapper = wrapper.setter(_wrap_function(class_name, prop.fset.__name__, prop.fset, logger))
-
-    return wrapper
-
-
-def _wrap_missing_function(class_name, function_name, func, original, logger):
-
-    if not hasattr(original, function_name):
-        return func
-
-    signature = inspect.signature(getattr(original, function_name))
-
-    is_deprecated = func.__name__ == "deprecated_function"
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        finally:
-            logger.log_missing(class_name, function_name, is_deprecated, signature)
-
-    return wrapper
-
-
-def _wrap_missing_property(class_name, property_name, prop, logger):
-
-    is_deprecated = prop.fget.__name__ == "deprecated_property"
-
-    @property
-    def wrapper(self):
-        try:
-            return prop.fget(self)
-        finally:
-            logger.log_missing(class_name, property_name, is_deprecated)
-
-    return wrapper
+    _attach(logger_module, modules, classes, missings)

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -17,19 +17,14 @@
 #
 
 import functools
-import inspect
 import itertools
-import importlib
 import os
 import platform
 import re
 import sys
 import threading
-import time
 import traceback
-from types import ModuleType
 from types import TracebackType
-from typing import Union
 from typing import Any, Callable, Iterator, List, Optional, TextIO, Tuple
 
 from py4j.clientserver import ClientServer  # type: ignore[import]
@@ -424,159 +419,6 @@ class InheritableThread(threading.Thread):
                 return
             finally:
                 thread_connection.close()
-
-
-_local = threading.local()
-
-
-def _wrap_function(class_name: str, function_name: str, func: Callable, logger: Any) -> Callable:
-
-    signature = inspect.signature(func)
-
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        if hasattr(_local, "logging") and _local.logging:
-            # no need to log since this should be internal call.
-            return func(*args, **kwargs)
-        _local.logging = True
-        try:
-            start = time.perf_counter()
-            try:
-                res = func(*args, **kwargs)
-                logger.log_success(
-                    class_name, function_name, time.perf_counter() - start, signature
-                )
-                return res
-            except Exception as ex:
-                logger.log_failure(
-                    class_name, function_name, ex, time.perf_counter() - start, signature
-                )
-                raise
-        finally:
-            _local.logging = False
-
-    return wrapper
-
-
-def _wrap_property(class_name: str, property_name: str, prop: Any, logger: Any) -> Any:
-    @property  # type: ignore[misc]
-    def wrapper(self: Any) -> Any:
-        if hasattr(_local, "logging") and _local.logging:
-            # no need to log since this should be internal call.
-            return prop.fget(self)
-        _local.logging = True
-        try:
-            start = time.perf_counter()
-            try:
-                res = prop.fget(self)
-                logger.log_success(class_name, property_name, time.perf_counter() - start)
-                return res
-            except Exception as ex:
-                logger.log_failure(class_name, property_name, ex, time.perf_counter() - start)
-                raise
-        finally:
-            _local.logging = False
-
-    wrapper.__doc__ = prop.__doc__
-
-    if prop.fset is not None:
-        wrapper = wrapper.setter(  # type: ignore[attr-defined]
-            _wrap_function(class_name, prop.fset.__name__, prop.fset, logger)
-        )
-
-    return wrapper
-
-
-def _wrap_missing_function(
-    class_name: str, function_name: str, func: Callable, original: Any, logger: Any
-) -> Any:
-
-    if not hasattr(original, function_name):
-        return func
-
-    signature = inspect.signature(getattr(original, function_name))
-
-    is_deprecated = func.__name__ == "deprecated_function"
-
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        try:
-            return func(*args, **kwargs)
-        finally:
-            logger.log_missing(class_name, function_name, is_deprecated, signature)
-
-    return wrapper
-
-
-def _wrap_missing_property(class_name: str, property_name: str, prop: Any, logger: Any) -> Any:
-
-    is_deprecated = prop.fget.__name__ == "deprecated_property"
-
-    @property  # type: ignore[misc]
-    def wrapper(self: Any) -> Any:
-        try:
-            return prop.fget(self)
-        finally:
-            logger.log_missing(class_name, property_name, is_deprecated)
-
-    return wrapper
-
-
-def _attach(
-    logger_module: Union[str, ModuleType], modules: Any, classes: Any, missings: Any
-) -> None:
-    if isinstance(logger_module, str):
-        logger_module = importlib.import_module(logger_module)
-
-    logger = getattr(logger_module, "get_logger")()
-
-    special_functions = set(
-        [
-            "__init__",
-            "__repr__",
-            "__str__",
-            "_repr_html_",
-            "__len__",
-            "__getitem__",
-            "__setitem__",
-            "__getattr__",
-            "__enter__",
-            "__exit__",
-        ]
-    )
-
-    # Modules
-    for target_module in modules:
-        target_name = target_module.__name__.split(".")[-1]
-        for name in getattr(target_module, "__all__"):
-            func = getattr(target_module, name)
-            if not inspect.isfunction(func):
-                continue
-            setattr(target_module, name, _wrap_function(target_name, name, func, logger))
-
-    # Classes
-    for target_class in classes:
-        for name, func in inspect.getmembers(target_class, inspect.isfunction):
-            if name.startswith("_") and name not in special_functions:
-                continue
-            setattr(target_class, name, _wrap_function(target_class.__name__, name, func, logger))
-
-        for name, prop in inspect.getmembers(target_class, lambda o: isinstance(o, property)):
-            if name.startswith("_"):
-                continue
-            setattr(target_class, name, _wrap_property(target_class.__name__, name, prop, logger))
-
-    # Missings
-    for original, missing in missings:
-        for name, func in inspect.getmembers(missing, inspect.isfunction):
-            setattr(
-                missing,
-                name,
-                _wrap_missing_function(original.__name__, name, func, original, logger),
-            )
-
-        for name, prop in inspect.getmembers(missing, lambda o: isinstance(o, property)):
-            setattr(missing, name, _wrap_missing_property(original.__name__, name, prop, logger))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -425,7 +425,9 @@ class InheritableThread(threading.Thread):
             finally:
                 thread_connection.close()
 
-local = threading.local()
+
+_local = threading.local()
+
 
 def _wrap_function(class_name, function_name, func, logger):
 
@@ -569,8 +571,6 @@ def _attach(logger_module: Union[str, ModuleType], modules, classes, missings):
 
         for name, prop in inspect.getmembers(missing, lambda o: isinstance(o, property)):
             setattr(missing, name, _wrap_missing_property(original.__name__, name, prop, logger))
-
-
 
 
 if __name__ == "__main__":

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -429,12 +429,12 @@ class InheritableThread(threading.Thread):
 _local = threading.local()
 
 
-def _wrap_function(class_name, function_name, func, logger):
+def _wrap_function(class_name: str, function_name: str, func: Callable, logger: Any) -> Callable:
 
     signature = inspect.signature(func)
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         if hasattr(_local, "logging") and _local.logging:
             # no need to log since this should be internal call.
             return func(*args, **kwargs)
@@ -458,9 +458,9 @@ def _wrap_function(class_name, function_name, func, logger):
     return wrapper
 
 
-def _wrap_property(class_name, property_name, prop, logger):
-    @property
-    def wrapper(self):
+def _wrap_property(class_name: str, property_name: str, prop: Any, logger: Any) -> Any:
+    @property  # type: ignore[misc]
+    def wrapper(self: Any) -> Any:
         if hasattr(_local, "logging") and _local.logging:
             # no need to log since this should be internal call.
             return prop.fget(self)
@@ -480,12 +480,16 @@ def _wrap_property(class_name, property_name, prop, logger):
     wrapper.__doc__ = prop.__doc__
 
     if prop.fset is not None:
-        wrapper = wrapper.setter(_wrap_function(class_name, prop.fset.__name__, prop.fset, logger))
+        wrapper = wrapper.setter(  # type: ignore[attr-defined]
+            _wrap_function(class_name, prop.fset.__name__, prop.fset, logger)
+        )
 
     return wrapper
 
 
-def _wrap_missing_function(class_name, function_name, func, original, logger):
+def _wrap_missing_function(
+    class_name: str, function_name: str, func: Callable, original: Any, logger: Any
+) -> Any:
 
     if not hasattr(original, function_name):
         return func
@@ -495,7 +499,7 @@ def _wrap_missing_function(class_name, function_name, func, original, logger):
     is_deprecated = func.__name__ == "deprecated_function"
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
         finally:
@@ -504,12 +508,12 @@ def _wrap_missing_function(class_name, function_name, func, original, logger):
     return wrapper
 
 
-def _wrap_missing_property(class_name, property_name, prop, logger):
+def _wrap_missing_property(class_name: str, property_name: str, prop: Any, logger: Any) -> Any:
 
     is_deprecated = prop.fget.__name__ == "deprecated_property"
 
-    @property
-    def wrapper(self):
+    @property  # type: ignore[misc]
+    def wrapper(self: Any) -> Any:
         try:
             return prop.fget(self)
         finally:
@@ -518,7 +522,9 @@ def _wrap_missing_property(class_name, property_name, prop, logger):
     return wrapper
 
 
-def _attach(logger_module: Union[str, ModuleType], modules, classes, missings):
+def _attach(
+    logger_module: Union[str, ModuleType], modules: Any, classes: Any, missings: Any
+) -> None:
     if isinstance(logger_module, str):
         logger_module = importlib.import_module(logger_module)
 

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -17,14 +17,19 @@
 #
 
 import functools
+import inspect
 import itertools
+import importlib
 import os
 import platform
 import re
 import sys
 import threading
+import time
 import traceback
+from types import ModuleType
 from types import TracebackType
+from typing import Union
 from typing import Any, Callable, Iterator, List, Optional, TextIO, Tuple
 
 from py4j.clientserver import ClientServer  # type: ignore[import]
@@ -419,6 +424,153 @@ class InheritableThread(threading.Thread):
                 return
             finally:
                 thread_connection.close()
+
+local = threading.local()
+
+def _wrap_function(class_name, function_name, func, logger):
+
+    signature = inspect.signature(func)
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if hasattr(_local, "logging") and _local.logging:
+            # no need to log since this should be internal call.
+            return func(*args, **kwargs)
+        _local.logging = True
+        try:
+            start = time.perf_counter()
+            try:
+                res = func(*args, **kwargs)
+                logger.log_success(
+                    class_name, function_name, time.perf_counter() - start, signature
+                )
+                return res
+            except Exception as ex:
+                logger.log_failure(
+                    class_name, function_name, ex, time.perf_counter() - start, signature
+                )
+                raise
+        finally:
+            _local.logging = False
+
+    return wrapper
+
+
+def _wrap_property(class_name, property_name, prop, logger):
+    @property
+    def wrapper(self):
+        if hasattr(_local, "logging") and _local.logging:
+            # no need to log since this should be internal call.
+            return prop.fget(self)
+        _local.logging = True
+        try:
+            start = time.perf_counter()
+            try:
+                res = prop.fget(self)
+                logger.log_success(class_name, property_name, time.perf_counter() - start)
+                return res
+            except Exception as ex:
+                logger.log_failure(class_name, property_name, ex, time.perf_counter() - start)
+                raise
+        finally:
+            _local.logging = False
+
+    wrapper.__doc__ = prop.__doc__
+
+    if prop.fset is not None:
+        wrapper = wrapper.setter(_wrap_function(class_name, prop.fset.__name__, prop.fset, logger))
+
+    return wrapper
+
+
+def _wrap_missing_function(class_name, function_name, func, original, logger):
+
+    if not hasattr(original, function_name):
+        return func
+
+    signature = inspect.signature(getattr(original, function_name))
+
+    is_deprecated = func.__name__ == "deprecated_function"
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        finally:
+            logger.log_missing(class_name, function_name, is_deprecated, signature)
+
+    return wrapper
+
+
+def _wrap_missing_property(class_name, property_name, prop, logger):
+
+    is_deprecated = prop.fget.__name__ == "deprecated_property"
+
+    @property
+    def wrapper(self):
+        try:
+            return prop.fget(self)
+        finally:
+            logger.log_missing(class_name, property_name, is_deprecated)
+
+    return wrapper
+
+
+def _attach(logger_module: Union[str, ModuleType], modules, classes, missings):
+    if isinstance(logger_module, str):
+        logger_module = importlib.import_module(logger_module)
+
+    logger = getattr(logger_module, "get_logger")()
+
+    special_functions = set(
+        [
+            "__init__",
+            "__repr__",
+            "__str__",
+            "_repr_html_",
+            "__len__",
+            "__getitem__",
+            "__setitem__",
+            "__getattr__",
+            "__enter__",
+            "__exit__",
+        ]
+    )
+
+    # Modules
+    for target_module in modules:
+        target_name = target_module.__name__.split(".")[-1]
+        for name in getattr(target_module, "__all__"):
+            func = getattr(target_module, name)
+            if not inspect.isfunction(func):
+                continue
+            setattr(target_module, name, _wrap_function(target_name, name, func, logger))
+
+    # Classes
+    for target_class in classes:
+        for name, func in inspect.getmembers(target_class, inspect.isfunction):
+            if name.startswith("_") and name not in special_functions:
+                continue
+            setattr(target_class, name, _wrap_function(target_class.__name__, name, func, logger))
+
+        for name, prop in inspect.getmembers(target_class, lambda o: isinstance(o, property)):
+            if name.startswith("_"):
+                continue
+            setattr(target_class, name, _wrap_property(target_class.__name__, name, prop, logger))
+
+    # Missings
+    for original, missing in missings:
+        for name, func in inspect.getmembers(missing, inspect.isfunction):
+            setattr(
+                missing,
+                name,
+                _wrap_missing_function(original.__name__, name, func, original, logger),
+            )
+
+        for name, prop in inspect.getmembers(missing, lambda o: isinstance(o, property)):
+            setattr(missing, name, _wrap_missing_property(original.__name__, name, prop, logger))
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Move usage logging instrumentation util functions from pandas module to pyspark.util module

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
It will be helpful to attach the usage logger to other modules (e.g. sql) besides Pandas but other modules should not depend on Pandas modules to use the instrumentation utils (e.g. _wrap_function, _wrap_property ...).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
- Existing unit tests
- Manual test by running `./bin/pyspark` and verified the output:
```
>>> sc.setLogLevel("info")
>>> import pyspark.pandas as ps
22/03/15 17:17:16 INFO Log4jUsageLogger: pandasOnSparkImported=1.0, tags=List(), blob=
22/03/15 17:18:21 INFO Log4jUsageLogger: initialConfigLogging=1.0, tags=List(sparkApplicationId=local-1647360920525, sparkExecutionId=null, sparkJobGroupId=null), blob={"spark.sql.warehouse.dir":"file:/Users/yihong.he/spark/spark-warehouse","spark.executor.extraJavaOptions":"-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED","spark.driver.host":"10.120.131.148","spark.serializer.objectStreamReset":"100","spark.driver.port":"61338","spark.rdd.compress":"True","spark.app.name":"PySparkShell","spark.submit.pyFiles":"","spark.ui.showConsoleProgress":"true","spark.app.startTime":"1647360919721","spark.executor.id":"driver","spark.driver.extraJavaOptions":"-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED","spark.submit.deployMode":"client","spark.master":"local[*]","spark.sql.catalogImplementation":"hive","spark.app.id":"local-1647360920525"}
22/03/15 17:18:25 INFO Log4jUsageLogger: pandasOnSparkFunctionCalled=1.0, tags=List(pandasOnSparkFunction=__init__(self, data=None, index=None, columns=None, dtype=None, copy=False), className=DataFrame, status=success), blob={"duration": 3781.477633999998}
>>> psdf.columns
22/03/15 17:18:49 INFO Log4jUsageLogger: pandasOnSparkFunctionCalled=1.0, tags=List(pandasOnSparkProperty=columns, className=DataFrame, status=success), blob={"duration": 0.24742499999774736}
Index(['a', 'b'], dtype='object')
```