### PR TITLE
[SPARK-38525][K8S][TESTS] Check resource after yaml resource creation

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
@@ -110,6 +110,11 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
 
   private def createOrReplaceYAMLResource(yamlPath: String): Unit = {
     k8sClient.load(new FileInputStream(yamlPath)).createOrReplace()
+    Eventually.eventually(TIMEOUT, INTERVAL) {
+      val resources = k8sClient.load(new FileInputStream(yamlPath)).fromServer.get.asScala
+      // Make sure all elements are not null (get specific resources in cluster)
+      resources.foreach { r => assert(r != null) }
+    }
     testYAMLPaths += yamlPath
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check resource after yaml resource creation to make sure resource exsiting.


### Why are the changes needed?
The yaml create is async, we'd better to make sure the resource can be got from server.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
[info] VolcanoSuite:
[info] - Run SparkPi with volcano scheduler (11 seconds, 468 milliseconds)
[info] - SPARK-38187: Run SparkPi Jobs with minCPU (30 seconds, 636 milliseconds)
[info] - SPARK-38187: Run SparkPi Jobs with minMemory (31 seconds, 544 milliseconds)
[info] - SPARK-38188: Run SparkPi jobs with 2 queues (only 1 enabled) (13 seconds, 333 milliseconds)
[info] - SPARK-38188: Run SparkPi jobs with 2 queues (all enabled) (25 seconds, 486 milliseconds)
[info] - SPARK-38423: Run driver job to validate priority order (16 seconds, 488 milliseconds)
[info] Run completed in 2 minutes, 14 seconds.
[info] Total number of tests run: 6
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 6, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 163 s (02:43), completed 2022-3-11 21:40:53
```