### PR TITLE
[SPARK-38539][SQL][DOCS] Add document for ToNumber for DecimalFormat's compatibility

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
@@ -52,6 +52,11 @@ import org.apache.spark.unsafe.types.UTF8String
       > SELECT _FUNC_('12,454.8-', '99G999D9S');
        -12454.8
   """,
+  note = """
+    ToNumber chose DecimalFormat as the underlying implementation, so ToNumber keep
+    good compatibility with DecimalFormat. For example: to_number('1,11,6.11', '000,,0.00')
+    works good and returns 1116.11
+  """,
   since = "3.3.0",
   group = "string_funcs")
 case class ToNumber(left: Expression, right: Expression)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
@@ -54,8 +54,8 @@ import org.apache.spark.unsafe.types.UTF8String
   """,
   note = """
     ToNumber has better compatibility with number format based on the underlying implementation.
-    For example: to_number('1,11,6.11', '000,,0.00') works good and returns 1116.11. Please see
-    the implementation of NumberFormatter.
+    For example: to_number('1,11,6.11', '000,,0.00') is illegal or works bad in some databases,
+    but it works good and returns 1116.11 here. Please see the implementation of NumberFormatter.
   """,
   since = "3.3.0",
   group = "string_funcs")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/numberFormatExpressions.scala
@@ -53,9 +53,9 @@ import org.apache.spark.unsafe.types.UTF8String
        -12454.8
   """,
   note = """
-    ToNumber chose DecimalFormat as the underlying implementation, so ToNumber keep
-    good compatibility with DecimalFormat. For example: to_number('1,11,6.11', '000,,0.00')
-    works good and returns 1116.11
+    ToNumber has better compatibility with number format based on the underlying implementation.
+    For example: to_number('1,11,6.11', '000,,0.00') works good and returns 1116.11. Please see
+    the implementation of NumberFormatter.
   """,
   since = "3.3.0",
   group = "string_funcs")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberFormatter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/NumberFormatter.scala
@@ -52,6 +52,11 @@ class NumberFormatter(originNumberFormat: String, isParse: Boolean = true) exten
 
   private val transformedFormat = transform(normalizedNumberFormat)
 
+  // Spark chose DecimalFormat as the underlying implementation because of its good compatibility.
+  // For example:
+  // to_number('1,116.11', '0,000.00') returns 1116.11. The underlying format is '#,###.00'.
+  // to_number('1,11,6.11', '000,,0.00') returns 1116.11. The underlying format is '###,,#.00'.
+  // to_number('1,11,6.11', '000,,,0.00') returns 1116.11. The underlying format is '###,,,#.00'.
   private lazy val numberDecimalFormat = {
     val decimalFormat = new DecimalFormat(transformedFormat)
     decimalFormat.setParseBigDecimal(true)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark choose `DecimalFormat` as the underlying implementation.
because `DecimalFormat` have better compatibility, so ToNumber could have the better compatibility than it in some database (e.g. Oracle).


### Why are the changes needed?
Explain why ToNumber have the better compatibility.


### Does this PR introduce _any_ user-facing change?
'No'. New feature.


### How was this patch tested?
No need.
