### PR TITLE
[SPARK-38639] Support cleanedSourcePrint flag to print Codegen cleanedSource

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1475,7 +1475,7 @@ object SQLConf {
   val WHOLESTAGE_CODEGEN_CLEAN_SOURCE_ENABLED = buildConf("spark.sql.codegen.cleanedSourcePrint")
       .internal()
       .doc("When true, and `spark.sql.codegen.wholeStage` is true, the whole stage will be " +
-          "compiled into single java method that will be printed in log")
+          "compiled into single java method that will be printed")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1472,6 +1472,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val WHOLESTAGE_CODEGEN_CLEAN_SOURCE_ENABLED = buildConf("spark.sql.codegen.cleanedSourcePrint")
+      .internal()
+      .doc("When true, and `spark.sql.codegen.wholeStage` is true, the whole stage will be " +
+          "compiled into single java method that will be printed in log")
+      .version("3.2.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val WHOLESTAGE_CODEGEN_ENABLED = buildConf("spark.sql.codegen.wholeStage")
     .internal()
     .doc("When true, the whole stage (of multiple operators) will be compiled into single java" +
@@ -3984,6 +3992,8 @@ class SQLConf extends Serializable with Logging {
   def gatherFastStats: Boolean = getConf(GATHER_FASTSTAT)
 
   def optimizerMetadataOnly: Boolean = getConf(OPTIMIZER_METADATA_ONLY)
+
+  def wholeStageCleanCodePrintEnabled: Boolean = getConf(WHOLESTAGE_CODEGEN_CLEAN_SOURCE_ENABLED)
 
   def wholeStageEnabled: Boolean = getConf(WHOLESTAGE_CODEGEN_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1474,8 +1474,8 @@ object SQLConf {
 
   val WHOLESTAGE_CODEGEN_CLEAN_SOURCE_ENABLED = buildConf("spark.sql.codegen.cleanedSourcePrint")
       .internal()
-      .doc("When true, and `spark.sql.codegen.wholeStage` is true, the whole stage will be " +
-          "compiled into single java method that will be printed")
+      .doc("When true, and `spark.sql.codegen.wholeStage` is true, the whole stage " +
+        "(of multiple operators) will be compiled into single java method that will be printed")
       .version("3.2.0")
       .booleanConf
       .createWithDefault(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -709,7 +709,12 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
     val duration = System.nanoTime() - startTime
     WholeStageCodegenExec.increaseCodeGenTime(duration)
 
-    logDebug(s"\n${CodeFormatter.format(cleanedSource)}")
+    val formatCleanCode = CodeFormatter.format(cleanedSource)
+    if (conf.wholeStageCleanCodePrintEnabled) {
+      logInfo(s"\n$formatCleanCode")
+    } else {
+      logDebug(s"\n$formatCleanCode")
+    }
     (ctx, cleanedSource)
   }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
adding a config: spark.sql.codegen.cleanedSourcePrint triggers to print codegen clean source


### Why are the changes needed?
When we use spark-sql, encountering problems in codegen source, we often have to change the log level to DEBUG, but there are too many logs in this mode (DEBUG) .
Then `spark.sql.codegen.cleanedSourcePrint` can ensure that just printing codegen source.


### Does this PR introduce _any_ user-facing change?
Yes, add new config: `spark.sql.codegen.cleanedSourcePrint`


### How was this patch tested?
Existed UT
