### PR TITLE
[SPARK-38609][PYTHON] Add `PYSPARK_PANDAS_USAGE_LOGGER` environment variable as an alias of  `KOALAS_USAGE_LOGGER`

### DIFF
--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -101,8 +101,8 @@ def _auto_patch_spark() -> None:
     import os
     import logging
 
-    # Attach a usage logger.
-    logger_module = os.getenv("KOALAS_USAGE_LOGGER", "")
+    # Attach a usage logger. 'KOALAS_USAGE_LOGGER' is legacy, and it's for compatibility.
+    logger_module = os.getenv("PYSPARK_PANDAS_USAGE_LOGGER", os.getenv("KOALAS_USAGE_LOGGER", ""))
     if logger_module != "":
         try:
             from pyspark.pandas import usage_logging


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a new alias `PYSPARK_PANDAS_USAGE_LOGGER` for `KOALAS_USAGE_LOGGER`.

### Why are the changes needed?

To avoid legacy name, Koalas.

### Does this PR introduce _any_ user-facing change?
Yes, uses can set `PYSPARK_PANDAS_USAGE_LOGGER` environment variable for using a usage logger.

### How was this patch tested?

Manual positive tests:

```bash
PYSPARK_PANDAS_USAGE_LOGGER=pyspark.pandas.usage_logging.usage_logger ./bin/pyspark
```

```python
>>> import pyspark.pandas as ps
>>> df = ps.range(1)
>>> import logging
>>> import sys
>>> root = logging.getLogger()
>>> root.setLevel(logging.INFO)
>>> handler = logging.StreamHandler(sys.stdout)
>>> handler.setLevel(logging.INFO)
>>> formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
>>> handler.setFormatter(formatter)
>>> root.addHandler(handler)
>>> df.id.sort_values()
...
INFO:pyspark.pandas.usage_logger:A function `DataFrame.__getattr__(self, key)` was successfully finished after 0.136 ms.
....
```

```bash
KOALAS_USAGE_LOGGER=pyspark.pandas.usage_logging.usage_logger ./bin/pyspark
```

```python
>>> import pyspark.pandas as ps
>>> df = ps.range(1)
>>> import logging
>>> import sys
>>> root = logging.getLogger()
>>> root.setLevel(logging.INFO)
>>> handler = logging.StreamHandler(sys.stdout)
>>> handler.setLevel(logging.INFO)
>>> formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
>>> handler.setFormatter(formatter)
>>> root.addHandler(handler)
>>> df.id.sort_values()
...
2022-03-21 11:51:21,039 - pyspark.pandas.usage_logger - INFO - A function `DataFrame.__getattr__(self, key)` was successfully finished after 0.107 ms.
...
```

Manual negative tests:

```bash
PYSPARK_PANDAS_USAGE_LOGGER=abc ./bin/pyspark
```

```python
>>> import pyspark.pandas as ps
WARNING:pyspark.pandas.usage_logger:Tried to attach usage logger `abc`, but an exception was raised: module 'abc' has no attribute 'get_logger'
```

```bash
KOALAS_USAGE_LOGGER=abc ./bin/pyspark
```

```python
>>> import pyspark.pandas as ps
WARNING:pyspark.pandas.usage_logger:Tried to attach usage logger `abc`, but an exception was raised: module 'abc' has no attribute 'get_logger'
```