### PR TITLE
[SPARK-38641][BUILD] Get rid of invalid configuration elements in mvn_scalafmt in main pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,6 @@
        -->
 
     <scala-maven-plugin.version>4.5.6</scala-maven-plugin.version>
-    <scalafmt.parameters>--test</scalafmt.parameters>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
@@ -3350,8 +3349,7 @@
         <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
         <version>1.0.4</version>
         <configuration>
-          <parameters>${scalafmt.parameters}</parameters> <!-- (Optional) Additional command line arguments -->
-          <skip>${scalafmt.skip}</skip> <!-- (Optional) skip formatting -->
+          <validateOnly>${scalafmt.skip}</validateOnly> <!-- (Optional) skip formatting -->
           <skipSources>${scalafmt.skip}</skipSources>
           <skipTestSources>${scalafmt.skip}</skipTestSources>
           <configLocation>dev/.scalafmt.conf</configLocation> <!-- (Optional) config location -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
In main pom.xml, for mvn_scalafmt plugin, I removed 'parameters' since it's invalid , and replace 'skip' with 'validateOnly' since 'skip' is invalid too.


### Why are the changes needed?
I think we should not leave invalid items there in the pom.xml

I've contacted the author of mvn_scalafmt, Ciaran Kearney, to confirm if these 2 configuration items are no longer there since v 1.0.0, and he said: "That's correct.  The command line parameters were removed by scalafmt itself a few versions ago and skip was replaced by validateOnly (which checks formatting without changing files."


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Run mvn-scalafmt_2.12:format locally via mvn. 
