### PR TITLE
[SPARK-38578][SQL] AdaptiveSparkPlanExec should ensure user-specified ordering

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
@@ -62,7 +62,7 @@ object AQEUtils {
   // Analyze the given plan and calculate the required ordering of this plan w.r.t. the
   // user-specified sort.
   def getRequiredOrdering(p: SparkPlan): Seq[SortOrder] = p match {
-    // User-specified repartition is only effective when it's the root node, or under
+    // User-specified sort is only effective when it's the root node, or under
     // Project/Filter/CollectMetrics.
     case f: FilterExec => getRequiredOrdering(f.child)
     case c: CollectMetricsExec => getRequiredOrdering(c.child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
@@ -62,6 +62,8 @@ object AQEUtils {
   // Analyze the given plan and calculate the required ordering of this plan w.r.t. the
   // user-specified sort.
   def getRequiredOrdering(p: SparkPlan): Seq[SortOrder] = p match {
+    // User-specified repartition is only effective when it's the root node, or under
+    // Project/Filter/CollectMetrics.
     case f: FilterExec => getRequiredOrdering(f.child)
     case c: CollectMetricsExec => getRequiredOrdering(c.child)
     // We do not need to care whether the sort is global or not, since the output partitioning

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ValidateRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ValidateRequirements.scala
@@ -30,6 +30,14 @@ import org.apache.spark.sql.execution._
  */
 object ValidateRequirements extends Logging {
 
+  def validate(
+      plan: SparkPlan,
+      requiredDistribution: Distribution,
+      requiredOrdering: Seq[SortOrder]): Boolean = {
+    validate(plan, requiredDistribution) &&
+      SortOrder.orderingSatisfies(plan.outputOrdering, requiredOrdering)
+  }
+
   def validate(plan: SparkPlan, requiredDistribution: Distribution): Boolean = {
     validate(plan) && plan.outputPartitioning.satisfies(requiredDistribution)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2583,6 +2583,8 @@ class AdaptiveQueryExecSuite
       ("key", "key", true),
       ("key, value", "key", true)
     ).foreach { case (project, sort, required) =>
+      // During re-optimize in AQE, the sort will be converted to local relation if it's empty
+      // So this test ensure we will add sort back if it is User-specified
       val (origin, adaptive) = runAdaptiveAndVerifyResult(
         s"""
            |SELECT $project FROM testdata where key < 0 ORDER BY $sort

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2576,7 +2576,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-38578: Avoid unnecessary sort in FileFormatWriter if user has specified sort") {
+  test("SPARK-38578: AdaptiveSparkPlanExec should ensure user-specified ordering") {
     Seq(
       ("key", "key, value", false),
       ("key as x", "key, value", false),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Ensure output ordering using `requiredOrdering `
- Override `outputOrdering` in `AdaptiveSparkPlanExec`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`AdaptiveSparkPlanExec` should ensure the output ordering is the `requiredOrdering`, so we leverage the  `EnsureRequirements` to add sort if need.

FileFormatWriter will check and add an implicit sort for dynamic partition columns or bucket columns according to the input physical plan. The check became always failure since AQE AdaptiveSparkPlanExec has no outputOrdering.

That casues a redundant sort if user has specified a sort which satisfies the required ordering (dynamic partition and bucket columns).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no, improve performance

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test 

```sql
CREATE TABLE t1 (c int) USING PARQUET PARTITIONED BY(p string);
CREATE TABLE t2 USING PARQUET AS SELECT 1 c, 'a' p;
INSERT INTO TABLE t1 PARTITION(p) select c, p from t2 order by p;
```
Before:
<img width="180" alt="image" src="https://user-images.githubusercontent.com/12025282/159392438-18328c4e-47d4-438b-85bd-dbdb0db23856.png">

After:
<img width="180" alt="image" src="https://user-images.githubusercontent.com/12025282/159392466-78ee5f49-fd34-48a7-afc8-b020ee6fd085.png">