### PR TITLE
[SPARK-38488][INFRA] Upgrade ffi to 1.15.5 with --enable-libffi-alloc to fix doc build error on MacOS M1

### DIFF
--- a/docs/.bundle/config
+++ b/docs/.bundle/config
@@ -1,2 +1,3 @@
 ---
 BUNDLE_PATH: ".local_ruby_bundle"
+BUNDLE_BUILD__FFI: "--enable-libffi-alloc"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -17,6 +17,7 @@
 
 source "https://rubygems.org"
 
+gem "ffi", "1.15.5"
 gem "jekyll", "4.2.1"
 gem "rouge", "3.26.0"
 gem "jekyll-redirect-from", "0.16.0"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.15.4)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.11)
@@ -64,10 +64,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ffi (= 1.15.5)
   jekyll (= 4.2.1)
   jekyll-redirect-from (= 0.16.0)
   rouge (= 3.26.0)
   webrick (= 1.7)
 
 BUNDLED WITH
-   2.2.9
+   2.3.8


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade ffi to 1.15.5 with --enable-libffi-alloc to fix error on MacOS M1

### Why are the changes needed?
Spark doc build not work on Mac OS M1 (linux x86/linux arm64 works well before)
JIRA detail: https://issues.apache.org/jira/browse/SPARK-38488


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
sudo gem install bundler
cd docs
bundle install
SKIP_API=1 bundle exec jekyll build
```

works well in x86 linux/arm64 linux/macos m1
