### PR TITLE
[SPARK-38670][SS] Add offset commit time to streaming query listener

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala
@@ -672,9 +672,11 @@ class MicroBatchExecution(
     withProgressLocked {
       sinkCommitProgress = batchSinkProgress
       watermarkTracker.updateWatermark(lastExecution.executedPlan)
-      assert(commitLog.add(currentBatchId, CommitMetadata(watermarkTracker.currentWatermark)),
-        "Concurrent update to the commit log. Multiple streaming jobs detected for " +
-          s"$currentBatchId")
+      reportTimeTaken("commitOffsets") {
+        assert(commitLog.add(currentBatchId, CommitMetadata(watermarkTracker.currentWatermark)),
+          "Concurrent update to the commit log. Multiple streaming jobs detected for " +
+            s"$currentBatchId")
+      }
       committedOffsets ++= availableOffsets
     }
     logDebug(s"Completed batch ${currentBatchId}")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -316,6 +316,8 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
         assert(query.recentProgress.last.eq(query.lastProgress))
 
         val progress = query.lastProgress
+        logInfo("progress: " + progress.prettyJson)
+
         assert(progress.id === query.id)
         assert(progress.name === query.name)
         assert(progress.batchId === 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -316,7 +316,6 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
         assert(query.recentProgress.last.eq(query.lastProgress))
 
         val progress = query.lastProgress
-        logInfo("progress: " + progress.prettyJson)
 
         assert(progress.id === query.id)
         assert(progress.name === query.name)
@@ -328,6 +327,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
         assert(progress.durationMs.get("latestOffset") === 50)
         assert(progress.durationMs.get("queryPlanning") === 100)
         assert(progress.durationMs.get("walCommit") === 0)
+        assert(progress.durationMs.get("commitOffsets") === 0)
         assert(progress.durationMs.get("addBatch") === 350)
         assert(progress.durationMs.get("triggerExecution") === 500)
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add a metric called "commitOffsets" to the StreamingQueryListener


### Why are the changes needed?
A good portion of the batch duration is committing offsets at the end of the micro-batch.  The timing for this operation is missing from the durationMs metrics.  Lets add this metric to have a more complete picture of where the time is going during the processing of a micro-batch



### Does this PR introduce _any_ user-facing change?
Yes, an event returned from the StreamingQueryListener will now contain an additional metric:

```
  "durationMs" : {
    "addBatch" : 39,
    "getBatch" : 0,
    "latestOffset" : 0,
    "queryPlanning" : 9,
    "triggerExecution" : 228,
    "walCommit" : 82,
    "commitOffsets": 81 // <---- added this metric
  },
```


### How was this patch tested?
add a test