### PR TITLE
[SPARK-38628][SQL] Complete the copy method in subclasses of InternalRow, ArrayData, and MapData to safely copy their instances

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarArray.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarArray.java
@@ -68,7 +68,7 @@ public final class ColumnarArray extends ArrayData {
     } else if (dt instanceof DoubleType) {
       return UnsafeArrayData.fromPrimitiveArray(toDoubleArray());
     } else {
-      return new GenericArrayData(toObjectArray(dt));
+      return new GenericArrayData(toObjectArray(dt)).copy(); // ensure the elements are copied.
     }
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
@@ -71,6 +71,12 @@ public final class ColumnarBatchRow extends InternalRow {
           row.setInt(i, getInt(i));
         } else if (dt instanceof TimestampType) {
           row.setLong(i, getLong(i));
+        } else if (dt instanceof StructType) {
+          row.update(i, getStruct(i, ((StructType) dt).fields().length).copy());
+        } else if (dt instanceof ArrayType) {
+          row.update(i, getArray(i).copy());
+        } else if (dt instanceof MapType) {
+          row.update(i, getMap(i).copy());
         } else {
           throw new RuntimeException("Not implemented. " + dt);
         }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarRow.java
@@ -80,6 +80,12 @@ public final class ColumnarRow extends InternalRow {
           row.setInt(i, getInt(i));
         } else if (dt instanceof TimestampType) {
           row.setLong(i, getLong(i));
+        } else if (dt instanceof StructType) {
+          row.update(i, getStruct(i, ((StructType) dt).fields().length).copy());
+        } else if (dt instanceof ArrayType) {
+          row.update(i, getArray(i).copy());
+        } else if (dt instanceof MapType) {
+          row.update(i, getMap(i).copy());
         } else {
           throw new RuntimeException("Not implemented. " + dt);
         }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/MutableColumnarRow.java
@@ -80,6 +80,12 @@ public final class MutableColumnarRow extends InternalRow {
           row.setInt(i, getInt(i));
         } else if (dt instanceof TimestampType) {
           row.setLong(i, getLong(i));
+        } else if (dt instanceof StructType) {
+          row.update(i, getStruct(i, ((StructType) dt).fields().length).copy());
+        } else if (dt instanceof ArrayType) {
+          row.update(i, getArray(i).copy());
+        } else if (dt instanceof MapType) {
+          row.update(i, getMap(i).copy());
         } else {
           throw new RuntimeException("Not implemented. " + dt);
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Completes the `copy` method in subclasses of `InternalRow`, `ArrayData`, and `MapData` to safely copy their instances.

### Why are the changes needed?

Some subclasses of `InternalRow`, `ArrayData`, and `MapData` missing support for `StructType`, `ArrayType`, and `MapType` in their copy method.
We should complete them to safely copy their instances and prevent potential issues.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing tests.