### PR TITLE
[SPARK-38552][PYTHON] Implement `keep` parameter of `frame.nlargest/nsmallest` to decide how to resolve ties

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6826,6 +6826,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
                     )
             return DataFrame(internal)
 
+    def _prepare_sort_by_scols(self, by: Union[Name, List[Name]]) -> List[Column]:
+        if is_name_like_value(by):
+            by = [by]
+        else:
+            assert is_list_like(by), type(by)
+        new_by = []
+        for colname in by:
+            ser = self[colname]
+            if not isinstance(ser, ps.Series):
+                raise ValueError(
+                    "The column %s is not unique. For a multi-index, the label must be a tuple "
+                    "with elements corresponding to each level." % name_like_string(colname)
+                )
+            new_by.append(ser.spark.column)
+        return new_by
+
     def _sort(
         self,
         by: List[Column],
@@ -6967,22 +6983,6 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             return None
         else:
             return psdf.reset_index(drop=True) if ignore_index else psdf
-
-    def _prepare_sort_by_scols(self, by: Union[Name, List[Name]]) -> List[Column]:
-        if is_name_like_value(by):
-            by = [by]
-        else:
-            assert is_list_like(by), type(by)
-        new_by = []
-        for colname in by:
-            ser = self[colname]
-            if not isinstance(ser, ps.Series):
-                raise ValueError(
-                    "The column %s is not unique. For a multi-index, the label must be a tuple "
-                    "with elements corresponding to each level." % name_like_string(colname)
-                )
-            new_by.append(ser.spark.column)
-        return new_by
 
     def sort_index(
         self,

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7338,7 +7338,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Number of rows to return.
         columns : label or list of labels
             Column label(s) to order by.
-        keep : {'first', 'last'}, default 'first'
+        keep : {'first', 'last'}, default 'first'. 'all' is not implemented yet.
             Determines which duplicates (if any) to keep.
             - ``first`` : Keep the first occurrence.
             - ``last`` : Keep the last occurrence.
@@ -7451,7 +7451,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
             Number of items to retrieve.
         columns : list or str
             Column name or names to order by.
-        keep : {'first', 'last'}, default 'first'
+        keep : {'first', 'last'}, default 'first'. 'all' is not implemented yet.
             Determines which duplicates (if any) to keep.
             - ``first`` : Keep the first occurrence.
             - ``last`` : Keep the last occurrence.

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6852,11 +6852,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         by = [mapper[(asc, na_position)](scol) for scol, asc in zip(by, ascending)]
 
         natural_order_scol = F.col(NATURAL_ORDER_COLUMN_NAME)
-        if keep == "first":
-            natural_order_scol = Column.asc(natural_order_scol)
-        elif keep == "last":
+
+        if keep == "last":
             natural_order_scol = Column.desc(natural_order_scol)
-        else:
+        elif keep != "first":
             raise NotImplementedError(
                 "`keep`=%s is not supported. Only 'first' and 'last' are supported." % keep
             )

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6871,10 +6871,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         if keep == "last":
             natural_order_scol = Column.desc(natural_order_scol)
+        elif keep == "all":
+            raise NotImplementedError("`keep`=all is not implemented yet.")
         elif keep != "first":
-            raise NotImplementedError(
-                "`keep`=%s is not supported. Only 'first' and 'last' are supported." % keep
-            )
+            raise ValueError('keep must be either "first", "last" or "all"')
         sdf = self._internal.resolved_copy.spark_frame.sort(*by, natural_order_scol)
         return DataFrame(self._internal.with_new_sdf(sdf))
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7395,6 +7395,39 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         6  NaN  12
         5  7.0  11
         4  6.0  10
+
+        The examples below show how ties are resolved, which is decided by `keep`.
+
+        >>> tied_df = ps.DataFrame({'X': [1, 2, 2, 3, 3]}, index=['a', 'b', 'c', 'd', 'e'])
+        >>> tied_df
+           X
+        a  1
+        b  2
+        c  2
+        d  3
+        e  3
+
+        When using keep='first' (by default), ties are resolved in order:
+
+        >>> tied_df.nlargest(3, 'X')
+           X
+        d  3
+        e  3
+        b  2
+
+        >>> tied_df.nlargest(3, 'X', keep='first')
+           X
+        d  3
+        e  3
+        b  2
+
+        When using keep='last', ties are resolved in reverse order:
+
+        >>> tied_df.nlargest(3, 'X', keep='last')
+           X
+        e  3
+        d  3
+        c  2
         """
         by_scols = self._prepare_sort_by_scols(columns)
         return self._sort(by=by_scols, ascending=False, na_position="last", keep=keep).head(n=n)
@@ -7466,6 +7499,39 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         0  1.0   6
         1  2.0   7
         2  3.0   8
+
+        The examples below show how ties are resolved, which is decided by `keep`.
+
+        >>> tied_df = ps.DataFrame({'X': [1, 1, 2, 2, 3]}, index=['a', 'b', 'c', 'd', 'e'])
+        >>> tied_df
+           X
+        a  1
+        b  1
+        c  2
+        d  2
+        e  3
+
+        When using keep='first' (by default), ties are resolved in order:
+
+        >>> tied_df.nsmallest(3, 'X')
+           X
+        a  1
+        b  1
+        c  2
+
+        >>> tied_df.nsmallest(3, 'X', keep='first')
+           X
+        a  1
+        b  1
+        c  2
+
+        When using keep='last', ties are resolved in reverse order:
+
+        >>> tied_df.nsmallest(3, 'X', keep='last')
+           X
+        b  1
+        a  1
+        d  2
         """
         by_scols = self._prepare_sort_by_scols(columns)
         return self._sort(by=by_scols, ascending=True, na_position="last", keep=keep).head(n=n)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -6874,7 +6874,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         elif keep == "all":
             raise NotImplementedError("`keep`=all is not implemented yet.")
         elif keep != "first":
-            raise ValueError('keep must be either "first", "last" or "all"')
+            raise ValueError('keep must be either "first", "last" or "all".')
         sdf = self._internal.resolved_copy.spark_frame.sort(*by, natural_order_scol)
         return DataFrame(self._internal.with_new_sdf(sdf))
 

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1789,20 +1789,40 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
     def test_nlargest(self):
         pdf = pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
+            {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1], "c": [1, 1, 2, 2, 3, 3, 3]},
+            index=np.random.rand(7),
         )
         psdf = ps.from_pandas(pdf)
         self.assert_eq(psdf.nlargest(n=5, columns="a"), pdf.nlargest(5, columns="a"))
         self.assert_eq(psdf.nlargest(n=5, columns=["a", "b"]), pdf.nlargest(5, columns=["a", "b"]))
+        self.assert_eq(psdf.nlargest(n=5, columns=["c"]), pdf.nlargest(5, columns=["c"]))
+        self.assert_eq(
+            psdf.nlargest(n=5, columns=["c"], keep="first"),
+            pdf.nlargest(5, columns=["c"], keep="first"),
+        )
+        self.assert_eq(
+            psdf.nlargest(n=5, columns=["c"], keep="last"),
+            pdf.nlargest(5, columns=["c"], keep="last"),
+        )
 
     def test_nsmallest(self):
         pdf = pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1]}, index=np.random.rand(7)
+            {"a": [1, 2, 3, 4, 5, None, 7], "b": [7, 6, 5, 4, 3, 2, 1], "c": [1, 1, 2, 2, 3, 3, 3]},
+            index=np.random.rand(7),
         )
         psdf = ps.from_pandas(pdf)
         self.assert_eq(psdf.nsmallest(n=5, columns="a"), pdf.nsmallest(5, columns="a"))
         self.assert_eq(
             psdf.nsmallest(n=5, columns=["a", "b"]), pdf.nsmallest(5, columns=["a", "b"])
+        )
+        self.assert_eq(psdf.nsmallest(n=5, columns=["c"]), pdf.nsmallest(5, columns=["c"]))
+        self.assert_eq(
+            psdf.nsmallest(n=5, columns=["c"], keep="first"),
+            pdf.nsmallest(5, columns=["c"], keep="first"),
+        )
+        self.assert_eq(
+            psdf.nsmallest(n=5, columns=["c"], keep="last"),
+            pdf.nsmallest(5, columns=["c"], keep="last"),
         )
 
     def test_xs(self):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1804,9 +1804,12 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             psdf.nlargest(5, columns=["c"], keep="last"),
             pdf.nlargest(5, columns=["c"], keep="last"),
         )
-        msg = "`keep`=all is not supported. Only 'first' and 'last' are supported."
+        msg = "`keep`=all is not implemented yet."
         with self.assertRaisesRegex(NotImplementedError, msg):
             psdf.nlargest(5, columns=["c"], keep="all")
+        msg = 'keep must be either "first", "last" or "all".'
+        with self.assertRaisesRegex(ValueError, msg):
+            psdf.nlargest(5, columns=["c"], keep="xx")
 
     def test_nsmallest(self):
         pdf = pd.DataFrame(
@@ -1827,9 +1830,12 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             psdf.nsmallest(n=5, columns=["c"], keep="last"),
             pdf.nsmallest(5, columns=["c"], keep="last"),
         )
-        msg = "`keep`=all is not supported. Only 'first' and 'last' are supported."
+        msg = "`keep`=all is not implemented yet."
         with self.assertRaisesRegex(NotImplementedError, msg):
-            psdf.nsmallest(n=5, columns=["c"], keep="all")
+            psdf.nlargest(5, columns=["c"], keep="all")
+        msg = 'keep must be either "first", "last" or "all".'
+        with self.assertRaisesRegex(ValueError, msg):
+            psdf.nlargest(5, columns=["c"], keep="xx")
 
     def test_xs(self):
         d = {

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1793,20 +1793,20 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             index=np.random.rand(7),
         )
         psdf = ps.from_pandas(pdf)
-        self.assert_eq(psdf.nlargest(n=5, columns="a"), pdf.nlargest(5, columns="a"))
-        self.assert_eq(psdf.nlargest(n=5, columns=["a", "b"]), pdf.nlargest(5, columns=["a", "b"]))
-        self.assert_eq(psdf.nlargest(n=5, columns=["c"]), pdf.nlargest(5, columns=["c"]))
+        self.assert_eq(psdf.nlargest(5, columns="a"), pdf.nlargest(5, columns="a"))
+        self.assert_eq(psdf.nlargest(5, columns=["a", "b"]), pdf.nlargest(5, columns=["a", "b"]))
+        self.assert_eq(psdf.nlargest(5, columns=["c"]), pdf.nlargest(5, columns=["c"]))
         self.assert_eq(
-            psdf.nlargest(n=5, columns=["c"], keep="first"),
+            psdf.nlargest(5, columns=["c"], keep="first"),
             pdf.nlargest(5, columns=["c"], keep="first"),
         )
         self.assert_eq(
-            psdf.nlargest(n=5, columns=["c"], keep="last"),
+            psdf.nlargest(5, columns=["c"], keep="last"),
             pdf.nlargest(5, columns=["c"], keep="last"),
         )
         msg = "`keep`=all is not supported. Only 'first' and 'last' are supported."
         with self.assertRaisesRegex(NotImplementedError, msg):
-            psdf.nlargest(n=5, columns=["c"], keep="all")
+            psdf.nlargest(5, columns=["c"], keep="all")
 
     def test_nsmallest(self):
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1804,6 +1804,9 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             psdf.nlargest(n=5, columns=["c"], keep="last"),
             pdf.nlargest(5, columns=["c"], keep="last"),
         )
+        msg = "`keep`=all is not supported. Only 'first' and 'last' are supported."
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            psdf.nlargest(n=5, columns=["c"], keep="all")
 
     def test_nsmallest(self):
         pdf = pd.DataFrame(
@@ -1824,6 +1827,9 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             psdf.nsmallest(n=5, columns=["c"], keep="last"),
             pdf.nsmallest(5, columns=["c"], keep="last"),
         )
+        msg = "`keep`=all is not supported. Only 'first' and 'last' are supported."
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            psdf.nsmallest(n=5, columns=["c"], keep="all")
 
     def test_xs(self):
         d = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `keep` parameter of `frame.nlargest/nsmallest` to decide how to resolve ties.

### Why are the changes needed?
To reach parity with pandas.

### Does this PR introduce _any_ user-facing change?
`keep` parameter of `frame.largest/nsmallest` is supported as below.
```py
>>> tied_df = ps.DataFrame({'X': [1, 2, 2, 3, 3]}, index=['a', 'b', 'c', 'd', 'e'])
>>> tied_df
   X
a  1
b  2
c  2
d  3
e  3
>>> tied_df.nlargest(3, 'X', keep='first')  # ties are resolved in order
   X
d  3
e  3
b  2
>>> tied_df.nlargest(3, 'X', keep='last')  # ties are resolved in reverse order
   X
e  3
d  3
c  2
>>> tied_df.nsmallest(3, 'X', keep='first')  # ties are resolved in order
   X
a  1
b  2
c  2
>>> tied_df.nsmallest(3, 'X', keep='last') # ties are resolved in reverse order
   X
a  1
c  2
b  2
```

### How was this patch tested?
Unit test.
