### PR TITLE
[SPARK-38461][CORE] Use error classes in org.apache.spark.broadcast

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -28,6 +28,9 @@
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },
+  "CORRUPTED_REMOTE_BLOCK" : {
+    "message" : [ "Corrupted remote block: '%s'" ]
+  },
   "DATETIME_OVERFLOW" : {
     "message" : [ "Datetime operation overflow: %s." ],
     "sqlState" : "22008"
@@ -49,6 +52,12 @@
   },
   "FAILED_SET_ORIGINAL_PERMISSION_BACK" : {
     "message" : [ "Failed to set original permission %s back to the created path: %s. Exception: %s" ]
+  },
+  "GET_BLOCK_ERROR" : {
+    "message" : [ "Failed to get block: '%s'" ]
+  },
+  "GET_LOCAL_BLOCK_ERROR" : {
+    "message" : [ "Failed to get local block: '%s'" ]
   },
   "GRAPHITE_SINK_INVALID_PROTOCOL" : {
     "message" : [ "Invalid Graphite protocol: %s" ]
@@ -157,6 +166,9 @@
   "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER" : {
     "message" : [ "The second argument of '%s' function needs to be an integer." ],
     "sqlState" : "22023"
+  },
+  "STORE_BLOCK_ERROR" : {
+    "message" : [ "Failed to store block: %s" ]
   },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [ "Unable to acquire %s bytes of memory, got %s" ]

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -325,4 +325,24 @@ object SparkCoreErrors {
     new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
       messageParameters = Array(missingProperty), cause = null)
   }
+
+  def storeBlockError(blockId: BlockId, cause: Throwable = null): Throwable = {
+    new SparkException(errorClass = "STORE_BLOCK_ERROR",
+      messageParameters = Array(blockId.toString), cause = cause)
+  }
+
+  def getBlockError(blockId: BlockId): Throwable = {
+    new SparkException(errorClass = "GET_BLOCK_ERROR",
+      messageParameters = Array(blockId.toString), cause = null)
+  }
+
+  def getLocalBlockError(blockId: BlockId): Throwable = {
+    new SparkException(errorClass = "GET_LOCAL_BLOCK_ERROR",
+      messageParameters = Array(blockId.toString), cause = null)
+  }
+
+  def corruptedRemoteBlockError(blockId: BlockId): Throwable = {
+    new SparkException(errorClass = "CORRUPTED_REMOTE_BLOCK",
+      messageParameters = Array(blockId.toString), cause = null)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change is to refactor exceptions thrown in org.apache.spark.broadcast to use error class framework.

### Why are the changes needed?
This is to follow the error class framework.

### Does this PR introduce _any_ user-facing change?
Yes. To aggregate the exceptions, there are minor changes in error messages in the exceptions thrown.

### How was this patch tested?
Added unit tests.
