### PR TITLE
[SPARK-38521][SQL][WIP] Insert overwrite partitioned datasource table with dynamic mode

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -309,8 +309,8 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
             val message = intercept[AnalysisException] {
               sql(
                 """
-                  |INSERT OVERWRITE TABLE insertTable PARTITION(part1=1, part2)
-                  |SELECT i + 1, part2 FROM insertTable
+                  |INSERT OVERWRITE TABLE insertTable PARTITION(part1=1, part2=1)
+                  |SELECT i + 1 FROM insertTable
                 """.stripMargin)
             }.getMessage
             assert(
@@ -979,7 +979,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         checkAnswer(spark.table("t"), Row(2, 1, 1) :: Row(2, 2, 2) :: Row(3, 1, 2) :: Nil)
 
         sql("insert overwrite table t partition(part1=1, part2) select 4, 1")
-        checkAnswer(spark.table("t"), Row(4, 1, 1) :: Row(2, 2, 2) :: Nil)
+        checkAnswer(spark.table("t"), Row(4, 1, 1) :: Row(2, 2, 2) :: Row(3, 1, 2) :: Nil)
       }
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
@@ -296,7 +296,7 @@ class PartitionProviderCompatibilitySuite
             .write.partitionBy("A", "B").mode("overwrite")
             .saveAsTable("test")
           spark.sql("insert overwrite table test select id, id, 'x' from range(1)")
-          assert(spark.sql("select * from test").count() == 1)
+          assert(spark.sql("select * from test").count() == {if (enabled) 10 else 1})
 
           spark.range(10)
             .selectExpr("id", "id as A", "'x' as B")
@@ -304,7 +304,7 @@ class PartitionProviderCompatibilitySuite
             .saveAsTable("test")
           spark.sql(
             "insert overwrite table test partition (A, B) select id, id, 'x' from range(1)")
-          assert(spark.sql("select * from test").count() == 1)
+          assert(spark.sql("select * from test").count() == {if (enabled) 10 else 1})
         }
       }
     }
@@ -455,20 +455,20 @@ class PartitionProviderCompatibilitySuite
       assert(spark.sql("select * from test").count() == 10)
       assert(spark.sql("show partitions test").count() == 12)
       spark.sql("insert overwrite table test partition (P1=0, P2) select id, id from range(5)")
-      assert(spark.sql("select * from test").count() == 5)
-      assert(spark.sql("show partitions test").count() == 7)
+      assert(spark.sql("select * from test").count() == 10)
+      assert(spark.sql("show partitions test").count() == 12)
       spark.sql("insert overwrite table test partition (P1=0, P2) select id, id from range(1)")
-      assert(spark.sql("select * from test").count() == 1)
-      assert(spark.sql("show partitions test").count() == 3)
+      assert(spark.sql("select * from test").count() == 10)
+      assert(spark.sql("show partitions test").count() == 12)
       spark.sql("insert overwrite table test partition (P1=1, P2) select id, id from range(10)")
-      assert(spark.sql("select * from test").count() == 11)
-      assert(spark.sql("show partitions test").count() == 11)
+      assert(spark.sql("select * from test").count() == 20)
+      assert(spark.sql("show partitions test").count() == 20)
       spark.sql("insert overwrite table test partition (P1=1, P2) select id, id from range(1)")
-      assert(spark.sql("select * from test").count() == 2)
-      assert(spark.sql("show partitions test").count() == 2)
+      assert(spark.sql("select * from test").count() == 20)
+      assert(spark.sql("show partitions test").count() == 20)
       spark.sql("insert overwrite table test partition (P1=3, P2) select id, id from range(100)")
-      assert(spark.sql("select * from test").count() == 102)
-      assert(spark.sql("show partitions test").count() == 102)
+      assert(spark.sql("select * from test").count() == 120)
+      assert(spark.sql("show partitions test").count() == 120)
     }
   }
 
@@ -476,10 +476,10 @@ class PartitionProviderCompatibilitySuite
     testCustomLocations {
       spark.sql("insert overwrite table test partition (P1, P2) select id, id, id from range(10)")
       assert(spark.sql("select * from test").count() == 10)
-      assert(spark.sql("show partitions test").count() == 10)
+      assert(spark.sql("show partitions test").count() == 12)
       spark.sql("insert overwrite table test partition (P1, P2) select id, id, id from range(5)")
-      assert(spark.sql("select * from test").count() == 5)
-      assert(spark.sql("show partitions test").count() == 5)
+      assert(spark.sql("select * from test").count() == 10)
+      assert(spark.sql("show partitions test").count() == 12)
     }
   }
 


### PR DESCRIPTION
### Why are the changes needed?
We have supported partition overwrite with static mode by default while partition manged by catalog for a long time. It looks weird to me as `static mode` behaves catastrophically and deletes all data in table. Maybe setting partition overwrite with dynamic mode by default while partition manged by catalog, and user can set `partitionOverwriteMode` in table properties to support old behaviors. And also, this change can also bring a better experience to users when migrating from the original hive table to the datasource table, rather than the old data being deleted when the user does not know the meaning of `partitionOverwriteMode`.

### Does this PR introduce _any_ user-facing change?
Yes. We will no longer delete old partition data by default when user insert overwrite partitioned datasource tables.

### How was this patch tested?
Origin UT