### PR TITLE
[SPARK-38588][ML] Validate input dataset of ml.classification

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/Classifier.scala
@@ -24,7 +24,8 @@ import org.apache.spark.ml.feature.{Instance, LabeledPoint}
 import org.apache.spark.ml.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.param.shared.HasRawPredictionCol
-import org.apache.spark.ml.util.{MetadataUtils, SchemaUtils}
+import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.apache.spark.sql.functions._
@@ -143,7 +144,9 @@ abstract class Classifier[
       case Some(n: Int) => n
       case None =>
         // Get number of classes from dataset itself.
-        val maxLabelRow: Array[Row] = dataset.select(max($(labelCol))).take(1)
+        val maxLabelRow: Array[Row] = dataset
+          .select(max(checkClassificationLabels($(labelCol), Some(maxNumClasses))))
+          .take(1)
         if (maxLabelRow.isEmpty || maxLabelRow(0).get(0) == null) {
           throw new SparkException("ML algorithm was given empty dataset.")
         }

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/DecisionTreeClassifier.scala
@@ -22,6 +22,7 @@ import org.json4s.{DefaultFormats, JObject}
 import org.json4s.JsonDSL._
 
 import org.apache.spark.annotation.Since
+import org.apache.spark.ml.feature._
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.tree._
@@ -29,10 +30,11 @@ import org.apache.spark.ml.tree.{DecisionTreeModel, Node, TreeClassifierParams}
 import org.apache.spark.ml.tree.DecisionTreeModelReadWrite._
 import org.apache.spark.ml.tree.impl.RandomForest
 import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo, Strategy => OldStrategy}
 import org.apache.spark.mllib.tree.model.{DecisionTreeModel => OldDecisionTreeModel}
-import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql._
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.StructType
 
@@ -123,7 +125,14 @@ class DecisionTreeClassifier @Since("1.4.0") (
         s" numClasses=$numClasses, but thresholds has length ${$(thresholds).length}")
     }
     validateNumClasses(numClasses)
-    val instances = extractInstances(dataset, numClasses)
+
+    val instances = dataset.select(
+      checkClassificationLabels($(labelCol), Some(numClasses)),
+      checkNonNegativeWeights(get(weightCol)),
+      checkNonNanVectors($(featuresCol))
+    ).rdd.map { case Row(l: Double, w: Double, v: Vector) => Instance(l, w, v)
+    }.setName("training instances")
+
     val strategy = getOldStrategy(categoricalFeatures, numClasses)
     require(!strategy.bootstrap, "DecisionTreeClassifier does not need bootstrap sampling")
     instr.logNumClasses(numClasses)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/FMClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/FMClassifier.scala
@@ -26,10 +26,9 @@ import org.apache.spark.ml.param._
 import org.apache.spark.ml.regression.{FactorizationMachines, FactorizationMachinesParams}
 import org.apache.spark.ml.regression.FactorizationMachines._
 import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
-import org.apache.spark.mllib.linalg.{Vector => OldVector}
-import org.apache.spark.mllib.linalg.VectorImplicits._
-import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.linalg.{Vectors => OldVectors}
 import org.apache.spark.sql._
 import org.apache.spark.storage.StorageLevel
 
@@ -195,8 +194,12 @@ class FMClassifier @Since("3.0.0") (
     instr.logNumFeatures(numFeatures)
 
     val handlePersistence = dataset.storageLevel == StorageLevel.NONE
-    val labeledPoint = extractLabeledPoints(dataset, numClasses)
-    val data: RDD[(Double, OldVector)] = labeledPoint.map(x => (x.label, x.features))
+
+    val data = dataset.select(
+      checkClassificationLabels($(labelCol), Some(2)),
+      checkNonNanVectors($(featuresCol))
+    ).rdd.map { case Row(l: Double, v: Vector) => (l, OldVectors.fromML(v))
+    }.setName("training instances")
 
     if (handlePersistence) data.persist(StorageLevel.MEMORY_AND_DISK)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -182,7 +182,7 @@ class LinearSVC @Since("2.2.0") (
     }
 
     val instances = dataset.select(
-      checkBinaryLabels($(labelCol)),
+      checkClassificationLabels($(labelCol), Some(2)),
       checkNonNegativeWeights(get(weightCol)),
       checkNonNanVectors($(featuresCol))
     ).rdd.map { case Row(l: Double, w: Double, v: Vector) => Instance(l, w, v)

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -34,6 +34,7 @@ import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.stat._
 import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
@@ -180,8 +181,12 @@ class LinearSVC @Since("2.2.0") (
         s"then cached during training. Be careful of double caching!")
     }
 
-    val instances = extractInstances(dataset)
-      .setName("training instances")
+    val instances = dataset.select(
+      getBinaryLabelCol($(labelCol)),
+      getNonNegativeWeightCol(get(weightCol)),
+      getNonNanVectorCol($(featuresCol))
+    ).rdd.map { case Row(l: Double, w: Double, v: Vector) => Instance(l, w, v)
+    }.setName("training instances")
 
     val (summarizer, labelSummarizer) = Summarizer
       .getClassificationSummarizers(instances, $(aggregationDepth), Seq("mean", "std", "count"))

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/LinearSVC.scala
@@ -182,9 +182,9 @@ class LinearSVC @Since("2.2.0") (
     }
 
     val instances = dataset.select(
-      getBinaryLabelCol($(labelCol)),
-      getNonNegativeWeightCol(get(weightCol)),
-      getNonNanVectorCol($(featuresCol))
+      checkBinaryLabels($(labelCol)),
+      checkNonNegativeWeights(get(weightCol)),
+      checkNonNanVectors($(featuresCol))
     ).rdd.map { case Row(l: Double, w: Double, v: Vector) => Instance(l, w, v)
     }.setName("training instances")
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -167,7 +167,8 @@ class NaiveBayes @Since("1.5.0") (
         val vecCol = col($(featuresCol))
         when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be Null")))
           .when(!checkNonNegativeVector(vecCol),
-            raise_error(concat(lit("Vector values MUST NOT be Negative or Infinity, but got "),
+            raise_error(concat(
+              lit("Vector values MUST NOT be Negative, NaN or Infinity, but got "),
               vecCol.cast(StringType))))
           .otherwise(vecCol)
 
@@ -181,7 +182,8 @@ class NaiveBayes @Since("1.5.0") (
         val vecCol = col($(featuresCol))
         when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be Null")))
           .when(!checkBinaryVector(vecCol),
-            raise_error(concat(lit("Vector values MUST be in {0, 1}, but got "),
+            raise_error(concat(
+              lit("Vector values MUST be in {0, 1}, but got "),
               vecCol.cast(StringType))))
           .otherwise(vecCol)
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -22,16 +22,16 @@ import org.json4s.DefaultFormats
 
 import org.apache.spark.annotation.Since
 import org.apache.spark.ml.PredictorParams
-import org.apache.spark.ml.functions.checkNonNegativeWeight
 import org.apache.spark.ml.impl.Utils
 import org.apache.spark.ml.linalg._
 import org.apache.spark.ml.param.{DoubleParam, Param, ParamMap, ParamValidators}
 import org.apache.spark.ml.param.shared.HasWeightCol
 import org.apache.spark.ml.stat.Summarizer
 import org.apache.spark.ml.util._
+import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
 import org.apache.spark.mllib.util.MLUtils
-import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.VersionUtils
@@ -131,7 +131,7 @@ class NaiveBayes @Since("1.5.0") (
   def setWeightCol(value: String): this.type = set(weightCol, value)
 
   override protected def train(dataset: Dataset[_]): NaiveBayesModel = {
-    trainWithLabelCheck(dataset, positiveLabel = true)
+    trainWithLabelCheck(dataset, nonNegativeLabel = true)
   }
 
   /**
@@ -142,25 +142,63 @@ class NaiveBayes @Since("1.5.0") (
    */
   private[spark] def trainWithLabelCheck(
       dataset: Dataset[_],
-      positiveLabel: Boolean): NaiveBayesModel = instrumented { instr =>
+      nonNegativeLabel: Boolean): NaiveBayesModel = instrumented { instr =>
     instr.logPipelineStage(this)
     instr.logDataset(dataset)
     instr.logParams(this, labelCol, featuresCol, weightCol, predictionCol, rawPredictionCol,
       probabilityCol, modelType, smoothing, thresholds)
 
-    if (positiveLabel && isDefined(thresholds)) {
-      val numClasses = getNumClasses(dataset)
-      instr.logNumClasses(numClasses)
-      require($(thresholds).length == numClasses, this.getClass.getSimpleName +
-        ".train() called with non-matching numClasses and thresholds.length." +
-        s" numClasses=$numClasses, but thresholds has length ${$(thresholds).length}")
+    val validatedLabelCol = if (nonNegativeLabel) {
+      checkClassificationLabels($(labelCol), get(thresholds).map(_.length))
+    } else {
+      checkRegressionLabels($(labelCol))
     }
+
+    val validatedWeightCol = checkNonNegativeWeights(get(weightCol))
+
+    val validatedfeaturesCol = $(modelType) match {
+      case Multinomial | Complement =>
+        val checkNonNegativeVector = udf { vector: Vector =>
+          vector match {
+            case dv: DenseVector => dv.values.forall(v => v >= 0 && !v.isInfinity)
+            case sv: SparseVector => sv.values.forall(v => v >= 0 && !v.isInfinity)
+          }
+        }
+        val vecCol = col($(featuresCol))
+        when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be Null")))
+          .when(!checkNonNegativeVector(vecCol),
+            raise_error(concat(lit("Vector values MUST NOT be Negative or Infinity, but got "),
+              vecCol.cast(StringType))))
+          .otherwise(vecCol)
+
+      case Bernoulli =>
+        val checkBinaryVector = udf { vector: Vector =>
+          vector match {
+            case dv: DenseVector => dv.values.forall(v => v == 0 || v == 1)
+            case sv: SparseVector => sv.values.forall(v => v == 0 || v == 1)
+          }
+        }
+        val vecCol = col($(featuresCol))
+        when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be Null")))
+          .when(!checkBinaryVector(vecCol),
+            raise_error(concat(lit("Vector values MUST be in {0, 1}, but got "),
+              vecCol.cast(StringType))))
+          .otherwise(vecCol)
+
+      case _ => checkNonNanVectors($(featuresCol))
+    }
+
+    val validated = dataset.select(
+      validatedLabelCol.as("_validated_label_"),
+      validatedWeightCol.as("_validated_weight_"),
+      validatedfeaturesCol.as("_validated_features_")
+    )
 
     $(modelType) match {
       case Bernoulli | Multinomial | Complement =>
-        trainDiscreteImpl(dataset, instr)
+        trainDiscreteImpl(validated, instr)
       case Gaussian =>
-        trainGaussianImpl(dataset, instr)
+        trainGaussianImpl(validated, instr)
       case _ =>
         // This should never happen.
         throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}.")
@@ -172,25 +210,13 @@ class NaiveBayes @Since("1.5.0") (
       instr: Instrumentation): NaiveBayesModel = {
     val spark = dataset.sparkSession
     import spark.implicits._
-
-    val validateUDF = $(modelType) match {
-      case Multinomial | Complement =>
-        udf { vector: Vector => requireNonnegativeValues(vector); vector }
-      case Bernoulli =>
-        udf { vector: Vector => requireZeroOneBernoulliValues(vector); vector }
-    }
-
-    val w = if (isDefined(weightCol) && $(weightCol).nonEmpty) {
-      checkNonNegativeWeight(col($(weightCol)).cast(DoubleType))
-    } else {
-      lit(1.0)
-    }
+    val Array(label, weight, featuers) = dataset.schema.fieldNames
 
     // Aggregates term frequencies per label.
-    val aggregated = dataset.groupBy(col($(labelCol)))
-      .agg(sum(w).as("weightSum"), Summarizer.metrics("sum", "count")
-        .summary(validateUDF(col($(featuresCol))), w).as("summary"))
-      .select($(labelCol), "weightSum", "summary.sum", "summary.count")
+    val aggregated = dataset.groupBy(col(label))
+      .agg(sum(col(weight)).as("weightSum"),
+        Summarizer.metrics("sum", "count").summary(col(featuers), col(weight)).as("summary"))
+      .select(label, "weightSum", "summary.sum", "summary.count")
       .as[(Double, Double, Vector, Long)]
       .collect().sortBy(_._1)
 
@@ -259,18 +285,13 @@ class NaiveBayes @Since("1.5.0") (
       instr: Instrumentation): NaiveBayesModel = {
     val spark = dataset.sparkSession
     import spark.implicits._
-
-    val w = if (isDefined(weightCol) && $(weightCol).nonEmpty) {
-      checkNonNegativeWeight(col($(weightCol)).cast(DoubleType))
-    } else {
-      lit(1.0)
-    }
+    val Array(label, weight, featuers) = dataset.schema.fieldNames
 
     // Aggregates mean vector and square-sum vector per label.
-    val aggregated = dataset.groupBy(col($(labelCol)))
-      .agg(sum(w).as("weightSum"), Summarizer.metrics("mean", "normL2")
-        .summary(col($(featuresCol)), w).as("summary"))
-      .select($(labelCol), "weightSum", "summary.mean", "summary.normL2")
+    val aggregated = dataset.groupBy(col(label))
+      .agg(sum(col(weight)).as("weightSum"),
+        Summarizer.metrics("mean", "normL2").summary(col(featuers), col(weight)).as("summary"))
+      .select(label, "weightSum", "summary.mean", "summary.normL2")
       .as[(Double, Double, Vector, Vector)]
       .map { case (label, weightSum, mean, normL2) =>
         (label, weightSum, mean, Vectors.dense(normL2.toArray.map(v => v * v)))

--- a/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
@@ -29,8 +29,7 @@ private[spark] object DatasetUtils {
 
   private[ml] def checkBinaryLabels(labelCol: String): Column = {
     val casted = col(labelCol).cast(DoubleType)
-    when(casted.isNull || casted.isNaN,
-      raise_error(lit("Labels MUST NOT be NULL or NaN")))
+    when(casted.isNull || casted.isNaN, raise_error(lit("Labels MUST NOT be NULL or NaN")))
       .when(casted =!= 0 && casted =!= 1,
         raise_error(concat(lit("Labels MUST be in {0, 1}, but got "), casted)))
       .otherwise(casted)
@@ -38,8 +37,7 @@ private[spark] object DatasetUtils {
 
   private[ml] def checkNonNegativeWeights(weightCol: String): Column = {
     val casted = col(weightCol).cast(DoubleType)
-    when(casted.isNull || casted.isNaN,
-      raise_error(lit("Weights MUST NOT be NULL or NaN")))
+    when(casted.isNull || casted.isNaN, raise_error(lit("Weights MUST NOT be NULL or NaN")))
       .when(casted < 0 || casted === Double.PositiveInfinity,
         raise_error(concat(lit("Weights MUST NOT be Negative or Infinity, but got "), casted)))
       .otherwise(casted)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
@@ -29,19 +29,19 @@ private[spark] object DatasetUtils {
 
   private[ml] def checkBinaryLabels(labelCol: String): Column = {
     val casted = col(labelCol).cast(DoubleType)
-    when(casted.isNull, raise_error(lit("Labels MUST NOT be NULL")))
+    when(casted.isNull || casted.isNaN,
+      raise_error(lit("Labels MUST NOT be NULL or NaN")))
       .when(casted =!= 0 && casted =!= 1,
-        raise_error(concat(lit("Labels MUST be in {0, 1}, but got "),
-          casted.cast(StringType))))
+        raise_error(concat(lit("Labels MUST be in {0, 1}, but got "), casted)))
       .otherwise(casted)
   }
 
   private[ml] def checkNonNegativeWeights(weightCol: String): Column = {
     val casted = col(weightCol).cast(DoubleType)
-    when(casted.isNull, raise_error(lit("Weights MUST NOT be NULL")))
+    when(casted.isNull || casted.isNaN,
+      raise_error(lit("Weights MUST NOT be NULL or NaN")))
       .when(casted < 0 || casted === Double.PositiveInfinity,
-        raise_error(concat(lit("Weights MUST be non-Negative and finite, but got "),
-          casted.cast(StringType))))
+        raise_error(concat(lit("Weights MUST be non-Negative and finite, but got "), casted)))
       .otherwise(casted)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
@@ -41,7 +41,7 @@ private[spark] object DatasetUtils {
     when(casted.isNull || casted.isNaN,
       raise_error(lit("Weights MUST NOT be NULL or NaN")))
       .when(casted < 0 || casted === Double.PositiveInfinity,
-        raise_error(concat(lit("Weights MUST be non-Negative and finite, but got "), casted)))
+        raise_error(concat(lit("Weights MUST NOT be Negative or Infinity, but got "), casted)))
       .otherwise(casted)
   }
 
@@ -54,7 +54,7 @@ private[spark] object DatasetUtils {
     val vecCol = col(vectorCol)
     when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be NULL")))
       .when(!validateVector(vecCol),
-        raise_error(concat(lit("Vector values MUST be non-NaN and finite, but got "),
+        raise_error(concat(lit("Vector values MUST NOT be NaN or Infinity, but got "),
           vecCol.cast(StringType))))
       .otherwise(vecCol)
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/DatasetUtils.scala
@@ -20,24 +20,47 @@ package org.apache.spark.ml.util
 import org.apache.spark.ml.linalg._
 import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Column, Dataset, Row}
+import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{ArrayType, DoubleType, FloatType, StringType}
+import org.apache.spark.sql.types._
 
 
 private[spark] object DatasetUtils {
 
-  private[ml] def checkBinaryLabels(labelCol: String): Column = {
+  private[ml] def checkRegressionLabels(labelCol: String): Column = {
     val casted = col(labelCol).cast(DoubleType)
-    when(casted.isNull || casted.isNaN, raise_error(lit("Labels MUST NOT be NULL or NaN")))
-      .when(casted =!= 0 && casted =!= 1,
-        raise_error(concat(lit("Labels MUST be in {0, 1}, but got "), casted)))
+    when(casted.isNull || casted.isNaN, raise_error(lit("Labels MUST NOT be Null or NaN")))
+      .when(casted === Double.NegativeInfinity || casted === Double.PositiveInfinity,
+        raise_error(concat(lit("Labels MUST NOT be Infinity, but got "), casted)))
       .otherwise(casted)
+  }
+
+  private[ml] def checkClassificationLabels(
+    labelCol: String,
+    numClasses: Option[Int]): Column = {
+    val casted = col(labelCol).cast(DoubleType)
+    numClasses match {
+      case Some(2) =>
+        when(casted.isNull || casted.isNaN, raise_error(lit("Labels MUST NOT be Null or NaN")))
+          .when(casted =!= 0 && casted =!= 1,
+            raise_error(concat(lit("Labels MUST be in {0, 1}, but got "), casted)))
+          .otherwise(casted)
+
+      case _ =>
+        val n = numClasses.getOrElse(Int.MaxValue)
+        require(0 < n && n <= Int.MaxValue)
+        when(casted.isNull || casted.isNaN, raise_error(lit("Labels MUST NOT be Null or NaN")))
+          .when(casted < 0 || casted >= n,
+            raise_error(concat(lit(s"Labels MUST be in [0, $n), but got "), casted)))
+          .when(casted =!= casted.cast(IntegerType),
+            raise_error(concat(lit("Labels MUST be Integers, but got "), casted)))
+          .otherwise(casted)
+    }
   }
 
   private[ml] def checkNonNegativeWeights(weightCol: String): Column = {
     val casted = col(weightCol).cast(DoubleType)
-    when(casted.isNull || casted.isNaN, raise_error(lit("Weights MUST NOT be NULL or NaN")))
+    when(casted.isNull || casted.isNaN, raise_error(lit("Weights MUST NOT be Null or NaN")))
       .when(casted < 0 || casted === Double.PositiveInfinity,
         raise_error(concat(lit("Weights MUST NOT be Negative or Infinity, but got "), casted)))
       .otherwise(casted)
@@ -50,7 +73,7 @@ private[spark] object DatasetUtils {
 
   private[ml] def checkNonNanVectors(vectorCol: String): Column = {
     val vecCol = col(vectorCol)
-    when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be NULL")))
+    when(vecCol.isNull, raise_error(lit("Vectors MUST NOT be Null")))
       .when(!validateVector(vecCol),
         raise_error(concat(lit("Vector values MUST NOT be NaN or Infinity, but got "),
           vecCol.cast(StringType))))

--- a/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/classification/NaiveBayes.scala
@@ -367,8 +367,8 @@ class NaiveBayes private (
     val dataset = data.map { case LabeledPoint(label, features) => (label, features.asML) }
       .toDF("label", "features")
 
-    // mllib NaiveBayes allows input labels like {-1, +1}, so set `positiveLabel` as false.
-    val newModel = nb.trainWithLabelCheck(dataset, positiveLabel = false)
+    // mllib NaiveBayes allows input labels like {-1, +1}, so set `nonNegativeLabel` as false.
+    val newModel = nb.trainWithLabelCheck(dataset, nonNegativeLabel = false)
 
     val pi = newModel.pi.toArray
     val theta = Array.ofDim[Double](newModel.numClasses, newModel.numFeatures)

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/ClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/ClassifierSuite.scala
@@ -78,17 +78,17 @@ class ClassifierSuite extends SparkFunSuite with MLlibTestSparkContext {
     // Invalid datasets
     val df1 = getTestData(Seq(0.0, 2.0, 1.0, 5.1))
     withClue("getNumClasses should fail if label is max label not an integer") {
-      val e: IllegalArgumentException = intercept[IllegalArgumentException] {
+      val e = intercept[Exception] {
         c.getNumClasses(df1)
       }
-      assert(e.getMessage.contains("requires integers in range"))
+      assert(e.getMessage.contains("Labels MUST be Integers"))
     }
     val df2 = getTestData(Seq(0.0, 2.0, 1.0, Int.MaxValue.toDouble))
     withClue("getNumClasses should fail if label is max label is >= Int.MaxValue") {
-      val e: IllegalArgumentException = intercept[IllegalArgumentException] {
+      val e = intercept[Exception] {
         c.getNumClasses(df2)
       }
-      assert(e.getMessage.contains("requires integers in range"))
+      assert(e.getMessage.contains("Labels MUST be in [0"))
     }
     val df3 = getTestData(Seq.empty[Double])
     withClue("getNumClasses should fail if dataset is empty") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/DecisionTreeClassifierSuite.scala
@@ -67,6 +67,12 @@ class DecisionTreeClassifierSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(model)
   }
 
+  test("DecisionTreeClassifier validate input dataset") {
+    testInvalidClassificationLabels(new DecisionTreeClassifier().fit(_), None)
+    testInvalidWeights(new DecisionTreeClassifier().setWeightCol("weight").fit(_))
+    testInvalidVectors(new DecisionTreeClassifier().fit(_))
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Tests calling train()
   /////////////////////////////////////////////////////////////////////////////

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/FMClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/FMClassifierSuite.scala
@@ -45,6 +45,11 @@ class FMClassifierSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(model)
   }
 
+  test("FMClassifier validate input dataset") {
+    testInvalidClassificationLabels(new FMClassifier().fit(_), Some(2))
+    testInvalidVectors(new FMClassifier().fit(_))
+  }
+
   test("FMClassifier: Predictor, Classifier methods") {
     val sqlContext = smallBinaryDataset.sqlContext
     import sqlContext.implicits._

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
@@ -90,7 +90,7 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
     val e2 = intercept[Exception] {
       new LinearSVC().setWeightCol("weight").fit(df2)
     }
-    assert(e2.getMessage.contains("Weights MUST be non-Negative and finite"))
+    assert(e2.getMessage.contains("Weights MUST NOT be Negative or Infinity"))
 
     val df3 = sc.parallelize(Seq(
       LabeledPoint(1.0, Vectors.dense(1.0, Double.NaN)),
@@ -99,7 +99,7 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
     val e3 = intercept[Exception] {
       new LinearSVC().fit(df3)
     }
-    assert(e3.getMessage.contains("Vector values MUST be non-NaN and finite"))
+    assert(e3.getMessage.contains("Vector values MUST NOT be NaN or Infinity"))
   }
 
   test("Linear SVC binary classification") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LinearSVCSuite.scala
@@ -73,90 +73,6 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
     }.repartition(1).saveAsTextFile("target/tmp/LinearSVC/binaryDataset")
   }
 
-  test("LinearSVC validate input dataset") {
-    // labels contains NULL
-    val df1 = sc.parallelize(Seq(
-      (null, 1.0, Vectors.dense(1.0, 2.0)),
-      ("1.0", 1.0, Vectors.dense(1.0, 2.0))
-    )).toDF("str_label", "weight", "features")
-      .select(col("str_label").cast("double").as("label"), col("weight"), col("features"))
-    val e1 = intercept[Exception] { new LinearSVC().fit(df1) }
-    assert(e1.getMessage.contains("Labels MUST NOT be NULL or NaN"))
-
-    // labels contains NaN
-    val df2 = sc.parallelize(Seq(
-      (Double.NaN, 1.0, Vectors.dense(1.0, 2.0)),
-      (1.0, 1.0, Vectors.dense(1.0, 2.0))
-    )).toDF("label", "weight", "features")
-    val e2 = intercept[Exception] { new LinearSVC().fit(df2) }
-    assert(e2.getMessage.contains("Labels MUST NOT be NULL or NaN"))
-
-    // labels contains invalid value: 3
-    val df3 = sc.parallelize(Seq(
-      (3.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (1.0, 1.0, Vectors.dense(1.0, 2.0))
-    )).toDF("label", "weight", "features")
-    val e3 = intercept[Exception] { new LinearSVC().fit(df3) }
-    assert(e3.getMessage.contains("Labels MUST be in {0, 1}"))
-
-    // weights contains NULL
-    val df4 = sc.parallelize(Seq(
-      (1.0, "1.0", Vectors.dense(1.0, 2.0)),
-      (0.0, null, Vectors.dense(1.0, 2.0))
-    )).toDF("label", "str_weight", "features")
-      .select(col("label"), col("str_weight").cast("double").as("weight"), col("features"))
-    val e4 = intercept[Exception] { new LinearSVC().setWeightCol("weight").fit(df4) }
-    assert(e4.getMessage.contains("Weights MUST NOT be NULL or NaN"))
-
-    // weights contains NaN
-    val df5 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (0.0, Double.NaN, Vectors.dense(1.0, 2.0))
-    )).toDF("label", "weight", "features")
-    val e5 = intercept[Exception] { new LinearSVC().setWeightCol("weight").fit(df5) }
-    assert(e5.getMessage.contains("Weights MUST NOT be NULL or NaN"))
-
-    // weights contains invalid value: -3
-    val df6 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (0.0, -3.0, Vectors.dense(1.0, 2.0))
-    )).toDF("label", "weight", "features")
-    val e6 = intercept[Exception] { new LinearSVC().setWeightCol("weight").fit(df6) }
-    assert(e6.getMessage.contains("Weights MUST NOT be Negative or Infinity"))
-
-    // weights contains invalid value: Infinity
-    val df7 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (0.0, Double.PositiveInfinity, Vectors.dense(1.0, 2.0))
-    )).toDF("label", "weight", "features")
-    val e7 = intercept[Exception] { new LinearSVC().setWeightCol("weight").fit(df7) }
-    assert(e7.getMessage.contains("Weights MUST NOT be Negative or Infinity"))
-
-    // vectors contains NULL
-    val df8 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (0.0, 1.0, null)
-    )).toDF("label", "weight", "features")
-    val e8 = intercept[Exception] { new LinearSVC().fit(df8) }
-    assert(e8.getMessage.contains("Vectors MUST NOT be NULL"))
-
-    // vectors contains NaN
-    val df9 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (0.0, 1.0, Vectors.dense(Double.NaN, 2.0))
-    )).toDF("label", "weight", "features")
-    val e9 = intercept[Exception] { new LinearSVC().fit(df9) }
-    assert(e9.getMessage.contains("Vector values MUST NOT be NaN or Infinity"))
-
-    // vectors contains Infinity
-    val df10 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
-      (0.0, 1.0, Vectors.dense(1.0, Double.NegativeInfinity))
-    )).toDF("label", "weight", "features")
-    val e10 = intercept[Exception] { new LinearSVC().fit(df10) }
-    assert(e10.getMessage.contains("Vector values MUST NOT be NaN or Infinity"))
-  }
-
   test("Linear SVC binary classification") {
     val svm = new LinearSVC()
     val model = svm.fit(smallBinaryDataset)
@@ -213,6 +129,12 @@ class LinearSVCSuite extends MLTest with DefaultReadWriteTest {
     assert(model.numFeatures === 2)
 
     MLTestingUtils.checkCopyAndUids(lsvc, model)
+  }
+
+  test("LinearSVC validate input dataset") {
+    testInvalidClassificationLabels(new LinearSVC().fit(_), Some(2))
+    testInvalidWeights(new LinearSVC().setWeightCol("weight").fit(_))
+    testInvalidVectors(new LinearSVC().fit(_))
   }
 
   test("LinearSVC threshold acts on rawPrediction") {

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/LogisticRegressionSuite.scala
@@ -221,6 +221,12 @@ class LogisticRegressionSuite extends MLTest with DefaultReadWriteTest {
     assert(!model.hasSummary)
   }
 
+  test("LogisticRegression validate input dataset") {
+    testInvalidClassificationLabels(new LogisticRegression().fit(_), None)
+    testInvalidWeights(new LogisticRegression().setWeightCol("weight").fit(_))
+    testInvalidVectors(new LogisticRegression().fit(_))
+  }
+
   test("logistic regression: illegal params") {
     val lowerBoundsOnCoefficients = Matrices.dense(1, 4, Array(1.0, 0.0, 1.0, 0.0))
     val upperBoundsOnCoefficients1 = Matrices.dense(1, 4, Array(0.0, 1.0, 1.0, 0.0))

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/MultilayerPerceptronClassifierSuite.scala
@@ -61,6 +61,20 @@ class MultilayerPerceptronClassifierSuite extends MLTest with DefaultReadWriteTe
     mlpc.setLayers(Array[Int](1, 1))
   }
 
+  test("MultilayerPerceptronClassifier validate input dataset") {
+    testInvalidClassificationLabels(
+      new MultilayerPerceptronClassifier().setLayers(Array[Int](2, 5, 2)).fit(_),
+      Some(2)
+    )
+    testInvalidClassificationLabels(
+      new MultilayerPerceptronClassifier().setLayers(Array[Int](2, 5, 3)).fit(_),
+      Some(3)
+    )
+    testInvalidVectors(
+      new MultilayerPerceptronClassifier().setLayers(Array[Int](2, 5, 2)).fit(_)
+    )
+  }
+
   test("XOR function learning as binary classification problem with two outputs.") {
     val layers = Array[Int](2, 5, 2)
     val trainer = new MultilayerPerceptronClassifier()

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/RandomForestClassifierSuite.scala
@@ -80,6 +80,12 @@ class RandomForestClassifierSuite extends MLTest with DefaultReadWriteTest {
     ParamsSuite.checkParams(model)
   }
 
+  test("RandomForestClassifier validate input dataset") {
+    testInvalidClassificationLabels(new RandomForestClassifier().fit(_), None)
+    testInvalidWeights(new RandomForestClassifier().setWeightCol("weight").fit(_))
+    testInvalidVectors(new RandomForestClassifier().fit(_))
+  }
+
   test("Binary classification with continuous features:" +
     " comparing DecisionTree vs. RandomForest(numTrees = 1)") {
     val rf = new RandomForestClassifier()

--- a/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/MLTest.scala
@@ -25,8 +25,8 @@ import org.apache.spark.{DebugFilesystem, SparkConf, SparkContext, TestUtils}
 import org.apache.spark.internal.config.UNSAFE_EXCEPTION_ON_MEMORY_LEAK
 import org.apache.spark.ml.{Model, PredictionModel, Transformer}
 import org.apache.spark.ml.attribute._
-import org.apache.spark.ml.classification.{ClassificationModel, ProbabilisticClassificationModel}
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.classification._
+import org.apache.spark.ml.linalg._
 import org.apache.spark.sql.{DataFrame, Dataset, Encoder, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
@@ -231,5 +231,127 @@ trait MLTest extends StreamTest with TempDirectory { self: Suite =>
       case Row(features: Vector, prediction: Vector) =>
         assert(prediction === transform(features))
     }
+  }
+
+  def testInvalidClassificationLabels(f: DataFrame => Any, numClasses: Option[Int]): Unit = {
+    import testImplicits._
+
+    // labels contains NULL
+    val df1 = sc.parallelize(Seq(
+      (null, 1.0, Vectors.dense(1.0, 2.0)),
+      ("1.0", 1.0, Vectors.dense(1.0, 2.0))
+    )).toDF("str_label", "weight", "features")
+      .select(col("str_label").cast("double").as("label"), col("weight"), col("features"))
+    val e1 = intercept[Exception](f(df1))
+    assert(e1.getMessage.contains("Labels MUST NOT be Null or NaN"))
+
+    // labels contains NaN
+    val df2 = sc.parallelize(Seq(
+      (Double.NaN, 1.0, Vectors.dense(1.0, 2.0)),
+      (1.0, 1.0, Vectors.dense(1.0, 2.0))
+    )).toDF("label", "weight", "features")
+    val e2 = intercept[Exception](f(df2))
+    assert(e2.getMessage.contains("Labels MUST NOT be Null or NaN"))
+
+    numClasses match {
+      case Some(2) =>
+        // labels contains invalid value: 3
+        val df3 = sc.parallelize(Seq(
+          (3.0, 1.0, Vectors.dense(1.0, 2.0)),
+          (1.0, 1.0, Vectors.dense(1.0, 2.0))
+        )).toDF("label", "weight", "features")
+        val e3 = intercept[Exception](f(df3))
+        assert(e3.getMessage.contains("Labels MUST be in {0, 1}"))
+
+      case _ =>
+        // labels contains invalid value: -3
+        val df3 = sc.parallelize(Seq(
+          (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+          (-3.0, 1.0, Vectors.dense(1.0, 2.0))
+        )).toDF("label", "weight", "features")
+        val e3 = intercept[Exception](f(df3))
+        assert(e3.getMessage.contains("Labels MUST be in [0"))
+
+        // labels contains invalid value: Infinity
+        val df4 = sc.parallelize(Seq(
+          (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+          (Double.PositiveInfinity, 1.0, Vectors.dense(1.0, 2.0))
+        )).toDF("label", "weight", "features")
+        val e4 = intercept[Exception](f(df4))
+        assert(e4.getMessage.contains("Labels MUST be in [0"))
+
+        // labels contains invalid value: 0.1
+        val df5 = sc.parallelize(Seq(
+          (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+          (0.1, 1.0, Vectors.dense(1.0, 2.0))
+        )).toDF("label", "weight", "features")
+        val e5 = intercept[Exception](f(df5))
+        assert(e5.getMessage.contains("Labels MUST be Integers"))
+    }
+  }
+
+  def testInvalidWeights(f: DataFrame => Any): Unit = {
+    import testImplicits._
+
+    // weights contains NULL
+    val df1 = sc.parallelize(Seq(
+      (1.0, "1.0", Vectors.dense(1.0, 2.0)),
+      (0.0, null, Vectors.dense(1.0, 2.0))
+    )).toDF("label", "str_weight", "features")
+      .select(col("label"), col("str_weight").cast("double").as("weight"), col("features"))
+    val e1 = intercept[Exception](f(df1))
+    assert(e1.getMessage.contains("Weights MUST NOT be Null or NaN"))
+
+    // weights contains NaN
+    val df2 = sc.parallelize(Seq(
+      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (0.0, Double.NaN, Vectors.dense(1.0, 2.0))
+    )).toDF("label", "weight", "features")
+    val e2 = intercept[Exception](f(df2))
+    assert(e2.getMessage.contains("Weights MUST NOT be Null or NaN"))
+
+    // weights contains invalid value: -3
+    val df3 = sc.parallelize(Seq(
+      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (0.0, -3.0, Vectors.dense(1.0, 2.0))
+    )).toDF("label", "weight", "features")
+    val e3 = intercept[Exception](f(df3))
+    assert(e3.getMessage.contains("Weights MUST NOT be Negative or Infinity"))
+
+    // weights contains invalid value: Infinity
+    val df4 = sc.parallelize(Seq(
+      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (0.0, Double.PositiveInfinity, Vectors.dense(1.0, 2.0))
+    )).toDF("label", "weight", "features")
+    val e4 = intercept[Exception](f(df4))
+    assert(e4.getMessage.contains("Weights MUST NOT be Negative or Infinity"))
+  }
+
+  def testInvalidVectors(f: DataFrame => Any): Unit = {
+    import testImplicits._
+
+    // vectors contains NULL
+    val df1 = sc.parallelize(Seq(
+      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (0.0, 1.0, null)
+    )).toDF("label", "weight", "features")
+    val e1 = intercept[Exception](f(df1))
+    assert(e1.getMessage.contains("Vectors MUST NOT be Null"))
+
+    // vectors contains NaN
+    val df2 = sc.parallelize(Seq(
+      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (0.0, 1.0, Vectors.dense(Double.NaN, 2.0))
+    )).toDF("label", "weight", "features")
+    val e2 = intercept[Exception](f(df2))
+    assert(e2.getMessage.contains("Vector values MUST NOT be NaN or Infinity"))
+
+    // vectors contains Infinity
+    val df3 = sc.parallelize(Seq(
+      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (0.0, 1.0, Vectors.dense(1.0, Double.NegativeInfinity))
+    )).toDF("label", "weight", "features")
+    val e3 = intercept[Exception](f(df3))
+    assert(e3.getMessage.contains("Vector values MUST NOT be NaN or Infinity"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, add validation methods in `DatasetUtils`;
2, use the new methods to check the input dataset of ml.classification;



### Why are the changes needed?
LinearSVC should fail fast if the input dataset contains invalid values:

```
import org.apache.spark.ml.feature._
import org.apache.spark.ml.linalg._
import org.apache.spark.ml.classification._
import org.apache.spark.ml.clustering._
val df = sc.parallelize(Seq(LabeledPoint(1.0, Vectors.dense(1.0, Double.NaN)), LabeledPoint(0.0, Vectors.dense(Double.PositiveInfinity, 2.0)))).toDF()

val svc = new LinearSVC()
val model = svc.fit(df)

scala> model.intercept
res0: Double = NaN

scala> model.coefficients
res1: org.apache.spark.ml.linalg.Vector = [NaN,NaN] 

```


### Does this PR introduce _any_ user-facing change?

Yes. When input features contains invalid values like NaN, it will fail fast now, rather than returning a model containing NaN coefficients.

### How was this patch tested?
added test