### PR TITLE
[SPARK-37865][SQL][FOLLOWUP] Fix compilation error for union deduplication correctness bug fixup

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1343,7 +1343,7 @@ class Analyzer(
         }
         u.copy(children = newChildren)
 
-      case u @ Union(children, _, _)
+      case u @ Union(children)
         // if there are duplicate output columns, give them unique expr ids
           if children.exists(c => c.output.map(_.exprId).distinct.length < c.output.length) =>
         val newChildren = children.map { c =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes compilation error following https://github.com/apache/spark/pull/35760.

### Why are the changes needed?

Compilation error: https://github.com/apache/spark/runs/5473941519?check_suite_focus=true

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit tests