### PR TITLE
[SPARK-38663][TESTS][3.0] Remove inaccessible repository: https://dl.bintray.com

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,9 +32,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-// SPARK-29560 Only sbt-mima-plugin needs this repo
-resolvers += Resolver.url("bintray",
-  new java.net.URL("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.defaultIvyPatterns)
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 // sbt 1.0.0 support: https://github.com/AlpineNow/junit_xml_listener/issues/6


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr removes the resolver of https://dl.bintray.com/typesafe/sbt-plugins.

### Why are the changes needed?

https://dl.bintray.com/typesafe/sbt-plugins is invalid:
```
Run ./dev/lint-scala
Scalastyle checks failed at following occurrences:
[error] SERVER ERROR: Bad Gateway url=https://dl.bintray.com/typesafe/sbt-plugins/com.etsy/sbt-checkstyle-plugin/3.1.1/jars/sbt-checkstyle-plugin.jar
[error] SERVER ERROR: Bad Gateway url=https://dl.bintray.com/typesafe/sbt-plugins/org.sonatype.oss/oss-parent/7/jars/oss-parent.jar
[error] SERVER ERROR: Bad Gateway url=https://dl.bintray.com/typesafe/sbt-plugins/org.antlr/antlr4-master/4.7.2/jars/antlr4-master.jar
[error] SERVER ERROR: Bad Gateway url=https://dl.bintray.com/typesafe/sbt-plugins/org.apache/apache/1[9](https://github.com/apache/spark/runs/5657909908?check_suite_focus=true#step:11:9)/jars/apache.jar
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Local test:
```
rm -rf ~/.ivy2/
build/sbt scalastyle test:scalastyle
...
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe/sbt-mima-plugin/scala_2.10/sbt_0.13/0.3.0/jars/sbt-mima-plugin.jar ...
[info]  [SUCCESSFUL ] com.typesafe#sbt-mima-plugin;0.3.0!sbt-mima-plugin.jar (4989ms)
...
```
