### PR TITLE
[SPARK-38630][K8S] K8s app name label should start and end with alphanumeric char

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -268,12 +268,10 @@ private[spark] object KubernetesConf {
         .trim
         .toLowerCase(Locale.ROOT)
         .replaceAll("[^a-z0-9\\-]", "-")
-        .replaceAll("-+", "-")
-        .stripPrefix("-")
-        .stripSuffix("-"),
+        .replaceAll("-+", "-"),
       "",
       KUBERNETES_DNSNAME_MAX_LENGTH
-    )
+    ).stripPrefix("-").stripSuffix("-")
   }
 
   /**

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesConf.scala
@@ -261,13 +261,16 @@ private[spark] object KubernetesConf {
   def getAppNameLabel(appName: String): String = {
     // According to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels,
     // must be 63 characters or less to follow the DNS label standard, so take the 63 characters
-    // of the appName name as the label.
+    // of the appName name as the label. In addition, label value must start and end with
+    // an alphanumeric character.
     StringUtils.abbreviate(
       s"$appName"
         .trim
         .toLowerCase(Locale.ROOT)
         .replaceAll("[^a-z0-9\\-]", "-")
-        .replaceAll("-+", "-"),
+        .replaceAll("-+", "-")
+        .stripPrefix("-")
+        .stripSuffix("-"),
       "",
       KUBERNETES_DNSNAME_MAX_LENGTH
     )

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -247,5 +247,7 @@ class KubernetesConfSuite extends SparkFunSuite {
 
   test("SPARK-38630: K8s label value should start and end with alphanumeric") {
     assert(KubernetesConf.getAppNameLabel("-hello-") === "hello")
+    assert(KubernetesConf.getAppNameLabel("a" * 62 + "-aaa") === "a" * 62)
+    assert(KubernetesConf.getAppNameLabel("-" + "a" * 63) === "a" * 62)
   }
 }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -244,4 +244,8 @@ class KubernetesConfSuite extends SparkFunSuite {
     assert(KubernetesConf.getAppNameLabel("a" * 64) === "a" * 63)
     assert(KubernetesConf.getAppNameLabel("a" * 253) === "a" * 63)
   }
+
+  test("SPARK-38630: K8s label value should start and end with alphanumeric") {
+    assert(KubernetesConf.getAppNameLabel("-hello-") === "hello")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `getAppNameLabel` by removing the prefix and suffix `-` character from app name label.

### Why are the changes needed?

Currently, `master/branch-3.3` has this regression.
```
io.fabric8.kubernetes.client.KubernetesClientException:
Failure executing: POST at: https://kubernetes.default.svc/api/v1/namespaces/default/pods.
Message: Pod "..." is invalid:
metadata.labels: Invalid value: "...-tpcds-1000g-parquet-":
a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and
must start and end with an alphanumeric character
```

### Does this PR introduce _any_ user-facing change?

This is a regression at Apache Spark 3.3.0.

### How was this patch tested?

Pass the CI with the newly added test case.