### PR TITLE
[SPARK-38604][SQL] Keep ceil and floor with only a single argument the same as before

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1783,7 +1783,9 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def ceil(e: Column): Column = ceil(e, lit(0))
+  def ceil(e: Column): Column = withExpr {
+    UnresolvedFunction(Seq("ceil"), Seq(e.expr), isDistinct = false)
+  }
 
   /**
    * Computes the ceiling of the given value of `e` to 0 decimal places.
@@ -1913,7 +1915,9 @@ object functions {
    * @group math_funcs
    * @since 1.4.0
    */
-  def floor(e: Column): Column = floor(e, lit(0))
+  def floor(e: Column): Column = withExpr {
+    UnresolvedFunction(Seq("floor"), Seq(e.expr), isDistinct = false)
+  }
 
   /**
    * Computes the floor of the given column value to 0 decimal places.

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -202,6 +202,13 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("ceil and ceiling") {
     testOneToOneMathFunction(ceil, (d: Double) => math.ceil(d).toLong)
+    // testOneToOneMathFunction does not validate the resulting data type
+    assert(
+      spark.range(1).select(ceil(col("id")).alias("a")).schema ==
+          types.StructType(Seq(types.StructField("a", types.LongType))))
+    assert(
+      spark.range(1).select(ceil(col("id"), lit(0)).alias("a")).schema ==
+          types.StructType(Seq(types.StructField("a", types.DecimalType(20, 0)))))
     checkAnswer(
       sql("SELECT ceiling(0), ceiling(1), ceiling(1.5)"),
       Row(0L, 1L, 2L))
@@ -250,6 +257,13 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("floor") {
     testOneToOneMathFunction(floor, (d: Double) => math.floor(d).toLong)
+    // testOneToOneMathFunction does not validate the resulting data type
+    assert(
+      spark.range(1).select(floor(col("id")).alias("a")).schema ==
+          types.StructType(Seq(types.StructField("a", types.LongType))))
+    assert(
+      spark.range(1).select(floor(col("id"), lit(0)).alias("a")).schema ==
+          types.StructType(Seq(types.StructField("a", types.DecimalType(20, 0)))))
   }
 
   test("factorial") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `ceil(column)` in Scala/Python/Java APIs to keep the previous behaviour by returning `LongType` instead of `DecimalType`.

### Why are the changes needed?
We shouldn't break compatibility and should keep the old behaviour of `ceil(column)` that returns `LongType`.

### Does this PR introduce _any_ user-facing change?
No to end users. 

This fixes a return type. In old version, `ceil(column)` returns `LongType`.
https://github.com/apache/spark/commit/62421455e552b892d6e4f908d55a5886b37a37a9 mistakenly missed this case for Scala/Python APIs so it returns `DecimalType`.

This PR restores the previous behaviour back.

### How was this patch tested?
Unit test was added