### PR TITLE
[SPARK-38650][SQL] Better ParseException message for char types without length

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -138,6 +138,10 @@
     "message" : [ "PARTITION clause cannot contain a non-partition column name: %s" ],
     "sqlState" : "42000"
   },
+  "PARSE_CHAR_MISSING_LENGTH" : {
+    "message" : [ "DataType %s requires a length parameter, for example %s(10). Please specify the length." ],
+    "sqlState" : "42000"
+  },
   "PARSE_EMPTY_STATEMENT" : {
     "message" : [ "Syntax error, unexpected empty statement" ],
     "sqlState" : "42000"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2671,6 +2671,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         DecimalType(precision.getText.toInt, scale.getText.toInt)
       case ("void", Nil) => NullType
       case ("interval", Nil) => CalendarIntervalType
+      case (dt @ ("character" | "char" | "varchar"), Nil) =>
+        throw QueryParsingErrors.charTypeMissingLengthError(dt, ctx)
       case (dt, params) =>
         val dtStr = if (params.nonEmpty) s"$dt(${params.mkString(",")})" else dt
         throw QueryParsingErrors.dataTypeUnsupportedError(dtStr, ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -221,6 +221,11 @@ object QueryParsingErrors {
     new ParseException(s"DataType $dataType is not supported.", ctx)
   }
 
+  def charTypeMissingLengthError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {
+    new ParseException(s"DataType $dataType requires a length parameter, for example " +
+      s"$dataType(10). Please specify the length.", ctx)
+  }
+
   def partitionTransformNotExpectedError(
       name: String, describe: String, ctx: ApplyTransformContext): Throwable = {
     new ParseException(s"Expected a column reference for transform $name: $describe", ctx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -222,8 +222,7 @@ object QueryParsingErrors {
   }
 
   def charTypeMissingLengthError(dataType: String, ctx: PrimitiveDataTypeContext): Throwable = {
-    new ParseException(s"DataType $dataType requires a length parameter, for example " +
-      s"$dataType(10). Please specify the length.", ctx)
+    new ParseException("PARSE_CHAR_MISSING_LENGTH", Array(dataType, dataType), ctx)
   }
 
   def partitionTransformNotExpectedError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
@@ -255,4 +255,16 @@ class ErrorParserSuite extends AnalysisTest {
         |SELECT b
       """.stripMargin, 2, 9, 10, msg + " test-table")
   }
+
+  test("datatype not supported") {
+    // general bad types
+    intercept("SELECT cast(1 as badtype)", 1, 17, 17, "DataType badtype is not supported.")
+
+    // special handling on char and varchar
+    intercept("SELECT cast('a' as CHAR)", 1, 19, 19, "DataType char requires a length parameter")
+    intercept("SELECT cast('a' as Varchar)", 1, 19, 19,
+      "DataType varchar requires a length parameter")
+    intercept("SELECT cast('a' as Character)", 1, 19, 19,
+      "DataType character requires a length parameter")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
@@ -261,10 +261,11 @@ class ErrorParserSuite extends AnalysisTest {
     intercept("SELECT cast(1 as badtype)", 1, 17, 17, "DataType badtype is not supported.")
 
     // special handling on char and varchar
-    intercept("SELECT cast('a' as CHAR)", 1, 19, 19, "DataType char requires a length parameter")
-    intercept("SELECT cast('a' as Varchar)", 1, 19, 19,
+    intercept("SELECT cast('a' as CHAR)", "PARSE_CHAR_MISSING_LENGTH", 1, 19, 19,
+      "DataType char requires a length parameter")
+    intercept("SELECT cast('a' as Varchar)", "PARSE_CHAR_MISSING_LENGTH", 1, 19, 19,
       "DataType varchar requires a length parameter")
-    intercept("SELECT cast('a' as Character)", 1, 19, 19,
+    intercept("SELECT cast('a' as Character)", "PARSE_CHAR_MISSING_LENGTH", 1, 19, 19,
       "DataType character requires a length parameter")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves the error messages for the char / varchar / character datatypes without length. It also added related testcases.

#### Details
We support char and varchar types. But when users input the type without length, the message is confusing and not helpful at all:

```
> SELECT cast('a' as CHAR)

DataType char is not supported.(line 1, pos 19)

== SQL ==
SELECT cast('a' AS CHAR)
-------------------^^^
```
In the after case, the messages would be:
```
Datatype char requires a length parameter, for example char(10). Please specify the length.

== SQL ==
SELECT cast('a' AS CHAR)
-------------------^^^
```

### Why are the changes needed?
To improve error messages for better usability.

### Does this PR introduce _any_ user-facing change?
If error messages are considered as user-facing changes, then yes. It improves the messages as above.

### How was this patch tested?
It's tested by newly added unit tests.
