### PR TITLE
[SPARK-38676][SQL] Provide SQL query context in runtime error message of Add/Subtract/Multiply

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -268,19 +268,16 @@ abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant {
            |${ev.value} = (${CodeGenerator.javaType(dataType)})($tmpResult);
          """.stripMargin
       })
-    case IntegerType | LongType =>
+    case IntegerType | LongType if failOnError && exactMathMethod.isDefined =>
       nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
-        val operation = if (failOnError && exactMathMethod.isDefined) {
-          val mathUtils = MathUtils.getClass.getCanonicalName.stripSuffix("$")
-          s"$mathUtils.${exactMathMethod.get}($eval1, $eval2)"
-        } else {
-          s"$eval1 $symbol $eval2"
-        }
+        val errorContext = ctx.addReferenceObj("errCtx", origin.context)
+        val mathUtils = MathUtils.getClass.getCanonicalName.stripSuffix("$")
         s"""
-           |${ev.value} = $operation;
+           |${ev.value} = $mathUtils.${exactMathMethod.get}($eval1, $eval2, $errorContext);
          """.stripMargin
       })
-    case DoubleType | FloatType =>
+
+    case IntegerType | LongType | DoubleType | FloatType =>
       // When Double/Float overflows, there can be 2 cases:
       // - precision loss: according to SQL standard, the number is truncated;
       // - returns (+/-)Infinite: same behavior also other DBs have (e.g. Postgres)
@@ -333,6 +330,10 @@ case class Add(
       MathUtils.addExact(input1.asInstanceOf[Long], input2.asInstanceOf[Long])
     case _: YearMonthIntervalType =>
       MathUtils.addExact(input1.asInstanceOf[Int], input2.asInstanceOf[Int])
+    case _: IntegerType if failOnError =>
+      MathUtils.addExact(input1.asInstanceOf[Int], input2.asInstanceOf[Int], origin.context)
+    case _: LongType if failOnError =>
+      MathUtils.addExact(input1.asInstanceOf[Long], input2.asInstanceOf[Long], origin.context)
     case _ => numeric.plus(input1, input2)
   }
 
@@ -379,6 +380,10 @@ case class Subtract(
       MathUtils.subtractExact(input1.asInstanceOf[Long], input2.asInstanceOf[Long])
     case _: YearMonthIntervalType =>
       MathUtils.subtractExact(input1.asInstanceOf[Int], input2.asInstanceOf[Int])
+    case _: IntegerType if failOnError =>
+      MathUtils.subtractExact(input1.asInstanceOf[Int], input2.asInstanceOf[Int], origin.context)
+    case _: LongType if failOnError =>
+      MathUtils.subtractExact(input1.asInstanceOf[Long], input2.asInstanceOf[Long], origin.context)
     case _ => numeric.minus(input1, input2)
   }
 
@@ -411,7 +416,13 @@ case class Multiply(
 
   private lazy val numeric = TypeUtils.getNumeric(dataType, failOnError)
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Any = numeric.times(input1, input2)
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = dataType match {
+    case _: IntegerType if failOnError =>
+      MathUtils.multiplyExact(input1.asInstanceOf[Int], input2.asInstanceOf[Int], origin.context)
+    case _: LongType if failOnError =>
+      MathUtils.multiplyExact(input1.asInstanceOf[Long], input2.asInstanceOf[Long], origin.context)
+    case _ => numeric.times(input1, input2)
+  }
 
   override def exactMathMethod: Option[String] = Some("multiplyExact")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -120,10 +120,10 @@ case class Origin(
         startTruncated = false
       }
       (0 until lineText.length).foreach { _ =>
-        if (currentIndex >= start && currentIndex <= stop) {
-          builder ++= "^"
-        } else {
+        if (currentIndex < start) {
           builder ++= " "
+        } else if (currentIndex >= start && currentIndex <= stop) {
+          builder ++= "^"
         }
         currentIndex += 1
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -64,7 +64,33 @@ case class Origin(
   stopIndex: Option[Int] = None,
   sqlText: Option[String] = None,
   objectType: Option[String] = None,
-  objectName: Option[String] = None)
+  objectName: Option[String] = None) {
+
+  lazy val context: String = {
+    val positionContext = if (line.isDefined && startPosition.isDefined) {
+      s"(line ${line.get}, position ${startPosition.get})"
+    } else {
+      ""
+    }
+    val objectContext = if (objectType.isDefined && objectName.isDefined) {
+      s" of ${objectType.get} ${objectName.get}"
+    } else {
+      ""
+    }
+
+    if (sqlText.isDefined) {
+      val start = startIndex.getOrElse(0)
+      val stop = stopIndex.getOrElse(sqlText.get.length - 1)
+      s"""
+         |
+         |== SQL$objectContext$positionContext ==
+         |${sqlText.map(_.substring(start, stop + 1)).getOrElse("")}
+         |""".stripMargin
+    } else {
+      ""
+    }
+  }
+}
 
 /**
  * Provides a location for TreeNodes to ask about the context of their origin.  For example, which

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -26,15 +26,33 @@ object MathUtils {
 
   def addExact(a: Int, b: Int): Int = withOverflow(Math.addExact(a, b))
 
+  def addExact(a: Int, b: Int, errorContext: String): Int =
+    withOverflow(Math.addExact(a, b), errorContext = errorContext)
+
   def addExact(a: Long, b: Long): Long = withOverflow(Math.addExact(a, b))
+
+  def addExact(a: Long, b: Long, errorContext: String): Long =
+    withOverflow(Math.addExact(a, b), errorContext = errorContext)
 
   def subtractExact(a: Int, b: Int): Int = withOverflow(Math.subtractExact(a, b))
 
+  def subtractExact(a: Int, b: Int, errorContext: String): Int =
+    withOverflow(Math.subtractExact(a, b), errorContext = errorContext)
+
   def subtractExact(a: Long, b: Long): Long = withOverflow(Math.subtractExact(a, b))
+
+  def subtractExact(a: Long, b: Long, errorContext: String): Long =
+    withOverflow(Math.subtractExact(a, b), errorContext = errorContext)
 
   def multiplyExact(a: Int, b: Int): Int = withOverflow(Math.multiplyExact(a, b))
 
+  def multiplyExact(a: Int, b: Int, errorContext: String): Int =
+    withOverflow(Math.multiplyExact(a, b), errorContext = errorContext)
+
   def multiplyExact(a: Long, b: Long): Long = withOverflow(Math.multiplyExact(a, b))
+
+  def multiplyExact(a: Long, b: Long, errorContext: String): Long =
+    withOverflow(Math.multiplyExact(a, b), errorContext = errorContext)
 
   def negateExact(a: Int): Int = withOverflow(Math.negateExact(a))
 
@@ -50,12 +68,12 @@ object MathUtils {
 
   def floorMod(a: Long, b: Long): Long = withOverflow(Math.floorMod(a, b))
 
-  private def withOverflow[A](f: => A, hint: String = ""): A = {
+  private def withOverflow[A](f: => A, hint: String = "", errorContext: String = ""): A = {
     try {
       f
     } catch {
       case e: ArithmeticException =>
-        throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage, hint)
+        throw QueryExecutionErrors.arithmeticOverflowError(e.getMessage, hint, errorContext)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -441,10 +441,14 @@ object QueryExecutionErrors {
       s"to false to bypass this error.")
   }
 
-  def arithmeticOverflowError(message: String, hint: String = ""): ArithmeticException = {
+  def arithmeticOverflowError(
+      message: String,
+      hint: String = "",
+      errorContext: String = ""): ArithmeticException = {
     val alternative = if (hint.nonEmpty) s" To return NULL instead, use '$hint'." else ""
     new ArithmeticException(s"$message.$alternative If necessary set " +
-      s"${SQLConf.ANSI_ENABLED.key} to false (except for ANSI interval type) to bypass this error.")
+      s"${SQLConf.ANSI_ENABLED.key} to false (except for ANSI interval type) to bypass this " +
+      "error." + errorContext)
   }
 
   def unaryMinusCauseOverflowError(originValue: AnyVal): ArithmeticException = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -856,4 +856,37 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
     val node = Node(Set("second", "first"), Seq(Set(3, 1), Set(2, 1)))
     assert(node.argString(10) == "{first, second}, [{1, 3}, {1, 2}]")
   }
+
+  test("SPARK-38676: truncate before/after sql text if too long") {
+    val text =
+      """
+        |
+        |SELECT
+        |1234567890 + 1234567890 + 1234567890, cast('a'
+        |as /* comment */
+        |int), 1234567890 + 1234567890 + 1234567890
+        |as foo
+        |""".stripMargin
+    val origin = Origin(
+      line = Some(3),
+      startPosition = Some(38),
+      startIndex = Some(47),
+      stopIndex = Some(77),
+      sqlText = Some(text),
+      objectType = Some("VIEW"),
+      objectName = Some("some_view"))
+    val expected =
+      """
+        |== SQL of VIEW some_view ==
+        |...7890 + 1234567890 + 1234567890, cast(1
+        |                                   ^^^^^
+        |as /* comment */
+        |^^^^^^^^^^^^^^^^
+        |string), 1234567890 + 1234567890 + 1234...
+        |^^^^^^^^
+        |""".stripMargin
+
+    println(origin.context)
+    assert(origin.context.trim == expected)
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -877,16 +877,15 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
       objectName = Some("some_view"))
     val expected =
       """
-        |== SQL of VIEW some_view ==
-        |...7890 + 1234567890 + 1234567890, cast(1
-        |                                   ^^^^^
+        |== SQL of VIEW some_view(line 3, position 38) ==
+        |...7890 + 1234567890 + 1234567890, cast('a'
+        |                                   ^^^^^^^^
         |as /* comment */
         |^^^^^^^^^^^^^^^^
-        |string), 1234567890 + 1234567890 + 1234...
-        |^^^^^^^^
+        |int), 1234567890 + 1234567890 + 12345...
+        |^^^^^
         |""".stripMargin
 
-    println(origin.context)
-    assert(origin.context.trim == expected)
+    assert(origin.context == expected)
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
@@ -202,6 +202,9 @@ struct<>
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
+== SQL(line 1, position 25) ==
+i.f1 * smallint('2')
+
 
 -- !query
 SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i
@@ -222,6 +225,9 @@ struct<>
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
+== SQL(line 1, position 25) ==
+i.f1 * int('2')
+
 
 -- !query
 SELECT '' AS five, i.f1, i.f1 * int('2') AS x FROM INT4_TBL i
@@ -241,6 +247,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+
+== SQL(line 1, position 25) ==
+i.f1 + smallint('2')
 
 
 -- !query
@@ -262,6 +271,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+
+== SQL(line 1, position 25) ==
+i.f1 + int('2')
 
 
 -- !query
@@ -283,6 +295,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+
+== SQL(line 1, position 25) ==
+i.f1 - smallint('2')
 
 
 -- !query
@@ -304,6 +319,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+
+== SQL(line 1, position 25) ==
+i.f1 - int('2')
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int4.sql.out
@@ -201,9 +201,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 25) ==
-i.f1 * smallint('2')
+SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i
+                         ^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -224,9 +224,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 25) ==
-i.f1 * int('2')
+SELECT '' AS five, i.f1, i.f1 * int('2') AS x FROM INT4_TBL i
+                         ^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -247,9 +247,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 25) ==
-i.f1 + smallint('2')
+SELECT '' AS five, i.f1, i.f1 + smallint('2') AS x FROM INT4_TBL i
+                         ^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -271,9 +271,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 25) ==
-i.f1 + int('2')
+SELECT '' AS five, i.f1, i.f1 + int('2') AS x FROM INT4_TBL i
+                         ^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -295,9 +295,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 25) ==
-i.f1 - smallint('2')
+SELECT '' AS five, i.f1, i.f1 - smallint('2') AS x FROM INT4_TBL i
+                         ^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -319,9 +319,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 25) ==
-i.f1 - int('2')
+SELECT '' AS five, i.f1, i.f1 - int('2') AS x FROM INT4_TBL i
+                         ^^^^^^^^^^^^^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -393,9 +393,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
-
 == SQL(line 1, position 28) ==
-q1 * q2
+SELECT '' AS three, q1, q2, q1 * q2 AS multiply FROM INT8_TBL
+                            ^^^^^^^
 
 
 -- !query
@@ -746,6 +746,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT bigint((-9223372036854775808)) * bigint((-1))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -771,6 +774,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT bigint((-9223372036854775808)) * int((-1))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -796,6 +802,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT bigint((-9223372036854775808)) * smallint((-1))
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -394,6 +394,9 @@ struct<>
 java.lang.ArithmeticException
 long overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
 
+== SQL(line 1, position 28) ==
+q1 * q2
+
 
 -- !query
 SELECT '' AS three, q1, q2, q1 * q2 AS multiply FROM INT8_TBL


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Provide SQL query context in runtime error of Add/Subtract/Multiply if the data type is Int or Long. This is the first PR for improving the runtime error message. There are more to be done after we decide what the error message should be like.

Before changes:
```
> SELECT i.f1 - 100, i.f1 * smallint('2') AS x FROM INT4_TBL i
java.lang.ArithmeticException
integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
```
After changes:
```
> SELECT i.f1 - 100, i.f1 * smallint('2') AS x FROM INT4_TBL i
java.lang.ArithmeticException
integer overflow. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.

== SQL(line 1, position 25) ==
SELECT '' AS five, i.f1, i.f1 * smallint('2') AS x FROM INT4_TBL i
                         ^^^^^^^^^^^^^^^^^^^^
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Provide SQL query context of runtime errors to users, so that they can understand it better.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, improve the runtime error message of Add/Subtract/Multiply

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT