### PR TITLE
[SPARK-38616][SQL] Keep track of SQL query text in Catalyst TreeNode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.catalyst.analysis.FunctionRegistry.FunctionBuilder
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, ExpressionInfo, UpCast}
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, SubqueryAlias, View}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, StringUtils}
 import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -873,9 +874,20 @@ class SessionCatalog(
       throw new IllegalStateException("Invalid view without text.")
     }
     val viewConfigs = metadata.viewSQLConfigs
+    val origin = Origin(
+      line = Some(0),
+      startPosition = Some(0),
+      startIndex = Some(0),
+      stopIndex = Some(viewText.length - 1),
+      sqlText = Some(viewText),
+      objectType = Some("VIEW"),
+      objectName = Some(metadata.qualifiedName)
+    )
     val parsedPlan = SQLConf.withExistingConf(View.effectiveSQLConf(viewConfigs, isTempView)) {
       try {
-        parser.parseQuery(viewText)
+        CurrentOrigin.withOrigin(origin) {
+          parser.parseQuery(viewText)
+        }
       } catch {
         case _: ParseException =>
           throw QueryCompilationErrors.invalidViewText(viewText, metadata.qualifiedName)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -875,11 +875,6 @@ class SessionCatalog(
     }
     val viewConfigs = metadata.viewSQLConfigs
     val origin = Origin(
-      line = Some(0),
-      startPosition = Some(0),
-      startIndex = Some(0),
-      stopIndex = Some(viewText.length - 1),
-      sqlText = Some(viewText),
       objectType = Some("VIEW"),
       objectName = Some(metadata.qualifiedName)
     )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -44,7 +44,10 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
 
   /** Creates Expression for a given SQL string. */
   override def parseExpression(sqlText: String): Expression = parse(sqlText) { parser =>
-    astBuilder.visitSingleExpression(parser.singleExpression())
+    val ctx = parser.singleExpression()
+    withOrigin(ctx, Some(sqlText)) {
+      astBuilder.visitSingleExpression(ctx)
+    }
   }
 
   /** Creates TableIdentifier for a given SQL string. */
@@ -76,7 +79,10 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
 
   /** Creates LogicalPlan for a given SQL string of query. */
   override def parseQuery(sqlText: String): LogicalPlan = parse(sqlText) { parser =>
-    astBuilder.visitQuery(parser.query())
+    val ctx = parser.query()
+    withOrigin(ctx, Some(sqlText)) {
+      astBuilder.visitQuery(ctx)
+    }
   }
 
   /** Creates LogicalPlan for a given SQL string. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -26,6 +26,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, SQLConfHelper, TableIdentifier}
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserUtils.withOrigin
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.QueryParsingErrors
@@ -80,11 +81,14 @@ abstract class AbstractSqlParser extends ParserInterface with SQLConfHelper with
 
   /** Creates LogicalPlan for a given SQL string. */
   override def parsePlan(sqlText: String): LogicalPlan = parse(sqlText) { parser =>
-    astBuilder.visitSingleStatement(parser.singleStatement()) match {
-      case plan: LogicalPlan => plan
-      case _ =>
-        val position = Origin(None, None)
-        throw QueryParsingErrors.sqlStatementUnsupportedError(sqlText, position)
+    val ctx = parser.singleStatement()
+    withOrigin(ctx, Some(sqlText)) {
+      astBuilder.visitSingleStatement(ctx) match {
+        case plan: LogicalPlan => plan
+        case _ =>
+          val position = Origin(None, None)
+          throw QueryParsingErrors.sqlStatementUnsupportedError(sqlText, position)
+      }
     }
   }
 
@@ -271,7 +275,7 @@ class ParseException(
     val builder = new StringBuilder
     builder ++= "\n" ++= message
     start match {
-      case Origin(Some(l), Some(p)) =>
+      case Origin(Some(l), Some(p), _, _, _) =>
         builder ++= s"(line $l, pos $p)\n"
         command.foreach { cmd =>
           val (above, below) = cmd.split("\n").splitAt(l)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -281,7 +281,7 @@ class ParseException(
     val builder = new StringBuilder
     builder ++= "\n" ++= message
     start match {
-      case Origin(Some(l), Some(p), _, _, _) =>
+      case Origin(Some(l), Some(p), _, _, _, _, _) =>
         builder ++= s"(line $l, pos $p)\n"
         command.foreach { cmd =>
           val (above, below) = cmd.split("\n").splitAt(l)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -114,7 +114,12 @@ object ParserUtils {
     Origin(opt.map(_.getLine), opt.map(_.getCharPositionInLine))
   }
 
-  def positionAndText(startToken: Token, stopToken: Token, sqlText: String): Origin = {
+  def positionAndText(
+      startToken: Token,
+      stopToken: Token,
+      sqlText: String,
+      objectType: Option[String],
+      objectName: Option[String]): Origin = {
     val startOpt = Option(startToken)
     val stopOpt = Option(stopToken)
     Origin(
@@ -122,7 +127,9 @@ object ParserUtils {
       startPosition = startOpt.map(_.getCharPositionInLine),
       startIndex = startOpt.map(_.getStartIndex),
       stopIndex = stopOpt.map(_.getStopIndex),
-      sqlText = Some(sqlText))
+      sqlText = Some(sqlText),
+      objectType = objectType,
+      objectName = objectName)
   }
 
   /** Validate the condition. If it doesn't throw a parse exception. */
@@ -143,7 +150,8 @@ object ParserUtils {
     if (text.isEmpty) {
       CurrentOrigin.set(position(ctx.getStart))
     } else {
-      CurrentOrigin.set(positionAndText(ctx.getStart, ctx.getStop, text.get))
+      CurrentOrigin.set(positionAndText(ctx.getStart, ctx.getStop, text.get,
+        current.objectType, current.objectName))
     }
     try {
       f

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -114,6 +114,17 @@ object ParserUtils {
     Origin(opt.map(_.getLine), opt.map(_.getCharPositionInLine))
   }
 
+  def positionAndText(startToken: Token, stopToken: Token, sqlText: String): Origin = {
+    val startOpt = Option(startToken)
+    val stopOpt = Option(stopToken)
+    Origin(
+      line = startOpt.map(_.getLine),
+      startPosition = startOpt.map(_.getCharPositionInLine),
+      startIndex = startOpt.map(_.getStartIndex),
+      stopIndex = stopOpt.map(_.getStopIndex),
+      sqlText = Some(sqlText))
+  }
+
   /** Validate the condition. If it doesn't throw a parse exception. */
   def validate(f: => Boolean, message: String, ctx: ParserRuleContext): Unit = {
     if (!f) {
@@ -126,9 +137,14 @@ object ParserUtils {
    * registered origin. This method restores the previously set origin after completion of the
    * closure.
    */
-  def withOrigin[T](ctx: ParserRuleContext)(f: => T): T = {
+  def withOrigin[T](ctx: ParserRuleContext, sqlText: Option[String] = None)(f: => T): T = {
     val current = CurrentOrigin.get
-    CurrentOrigin.set(position(ctx.getStart))
+    val text = sqlText.orElse(current.sqlText)
+    if (text.isEmpty) {
+      CurrentOrigin.set(position(ctx.getStart))
+    } else {
+      CurrentOrigin.set(positionAndText(ctx.getStart, ctx.getStop, text.get))
+    }
     try {
       f
     } finally {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -52,6 +52,11 @@ import org.apache.spark.util.collection.BitSet
 /** Used by [[TreeNode.getNodeNumbered]] when traversing the tree for a given number */
 private class MutableInt(var i: Int)
 
+/**
+ * Contexts of TreeNodes, including location, SQL text, object type and object name.
+ * The only supported object type is "VIEW" now. In the future, we may support SQL UDF or other
+ * objects which contain SQL text.
+ */
 case class Origin(
   line: Option[Int] = None,
   startPosition: Option[Int] = None,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -54,7 +54,10 @@ private class MutableInt(var i: Int)
 
 case class Origin(
   line: Option[Int] = None,
-  startPosition: Option[Int] = None)
+  startPosition: Option[Int] = None,
+  startIndex: Option[Int] = None,
+  stopIndex: Option[Int] = None,
+  sqlText: Option[String] = None)
 
 /**
  * Provides a location for TreeNodes to ask about the context of their origin.  For example, which

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -57,7 +57,9 @@ case class Origin(
   startPosition: Option[Int] = None,
   startIndex: Option[Int] = None,
   stopIndex: Option[Int] = None,
-  sqlText: Option[String] = None)
+  sqlText: Option[String] = None,
+  objectType: Option[String] = None,
+  objectName: Option[String] = None)
 
 /**
  * Provides a location for TreeNodes to ask about the context of their origin.  For example, which

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -918,7 +918,12 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
       Seq("", "temp")
       withView("v") {
         val viewText = "SELECT a + b c FROM t"
-        sql(s"CREATE VIEW v AS $viewText")
+        sql(
+          s"""
+            |CREATE VIEW v AS
+            |-- the body of the view
+            |$viewText
+            |""".stripMargin)
         val plan = sql("select c / 2.0D d from v").logicalPlan
         val add = plan.collectFirst {
           case Project(Seq(Alias(a: Add, _)), _) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -20,7 +20,10 @@ package org.apache.spark.sql.execution
 import org.apache.spark.SparkException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Divide}
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 
@@ -905,6 +908,48 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
           sql("SELECT * FROM v1").collect()
         }.getMessage
         assert(e.contains("divide by zero"))
+      }
+    }
+  }
+
+  test("CurrentOrigin is correctly set in and out of the View") {
+    withTable("t") {
+      Seq((1, 1), (2, 2)).toDF("a", "b").write.format("parquet").saveAsTable("t")
+      Seq("", "temp")
+      withView("v") {
+        val viewText = "SELECT a + b c FROM t"
+        sql(s"CREATE VIEW v AS $viewText")
+        val plan = sql("select c / 2.0D d from v").logicalPlan
+        val add = plan.collectFirst {
+          case Project(Seq(Alias(a: Add, _)), _) =>
+              a
+        }
+        assert(add.isDefined)
+        val expectedAddOrigin = Origin(
+          line = Some(1),
+          startPosition = Some(7),
+          startIndex = Some(7),
+          stopIndex = Some(11),
+          sqlText = Some("SELECT a + b c FROM t"),
+          objectType = Some("VIEW"),
+          objectName = Some("default.v")
+        )
+        assert(add.get.origin == expectedAddOrigin)
+
+        val divide = plan.collectFirst {
+          case Project(Seq(Alias(d: Divide, _)), _) =>
+            d
+        }
+        assert(divide.isDefined)
+        val expectedDivideOrigin = Origin(
+          line = Some(1),
+          startPosition = Some(7),
+          startIndex = Some(7),
+          stopIndex = Some(14),
+          sqlText = Some("select c / 2.0D d from v"),
+          objectType = None,
+          objectName = None)
+        assert(divide.get.origin == expectedDivideOrigin)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -926,8 +926,7 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
             |""".stripMargin)
         val plan = sql("select c / 2.0D d from v").logicalPlan
         val add = plan.collectFirst {
-          case Project(Seq(Alias(a: Add, _)), _) =>
-              a
+          case Project(Seq(Alias(a: Add, _)), _) => a
         }
         assert(add.isDefined)
         val expectedAddOrigin = Origin(
@@ -942,8 +941,7 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
         assert(add.get.origin == expectedAddOrigin)
 
         val divide = plan.collectFirst {
-          case Project(Seq(Alias(d: Divide, _)), _) =>
-            d
+          case Project(Seq(Alias(d: Divide, _)), _) => d
         }
         assert(divide.isDefined)
         val expectedDivideOrigin = Origin(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Spark SQL uses the class Origin for tracking the position of each TreeNode in the SQL query text. When there is a parser error, we can show the position info in the error message:
```
> sql("create tabe foo(i int)")
org.apache.spark.sql.catalyst.parser.ParseException:
no viable alternative at input 'create tabe'(line 1, pos 7)


== SQL ==
create tabe foo(i int)
-------^^^ 
```
It contains two fields: line and startPosition. This is enough for the parser since the SQL query text is known.

However, the SQL query text is unknown in the execution phase. Spark SQL can't show the problematic SQL clause on ANSI runtime failures. 
This PR is to include the query text in Origin. After this, we can provide details in the error messages of Expressions which can throw runtime exceptions when ANSI mode is on.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently,  there is not enough error context for runtime ANSI failures.

In the following example, the error message only tells that there is a "divide by zero" error, without pointing out where the exact SQL statement is.
```
SELECT
  ws2.web_sales / ws1.web_sales web_q1_q2, ss2.store_sales / ss1.store_sales store_q1_q2,
  ws3.web_sales / ws2.web_sales web_q2_q3, ss3.store_sales / ss2.store_sales store_q2_q3
FROM
  ss ss1, ss ss2, ss ss3, ws ws1, ws ws2, ws ws3
WHERE
    ....  
    AND CASE WHEN ws1.web_sales > 0
    THEN ws2.web_sales / ws1.web_sales
        ELSE NULL END
    > CASE WHEN ss1.store_sales > 0
    THEN ss2.store_sales / ss1.store_sales
      ELSE NULL END
    AND CASE WHEN ws2.web_sales > 0
    THEN ws3.web_sales / ws2.web_sales
        ELSE NULL END
    > CASE WHEN ss2.store_sales > 0
    THEN ss3.store_sales / ss2.store_sales
      ELSE NULL END
ORDER BY ss1.ca_county
```

```
org.apache.spark.SparkArithmeticException: divide by zero at 
org.apache.spark.sql.errors.QueryExecutionErrors$.divideByZeroError(QueryExecutionErrors.scala:140) at 
org.apache.spark.sql.catalyst.expressions.DivModLike.eval(arithmetic.scala:437) at 
org.apache.spark.sql.catalyst.expressions.DivModLike.eval$(arithmetic.scala:425) at 
org.apache.spark.sql.catalyst.expressions.Divide.eval(arithmetic.scala:534)
```
This PR is the initial PR for the project https://issues.apache.org/jira/browse/SPARK-38615
The project is able to provide such error context:
```
org.apache.spark.SparkArithmeticException: divide by zero
SparkArithmeticException: divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
== SQL(line 2, position 43) ==
ws2.web_sales / ws1.web_sales web_q1_q2, ss2.store_sales / ss1.store_sales store_q1_q2
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT