### PR TITLE
 [SPARK-38651][SQL] Add `spark.sql.legacy.allowEmptySchemaWrite`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2912,6 +2912,14 @@ object SQLConf {
     .stringConf
     .createWithDefault("avro,csv,json,kafka,orc,parquet,text")
 
+  val ALLOW_EMPTY_SCHEMAS_FOR_WRITES =
+    buildConf("spark.sql.legacy.allowEmptySchemaWrite")
+    .doc("When this option is set to true, validation of empty or empty nested schemas that" +
+      "occurs when writing into a FileFormat based data source does not happen.")
+    .version("3.4.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val DISABLED_V2_STREAMING_WRITERS = buildConf("spark.sql.streaming.disabledV2Writers")
     .doc("A comma-separated list of fully qualified data source register class names for which" +
       " StreamWriteSupport is disabled. Writes to these sources will fall back to the V1 Sinks.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2914,7 +2914,7 @@ object SQLConf {
 
   val ALLOW_EMPTY_SCHEMAS_FOR_WRITES =
     buildConf("spark.sql.legacy.allowEmptySchemaWrite")
-    .doc("When this option is set to true, validation of empty or empty nested schemas that" +
+    .doc("When this option is set to true, validation of empty or empty nested schemas that " +
       "occurs when writing into a FileFormat based data source does not happen.")
     .version("3.4.0")
     .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2912,8 +2912,8 @@ object SQLConf {
     .stringConf
     .createWithDefault("avro,csv,json,kafka,orc,parquet,text")
 
-  val ALLOW_EMPTY_SCHEMAS_FOR_WRITES =
-    buildConf("spark.sql.legacy.allowEmptySchemaWrite")
+  val ALLOW_EMPTY_SCHEMAS_FOR_WRITES = buildConf("spark.sql.legacy.allowEmptySchemaWrite")
+    .internal()
     .doc("When this option is set to true, validation of empty or empty nested schemas that " +
       "occurs when writing into a FileFormat based data source does not happen.")
     .version("3.4.0")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileWrite.scala
@@ -52,7 +52,7 @@ trait FileWrite extends Write {
 
   override def toBatch: BatchWrite = {
     val sparkSession = SparkSession.active
-    validateInputs(sparkSession.sessionState.conf.caseSensitiveAnalysis)
+    validateInputs(sparkSession.sessionState.conf)
     val path = new Path(paths.head)
     val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
     // Hadoop Configurations are case sensitive.
@@ -80,7 +80,8 @@ trait FileWrite extends Write {
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory
 
-  private def validateInputs(caseSensitiveAnalysis: Boolean): Unit = {
+  private def validateInputs(sqlConf: SQLConf): Unit = {
+    val caseSensitiveAnalysis = sqlConf.caseSensitiveAnalysis
     assert(schema != null, "Missing input data schema")
     assert(queryId != null, "Missing query ID")
 
@@ -90,7 +91,7 @@ trait FileWrite extends Write {
     }
     val pathName = paths.head
     SchemaUtils.checkColumnNameDuplication(schema.fields.map(_.name), caseSensitiveAnalysis)
-    DataSource.validateSchema(schema)
+    DataSource.validateSchema(schema, sqlConf)
 
     // TODO: [SPARK-36340] Unify check schema filed of DataSource V2 Insert.
     schema.foreach { field =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -154,6 +154,19 @@ class FileBasedDataSourceSuite extends QueryTest
     }
   }
 
+  val emptySchemaSupportedDataSources = Seq("orc", "csv", "json")
+  emptySchemaSupportedDataSources.foreach { format =>
+    val emptySchemaValidationConf = SQLConf.ALLOW_EMPTY_SCHEMAS_FOR_WRITES.key
+    test(s"SPARK-38651 allow writing empty schema files " +
+      s"using $format when ${emptySchemaValidationConf} is enabled") {
+      withSQLConf(emptySchemaValidationConf -> "true") {
+        withTempPath { outputPath =>
+          spark.emptyDataFrame.write.format(format).save(outputPath.toString)
+        }
+      }
+    }
+  }
+
   allFileBasedDataSources.foreach { format =>
     test(s"SPARK-22146 read files containing special characters using $format") {
       withTempDir { dir =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -157,7 +157,7 @@ class FileBasedDataSourceSuite extends QueryTest
   val emptySchemaSupportedDataSources = Seq("orc", "csv", "json")
   emptySchemaSupportedDataSources.foreach { format =>
     val emptySchemaValidationConf = SQLConf.ALLOW_EMPTY_SCHEMAS_FOR_WRITES.key
-    test(s"SPARK-38651 allow writing empty schema files " +
+    test("SPARK-38651 allow writing empty schema files " +
       s"using $format when ${emptySchemaValidationConf} is enabled") {
       withSQLConf(emptySchemaValidationConf -> "true") {
         withTempPath { outputPath =>


### PR DESCRIPTION
 ### What changes were proposed in this pull request?
 Add SQL configuration `spark.sql.legacy.allowEmptySchemaWrite` to allow support for writing out empty schemas to certain file based datasources that support it.

 ### Why are the changes needed?
 Without this change, there is backward in-compatibility introduced while applications are migrated past Spark 2.3 since Spark 2.4 introduced a breaking change that would disallow empty schemas. Since some file formats like ORC support empty schemas, we should honor this by not validating for empty schemas.

 ### Does this PR introduce _any_ user-facing change?
 Yes

 ### How was this patch tested?
 Added a unit test to test this behavior
