### PR TITLE
[SPARK-38546][EXAMPLES] Replace deprecated ChiSqSelector with UnivariateFeatureSelector

### DIFF
--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaChiSqSelectorExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaChiSqSelectorExample.java
@@ -24,7 +24,7 @@ import org.apache.spark.sql.SparkSession;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.spark.ml.feature.ChiSqSelector;
+import org.apache.spark.ml.feature.UnivariateFeatureSelector;
 import org.apache.spark.ml.linalg.VectorUDT;
 import org.apache.spark.ml.linalg.Vectors;
 import org.apache.spark.sql.Row;
@@ -56,16 +56,20 @@ public class JavaChiSqSelectorExample {
 
     Dataset<Row> df = spark.createDataFrame(data, schema);
 
-    ChiSqSelector selector = new ChiSqSelector()
-      .setNumTopFeatures(1)
+    UnivariateFeatureSelector selector = new UnivariateFeatureSelector()
+      // for chi-squared
+      .setFeatureType("categorical")
+      .setLabelType("categorical")
+      .setSelectionMode("numTopFeatures")
+      .setSelectionThreshold(1)
       .setFeaturesCol("features")
       .setLabelCol("clicked")
       .setOutputCol("selectedFeatures");
 
     Dataset<Row> result = selector.fit(df).transform(df);
 
-    System.out.println("ChiSqSelector output with top " + selector.getNumTopFeatures()
-        + " features selected");
+    System.out.println("UnivariateFeatureSelector for chi-squared output with top " +
+        selector.getSelectionThreshold() + " features selected");
     result.show();
 
     // $example off$


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to replace deprecated ChiSqSelector with UnivariateFeatureSelector.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In #31160, ChiSqSelector was labeled as deprecated.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Run JavaChiSqSelectorExample Before the PR
```plain
ChiSqSelector output with top 1 features selected
22/03/14 15:11:56 INFO CodeGenerator: Code generated in 6.124107 ms
22/03/14 15:11:56 INFO CodeGenerator: Code generated in 12.399323 ms
22/03/14 15:11:56 INFO CodeGenerator: Code generated in 6.305541 ms
22/03/14 15:11:56 INFO CodeGenerator: Code generated in 8.784765 ms
+---+------------------+-------+----------------+
| id|          features|clicked|selectedFeatures|
+---+------------------+-------+----------------+
|  7|[0.0,0.0,18.0,1.0]|    1.0|          [18.0]|
|  8|[0.0,1.0,12.0,0.0]|    0.0|          [12.0]|
|  9|[1.0,0.0,15.0,0.1]|    0.0|          [15.0]|
+---+------------------+-------+----------------+
```
Run JavaChiSqSelectorExample After the PR
```plain
UnivariateFeatureSelector for chi-squared output with top 1.0 features selected
22/03/14 19:36:54 INFO CodeGenerator: Code generated in 9.093969 ms
22/03/14 19:36:54 INFO CodeGenerator: Code generated in 15.667814 ms
22/03/14 19:36:54 INFO CodeGenerator: Code generated in 10.053778 ms
22/03/14 19:36:54 INFO CodeGenerator: Code generated in 12.287391 ms
+---+------------------+-------+----------------+
| id|          features|clicked|selectedFeatures|
+---+------------------+-------+----------------+
|  7|[0.0,0.0,18.0,1.0]|    1.0|          [18.0]|
|  8|[0.0,1.0,12.0,0.0]|    0.0|          [12.0]|
|  9|[1.0,0.0,15.0,0.1]|    0.0|          [15.0]|
+---+------------------+-------+----------------+
```