### PR TITLE
[SPARK-38564][SS][TESTS] Wait all events to arrive in ReportSinkMetricsSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ReportSinkMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ReportSinkMetricsSuite.scala
@@ -72,6 +72,8 @@ class ReportSinkMetricsSuite extends StreamTest {
           query.processAllAvailable()
         }
 
+        spark.sparkContext.listenerBus.waitUntilEmpty()
+
         assertResult(metricsMap) {
           Map("metrics-1" -> "value-1", "metrics-2" -> "value-2").asJava
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The test is flaky: 

```
ReportSinkMetricsSuite:
- test ReportSinkMetrics *** FAILED *** (244 milliseconds)
  Expected null, but got {"metrics-1"="value-1", "metrics-2"="value-2"} (ReportSinkMetricsSuite.scala:75)
  org.scalatest.exceptions.TestFailedException:
  at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
  at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
  at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1563)
  at org.scalatest.Assertions.assertResult(Assertions.scala:867)
  at org.scalatest.Assertions.assertResult$(Assertions.scala:863)
  at org.scalatest.funsuite.AnyFunSuite.assertResult(AnyFunSuite.scala:1563)
  at org.apache.spark.sql.streaming.ReportSinkMetricsSuite.$anonfun$new$2(ReportSinkMetricsSuite.scala:75)
  at org.apache.spark.sql.streaming.ReportSinkMetricsSuite.$anonfun$new$2$adapted(ReportSinkMetricsSuite.scala:60)
  at org.apache.spark.sql.test.SQLTestUtils.$anonfun$withTempDir$1(SQLTestUtils.scala:79)
  at org.apache.spark.sql.test.SQLTestUtils.$anonfun$withTempDir$1$adapted(SQLTestUtils.scala:78)
  at org.apache.spark.SparkFunSuite.withTempDir(SparkFunSuite.scala:221)
  at org.apache.spark.sql.streaming.ReportSinkMetricsSuite.org$apache$spark$sql$test$SQLTestUtils$$super$withTempDir(ReportSinkMetricsSuite.scala:35)
  at org.apache.spark.sql.test.SQLTestUtils.withTempDir(SQLTestUtils.scala:78)
  at org.apache.spark.sql.test.SQLTestUtils.withTempDir$(SQLTestUtils.scala:77)
  at org.apache.spark.sql.streaming.ReportSinkMetricsSuite.withTempDir(ReportSinkMetricsSuite.scala:35)
  at org.apache.spark.sql.streaming.ReportSinkMetricsSuite.$anonfun$new$1(ReportSinkMetricsSuite.scala:60)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
```

We should wait all events to be processed.

See  https://github.com/apache/spark/pull/35872#discussion_r832807001.

### Why are the changes needed?

To make the test not flaky.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Existing tests. CI in this PR should test it out.