### PR TITLE
[SPARK-38657][UI][SQL] Rename 'SQL' to 'SQL / DataFrame' in SQL UI page

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -88,12 +88,14 @@ a:not([href]):hover {
   height: 50px;
   padding: 10px 15px 10px;
   line-height: 2;
+  white-space: nowrap;
 }
 
 .navbar .navbar-nav .nav-item.active .nav-link {
   background-color: #e5e5e5;
   box-shadow: inset 0 3px 8px rgba(0, 0, 0, 0.125);
   color: #555555;
+  white-space: nowrap;
 }
 
 table.sortable thead {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -66,7 +66,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
                 'aggregated-runningExecutions')">
             <h4>
               <span class="collapse-table-arrow arrow-open"></span>
-              <a>Running Executions ({running.size})</a>
+              <a>Running Queries ({running.size})</a>
             </h4>
           </span> ++
             <div class="aggregated-runningExecutions collapsible-table">
@@ -84,7 +84,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
                 'aggregated-completedExecutions')">
             <h4>
               <span class="collapse-table-arrow arrow-open"></span>
-              <a>Completed Executions ({completed.size})</a>
+              <a>Completed Queries ({completed.size})</a>
             </h4>
           </span> ++
             <div class="aggregated-completedExecutions collapsible-table">
@@ -102,7 +102,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
                 'aggregated-failedExecutions')">
             <h4>
               <span class="collapse-table-arrow arrow-open"></span>
-              <a>Failed Executions ({failed.size})</a>
+              <a>Failed Queries ({failed.size})</a>
             </h4>
           </span> ++
             <div class="aggregated-failedExecutions collapsible-table">
@@ -123,7 +123,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           {
             if (running.nonEmpty) {
               <li>
-                <a href="#running"><strong>Running Executions:</strong></a>
+                <a href="#running"><strong>Running Queries:</strong></a>
                 {running.size}
               </li>
             }
@@ -131,7 +131,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           {
             if (completed.nonEmpty) {
               <li>
-                <a href="#completed"><strong>Completed Executions:</strong></a>
+                <a href="#completed"><strong>Completed Queries:</strong></a>
                 {completed.size}
               </li>
             }
@@ -139,7 +139,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           {
             if (failed.nonEmpty) {
               <li>
-                <a href="#failed"><strong>Failed Executions:</strong></a>
+                <a href="#failed"><strong>Failed Queries:</strong></a>
                 {failed.size}
               </li>
             }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -66,7 +66,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
                 'aggregated-runningExecutions')">
             <h4>
               <span class="collapse-table-arrow arrow-open"></span>
-              <a>Running Queries ({running.size})</a>
+              <a>Running Executions ({running.size})</a>
             </h4>
           </span> ++
             <div class="aggregated-runningExecutions collapsible-table">
@@ -84,7 +84,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
                 'aggregated-completedExecutions')">
             <h4>
               <span class="collapse-table-arrow arrow-open"></span>
-              <a>Completed Queries ({completed.size})</a>
+              <a>Completed Executions ({completed.size})</a>
             </h4>
           </span> ++
             <div class="aggregated-completedExecutions collapsible-table">
@@ -102,7 +102,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
                 'aggregated-failedExecutions')">
             <h4>
               <span class="collapse-table-arrow arrow-open"></span>
-              <a>Failed Queries ({failed.size})</a>
+              <a>Failed Executions ({failed.size})</a>
             </h4>
           </span> ++
             <div class="aggregated-failedExecutions collapsible-table">
@@ -123,7 +123,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           {
             if (running.nonEmpty) {
               <li>
-                <a href="#running"><strong>Running Queries:</strong></a>
+                <a href="#running"><strong>Running Executions:</strong></a>
                 {running.size}
               </li>
             }
@@ -131,7 +131,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           {
             if (completed.nonEmpty) {
               <li>
-                <a href="#completed"><strong>Completed Queries:</strong></a>
+                <a href="#completed"><strong>Completed Executions:</strong></a>
                 {completed.size}
               </li>
             }
@@ -139,7 +139,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
           {
             if (failed.nonEmpty) {
               <li>
-                <a href="#failed"><strong>Failed Queries:</strong></a>
+                <a href="#failed"><strong>Failed Executions:</strong></a>
                 {failed.size}
               </li>
             }
@@ -147,7 +147,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
         </ul>
       </div>
 
-    UIUtils.headerSparkPage(request, "SQL", summary ++ content, parent)
+    UIUtils.headerSparkPage(request, "SQL & DataFrame", summary ++ content, parent)
   }
 
   private def executionsTable(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/AllExecutionsPage.scala
@@ -147,7 +147,7 @@ private[ui] class AllExecutionsPage(parent: SQLTab) extends WebUIPage("") with L
         </ul>
       </div>
 
-    UIUtils.headerSparkPage(request, "SQL & DataFrame", summary ++ content, parent)
+    UIUtils.headerSparkPage(request, "SQL / DataFrame", summary ++ content, parent)
   }
 
   private def executionsTable(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -159,7 +159,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
       <span class="collapse-sql-properties collapse-table"
             onClick="collapseTable('collapse-sql-properties', 'sql-properties')">
         <span class="collapse-table-arrow arrow-closed"></span>
-        <a>SQL &amp; DataFrame: Properties</a>
+        <a>SQL / DataFrame Properties</a>
       </span>
       <div class="sql-properties collapsible-table collapsed">
         {configs}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -84,11 +84,11 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
         physicalPlanDescription(executionUIData.physicalPlanDescription) ++
         modifiedConfigs(executionUIData.modifiedConfigs)
     }.getOrElse {
-      <div>No information to display for execution {executionId}</div>
+      <div>No information to display for query {executionId}</div>
     }
 
     UIUtils.headerSparkPage(
-      request, s"Details for Execution $executionId", content, parent)
+      request, s"Details for Query $executionId", content, parent)
   }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/ExecutionPage.scala
@@ -84,11 +84,11 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
         physicalPlanDescription(executionUIData.physicalPlanDescription) ++
         modifiedConfigs(executionUIData.modifiedConfigs)
     }.getOrElse {
-      <div>No information to display for query {executionId}</div>
+      <div>No information to display for execution {executionId}</div>
     }
 
     UIUtils.headerSparkPage(
-      request, s"Details for Query $executionId", content, parent)
+      request, s"Details for Execution $executionId", content, parent)
   }
 
 
@@ -159,7 +159,7 @@ class ExecutionPage(parent: SQLTab) extends WebUIPage("execution") with Logging 
       <span class="collapse-sql-properties collapse-table"
             onClick="collapseTable('collapse-sql-properties', 'sql-properties')">
         <span class="collapse-table-arrow arrow-closed"></span>
-        <a>SQL Properties</a>
+        <a>SQL &amp; DataFrame: Properties</a>
       </span>
       <div class="sql-properties collapsible-table collapsed">
         {configs}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
@@ -23,7 +23,7 @@ import org.apache.spark.ui.{SparkUI, SparkUITab}
 class SQLTab(val sqlStore: SQLAppStatusStore, sparkUI: SparkUI)
   extends SparkUITab(sparkUI, "SQL") with Logging {
 
-  override val name = "SQL & DataFrame"
+  override val name = "SQL / DataFrame"
 
   val parent = sparkUI
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SQLTab.scala
@@ -23,6 +23,8 @@ import org.apache.spark.ui.{SparkUI, SparkUITab}
 class SQLTab(val sqlStore: SQLAppStatusStore, sparkUI: SparkUI)
   extends SparkUITab(sparkUI, "SQL") with Logging {
 
+  override val name = "SQL & DataFrame"
+
   val parent = sparkUI
 
   attachPage(new AllExecutionsPage(this))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/AllExecutionsPageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/AllExecutionsPageSuite.scala
@@ -56,7 +56,7 @@ class AllExecutionsPageSuite extends SharedSparkSession with BeforeAndAfter {
     when(tab.headerTabs).thenReturn(Seq.empty)
 
     val html = renderSQLPage(request, tab, statusStore).toString().toLowerCase(Locale.ROOT)
-    assert(html.contains("failed executions"))
+    assert(html.contains("failed queries"))
     assert(!html.contains("1970/01/01"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/AllExecutionsPageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/AllExecutionsPageSuite.scala
@@ -56,7 +56,7 @@ class AllExecutionsPageSuite extends SharedSparkSession with BeforeAndAfter {
     when(tab.headerTabs).thenReturn(Seq.empty)
 
     val html = renderSQLPage(request, tab, statusStore).toString().toLowerCase(Locale.ROOT)
-    assert(html.contains("failed queries"))
+    assert(html.contains("failed executions"))
     assert(!html.contains("1970/01/01"))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename, in SQL UI page,

- `SQL` -> `SQL / DataFrame`

### Why are the changes needed?

- DataFrame executions are also included in this page.
- Spark ML users will run DataFrame-based MLlib API, but they will have to check the "SQL" tab.
- Pandas API on Spark arguably has no link to SQL itself conceptually. It makes less sense to users of pandas API.

### Does this PR introduce _any_ user-facing change?

Yes. After this change, the rename proposed above will be applied as below:

<img width="1212" alt="Screen Shot 2022-03-28 at 10 01 38 AM" src="https://user-images.githubusercontent.com/6477701/160309790-04dc68c0-5154-4ef4-8e58-18b83cccb830.png">
<img width="662" alt="Screen Shot 2022-03-28 at 10 01 45 AM" src="https://user-images.githubusercontent.com/6477701/160309796-50ba31e0-a3e8-407d-aa82-9ec6151762fe.png">



### How was this patch tested?
Manually tested as above.

