### PR TITLE
[SPARK-38574][DOCS] Enrich the documentation of option avroSchema

### DIFF
--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -235,8 +235,7 @@ Data source options of Avro can be set via:
           the actual Avro schema. The deserialization schema will be consistent with the evolved schema.
           For example, if we set an evolved schema containing one additional column with a default value,
           the reading result in Spark will contain the new column too. Note that when using this option with 
-          <code>from_avro</code>, you still need to pass the actual schema as a parameter to the function. 
-          Otherwise, the behavior is undefined: it may fail or return arbitrary result.
+          <code>from_avro</code>, you still need to pass the actual Avro schema as a parameter to the function.
         </li>
         <li>
           When writing Avro, this option can be set if the expected output Avro schema doesn't match the

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -231,7 +231,7 @@ Data source options of Avro can be set via:
     <td>Optional schema provided by a user in JSON format.
       <ul>
         <li>
-          When reading Avro, this option can be set to an evolved schema, which is compatible but different with
+          When reading Avro files or calling function <code>from_avro</code>, this option can be set to an evolved schema, which is compatible but different with
           the actual Avro schema. The deserialization schema will be consistent with the evolved schema.
           For example, if we set an evolved schema containing one additional column with a default value,
           the reading result in Spark will contain the new column too. Note that when using this option with 

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -234,7 +234,9 @@ Data source options of Avro can be set via:
           When reading Avro, this option can be set to an evolved schema, which is compatible but different with
           the actual Avro schema. The deserialization schema will be consistent with the evolved schema.
           For example, if we set an evolved schema containing one additional column with a default value,
-          the reading result in Spark will contain the new column too.
+          the reading result in Spark will contain the new column too. Note that when using this option with 
+          <code>from_avro</code>, you still need to pass the actual schema as a parameter to the function. 
+          Otherwise, the behavior is undefined: it may fail or return arbitrary result.
         </li>
         <li>
           When writing Avro, this option can be set if the expected output Avro schema doesn't match the


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enrich Avro data source documentation to emphasize the difference between
`avroSchema` which is an option, and `jsonFormatSchema` which is a parameter to function `from_avro` .

When using `from_avro`, `avroSchema` option can be set to a compatible and evolved schema, while `jsonFormatSchema` has to be the actual schema. Elsewise, the behavior is undefined.


### Why are the changes needed?
Reduce confusion caused by option and parameter having similar namings.


### Does this PR introduce _any_ user-facing change?
Yes, Avro data source documentation is enriched a bit.


### How was this patch tested?
No testing required. Just a documentation change
