### PR TITLE
[SPARK-38561][K8S][DOCS][FOLLOWUP] Add note for specific scheduler configuration and fix typos

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1717,14 +1717,14 @@ spec:
 
 Spark allows users to specify a custom Kubernetes schedulers.
 
-1. Specify scheduler name.
+1. Specify a scheduler name.
 
-   Users can specify a custom scheduler using <code>spark.kubernetes.scheduler.name</code> or
+   Users can specify custom scheduler using <code>spark.kubernetes.scheduler.name</code> or
    <code>spark.kubernetes.{driver/executor}.scheduler.name</code> configuration.
 
 2. Specify scheduler related configurations.
 
-   To configure the custom scheduler the user can use [Pod templates](#pod-template), add labels (<code>spark.kubernetes.{driver,executor}.label.*</code>)  and/or annotations (<code>spark.kubernetes.{driver/executor}.annotation.*</code>).
+   To configure the custom scheduler the user can use [Pod templates](#pod-template), add labels (<code>spark.kubernetes.{driver,executor}.label.*</code>), annotations (<code>spark.kubernetes.{driver/executor}.annotation.*</code>) or scheduler specific configurations (such as <code>spark.kubernetes.scheduler.volcano.podGroupTemplateFile</code>).
 
 3. Specify scheduler feature step.
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1719,7 +1719,7 @@ Spark allows users to specify a custom Kubernetes schedulers.
 
 1. Specify a scheduler name.
 
-   Users can specify custom scheduler using <code>spark.kubernetes.scheduler.name</code> or
+   Users can specify a custom scheduler using <code>spark.kubernetes.scheduler.name</code> or
    <code>spark.kubernetes.{driver/executor}.scheduler.name</code> configuration.
 
 2. Specify scheduler related configurations.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add note for specific scheduler configuration and fix typos


### Why are the changes needed?
We addressed some comments on https://github.com/apache/spark/pull/35955 when backport to 3.3 branch.


### Does this PR introduce _any_ user-facing change?
No, doc only


### How was this patch tested?
![image](https://user-images.githubusercontent.com/1736354/160582401-ced6071e-61f4-42fe-a62a-d32f42e67a53.png)

SKIP_API=1 bundle exec jekyll serve --watch