### PR TITLE
 [SPARK-38624][SQL] Reduce UnsafeProjection.create call times when Percentile function serializes the aggregation buffer object.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Percentile.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Percentile.scala
@@ -268,12 +268,13 @@ case class Percentile(
     }
   }
 
+  private lazy val projection = UnsafeProjection.create(Array[DataType](child.dataType, LongType))
+
   override def serialize(obj: OpenHashMap[AnyRef, Long]): Array[Byte] = {
     val buffer = new Array[Byte](4 << 10)  // 4K
     val bos = new ByteArrayOutputStream()
     val out = new DataOutputStream(bos)
     try {
-      val projection = UnsafeProjection.create(Array[DataType](child.dataType, LongType))
       // Write pairs in counts map to byte buffer.
       obj.foreach { case (key, count) =>
         val row = InternalRow.apply(key, count)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Percentile serialize method does not call UnsafeProjection.create.
UnsafeProjection as a field for Percentile.

### Why are the changes needed?
Considered the performance, it doesn't have to call UnsafeProjection.create every time.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?
Existing UTs
