### PR TITLE
[SPARK-37512][PYTHON][FOLLOWUP] Add test_timedelta_ops to modules

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -613,6 +613,7 @@ pyspark_pandas = Module(
         "pyspark.pandas.tests.data_type_ops.test_num_ops",
         "pyspark.pandas.tests.data_type_ops.test_string_ops",
         "pyspark.pandas.tests.data_type_ops.test_udt_ops",
+        "pyspark.pandas.tests.data_type_ops.test_timedelta_ops",
         "pyspark.pandas.tests.indexes.test_category",
         "pyspark.pandas.tests.indexes.test_timedelta",
         "pyspark.pandas.tests.plot.test_frame_plot",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `test_timedelta_ops` to modules

### Why are the changes needed?
`test_timedelta_ops` wasn't added to modules in original PR https://github.com/apache/spark/pull/34776.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- UT passed
- `Build modules (master, regular job): pyspark-pandas` contains test_timedelta_ops.