### PR TITLE
[WIP][SPARK-38512] Rebased traversal order from "pre-order" to "post-order" for `ResolveFunctions` Rule

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2088,7 +2088,7 @@ class Analyzer(override val catalogManager: CatalogManager)
         }
 
       case q: LogicalPlan =>
-        q.transformExpressionsWithPruning(
+        q.transformExpressionsUpWithPruning(
           _.containsAnyPattern(UNRESOLVED_FUNCTION, GENERATOR), ruleId) {
           case u @ UnresolvedFunction(nameParts, arguments, _, _, _)
               if hasLambdaAndResolvedArguments(arguments) => withPosition(u) {


### PR DESCRIPTION
Rebased traversal order from "pre-order" to "post-order" for `ResolveFunctions` rule to make sure most expressions are able to be resolved in a single pass

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Rebased traversal order from "pre-order" to "post-order" for `ResolveFunctions` rule to make sure most expressions are able to be resolved in a single pass.

This is required to address SPARK-38512


### Why are the changes needed?

ResolveFunctions Rule is implemented incorrectly requiring multiple passes to Resolve Nested Expressions:

While Plan object is traversed correctly in post-order (bottoms-up, `plan.resolveOperatorsUpWithPruning), internally, Plan children though are traversed incorrectly in pre-order (top-down, using `transformExpressionsWithPruning`):

Traversing in pre-order means that attempt is taken to resolve the current node, before its children are resolved, which is incorrect, since the node itself could not be resolved before its children are.

While this is not leading to failures yet, this is taxing on performance – most of the expressions in Spark should be able to be resolved in a single pass (if resolved bottoms-up, take reproducible sample at the bottom). Instead, it currently takes Spark at least N  iterations to resolve such expressions, where N is proportional to the depth of the Expression tree.

Example to reproduce: 

```
def resolveExpr(spark: SparkSession, exprStr: String, tableSchema: StructType): Expression = {
  val expr = spark.sessionState.sqlParser.parseExpression(exprStr)
  val analyzer = spark.sessionState.analyzer
  val schemaFields = tableSchema.fields

  val resolvedExpr = {
    val plan: LogicalPlan = Filter(expr, LocalRelation(schemaFields.head, schemaFields.drop(1): _*))
    val rules: Seq[Rule[LogicalPlan]] = {
      analyzer.ResolveFunctions ::
      analyzer.ResolveReferences ::
      Nil
    }

    rules.foldRight(plan)((rule, plan) => rule.apply(plan))
      .asInstanceOf[Filter]
      .condition
  }
  resolvedExpr
}

// Invoke with
resolveExpr(spark, "date_format(to_timestamp(B, 'yyyy-MM-dd'), 'MM/dd/yyyy')", StructType(StructField("B", StringType)))
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Adding a regression test.
