### PR TITLE
[SPARK-38586][INFRA] Trigger notifying workflow in branch-3.3 and other future branches

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - name: "Notify test workflow"
         uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # pin@v3
-        if: ${{ github.base_ref == 'master' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes `Notify test workflow` workflow to be triggered against PRs. 

In fact, we don't need to check if the branch is `master` since the event triggers the workflow that's found in the commit SHA.

### Why are the changes needed?

To link builds to the CI status in PRs.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will be checked after it gets merged - it's pretty straightforward.