### PR TITLE
[SPARK-38527][K8S][DOCS][FOLLOWUP] Use v1.5.0 tag instead of release-1.5

### DIFF
--- a/resource-managers/kubernetes/integration-tests/README.md
+++ b/resource-managers/kubernetes/integration-tests/README.md
@@ -317,10 +317,10 @@ Volcano integration is experimental in Aapche Spark 3.3.0 and the test coverage 
 ## Installation
 
     # x86_64
-    kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/release-1.5/installer/volcano-development.yaml
+    kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.5.0/installer/volcano-development.yaml
 
     # arm64:
-    kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/release-1.5/installer/volcano-development-arm64.yaml
+    kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.5.0/installer/volcano-development-arm64.yaml
 
 ## Run tests
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses the `v1.5.0` tag instead of the branch name.

### Why are the changes needed?

It was a mistake to use `branch` name. It should be an immutable tag.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.