### PR TITLE
[MINOR][BUILD] Remove `TODO` `Indentation|ImportOrder` module comments from Java `checkstyle.xml`

### DIFF
--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -142,25 +142,6 @@
              <message key="ws.notPreceded"
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
-        <!-- TODO: 11/09/15 disabled - indentation is currently inconsistent -->
-        <!--
-        <module name="Indentation">
-            <property name="basicOffset" value="4"/>
-            <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="4"/>
-            <property name="throwsIndent" value="4"/>
-            <property name="lineWrappingIndentation" value="4"/>
-            <property name="arrayInitIndent" value="4"/>
-        </module>
-        -->
-        <!-- TODO: 11/09/15 disabled - order is currently wrong in many places -->
-        <!--
-        <module name="ImportOrder">
-            <property name="separated" value="true"/>
-            <property name="ordered" value="true"/>
-            <property name="groups" value="/^javax?\./,scala,*,org.apache.spark"/>
-        </module>
-        -->
         <module name="MethodParamPad"/>
         <module name="AnnotationLocation">
             <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are 2 TODOs in `checkstyle.xml`: `Indentation` and `ImportOrder`. Re enabling and fix them will involves hundreds of `Java` files, which not worth. So this pr delete these TODOs.



### Why are the changes needed?
Remove Impossible `TODO` of Java style check


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA