### PR TITLE
[SPARK-38664][CORE] Support compact EventLog when there are illegal characters in the path

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileCompactor.scala
@@ -221,5 +221,5 @@ private class CompactedEventLogFileWriter(
     hadoopConf: Configuration)
   extends SingleEventLogFileWriter(appId, appAttemptId, logBaseDir, sparkConf, hadoopConf) {
 
-  override val logPath: String = originalFilePath.toUri.toString + EventLogFileWriter.COMPACTED
+  override val logPath: String = originalFilePath.toString + EventLogFileWriter.COMPACTED
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not escape illegal characters.

### Why are the changes needed?
Compact EventLog fail.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Unit Test