### PR TITLE
[SPARK-38547][CORE][R] Use more generic `Channel` type to initialize Netty `BootStrap`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/TransportContext.java
@@ -25,7 +25,6 @@ import com.codahale.metrics.Counter;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,7 +167,7 @@ public class TransportContext implements Closeable {
     return createServer(0, new ArrayList<>());
   }
 
-  public TransportChannelHandler initializePipeline(SocketChannel channel) {
+  public TransportChannelHandler initializePipeline(Channel channel) {
     return initializePipeline(channel, rpcHandler);
   }
 
@@ -185,7 +184,7 @@ public class TransportContext implements Closeable {
    * ChannelHandler to ensure all users of the same channel get the same TransportClient object.
    */
   public TransportChannelHandler initializePipeline(
-      SocketChannel channel,
+      Channel channel,
       RpcHandler channelRpcHandler) {
     try {
       TransportChannelHandler channelHandler = createChannelHandler(channel, channelRpcHandler);

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -28,11 +28,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
 import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,9 +131,9 @@ public class TransportServer implements Closeable {
       bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
     }
 
-    bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
+    bootstrap.childHandler(new ChannelInitializer<Channel>() {
       @Override
-      protected void initChannel(SocketChannel ch) {
+      protected void initChannel(Channel ch) {
         logger.debug("New connection accepted for remote address {}.", ch.remoteAddress());
 
         RpcHandler rpcHandler = appRpcHandler;

--- a/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.{Channel, ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
 import io.netty.handler.timeout.ReadTimeoutHandler
@@ -46,16 +45,18 @@ private[spark] class RBackend {
   private[r] val jvmObjectTracker = new JVMObjectTracker
 
   def init(): (Int, RAuthHelper) = {
+    import org.apache.spark.network.util.{IOMode, NettyUtils}
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
     val backendConnectionTimeout = conf.get(R_BACKEND_CONNECTION_TIMEOUT)
     bossGroup = new NioEventLoopGroup(conf.get(R_NUM_BACKEND_THREADS))
     val workerGroup = bossGroup
     val handler = new RBackendHandler(this)
     val authHelper = new RAuthHelper(conf)
+    val channelClass = NettyUtils.getServerChannelClass(IOMode.NIO)
 
     bootstrap = new ServerBootstrap()
       .group(bossGroup, workerGroup)
-      .channel(classOf[NioServerSocketChannel])
+      .channel(channelClass)
 
     bootstrap.childHandler(new ChannelInitializer[Channel]() {
       def initChannel(ch: Channel): Unit = {

--- a/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
@@ -22,9 +22,8 @@ import java.net.{InetAddress, InetSocketAddress, ServerSocket, Socket}
 import java.util.concurrent.TimeUnit
 
 import io.netty.bootstrap.ServerBootstrap
-import io.netty.channel.{ChannelFuture, ChannelInitializer, EventLoopGroup}
+import io.netty.channel.{Channel, ChannelFuture, ChannelInitializer, EventLoopGroup}
 import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.bytes.{ByteArrayDecoder, ByteArrayEncoder}
@@ -58,8 +57,8 @@ private[spark] class RBackend {
       .group(bossGroup, workerGroup)
       .channel(classOf[NioServerSocketChannel])
 
-    bootstrap.childHandler(new ChannelInitializer[SocketChannel]() {
-      def initChannel(ch: SocketChannel): Unit = {
+    bootstrap.childHandler(new ChannelInitializer[Channel]() {
+      def initChannel(ch: Channel): Unit = {
         ch.pipeline()
           .addLast("encoder", new ByteArrayEncoder())
           .addLast("frameDecoder",

--- a/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/RBackend.scala
@@ -31,6 +31,7 @@ import io.netty.handler.timeout.ReadTimeoutHandler
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.R._
+import org.apache.spark.network.util.{IOMode, NettyUtils}
 
 /**
  * Netty-based backend server that is used to communicate between R and Java.
@@ -45,7 +46,6 @@ private[spark] class RBackend {
   private[r] val jvmObjectTracker = new JVMObjectTracker
 
   def init(): (Int, RAuthHelper) = {
-    import org.apache.spark.network.util.{IOMode, NettyUtils}
     val conf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf())
     val backendConnectionTimeout = conf.get(R_BACKEND_CONNECTION_TIMEOUT)
     bossGroup = new NioEventLoopGroup(conf.get(R_NUM_BACKEND_THREADS))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark use `SocketChannel` type to initialize `BootStrap` now, but there is no need to limit the type to `Socket`, so this pr change the related type definitions from `SocketChannel` to `Channel`.

On the other hand, the current pr ensures all `channelClass` used to configure `BootStrap.channel` in Spark code  produced by `NettyUtils.getServer/ClientChannelClass`.


### Why are the changes needed?
Use more generic `Channel` type to initialize Netty `BootStrap`.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA