### PR TITLE
[SPARK-38527][K8S][DOCS] Set the minimum Volcano version

### DIFF
--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -312,7 +312,6 @@ Volcano integration is experimental in Aapche Spark 3.3.0 and the test coverage 
 
 ## Requirements
 - A minimum of 6 CPUs and 9G of memory is required to complete all Volcano test cases.
-- Kubernetes v1.22.5+
 - Volcano v1.5.0.
 
 ## Installation

--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -308,9 +308,22 @@ You can also specify your specific dockerfile to build JVM/Python/R based image 
 
 # Running the Volcano Integration Tests
 
-Prerequisites
-- Install Volcano according to [link](https://volcano.sh/en/docs/installation/).
+Volcano integration is experimental in Aapche Spark 3.3.0 and the test coverage is limited.
+
+## Requirements
 - A minimum of 6 CPUs and 9G of memory is required to complete all Volcano test cases.
+- Kubernetes v1.22.5+
+- Volcano v1.5.0.
+
+## Installation
+
+    # x86_64
+    kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/release-1.5/installer/volcano-development.yaml
+
+    # arm64:
+    kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/release-1.5/installer/volcano-development-arm64.yaml
+
+## Run tests
 
 You can specify `-Pvolcano` to enable volcano module to run all Kubernetes and Volcano tests
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set the minimum `Volcano` version instead of `latest` tag in order to prevent accidental failures like SPARK-38508 and SPARK-38515 due to the unknown Volcano regression.

### Why are the changes needed?

Volcano `v1.5.0` is the latest released version released 20 days ago.

- https://github.com/volcano-sh/volcano/releases/tag/v1.5.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a doc-only change.