### PR TITLE
[SPARK-38486][K8S][TESTS] Upgrade the minimum Minikube version to 1.18.0

### DIFF
--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -28,7 +28,7 @@ To run tests with Hadoop 2.x instead of Hadoop 3.x, use `--hadoop-profile`.
 
     ./dev/dev-run-integration-tests.sh --hadoop-profile hadoop-2
 
-The minimum tested version of Minikube is 1.7.3. The kube-dns addon must be enabled. Minikube should
+The minimum tested version of Minikube is 1.18.0. The kube-dns addon must be enabled. Minikube should
 run with a minimum of 4 CPUs and 6G of memory:
 
     minikube start --cpus 4 --memory 6144
@@ -47,7 +47,7 @@ default this is set to `minikube`, the available backends are their prerequisite
 
 ### `minikube`
 
-Uses the local `minikube` cluster, this requires that `minikube` 1.7.3 or greater be installed and that it be allocated
+Uses the local `minikube` cluster, this requires that `minikube` 1.18.0 or greater be installed and that it be allocated
 at least 4 CPUs and 6GB memory (some users have reported success with as few as 3 CPUs and 4GB memory).  The tests will 
 check if `minikube` is started and abort early if it isn't currently running.
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/minikube/Minikube.scala
@@ -48,9 +48,9 @@ private[spark] object Minikube extends Logging {
 
     versionArrayOpt match {
       case Some(Array(x, y, z)) =>
-        if (Ordering.Tuple3[Int, Int, Int].lt((x, y, z), (1, 7, 3))) {
+        if (Ordering.Tuple3[Int, Int, Int].lt((x, y, z), (1, 18, 0))) {
           assert(false, s"Unsupported Minikube version is detected: $minikubeVersionString." +
-            "For integration testing Minikube version 1.7.3 or greater is expected.")
+            "For integration testing Minikube version 1.18.0 or greater is expected.")
         }
       case _ =>
         assert(false, s"Unexpected version format detected in `$minikubeVersionString`." +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the minimum Minikube version to 1.18.0 from 1.7.3 at Apache Spark 3.3.0.

### Why are the changes needed?

Minikube v1.18.0 was released one year ago on March 2021, and the first version supporting Apple Silicon natively. Previously, there exists some issues while running Intel arch binary on Apple Silicon.
- https://github.com/kubernetes/minikube/releases/download/v1.18.0/minikube-darwin-arm64
- https://github.com/kubernetes/minikube/releases/tag/v1.18.0

### Does this PR introduce _any_ user-facing change?

No, this is a test-only PR.

### How was this patch tested?

Manually.