### PR TITLE
[SPARK-38639][SQL] Support ignoreCorruptRecord flag to ensure querying broken sequence file table smoothly

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1614,6 +1614,12 @@ object SQLConf {
     .longConf
     .createWithDefault(0)
 
+  val IGNORE_CORRUPT_RECORD = buildConf("spark.sql.hive.ignoreCorruptRecord")
+      .doc("Whether to ignore corrupt record. If true, the Spark jobs will continue to run when " +
+        "encountering corrupted record and the contents that have been read will be returned.")
+      .booleanConf
+      .createWithDefault(false)
+
   val EXCHANGE_REUSE_ENABLED = buildConf("spark.sql.exchange.reuse")
     .internal()
     .doc("When true, the planner will try to find out duplicated exchanges and re-use them.")
@@ -3899,6 +3905,8 @@ class SQLConf extends Serializable with Logging {
   def ignoreMissingFiles: Boolean = getConf(IGNORE_MISSING_FILES)
 
   def maxRecordsPerFile: Long = getConf(MAX_RECORDS_PER_FILE)
+
+  def ignoreCorruptRecord: Boolean = getConf(IGNORE_CORRUPT_RECORD)
 
   def useCompression: Boolean = getConf(COMPRESS_CACHED)
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR adds a "spark.sql.hive.ignoreCorruptRecord" to fill out the functionality that users can query successfully in dirty data(mixed schema in one table).


### Why are the changes needed?
There's an existing flag "spark.sql.files.ignoreCorruptFiles" and "spark.sql.files.ignoreMissingFiles" that will quietly ignore attempted reads from files that have been corrupted, but it still allows the query to fail on sequence files.

Being able to ignore corrupt record is useful in the scenarios that users want to query successfully in dirty data(mixed schema in one table).

We would like to add a "spark.sql.hive.ignoreCorruptRecord" to fill out the functionality.


### Does this PR introduce _any_ user-facing change?
Yes, add new config: "spark.sql.hive.ignoreCorruptRecord"


### How was this patch tested?
Manually tested in local and existed UT
