### PR TITLE
[SPARK-38511][K8S][TESTS][FOLLOWUP] Remove `verifyPriority` from `VolcanoFeatureStepSuite`

### DIFF
--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/VolcanoFeatureStepSuite.scala
@@ -66,14 +66,4 @@ class VolcanoFeatureStepSuite extends SparkFunSuite {
     assert(podGroup.getSpec.getPriorityClassName == "driver-priority")
     assert(podGroup.getSpec.getQueue == "driver-queue")
   }
-
-  private def verifyPriority(pod: SparkPod): Unit = {
-    val sparkConf = new SparkConf()
-    val kubernetesConf = KubernetesTestConf.createDriverConf(sparkConf)
-    val step = new VolcanoFeatureStep()
-    step.init(kubernetesConf)
-    val sparkPod = step.configurePod(pod)
-    val podGroup = step.getAdditionalPreKubernetesResources().head.asInstanceOf[PodGroup]
-    assert(podGroup.getSpec.getPriorityClassName === sparkPod.pod.getSpec.getPriorityClassName)
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove `verifyPriority` from `VolcanoFeatureStepSuite.scala`.

### Why are the changes needed?
This is unused. 

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.
