### PR TITLE
[SPARK-38513][K8S] Move custom scheduler-specific configs to under `spark.kubernetes.scheduler.NAME` prefix

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -292,20 +292,6 @@ private[spark] object Config extends Logging {
       .stringConf
       .createOptional
 
-  val KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE =
-    ConfigBuilder("spark.kubernetes.driver.podGroupTemplateFile")
-      .doc("File containing a template pod group spec for driver")
-      .version("3.3.0")
-      .stringConf
-      .createOptional
-
-  val KUBERNETES_EXECUTOR_PODGROUP_TEMPLATE_FILE =
-    ConfigBuilder("spark.kubernetes.executor.podGroupTemplateFile")
-      .doc("File containing a template pod group spec for executors")
-      .version("3.3.0")
-      .stringConf
-      .createOptional
-
   val KUBERNETES_EXECUTOR_REQUEST_CORES =
     ConfigBuilder("spark.kubernetes.executor.request.cores")
       .doc("Specify the cpu request for each executor pod")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStep.scala
@@ -21,14 +21,12 @@ import io.fabric8.volcano.client.DefaultVolcanoClient
 import io.fabric8.volcano.scheduling.v1beta1.{PodGroup, PodGroupSpec}
 
 import org.apache.spark.deploy.k8s.{KubernetesConf, KubernetesDriverConf, KubernetesExecutorConf, SparkPod}
-import org.apache.spark.deploy.k8s.Config._
 
 private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureConfigStep
   with KubernetesExecutorCustomFeatureConfigStep {
+  import VolcanoFeatureStep._
 
   private var kubernetesConf: KubernetesConf = _
-
-  private val POD_GROUP_ANNOTATION = "scheduling.k8s.io/group-name"
 
   private lazy val podGroupName = s"${kubernetesConf.appId}-podgroup"
   private lazy val namespace = kubernetesConf.namespace
@@ -44,12 +42,7 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
 
   override def getAdditionalPreKubernetesResources(): Seq[HasMetadata] = {
     val client = new DefaultVolcanoClient
-
-    val template = if (kubernetesConf.isInstanceOf[KubernetesDriverConf]) {
-      kubernetesConf.get(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE)
-    } else {
-      kubernetesConf.get(KUBERNETES_EXECUTOR_PODGROUP_TEMPLATE_FILE)
-    }
+    val template = kubernetesConf.getOption(POD_GROUP_TEMPLATE_FILE_KEY)
     val pg = template.map(client.podGroups.load(_).get).getOrElse(new PodGroup())
     var metadata = pg.getMetadata
     if (metadata == null) metadata = new ObjectMeta
@@ -76,4 +69,9 @@ private[spark] class VolcanoFeatureStep extends KubernetesDriverCustomFeatureCon
     val k8sPod = k8sPodBuilder.build()
     SparkPod(k8sPod, pod.container)
   }
+}
+
+private[spark] object VolcanoFeatureStep {
+  val POD_GROUP_ANNOTATION = "scheduling.k8s.io/group-name"
+  val POD_GROUP_TEMPLATE_FILE_KEY = "spark.kubernetes.scheduler.volcano.podGroupTemplateFile"
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
@@ -23,7 +23,6 @@ import io.fabric8.volcano.scheduling.v1beta1.PodGroup
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s._
-import org.apache.spark.deploy.k8s.Config._
 
 class VolcanoFeatureStepSuite extends SparkFunSuite {
 
@@ -74,7 +73,7 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
     val templatePath = new File(
       getClass.getResource("/driver-podgroup-template.yml").getFile).getAbsolutePath
     val sparkConf = new SparkConf()
-      .set(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE.key, templatePath)
+      .set(VolcanoFeatureStep.POD_GROUP_TEMPLATE_FILE_KEY, templatePath)
     val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf)
     val step = new VolcanoFeatureStep()
     step.init(kubernetesConf)
@@ -86,24 +85,6 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
     assert(podGroup.getSpec.getMinResources.get("memory").getFormat == "Mi")
     assert(podGroup.getSpec.getPriorityClassName == "driver-priority")
     assert(podGroup.getSpec.getQueue == "driver-queue")
-  }
-
-  test("SPARK-38455: Support executor podgroup template") {
-    val templatePath = new File(
-      getClass.getResource("/executor-podgroup-template.yml").getFile).getAbsolutePath
-    val sparkConf = new SparkConf()
-      .set(KUBERNETES_EXECUTOR_PODGROUP_TEMPLATE_FILE.key, templatePath)
-    val kubernetesConf = KubernetesTestConf.createExecutorConf(sparkConf)
-    val step = new VolcanoFeatureStep()
-    step.init(kubernetesConf)
-    step.configurePod(SparkPod.initialPod())
-    val podGroup = step.getAdditionalPreKubernetesResources().head.asInstanceOf[PodGroup]
-    assert(podGroup.getSpec.getMinMember == 1000)
-    assert(podGroup.getSpec.getMinResources.get("cpu").getAmount == "4")
-    assert(podGroup.getSpec.getMinResources.get("memory").getAmount == "16")
-    assert(podGroup.getSpec.getMinResources.get("memory").getFormat == "Gi")
-    assert(podGroup.getSpec.getPriorityClassName == "executor-priority")
-    assert(podGroup.getSpec.getQueue == "executor-queue")
   }
 
   private def verifyPriority(pod: SparkPod): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
@@ -214,12 +214,12 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
       .set(KUBERNETES_DRIVER_POD_FEATURE_STEPS.key, VOLCANO_FEATURE_STEP)
       .set(KUBERNETES_EXECUTOR_POD_FEATURE_STEPS.key, VOLCANO_FEATURE_STEP)
     queue.foreach { q =>
-      conf.set(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE.key,
+      conf.set(VolcanoFeatureStep.POD_GROUP_TEMPLATE_FILE_KEY,
         new File(
           getClass.getResource(s"/volcano/$q-driver-podgroup-template.yml").getFile
         ).getAbsolutePath)
     }
-    driverPodGroupTemplate.foreach(conf.set(KUBERNETES_DRIVER_PODGROUP_TEMPLATE_FILE.key, _))
+    driverPodGroupTemplate.foreach(conf.set(VolcanoFeatureStep.POD_GROUP_TEMPLATE_FILE_KEY, _))
     groupLoc.foreach { locator =>
       conf.set(s"${KUBERNETES_DRIVER_LABEL_PREFIX}spark-group-locator", locator)
       conf.set(s"${KUBERNETES_EXECUTOR_LABEL_PREFIX}spark-group-locator", locator)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move custom scheduler configs to under its name prefix, `spark.kubernetes.scheduler.NAME`.

Since this PR moved `spark.kubernetes.executor.podGroupTemplateFile` to `spark.kubernetes.scheduler.volcano.executor.podGroupTemplateFile`. We can delete it because there is no plan for `volcano` scheduler to use executor pod group template at Apache Spark 3.3.x.

For the other custom schedulers, they still can use `spark.kubernetes.scheduler.XXX.executor.podGroupTemplateFile`.

### Why are the changes needed?

To support multiple customer schedulers in an isolated manner, we need to isolate configurations from Spark's configuration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and K8s IT.