### PR TITLE
[SPARK-38633][SQL][FOLLOWUP] JDBCSQLBuilder should build cast to type of databases

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -234,6 +234,12 @@ abstract class JdbcDialect extends Serializable with Logging{
       }
       quoteIdentifier(namedRef.fieldNames.head)
     }
+
+    override def visitCast(l: String, dataType: DataType): String = {
+      val databaseTypeDefinition =
+        getJDBCType(dataType).map(_.databaseTypeDefinition).getOrElse(dataType.typeName)
+      s"CAST($l AS $databaseTypeDefinition)"
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
DS V2 supports push down CAST to database.
The current implement only uses the typeName of DataType.
For example: `Cast(column, StringType)` will be build to `CAST(column AS String)`.
But it should be `CAST(column AS TEXT)` for Postgres or `CAST(column AS VARCHAR2(255))` for Oracle.


### Why are the changes needed?
Improve the implement of push down CAST.


### Does this PR introduce _any_ user-facing change?
'No'.
Just new feature.


### How was this patch tested?
Exists tests
