### PR TITLE
[SPARK-38593][SS] Incorporate numRowsDroppedByWatermark metric from SessionWindowStateStoreRestoreExec into StateOperatorProgress

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -57,7 +57,10 @@ object MimaExcludes {
     // [SPARK-37600][BUILD] Upgrade to Hadoop 3.3.2
     ProblemFilters.exclude[MissingClassProblem]("org.apache.hadoop.shaded.net.jpountz.lz4.LZ4Compressor"),
     ProblemFilters.exclude[MissingClassProblem]("org.apache.hadoop.shaded.net.jpountz.lz4.LZ4Factory"),
-    ProblemFilters.exclude[MissingClassProblem]("org.apache.hadoop.shaded.net.jpountz.lz4.LZ4SafeDecompressor")
+    ProblemFilters.exclude[MissingClassProblem]("org.apache.hadoop.shaded.net.jpountz.lz4.LZ4SafeDecompressor"),
+
+    // [SPARK-38593][SS] Incorporate numRowsDroppedByWatermark metric from SessionWindowStateStoreRestoreExec into StateOperatorProgress
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.sql.streaming.StreamingQueryProgress.this")
   )
 
   // Exclude rules for 3.2.x from 3.1.1

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ProgressReporter.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.streaming
 
 import java.text.SimpleDateFormat
+import java.{util => ju}
 import java.util.{Date, Optional, UUID}
 
 import scala.collection.JavaConverters._
@@ -245,6 +246,13 @@ trait ProgressReporter extends Logging {
           progress
         } else {
           progress.copy(newNumRowsUpdated = 0, newNumRowsDroppedByWatermark = 0)
+        }
+      case p if p.isInstanceOf[StreamingOperator] =>
+        val progress = p.asInstanceOf[StreamingOperator].getProgress()
+        if (hasExecuted) {
+          progress
+        } else {
+          progress.copy(newMetrics = new ju.HashMap())
         }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -78,7 +78,7 @@ trait StreamingOperator { self: SparkPlan =>
    */
   def getProgress(): StreamingOperatorProgress = {
     val metrics = self.metrics.map { case (key, metric) =>
-      (key -> metric.value)
+      (key -> long2Long(metric.value))
     }.asJava
 
     new StreamingOperatorProgress(operatorName, metrics)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -73,7 +73,7 @@ trait StreamingOperator { self: SparkPlan =>
   val operatorName = self.nodeName
 
   /**
-   * Get the progress made by this stateful operator after execution. This should be called in
+   * Get the progress made by this streaming operator after execution. This should be called in
    * the driver after this SparkPlan has been executed and metrics have been updated.
    */
   def getProgress(): StreamingOperatorProgress = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryStatusAndProgressSuite.scala
@@ -359,7 +359,8 @@ object StreamingQueryStatusAndProgressSuite {
     sink = SinkProgress("sink", None),
     observedMetrics = new java.util.HashMap(Map(
       "event1" -> row(schema1, 1L, 3.0d),
-      "event2" -> row(schema2, 1L, "hello", "world")).asJava)
+      "event2" -> row(schema2, 1L, "hello", "world")).asJava),
+    operatorProgress = Array.empty[StreamingOperatorProgress]
   )
 
   val testProgress2 = new StreamingQueryProgress(
@@ -391,7 +392,8 @@ object StreamingQueryStatusAndProgressSuite {
     observedMetrics = new java.util.HashMap(Map(
       "event_a" -> row(schema1, null, -20.7d),
       "event_b1" -> row(schema2, 33L, "foo", "bar"),
-      "event_b2" -> row(schema2, 200L, "fzo", "baz")).asJava)
+      "event_b2" -> row(schema2, 200L, "fzo", "baz")).asJava),
+    operatorProgress = Array.empty[StreamingOperatorProgress]
   )
 
   val testStatus = new StreamingQueryStatus("active", true, false)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds `StreamingOperatorProgress` to collect metrics from streaming operators other than `StateOperatorProgress` which is only for `StateStoreWriter`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Although we added `numRowsDroppedByWatermark` to `SessionWindowStateStoreRestoreExec`, but currently only `StateStoreWriter` will be collected metrics for `StateOperatorProgress`. So if we need `numRowsDroppedByWatermark` from `SessionWindowStateStoreRestoreExec` to be used in streaming listener, we need to incorporate `SessionWindowStateStoreRestoreExec` into `StateOperatorProgress`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. Added one new field `operatorProgress` to `StreamingQueryProgress`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test