### PR TITLE
[SPARK-38680][INFRA] Set upperbound for pandas-stubs in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -518,7 +518,7 @@ jobs:
         # Jinja2 3.0.0+ causes error when building with Sphinx.
         #   See also https://issues.apache.org/jira/browse/SPARK-35375.
         python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==21.12b0'
-        python3.9 -m pip install pandas-stubs
+        python3.9 -m pip install 'pandas-stubs==1.2.0.53'
     - name: Install R linter dependencies and SparkR
       run: |
         apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -21,7 +21,8 @@ coverage
 mypy
 pytest-mypy-plugins==1.9.3
 flake8==3.9.0
-pandas-stubs
+# See SPARK-38680.
+pandas-stubs<1.2.0.54
 
 # Documentation (SQL)
 mkdocs


### PR DESCRIPTION
### What changes were proposed in this pull request?

`pandas-stubs` released `1.2.0.54` but that seems like havng a breaking change:

e.g., ) https://github.com/apache/spark/runs/5729037000?check_suite_focus=true

```
starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/pandas/ml.py:62: error: Incompatible types in assignment (expression has type "Index", variable has type "MultiIndex")  [assignment]
python/pyspark/pandas/frame.py:6133: error: unused "type: ignore" comment
python/pyspark/pandas/frame.py:6292: error: Incompatible types in assignment (expression has type "Index", variable has type "MultiIndex")  [assignment]
Found 3 errors in 2 files (checked 325 source files)
```

This PR proposes to pin pandas-stubs version for now to avoid breaking CI.

### Why are the changes needed?

To have the stable CI status.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

It should be tested in this CI.