### PR TITLE
[SPARK-38520][SQL] ANSI interval overflow when reading CSV

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -352,13 +352,16 @@ object IntervalUtils {
           val sign = finalSign(firstSign, secondSign)
           unit.toUpperCase(Locale.ROOT) match {
             case "DAY" if suffix == null && value.length <= 9 && checkTargetType(DT.DAY, DT.DAY) =>
-              sign * value.toLong * MICROS_PER_DAY
+              val days = toLongWithRange(dayStr, value, 0, MAX_DAY)
+              sign * days * MICROS_PER_DAY
             case "HOUR" if suffix == null && value.length <= 10
-              && checkTargetType(DT.HOUR, DT.HOUR) =>
-              sign * value.toLong * MICROS_PER_HOUR
+                && checkTargetType(DT.HOUR, DT.HOUR) =>
+              val hours = toLongWithRange(hourStr, value, 0, MAX_HOUR)
+              sign * hours * MICROS_PER_HOUR
             case "MINUTE" if suffix == null && value.length <= 12
-              && checkTargetType(DT.MINUTE, DT.MINUTE) =>
-              sign * value.toLong * MICROS_PER_MINUTE
+                && checkTargetType(DT.MINUTE, DT.MINUTE) =>
+              val minutes = toLongWithRange(minuteStr, value, 0, MAX_MINUTE)
+              sign * minutes * MICROS_PER_MINUTE
             case "SECOND" if value.length <= 13 && checkTargetType(DT.SECOND, DT.SECOND) =>
               sign match {
                 case 1 => parseSecondNano(secondAndMicro(value, suffix))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -348,19 +348,24 @@ object IntervalUtils {
           }
         }
       case dayTimeIndividualLiteralRegex(firstSign, secondSign, value, suffix, unit) =>
+        // formats are as following with extra `-` possibly:
+        // interval 'x' day || interval 'xx' hour || interval 'xx' minute || interval 'xx' second
         safeToInterval("day-time") {
           val sign = finalSign(firstSign, secondSign)
           unit.toUpperCase(Locale.ROOT) match {
             case "DAY" if suffix == null && value.length <= 9 && checkTargetType(DT.DAY, DT.DAY) =>
               val days = toLongWithRange(dayStr, value, 0, MAX_DAY)
+              // will not overflow, because of checked the range
               sign * days * MICROS_PER_DAY
             case "HOUR" if suffix == null && value.length <= 10
                 && checkTargetType(DT.HOUR, DT.HOUR) =>
               val hours = toLongWithRange(hourStr, value, 0, MAX_HOUR)
+              // will not overflow, because of checked the range
               sign * hours * MICROS_PER_HOUR
             case "MINUTE" if suffix == null && value.length <= 12
                 && checkTargetType(DT.MINUTE, DT.MINUTE) =>
               val minutes = toLongWithRange(minuteStr, value, 0, MAX_MINUTE)
+              // will not overflow, because of checked the range
               sign * minutes * MICROS_PER_MINUTE
             case "SECOND" if value.length <= 13 && checkTargetType(DT.SECOND, DT.SECOND) =>
               sign match {
@@ -550,7 +555,7 @@ object IntervalUtils {
   }
 
   /**
-   * Parse second_nano string in ss.nnnnnnnnn format to microseconds
+   * Parse second_nano string in `+ss.nnnnnnnnn` or `-ss.nnnnnnnnn` format to microseconds
    */
   private def parseSecondNano(secondNano: String): Long = {
     def parseSeconds(secondsStr: String): Long = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -354,9 +354,7 @@ object IntervalUtils {
           val sign = finalSign(firstSign, secondSign)
           unit.toUpperCase(Locale.ROOT) match {
             case "DAY" if suffix == null && value.length <= 9 && checkTargetType(DT.DAY, DT.DAY) =>
-              val days = toLongWithRange(dayStr, value, 0, MAX_DAY)
-              // will not overflow, because of checked the range
-              sign * days * MICROS_PER_DAY
+              toDTInterval(value, "0", "0", "0", sign)
             case "HOUR" if suffix == null && value.length <= 10
                 && checkTargetType(DT.HOUR, DT.HOUR) =>
               val hours = toLongWithRange(hourStr, value, 0, MAX_HOUR)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2735,29 +2735,6 @@ abstract class CSVSuite
       }
     }
   }
-
-  test("SPARK-38520: Intervals are overflow") {
-    Seq(
-      (DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY),
-          s"interval '${Long.MaxValue / 24L / 60L / 60L / 1000000L + 1}' day"),
-      (DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.HOUR),
-          s"interval '${Long.MaxValue / 60L / 60L / 1000000L + 1}' hour"),
-      (DayTimeIntervalType(DayTimeIntervalType.MINUTE, DayTimeIntervalType.MINUTE),
-          s"interval '${Long.MaxValue / 60L / 1000000L + 1}' minute"),
-      (DayTimeIntervalType(DayTimeIntervalType.SECOND, DayTimeIntervalType.SECOND),
-          s"interval '${Long.MaxValue / 1000000L + 1}' second")
-    ).foreach { case (intervalType, intervalString) =>
-      withTempPath { path =>
-        Seq(intervalString).toDF().repartition(1).write.text(path.getCanonicalPath)
-        val readBack = spark.read.schema(StructType(Array(StructField("_c1", intervalType))))
-          .csv(path.getCanonicalPath)
-        checkAnswer(
-          readBack,
-          // the interval is overflow, should be null
-          Seq(Row(null)))
-      }
-    }
-  }
 }
 
 class CSVv1Suite extends CSVSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -2735,6 +2735,29 @@ abstract class CSVSuite
       }
     }
   }
+
+  test("SPARK-38520: Intervals are overflow") {
+    Seq(
+      (DayTimeIntervalType(DayTimeIntervalType.DAY, DayTimeIntervalType.DAY),
+          s"interval '${Long.MaxValue / 24L / 60L / 60L / 1000000L + 1}' day"),
+      (DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.HOUR),
+          s"interval '${Long.MaxValue / 60L / 60L / 1000000L + 1}' hour"),
+      (DayTimeIntervalType(DayTimeIntervalType.MINUTE, DayTimeIntervalType.MINUTE),
+          s"interval '${Long.MaxValue / 60L / 1000000L + 1}' minute"),
+      (DayTimeIntervalType(DayTimeIntervalType.SECOND, DayTimeIntervalType.SECOND),
+          s"interval '${Long.MaxValue / 1000000L + 1}' second")
+    ).foreach { case (intervalType, intervalString) =>
+      withTempPath { path =>
+        Seq(intervalString).toDF().repartition(1).write.text(path.getCanonicalPath)
+        val readBack = spark.read.schema(StructType(Array(StructField("_c1", intervalType))))
+          .csv(path.getCanonicalPath)
+        checkAnswer(
+          readBack,
+          // the interval is overflow, should be null
+          Seq(Row(null)))
+      }
+    }
+  }
 }
 
 class CSVv1Suite extends CSVSuite {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix overflow bug when reading interval string from CSV file.
e.g.: 
interval '106751992' day will be converted to INTERVAL '-106751990' DAY.
interval '2562047789' hour => INTERVAL '-2562047787' HOUR
interval '153722867281' minute => INTERVAL '-153722867280' MINUTE

This PR added the range check, throws exception if the interval is overflow.

### Why are the changes needed?
To get the correct interval from CSV.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
UT.
