### PR TITLE
[SPARK-38674][SQL] Avoid deduplication if the keys of the HashedRelation are unique

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SubqueryBroadcastExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SubqueryBroadcastExec.scala
@@ -60,6 +60,7 @@ case class SubqueryBroadcastExec(
   }
 
   override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"),
     "dataSize" -> SQLMetrics.createMetric(sparkContext, "data size (bytes)"),
     "collectTime" -> SQLMetrics.createMetric(sparkContext, "time to collect (ms)"))
 
@@ -89,10 +90,15 @@ case class SubqueryBroadcastExec(
         val proj = UnsafeProjection.create(expr)
         val keyIter = iter.map(proj).map(_.copy())
 
-        val rows = keyIter.toArray[InternalRow].distinct
+        val rows = if (broadcastRelation.keyIsUnique) {
+          keyIter.toArray[InternalRow]
+        } else {
+          keyIter.toArray[InternalRow].distinct
+        }
         val beforeBuild = System.nanoTime()
         longMetric("collectTime") += (beforeBuild - beforeCollect) / 1000000
         val dataSize = rows.map(_.asInstanceOf[UnsafeRow].getSizeInBytes).sum
+        longMetric("numOutputRows") += rows.length
         longMetric("dataSize") += dataSize
         SQLMetrics.postDriverMetricUpdates(sparkContext, executionId, metrics.values.toSeq)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1556,6 +1556,37 @@ abstract class DynamicPartitionPruningSuiteBase
       checkAnswer(df, Row(4, 1300, "California") :: Row(5, 1000, "Texas") :: Nil)
     }
   }
+
+  test("SPARK-38674: Remove useless deduplicate in SubqueryBroadcastExec") {
+    withTable("duplicate_keys") {
+      withSQLConf(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED.key -> "true") {
+        Seq[(Int, String)]((1, "NL"), (1, "NL"), (3, "US"), (3, "US"), (3, "US"))
+          .toDF("store_id", "country")
+          .write
+          .format(tableFormat)
+          .saveAsTable("duplicate_keys")
+
+        val df = sql(
+          """
+            |SELECT date_id, product_id FROM fact_sk f
+            |JOIN duplicate_keys s
+            |ON f.store_id = s.store_id WHERE s.country = 'US' AND date_id > 1050
+          """.stripMargin)
+
+        checkPartitionPruningPredicate(df, withSubquery = false, withBroadcast = true)
+
+        val subqueryBroadcastExecs = collectWithSubqueries(df.queryExecution.executedPlan) {
+          case s: SubqueryBroadcastExec => s
+        }
+        assert(subqueryBroadcastExecs.size === 1)
+        subqueryBroadcastExecs.foreach { subqueryBroadcastExec =>
+          assert(subqueryBroadcastExec.metrics("numOutputRows").value === 1)
+        }
+
+        checkAnswer(df, Row(1060, 2) :: Row(1060, 2) :: Row(1060, 2) :: Nil)
+      }
+    }
+  }
 }
 
 abstract class DynamicPartitionPruningDataSourceSuiteBase


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it avoid deduplication if the keys of the HashedRelation are unique.

### Why are the changes needed?

Deduplication is not need if it is [`LongHashedRelation`](https://github.com/apache/spark/blob/8476c8b846ffd2622a6bcf1accf9fa55ffbdc0db/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala#L1062) or the keys of the [`UnsafeHashedRelation`](https://github.com/apache/spark/blob/8476c8b846ffd2622a6bcf1accf9fa55ffbdc0db/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala#L221) are unique.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and UI test:
<img src="https://user-images.githubusercontent.com/5399861/160396221-21432bdf-8b11-4a95-b496-d8b00ce643ae.png" width="350">