### PR TITLE
[SPARK-38522][SS] Enrich the method contract of iterator in StateStore to not expect strong consistency on certain condition

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -126,10 +126,11 @@ trait StateStore extends ReadStateStore {
 
   /**
    * Return an iterator containing all the key-value pairs in the StateStore. Implementations must
-   * ensure that updates (puts, removes) can be made while iterating over this iterator, but it is
-   * not required for implementations to ensure the iterator reflects all updates being performed
-   * after initialization of the iterator. Callers should perform all updates before calling this
-   * method if all updates should be visible in the returned iterator.
+   * ensure that updates (puts, removes) can be made while iterating over this iterator.
+   *
+   * It is not required for implementations to ensure the iterator reflects all updates being
+   * performed after initialization of the iterator. Callers should perform all updates before
+   * calling this method if all updates should be visible in the returned iterator.
    */
   override def iterator(): Iterator[UnsafeRowPair]
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -126,7 +126,10 @@ trait StateStore extends ReadStateStore {
 
   /**
    * Return an iterator containing all the key-value pairs in the StateStore. Implementations must
-   * ensure that updates (puts, removes) can be made while iterating over this iterator.
+   * ensure that updates (puts, removes) can be made while iterating over this iterator, but it is
+   * not required for implementations to ensure the iterator reflects all updates being performed
+   * after initialization of the iterator. Callers should perform all updates before calling this
+   * method if all updates should be visible in the returned iterator.
    */
   override def iterator(): Iterator[UnsafeRowPair]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enrich the method contract of iterator in StateStore, that the returned iterator is not guaranteed to reflect all updates being performed "after" it has been initialized.

### Why are the changes needed?

The lack of information on the method contract could mislead callers to expect some guarantees although not described. It would be nice to add to the contract to make clear. It could also help to implementations that they are not required to guarantee such thing.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

N/A