### PR TITLE
[SPARK-38575][INFRA][FOLLOW-UP] Use GITHUB_REF to get the current branch

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -96,7 +96,7 @@ jobs:
           echo '::set-output name=hadoop::hadoop3'
         else
           echo '::set-output name=java::8'
-          echo "::set-output name=branch::`git branch --show-current`"
+          echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
           echo '::set-output name=type::regular'
           echo '::set-output name=envs::{"SPARK_ANSI_SQL_MODE": "${{ inputs.ansi_enabled }}"}'
           echo '::set-output name=hadoop::hadoop3'


### PR DESCRIPTION
### What changes were proposed in this pull request?

Current `git --show-current` doesn't work because we're not in a git repository when we calculate the changes we need.
Instead, this PR proposes to use `GITHUB_REF` environment variable to get the current branch.

### Why are the changes needed?

To fix up the build. See https://github.com/apache/spark/runs/5583091595?check_suite_focus=true (branch names)


### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Should monitor test.