### PR TITLE
[SPARK-38607][INFRA] Test result report for ANSI mode

### DIFF
--- a/.github/workflows/build_and_test_ansi.yml
+++ b/.github/workflows/build_and_test_ansi.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: ANSI SQL mode test
+name: "Build and test (ANSI)"
 
 on:
   push:
@@ -25,10 +25,10 @@ on:
       - '**'
 
 jobs:
-  ansi_sql_test:
+  call-build-and-test:
+    name: Call main build
     uses: ./.github/workflows/build_and_test.yml
     if: github.repository == 'apache/spark'
     with:
       ansi_enabled: true
-
 

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -20,7 +20,7 @@
 name: Report test results
 on:
   workflow_run:
-    workflows: ["Build and test"]
+    workflows: ["Build and test", "Build and test (ANSI)"]
     types:
       - completed
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes two:

1. Report test results for ANSI mode enabled too. All "Build and test" is reused, and all steps are ready. We can just post the status to GitHub Checks status (like https://github.com/apache/spark/runs/5618763442)
2. Rename `Build and test (ANSI)` -> `ANSI SQL mode test`, and `.github/workflows/ansi_sql_mode_test.yml` -> `.github/workflows/build_and_test_ansi.yml` for naming consistency.

### Why are the changes needed?

1. To easily navigate the test results.
2. The current naming looks a bit messy:
    <img width="487" alt="Screen Shot 2022-03-21 at 10 12 37 AM" src="https://user-images.githubusercontent.com/6477701/159194495-db25d0a9-c46b-4624-a5c7-8db4bb7521dc.png">
    After this PR, it would look more consistent.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should tests. It should be monitored after it gets merged too.