### PR TITLE
[SPARK-38575][INFRA] Duduplicate branch specification in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ansi_sql_mode_test.yml
+++ b/.github/workflows/ansi_sql_mode_test.yml
@@ -22,7 +22,7 @@ name: ANSI SQL mode test
 on:
   push:
     branches:
-      - master
+      - **
 
 jobs:
   ansi_sql_test:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,8 +23,8 @@ on:
   push:
     branches:
     - '**'
-    - '!branch-*.*'
   schedule:
+    # Note that the scheduled jobs are only for master branch.
     # master, Hadoop 2
     - cron: '0 1 * * *'
     # master
@@ -96,7 +96,7 @@ jobs:
           echo '::set-output name=hadoop::hadoop3'
         else
           echo '::set-output name=java::8'
-          echo '::set-output name=branch::master' # Default branch to run on. CHANGE here when a branch is cut out.
+          echo "::set-output name=branch::`git branch --show-current`"
           echo '::set-output name=type::regular'
           echo '::set-output name=envs::{"SPARK_ANSI_SQL_MODE": "${{ inputs.ansi_enabled }}"}'
           echo '::set-output name=hadoop::hadoop3'
@@ -105,6 +105,7 @@ jobs:
   precondition:
     name: Check changes
     runs-on: ubuntu-20.04
+    needs: configure-jobs
     env:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     outputs:
@@ -115,7 +116,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -325,7 +326,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -413,7 +414,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -477,7 +478,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -590,7 +591,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -639,7 +640,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -687,7 +688,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -786,7 +787,7 @@ jobs:
       with:
         fetch-depth: 0
         repository: apache/spark
-        ref: master
+        ref: ${{ needs.configure-jobs.outputs.branch }}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make the GitHub Actions workflow independent from branch.

### Why are the changes needed?

Currently we should make some changes every time we make a branch https://github.com/apache/spark/commit/1ec220f029f90a6ab109ef87f7c17337038d91d3 that is not quite smart.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this build should test, and it should be monitored after getting merged.