### PR TITLE
[SPARK-38671][INFRA] Publish snapshot from branch-3.3

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         branch:
           - master
+          - branch-3.3
           - branch-3.2
           - branch-3.1
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it publish snapshot from branch-3.3.

### Why are the changes needed?

Currently, it's publishing master and branch-3.2 and branch-3.1.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A