### PR TITLE
[SPARK-38521][SQL] Throw Exception if overwriting hive partition table with dynamic and staticPartitionOverwriteMode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2661,7 +2661,8 @@ object SQLConf {
         "overwriting. In dynamic mode, Spark doesn't delete partitions ahead, and only overwrite " +
         "those partitions that have data written into it at runtime. By default we use static " +
         "mode to keep the same behavior of Spark prior to 2.3. Note that this config doesn't " +
-        "affect Hive serde tables, as they are always overwritten with dynamic mode. This can " +
+        "affect tables whoes partitions are managed by catalogs, suche as Hive serde tables, " +
+        "as they are always overwritten with dynamic mode. This can " +
         "also be set as an output option for a data source using key partitionOverwriteMode " +
         "(which takes precedence over this setting), e.g. " +
         "dataframe.write.option(\"partitionOverwriteMode\", \"dynamic\").save(path)."

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -126,7 +126,7 @@ case class InsertIntoHadoopFsRelationCommand(
             // For dynamic partition overwrite, do not delete partition directories ahead.
             true
           } else {
-            assert(dynamicPartition && !partitionsTrackedByCatalog,
+            assert(!dynamicPartition || !partitionsTrackedByCatalog,
               "'partitionOverwriteMode' in table properties should be set to 'overwrite' " +
                 "while partitions are managed by catalogs")
             deleteMatchingPartitions(fs, qualifiedOutputPath, customPartitionLocations, committer)


### PR DESCRIPTION
### Why are the changes needed?
The `spark.sql.sources.partitionOverwriteMode` allows us to overwrite the existing data of the table through staticmode, but for hive table, it is disastrous. It may deleting all data in hive partitioned table while writing with dynamic overwrite and `partitionOverwriteMode=STATIC`.
Here we add a check for this and throw Exception if this happends.

### Does this PR introduce _any_ user-facing change?
'No'.

### How was this patch tested?
Add new ut
