### PR TITLE
[SPARK-38561][K8S][DOCS] Add doc for `Customized Kubernetes Schedulers`

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1724,22 +1724,22 @@ spec:
 
 #### Customized Kubernetes Schedulers for Spark on Kubernetes
 
-Spark allows users to specify a customized scheduler as Spark on Kubernetes scheduler.
+Spark allows users to specify a custom Kubernetes schedulers.
 
 1. Specify scheduler name.
 
-   Users can specify customized scheduler using <code>spark.kubernetes.scheduler.name</code> or
+   Users can specify a custom scheduler using <code>spark.kubernetes.scheduler.name</code> or
    <code>spark.kubernetes.{driver/executor}.scheduler.name</code> configuration.
 
 2. Specify scheduler related configurations.
 
-   Users can use [Pod template](#pod-template), existing configurations to specify label (<code>spark.kubernetes.{driver,executor}.label.*</code>), annotations style (<code>spark.kubernetes.{driver/executor}.annotation.*</code>) scheduler hints.
+   To configure the custom scheduler the user can use [Pod templates](#pod-template), add labels (<code>spark.kubernetes.{driver,executor}.label.*</code>)  and/or annotations (<code>spark.kubernetes.{driver/executor}.annotation.*</code>).
 
 3. Specify scheduler feature step.
 
-   Users may also consider to use <code>spark.kubernetes.{driver/executor}.pod.featureSteps</code> to support more complex requirements and more centralized scheduler hints configure, included but not limited to:
-  - Creating a scheduler needed additional Kubernetes custom resource for driver/executor scheduling.
-  - Setting scheduler hints according to configuration or existing Pod info dynamically.
+   Users may also consider to use <code>spark.kubernetes.{driver/executor}.pod.featureSteps</code> to support more complex requirements, including but not limited to:
+  - Create additional Kubernetes custom resources for driver/executor scheduling.
+  - Set scheduler hints according to configuration or existing Pod info dynamically.
 
 ### Stage Level Scheduling Overview
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1722,6 +1722,25 @@ spec:
     image: will-be-overwritten
 ```
 
+#### Customized Kubernetes Schedulers for Spark on Kubernetes
+
+Spark allows users to specify a customized scheduler as Spark on Kubernetes scheduler.
+
+1. Specify scheduler name.
+
+   Users can specify customized scheduler using <code>spark.kubernetes.scheduler.name</code> or
+   <code>spark.kubernetes.{driver/executor}.scheduler.name</code> configuration.
+
+2. Specify scheduler related configurations.
+
+   Users can use [Pod template](#pod-template), existing configurations to specify label (<code>spark.kubernetes.{driver,executor}.label.*</code>), annotations style (<code>spark.kubernetes.{driver/executor}.annotation.*</code>) scheduler hints.
+
+3. Specify scheduler feature step.
+
+   Users may also consider to use <code>spark.kubernetes.{driver/executor}.pod.featureSteps</code> to support more complex requirements and more centralized scheduler hints configure, included but not limited to:
+  - Creating a scheduler needed additional Kubernetes custom resource for driver/executor scheduling.
+  - Setting scheduler hints according to configuration or existing Pod info dynamically.
+
 ### Stage Level Scheduling Overview
 
 Stage level scheduling is supported on Kubernetes when dynamic allocation is enabled. This also requires <code>spark.dynamicAllocation.shuffleTracking.enabled</code> to be enabled since Kubernetes doesn't support an external shuffle service at this time. The order in which containers for different profiles is requested from Kubernetes is not guaranteed. Note that since dynamic allocation on Kubernetes requires the shuffle tracking feature, this means that executors from previous stages that used a different ResourceProfile may not idle timeout due to having shuffle data on them. This could result in using more cluster resources and in the worst case if there are no remaining resources on the Kubernetes cluster then Spark could potentially hang. You may consider looking at config <code>spark.dynamicAllocation.shuffleTracking.timeout</code> to set a timeout, but that could result in data having to be recomputed if the shuffle data is really needed.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is PR to doc for basic framework capability for Customized Kubernetes Schedulers.


### Why are the changes needed?
Guide user how to use spark on kubernetes custom scheduler


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
