### PR TITLE
[SPARK-38506][SQL] Push partial aggregation through join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -282,7 +282,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
               failAnalysis("Input argument tolerance must be non-negative.")
             }
 
-          case a @ Aggregate(groupingExprs, aggregateExprs, child) =>
+          case a @ Aggregate(groupingExprs, aggregateExprs, _, _) =>
             def isAggregateExpression(expr: Expression): Boolean = {
               expr.isInstanceOf[AggregateExpression] || PythonUDF.isGroupedAggPandasUDF(expr)
             }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeduplicateRelations.scala
@@ -217,14 +217,14 @@ object DeduplicateRelations extends Rule[LogicalPlan] {
         if findAliases(projectList).size == projectList.size =>
         Nil
 
-      case oldVersion @ Aggregate(_, aggregateExpressions, _)
+      case oldVersion @ Aggregate(_, aggregateExpressions, _, _)
           if findAliases(aggregateExpressions).intersect(conflictingAttributes).nonEmpty =>
         val newVersion = oldVersion.copy(aggregateExpressions = newAliases(aggregateExpressions))
         newVersion.copyTagsFrom(oldVersion)
         Seq((oldVersion, newVersion))
 
       // We don't search the child plan recursively for the same reason as the above Project.
-      case _ @ Aggregate(_, aggregateExpressions, _)
+      case _ @ Aggregate(_, aggregateExpressions, _, _)
         if findAliases(aggregateExpressions).size == aggregateExpressions.size =>
         Nil
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -442,7 +442,7 @@ package object dsl {
           case ne: NamedExpression => ne
           case e => UnresolvedAlias(e)
         }
-        Aggregate(groupingExprs, aliasedExprs, logicalPlan)
+        Aggregate(groupingExprs, aliasedExprs, false, logicalPlan)
       }
 
       def having(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuery.scala
@@ -286,7 +286,7 @@ object DecorrelateInnerQuery extends PredicateHelper {
         // Construct a domain with the outer query plan.
         // DomainJoin [a', b']  =>  Aggregate [a, b] [a AS a', b AS b']
         //                          +- Relation [a, b]
-        val domain = Aggregate(groupingExprs, aggregateExprs, outerPlan)
+        val domain = Aggregate(groupingExprs, aggregateExprs, false, outerPlan)
         newChild match {
           // A special optimization for OneRowRelation.
           // TODO: add a more general rule to optimize join with OneRowRelation.
@@ -466,7 +466,7 @@ object DecorrelateInnerQuery extends PredicateHelper {
             val newProject = Project(newProjectList ++ referencesToAdd, newChild)
             (newProject, joinCond, outerReferenceMap)
 
-          case a @ Aggregate(groupingExpressions, aggregateExpressions, child) =>
+          case a @ Aggregate(groupingExpressions, aggregateExpressions, _, child) =>
             val outerReferences = collectOuterReferences(a.expressions)
             val newOuterReferences = parentOuterReferences ++ outerReferences
             val (newChild, joinCond, outerReferenceMap) =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -85,7 +85,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     val aggExp = AggregateExpression(bloomFilterAgg, Complete, isDistinct = false, None)
     val alias = Alias(aggExp, "bloomFilter")()
     val aggregate =
-      ConstantFolding(ColumnPruning(Aggregate(Nil, Seq(alias), false filterCreationSidePlan)))
+      ConstantFolding(ColumnPruning(Aggregate(Nil, Seq(alias), false, filterCreationSidePlan)))
     val bloomFilterSubquery = ScalarSubquery(aggregate, Nil)
     val filter = BloomFilterMightContain(bloomFilterSubquery,
       new XxHash64(Seq(filterApplicationSideExp)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeOneRowPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeOneRowPlan.scala
@@ -37,7 +37,7 @@ object OptimizeOneRowPlan extends Rule[LogicalPlan] {
     plan.transformUpWithPruning(_.containsAnyPattern(SORT, AGGREGATE), ruleId) {
       case Sort(_, _, child) if child.maxRows.exists(_ <= 1L) => child
       case Sort(_, false, child) if child.maxRowsPerPartition.exists(_ <= 1L) => child
-      case agg @ Aggregate(_, _, child) if agg.groupOnly && child.maxRows.exists(_ <= 1L) =>
+      case agg @ Aggregate(_, _, _, child) if agg.groupOnly && child.maxRows.exists(_ <= 1L) =>
         Project(agg.aggregateExpressions, child)
       case agg: Aggregate if agg.child.maxRows.exists(_ <= 1L) =>
         agg.transformExpressions {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -88,6 +88,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         LimitPushDownThroughWindow,
         ColumnPruning,
         GenerateOptimization,
+        PushPartialAggregationThroughJoin,
         // Operator combine
         CollapseRepartition,
         CollapseProject,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -153,7 +153,7 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
       // Aggregation on empty LocalRelation generated from a streaming source is not eliminated
       // as stateful streaming aggregation need to perform other state management operations other
       // than just processing the input data.
-      case Aggregate(ge, _, _) if ge.nonEmpty && !p.isStreaming => empty(p)
+      case Aggregate(ge, _, _, _) if ge.nonEmpty && !p.isStreaming => empty(p)
       // Generators like Hive-style UDTF may return their records within `close`.
       case Generate(_: Explode, _, _, _, _, _) => empty(p)
       case Expand(_, _, _) => empty(p)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala
@@ -71,7 +71,7 @@ object PullOutGroupingExpressions extends Rule[LogicalPlan] {
           val newAggregateExpressions = a.aggregateExpressions
             .map(replaceComplexGroupingExpressions(_).asInstanceOf[NamedExpression])
           val newChild = Project(a.child.output ++ complexGroupingExpressionMap.values, a.child)
-          Aggregate(newGroupingExpressions, newAggregateExpressions, newChild)
+          Aggregate(newGroupingExpressions, newAggregateExpressions, false, newChild)
         } else {
           a
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushPartialAggregationThroughJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushPartialAggregationThroughJoin.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.plans.Inner
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern._
+
+/**
+ * Push down the partial aggregation through join if it cannot be planned as broadcast hash join.
+ */
+object PushPartialAggregationThroughJoin extends Rule[LogicalPlan]
+  with PredicateHelper
+  with JoinSelectionHelper {
+
+  private def isSupportPushdown(aggregateExpressions: Seq[NamedExpression]): Boolean = {
+    aggregateExpressions.forall {
+      case _: Attribute => true
+      case Alias(_: Attribute, _) => true
+      case Alias(_: Literal, _) => true
+      case _ => false
+    }
+  }
+
+  private def split(expressions: Seq[NamedExpression], left: LogicalPlan, right: LogicalPlan) = {
+    val (leftExpressions, rest) =
+      expressions.partition(e => e.references.nonEmpty && e.references.subsetOf(left.outputSet))
+    val (rightExpressions, remainingExpressions) =
+      rest.partition(e => e.references.nonEmpty && e.references.subsetOf(right.outputSet))
+
+    (leftExpressions, rightExpressions, remainingExpressions)
+  }
+
+  private def pushdown(
+      agg: Aggregate,
+      leftKeys: Seq[Expression],
+      rightKeys: Seq[Expression],
+      join: Join): LogicalPlan = {
+    val (leftGroupExps, rightGroupExps, remainingGroupExps) =
+      split(agg.groupingExpressions.map(_.asInstanceOf[NamedExpression]), join.left, join.right)
+
+    val (leftAggExps, rightAggExps, remainingAggExps) =
+      split(agg.aggregateExpressions, join.left, join.right)
+
+    val newLeftGroup = leftGroupExps ++ leftKeys.flatMap(_.references)
+    val newLeftAgg: Seq[NamedExpression] = newLeftGroup ++ leftAggExps.flatMap(_.references)
+
+    val newRightGroup = rightGroupExps ++ rightKeys.flatMap(_.references)
+    val newRightAgg: Seq[NamedExpression] = newRightGroup ++ rightAggExps.flatMap(_.references)
+
+    val newJoin = join.copy(
+      left = Aggregate(newLeftGroup.distinct, newLeftAgg.distinct, true, join.left),
+      right = Aggregate(newRightGroup.distinct, newRightAgg.distinct, true, join.right))
+
+    if (agg.isPartialOnly) {
+      Project(agg.aggregateExpressions, newJoin)
+    } else {
+      agg.copy(child = newJoin)
+    }
+  }
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsAllPatterns(AGGREGATE, JOIN), ruleId) {
+    case agg @ Aggregate(_, _, _, join: Join)
+        if join.left.isInstanceOf[Aggregate] || join.right.isInstanceOf[Aggregate] =>
+      agg
+    case agg @ Aggregate(_, _, _, Project(_, join: Join))
+        if join.left.isInstanceOf[Aggregate] || join.right.isInstanceOf[Aggregate] =>
+      agg
+
+    case agg @ Aggregate(_, aggExprs, _,
+          join @ ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, None, _, left, right, _))
+        if isSupportPushdown(aggExprs) && (leftKeys ++ rightKeys).nonEmpty &&
+          !canPlanAsBroadcastHashJoin(join, conf) =>
+      pushdown(agg, leftKeys, rightKeys, join)
+
+    case agg @ Aggregate(_, aggExprs, _, Project(projectList,
+          join @ ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, None, _, left, right, _)))
+        if isSupportPushdown(aggExprs) && (leftKeys ++ rightKeys).nonEmpty &&
+          projectList.forall(_.isInstanceOf[Attribute]) &&
+          !canPlanAsBroadcastHashJoin(join, conf) =>
+      pushdown(agg, leftKeys, rightKeys, join)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoin.scala
@@ -65,7 +65,7 @@ object RewriteAsOfJoin extends Rule[LogicalPlan] {
       val nearestRight = MinBy(rightStruct, orderExpressionWithOuterReference)
         .toAggregateExpression()
       val aggExpr = Alias(nearestRight, "__nearest_right__")()
-      val aggregate = Aggregate(Seq.empty, Seq(aggExpr), filtered)
+      val aggregate = Aggregate(Seq.empty, Seq(aggExpr), false, filtered)
 
       val projectWithScalarSubquery = Project(
         left.output :+ Alias(ScalarSubquery(aggregate, left.output), "__right__")(),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
@@ -383,6 +383,7 @@ object RewriteDistinctAggregates extends Rule[LogicalPlan] {
       val firstAggregate = Aggregate(
         firstAggregateGroupBy,
         firstAggregateGroupBy ++ maxConds ++ regularAggOperatorMap.map(_._2),
+        false,
         expand)
 
       // Construct the second aggregate
@@ -402,7 +403,7 @@ object RewriteDistinctAggregates extends Rule[LogicalPlan] {
               .getOrElse(transformations.getOrElse(e, e))
         }.asInstanceOf[NamedExpression]
       }
-      Aggregate(groupByAttrs, patchedAggExpressions, firstAggregate)
+      Aggregate(groupByAttrs, patchedAggExpressions, false, firstAggregate)
     } else {
       a
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -209,7 +209,7 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
   }
 
   private def collectGroupingExpressions(plan: LogicalPlan): ExpressionSet = plan match {
-    case Aggregate(groupingExpressions, aggregateExpressions, child) =>
+    case Aggregate(groupingExpressions, aggregateExpressions, _, child) =>
       ExpressionSet.apply(groupingExpressions)
     case _ => ExpressionSet(Seq.empty)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -172,16 +172,16 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
       val newJoinType = buildNewJoinType(f, j)
       if (j.joinType == newJoinType) f else Filter(condition, j.copy(joinType = newJoinType))
 
-    case a @ Aggregate(_, _, Join(left, _, LeftOuter, _, _))
+    case a @ Aggregate(_, _, _, Join(left, _, LeftOuter, _, _))
         if a.groupOnly && a.references.subsetOf(left.outputSet) =>
       a.copy(child = left)
-    case a @ Aggregate(_, _, Join(_, right, RightOuter, _, _))
+    case a @ Aggregate(_, _, _, Join(_, right, RightOuter, _, _))
         if a.groupOnly && a.references.subsetOf(right.outputSet) =>
       a.copy(child = right)
-    case a @ Aggregate(_, _, p @ Project(_, Join(left, _, LeftOuter, _, _)))
+    case a @ Aggregate(_, _, _, p @ Project(_, Join(left, _, LeftOuter, _, _)))
         if a.groupOnly && p.references.subsetOf(left.outputSet) =>
       a.copy(child = p.copy(child = left))
-    case a @ Aggregate(_, _, p @ Project(_, Join(_, right, RightOuter, _, _)))
+    case a @ Aggregate(_, _, _, p @ Project(_, Join(_, right, RightOuter, _, _)))
         if a.groupOnly && p.references.subsetOf(right.outputSet) =>
       a.copy(child = p.copy(child = right))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -785,7 +785,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         Filter(predicate, createProject())
       } else {
         // According to SQL standard, HAVING without GROUP BY means global aggregate.
-        withHavingClause(havingClause, Aggregate(Nil, namedExpressions, withFilter))
+        withHavingClause(havingClause, Aggregate(Nil, namedExpressions, false, withFilter))
       }
     } else if (aggregationClause != null) {
       val aggregate = withAggregationClause(aggregationClause, namedExpressions, withFilter)
@@ -989,7 +989,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         val groupingSets =
           ctx.groupingSet.asScala.map(_.expression.asScala.map(e => expression(e)).toSeq)
         Aggregate(Seq(GroupingSets(groupingSets.toSeq, groupByExpressions)),
-          selectExpressions, query)
+          selectExpressions, false, query)
       } else {
         // GROUP BY .... (WITH CUBE | WITH ROLLUP)?
         val mappedGroupByExpressions = if (ctx.CUBE != null) {
@@ -999,7 +999,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         } else {
           groupByExpressions
         }
-        Aggregate(mappedGroupByExpressions, selectExpressions, query)
+        Aggregate(mappedGroupByExpressions, selectExpressions, false, query)
       }
     } else {
       val groupByExpressions =
@@ -1012,7 +1012,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
               expression(groupByExpr.expression)
             }
           })
-      Aggregate(groupByExpressions.toSeq, selectExpressions, query)
+      Aggregate(groupByExpressions.toSeq, selectExpressions, false, query)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -254,7 +254,7 @@ object ExtractFiltersAndInnerJoins extends PredicateHelper {
 object PhysicalAggregation {
   // groupingExpressions, aggregateExpressions, resultExpressions, child
   type ReturnType =
-    (Seq[NamedExpression], Seq[Expression], Seq[NamedExpression], LogicalPlan)
+    (Seq[NamedExpression], Seq[Expression], Seq[NamedExpression], Boolean, LogicalPlan)
 
   def unapply(a: Any): Option[ReturnType] = a match {
     case logical.Aggregate(groupingExpressions, resultExpressions, isPartialOnly, child) =>
@@ -316,6 +316,7 @@ object PhysicalAggregation {
         namedGroupingExpressions.map(_._2),
         aggregateExpressions,
         rewrittenResultExpressions,
+        isPartialOnly,
         child))
 
     case _ => None

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -257,7 +257,7 @@ object PhysicalAggregation {
     (Seq[NamedExpression], Seq[Expression], Seq[NamedExpression], LogicalPlan)
 
   def unapply(a: Any): Option[ReturnType] = a match {
-    case logical.Aggregate(groupingExpressions, resultExpressions, child) =>
+    case logical.Aggregate(groupingExpressions, resultExpressions, isPartialOnly, child) =>
       // A single aggregate expression might appear multiple times in resultExpressions.
       // In order to avoid evaluating an individual aggregate function multiple times, we'll
       // build a set of semantically distinct aggregate expressions and re-write expressions so

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitor.scala
@@ -69,8 +69,13 @@ object DistinctKeyVisitor extends LogicalPlanVisitor[Set[ExpressionSet]] {
   override def default(p: LogicalPlan): Set[ExpressionSet] = Set.empty[ExpressionSet]
 
   override def visitAggregate(p: Aggregate): Set[ExpressionSet] = {
-    val groupingExps = ExpressionSet(p.groupingExpressions) // handle group by a, a
-    projectDistinctKeys(addDistinctKey(p.child.distinctKeys, groupingExps), p.aggregateExpressions)
+    if (p.isPartialOnly) {
+      default(p)
+    } else {
+      val groupingExps = ExpressionSet(p.groupingExpressions) // handle group by a, a
+      projectDistinctKeys(
+        addDistinctKey(p.child.distinctKeys, groupingExps), p.aggregateExpressions)
+    }
   }
 
   override def visitDistinct(p: Distinct): Set[ExpressionSet] = Set(ExpressionSet(p.output))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitor.scala
@@ -70,7 +70,7 @@ object DistinctKeyVisitor extends LogicalPlanVisitor[Set[ExpressionSet]] {
 
   override def visitAggregate(p: Aggregate): Set[ExpressionSet] = {
     if (p.isPartialOnly) {
-      default(p)
+      p.child.distinctKeys
     } else {
       val groupingExps = ExpressionSet(p.groupingExpressions) // handle group by a, a
       projectDistinctKeys(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -955,6 +955,7 @@ case class Range(
  * @param groupingExpressions expressions for grouping keys
  * @param aggregateExpressions expressions for a project list, which could contain
  *                             [[AggregateExpression]]s.
+ * @param isPartialOnly whether this aggregate only do partial aggregation.
  *
  * Note: Currently, aggregateExpressions is the project list of this Group by operator. Before
  * separating projection from grouping and aggregate, we should avoid expression-level optimization

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -964,6 +964,7 @@ case class Range(
 case class Aggregate(
     groupingExpressions: Seq[Expression],
     aggregateExpressions: Seq[NamedExpression],
+    isPartialOnly: Boolean,
     child: LogicalPlan)
   extends UnaryNode {
 
@@ -979,7 +980,7 @@ case class Aggregate(
   override def output: Seq[Attribute] = aggregateExpressions.map(_.toAttribute)
   override def metadataOutput: Seq[Attribute] = Nil
   override def maxRows: Option[Long] = {
-    if (groupingExpressions.isEmpty) {
+    if (groupingExpressions.isEmpty && !isPartialOnly) {
       Some(1L)
     } else {
       child.maxRows

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -40,7 +40,11 @@ object BasicStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
   }
 
   override def visitAggregate(p: Aggregate): Statistics = {
-    AggregateEstimation.estimate(p).getOrElse(fallback(p))
+    if (p.groupOnly) {
+      p.child.stats
+    } else {
+      AggregateEstimation.estimate(p).getOrElse(fallback(p))
+    }
   }
 
   override def visitDistinct(p: Distinct): Statistics = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -45,7 +45,7 @@ object BasicStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitDistinct(p: Distinct): Statistics = {
     val child = p.child
-    visitAggregate(Aggregate(child.output, child.output, child))
+    visitAggregate(Aggregate(child.output, child.output, false, child))
   }
 
   override def visitExcept(p: Except): Statistics = fallback(p)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -133,6 +133,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushFoldableIntoBranches" ::
       "org.apache.spark.sql.catalyst.optimizer.PushLeftSemiLeftAntiThroughJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.PushPartialAggregationThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.ReassignLambdaVariableID" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveDispensableExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -564,7 +564,7 @@ class AnalysisErrorSuite extends AnalysisTest {
     val resolved = s"${attrA.toString},${attrC.toString}"
 
     val errorMsg = s"Resolved attribute(s) $resolved missing from ${otherA.toString} " +
-                     s"in operator !Aggregate [${aliases.mkString(", ")}]. " +
+                     s"in operator !Aggregate [${aliases.mkString(", ")}], false. " +
                      s"Attribute(s) with the same name appear in the operation: a. " +
                      "Please check if the right attribute(s) are used."
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -802,7 +802,8 @@ class AnalysisSuite extends AnalysisTest with Matchers {
       "Multiple definitions of observed metrics" :: "evt1" :: Nil)
 
     // Subquery different tree - fail
-    val subquery = Aggregate(Nil, sum :: Nil, CollectMetrics("evt1", count :: Nil, testRelation))
+    val subquery = Aggregate(Nil, sum :: Nil, false,
+      CollectMetrics("evt1", count :: Nil, testRelation))
     val query = Project(
       b :: ScalarSubquery(subquery, Nil).as("sum") :: Nil,
       CollectMetrics("evt1", count :: Nil, tblB))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercionSuite.scala
@@ -891,7 +891,8 @@ class AnsiTypeCoercionSuite extends TypeCoercionSuiteBase {
     assert(wp1.isInstanceOf[Project])
     // The attribute `p1.output.head` should be replaced in the root `Project`.
     assert(wp1.expressions.forall(!_.exists(_ == p1.output.head)))
-    val wp2 = widenSetOperationTypes(Aggregate(Nil, sum(p1.output.head).as("v") :: Nil, union))
+    val wp2 = widenSetOperationTypes(
+      Aggregate(Nil, sum(p1.output.head).as("v") :: Nil, false, union))
     assert(wp2.isInstanceOf[Aggregate])
     assert(wp2.missingInput.isEmpty)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveGroupingAnalyticsSuite.scala
@@ -69,8 +69,8 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
   test("grouping sets") {
     val originalPlan = Aggregate(
       Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
-        Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), r1)
-    val expected = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")),
+        Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")), false,
       Expand(
         Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L), Seq(a, b, c, a, b, 0L)),
         Seq(a, b, c, a, b, gid),
@@ -79,8 +79,8 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
 
     val originalPlan2 = Aggregate(
       Seq(GroupingSets(Seq(), Seq(unresolved_a, unresolved_b))),
-      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), r1)
-    val expected2 = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")),
+      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected2 = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")), false,
       Expand(
         Seq(),
         Seq(a, b, c, a, b, gid),
@@ -90,8 +90,8 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     // `b` should be included in the GROUP BY expressions even though it's not in the grouping sets.
     val originalPlan3 = Aggregate(
       Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a)), Seq(unresolved_a, unresolved_b))),
-      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), r1)
-    val expected3 = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")),
+      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected3 = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")), false,
       Expand(
         Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L)),
         Seq(a, b, c, a, b, gid),
@@ -105,7 +105,7 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
         Seq(Multiply(unresolved_a, Literal(2))),
         Seq(Multiply(Literal(2), unresolved_a), unresolved_b)))),
       Seq(UnresolvedAlias(Multiply(unresolved_a, Literal(2))),
-        unresolved_b, UnresolvedAlias(count(unresolved_c))), r1)
+        unresolved_b, UnresolvedAlias(count(unresolved_c))), false, r1)
 
     val resultPlan = getAnalyzer.executeAndCheck(originalPlan4, new QueryPlanningTracker)
     val gExpressions = resultPlan.asInstanceOf[Aggregate].groupingExpressions
@@ -119,8 +119,8 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
 
   test("cube") {
     val originalPlan = Aggregate(Seq(Cube(Seq(Seq(unresolved_a), Seq(unresolved_b)))),
-      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), r1)
-    val expected = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")),
+      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")), false,
       Expand(
         Seq(Seq(a, b, c, a, b, 0L), Seq(a, b, c, a, nulStr, 1L),
           Seq(a, b, c, nulInt, b, 2L), Seq(a, b, c, nulInt, nulStr, 3L)),
@@ -128,8 +128,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
         Project(Seq(a, b, c, a.as("a"), b.as("b")), r1)))
     checkAnalysis(originalPlan, expected)
 
-    val originalPlan2 = Aggregate(Seq(Cube(Seq())), Seq(UnresolvedAlias(count(unresolved_c))), r1)
-    val expected2 = Aggregate(Seq(gid), Seq(count(c).as("count(c)")),
+    val originalPlan2 =
+      Aggregate(Seq(Cube(Seq())), Seq(UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected2 = Aggregate(Seq(gid), Seq(count(c).as("count(c)")), false,
       Expand(
         Seq(Seq(a, b, c, 0L)),
         Seq(a, b, c, gid),
@@ -139,16 +140,17 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
 
   test("rollup") {
     val originalPlan = Aggregate(Seq(Rollup(Seq(Seq(unresolved_a), Seq(unresolved_b)))),
-      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), r1)
-    val expected = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")),
+      Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected = Aggregate(Seq(a, b, gid), Seq(a, b, count(c).as("count(c)")), false,
       Expand(
         Seq(Seq(a, b, c, a, b, 0L), Seq(a, b, c, a, nulStr, 1L), Seq(a, b, c, nulInt, nulStr, 3L)),
         Seq(a, b, c, a, b, gid),
         Project(Seq(a, b, c, a.as("a"), b.as("b")), r1)))
     checkAnalysis(originalPlan, expected)
 
-    val originalPlan2 = Aggregate(Seq(Rollup(Seq())), Seq(UnresolvedAlias(count(unresolved_c))), r1)
-    val expected2 = Aggregate(Seq(gid), Seq(count(c).as("count(c)")),
+    val originalPlan2 =
+      Aggregate(Seq(Rollup(Seq())), Seq(UnresolvedAlias(count(unresolved_c))), false, r1)
+    val expected2 = Aggregate(Seq(gid), Seq(count(c).as("count(c)")), false,
       Expand(
         Seq(Seq(a, b, c, 0L)),
         Seq(a, b, c, gid),
@@ -161,9 +163,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     val originalPlan = Aggregate(
       Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
       Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c)),
-        UnresolvedAlias(Grouping(unresolved_a))), r1)
+        UnresolvedAlias(Grouping(unresolved_a))), false, r1)
     val expected = Aggregate(Seq(a, b, gid),
-      Seq(a, b, count(c).as("count(c)"), grouping_a.as("grouping(a)")),
+      Seq(a, b, count(c).as("count(c)"), grouping_a.as("grouping(a)")), false,
       Expand(
         Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L), Seq(a, b, c, a, b, 0L)),
         Seq(a, b, c, a, b, gid),
@@ -173,9 +175,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     // Cube
     val originalPlan2 = Aggregate(Seq(Cube(Seq(Seq(unresolved_a), Seq(unresolved_b)))),
       Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c)),
-        UnresolvedAlias(Grouping(unresolved_a))), r1)
+        UnresolvedAlias(Grouping(unresolved_a))), false, r1)
     val expected2 = Aggregate(Seq(a, b, gid),
-      Seq(a, b, count(c).as("count(c)"), grouping_a.as("grouping(a)")),
+      Seq(a, b, count(c).as("count(c)"), grouping_a.as("grouping(a)")), false,
       Expand(
         Seq(Seq(a, b, c, a, b, 0L), Seq(a, b, c, a, nulStr, 1L),
           Seq(a, b, c, nulInt, b, 2L), Seq(a, b, c, nulInt, nulStr, 3L)),
@@ -186,9 +188,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     // Rollup
     val originalPlan3 = Aggregate(Seq(Rollup(Seq(Seq(unresolved_a), Seq(unresolved_b)))),
       Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c)),
-        UnresolvedAlias(Grouping(unresolved_a))), r1)
+        UnresolvedAlias(Grouping(unresolved_a))), false, r1)
     val expected3 = Aggregate(Seq(a, b, gid),
-      Seq(a, b, count(c).as("count(c)"), grouping_a.as("grouping(a)")),
+      Seq(a, b, count(c).as("count(c)"), grouping_a.as("grouping(a)")), false,
       Expand(
         Seq(Seq(a, b, c, a, b, 0L), Seq(a, b, c, a, nulStr, 1L), Seq(a, b, c, nulInt, nulStr, 3L)),
         Seq(a, b, c, a, b, gid),
@@ -201,9 +203,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     val originalPlan = Aggregate(
       Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
       Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c)),
-        UnresolvedAlias(GroupingID(Seq(unresolved_a, unresolved_b)))), r1)
+        UnresolvedAlias(GroupingID(Seq(unresolved_a, unresolved_b)))), false, r1)
     val expected = Aggregate(Seq(a, b, gid),
-      Seq(a, b, count(c).as("count(c)"), gid.as("grouping_id(a, b)")),
+      Seq(a, b, count(c).as("count(c)"), gid.as("grouping_id(a, b)")), false,
       Expand(
         Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L), Seq(a, b, c, a, b, 0L)),
         Seq(a, b, c, a, b, gid),
@@ -213,9 +215,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     // Cube
     val originalPlan2 = Aggregate(Seq(Cube(Seq(Seq(unresolved_a), Seq(unresolved_b)))),
       Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c)),
-        UnresolvedAlias(GroupingID(Seq(unresolved_a, unresolved_b)))), r1)
+        UnresolvedAlias(GroupingID(Seq(unresolved_a, unresolved_b)))), false, r1)
     val expected2 = Aggregate(Seq(a, b, gid),
-      Seq(a, b, count(c).as("count(c)"), gid.as("grouping_id(a, b)")),
+      Seq(a, b, count(c).as("count(c)"), gid.as("grouping_id(a, b)")), false,
       Expand(
         Seq(Seq(a, b, c, a, b, 0L), Seq(a, b, c, a, nulStr, 1L),
           Seq(a, b, c, nulInt, b, 2L), Seq(a, b, c, nulInt, nulStr, 3L)),
@@ -226,9 +228,9 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     // Rollup
     val originalPlan3 = Aggregate(Seq(Rollup(Seq(Seq(unresolved_a), Seq(unresolved_b)))),
       Seq(unresolved_a, unresolved_b, UnresolvedAlias(count(unresolved_c)),
-        UnresolvedAlias(GroupingID(Seq(unresolved_a, unresolved_b)))), r1)
+        UnresolvedAlias(GroupingID(Seq(unresolved_a, unresolved_b)))), false, r1)
     val expected3 = Aggregate(Seq(a, b, gid),
-      Seq(a, b, count(c).as("count(c)"), gid.as("grouping_id(a, b)")),
+      Seq(a, b, count(c).as("count(c)"), gid.as("grouping_id(a, b)")), false,
       Expand(
         Seq(Seq(a, b, c, a, b, 0L), Seq(a, b, c, a, nulStr, 1L), Seq(a, b, c, nulInt, nulStr, 3L)),
         Seq(a, b, c, a, b, gid),
@@ -241,11 +243,12 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     val originalPlan = Filter(Grouping(unresolved_a) === 0,
       Aggregate(
         Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
-        Seq(unresolved_a, unresolved_b), r1))
+        Seq(unresolved_a, unresolved_b), false, r1))
     val expected = Project(Seq(a, b),
       Filter(Cast(grouping_a, IntegerType, Option(TimeZone.getDefault().getID)) === 0,
       Aggregate(Seq(a, b, gid),
         Seq(a, b, gid),
+        false,
         Expand(
           Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L),
             Seq(a, b, c, a, b, 0L)),
@@ -254,7 +257,7 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     checkAnalysis(originalPlan, expected)
 
     val originalPlan2 = Filter(Grouping(unresolved_a) === 0,
-      Aggregate(Seq(unresolved_a), Seq(UnresolvedAlias(count(unresolved_b))), r1))
+      Aggregate(Seq(unresolved_a), Seq(UnresolvedAlias(count(unresolved_b))), false, r1))
     assertAnalysisError(originalPlan2,
       Seq("grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup"))
 
@@ -262,10 +265,11 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     val originalPlan3 = Filter(GroupingID(Seq(unresolved_a, unresolved_b)) === 1L,
       Aggregate(
         Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
-        Seq(unresolved_a, unresolved_b), r1))
+        Seq(unresolved_a, unresolved_b), false, r1))
     val expected3 = Project(Seq(a, b), Filter(gid === 1L,
       Aggregate(Seq(a, b, gid),
         Seq(a, b, gid),
+        false,
         Expand(
           Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L),
             Seq(a, b, c, a, b, 0L)),
@@ -274,7 +278,7 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     checkAnalysis(originalPlan3, expected3)
 
     val originalPlan4 = Filter(GroupingID(Seq(unresolved_a)) === 1,
-      Aggregate(Seq(unresolved_a), Seq(UnresolvedAlias(count(unresolved_b))), r1))
+      Aggregate(Seq(unresolved_a), Seq(UnresolvedAlias(count(unresolved_b))), false, r1))
     assertAnalysisError(originalPlan4,
       Seq("grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup"))
   }
@@ -285,11 +289,12 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
       Seq(SortOrder(Grouping(unresolved_a), Ascending)), true,
       Aggregate(
         Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
-        Seq(unresolved_a, unresolved_b), r1))
+        Seq(unresolved_a, unresolved_b), false, r1))
     val expected = Project(Seq(a, b), Sort(
       Seq(SortOrder(grouping_a, Ascending)), true,
       Aggregate(Seq(a, b, gid),
         Seq(a, b, gid),
+        false,
         Expand(
           Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L),
             Seq(a, b, c, a, b, 0L)),
@@ -298,7 +303,8 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
     checkAnalysis(originalPlan, expected)
 
     val originalPlan2 = Sort(Seq(SortOrder(Grouping(unresolved_a), Ascending)), true,
-      Aggregate(Seq(unresolved_a), Seq(unresolved_a, UnresolvedAlias(count(unresolved_b))), r1))
+      Aggregate(Seq(unresolved_a), Seq(unresolved_a, UnresolvedAlias(count(unresolved_b))),
+        false, r1))
     assertAnalysisError(originalPlan2,
       Seq("grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup"))
 
@@ -307,11 +313,12 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
       Seq(SortOrder(GroupingID(Seq(unresolved_a, unresolved_b)), Ascending)), true,
       Aggregate(
         Seq(GroupingSets(Seq(Seq(), Seq(unresolved_a), Seq(unresolved_a, unresolved_b)))),
-        Seq(unresolved_a, unresolved_b), r1))
+        Seq(unresolved_a, unresolved_b), false, r1))
     val expected3 = Project(Seq(a, b), Sort(
       Seq(SortOrder(gid, Ascending)), true,
       Aggregate(Seq(a, b, gid),
         Seq(a, b, gid),
+        false,
         Expand(
           Seq(Seq(a, b, c, nulInt, nulStr, 3L), Seq(a, b, c, a, nulStr, 1L),
             Seq(a, b, c, a, b, 0L)),
@@ -321,7 +328,8 @@ class ResolveGroupingAnalyticsSuite extends AnalysisTest {
 
     val originalPlan4 = Sort(
       Seq(SortOrder(GroupingID(Seq(unresolved_a)), Ascending)), true,
-      Aggregate(Seq(unresolved_a), Seq(unresolved_a, UnresolvedAlias(count(unresolved_b))), r1))
+      Aggregate(Seq(unresolved_a), Seq(unresolved_a, UnresolvedAlias(count(unresolved_b))),
+        false, r1))
     assertAnalysisError(originalPlan4,
       Seq("grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup"))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionSuite.scala
@@ -1491,7 +1491,8 @@ class TypeCoercionSuite extends TypeCoercionSuiteBase {
     assert(wp1.isInstanceOf[Project])
     // The attribute `p1.output.head` should be replaced in the root `Project`.
     assert(wp1.expressions.forall(!_.exists(_ == p1.output.head)))
-    val wp2 = widenSetOperationTypes(Aggregate(Nil, sum(p1.output.head).as("v") :: Nil, union))
+    val wp2 =
+      widenSetOperationTypes(Aggregate(Nil, sum(p1.output.head).as("v") :: Nil, false, union))
     assert(wp2.isInstanceOf[Aggregate])
     assert(wp2.missingInput.isEmpty)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -102,7 +102,7 @@ class AggregateOptimizeSuite extends AnalysisTest {
     val y = testRelation.subquery(Symbol("y"))
     val query = Distinct(x.join(y, RightOuter, Some("x.a".attr === "y.a".attr))
       .select("x.b".attr, "y.c".attr))
-    val correctAnswer = Aggregate(query.child.output, query.child.output, query.child)
+    val correctAnswer = Aggregate(query.child.output, query.child.output, false, query.child)
 
     comparePlans(Optimize.execute(query.analyze), correctAnswer.analyze)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -196,6 +196,7 @@ class ColumnPruningSuite extends PlanTest {
       Aggregate(
         Seq($"aa", $"gid"),
         Seq(sum($"c").as("sum")),
+        false,
         Expand(
           Seq(
             Seq($"a", $"b", $"c", Literal.create(null, StringType), 1),
@@ -208,6 +209,7 @@ class ColumnPruningSuite extends PlanTest {
       Aggregate(
         Seq($"aa", $"gid"),
         Seq(sum($"c").as("sum")),
+        false,
         Expand(
           Seq(
             Seq($"c", Literal.create(null, StringType), 1),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecorrelateInnerQuerySuite.scala
@@ -115,11 +115,11 @@ class DecorrelateInnerQuerySuite extends PlanTest {
     val outerPlan = testRelation2
     val minB = Alias(min(b), "min_b")()
     val innerPlan =
-      Aggregate(Nil, Seq(minB),
+      Aggregate(Nil, Seq(minB), false,
         Filter(And(OuterReference(x) === a, b === 3),
           testRelation))
     val correctAnswer =
-      Aggregate(Seq(a), Seq(minB, a),
+      Aggregate(Seq(a), Seq(minB, a), false,
         Filter(b === 3,
           testRelation))
     check(innerPlan, outerPlan, correctAnswer, Seq(x === a))
@@ -129,11 +129,11 @@ class DecorrelateInnerQuerySuite extends PlanTest {
     val outerPlan = testRelation2
     val minB = Alias(min(b), "min_b")()
     val innerPlan =
-      Aggregate(Nil, Seq(minB),
+      Aggregate(Nil, Seq(minB), false,
         Filter(OuterReference(x) === OuterReference(y) + a,
           testRelation))
     val correctAnswer =
-      Aggregate(Seq(x, y), Seq(minB, x, y),
+      Aggregate(Seq(x, y), Seq(minB, x, y), false,
         Filter(x === y + a,
           DomainJoin(Seq(x, y), testRelation)))
     check(innerPlan, outerPlan, correctAnswer, Seq(x <=> x, y <=> y))
@@ -143,11 +143,11 @@ class DecorrelateInnerQuerySuite extends PlanTest {
     val outerPlan = testRelation2
     val minB = Alias(min(b), "min_b")()
     val innerPlan =
-      Aggregate(Nil, Seq(minB),
+      Aggregate(Nil, Seq(minB), false,
         Filter(OuterReference(x) === OuterReference(y),
           testRelation))
     val correctAnswer =
-      Aggregate(Nil, Seq(minB),
+      Aggregate(Nil, Seq(minB), false,
         testRelation)
     check(innerPlan, outerPlan, correctAnswer, Seq(x === y))
   }
@@ -156,11 +156,11 @@ class DecorrelateInnerQuerySuite extends PlanTest {
     val outerPlan = testRelation2
     val minB = Alias(min(b), "min_b")()
     val innerPlan =
-      Aggregate(Nil, Seq(minB),
+      Aggregate(Nil, Seq(minB), false,
         Filter(OuterReference(x) > a,
           testRelation))
     val correctAnswer =
-      Aggregate(Seq(x), Seq(minB, x),
+      Aggregate(Seq(x), Seq(minB, x), false,
         Filter(x > a,
           DomainJoin(Seq(x), testRelation)))
     check(innerPlan, outerPlan, correctAnswer, Seq(x <=> x))
@@ -263,7 +263,7 @@ class DecorrelateInnerQuerySuite extends PlanTest {
     val outerPlan = testRelation2
     val innerPlan =
       Aggregate(
-        Seq($"x1"), Seq(min($"y1").as("min_y1")),
+        Seq($"x1"), Seq(min($"y1").as("min_y1")), false,
         Project(
           Seq(a, OuterReference(x).as("x1"), OuterReference(y).as("y1")),
           Filter(
@@ -274,7 +274,7 @@ class DecorrelateInnerQuerySuite extends PlanTest {
       ).analyze
     val correctAnswer =
       Aggregate(
-        Seq($"x1", y, a), Seq(min($"y1").as("min_y1"), y, a),
+        Seq($"x1", y, a), Seq(min($"y1").as("min_y1"), y, a), false,
         Project(
           Seq(a, a.as("x1"), y.as("y1"), y),
           DomainJoin(Seq(y), testRelation)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
@@ -35,7 +35,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
       case Project(projectList, child) =>
         val newAttr = UnresolvedAttribute("unresolvedAttr")
         Project(projectList ++ Seq(newAttr), child)
-      case agg @ Aggregate(Nil, aggregateExpressions, child) =>
+      case agg @ Aggregate(Nil, aggregateExpressions, _, child) =>
         // Project cannot host AggregateExpression
         Project(aggregateExpressions, child)
     }
@@ -62,7 +62,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
 
   test("check for invalid plan after execution of rule - special expression in wrong operator") {
     val analyzed =
-      Aggregate(Nil, Seq[NamedExpression](max($"id") as Symbol("m")),
+      Aggregate(Nil, Seq[NamedExpression](max($"id") as Symbol("m")), false,
         LocalRelation($"id".long)).analyze
     assert(analyzed.resolved)
 
@@ -80,7 +80,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
 
   test("check for invalid plan before execution of any rule") {
     val analyzed =
-      Aggregate(Nil, Seq[NamedExpression](max($"id") as Symbol("m")),
+      Aggregate(Nil, Seq[NamedExpression](max($"id") as Symbol("m")), false,
         LocalRelation($"id".long)).analyze
     val invalidPlan = OptimizeRuleBreakSI.apply(analyzed)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushPartialAggregationThroughJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushPartialAggregationThroughJoinSuite.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans.{Inner, LeftOuter, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalRelation, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.internal.SQLConf
+
+class PushPartialAggregationThroughJoinSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Optimizer Batch", FixedPoint(100),
+      PushPartialAggregationThroughJoin) :: Nil
+  }
+
+  private val testRelation1 = LocalRelation('a.int, 'b.int, 'c.int)
+  private val testRelation2 = LocalRelation('x.int, 'y.long)
+
+  test("Basic case") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = testRelation1.where('c > 0)
+        .join(testRelation2, Inner, Some('a === 'x))
+        .groupBy('a, 'b, 'y)('a, 'b, 'y)
+
+      val correctAnswer = Aggregate(Seq('a, 'b), Seq('a, 'b), true, testRelation1.where('c > 0))
+        .join(Aggregate(Seq('y, 'x), Seq('y, 'x), true, testRelation2), Inner, Some('a === 'x))
+        .groupBy('a, 'b, 'y)('a, 'b, 'y)
+
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
+  test("AggregateExpressions contains alias") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = testRelation1.where('c > 0)
+        .join(testRelation2, Inner, Some('a === 'x))
+        .groupBy('a, 'b, 'y)('a.as("alias_a"), 'b, 'y)
+
+      val correctAnswer = Aggregate(Seq('a, 'b), Seq('a, 'b), true, testRelation1.where('c > 0))
+        .join(Aggregate(Seq('y, 'x), Seq('y, 'x), true, testRelation2), Inner, Some('a === 'x))
+        .groupBy('a, 'b, 'y)('a.as("alias_a"), 'b, 'y)
+
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
+  test("Complex join condition") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = testRelation1.where('c > 0)
+        .join(testRelation2, Inner, Some('a === 'y))
+        .groupBy('a, 'b)('a.as("alias_a"), 'b)
+
+      val correctAnswer = Aggregate(Seq('a, 'b), Seq('a, 'b), true, testRelation1.where('c > 0))
+        .join(Aggregate(Seq('y), Seq('y), true, testRelation2), Inner, Some('a === 'y))
+        .groupBy('a, 'b)('a.as("alias_a"), 'b)
+
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
+  test("AggregateExpressions contains Literal") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = testRelation1.where('c > 0)
+        .join(testRelation2, Inner, Some('a === 'y))
+        .groupBy('a, 'b)('a.as("alias_a"), 'b, 1)
+
+      val correctAnswer = Aggregate(Seq('a, 'b), Seq('a, 'b), true, testRelation1.where('c > 0))
+        .join(Aggregate(Seq('y), Seq('y), true, testRelation2), Inner, Some('a === 'y))
+        .groupBy('a, 'b)('a.as("alias_a"), 'b, 1)
+
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
+  test("Push partial only aggregate through join") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = Aggregate(Seq('c, 'y), Seq('c, 'y), true, testRelation1.where('c > 0)
+        .join(testRelation2, Inner, Some('a === 'x)))
+
+      val correctAnswer = Project(Seq('c, 'y),
+        Aggregate(Seq('c, 'a), Seq('c, 'a), true, testRelation1.where('c > 0))
+        .join(Aggregate(Seq('y, 'x), Seq('y, 'x), true, testRelation2), Inner, Some('a === 'x)))
+
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    }
+  }
+
+  test("Unsupported cast: contains AggregateFunction") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = testRelation1.where('c > 0)
+        .join(testRelation2, Inner, Some('a === 'y))
+        .groupBy('a, 'b)('a.as("alias_a"), 'b, sum('c))
+
+      comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+    }
+  }
+
+  test("Unsupported cast: outer join") {
+    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val originalQuery = testRelation1.where('c > 0)
+        .join(testRelation2, LeftOuter, Some('a === 'y))
+        .groupBy('a, 'b)('a.as("alias_a"), 'b)
+
+      comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+    }
+  }
+
+  test("Unsupported cast: broadcast join") {
+    val originalQuery = testRelation1.where('c > 0)
+      .join(testRelation2, Inner, Some('a === 'x))
+      .groupBy('a, 'b, 'y)('a, 'b, 'y)
+
+    comparePlans(Optimize.execute(originalQuery.analyze), originalQuery.analyze)
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
@@ -30,7 +30,7 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
   val testRelation = LocalRelation($"a".string, $"b".string, $"c".string, $"d".string, $"e".int)
 
   private def checkRewrite(rewrite: LogicalPlan): Unit = rewrite match {
-    case Aggregate(_, _, Aggregate(_, _, _: Expand)) =>
+    case Aggregate(_, _, _, Aggregate(_, _, _, _: Expand)) =>
     case _ => fail(s"Plan is not rewritten:\n$rewrite")
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -402,11 +402,11 @@ class PlanParserSuite extends AnalysisTest {
     // Grouping Sets
     assertEqual(s"$sql grouping sets((a, b), (a), ())",
       Aggregate(Seq(GroupingSets(Seq(Seq($"a", $"b"), Seq($"a"), Seq()), Seq($"a", $"b"))),
-        Seq($"a", $"b", $"sum".function($"c").as("c")), table("d")))
+        Seq($"a", $"b", $"sum".function($"c").as("c")), false, table("d")))
 
     assertEqual(s"$sqlWithoutGroupBy group by grouping sets((a, b), (a), ())",
       Aggregate(Seq(GroupingSets(Seq(Seq($"a", $"b"), Seq($"a"), Seq()))),
-        Seq($"a", $"b", $"sum".function($"c").as("c")), table("d")))
+        Seq($"a", $"b", $"sum".function($"c").as("c")), false, table("d")))
 
     val m = intercept[ParseException] {
       parsePlan("SELECT a, b, count(distinct a, distinct b) as c FROM d GROUP BY a, b")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/PhysicalAggregationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/PhysicalAggregationSuite.scala
@@ -39,6 +39,7 @@ class PhysicalAggregationSuite extends PlanTest {
       groupingExpressions,
       aggregateExpressions,
       resultExpressions,
+      false,
       _ /* child */
     ) = analyzedQuery
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -610,7 +610,7 @@ class KeyValueGroupedDataset[K, V] private[sql](
     } else {
       Alias(CreateStruct(groupingAttributes), "key")()
     }
-    val aggregate = Aggregate(groupingAttributes, keyColumn +: namedColumns, logicalPlan)
+    val aggregate = Aggregate(groupingAttributes, keyColumn +: namedColumns, false, logicalPlan)
     val execution = new QueryExecution(sparkSession, aggregate)
 
     new Dataset(execution, ExpressionEncoder.tuple(kExprEnc +: encoders))

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -67,15 +67,15 @@ class RelationalGroupedDataset protected[sql](
 
     groupType match {
       case RelationalGroupedDataset.GroupByType =>
-        Dataset.ofRows(df.sparkSession, Aggregate(groupingExprs, aliasedAgg, df.logicalPlan))
+        Dataset.ofRows(df.sparkSession, Aggregate(groupingExprs, aliasedAgg, false, df.logicalPlan))
       case RelationalGroupedDataset.RollupType =>
         Dataset.ofRows(
           df.sparkSession, Aggregate(Seq(Rollup(groupingExprs.map(Seq(_)))),
-            aliasedAgg, df.logicalPlan))
+            aliasedAgg, false, df.logicalPlan))
       case RelationalGroupedDataset.CubeType =>
         Dataset.ofRows(
           df.sparkSession, Aggregate(Seq(Cube(groupingExprs.map(Seq(_)))),
-            aliasedAgg, df.logicalPlan))
+            aliasedAgg, false, df.logicalPlan))
       case RelationalGroupedDataset.PivotType(pivotCol, values) =>
         val aliasedGrps = groupingExprs.map(alias)
         Dataset.ofRows(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.scala
@@ -50,7 +50,7 @@ case class OptimizeMetadataOnlyQuery(catalog: SessionCatalog) extends Rule[Logic
     }
 
     plan.transform {
-      case a @ Aggregate(_, aggExprs, child @ PhysicalOperation(
+      case a @ Aggregate(_, aggExprs, false, child @ PhysicalOperation(
           projectList, filters, PartitionedRelation(partAttrs, rel))) =>
         // We only apply this optimization when only partitioned attributes are scanned.
         if (AttributeSet((projectList ++ filters).flatMap(_.references)).subsetOf(partAttrs)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -68,7 +68,7 @@ case class PlanAdaptiveDynamicPruningFilters(
         } else {
           // we need to apply an aggregate on the buildPlan in order to be column pruned
           val alias = Alias(buildKeys(index), buildKeys(index).toString)()
-          val aggregate = Aggregate(Seq(alias), Seq(alias), buildPlan)
+          val aggregate = Aggregate(Seq(alias), Seq(alias), false, buildPlan)
 
           val session = adaptivePlan.context.session
           val sparkPlan = QueryExecution.prepareExecutedPlan(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala
@@ -122,6 +122,7 @@ object AggUtils {
       groupingExpressions: Seq[NamedExpression],
       aggregateExpressions: Seq[AggregateExpression],
       resultExpressions: Seq[NamedExpression],
+      isPartialOnly: Boolean,
       child: SparkPlan): Seq[SparkPlan] = {
     // Check if we can use HashAggregate.
 
@@ -164,7 +165,11 @@ object AggUtils {
         resultExpressions = resultExpressions,
         child = interExec)
 
-    finalAggregate :: Nil
+    if (isPartialOnly) {
+      partialAggregate :: Nil
+    } else {
+      finalAggregate :: Nil
+    }
   }
 
   def planAggregateWithOneDistinct(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/CommandUtils.scala
@@ -263,7 +263,8 @@ object CommandUtils extends Logging {
       columns.map(statExprs(_, conf, attributePercentiles))
 
     val namedExpressions = expressions.map(e => Alias(e, e.toString)())
-    val statsRow = new QueryExecution(sparkSession, Aggregate(Nil, namedExpressions, relation))
+    val statsRow = new QueryExecution(sparkSession,
+      Aggregate(Nil, namedExpressions, false, relation))
       .executedPlan.executeTake(1).head
 
     val rowCount = statsRow.getLong(0)
@@ -300,7 +301,8 @@ object CommandUtils extends Logging {
         Alias(expr, expr.toString)()
       }
 
-      val percentilesRow = new QueryExecution(sparkSession, Aggregate(Nil, namedExprs, relation))
+      val percentilesRow = new QueryExecution(sparkSession,
+        Aggregate(Nil, namedExprs, false, relation))
         .executedPlan.executeTake(1).head
       attrsToGenHistogram.zipWithIndex.foreach { case (attr, i) =>
         val percentiles = percentilesRow.getArray(i)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -93,7 +93,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
 
   def pushDownAggregates(plan: LogicalPlan): LogicalPlan = plan.transform {
     // update the scan builder with agg pushdown and return a new plan with agg pushed
-    case aggNode @ Aggregate(groupingExpressions, resultExpressions, child) =>
+    case aggNode @ Aggregate(groupingExpressions, resultExpressions, false, child) =>
       child match {
         case ScanOperation(project, filters, sHolder: ScanBuilderHolder)
           if filters.isEmpty && CollapseProject.canCollapseExpressions(
@@ -219,7 +219,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
                     Project(projectExpressions, scanRelation)
                   } else {
                     val plan = Aggregate(output.take(groupingExpressions.length),
-                      finalResultExpressions, scanRelation)
+                      finalResultExpressions, false, scanRelation)
 
                     // scalastyle:off
                     // Change the optimized logical plan to reflect the pushed down aggregate

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
@@ -82,7 +82,7 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession)
         } else {
           // we need to apply an aggregate on the buildPlan in order to be column pruned
           val alias = Alias(buildKeys(broadcastKeyIndex), buildKeys(broadcastKeyIndex).toString)()
-          val aggregate = Aggregate(Seq(alias), Seq(alias), buildPlan)
+          val aggregate = Aggregate(Seq(alias), Seq(alias), false, buildPlan)
           DynamicPruningExpression(expressions.InSubquery(
             Seq(value), ListQuery(aggregate, childOutputs = aggregate.output)))
         }

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -55,12 +55,12 @@ struct<plan:string>
 
 == Analyzed Logical Plan ==
 sum(DISTINCT val): bigint
-Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL]
+Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL], false
 +- SubqueryAlias spark_catalog.default.explain_temp1
    +- Relation default.explain_temp1[key#x,val#x] parquet
 
 == Optimized Logical Plan ==
-Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL]
+Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL], false
 +- Project [val#x]
    +- Relation default.explain_temp1[key#x,val#x] parquet
 

--- a/sql/core/src/test/resources/sql-tests/results/explain-cbo.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-cbo.sql.out
@@ -56,8 +56,8 @@ struct<plan:string>
 == Optimized Logical Plan ==
 Project [c#x], Statistics(sizeInBytes=1.0 B, rowCount=0)
 +- Filter (isnotnull(d#x) AND (cast(d#x as bigint) > scalar-subquery#x [])), Statistics(sizeInBytes=1.0 B, rowCount=0)
-   :  +- Aggregate [max(csales#xL) AS tpcds_cmax#xL], Statistics(sizeInBytes=16.0 B, rowCount=1)
-   :     +- Aggregate [sum(b#x) AS csales#xL], Statistics(sizeInBytes=16.0 B, rowCount=1)
+   :  +- Aggregate [max(csales#xL) AS tpcds_cmax#xL], false, Statistics(sizeInBytes=16.0 B, rowCount=1)
+   :     +- Aggregate [sum(b#x) AS csales#xL], false, Statistics(sizeInBytes=16.0 B, rowCount=1)
    :        +- Project [b#x], Statistics(sizeInBytes=1.0 B, rowCount=0)
    :           +- Filter (isnotnull(a#x) AND (a#x < 100)), Statistics(sizeInBytes=1.0 B, rowCount=0)
    :              +- Relation default.explain_temp1[a#x,b#x] parquet, Statistics(sizeInBytes=1.0 B, rowCount=0)

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -55,12 +55,12 @@ struct<plan:string>
 
 == Analyzed Logical Plan ==
 sum(DISTINCT val): bigint
-Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL]
+Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL], false
 +- SubqueryAlias spark_catalog.default.explain_temp1
    +- Relation default.explain_temp1[key#x,val#x] parquet
 
 == Optimized Logical Plan ==
-Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL]
+Aggregate [sum(distinct val#x) AS sum(DISTINCT val)#xL], false
 +- Project [val#x]
    +- Relation default.explain_temp1[key#x,val#x] parquet
 

--- a/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/negative-cases/invalid-correlation.sql.out
@@ -109,7 +109,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 Expressions referencing the outer query are not supported outside of WHERE/HAVING clauses:
-Aggregate [min(outer(t2a#x)) AS min(outer(t2.t2a))#x]
+Aggregate [min(outer(t2a#x)) AS min(outer(t2.t2a))#x], false
 +- SubqueryAlias t3
    +- View (`t3`, [t3a#x,t3b#x,t3c#x])
       +- Project [cast(t3a#x as int) AS t3a#x, cast(t3b#x as int) AS t3b#x, cast(t3c#x as int) AS t3c#x]

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-except.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-except.sql.out
@@ -104,7 +104,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 Correlated column is not allowed in predicate (CAST(udf(cast(k as string)) AS STRING) = CAST(udf(cast(outer(k#x) as string)) AS STRING)):
-Aggregate [cast(udf(cast(max(cast(udf(cast(v#x as string)) as int)) as string)) as int) AS udf(max(udf(v)))#x]
+Aggregate [cast(udf(cast(max(cast(udf(cast(v#x as string)) as int)) as string)) as int) AS udf(max(udf(v)))#x], false
 +- Filter (cast(udf(cast(k#x as string)) as string) = cast(udf(cast(outer(k#x) as string)) as string))
    +- SubqueryAlias t2
       +- View (`t2`, [k#x,v#x])

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -23,57 +23,57 @@ TakeOrderedAndProject (123)
                :                    :     :  +- * Sort (59)
                :                    :     :     +- Exchange (58)
                :                    :     :        +- * Project (57)
-               :                    :     :           +- * BroadcastHashJoin Inner BuildRight (56)
-               :                    :     :              :- * Filter (8)
-               :                    :     :              :  +- * ColumnarToRow (7)
-               :                    :     :              :     +- Scan parquet default.item (6)
-               :                    :     :              +- BroadcastExchange (55)
-               :                    :     :                 +- * SortMergeJoin LeftSemi (54)
-               :                    :     :                    :- * Sort (42)
-               :                    :     :                    :  +- Exchange (41)
-               :                    :     :                    :     +- * HashAggregate (40)
-               :                    :     :                    :        +- Exchange (39)
-               :                    :     :                    :           +- * HashAggregate (38)
-               :                    :     :                    :              +- * Project (37)
-               :                    :     :                    :                 +- * BroadcastHashJoin Inner BuildRight (36)
-               :                    :     :                    :                    :- * Project (14)
-               :                    :     :                    :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-               :                    :     :                    :                    :     :- * Filter (11)
-               :                    :     :                    :                    :     :  +- * ColumnarToRow (10)
-               :                    :     :                    :                    :     :     +- Scan parquet default.store_sales (9)
-               :                    :     :                    :                    :     +- ReusedExchange (12)
-               :                    :     :                    :                    +- BroadcastExchange (35)
-               :                    :     :                    :                       +- * SortMergeJoin LeftSemi (34)
-               :                    :     :                    :                          :- * Sort (19)
-               :                    :     :                    :                          :  +- Exchange (18)
-               :                    :     :                    :                          :     +- * Filter (17)
-               :                    :     :                    :                          :        +- * ColumnarToRow (16)
-               :                    :     :                    :                          :           +- Scan parquet default.item (15)
-               :                    :     :                    :                          +- * Sort (33)
-               :                    :     :                    :                             +- Exchange (32)
-               :                    :     :                    :                                +- * Project (31)
-               :                    :     :                    :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-               :                    :     :                    :                                      :- * Project (25)
-               :                    :     :                    :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-               :                    :     :                    :                                      :     :- * Filter (22)
-               :                    :     :                    :                                      :     :  +- * ColumnarToRow (21)
-               :                    :     :                    :                                      :     :     +- Scan parquet default.catalog_sales (20)
-               :                    :     :                    :                                      :     +- ReusedExchange (23)
-               :                    :     :                    :                                      +- BroadcastExchange (29)
-               :                    :     :                    :                                         +- * Filter (28)
-               :                    :     :                    :                                            +- * ColumnarToRow (27)
-               :                    :     :                    :                                               +- Scan parquet default.item (26)
-               :                    :     :                    +- * Sort (53)
-               :                    :     :                       +- Exchange (52)
-               :                    :     :                          +- * Project (51)
-               :                    :     :                             +- * BroadcastHashJoin Inner BuildRight (50)
-               :                    :     :                                :- * Project (48)
-               :                    :     :                                :  +- * BroadcastHashJoin Inner BuildRight (47)
-               :                    :     :                                :     :- * Filter (45)
-               :                    :     :                                :     :  +- * ColumnarToRow (44)
-               :                    :     :                                :     :     +- Scan parquet default.web_sales (43)
-               :                    :     :                                :     +- ReusedExchange (46)
-               :                    :     :                                +- ReusedExchange (49)
+               :                    :     :           +- * BroadcastHashJoin Inner BuildLeft (56)
+               :                    :     :              :- BroadcastExchange (9)
+               :                    :     :              :  +- * Filter (8)
+               :                    :     :              :     +- * ColumnarToRow (7)
+               :                    :     :              :        +- Scan parquet default.item (6)
+               :                    :     :              +- * SortMergeJoin LeftSemi (55)
+               :                    :     :                 :- * Sort (43)
+               :                    :     :                 :  +- Exchange (42)
+               :                    :     :                 :     +- * HashAggregate (41)
+               :                    :     :                 :        +- Exchange (40)
+               :                    :     :                 :           +- * HashAggregate (39)
+               :                    :     :                 :              +- * Project (38)
+               :                    :     :                 :                 +- * BroadcastHashJoin Inner BuildRight (37)
+               :                    :     :                 :                    :- * Project (15)
+               :                    :     :                 :                    :  +- * BroadcastHashJoin Inner BuildRight (14)
+               :                    :     :                 :                    :     :- * Filter (12)
+               :                    :     :                 :                    :     :  +- * ColumnarToRow (11)
+               :                    :     :                 :                    :     :     +- Scan parquet default.store_sales (10)
+               :                    :     :                 :                    :     +- ReusedExchange (13)
+               :                    :     :                 :                    +- BroadcastExchange (36)
+               :                    :     :                 :                       +- * SortMergeJoin LeftSemi (35)
+               :                    :     :                 :                          :- * Sort (20)
+               :                    :     :                 :                          :  +- Exchange (19)
+               :                    :     :                 :                          :     +- * Filter (18)
+               :                    :     :                 :                          :        +- * ColumnarToRow (17)
+               :                    :     :                 :                          :           +- Scan parquet default.item (16)
+               :                    :     :                 :                          +- * Sort (34)
+               :                    :     :                 :                             +- Exchange (33)
+               :                    :     :                 :                                +- * Project (32)
+               :                    :     :                 :                                   +- * BroadcastHashJoin Inner BuildRight (31)
+               :                    :     :                 :                                      :- * Project (26)
+               :                    :     :                 :                                      :  +- * BroadcastHashJoin Inner BuildRight (25)
+               :                    :     :                 :                                      :     :- * Filter (23)
+               :                    :     :                 :                                      :     :  +- * ColumnarToRow (22)
+               :                    :     :                 :                                      :     :     +- Scan parquet default.catalog_sales (21)
+               :                    :     :                 :                                      :     +- ReusedExchange (24)
+               :                    :     :                 :                                      +- BroadcastExchange (30)
+               :                    :     :                 :                                         +- * Filter (29)
+               :                    :     :                 :                                            +- * ColumnarToRow (28)
+               :                    :     :                 :                                               +- Scan parquet default.item (27)
+               :                    :     :                 +- * Sort (54)
+               :                    :     :                    +- Exchange (53)
+               :                    :     :                       +- * Project (52)
+               :                    :     :                          +- * BroadcastHashJoin Inner BuildRight (51)
+               :                    :     :                             :- * Project (49)
+               :                    :     :                             :  +- * BroadcastHashJoin Inner BuildRight (48)
+               :                    :     :                             :     :- * Filter (46)
+               :                    :     :                             :     :  +- * ColumnarToRow (45)
+               :                    :     :                             :     :     +- Scan parquet default.web_sales (44)
+               :                    :     :                             :     +- ReusedExchange (47)
+               :                    :     :                             +- ReusedExchange (50)
                :                    :     +- ReusedExchange (61)
                :                    +- BroadcastExchange (72)
                :                       +- * SortMergeJoin LeftSemi (71)
@@ -154,232 +154,232 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 19]
+(7) ColumnarToRow [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 
-(8) Filter [codegen id : 19]
+(8) Filter [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(9) BroadcastExchange
+Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[2, int, false], input[3, int, false]),false), [id=#11]
+
+(10) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#13), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(11) ColumnarToRow [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(12) Filter [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
+Condition : isnotnull(ss_item_sk#12)
 
-(12) ReusedExchange [Reuses operator id: 152]
-Output [1]: [d_date_sk#14]
+(13) ReusedExchange [Reuses operator id: 152]
+Output [1]: [d_date_sk#15]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(14) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_sold_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(15) Project [codegen id : 12]
+Output [1]: [ss_item_sk#12]
+Input [3]: [ss_item_sk#12, ss_sold_date_sk#13, d_date_sk#15]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(16) Scan parquet default.item
+Output [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(17) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(18) Filter [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Condition : (((isnotnull(i_item_sk#16) AND isnotnull(i_brand_id#17)) AND isnotnull(i_class_id#18)) AND isnotnull(i_category_id#19))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(19) Exchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: hashpartitioning(coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19), 5), ENSURE_REQUIREMENTS, [id=#20]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(20) Sort [codegen id : 6]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: [coalesce(i_brand_id#17, 0) ASC NULLS FIRST, isnull(i_brand_id#17) ASC NULLS FIRST, coalesce(i_class_id#18, 0) ASC NULLS FIRST, isnull(i_class_id#18) ASC NULLS FIRST, coalesce(i_category_id#19, 0) ASC NULLS FIRST, isnull(i_category_id#19) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(21) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#22), dynamicpruningexpression(cs_sold_date_sk#22 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(22) ColumnarToRow [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(23) Filter [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
+Condition : isnotnull(cs_item_sk#21)
 
-(23) ReusedExchange [Reuses operator id: 152]
-Output [1]: [d_date_sk#22]
+(24) ReusedExchange [Reuses operator id: 152]
+Output [1]: [d_date_sk#23]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(25) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_sold_date_sk#22]
+Right keys [1]: [d_date_sk#23]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(26) Project [codegen id : 9]
+Output [1]: [cs_item_sk#21]
+Input [3]: [cs_item_sk#21, cs_sold_date_sk#22, d_date_sk#23]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(27) Scan parquet default.item
+Output [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(28) ColumnarToRow [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(29) Filter [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Condition : isnotnull(i_item_sk#24)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(30) BroadcastExchange
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(31) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_item_sk#21]
+Right keys [1]: [i_item_sk#24]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(32) Project [codegen id : 9]
+Output [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Input [5]: [cs_item_sk#21, i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(33) Exchange
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: hashpartitioning(coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27), 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 10]
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: [coalesce(i_brand_id#25, 0) ASC NULLS FIRST, isnull(i_brand_id#25) ASC NULLS FIRST, coalesce(i_class_id#26, 0) ASC NULLS FIRST, isnull(i_class_id#26) ASC NULLS FIRST, coalesce(i_category_id#27, 0) ASC NULLS FIRST, isnull(i_category_id#27) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(35) SortMergeJoin [codegen id : 11]
+Left keys [6]: [coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19)]
+Right keys [6]: [coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(36) BroadcastExchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(37) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_item_sk#12]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(38) Project [codegen id : 12]
+Output [3]: [i_brand_id#17 AS brand_id#31, i_class_id#18 AS class_id#32, i_category_id#19 AS category_id#33]
+Input [5]: [ss_item_sk#12, i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(39) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+(40) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(brand_id#31, class_id#32, category_id#33, 5), ENSURE_REQUIREMENTS, [id=#34]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(41) HashAggregate [codegen id : 13]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
+(42) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33), 5), ENSURE_REQUIREMENTS, [id=#35]
 
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
+(43) Sort [codegen id : 14]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: [coalesce(brand_id#31, 0) ASC NULLS FIRST, isnull(brand_id#31) ASC NULLS FIRST, coalesce(class_id#32, 0) ASC NULLS FIRST, isnull(class_id#32) ASC NULLS FIRST, coalesce(category_id#33, 0) ASC NULLS FIRST, isnull(category_id#33) ASC NULLS FIRST], false, 0
 
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(44) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#37), dynamicpruningexpression(ws_sold_date_sk#37 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(45) ColumnarToRow [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(46) Filter [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
+Condition : isnotnull(ws_item_sk#36)
 
-(46) ReusedExchange [Reuses operator id: 152]
-Output [1]: [d_date_sk#37]
+(47) ReusedExchange [Reuses operator id: 152]
+Output [1]: [d_date_sk#38]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(48) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#37]
+Right keys [1]: [d_date_sk#38]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(49) Project [codegen id : 17]
+Output [1]: [ws_item_sk#36]
+Input [3]: [ws_item_sk#36, ws_sold_date_sk#37, d_date_sk#38]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(50) ReusedExchange [Reuses operator id: 30]
+Output [4]: [i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(51) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#36]
+Right keys [1]: [i_item_sk#39]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(52) Project [codegen id : 17]
+Output [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Input [5]: [ws_item_sk#36, i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(53) Exchange
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: hashpartitioning(coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42), 5), ENSURE_REQUIREMENTS, [id=#43]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(54) Sort [codegen id : 18]
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: [coalesce(i_brand_id#40, 0) ASC NULLS FIRST, isnull(i_brand_id#40) ASC NULLS FIRST, coalesce(i_class_id#41, 0) ASC NULLS FIRST, isnull(i_class_id#41) ASC NULLS FIRST, coalesce(i_category_id#42, 0) ASC NULLS FIRST, isnull(i_category_id#42) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(55) SortMergeJoin
+Left keys [6]: [coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33)]
+Right keys [6]: [coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42)]
 Join condition: None
-
-(55) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+Right keys [3]: [brand_id#31, class_id#32, category_id#33]
 Join condition: None
 
 (57) Project [codegen id : 19]
 Output [1]: [i_item_sk#7 AS ss_item_sk#44]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#31, class_id#32, category_id#33]
 
 (58) Exchange
 Input [1]: [ss_item_sk#44]
@@ -705,7 +705,7 @@ Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquer
 Output [3]: [ss_quantity#127, ss_list_price#128, ss_sold_date_sk#129]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#129), dynamicpruningexpression(ss_sold_date_sk#129 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#129), dynamicpruningexpression(ss_sold_date_sk#129 IN dynamicpruning#14)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (125) ColumnarToRow [codegen id : 2]
@@ -727,7 +727,7 @@ Input [4]: [ss_quantity#127, ss_list_price#128, ss_sold_date_sk#129, d_date_sk#1
 Output [3]: [cs_quantity#133, cs_list_price#134, cs_sold_date_sk#135]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#135), dynamicpruningexpression(cs_sold_date_sk#135 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#135), dynamicpruningexpression(cs_sold_date_sk#135 IN dynamicpruning#14)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (130) ColumnarToRow [codegen id : 4]
@@ -749,7 +749,7 @@ Input [4]: [cs_quantity#133, cs_list_price#134, cs_sold_date_sk#135, d_date_sk#1
 Output [3]: [ws_quantity#139, ws_list_price#140, ws_sold_date_sk#141]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#141), dynamicpruningexpression(ws_sold_date_sk#141 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#141), dynamicpruningexpression(ws_sold_date_sk#141 IN dynamicpruning#14)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (135) ColumnarToRow [codegen id : 6]
@@ -787,11 +787,11 @@ Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#131 as decima
 Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#131 as decimal(12,2))) * promote_precision(cast(list_price#132 as decimal(12,2)))), DecimalType(18,2)))#150]
 Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#131 as decimal(12,2))) * promote_precision(cast(list_price#132 as decimal(12,2)))), DecimalType(18,2)))#150 AS average_sales#151]
 
-Subquery:2 Hosting operator id = 124 Hosting Expression = ss_sold_date_sk#129 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 124 Hosting Expression = ss_sold_date_sk#129 IN dynamicpruning#14
 
-Subquery:3 Hosting operator id = 129 Hosting Expression = cs_sold_date_sk#135 IN dynamicpruning#13
+Subquery:3 Hosting operator id = 129 Hosting Expression = cs_sold_date_sk#135 IN dynamicpruning#14
 
-Subquery:4 Hosting operator id = 134 Hosting Expression = ws_sold_date_sk#141 IN dynamicpruning#13
+Subquery:4 Hosting operator id = 134 Hosting Expression = ws_sold_date_sk#141 IN dynamicpruning#14
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (147)
@@ -823,7 +823,7 @@ Input [3]: [d_date_sk#46, d_year#152, d_moy#153]
 Input [1]: [d_date_sk#46]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#154]
 
-Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
+Subquery:6 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (152)
 +- * Project (151)
    +- * Filter (150)
@@ -832,30 +832,30 @@ BroadcastExchange (152)
 
 
 (148) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#155]
+Output [2]: [d_date_sk#15, d_year#155]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (149) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#155]
+Input [2]: [d_date_sk#15, d_year#155]
 
 (150) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#155]
-Condition : (((isnotnull(d_year#155) AND (d_year#155 >= 1999)) AND (d_year#155 <= 2001)) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#15, d_year#155]
+Condition : (((isnotnull(d_year#155) AND (d_year#155 >= 1999)) AND (d_year#155 <= 2001)) AND isnotnull(d_date_sk#15))
 
 (151) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#155]
+Output [1]: [d_date_sk#15]
+Input [2]: [d_date_sk#15, d_year#155]
 
 (152) BroadcastExchange
-Input [1]: [d_date_sk#14]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#156]
 
-Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:7 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#22 IN dynamicpruning#14
 
-Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 44 Hosting Expression = ws_sold_date_sk#37 IN dynamicpruning#14
 
 Subquery:9 Hosting operator id = 97 Hosting Expression = ReusedSubquery Subquery scalar-subquery#64, [id=#65]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/simplified.txt
@@ -83,100 +83,100 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum(sales),su
                                                         WholeStageCodegen (19)
                                                           Project [i_item_sk]
                                                             BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                                              Filter [i_brand_id,i_class_id,i_category_id]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                               InputAdapter
                                                                 BroadcastExchange #6
-                                                                  WholeStageCodegen (18)
-                                                                    SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                  WholeStageCodegen (3)
+                                                                    Filter [i_brand_id,i_class_id,i_category_id]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                              SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (14)
+                                                                    Sort [brand_id,class_id,category_id]
                                                                       InputAdapter
-                                                                        WholeStageCodegen (13)
-                                                                          Sort [brand_id,class_id,category_id]
-                                                                            InputAdapter
-                                                                              Exchange [brand_id,class_id,category_id] #7
-                                                                                WholeStageCodegen (12)
-                                                                                  HashAggregate [brand_id,class_id,category_id]
-                                                                                    InputAdapter
-                                                                                      Exchange [brand_id,class_id,category_id] #8
-                                                                                        WholeStageCodegen (11)
-                                                                                          HashAggregate [brand_id,class_id,category_id]
-                                                                                            Project [i_brand_id,i_class_id,i_category_id]
-                                                                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                Project [ss_item_sk]
-                                                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                    Filter [ss_item_sk]
-                                                                                                      ColumnarToRow
-                                                                                                        InputAdapter
-                                                                                                          Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                                            SubqueryBroadcast [d_date_sk] #2
-                                                                                                              BroadcastExchange #9
-                                                                                                                WholeStageCodegen (1)
-                                                                                                                  Project [d_date_sk]
-                                                                                                                    Filter [d_year,d_date_sk]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                    InputAdapter
-                                                                                                      ReusedExchange [d_date_sk] #9
-                                                                                                InputAdapter
-                                                                                                  BroadcastExchange #10
-                                                                                                    WholeStageCodegen (10)
-                                                                                                      SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                        InputAdapter
-                                                                                                          WholeStageCodegen (5)
-                                                                                                            Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                              InputAdapter
-                                                                                                                Exchange [i_brand_id,i_class_id,i_category_id] #11
-                                                                                                                  WholeStageCodegen (4)
-                                                                                                                    Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                      ColumnarToRow
-                                                                                                                        InputAdapter
-                                                                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                        InputAdapter
-                                                                                                          WholeStageCodegen (9)
-                                                                                                            Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                              InputAdapter
-                                                                                                                Exchange [i_brand_id,i_class_id,i_category_id] #12
-                                                                                                                  WholeStageCodegen (8)
-                                                                                                                    Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                        Project [cs_item_sk]
-                                                                                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                            Filter [cs_item_sk]
-                                                                                                                              ColumnarToRow
-                                                                                                                                InputAdapter
-                                                                                                                                  Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                                    ReusedSubquery [d_date_sk] #2
-                                                                                                                            InputAdapter
-                                                                                                                              ReusedExchange [d_date_sk] #9
-                                                                                                                        InputAdapter
-                                                                                                                          BroadcastExchange #13
-                                                                                                                            WholeStageCodegen (7)
-                                                                                                                              Filter [i_item_sk]
-                                                                                                                                ColumnarToRow
-                                                                                                                                  InputAdapter
-                                                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                      InputAdapter
-                                                                        WholeStageCodegen (17)
-                                                                          Sort [i_brand_id,i_class_id,i_category_id]
-                                                                            InputAdapter
-                                                                              Exchange [i_brand_id,i_class_id,i_category_id] #14
-                                                                                WholeStageCodegen (16)
-                                                                                  Project [i_brand_id,i_class_id,i_category_id]
-                                                                                    BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                      Project [ws_item_sk]
-                                                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                          Filter [ws_item_sk]
-                                                                                            ColumnarToRow
+                                                                        Exchange [brand_id,class_id,category_id] #7
+                                                                          WholeStageCodegen (13)
+                                                                            HashAggregate [brand_id,class_id,category_id]
+                                                                              InputAdapter
+                                                                                Exchange [brand_id,class_id,category_id] #8
+                                                                                  WholeStageCodegen (12)
+                                                                                    HashAggregate [brand_id,class_id,category_id]
+                                                                                      Project [i_brand_id,i_class_id,i_category_id]
+                                                                                        BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                          Project [ss_item_sk]
+                                                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                              Filter [ss_item_sk]
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                                      SubqueryBroadcast [d_date_sk] #2
+                                                                                                        BroadcastExchange #9
+                                                                                                          WholeStageCodegen (1)
+                                                                                                            Project [d_date_sk]
+                                                                                                              Filter [d_year,d_date_sk]
+                                                                                                                ColumnarToRow
+                                                                                                                  InputAdapter
+                                                                                                                    Scan parquet default.date_dim [d_date_sk,d_year]
                                                                                               InputAdapter
-                                                                                                Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                                  ReusedSubquery [d_date_sk] #2
+                                                                                                ReusedExchange [d_date_sk] #9
                                                                                           InputAdapter
-                                                                                            ReusedExchange [d_date_sk] #9
-                                                                                      InputAdapter
-                                                                                        ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
+                                                                                            BroadcastExchange #10
+                                                                                              WholeStageCodegen (11)
+                                                                                                SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                                  InputAdapter
+                                                                                                    WholeStageCodegen (6)
+                                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                        InputAdapter
+                                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                                            WholeStageCodegen (5)
+                                                                                                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                                ColumnarToRow
+                                                                                                                  InputAdapter
+                                                                                                                    Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                  InputAdapter
+                                                                                                    WholeStageCodegen (10)
+                                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                        InputAdapter
+                                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #12
+                                                                                                            WholeStageCodegen (9)
+                                                                                                              Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                  Project [cs_item_sk]
+                                                                                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                                      Filter [cs_item_sk]
+                                                                                                                        ColumnarToRow
+                                                                                                                          InputAdapter
+                                                                                                                            Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                                              ReusedSubquery [d_date_sk] #2
+                                                                                                                      InputAdapter
+                                                                                                                        ReusedExchange [d_date_sk] #9
+                                                                                                                  InputAdapter
+                                                                                                                    BroadcastExchange #13
+                                                                                                                      WholeStageCodegen (8)
+                                                                                                                        Filter [i_item_sk]
+                                                                                                                          ColumnarToRow
+                                                                                                                            InputAdapter
+                                                                                                                              Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                InputAdapter
+                                                                  WholeStageCodegen (18)
+                                                                    Sort [i_brand_id,i_class_id,i_category_id]
+                                                                      InputAdapter
+                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #14
+                                                                          WholeStageCodegen (17)
+                                                                            Project [i_brand_id,i_class_id,i_category_id]
+                                                                              BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                Project [ws_item_sk]
+                                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                    Filter [ws_item_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                                            ReusedSubquery [d_date_sk] #2
+                                                                                    InputAdapter
+                                                                                      ReusedExchange [d_date_sk] #9
+                                                                                InputAdapter
+                                                                                  ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
                                             InputAdapter
                                               ReusedExchange [d_date_sk] #4
                                         InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -18,57 +18,57 @@ TakeOrderedAndProject (99)
    :                 :     :  +- * Sort (59)
    :                 :     :     +- Exchange (58)
    :                 :     :        +- * Project (57)
-   :                 :     :           +- * BroadcastHashJoin Inner BuildRight (56)
-   :                 :     :              :- * Filter (8)
-   :                 :     :              :  +- * ColumnarToRow (7)
-   :                 :     :              :     +- Scan parquet default.item (6)
-   :                 :     :              +- BroadcastExchange (55)
-   :                 :     :                 +- * SortMergeJoin LeftSemi (54)
-   :                 :     :                    :- * Sort (42)
-   :                 :     :                    :  +- Exchange (41)
-   :                 :     :                    :     +- * HashAggregate (40)
-   :                 :     :                    :        +- Exchange (39)
-   :                 :     :                    :           +- * HashAggregate (38)
-   :                 :     :                    :              +- * Project (37)
-   :                 :     :                    :                 +- * BroadcastHashJoin Inner BuildRight (36)
-   :                 :     :                    :                    :- * Project (14)
-   :                 :     :                    :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-   :                 :     :                    :                    :     :- * Filter (11)
-   :                 :     :                    :                    :     :  +- * ColumnarToRow (10)
-   :                 :     :                    :                    :     :     +- Scan parquet default.store_sales (9)
-   :                 :     :                    :                    :     +- ReusedExchange (12)
-   :                 :     :                    :                    +- BroadcastExchange (35)
-   :                 :     :                    :                       +- * SortMergeJoin LeftSemi (34)
-   :                 :     :                    :                          :- * Sort (19)
-   :                 :     :                    :                          :  +- Exchange (18)
-   :                 :     :                    :                          :     +- * Filter (17)
-   :                 :     :                    :                          :        +- * ColumnarToRow (16)
-   :                 :     :                    :                          :           +- Scan parquet default.item (15)
-   :                 :     :                    :                          +- * Sort (33)
-   :                 :     :                    :                             +- Exchange (32)
-   :                 :     :                    :                                +- * Project (31)
-   :                 :     :                    :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-   :                 :     :                    :                                      :- * Project (25)
-   :                 :     :                    :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-   :                 :     :                    :                                      :     :- * Filter (22)
-   :                 :     :                    :                                      :     :  +- * ColumnarToRow (21)
-   :                 :     :                    :                                      :     :     +- Scan parquet default.catalog_sales (20)
-   :                 :     :                    :                                      :     +- ReusedExchange (23)
-   :                 :     :                    :                                      +- BroadcastExchange (29)
-   :                 :     :                    :                                         +- * Filter (28)
-   :                 :     :                    :                                            +- * ColumnarToRow (27)
-   :                 :     :                    :                                               +- Scan parquet default.item (26)
-   :                 :     :                    +- * Sort (53)
-   :                 :     :                       +- Exchange (52)
-   :                 :     :                          +- * Project (51)
-   :                 :     :                             +- * BroadcastHashJoin Inner BuildRight (50)
-   :                 :     :                                :- * Project (48)
-   :                 :     :                                :  +- * BroadcastHashJoin Inner BuildRight (47)
-   :                 :     :                                :     :- * Filter (45)
-   :                 :     :                                :     :  +- * ColumnarToRow (44)
-   :                 :     :                                :     :     +- Scan parquet default.web_sales (43)
-   :                 :     :                                :     +- ReusedExchange (46)
-   :                 :     :                                +- ReusedExchange (49)
+   :                 :     :           +- * BroadcastHashJoin Inner BuildLeft (56)
+   :                 :     :              :- BroadcastExchange (9)
+   :                 :     :              :  +- * Filter (8)
+   :                 :     :              :     +- * ColumnarToRow (7)
+   :                 :     :              :        +- Scan parquet default.item (6)
+   :                 :     :              +- * SortMergeJoin LeftSemi (55)
+   :                 :     :                 :- * Sort (43)
+   :                 :     :                 :  +- Exchange (42)
+   :                 :     :                 :     +- * HashAggregate (41)
+   :                 :     :                 :        +- Exchange (40)
+   :                 :     :                 :           +- * HashAggregate (39)
+   :                 :     :                 :              +- * Project (38)
+   :                 :     :                 :                 +- * BroadcastHashJoin Inner BuildRight (37)
+   :                 :     :                 :                    :- * Project (15)
+   :                 :     :                 :                    :  +- * BroadcastHashJoin Inner BuildRight (14)
+   :                 :     :                 :                    :     :- * Filter (12)
+   :                 :     :                 :                    :     :  +- * ColumnarToRow (11)
+   :                 :     :                 :                    :     :     +- Scan parquet default.store_sales (10)
+   :                 :     :                 :                    :     +- ReusedExchange (13)
+   :                 :     :                 :                    +- BroadcastExchange (36)
+   :                 :     :                 :                       +- * SortMergeJoin LeftSemi (35)
+   :                 :     :                 :                          :- * Sort (20)
+   :                 :     :                 :                          :  +- Exchange (19)
+   :                 :     :                 :                          :     +- * Filter (18)
+   :                 :     :                 :                          :        +- * ColumnarToRow (17)
+   :                 :     :                 :                          :           +- Scan parquet default.item (16)
+   :                 :     :                 :                          +- * Sort (34)
+   :                 :     :                 :                             +- Exchange (33)
+   :                 :     :                 :                                +- * Project (32)
+   :                 :     :                 :                                   +- * BroadcastHashJoin Inner BuildRight (31)
+   :                 :     :                 :                                      :- * Project (26)
+   :                 :     :                 :                                      :  +- * BroadcastHashJoin Inner BuildRight (25)
+   :                 :     :                 :                                      :     :- * Filter (23)
+   :                 :     :                 :                                      :     :  +- * ColumnarToRow (22)
+   :                 :     :                 :                                      :     :     +- Scan parquet default.catalog_sales (21)
+   :                 :     :                 :                                      :     +- ReusedExchange (24)
+   :                 :     :                 :                                      +- BroadcastExchange (30)
+   :                 :     :                 :                                         +- * Filter (29)
+   :                 :     :                 :                                            +- * ColumnarToRow (28)
+   :                 :     :                 :                                               +- Scan parquet default.item (27)
+   :                 :     :                 +- * Sort (54)
+   :                 :     :                    +- Exchange (53)
+   :                 :     :                       +- * Project (52)
+   :                 :     :                          +- * BroadcastHashJoin Inner BuildRight (51)
+   :                 :     :                             :- * Project (49)
+   :                 :     :                             :  +- * BroadcastHashJoin Inner BuildRight (48)
+   :                 :     :                             :     :- * Filter (46)
+   :                 :     :                             :     :  +- * ColumnarToRow (45)
+   :                 :     :                             :     :     +- Scan parquet default.web_sales (44)
+   :                 :     :                             :     +- ReusedExchange (47)
+   :                 :     :                             +- ReusedExchange (50)
    :                 :     +- ReusedExchange (61)
    :                 +- BroadcastExchange (72)
    :                    +- * SortMergeJoin LeftSemi (71)
@@ -130,232 +130,232 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 19]
+(7) ColumnarToRow [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 
-(8) Filter [codegen id : 19]
+(8) Filter [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(9) BroadcastExchange
+Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[2, int, false], input[3, int, false]),false), [id=#11]
+
+(10) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#13), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(11) ColumnarToRow [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(12) Filter [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
+Condition : isnotnull(ss_item_sk#12)
 
-(12) ReusedExchange [Reuses operator id: 132]
-Output [1]: [d_date_sk#14]
+(13) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#15]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(14) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_sold_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(15) Project [codegen id : 12]
+Output [1]: [ss_item_sk#12]
+Input [3]: [ss_item_sk#12, ss_sold_date_sk#13, d_date_sk#15]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(16) Scan parquet default.item
+Output [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(17) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(18) Filter [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Condition : (((isnotnull(i_item_sk#16) AND isnotnull(i_brand_id#17)) AND isnotnull(i_class_id#18)) AND isnotnull(i_category_id#19))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(19) Exchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: hashpartitioning(coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19), 5), ENSURE_REQUIREMENTS, [id=#20]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(20) Sort [codegen id : 6]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: [coalesce(i_brand_id#17, 0) ASC NULLS FIRST, isnull(i_brand_id#17) ASC NULLS FIRST, coalesce(i_class_id#18, 0) ASC NULLS FIRST, isnull(i_class_id#18) ASC NULLS FIRST, coalesce(i_category_id#19, 0) ASC NULLS FIRST, isnull(i_category_id#19) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(21) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#22), dynamicpruningexpression(cs_sold_date_sk#22 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(22) ColumnarToRow [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(23) Filter [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
+Condition : isnotnull(cs_item_sk#21)
 
-(23) ReusedExchange [Reuses operator id: 132]
-Output [1]: [d_date_sk#22]
+(24) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#23]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(25) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_sold_date_sk#22]
+Right keys [1]: [d_date_sk#23]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(26) Project [codegen id : 9]
+Output [1]: [cs_item_sk#21]
+Input [3]: [cs_item_sk#21, cs_sold_date_sk#22, d_date_sk#23]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(27) Scan parquet default.item
+Output [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(28) ColumnarToRow [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(29) Filter [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Condition : isnotnull(i_item_sk#24)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(30) BroadcastExchange
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(31) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_item_sk#21]
+Right keys [1]: [i_item_sk#24]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(32) Project [codegen id : 9]
+Output [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Input [5]: [cs_item_sk#21, i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(33) Exchange
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: hashpartitioning(coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27), 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 10]
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: [coalesce(i_brand_id#25, 0) ASC NULLS FIRST, isnull(i_brand_id#25) ASC NULLS FIRST, coalesce(i_class_id#26, 0) ASC NULLS FIRST, isnull(i_class_id#26) ASC NULLS FIRST, coalesce(i_category_id#27, 0) ASC NULLS FIRST, isnull(i_category_id#27) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(35) SortMergeJoin [codegen id : 11]
+Left keys [6]: [coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19)]
+Right keys [6]: [coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(36) BroadcastExchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(37) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_item_sk#12]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(38) Project [codegen id : 12]
+Output [3]: [i_brand_id#17 AS brand_id#31, i_class_id#18 AS class_id#32, i_category_id#19 AS category_id#33]
+Input [5]: [ss_item_sk#12, i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(39) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+(40) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(brand_id#31, class_id#32, category_id#33, 5), ENSURE_REQUIREMENTS, [id=#34]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(41) HashAggregate [codegen id : 13]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
+(42) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33), 5), ENSURE_REQUIREMENTS, [id=#35]
 
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
+(43) Sort [codegen id : 14]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: [coalesce(brand_id#31, 0) ASC NULLS FIRST, isnull(brand_id#31) ASC NULLS FIRST, coalesce(class_id#32, 0) ASC NULLS FIRST, isnull(class_id#32) ASC NULLS FIRST, coalesce(category_id#33, 0) ASC NULLS FIRST, isnull(category_id#33) ASC NULLS FIRST], false, 0
 
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(44) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#37), dynamicpruningexpression(ws_sold_date_sk#37 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(45) ColumnarToRow [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(46) Filter [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
+Condition : isnotnull(ws_item_sk#36)
 
-(46) ReusedExchange [Reuses operator id: 132]
-Output [1]: [d_date_sk#37]
+(47) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#38]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(48) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#37]
+Right keys [1]: [d_date_sk#38]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(49) Project [codegen id : 17]
+Output [1]: [ws_item_sk#36]
+Input [3]: [ws_item_sk#36, ws_sold_date_sk#37, d_date_sk#38]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(50) ReusedExchange [Reuses operator id: 30]
+Output [4]: [i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(51) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#36]
+Right keys [1]: [i_item_sk#39]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(52) Project [codegen id : 17]
+Output [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Input [5]: [ws_item_sk#36, i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(53) Exchange
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: hashpartitioning(coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42), 5), ENSURE_REQUIREMENTS, [id=#43]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(54) Sort [codegen id : 18]
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: [coalesce(i_brand_id#40, 0) ASC NULLS FIRST, isnull(i_brand_id#40) ASC NULLS FIRST, coalesce(i_class_id#41, 0) ASC NULLS FIRST, isnull(i_class_id#41) ASC NULLS FIRST, coalesce(i_category_id#42, 0) ASC NULLS FIRST, isnull(i_category_id#42) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(55) SortMergeJoin
+Left keys [6]: [coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33)]
+Right keys [6]: [coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42)]
 Join condition: None
-
-(55) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+Right keys [3]: [brand_id#31, class_id#32, category_id#33]
 Join condition: None
 
 (57) Project [codegen id : 19]
 Output [1]: [i_item_sk#7 AS ss_item_sk#44]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#31, class_id#32, category_id#33]
 
 (58) Exchange
 Input [1]: [ss_item_sk#44]
@@ -573,7 +573,7 @@ Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquer
 Output [3]: [ss_quantity#91, ss_list_price#92, ss_sold_date_sk#93]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#93), dynamicpruningexpression(ss_sold_date_sk#93 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#93), dynamicpruningexpression(ss_sold_date_sk#93 IN dynamicpruning#14)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (101) ColumnarToRow [codegen id : 2]
@@ -595,7 +595,7 @@ Input [4]: [ss_quantity#91, ss_list_price#92, ss_sold_date_sk#93, d_date_sk#94]
 Output [3]: [cs_quantity#97, cs_list_price#98, cs_sold_date_sk#99]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#99), dynamicpruningexpression(cs_sold_date_sk#99 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#99), dynamicpruningexpression(cs_sold_date_sk#99 IN dynamicpruning#14)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (106) ColumnarToRow [codegen id : 4]
@@ -617,7 +617,7 @@ Input [4]: [cs_quantity#97, cs_list_price#98, cs_sold_date_sk#99, d_date_sk#100]
 Output [3]: [ws_quantity#103, ws_list_price#104, ws_sold_date_sk#105]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#105), dynamicpruningexpression(ws_sold_date_sk#105 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#105), dynamicpruningexpression(ws_sold_date_sk#105 IN dynamicpruning#14)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (111) ColumnarToRow [codegen id : 6]
@@ -655,11 +655,11 @@ Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#95 as decimal
 Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#95 as decimal(12,2))) * promote_precision(cast(list_price#96 as decimal(12,2)))), DecimalType(18,2)))#114]
 Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#95 as decimal(12,2))) * promote_precision(cast(list_price#96 as decimal(12,2)))), DecimalType(18,2)))#114 AS average_sales#115]
 
-Subquery:2 Hosting operator id = 100 Hosting Expression = ss_sold_date_sk#93 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 100 Hosting Expression = ss_sold_date_sk#93 IN dynamicpruning#14
 
-Subquery:3 Hosting operator id = 105 Hosting Expression = cs_sold_date_sk#99 IN dynamicpruning#13
+Subquery:3 Hosting operator id = 105 Hosting Expression = cs_sold_date_sk#99 IN dynamicpruning#14
 
-Subquery:4 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#105 IN dynamicpruning#13
+Subquery:4 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#105 IN dynamicpruning#14
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (123)
@@ -716,7 +716,7 @@ Condition : (((((isnotnull(d_year#121) AND isnotnull(d_moy#122)) AND isnotnull(d
 Output [1]: [d_week_seq#120]
 Input [4]: [d_week_seq#120, d_year#121, d_moy#122, d_dom#123]
 
-Subquery:7 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
+Subquery:7 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (132)
 +- * Project (131)
    +- * Filter (130)
@@ -725,30 +725,30 @@ BroadcastExchange (132)
 
 
 (128) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#124]
+Output [2]: [d_date_sk#15, d_year#124]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (129) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#124]
+Input [2]: [d_date_sk#15, d_year#124]
 
 (130) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#124]
-Condition : (((isnotnull(d_year#124) AND (d_year#124 >= 1999)) AND (d_year#124 <= 2001)) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#15, d_year#124]
+Condition : (((isnotnull(d_year#124) AND (d_year#124 >= 1999)) AND (d_year#124 <= 2001)) AND isnotnull(d_date_sk#15))
 
 (131) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#124]
+Output [1]: [d_date_sk#15]
+Input [2]: [d_date_sk#15, d_year#124]
 
 (132) BroadcastExchange
-Input [1]: [d_date_sk#14]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#125]
 
-Subquery:8 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#22 IN dynamicpruning#14
 
-Subquery:9 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:9 Hosting operator id = 44 Hosting Expression = ws_sold_date_sk#37 IN dynamicpruning#14
 
 Subquery:10 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#65, [id=#66]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -81,100 +81,100 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       WholeStageCodegen (19)
                                         Project [i_item_sk]
                                           BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                            Filter [i_brand_id,i_class_id,i_category_id]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                             InputAdapter
                                               BroadcastExchange #5
-                                                WholeStageCodegen (18)
-                                                  SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                WholeStageCodegen (3)
+                                                  Filter [i_brand_id,i_class_id,i_category_id]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                            SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                              InputAdapter
+                                                WholeStageCodegen (14)
+                                                  Sort [brand_id,class_id,category_id]
                                                     InputAdapter
-                                                      WholeStageCodegen (13)
-                                                        Sort [brand_id,class_id,category_id]
-                                                          InputAdapter
-                                                            Exchange [brand_id,class_id,category_id] #6
-                                                              WholeStageCodegen (12)
-                                                                HashAggregate [brand_id,class_id,category_id]
-                                                                  InputAdapter
-                                                                    Exchange [brand_id,class_id,category_id] #7
-                                                                      WholeStageCodegen (11)
-                                                                        HashAggregate [brand_id,class_id,category_id]
-                                                                          Project [i_brand_id,i_class_id,i_category_id]
-                                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                              Project [ss_item_sk]
-                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                  Filter [ss_item_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                          SubqueryBroadcast [d_date_sk] #3
-                                                                                            BroadcastExchange #8
-                                                                                              WholeStageCodegen (1)
-                                                                                                Project [d_date_sk]
-                                                                                                  Filter [d_year,d_date_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk] #8
-                                                                              InputAdapter
-                                                                                BroadcastExchange #9
-                                                                                  WholeStageCodegen (10)
-                                                                                    SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                      InputAdapter
-                                                                                        WholeStageCodegen (5)
-                                                                                          Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                            InputAdapter
-                                                                                              Exchange [i_brand_id,i_class_id,i_category_id] #10
-                                                                                                WholeStageCodegen (4)
-                                                                                                  Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                      InputAdapter
-                                                                                        WholeStageCodegen (9)
-                                                                                          Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                            InputAdapter
-                                                                                              Exchange [i_brand_id,i_class_id,i_category_id] #11
-                                                                                                WholeStageCodegen (8)
-                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                      Project [cs_item_sk]
-                                                                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                          Filter [cs_item_sk]
-                                                                                                            ColumnarToRow
-                                                                                                              InputAdapter
-                                                                                                                Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                  ReusedSubquery [d_date_sk] #3
-                                                                                                          InputAdapter
-                                                                                                            ReusedExchange [d_date_sk] #8
-                                                                                                      InputAdapter
-                                                                                                        BroadcastExchange #12
-                                                                                                          WholeStageCodegen (7)
-                                                                                                            Filter [i_item_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                    InputAdapter
-                                                      WholeStageCodegen (17)
-                                                        Sort [i_brand_id,i_class_id,i_category_id]
-                                                          InputAdapter
-                                                            Exchange [i_brand_id,i_class_id,i_category_id] #13
-                                                              WholeStageCodegen (16)
-                                                                Project [i_brand_id,i_class_id,i_category_id]
-                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                    Project [ws_item_sk]
-                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                        Filter [ws_item_sk]
-                                                                          ColumnarToRow
+                                                      Exchange [brand_id,class_id,category_id] #6
+                                                        WholeStageCodegen (13)
+                                                          HashAggregate [brand_id,class_id,category_id]
+                                                            InputAdapter
+                                                              Exchange [brand_id,class_id,category_id] #7
+                                                                WholeStageCodegen (12)
+                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                        Project [ss_item_sk]
+                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                            Filter [ss_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                    SubqueryBroadcast [d_date_sk] #3
+                                                                                      BroadcastExchange #8
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [d_date_sk]
+                                                                                            Filter [d_year,d_date_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet default.date_dim [d_date_sk,d_year]
                                                                             InputAdapter
-                                                                              Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #3
+                                                                              ReusedExchange [d_date_sk] #8
                                                                         InputAdapter
-                                                                          ReusedExchange [d_date_sk] #8
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                                                                          BroadcastExchange #9
+                                                                            WholeStageCodegen (11)
+                                                                              SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                InputAdapter
+                                                                                  WholeStageCodegen (6)
+                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                      InputAdapter
+                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #10
+                                                                                          WholeStageCodegen (5)
+                                                                                            Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                InputAdapter
+                                                                                  WholeStageCodegen (10)
+                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                      InputAdapter
+                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                          WholeStageCodegen (9)
+                                                                                            Project [i_brand_id,i_class_id,i_category_id]
+                                                                                              BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                Project [cs_item_sk]
+                                                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                    Filter [cs_item_sk]
+                                                                                                      ColumnarToRow
+                                                                                                        InputAdapter
+                                                                                                          Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                            ReusedSubquery [d_date_sk] #3
+                                                                                                    InputAdapter
+                                                                                                      ReusedExchange [d_date_sk] #8
+                                                                                                InputAdapter
+                                                                                                  BroadcastExchange #12
+                                                                                                    WholeStageCodegen (8)
+                                                                                                      Filter [i_item_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                              InputAdapter
+                                                WholeStageCodegen (18)
+                                                  Sort [i_brand_id,i_class_id,i_category_id]
+                                                    InputAdapter
+                                                      Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                        WholeStageCodegen (17)
+                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                              Project [ws_item_sk]
+                                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                  Filter [ws_item_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                          ReusedSubquery [d_date_sk] #3
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk] #8
+                                                              InputAdapter
+                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
                           InputAdapter
                             ReusedExchange [d_date_sk] #3
                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -1,32 +1,34 @@
 == Physical Plan ==
-TakeOrderedAndProject (28)
-+- * HashAggregate (27)
-   +- Exchange (26)
-      +- * HashAggregate (25)
-         +- * Project (24)
-            +- * SortMergeJoin Inner (23)
-               :- * Sort (16)
-               :  +- Exchange (15)
-               :     +- * Project (14)
-               :        +- * BroadcastHashJoin Inner BuildRight (13)
-               :           :- * Project (11)
-               :           :  +- * BroadcastHashJoin Inner BuildLeft (10)
-               :           :     :- BroadcastExchange (5)
-               :           :     :  +- * Project (4)
-               :           :     :     +- * Filter (3)
-               :           :     :        +- * ColumnarToRow (2)
-               :           :     :           +- Scan parquet default.item (1)
-               :           :     +- * Project (9)
-               :           :        +- * Filter (8)
-               :           :           +- * ColumnarToRow (7)
-               :           :              +- Scan parquet default.inventory (6)
-               :           +- ReusedExchange (12)
-               +- * Sort (22)
-                  +- Exchange (21)
-                     +- * Project (20)
-                        +- * Filter (19)
-                           +- * ColumnarToRow (18)
-                              +- Scan parquet default.catalog_sales (17)
+TakeOrderedAndProject (30)
++- * HashAggregate (29)
+   +- Exchange (28)
+      +- * HashAggregate (27)
+         +- * Project (26)
+            +- * SortMergeJoin Inner (25)
+               :- * Sort (17)
+               :  +- Exchange (16)
+               :     +- * HashAggregate (15)
+               :        +- * Project (14)
+               :           +- * BroadcastHashJoin Inner BuildRight (13)
+               :              :- * Project (11)
+               :              :  +- * BroadcastHashJoin Inner BuildLeft (10)
+               :              :     :- BroadcastExchange (5)
+               :              :     :  +- * Project (4)
+               :              :     :     +- * Filter (3)
+               :              :     :        +- * ColumnarToRow (2)
+               :              :     :           +- Scan parquet default.item (1)
+               :              :     +- * Project (9)
+               :              :        +- * Filter (8)
+               :              :           +- * ColumnarToRow (7)
+               :              :              +- Scan parquet default.inventory (6)
+               :              +- ReusedExchange (12)
+               +- * Sort (24)
+                  +- Exchange (23)
+                     +- * HashAggregate (22)
+                        +- * Project (21)
+                           +- * Filter (20)
+                              +- * ColumnarToRow (19)
+                                 +- Scan parquet default.catalog_sales (18)
 
 
 (1) Scan parquet default.item
@@ -79,7 +81,7 @@ Join condition: None
 Output [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#9]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#7, inv_date_sk#9]
 
-(12) ReusedExchange [Reuses operator id: 33]
+(12) ReusedExchange [Reuses operator id: 35]
 Output [1]: [d_date_sk#11]
 
 (13) BroadcastHashJoin [codegen id : 3]
@@ -91,100 +93,114 @@ Join condition: None
 Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#9, d_date_sk#11]
 
-(15) Exchange
+(15) HashAggregate [codegen id : 3]
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Keys [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+Functions: []
+Aggregate Attributes: []
+Results [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+
+(16) Exchange
+Input [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
 Arguments: hashpartitioning(i_item_sk#1, 5), ENSURE_REQUIREMENTS, [id=#12]
 
-(16) Sort [codegen id : 4]
-Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+(17) Sort [codegen id : 4]
+Input [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
 Arguments: [i_item_sk#1 ASC NULLS FIRST], false, 0
 
-(17) Scan parquet default.catalog_sales
+(18) Scan parquet default.catalog_sales
 Output [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(18) ColumnarToRow [codegen id : 5]
+(19) ColumnarToRow [codegen id : 5]
 Input [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 
-(19) Filter [codegen id : 5]
+(20) Filter [codegen id : 5]
 Input [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 Condition : isnotnull(cs_item_sk#13)
 
-(20) Project [codegen id : 5]
+(21) Project [codegen id : 5]
 Output [1]: [cs_item_sk#13]
 Input [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 
-(21) Exchange
+(22) HashAggregate [codegen id : 5]
+Input [1]: [cs_item_sk#13]
+Keys [1]: [cs_item_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [cs_item_sk#13]
+
+(23) Exchange
 Input [1]: [cs_item_sk#13]
 Arguments: hashpartitioning(cs_item_sk#13, 5), ENSURE_REQUIREMENTS, [id=#15]
 
-(22) Sort [codegen id : 6]
+(24) Sort [codegen id : 6]
 Input [1]: [cs_item_sk#13]
 Arguments: [cs_item_sk#13 ASC NULLS FIRST], false, 0
 
-(23) SortMergeJoin [codegen id : 7]
+(25) SortMergeJoin [codegen id : 7]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#13]
 Join condition: None
 
-(24) Project [codegen id : 7]
+(26) Project [codegen id : 7]
 Output [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, cs_item_sk#13]
+Input [5]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1, cs_item_sk#13]
 
-(25) HashAggregate [codegen id : 7]
+(27) HashAggregate [codegen id : 7]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(26) Exchange
+(28) Exchange
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [id=#16]
 
-(27) HashAggregate [codegen id : 8]
+(29) HashAggregate [codegen id : 8]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(28) TakeOrderedAndProject
+(30) TakeOrderedAndProject
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: 100, [i_item_id#2 ASC NULLS FIRST], [i_item_id#2, i_item_desc#3, i_current_price#4]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = inv_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (33)
-+- * Project (32)
-   +- * Filter (31)
-      +- * ColumnarToRow (30)
-         +- Scan parquet default.date_dim (29)
+BroadcastExchange (35)
++- * Project (34)
+   +- * Filter (33)
+      +- * ColumnarToRow (32)
+         +- Scan parquet default.date_dim (31)
 
 
-(29) Scan parquet default.date_dim
+(31) Scan parquet default.date_dim
 Output [2]: [d_date_sk#11, d_date#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(30) ColumnarToRow [codegen id : 1]
+(32) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#17]
 
-(31) Filter [codegen id : 1]
+(33) Filter [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#17]
 Condition : (((isnotnull(d_date#17) AND (d_date#17 >= 2000-02-01)) AND (d_date#17 <= 2000-04-01)) AND isnotnull(d_date_sk#11))
 
-(32) Project [codegen id : 1]
+(34) Project [codegen id : 1]
 Output [1]: [d_date_sk#11]
 Input [2]: [d_date_sk#11, d_date#17]
 
-(33) BroadcastExchange
+(35) BroadcastExchange
 Input [1]: [d_date_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
@@ -13,41 +13,43 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                         InputAdapter
                           Exchange [i_item_sk] #2
                             WholeStageCodegen (3)
-                              Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                BroadcastHashJoin [inv_date_sk,d_date_sk]
-                                  Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
-                                    BroadcastHashJoin [i_item_sk,inv_item_sk]
-                                      InputAdapter
-                                        BroadcastExchange #3
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
-                                      Project [inv_item_sk,inv_date_sk]
-                                        Filter [inv_quantity_on_hand,inv_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #4
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_date,d_date_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.date_dim [d_date_sk,d_date]
-                                  InputAdapter
-                                    ReusedExchange [d_date_sk] #4
+                              HashAggregate [i_item_id,i_item_desc,i_current_price,i_item_sk]
+                                Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                  BroadcastHashJoin [inv_date_sk,d_date_sk]
+                                    Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
+                                      BroadcastHashJoin [i_item_sk,inv_item_sk]
+                                        InputAdapter
+                                          BroadcastExchange #3
+                                            WholeStageCodegen (1)
+                                              Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                                Filter [i_current_price,i_manufact_id,i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
+                                        Project [inv_item_sk,inv_date_sk]
+                                          Filter [inv_quantity_on_hand,inv_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
+                                                  SubqueryBroadcast [d_date_sk] #1
+                                                    BroadcastExchange #4
+                                                      WholeStageCodegen (1)
+                                                        Project [d_date_sk]
+                                                          Filter [d_date,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.date_dim [d_date_sk,d_date]
+                                    InputAdapter
+                                      ReusedExchange [d_date_sk] #4
                   InputAdapter
                     WholeStageCodegen (6)
                       Sort [cs_item_sk]
                         InputAdapter
                           Exchange [cs_item_sk] #5
                             WholeStageCodegen (5)
-                              Project [cs_item_sk]
-                                Filter [cs_item_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                              HashAggregate [cs_item_sk]
+                                Project [cs_item_sk]
+                                  Filter [cs_item_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/explain.txt
@@ -1,29 +1,31 @@
 == Physical Plan ==
-TakeOrderedAndProject (25)
-+- * HashAggregate (24)
-   +- Exchange (23)
-      +- * HashAggregate (22)
-         +- * Project (21)
-            +- * BroadcastHashJoin Inner BuildLeft (20)
-               :- BroadcastExchange (15)
-               :  +- * Project (14)
-               :     +- * BroadcastHashJoin Inner BuildRight (13)
-               :        :- * Project (11)
-               :        :  +- * BroadcastHashJoin Inner BuildRight (10)
-               :        :     :- * Project (4)
-               :        :     :  +- * Filter (3)
-               :        :     :     +- * ColumnarToRow (2)
-               :        :     :        +- Scan parquet default.item (1)
-               :        :     +- BroadcastExchange (9)
-               :        :        +- * Project (8)
-               :        :           +- * Filter (7)
-               :        :              +- * ColumnarToRow (6)
-               :        :                 +- Scan parquet default.inventory (5)
-               :        +- ReusedExchange (12)
-               +- * Project (19)
-                  +- * Filter (18)
-                     +- * ColumnarToRow (17)
-                        +- Scan parquet default.catalog_sales (16)
+TakeOrderedAndProject (27)
++- * HashAggregate (26)
+   +- Exchange (25)
+      +- * HashAggregate (24)
+         +- * Project (23)
+            +- * BroadcastHashJoin Inner BuildLeft (22)
+               :- BroadcastExchange (16)
+               :  +- * HashAggregate (15)
+               :     +- * Project (14)
+               :        +- * BroadcastHashJoin Inner BuildRight (13)
+               :           :- * Project (11)
+               :           :  +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :     :- * Project (4)
+               :           :     :  +- * Filter (3)
+               :           :     :     +- * ColumnarToRow (2)
+               :           :     :        +- Scan parquet default.item (1)
+               :           :     +- BroadcastExchange (9)
+               :           :        +- * Project (8)
+               :           :           +- * Filter (7)
+               :           :              +- * ColumnarToRow (6)
+               :           :                 +- Scan parquet default.inventory (5)
+               :           +- ReusedExchange (12)
+               +- * HashAggregate (21)
+                  +- * Project (20)
+                     +- * Filter (19)
+                        +- * ColumnarToRow (18)
+                           +- Scan parquet default.catalog_sales (17)
 
 
 (1) Scan parquet default.item
@@ -76,7 +78,7 @@ Join condition: None
 Output [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#6, inv_date_sk#8]
 
-(12) ReusedExchange [Reuses operator id: 30]
+(12) ReusedExchange [Reuses operator id: 32]
 Output [1]: [d_date_sk#11]
 
 (13) BroadcastHashJoin [codegen id : 3]
@@ -88,88 +90,102 @@ Join condition: None
 Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8, d_date_sk#11]
 
-(15) BroadcastExchange
+(15) HashAggregate [codegen id : 3]
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Keys [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+Functions: []
+Aggregate Attributes: []
+Results [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
 
-(16) Scan parquet default.catalog_sales
+(16) BroadcastExchange
+Input [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [id=#12]
+
+(17) Scan parquet default.catalog_sales
 Output [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(17) ColumnarToRow
+(18) ColumnarToRow
 Input [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 
-(18) Filter
+(19) Filter
 Input [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 Condition : isnotnull(cs_item_sk#13)
 
-(19) Project
+(20) Project
 Output [1]: [cs_item_sk#13]
 Input [2]: [cs_item_sk#13, cs_sold_date_sk#14]
 
-(20) BroadcastHashJoin [codegen id : 4]
+(21) HashAggregate
+Input [1]: [cs_item_sk#13]
+Keys [1]: [cs_item_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [cs_item_sk#13]
+
+(22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#13]
 Join condition: None
 
-(21) Project [codegen id : 4]
+(23) Project [codegen id : 4]
 Output [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, cs_item_sk#13]
+Input [5]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1, cs_item_sk#13]
 
-(22) HashAggregate [codegen id : 4]
+(24) HashAggregate [codegen id : 4]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(23) Exchange
+(25) Exchange
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [id=#15]
 
-(24) HashAggregate [codegen id : 5]
+(26) HashAggregate [codegen id : 5]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(25) TakeOrderedAndProject
+(27) TakeOrderedAndProject
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: 100, [i_item_id#2 ASC NULLS FIRST], [i_item_id#2, i_item_desc#3, i_current_price#4]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 5 Hosting Expression = inv_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (30)
-+- * Project (29)
-   +- * Filter (28)
-      +- * ColumnarToRow (27)
-         +- Scan parquet default.date_dim (26)
+BroadcastExchange (32)
++- * Project (31)
+   +- * Filter (30)
+      +- * ColumnarToRow (29)
+         +- Scan parquet default.date_dim (28)
 
 
-(26) Scan parquet default.date_dim
+(28) Scan parquet default.date_dim
 Output [2]: [d_date_sk#11, d_date#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(27) ColumnarToRow [codegen id : 1]
+(29) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#16]
 
-(28) Filter [codegen id : 1]
+(30) Filter [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#16]
 Condition : (((isnotnull(d_date#16) AND (d_date#16 >= 2000-02-01)) AND (d_date#16 <= 2000-04-01)) AND isnotnull(d_date_sk#11))
 
-(29) Project [codegen id : 1]
+(31) Project [codegen id : 1]
 Output [1]: [d_date_sk#11]
 Input [2]: [d_date_sk#11, d_date#16]
 
-(30) BroadcastExchange
+(32) BroadcastExchange
 Input [1]: [d_date_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/simplified.txt
@@ -10,35 +10,37 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                   InputAdapter
                     BroadcastExchange #2
                       WholeStageCodegen (3)
-                        Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                          BroadcastHashJoin [inv_date_sk,d_date_sk]
-                            Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
-                              BroadcastHashJoin [i_item_sk,inv_item_sk]
-                                Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                  Filter [i_current_price,i_manufact_id,i_item_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
-                                InputAdapter
-                                  BroadcastExchange #3
-                                    WholeStageCodegen (1)
-                                      Project [inv_item_sk,inv_date_sk]
-                                        Filter [inv_quantity_on_hand,inv_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #4
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_date,d_date_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.date_dim [d_date_sk,d_date]
-                            InputAdapter
-                              ReusedExchange [d_date_sk] #4
-                  Project [cs_item_sk]
-                    Filter [cs_item_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                        HashAggregate [i_item_id,i_item_desc,i_current_price,i_item_sk]
+                          Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                            BroadcastHashJoin [inv_date_sk,d_date_sk]
+                              Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
+                                BroadcastHashJoin [i_item_sk,inv_item_sk]
+                                  Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                    Filter [i_current_price,i_manufact_id,i_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
+                                  InputAdapter
+                                    BroadcastExchange #3
+                                      WholeStageCodegen (1)
+                                        Project [inv_item_sk,inv_date_sk]
+                                          Filter [inv_quantity_on_hand,inv_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
+                                                  SubqueryBroadcast [d_date_sk] #1
+                                                    BroadcastExchange #4
+                                                      WholeStageCodegen (1)
+                                                        Project [d_date_sk]
+                                                          Filter [d_date,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.date_dim [d_date_sk,d_date]
+                              InputAdapter
+                                ReusedExchange [d_date_sk] #4
+                  HashAggregate [cs_item_sk]
+                    Project [cs_item_sk]
+                      Filter [cs_item_sk]
+                        ColumnarToRow
+                          InputAdapter
+                            Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
@@ -1,64 +1,68 @@
 == Physical Plan ==
-* HashAggregate (60)
-+- Exchange (59)
-   +- * HashAggregate (58)
-      +- * Project (57)
-         +- * SortMergeJoin LeftSemi (56)
-            :- * SortMergeJoin LeftSemi (38)
-            :  :- * Sort (20)
-            :  :  +- Exchange (19)
-            :  :     +- * HashAggregate (18)
-            :  :        +- Exchange (17)
-            :  :           +- * HashAggregate (16)
-            :  :              +- * Project (15)
-            :  :                 +- * SortMergeJoin Inner (14)
-            :  :                    :- * Sort (8)
-            :  :                    :  +- Exchange (7)
-            :  :                    :     +- * Project (6)
-            :  :                    :        +- * BroadcastHashJoin Inner BuildRight (5)
-            :  :                    :           :- * Filter (3)
-            :  :                    :           :  +- * ColumnarToRow (2)
-            :  :                    :           :     +- Scan parquet default.store_sales (1)
-            :  :                    :           +- ReusedExchange (4)
-            :  :                    +- * Sort (13)
-            :  :                       +- Exchange (12)
-            :  :                          +- * Filter (11)
-            :  :                             +- * ColumnarToRow (10)
-            :  :                                +- Scan parquet default.customer (9)
-            :  +- * Sort (37)
-            :     +- Exchange (36)
-            :        +- * HashAggregate (35)
-            :           +- Exchange (34)
-            :              +- * HashAggregate (33)
-            :                 +- * Project (32)
-            :                    +- * SortMergeJoin Inner (31)
-            :                       :- * Sort (28)
-            :                       :  +- Exchange (27)
-            :                       :     +- * Project (26)
-            :                       :        +- * BroadcastHashJoin Inner BuildRight (25)
-            :                       :           :- * Filter (23)
-            :                       :           :  +- * ColumnarToRow (22)
-            :                       :           :     +- Scan parquet default.catalog_sales (21)
-            :                       :           +- ReusedExchange (24)
-            :                       +- * Sort (30)
-            :                          +- ReusedExchange (29)
-            +- * Sort (55)
-               +- Exchange (54)
-                  +- * HashAggregate (53)
-                     +- Exchange (52)
-                        +- * HashAggregate (51)
-                           +- * Project (50)
-                              +- * SortMergeJoin Inner (49)
-                                 :- * Sort (46)
-                                 :  +- Exchange (45)
-                                 :     +- * Project (44)
-                                 :        +- * BroadcastHashJoin Inner BuildRight (43)
-                                 :           :- * Filter (41)
-                                 :           :  +- * ColumnarToRow (40)
-                                 :           :     +- Scan parquet default.web_sales (39)
-                                 :           +- ReusedExchange (42)
-                                 +- * Sort (48)
-                                    +- ReusedExchange (47)
+* HashAggregate (64)
++- Exchange (63)
+   +- * HashAggregate (62)
+      +- * Project (61)
+         +- * SortMergeJoin LeftSemi (60)
+            :- * SortMergeJoin LeftSemi (41)
+            :  :- * Sort (22)
+            :  :  +- Exchange (21)
+            :  :     +- * HashAggregate (20)
+            :  :        +- Exchange (19)
+            :  :           +- * HashAggregate (18)
+            :  :              +- * Project (17)
+            :  :                 +- * SortMergeJoin Inner (16)
+            :  :                    :- * Sort (9)
+            :  :                    :  +- Exchange (8)
+            :  :                    :     +- * HashAggregate (7)
+            :  :                    :        +- * Project (6)
+            :  :                    :           +- * BroadcastHashJoin Inner BuildRight (5)
+            :  :                    :              :- * Filter (3)
+            :  :                    :              :  +- * ColumnarToRow (2)
+            :  :                    :              :     +- Scan parquet default.store_sales (1)
+            :  :                    :              +- ReusedExchange (4)
+            :  :                    +- * Sort (15)
+            :  :                       +- Exchange (14)
+            :  :                          +- * HashAggregate (13)
+            :  :                             +- * Filter (12)
+            :  :                                +- * ColumnarToRow (11)
+            :  :                                   +- Scan parquet default.customer (10)
+            :  +- * Sort (40)
+            :     +- Exchange (39)
+            :        +- * HashAggregate (38)
+            :           +- Exchange (37)
+            :              +- * HashAggregate (36)
+            :                 +- * Project (35)
+            :                    +- * SortMergeJoin Inner (34)
+            :                       :- * Sort (31)
+            :                       :  +- Exchange (30)
+            :                       :     +- * HashAggregate (29)
+            :                       :        +- * Project (28)
+            :                       :           +- * BroadcastHashJoin Inner BuildRight (27)
+            :                       :              :- * Filter (25)
+            :                       :              :  +- * ColumnarToRow (24)
+            :                       :              :     +- Scan parquet default.catalog_sales (23)
+            :                       :              +- ReusedExchange (26)
+            :                       +- * Sort (33)
+            :                          +- ReusedExchange (32)
+            +- * Sort (59)
+               +- Exchange (58)
+                  +- * HashAggregate (57)
+                     +- Exchange (56)
+                        +- * HashAggregate (55)
+                           +- * Project (54)
+                              +- * SortMergeJoin Inner (53)
+                                 :- * Sort (50)
+                                 :  +- Exchange (49)
+                                 :     +- * HashAggregate (48)
+                                 :        +- * Project (47)
+                                 :           +- * BroadcastHashJoin Inner BuildRight (46)
+                                 :              :- * Filter (44)
+                                 :              :  +- * ColumnarToRow (43)
+                                 :              :     +- Scan parquet default.web_sales (42)
+                                 :              +- ReusedExchange (45)
+                                 +- * Sort (52)
+                                    +- ReusedExchange (51)
 
 
 (1) Scan parquet default.store_sales
@@ -76,7 +80,7 @@ Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
 Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
 Condition : isnotnull(ss_customer_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 65]
+(4) ReusedExchange [Reuses operator id: 69]
 Output [2]: [d_date_sk#4, d_date#5]
 
 (5) BroadcastHashJoin [codegen id : 2]
@@ -88,58 +92,61 @@ Join condition: None
 Output [2]: [ss_customer_sk#1, d_date#5]
 Input [4]: [ss_customer_sk#1, ss_sold_date_sk#2, d_date_sk#4, d_date#5]
 
-(7) Exchange
+(7) HashAggregate [codegen id : 2]
 Input [2]: [ss_customer_sk#1, d_date#5]
+Keys [2]: [d_date#5, ss_customer_sk#1]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [d_date#5, ss_customer_sk#1]
+
+(8) Exchange
+Input [2]: [d_date#5, ss_customer_sk#1]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [id=#6]
 
-(8) Sort [codegen id : 3]
-Input [2]: [ss_customer_sk#1, d_date#5]
+(9) Sort [codegen id : 3]
+Input [2]: [d_date#5, ss_customer_sk#1]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet default.customer
+(10) Scan parquet default.customer
 Output [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(10) ColumnarToRow [codegen id : 4]
+(11) ColumnarToRow [codegen id : 4]
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 
-(11) Filter [codegen id : 4]
+(12) Filter [codegen id : 4]
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 Condition : isnotnull(c_customer_sk#7)
 
-(12) Exchange
+(13) HashAggregate [codegen id : 4]
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
+Keys [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
+
+(14) Exchange
+Input [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
 Arguments: hashpartitioning(c_customer_sk#7, 5), ENSURE_REQUIREMENTS, [id=#10]
 
-(13) Sort [codegen id : 5]
-Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
+(15) Sort [codegen id : 5]
+Input [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
 Arguments: [c_customer_sk#7 ASC NULLS FIRST], false, 0
 
-(14) SortMergeJoin [codegen id : 6]
+(16) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#7]
 Join condition: None
 
-(15) Project [codegen id : 6]
-Output [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Input [5]: [ss_customer_sk#1, d_date#5, c_customer_sk#7, c_first_name#8, c_last_name#9]
+(17) Project [codegen id : 6]
+Output [3]: [d_date#5, c_last_name#9, c_first_name#8]
+Input [5]: [d_date#5, ss_customer_sk#1, c_last_name#9, c_first_name#8, c_customer_sk#7]
 
-(16) HashAggregate [codegen id : 6]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#5]
-
-(17) Exchange
-Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#5, 5), ENSURE_REQUIREMENTS, [id=#11]
-
-(18) HashAggregate [codegen id : 7]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
+(18) HashAggregate [codegen id : 6]
+Input [3]: [d_date#5, c_last_name#9, c_first_name#8]
 Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Functions: []
 Aggregate Attributes: []
@@ -147,13 +154,24 @@ Results [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
 (19) Exchange
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
+Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#5, 5), ENSURE_REQUIREMENTS, [id=#11]
+
+(20) HashAggregate [codegen id : 7]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#5]
+
+(21) Exchange
+Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Arguments: hashpartitioning(coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#5, 1970-01-01), isnull(d_date#5), 5), ENSURE_REQUIREMENTS, [id=#12]
 
-(20) Sort [codegen id : 8]
+(22) Sort [codegen id : 8]
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Arguments: [coalesce(c_last_name#9, ) ASC NULLS FIRST, isnull(c_last_name#9) ASC NULLS FIRST, coalesce(c_first_name#8, ) ASC NULLS FIRST, isnull(c_first_name#8) ASC NULLS FIRST, coalesce(d_date#5, 1970-01-01) ASC NULLS FIRST, isnull(d_date#5) ASC NULLS FIRST], false, 0
 
-(21) Scan parquet default.catalog_sales
+(23) Scan parquet default.catalog_sales
 Output [2]: [cs_bill_customer_sk#13, cs_sold_date_sk#14]
 Batched: true
 Location: InMemoryFileIndex []
@@ -161,81 +179,88 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int>
 
-(22) ColumnarToRow [codegen id : 10]
+(24) ColumnarToRow [codegen id : 10]
 Input [2]: [cs_bill_customer_sk#13, cs_sold_date_sk#14]
 
-(23) Filter [codegen id : 10]
+(25) Filter [codegen id : 10]
 Input [2]: [cs_bill_customer_sk#13, cs_sold_date_sk#14]
 Condition : isnotnull(cs_bill_customer_sk#13)
 
-(24) ReusedExchange [Reuses operator id: 65]
+(26) ReusedExchange [Reuses operator id: 69]
 Output [2]: [d_date_sk#15, d_date#16]
 
-(25) BroadcastHashJoin [codegen id : 10]
+(27) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
 Join condition: None
 
-(26) Project [codegen id : 10]
+(28) Project [codegen id : 10]
 Output [2]: [cs_bill_customer_sk#13, d_date#16]
 Input [4]: [cs_bill_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15, d_date#16]
 
-(27) Exchange
+(29) HashAggregate [codegen id : 10]
 Input [2]: [cs_bill_customer_sk#13, d_date#16]
+Keys [2]: [d_date#16, cs_bill_customer_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [d_date#16, cs_bill_customer_sk#13]
+
+(30) Exchange
+Input [2]: [d_date#16, cs_bill_customer_sk#13]
 Arguments: hashpartitioning(cs_bill_customer_sk#13, 5), ENSURE_REQUIREMENTS, [id=#17]
 
-(28) Sort [codegen id : 11]
-Input [2]: [cs_bill_customer_sk#13, d_date#16]
+(31) Sort [codegen id : 11]
+Input [2]: [d_date#16, cs_bill_customer_sk#13]
 Arguments: [cs_bill_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(29) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#18, c_first_name#19, c_last_name#20]
+(32) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_last_name#18, c_first_name#19, c_customer_sk#20]
 
-(30) Sort [codegen id : 13]
-Input [3]: [c_customer_sk#18, c_first_name#19, c_last_name#20]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(33) Sort [codegen id : 13]
+Input [3]: [c_last_name#18, c_first_name#19, c_customer_sk#20]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 
-(31) SortMergeJoin [codegen id : 14]
+(34) SortMergeJoin [codegen id : 14]
 Left keys [1]: [cs_bill_customer_sk#13]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join condition: None
 
-(32) Project [codegen id : 14]
-Output [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Input [5]: [cs_bill_customer_sk#13, d_date#16, c_customer_sk#18, c_first_name#19, c_last_name#20]
+(35) Project [codegen id : 14]
+Output [3]: [d_date#16, c_last_name#18, c_first_name#19]
+Input [5]: [d_date#16, cs_bill_customer_sk#13, c_last_name#18, c_first_name#19, c_customer_sk#20]
 
-(33) HashAggregate [codegen id : 14]
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
+(36) HashAggregate [codegen id : 14]
+Input [3]: [d_date#16, c_last_name#18, c_first_name#19]
+Keys [3]: [c_last_name#18, c_first_name#19, d_date#16]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#20, c_first_name#19, d_date#16]
+Results [3]: [c_last_name#18, c_first_name#19, d_date#16]
 
-(34) Exchange
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Arguments: hashpartitioning(c_last_name#20, c_first_name#19, d_date#16, 5), ENSURE_REQUIREMENTS, [id=#21]
+(37) Exchange
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Arguments: hashpartitioning(c_last_name#18, c_first_name#19, d_date#16, 5), ENSURE_REQUIREMENTS, [id=#21]
 
-(35) HashAggregate [codegen id : 15]
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
+(38) HashAggregate [codegen id : 15]
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Keys [3]: [c_last_name#18, c_first_name#19, d_date#16]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#20, c_first_name#19, d_date#16]
+Results [3]: [c_last_name#18, c_first_name#19, d_date#16]
 
-(36) Exchange
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Arguments: hashpartitioning(coalesce(c_last_name#20, ), isnull(c_last_name#20), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16), 5), ENSURE_REQUIREMENTS, [id=#22]
+(39) Exchange
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Arguments: hashpartitioning(coalesce(c_last_name#18, ), isnull(c_last_name#18), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16), 5), ENSURE_REQUIREMENTS, [id=#22]
 
-(37) Sort [codegen id : 16]
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Arguments: [coalesce(c_last_name#20, ) ASC NULLS FIRST, isnull(c_last_name#20) ASC NULLS FIRST, coalesce(c_first_name#19, ) ASC NULLS FIRST, isnull(c_first_name#19) ASC NULLS FIRST, coalesce(d_date#16, 1970-01-01) ASC NULLS FIRST, isnull(d_date#16) ASC NULLS FIRST], false, 0
+(40) Sort [codegen id : 16]
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Arguments: [coalesce(c_last_name#18, ) ASC NULLS FIRST, isnull(c_last_name#18) ASC NULLS FIRST, coalesce(c_first_name#19, ) ASC NULLS FIRST, isnull(c_first_name#19) ASC NULLS FIRST, coalesce(d_date#16, 1970-01-01) ASC NULLS FIRST, isnull(d_date#16) ASC NULLS FIRST], false, 0
 
-(38) SortMergeJoin [codegen id : 17]
+(41) SortMergeJoin [codegen id : 17]
 Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#20, ), isnull(c_last_name#20), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16)]
+Right keys [6]: [coalesce(c_last_name#18, ), isnull(c_last_name#18), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16)]
 Join condition: None
 
-(39) Scan parquet default.web_sales
+(42) Scan parquet default.web_sales
 Output [2]: [ws_bill_customer_sk#23, ws_sold_date_sk#24]
 Batched: true
 Location: InMemoryFileIndex []
@@ -243,96 +268,103 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#24), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(40) ColumnarToRow [codegen id : 19]
+(43) ColumnarToRow [codegen id : 19]
 Input [2]: [ws_bill_customer_sk#23, ws_sold_date_sk#24]
 
-(41) Filter [codegen id : 19]
+(44) Filter [codegen id : 19]
 Input [2]: [ws_bill_customer_sk#23, ws_sold_date_sk#24]
 Condition : isnotnull(ws_bill_customer_sk#23)
 
-(42) ReusedExchange [Reuses operator id: 65]
+(45) ReusedExchange [Reuses operator id: 69]
 Output [2]: [d_date_sk#25, d_date#26]
 
-(43) BroadcastHashJoin [codegen id : 19]
+(46) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#24]
 Right keys [1]: [d_date_sk#25]
 Join condition: None
 
-(44) Project [codegen id : 19]
+(47) Project [codegen id : 19]
 Output [2]: [ws_bill_customer_sk#23, d_date#26]
 Input [4]: [ws_bill_customer_sk#23, ws_sold_date_sk#24, d_date_sk#25, d_date#26]
 
-(45) Exchange
+(48) HashAggregate [codegen id : 19]
 Input [2]: [ws_bill_customer_sk#23, d_date#26]
+Keys [2]: [d_date#26, ws_bill_customer_sk#23]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [d_date#26, ws_bill_customer_sk#23]
+
+(49) Exchange
+Input [2]: [d_date#26, ws_bill_customer_sk#23]
 Arguments: hashpartitioning(ws_bill_customer_sk#23, 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(46) Sort [codegen id : 20]
-Input [2]: [ws_bill_customer_sk#23, d_date#26]
+(50) Sort [codegen id : 20]
+Input [2]: [d_date#26, ws_bill_customer_sk#23]
 Arguments: [ws_bill_customer_sk#23 ASC NULLS FIRST], false, 0
 
-(47) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#28, c_first_name#29, c_last_name#30]
+(51) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_last_name#28, c_first_name#29, c_customer_sk#30]
 
-(48) Sort [codegen id : 22]
-Input [3]: [c_customer_sk#28, c_first_name#29, c_last_name#30]
-Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
+(52) Sort [codegen id : 22]
+Input [3]: [c_last_name#28, c_first_name#29, c_customer_sk#30]
+Arguments: [c_customer_sk#30 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 23]
+(53) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#23]
-Right keys [1]: [c_customer_sk#28]
+Right keys [1]: [c_customer_sk#30]
 Join condition: None
 
-(50) Project [codegen id : 23]
-Output [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Input [5]: [ws_bill_customer_sk#23, d_date#26, c_customer_sk#28, c_first_name#29, c_last_name#30]
+(54) Project [codegen id : 23]
+Output [3]: [d_date#26, c_last_name#28, c_first_name#29]
+Input [5]: [d_date#26, ws_bill_customer_sk#23, c_last_name#28, c_first_name#29, c_customer_sk#30]
 
-(51) HashAggregate [codegen id : 23]
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
+(55) HashAggregate [codegen id : 23]
+Input [3]: [d_date#26, c_last_name#28, c_first_name#29]
+Keys [3]: [c_last_name#28, c_first_name#29, d_date#26]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#30, c_first_name#29, d_date#26]
+Results [3]: [c_last_name#28, c_first_name#29, d_date#26]
 
-(52) Exchange
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Arguments: hashpartitioning(c_last_name#30, c_first_name#29, d_date#26, 5), ENSURE_REQUIREMENTS, [id=#31]
+(56) Exchange
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Arguments: hashpartitioning(c_last_name#28, c_first_name#29, d_date#26, 5), ENSURE_REQUIREMENTS, [id=#31]
 
-(53) HashAggregate [codegen id : 24]
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
+(57) HashAggregate [codegen id : 24]
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Keys [3]: [c_last_name#28, c_first_name#29, d_date#26]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#30, c_first_name#29, d_date#26]
+Results [3]: [c_last_name#28, c_first_name#29, d_date#26]
 
-(54) Exchange
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Arguments: hashpartitioning(coalesce(c_last_name#30, ), isnull(c_last_name#30), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26), 5), ENSURE_REQUIREMENTS, [id=#32]
+(58) Exchange
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Arguments: hashpartitioning(coalesce(c_last_name#28, ), isnull(c_last_name#28), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26), 5), ENSURE_REQUIREMENTS, [id=#32]
 
-(55) Sort [codegen id : 25]
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Arguments: [coalesce(c_last_name#30, ) ASC NULLS FIRST, isnull(c_last_name#30) ASC NULLS FIRST, coalesce(c_first_name#29, ) ASC NULLS FIRST, isnull(c_first_name#29) ASC NULLS FIRST, coalesce(d_date#26, 1970-01-01) ASC NULLS FIRST, isnull(d_date#26) ASC NULLS FIRST], false, 0
+(59) Sort [codegen id : 25]
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Arguments: [coalesce(c_last_name#28, ) ASC NULLS FIRST, isnull(c_last_name#28) ASC NULLS FIRST, coalesce(c_first_name#29, ) ASC NULLS FIRST, isnull(c_first_name#29) ASC NULLS FIRST, coalesce(d_date#26, 1970-01-01) ASC NULLS FIRST, isnull(d_date#26) ASC NULLS FIRST], false, 0
 
-(56) SortMergeJoin [codegen id : 26]
+(60) SortMergeJoin [codegen id : 26]
 Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#30, ), isnull(c_last_name#30), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26)]
+Right keys [6]: [coalesce(c_last_name#28, ), isnull(c_last_name#28), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26)]
 Join condition: None
 
-(57) Project [codegen id : 26]
+(61) Project [codegen id : 26]
 Output: []
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
-(58) HashAggregate [codegen id : 26]
+(62) HashAggregate [codegen id : 26]
 Input: []
 Keys: []
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#33]
 Results [1]: [count#34]
 
-(59) Exchange
+(63) Exchange
 Input [1]: [count#34]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#35]
 
-(60) HashAggregate [codegen id : 27]
+(64) HashAggregate [codegen id : 27]
 Input [1]: [count#34]
 Keys: []
 Functions [1]: [count(1)]
@@ -342,37 +374,37 @@ Results [1]: [count(1)#36 AS count(1)#37]
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#2 IN dynamicpruning#3
-BroadcastExchange (65)
-+- * Project (64)
-   +- * Filter (63)
-      +- * ColumnarToRow (62)
-         +- Scan parquet default.date_dim (61)
+BroadcastExchange (69)
++- * Project (68)
+   +- * Filter (67)
+      +- * ColumnarToRow (66)
+         +- Scan parquet default.date_dim (65)
 
 
-(61) Scan parquet default.date_dim
+(65) Scan parquet default.date_dim
 Output [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_month_seq:int>
 
-(62) ColumnarToRow [codegen id : 1]
+(66) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 
-(63) Filter [codegen id : 1]
+(67) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 Condition : (((isnotnull(d_month_seq#38) AND (d_month_seq#38 >= 1200)) AND (d_month_seq#38 <= 1211)) AND isnotnull(d_date_sk#4))
 
-(64) Project [codegen id : 1]
+(68) Project [codegen id : 1]
 Output [2]: [d_date_sk#4, d_date#5]
 Input [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 
-(65) BroadcastExchange
+(69) BroadcastExchange
 Input [2]: [d_date_sk#4, d_date#5]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
 
-Subquery:2 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#3
+Subquery:2 Hosting operator id = 23 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#3
 
-Subquery:3 Hosting operator id = 39 Hosting Expression = ws_sold_date_sk#24 IN dynamicpruning#3
+Subquery:3 Hosting operator id = 42 Hosting Expression = ws_sold_date_sk#24 IN dynamicpruning#3
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/simplified.txt
@@ -20,7 +20,7 @@ WholeStageCodegen (27)
                                       Exchange [c_last_name,c_first_name,d_date] #3
                                         WholeStageCodegen (6)
                                           HashAggregate [c_last_name,c_first_name,d_date]
-                                            Project [c_last_name,c_first_name,d_date]
+                                            Project [d_date,c_last_name,c_first_name]
                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
                                                 InputAdapter
                                                   WholeStageCodegen (3)
@@ -28,32 +28,34 @@ WholeStageCodegen (27)
                                                       InputAdapter
                                                         Exchange [ss_customer_sk] #4
                                                           WholeStageCodegen (2)
-                                                            Project [ss_customer_sk,d_date]
-                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                Filter [ss_customer_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                        SubqueryBroadcast [d_date_sk] #1
-                                                                          BroadcastExchange #5
-                                                                            WholeStageCodegen (1)
-                                                                              Project [d_date_sk,d_date]
-                                                                                Filter [d_month_seq,d_date_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.date_dim [d_date_sk,d_date,d_month_seq]
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_date] #5
+                                                            HashAggregate [d_date,ss_customer_sk]
+                                                              Project [ss_customer_sk,d_date]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  Filter [ss_customer_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                          SubqueryBroadcast [d_date_sk] #1
+                                                                            BroadcastExchange #5
+                                                                              WholeStageCodegen (1)
+                                                                                Project [d_date_sk,d_date]
+                                                                                  Filter [d_month_seq,d_date_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet default.date_dim [d_date_sk,d_date,d_month_seq]
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_date] #5
                                                 InputAdapter
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
                                                         Exchange [c_customer_sk] #6
                                                           WholeStageCodegen (4)
-                                                            Filter [c_customer_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet default.customer [c_customer_sk,c_first_name,c_last_name]
+                                                            HashAggregate [c_last_name,c_first_name,c_customer_sk]
+                                                              Filter [c_customer_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.customer [c_customer_sk,c_first_name,c_last_name]
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [c_last_name,c_first_name,d_date]
@@ -65,7 +67,7 @@ WholeStageCodegen (27)
                                       Exchange [c_last_name,c_first_name,d_date] #8
                                         WholeStageCodegen (14)
                                           HashAggregate [c_last_name,c_first_name,d_date]
-                                            Project [c_last_name,c_first_name,d_date]
+                                            Project [d_date,c_last_name,c_first_name]
                                               SortMergeJoin [cs_bill_customer_sk,c_customer_sk]
                                                 InputAdapter
                                                   WholeStageCodegen (11)
@@ -73,20 +75,21 @@ WholeStageCodegen (27)
                                                       InputAdapter
                                                         Exchange [cs_bill_customer_sk] #9
                                                           WholeStageCodegen (10)
-                                                            Project [cs_bill_customer_sk,d_date]
-                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                Filter [cs_bill_customer_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.catalog_sales [cs_bill_customer_sk,cs_sold_date_sk]
-                                                                        ReusedSubquery [d_date_sk] #1
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_date] #5
+                                                            HashAggregate [d_date,cs_bill_customer_sk]
+                                                              Project [cs_bill_customer_sk,d_date]
+                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                  Filter [cs_bill_customer_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.catalog_sales [cs_bill_customer_sk,cs_sold_date_sk]
+                                                                          ReusedSubquery [d_date_sk] #1
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_date] #5
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                        ReusedExchange [c_last_name,c_first_name,c_customer_sk] #6
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [c_last_name,c_first_name,d_date]
@@ -98,7 +101,7 @@ WholeStageCodegen (27)
                                 Exchange [c_last_name,c_first_name,d_date] #11
                                   WholeStageCodegen (23)
                                     HashAggregate [c_last_name,c_first_name,d_date]
-                                      Project [c_last_name,c_first_name,d_date]
+                                      Project [d_date,c_last_name,c_first_name]
                                         SortMergeJoin [ws_bill_customer_sk,c_customer_sk]
                                           InputAdapter
                                             WholeStageCodegen (20)
@@ -106,17 +109,18 @@ WholeStageCodegen (27)
                                                 InputAdapter
                                                   Exchange [ws_bill_customer_sk] #12
                                                     WholeStageCodegen (19)
-                                                      Project [ws_bill_customer_sk,d_date]
-                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                          Filter [ws_bill_customer_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #1
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk,d_date] #5
+                                                      HashAggregate [d_date,ws_bill_customer_sk]
+                                                        Project [ws_bill_customer_sk,d_date]
+                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                            Filter [ws_bill_customer_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                                    ReusedSubquery [d_date_sk] #1
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk,d_date] #5
                                           InputAdapter
                                             WholeStageCodegen (22)
                                               Sort [c_customer_sk]
                                                 InputAdapter
-                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                  ReusedExchange [c_last_name,c_first_name,c_customer_sk] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -1,15 +1,15 @@
 == Physical Plan ==
-TakeOrderedAndProject (59)
-+- * HashAggregate (58)
-   +- Exchange (57)
-      +- * HashAggregate (56)
-         +- * HashAggregate (55)
-            +- * HashAggregate (54)
-               +- * Project (53)
-                  +- * SortMergeJoin Inner (52)
-                     :- * Sort (43)
-                     :  +- * Project (42)
-                     :     +- * BroadcastHashJoin Inner BuildLeft (41)
+TakeOrderedAndProject (61)
++- * HashAggregate (60)
+   +- Exchange (59)
+      +- * HashAggregate (58)
+         +- * HashAggregate (57)
+            +- * HashAggregate (56)
+               +- * Project (55)
+                  +- * SortMergeJoin Inner (54)
+                     :- * Sort (45)
+                     :  +- * Project (44)
+                     :     +- * BroadcastHashJoin Inner BuildLeft (43)
                      :        :- BroadcastExchange (10)
                      :        :  +- * Project (9)
                      :        :     +- * BroadcastHashJoin Inner BuildRight (8)
@@ -20,44 +20,46 @@ TakeOrderedAndProject (59)
                      :        :           +- * Filter (6)
                      :        :              +- * ColumnarToRow (5)
                      :        :                 +- Scan parquet default.store (4)
-                     :        +- * HashAggregate (40)
-                     :           +- * HashAggregate (39)
-                     :              +- * Project (38)
-                     :                 +- * SortMergeJoin Inner (37)
-                     :                    :- * Sort (31)
-                     :                    :  +- Exchange (30)
-                     :                    :     +- * Project (29)
-                     :                    :        +- * BroadcastHashJoin Inner BuildRight (28)
-                     :                    :           :- * Project (22)
-                     :                    :           :  +- * BroadcastHashJoin Inner BuildRight (21)
-                     :                    :           :     :- Union (19)
-                     :                    :           :     :  :- * Project (14)
-                     :                    :           :     :  :  +- * Filter (13)
-                     :                    :           :     :  :     +- * ColumnarToRow (12)
-                     :                    :           :     :  :        +- Scan parquet default.catalog_sales (11)
-                     :                    :           :     :  +- * Project (18)
-                     :                    :           :     :     +- * Filter (17)
-                     :                    :           :     :        +- * ColumnarToRow (16)
-                     :                    :           :     :           +- Scan parquet default.web_sales (15)
-                     :                    :           :     +- ReusedExchange (20)
-                     :                    :           +- BroadcastExchange (27)
-                     :                    :              +- * Project (26)
-                     :                    :                 +- * Filter (25)
-                     :                    :                    +- * ColumnarToRow (24)
-                     :                    :                       +- Scan parquet default.item (23)
-                     :                    +- * Sort (36)
-                     :                       +- Exchange (35)
-                     :                          +- * Filter (34)
-                     :                             +- * ColumnarToRow (33)
-                     :                                +- Scan parquet default.customer (32)
-                     +- * Sort (51)
-                        +- Exchange (50)
-                           +- * Project (49)
-                              +- * BroadcastHashJoin Inner BuildRight (48)
-                                 :- * Filter (46)
-                                 :  +- * ColumnarToRow (45)
-                                 :     +- Scan parquet default.store_sales (44)
-                                 +- ReusedExchange (47)
+                     :        +- * HashAggregate (42)
+                     :           +- * HashAggregate (41)
+                     :              +- * Project (40)
+                     :                 +- * SortMergeJoin Inner (39)
+                     :                    :- * Sort (32)
+                     :                    :  +- Exchange (31)
+                     :                    :     +- * HashAggregate (30)
+                     :                    :        +- * Project (29)
+                     :                    :           +- * BroadcastHashJoin Inner BuildRight (28)
+                     :                    :              :- * Project (22)
+                     :                    :              :  +- * BroadcastHashJoin Inner BuildRight (21)
+                     :                    :              :     :- Union (19)
+                     :                    :              :     :  :- * Project (14)
+                     :                    :              :     :  :  +- * Filter (13)
+                     :                    :              :     :  :     +- * ColumnarToRow (12)
+                     :                    :              :     :  :        +- Scan parquet default.catalog_sales (11)
+                     :                    :              :     :  +- * Project (18)
+                     :                    :              :     :     +- * Filter (17)
+                     :                    :              :     :        +- * ColumnarToRow (16)
+                     :                    :              :     :           +- Scan parquet default.web_sales (15)
+                     :                    :              :     +- ReusedExchange (20)
+                     :                    :              +- BroadcastExchange (27)
+                     :                    :                 +- * Project (26)
+                     :                    :                    +- * Filter (25)
+                     :                    :                       +- * ColumnarToRow (24)
+                     :                    :                          +- Scan parquet default.item (23)
+                     :                    +- * Sort (38)
+                     :                       +- Exchange (37)
+                     :                          +- * HashAggregate (36)
+                     :                             +- * Filter (35)
+                     :                                +- * ColumnarToRow (34)
+                     :                                   +- Scan parquet default.customer (33)
+                     +- * Sort (53)
+                        +- Exchange (52)
+                           +- * Project (51)
+                              +- * BroadcastHashJoin Inner BuildRight (50)
+                                 :- * Filter (48)
+                                 :  +- * ColumnarToRow (47)
+                                 :     +- Scan parquet default.store_sales (46)
+                                 +- ReusedExchange (49)
 
 
 (1) Scan parquet default.customer_address
@@ -145,7 +147,7 @@ Input [3]: [ws_item_sk#15, ws_bill_customer_sk#16, ws_sold_date_sk#17]
 
 (19) Union
 
-(20) ReusedExchange [Reuses operator id: 64]
+(20) ReusedExchange [Reuses operator id: 66]
 Output [1]: [d_date_sk#21]
 
 (21) BroadcastHashJoin [codegen id : 7]
@@ -188,73 +190,87 @@ Join condition: None
 Output [1]: [customer_sk#13]
 Input [3]: [customer_sk#13, item_sk#14, i_item_sk#22]
 
-(30) Exchange
+(30) HashAggregate [codegen id : 7]
+Input [1]: [customer_sk#13]
+Keys [1]: [customer_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [customer_sk#13]
+
+(31) Exchange
 Input [1]: [customer_sk#13]
 Arguments: hashpartitioning(customer_sk#13, 5), ENSURE_REQUIREMENTS, [id=#26]
 
-(31) Sort [codegen id : 8]
+(32) Sort [codegen id : 8]
 Input [1]: [customer_sk#13]
 Arguments: [customer_sk#13 ASC NULLS FIRST], false, 0
 
-(32) Scan parquet default.customer
+(33) Scan parquet default.customer
 Output [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(33) ColumnarToRow [codegen id : 9]
+(34) ColumnarToRow [codegen id : 9]
 Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
 
-(34) Filter [codegen id : 9]
+(35) Filter [codegen id : 9]
 Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Condition : (isnotnull(c_customer_sk#27) AND isnotnull(c_current_addr_sk#28))
 
-(35) Exchange
+(36) HashAggregate [codegen id : 9]
+Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
+Keys [2]: [c_customer_sk#27, c_current_addr_sk#28]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [c_customer_sk#27, c_current_addr_sk#28]
+
+(37) Exchange
 Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Arguments: hashpartitioning(c_customer_sk#27, 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(36) Sort [codegen id : 10]
+(38) Sort [codegen id : 10]
 Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Arguments: [c_customer_sk#27 ASC NULLS FIRST], false, 0
 
-(37) SortMergeJoin
+(39) SortMergeJoin
 Left keys [1]: [customer_sk#13]
 Right keys [1]: [c_customer_sk#27]
 Join condition: None
 
-(38) Project
+(40) Project
 Output [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Input [3]: [customer_sk#13, c_customer_sk#27, c_current_addr_sk#28]
 
-(39) HashAggregate
+(41) HashAggregate
 Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Keys [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#27, c_current_addr_sk#28]
 
-(40) HashAggregate
+(42) HashAggregate
 Input [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Keys [2]: [c_customer_sk#27, c_current_addr_sk#28]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#27, c_current_addr_sk#28]
 
-(41) BroadcastHashJoin [codegen id : 11]
+(43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#28]
 Join condition: None
 
-(42) Project [codegen id : 11]
+(44) Project [codegen id : 11]
 Output [1]: [c_customer_sk#27]
 Input [3]: [ca_address_sk#1, c_customer_sk#27, c_current_addr_sk#28]
 
-(43) Sort [codegen id : 11]
+(45) Sort [codegen id : 11]
 Input [1]: [c_customer_sk#27]
 Arguments: [c_customer_sk#27 ASC NULLS FIRST], false, 0
 
-(44) Scan parquet default.store_sales
+(46) Scan parquet default.store_sales
 Output [3]: [ss_customer_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32]
 Batched: true
 Location: InMemoryFileIndex []
@@ -262,228 +278,228 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#32), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(45) ColumnarToRow [codegen id : 13]
+(47) ColumnarToRow [codegen id : 13]
 Input [3]: [ss_customer_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32]
 
-(46) Filter [codegen id : 13]
+(48) Filter [codegen id : 13]
 Input [3]: [ss_customer_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32]
 Condition : isnotnull(ss_customer_sk#30)
 
-(47) ReusedExchange [Reuses operator id: 69]
+(49) ReusedExchange [Reuses operator id: 71]
 Output [1]: [d_date_sk#34]
 
-(48) BroadcastHashJoin [codegen id : 13]
+(50) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#32]
 Right keys [1]: [d_date_sk#34]
 Join condition: None
 
-(49) Project [codegen id : 13]
+(51) Project [codegen id : 13]
 Output [2]: [ss_customer_sk#30, ss_ext_sales_price#31]
 Input [4]: [ss_customer_sk#30, ss_ext_sales_price#31, ss_sold_date_sk#32, d_date_sk#34]
 
-(50) Exchange
+(52) Exchange
 Input [2]: [ss_customer_sk#30, ss_ext_sales_price#31]
 Arguments: hashpartitioning(ss_customer_sk#30, 5), ENSURE_REQUIREMENTS, [id=#35]
 
-(51) Sort [codegen id : 14]
+(53) Sort [codegen id : 14]
 Input [2]: [ss_customer_sk#30, ss_ext_sales_price#31]
 Arguments: [ss_customer_sk#30 ASC NULLS FIRST], false, 0
 
-(52) SortMergeJoin [codegen id : 15]
+(54) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#27]
 Right keys [1]: [ss_customer_sk#30]
 Join condition: None
 
-(53) Project [codegen id : 15]
+(55) Project [codegen id : 15]
 Output [2]: [c_customer_sk#27, ss_ext_sales_price#31]
 Input [3]: [c_customer_sk#27, ss_customer_sk#30, ss_ext_sales_price#31]
 
-(54) HashAggregate [codegen id : 15]
+(56) HashAggregate [codegen id : 15]
 Input [2]: [c_customer_sk#27, ss_ext_sales_price#31]
 Keys [1]: [c_customer_sk#27]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#31))]
 Aggregate Attributes [1]: [sum#36]
 Results [2]: [c_customer_sk#27, sum#37]
 
-(55) HashAggregate [codegen id : 15]
+(57) HashAggregate [codegen id : 15]
 Input [2]: [c_customer_sk#27, sum#37]
 Keys [1]: [c_customer_sk#27]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#31))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#31))#38]
 Results [1]: [cast(CheckOverflow((promote_precision(MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#31))#38,17,2)) / 50.00), DecimalType(21,6)) as int) AS segment#39]
 
-(56) HashAggregate [codegen id : 15]
+(58) HashAggregate [codegen id : 15]
 Input [1]: [segment#39]
 Keys [1]: [segment#39]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#40]
 Results [2]: [segment#39, count#41]
 
-(57) Exchange
+(59) Exchange
 Input [2]: [segment#39, count#41]
 Arguments: hashpartitioning(segment#39, 5), ENSURE_REQUIREMENTS, [id=#42]
 
-(58) HashAggregate [codegen id : 16]
+(60) HashAggregate [codegen id : 16]
 Input [2]: [segment#39, count#41]
 Keys [1]: [segment#39]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#43]
 Results [3]: [segment#39, count(1)#43 AS num_customers#44, (segment#39 * 50) AS segment_base#45]
 
-(59) TakeOrderedAndProject
+(61) TakeOrderedAndProject
 Input [3]: [segment#39, num_customers#44, segment_base#45]
 Arguments: 100, [segment#39 ASC NULLS FIRST, num_customers#44 ASC NULLS FIRST], [segment#39, num_customers#44, segment_base#45]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 11 Hosting Expression = cs_sold_date_sk#10 IN dynamicpruning#11
-BroadcastExchange (64)
-+- * Project (63)
-   +- * Filter (62)
-      +- * ColumnarToRow (61)
-         +- Scan parquet default.date_dim (60)
+BroadcastExchange (66)
++- * Project (65)
+   +- * Filter (64)
+      +- * ColumnarToRow (63)
+         +- Scan parquet default.date_dim (62)
 
 
-(60) Scan parquet default.date_dim
+(62) Scan parquet default.date_dim
 Output [3]: [d_date_sk#21, d_year#46, d_moy#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,12), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(61) ColumnarToRow [codegen id : 1]
+(63) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#21, d_year#46, d_moy#47]
 
-(62) Filter [codegen id : 1]
+(64) Filter [codegen id : 1]
 Input [3]: [d_date_sk#21, d_year#46, d_moy#47]
 Condition : ((((isnotnull(d_moy#47) AND isnotnull(d_year#46)) AND (d_moy#47 = 12)) AND (d_year#46 = 1998)) AND isnotnull(d_date_sk#21))
 
-(63) Project [codegen id : 1]
+(65) Project [codegen id : 1]
 Output [1]: [d_date_sk#21]
 Input [3]: [d_date_sk#21, d_year#46, d_moy#47]
 
-(64) BroadcastExchange
+(66) BroadcastExchange
 Input [1]: [d_date_sk#21]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#48]
 
 Subquery:2 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#17 IN dynamicpruning#11
 
-Subquery:3 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#32 IN dynamicpruning#33
-BroadcastExchange (69)
-+- * Project (68)
-   +- * Filter (67)
-      +- * ColumnarToRow (66)
-         +- Scan parquet default.date_dim (65)
+Subquery:3 Hosting operator id = 46 Hosting Expression = ss_sold_date_sk#32 IN dynamicpruning#33
+BroadcastExchange (71)
++- * Project (70)
+   +- * Filter (69)
+      +- * ColumnarToRow (68)
+         +- Scan parquet default.date_dim (67)
 
 
-(65) Scan parquet default.date_dim
+(67) Scan parquet default.date_dim
 Output [2]: [d_date_sk#34, d_month_seq#49]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(66) ColumnarToRow [codegen id : 1]
+(68) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#34, d_month_seq#49]
 
-(67) Filter [codegen id : 1]
+(69) Filter [codegen id : 1]
 Input [2]: [d_date_sk#34, d_month_seq#49]
 Condition : (((isnotnull(d_month_seq#49) AND (d_month_seq#49 >= Subquery scalar-subquery#50, [id=#51])) AND (d_month_seq#49 <= Subquery scalar-subquery#52, [id=#53])) AND isnotnull(d_date_sk#34))
 
-(68) Project [codegen id : 1]
+(70) Project [codegen id : 1]
 Output [1]: [d_date_sk#34]
 Input [2]: [d_date_sk#34, d_month_seq#49]
 
-(69) BroadcastExchange
+(71) BroadcastExchange
 Input [1]: [d_date_sk#34]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#54]
 
-Subquery:4 Hosting operator id = 67 Hosting Expression = Subquery scalar-subquery#50, [id=#51]
-* HashAggregate (76)
-+- Exchange (75)
-   +- * HashAggregate (74)
-      +- * Project (73)
-         +- * Filter (72)
-            +- * ColumnarToRow (71)
-               +- Scan parquet default.date_dim (70)
+Subquery:4 Hosting operator id = 69 Hosting Expression = Subquery scalar-subquery#50, [id=#51]
+* HashAggregate (78)
++- Exchange (77)
+   +- * HashAggregate (76)
+      +- * Project (75)
+         +- * Filter (74)
+            +- * ColumnarToRow (73)
+               +- Scan parquet default.date_dim (72)
 
 
-(70) Scan parquet default.date_dim
+(72) Scan parquet default.date_dim
 Output [3]: [d_month_seq#55, d_year#56, d_moy#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(71) ColumnarToRow [codegen id : 1]
+(73) ColumnarToRow [codegen id : 1]
 Input [3]: [d_month_seq#55, d_year#56, d_moy#57]
 
-(72) Filter [codegen id : 1]
+(74) Filter [codegen id : 1]
 Input [3]: [d_month_seq#55, d_year#56, d_moy#57]
 Condition : (((isnotnull(d_year#56) AND isnotnull(d_moy#57)) AND (d_year#56 = 1998)) AND (d_moy#57 = 12))
 
-(73) Project [codegen id : 1]
+(75) Project [codegen id : 1]
 Output [1]: [(d_month_seq#55 + 1) AS (d_month_seq + 1)#58]
 Input [3]: [d_month_seq#55, d_year#56, d_moy#57]
 
-(74) HashAggregate [codegen id : 1]
+(76) HashAggregate [codegen id : 1]
 Input [1]: [(d_month_seq + 1)#58]
 Keys [1]: [(d_month_seq + 1)#58]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 1)#58]
 
-(75) Exchange
+(77) Exchange
 Input [1]: [(d_month_seq + 1)#58]
 Arguments: hashpartitioning((d_month_seq + 1)#58, 5), ENSURE_REQUIREMENTS, [id=#59]
 
-(76) HashAggregate [codegen id : 2]
+(78) HashAggregate [codegen id : 2]
 Input [1]: [(d_month_seq + 1)#58]
 Keys [1]: [(d_month_seq + 1)#58]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 1)#58]
 
-Subquery:5 Hosting operator id = 67 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
-* HashAggregate (83)
-+- Exchange (82)
-   +- * HashAggregate (81)
-      +- * Project (80)
-         +- * Filter (79)
-            +- * ColumnarToRow (78)
-               +- Scan parquet default.date_dim (77)
+Subquery:5 Hosting operator id = 69 Hosting Expression = Subquery scalar-subquery#52, [id=#53]
+* HashAggregate (85)
++- Exchange (84)
+   +- * HashAggregate (83)
+      +- * Project (82)
+         +- * Filter (81)
+            +- * ColumnarToRow (80)
+               +- Scan parquet default.date_dim (79)
 
 
-(77) Scan parquet default.date_dim
+(79) Scan parquet default.date_dim
 Output [3]: [d_month_seq#60, d_year#61, d_moy#62]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(78) ColumnarToRow [codegen id : 1]
+(80) ColumnarToRow [codegen id : 1]
 Input [3]: [d_month_seq#60, d_year#61, d_moy#62]
 
-(79) Filter [codegen id : 1]
+(81) Filter [codegen id : 1]
 Input [3]: [d_month_seq#60, d_year#61, d_moy#62]
 Condition : (((isnotnull(d_year#61) AND isnotnull(d_moy#62)) AND (d_year#61 = 1998)) AND (d_moy#62 = 12))
 
-(80) Project [codegen id : 1]
+(82) Project [codegen id : 1]
 Output [1]: [(d_month_seq#60 + 3) AS (d_month_seq + 3)#63]
 Input [3]: [d_month_seq#60, d_year#61, d_moy#62]
 
-(81) HashAggregate [codegen id : 1]
+(83) HashAggregate [codegen id : 1]
 Input [1]: [(d_month_seq + 3)#63]
 Keys [1]: [(d_month_seq + 3)#63]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 3)#63]
 
-(82) Exchange
+(84) Exchange
 Input [1]: [(d_month_seq + 3)#63]
 Arguments: hashpartitioning((d_month_seq + 3)#63, 5), ENSURE_REQUIREMENTS, [id=#64]
 
-(83) HashAggregate [codegen id : 2]
+(85) HashAggregate [codegen id : 2]
 Input [1]: [(d_month_seq + 3)#63]
 Keys [1]: [(d_month_seq + 3)#63]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
@@ -40,53 +40,55 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                               InputAdapter
                                                 Exchange [customer_sk] #4
                                                   WholeStageCodegen (7)
-                                                    Project [customer_sk]
-                                                      BroadcastHashJoin [item_sk,i_item_sk]
-                                                        Project [customer_sk,item_sk]
-                                                          BroadcastHashJoin [sold_date_sk,d_date_sk]
-                                                            InputAdapter
-                                                              Union
-                                                                WholeStageCodegen (3)
-                                                                  Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
-                                                                    Filter [cs_item_sk,cs_bill_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
-                                                                            SubqueryBroadcast [d_date_sk] #1
-                                                                              BroadcastExchange #5
-                                                                                WholeStageCodegen (1)
-                                                                                  Project [d_date_sk]
-                                                                                    Filter [d_moy,d_year,d_date_sk]
-                                                                                      ColumnarToRow
-                                                                                        InputAdapter
-                                                                                          Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
-                                                                WholeStageCodegen (4)
-                                                                  Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
-                                                                    Filter [ws_item_sk,ws_bill_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
-                                                                            ReusedSubquery [d_date_sk] #1
-                                                            InputAdapter
-                                                              ReusedExchange [d_date_sk] #5
-                                                        InputAdapter
-                                                          BroadcastExchange #6
-                                                            WholeStageCodegen (6)
-                                                              Project [i_item_sk]
-                                                                Filter [i_category,i_class,i_item_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.item [i_item_sk,i_class,i_category]
+                                                    HashAggregate [customer_sk]
+                                                      Project [customer_sk]
+                                                        BroadcastHashJoin [item_sk,i_item_sk]
+                                                          Project [customer_sk,item_sk]
+                                                            BroadcastHashJoin [sold_date_sk,d_date_sk]
+                                                              InputAdapter
+                                                                Union
+                                                                  WholeStageCodegen (3)
+                                                                    Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
+                                                                      Filter [cs_item_sk,cs_bill_customer_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
+                                                                              SubqueryBroadcast [d_date_sk] #1
+                                                                                BroadcastExchange #5
+                                                                                  WholeStageCodegen (1)
+                                                                                    Project [d_date_sk]
+                                                                                      Filter [d_moy,d_year,d_date_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet default.date_dim [d_date_sk,d_year,d_moy]
+                                                                  WholeStageCodegen (4)
+                                                                    Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
+                                                                      Filter [ws_item_sk,ws_bill_customer_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
+                                                                              ReusedSubquery [d_date_sk] #1
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #5
+                                                          InputAdapter
+                                                            BroadcastExchange #6
+                                                              WholeStageCodegen (6)
+                                                                Project [i_item_sk]
+                                                                  Filter [i_category,i_class,i_item_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.item [i_item_sk,i_class,i_category]
                                         InputAdapter
                                           WholeStageCodegen (10)
                                             Sort [c_customer_sk]
                                               InputAdapter
                                                 Exchange [c_customer_sk] #7
                                                   WholeStageCodegen (9)
-                                                    Filter [c_customer_sk,c_current_addr_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet default.customer [c_customer_sk,c_current_addr_sk]
+                                                    HashAggregate [c_customer_sk,c_current_addr_sk]
+                                                      Filter [c_customer_sk,c_current_addr_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet default.customer [c_customer_sk,c_current_addr_sk]
                       InputAdapter
                         WholeStageCodegen (14)
                           Sort [ss_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -1,32 +1,34 @@
 == Physical Plan ==
-TakeOrderedAndProject (28)
-+- * HashAggregate (27)
-   +- Exchange (26)
-      +- * HashAggregate (25)
-         +- * Project (24)
-            +- * SortMergeJoin Inner (23)
-               :- * Sort (16)
-               :  +- Exchange (15)
-               :     +- * Project (14)
-               :        +- * BroadcastHashJoin Inner BuildRight (13)
-               :           :- * Project (11)
-               :           :  +- * BroadcastHashJoin Inner BuildLeft (10)
-               :           :     :- BroadcastExchange (5)
-               :           :     :  +- * Project (4)
-               :           :     :     +- * Filter (3)
-               :           :     :        +- * ColumnarToRow (2)
-               :           :     :           +- Scan parquet default.item (1)
-               :           :     +- * Project (9)
-               :           :        +- * Filter (8)
-               :           :           +- * ColumnarToRow (7)
-               :           :              +- Scan parquet default.inventory (6)
-               :           +- ReusedExchange (12)
-               +- * Sort (22)
-                  +- Exchange (21)
-                     +- * Project (20)
-                        +- * Filter (19)
-                           +- * ColumnarToRow (18)
-                              +- Scan parquet default.store_sales (17)
+TakeOrderedAndProject (30)
++- * HashAggregate (29)
+   +- Exchange (28)
+      +- * HashAggregate (27)
+         +- * Project (26)
+            +- * SortMergeJoin Inner (25)
+               :- * Sort (17)
+               :  +- Exchange (16)
+               :     +- * HashAggregate (15)
+               :        +- * Project (14)
+               :           +- * BroadcastHashJoin Inner BuildRight (13)
+               :              :- * Project (11)
+               :              :  +- * BroadcastHashJoin Inner BuildLeft (10)
+               :              :     :- BroadcastExchange (5)
+               :              :     :  +- * Project (4)
+               :              :     :     +- * Filter (3)
+               :              :     :        +- * ColumnarToRow (2)
+               :              :     :           +- Scan parquet default.item (1)
+               :              :     +- * Project (9)
+               :              :        +- * Filter (8)
+               :              :           +- * ColumnarToRow (7)
+               :              :              +- Scan parquet default.inventory (6)
+               :              +- ReusedExchange (12)
+               +- * Sort (24)
+                  +- Exchange (23)
+                     +- * HashAggregate (22)
+                        +- * Project (21)
+                           +- * Filter (20)
+                              +- * ColumnarToRow (19)
+                                 +- Scan parquet default.store_sales (18)
 
 
 (1) Scan parquet default.item
@@ -79,7 +81,7 @@ Join condition: None
 Output [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#9]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#7, inv_date_sk#9]
 
-(12) ReusedExchange [Reuses operator id: 33]
+(12) ReusedExchange [Reuses operator id: 35]
 Output [1]: [d_date_sk#11]
 
 (13) BroadcastHashJoin [codegen id : 3]
@@ -91,100 +93,114 @@ Join condition: None
 Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#9, d_date_sk#11]
 
-(15) Exchange
+(15) HashAggregate [codegen id : 3]
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Keys [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+Functions: []
+Aggregate Attributes: []
+Results [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+
+(16) Exchange
+Input [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
 Arguments: hashpartitioning(i_item_sk#1, 5), ENSURE_REQUIREMENTS, [id=#12]
 
-(16) Sort [codegen id : 4]
-Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+(17) Sort [codegen id : 4]
+Input [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
 Arguments: [i_item_sk#1 ASC NULLS FIRST], false, 0
 
-(17) Scan parquet default.store_sales
+(18) Scan parquet default.store_sales
 Output [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(18) ColumnarToRow [codegen id : 5]
+(19) ColumnarToRow [codegen id : 5]
 Input [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 
-(19) Filter [codegen id : 5]
+(20) Filter [codegen id : 5]
 Input [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 Condition : isnotnull(ss_item_sk#13)
 
-(20) Project [codegen id : 5]
+(21) Project [codegen id : 5]
 Output [1]: [ss_item_sk#13]
 Input [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 
-(21) Exchange
+(22) HashAggregate [codegen id : 5]
+Input [1]: [ss_item_sk#13]
+Keys [1]: [ss_item_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [ss_item_sk#13]
+
+(23) Exchange
 Input [1]: [ss_item_sk#13]
 Arguments: hashpartitioning(ss_item_sk#13, 5), ENSURE_REQUIREMENTS, [id=#15]
 
-(22) Sort [codegen id : 6]
+(24) Sort [codegen id : 6]
 Input [1]: [ss_item_sk#13]
 Arguments: [ss_item_sk#13 ASC NULLS FIRST], false, 0
 
-(23) SortMergeJoin [codegen id : 7]
+(25) SortMergeJoin [codegen id : 7]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#13]
 Join condition: None
 
-(24) Project [codegen id : 7]
+(26) Project [codegen id : 7]
 Output [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, ss_item_sk#13]
+Input [5]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1, ss_item_sk#13]
 
-(25) HashAggregate [codegen id : 7]
+(27) HashAggregate [codegen id : 7]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(26) Exchange
+(28) Exchange
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [id=#16]
 
-(27) HashAggregate [codegen id : 8]
+(29) HashAggregate [codegen id : 8]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(28) TakeOrderedAndProject
+(30) TakeOrderedAndProject
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: 100, [i_item_id#2 ASC NULLS FIRST], [i_item_id#2, i_item_desc#3, i_current_price#4]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = inv_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (33)
-+- * Project (32)
-   +- * Filter (31)
-      +- * ColumnarToRow (30)
-         +- Scan parquet default.date_dim (29)
+BroadcastExchange (35)
++- * Project (34)
+   +- * Filter (33)
+      +- * ColumnarToRow (32)
+         +- Scan parquet default.date_dim (31)
 
 
-(29) Scan parquet default.date_dim
+(31) Scan parquet default.date_dim
 Output [2]: [d_date_sk#11, d_date#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(30) ColumnarToRow [codegen id : 1]
+(32) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#17]
 
-(31) Filter [codegen id : 1]
+(33) Filter [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#17]
 Condition : (((isnotnull(d_date#17) AND (d_date#17 >= 2000-05-25)) AND (d_date#17 <= 2000-07-24)) AND isnotnull(d_date_sk#11))
 
-(32) Project [codegen id : 1]
+(34) Project [codegen id : 1]
 Output [1]: [d_date_sk#11]
 Input [2]: [d_date_sk#11, d_date#17]
 
-(33) BroadcastExchange
+(35) BroadcastExchange
 Input [1]: [d_date_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#18]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
@@ -13,41 +13,43 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                         InputAdapter
                           Exchange [i_item_sk] #2
                             WholeStageCodegen (3)
-                              Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                BroadcastHashJoin [inv_date_sk,d_date_sk]
-                                  Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
-                                    BroadcastHashJoin [i_item_sk,inv_item_sk]
-                                      InputAdapter
-                                        BroadcastExchange #3
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
-                                      Project [inv_item_sk,inv_date_sk]
-                                        Filter [inv_quantity_on_hand,inv_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #4
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_date,d_date_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.date_dim [d_date_sk,d_date]
-                                  InputAdapter
-                                    ReusedExchange [d_date_sk] #4
+                              HashAggregate [i_item_id,i_item_desc,i_current_price,i_item_sk]
+                                Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                  BroadcastHashJoin [inv_date_sk,d_date_sk]
+                                    Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
+                                      BroadcastHashJoin [i_item_sk,inv_item_sk]
+                                        InputAdapter
+                                          BroadcastExchange #3
+                                            WholeStageCodegen (1)
+                                              Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                                Filter [i_current_price,i_manufact_id,i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
+                                        Project [inv_item_sk,inv_date_sk]
+                                          Filter [inv_quantity_on_hand,inv_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
+                                                  SubqueryBroadcast [d_date_sk] #1
+                                                    BroadcastExchange #4
+                                                      WholeStageCodegen (1)
+                                                        Project [d_date_sk]
+                                                          Filter [d_date,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.date_dim [d_date_sk,d_date]
+                                    InputAdapter
+                                      ReusedExchange [d_date_sk] #4
                   InputAdapter
                     WholeStageCodegen (6)
                       Sort [ss_item_sk]
                         InputAdapter
                           Exchange [ss_item_sk] #5
                             WholeStageCodegen (5)
-                              Project [ss_item_sk]
-                                Filter [ss_item_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                              HashAggregate [ss_item_sk]
+                                Project [ss_item_sk]
+                                  Filter [ss_item_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/explain.txt
@@ -1,29 +1,31 @@
 == Physical Plan ==
-TakeOrderedAndProject (25)
-+- * HashAggregate (24)
-   +- Exchange (23)
-      +- * HashAggregate (22)
-         +- * Project (21)
-            +- * BroadcastHashJoin Inner BuildLeft (20)
-               :- BroadcastExchange (15)
-               :  +- * Project (14)
-               :     +- * BroadcastHashJoin Inner BuildRight (13)
-               :        :- * Project (11)
-               :        :  +- * BroadcastHashJoin Inner BuildRight (10)
-               :        :     :- * Project (4)
-               :        :     :  +- * Filter (3)
-               :        :     :     +- * ColumnarToRow (2)
-               :        :     :        +- Scan parquet default.item (1)
-               :        :     +- BroadcastExchange (9)
-               :        :        +- * Project (8)
-               :        :           +- * Filter (7)
-               :        :              +- * ColumnarToRow (6)
-               :        :                 +- Scan parquet default.inventory (5)
-               :        +- ReusedExchange (12)
-               +- * Project (19)
-                  +- * Filter (18)
-                     +- * ColumnarToRow (17)
-                        +- Scan parquet default.store_sales (16)
+TakeOrderedAndProject (27)
++- * HashAggregate (26)
+   +- Exchange (25)
+      +- * HashAggregate (24)
+         +- * Project (23)
+            +- * BroadcastHashJoin Inner BuildLeft (22)
+               :- BroadcastExchange (16)
+               :  +- * HashAggregate (15)
+               :     +- * Project (14)
+               :        +- * BroadcastHashJoin Inner BuildRight (13)
+               :           :- * Project (11)
+               :           :  +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :     :- * Project (4)
+               :           :     :  +- * Filter (3)
+               :           :     :     +- * ColumnarToRow (2)
+               :           :     :        +- Scan parquet default.item (1)
+               :           :     +- BroadcastExchange (9)
+               :           :        +- * Project (8)
+               :           :           +- * Filter (7)
+               :           :              +- * ColumnarToRow (6)
+               :           :                 +- Scan parquet default.inventory (5)
+               :           +- ReusedExchange (12)
+               +- * HashAggregate (21)
+                  +- * Project (20)
+                     +- * Filter (19)
+                        +- * ColumnarToRow (18)
+                           +- Scan parquet default.store_sales (17)
 
 
 (1) Scan parquet default.item
@@ -76,7 +78,7 @@ Join condition: None
 Output [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#6, inv_date_sk#8]
 
-(12) ReusedExchange [Reuses operator id: 30]
+(12) ReusedExchange [Reuses operator id: 32]
 Output [1]: [d_date_sk#11]
 
 (13) BroadcastHashJoin [codegen id : 3]
@@ -88,88 +90,102 @@ Join condition: None
 Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
 Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8, d_date_sk#11]
 
-(15) BroadcastExchange
+(15) HashAggregate [codegen id : 3]
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#12]
+Keys [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+Functions: []
+Aggregate Attributes: []
+Results [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
 
-(16) Scan parquet default.store_sales
+(16) BroadcastExchange
+Input [4]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [id=#12]
+
+(17) Scan parquet default.store_sales
 Output [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(17) ColumnarToRow
+(18) ColumnarToRow
 Input [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 
-(18) Filter
+(19) Filter
 Input [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 Condition : isnotnull(ss_item_sk#13)
 
-(19) Project
+(20) Project
 Output [1]: [ss_item_sk#13]
 Input [2]: [ss_item_sk#13, ss_sold_date_sk#14]
 
-(20) BroadcastHashJoin [codegen id : 4]
+(21) HashAggregate
+Input [1]: [ss_item_sk#13]
+Keys [1]: [ss_item_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [1]: [ss_item_sk#13]
+
+(22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#13]
 Join condition: None
 
-(21) Project [codegen id : 4]
+(23) Project [codegen id : 4]
 Output [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, ss_item_sk#13]
+Input [5]: [i_item_id#2, i_item_desc#3, i_current_price#4, i_item_sk#1, ss_item_sk#13]
 
-(22) HashAggregate [codegen id : 4]
+(24) HashAggregate [codegen id : 4]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(23) Exchange
+(25) Exchange
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: hashpartitioning(i_item_id#2, i_item_desc#3, i_current_price#4, 5), ENSURE_REQUIREMENTS, [id=#15]
 
-(24) HashAggregate [codegen id : 5]
+(26) HashAggregate [codegen id : 5]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Keys [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Functions: []
 Aggregate Attributes: []
 Results [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 
-(25) TakeOrderedAndProject
+(27) TakeOrderedAndProject
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: 100, [i_item_id#2 ASC NULLS FIRST], [i_item_id#2, i_item_desc#3, i_current_price#4]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 5 Hosting Expression = inv_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (30)
-+- * Project (29)
-   +- * Filter (28)
-      +- * ColumnarToRow (27)
-         +- Scan parquet default.date_dim (26)
+BroadcastExchange (32)
++- * Project (31)
+   +- * Filter (30)
+      +- * ColumnarToRow (29)
+         +- Scan parquet default.date_dim (28)
 
 
-(26) Scan parquet default.date_dim
+(28) Scan parquet default.date_dim
 Output [2]: [d_date_sk#11, d_date#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(27) ColumnarToRow [codegen id : 1]
+(29) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#16]
 
-(28) Filter [codegen id : 1]
+(30) Filter [codegen id : 1]
 Input [2]: [d_date_sk#11, d_date#16]
 Condition : (((isnotnull(d_date#16) AND (d_date#16 >= 2000-05-25)) AND (d_date#16 <= 2000-07-24)) AND isnotnull(d_date_sk#11))
 
-(29) Project [codegen id : 1]
+(31) Project [codegen id : 1]
 Output [1]: [d_date_sk#11]
 Input [2]: [d_date_sk#11, d_date#16]
 
-(30) BroadcastExchange
+(32) BroadcastExchange
 Input [1]: [d_date_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#17]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/simplified.txt
@@ -10,35 +10,37 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
                   InputAdapter
                     BroadcastExchange #2
                       WholeStageCodegen (3)
-                        Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                          BroadcastHashJoin [inv_date_sk,d_date_sk]
-                            Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
-                              BroadcastHashJoin [i_item_sk,inv_item_sk]
-                                Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                  Filter [i_current_price,i_manufact_id,i_item_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
-                                InputAdapter
-                                  BroadcastExchange #3
-                                    WholeStageCodegen (1)
-                                      Project [inv_item_sk,inv_date_sk]
-                                        Filter [inv_quantity_on_hand,inv_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #4
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_date,d_date_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet default.date_dim [d_date_sk,d_date]
-                            InputAdapter
-                              ReusedExchange [d_date_sk] #4
-                  Project [ss_item_sk]
-                    Filter [ss_item_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                        HashAggregate [i_item_id,i_item_desc,i_current_price,i_item_sk]
+                          Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                            BroadcastHashJoin [inv_date_sk,d_date_sk]
+                              Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
+                                BroadcastHashJoin [i_item_sk,inv_item_sk]
+                                  Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                    Filter [i_current_price,i_manufact_id,i_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
+                                  InputAdapter
+                                    BroadcastExchange #3
+                                      WholeStageCodegen (1)
+                                        Project [inv_item_sk,inv_date_sk]
+                                          Filter [inv_quantity_on_hand,inv_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
+                                                  SubqueryBroadcast [d_date_sk] #1
+                                                    BroadcastExchange #4
+                                                      WholeStageCodegen (1)
+                                                        Project [d_date_sk]
+                                                          Filter [d_date,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet default.date_dim [d_date_sk,d_date]
+                              InputAdapter
+                                ReusedExchange [d_date_sk] #4
+                  HashAggregate [ss_item_sk]
+                    Project [ss_item_sk]
+                      Filter [ss_item_sk]
+                        ColumnarToRow
+                          InputAdapter
+                            Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
@@ -1,64 +1,68 @@
 == Physical Plan ==
-* HashAggregate (60)
-+- Exchange (59)
-   +- * HashAggregate (58)
-      +- * Project (57)
-         +- * SortMergeJoin LeftAnti (56)
-            :- * SortMergeJoin LeftAnti (38)
-            :  :- * Sort (20)
-            :  :  +- Exchange (19)
-            :  :     +- * HashAggregate (18)
-            :  :        +- Exchange (17)
-            :  :           +- * HashAggregate (16)
-            :  :              +- * Project (15)
-            :  :                 +- * SortMergeJoin Inner (14)
-            :  :                    :- * Sort (8)
-            :  :                    :  +- Exchange (7)
-            :  :                    :     +- * Project (6)
-            :  :                    :        +- * BroadcastHashJoin Inner BuildRight (5)
-            :  :                    :           :- * Filter (3)
-            :  :                    :           :  +- * ColumnarToRow (2)
-            :  :                    :           :     +- Scan parquet default.store_sales (1)
-            :  :                    :           +- ReusedExchange (4)
-            :  :                    +- * Sort (13)
-            :  :                       +- Exchange (12)
-            :  :                          +- * Filter (11)
-            :  :                             +- * ColumnarToRow (10)
-            :  :                                +- Scan parquet default.customer (9)
-            :  +- * Sort (37)
-            :     +- Exchange (36)
-            :        +- * HashAggregate (35)
-            :           +- Exchange (34)
-            :              +- * HashAggregate (33)
-            :                 +- * Project (32)
-            :                    +- * SortMergeJoin Inner (31)
-            :                       :- * Sort (28)
-            :                       :  +- Exchange (27)
-            :                       :     +- * Project (26)
-            :                       :        +- * BroadcastHashJoin Inner BuildRight (25)
-            :                       :           :- * Filter (23)
-            :                       :           :  +- * ColumnarToRow (22)
-            :                       :           :     +- Scan parquet default.catalog_sales (21)
-            :                       :           +- ReusedExchange (24)
-            :                       +- * Sort (30)
-            :                          +- ReusedExchange (29)
-            +- * Sort (55)
-               +- Exchange (54)
-                  +- * HashAggregate (53)
-                     +- Exchange (52)
-                        +- * HashAggregate (51)
-                           +- * Project (50)
-                              +- * SortMergeJoin Inner (49)
-                                 :- * Sort (46)
-                                 :  +- Exchange (45)
-                                 :     +- * Project (44)
-                                 :        +- * BroadcastHashJoin Inner BuildRight (43)
-                                 :           :- * Filter (41)
-                                 :           :  +- * ColumnarToRow (40)
-                                 :           :     +- Scan parquet default.web_sales (39)
-                                 :           +- ReusedExchange (42)
-                                 +- * Sort (48)
-                                    +- ReusedExchange (47)
+* HashAggregate (64)
++- Exchange (63)
+   +- * HashAggregate (62)
+      +- * Project (61)
+         +- * SortMergeJoin LeftAnti (60)
+            :- * SortMergeJoin LeftAnti (41)
+            :  :- * Sort (22)
+            :  :  +- Exchange (21)
+            :  :     +- * HashAggregate (20)
+            :  :        +- Exchange (19)
+            :  :           +- * HashAggregate (18)
+            :  :              +- * Project (17)
+            :  :                 +- * SortMergeJoin Inner (16)
+            :  :                    :- * Sort (9)
+            :  :                    :  +- Exchange (8)
+            :  :                    :     +- * HashAggregate (7)
+            :  :                    :        +- * Project (6)
+            :  :                    :           +- * BroadcastHashJoin Inner BuildRight (5)
+            :  :                    :              :- * Filter (3)
+            :  :                    :              :  +- * ColumnarToRow (2)
+            :  :                    :              :     +- Scan parquet default.store_sales (1)
+            :  :                    :              +- ReusedExchange (4)
+            :  :                    +- * Sort (15)
+            :  :                       +- Exchange (14)
+            :  :                          +- * HashAggregate (13)
+            :  :                             +- * Filter (12)
+            :  :                                +- * ColumnarToRow (11)
+            :  :                                   +- Scan parquet default.customer (10)
+            :  +- * Sort (40)
+            :     +- Exchange (39)
+            :        +- * HashAggregate (38)
+            :           +- Exchange (37)
+            :              +- * HashAggregate (36)
+            :                 +- * Project (35)
+            :                    +- * SortMergeJoin Inner (34)
+            :                       :- * Sort (31)
+            :                       :  +- Exchange (30)
+            :                       :     +- * HashAggregate (29)
+            :                       :        +- * Project (28)
+            :                       :           +- * BroadcastHashJoin Inner BuildRight (27)
+            :                       :              :- * Filter (25)
+            :                       :              :  +- * ColumnarToRow (24)
+            :                       :              :     +- Scan parquet default.catalog_sales (23)
+            :                       :              +- ReusedExchange (26)
+            :                       +- * Sort (33)
+            :                          +- ReusedExchange (32)
+            +- * Sort (59)
+               +- Exchange (58)
+                  +- * HashAggregate (57)
+                     +- Exchange (56)
+                        +- * HashAggregate (55)
+                           +- * Project (54)
+                              +- * SortMergeJoin Inner (53)
+                                 :- * Sort (50)
+                                 :  +- Exchange (49)
+                                 :     +- * HashAggregate (48)
+                                 :        +- * Project (47)
+                                 :           +- * BroadcastHashJoin Inner BuildRight (46)
+                                 :              :- * Filter (44)
+                                 :              :  +- * ColumnarToRow (43)
+                                 :              :     +- Scan parquet default.web_sales (42)
+                                 :              +- ReusedExchange (45)
+                                 +- * Sort (52)
+                                    +- ReusedExchange (51)
 
 
 (1) Scan parquet default.store_sales
@@ -76,7 +80,7 @@ Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
 Input [2]: [ss_customer_sk#1, ss_sold_date_sk#2]
 Condition : isnotnull(ss_customer_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 65]
+(4) ReusedExchange [Reuses operator id: 69]
 Output [2]: [d_date_sk#4, d_date#5]
 
 (5) BroadcastHashJoin [codegen id : 2]
@@ -88,58 +92,61 @@ Join condition: None
 Output [2]: [ss_customer_sk#1, d_date#5]
 Input [4]: [ss_customer_sk#1, ss_sold_date_sk#2, d_date_sk#4, d_date#5]
 
-(7) Exchange
+(7) HashAggregate [codegen id : 2]
 Input [2]: [ss_customer_sk#1, d_date#5]
+Keys [2]: [d_date#5, ss_customer_sk#1]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [d_date#5, ss_customer_sk#1]
+
+(8) Exchange
+Input [2]: [d_date#5, ss_customer_sk#1]
 Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [id=#6]
 
-(8) Sort [codegen id : 3]
-Input [2]: [ss_customer_sk#1, d_date#5]
+(9) Sort [codegen id : 3]
+Input [2]: [d_date#5, ss_customer_sk#1]
 Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(9) Scan parquet default.customer
+(10) Scan parquet default.customer
 Output [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_first_name:string,c_last_name:string>
 
-(10) ColumnarToRow [codegen id : 4]
+(11) ColumnarToRow [codegen id : 4]
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 
-(11) Filter [codegen id : 4]
+(12) Filter [codegen id : 4]
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
 Condition : isnotnull(c_customer_sk#7)
 
-(12) Exchange
+(13) HashAggregate [codegen id : 4]
 Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
+Keys [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
+
+(14) Exchange
+Input [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
 Arguments: hashpartitioning(c_customer_sk#7, 5), ENSURE_REQUIREMENTS, [id=#10]
 
-(13) Sort [codegen id : 5]
-Input [3]: [c_customer_sk#7, c_first_name#8, c_last_name#9]
+(15) Sort [codegen id : 5]
+Input [3]: [c_last_name#9, c_first_name#8, c_customer_sk#7]
 Arguments: [c_customer_sk#7 ASC NULLS FIRST], false, 0
 
-(14) SortMergeJoin [codegen id : 6]
+(16) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#7]
 Join condition: None
 
-(15) Project [codegen id : 6]
-Output [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Input [5]: [ss_customer_sk#1, d_date#5, c_customer_sk#7, c_first_name#8, c_last_name#9]
+(17) Project [codegen id : 6]
+Output [3]: [d_date#5, c_last_name#9, c_first_name#8]
+Input [5]: [d_date#5, ss_customer_sk#1, c_last_name#9, c_first_name#8, c_customer_sk#7]
 
-(16) HashAggregate [codegen id : 6]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Functions: []
-Aggregate Attributes: []
-Results [3]: [c_last_name#9, c_first_name#8, d_date#5]
-
-(17) Exchange
-Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
-Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#5, 5), ENSURE_REQUIREMENTS, [id=#11]
-
-(18) HashAggregate [codegen id : 7]
-Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
+(18) HashAggregate [codegen id : 6]
+Input [3]: [d_date#5, c_last_name#9, c_first_name#8]
 Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Functions: []
 Aggregate Attributes: []
@@ -147,13 +154,24 @@ Results [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
 (19) Exchange
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
+Arguments: hashpartitioning(c_last_name#9, c_first_name#8, d_date#5, 5), ENSURE_REQUIREMENTS, [id=#11]
+
+(20) HashAggregate [codegen id : 7]
+Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
+Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
+Functions: []
+Aggregate Attributes: []
+Results [3]: [c_last_name#9, c_first_name#8, d_date#5]
+
+(21) Exchange
+Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Arguments: hashpartitioning(coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#5, 1970-01-01), isnull(d_date#5), 5), ENSURE_REQUIREMENTS, [id=#12]
 
-(20) Sort [codegen id : 8]
+(22) Sort [codegen id : 8]
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Arguments: [coalesce(c_last_name#9, ) ASC NULLS FIRST, isnull(c_last_name#9) ASC NULLS FIRST, coalesce(c_first_name#8, ) ASC NULLS FIRST, isnull(c_first_name#8) ASC NULLS FIRST, coalesce(d_date#5, 1970-01-01) ASC NULLS FIRST, isnull(d_date#5) ASC NULLS FIRST], false, 0
 
-(21) Scan parquet default.catalog_sales
+(23) Scan parquet default.catalog_sales
 Output [2]: [cs_bill_customer_sk#13, cs_sold_date_sk#14]
 Batched: true
 Location: InMemoryFileIndex []
@@ -161,81 +179,88 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#14), dynamicpruningexpression(cs_so
 PushedFilters: [IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int>
 
-(22) ColumnarToRow [codegen id : 10]
+(24) ColumnarToRow [codegen id : 10]
 Input [2]: [cs_bill_customer_sk#13, cs_sold_date_sk#14]
 
-(23) Filter [codegen id : 10]
+(25) Filter [codegen id : 10]
 Input [2]: [cs_bill_customer_sk#13, cs_sold_date_sk#14]
 Condition : isnotnull(cs_bill_customer_sk#13)
 
-(24) ReusedExchange [Reuses operator id: 65]
+(26) ReusedExchange [Reuses operator id: 69]
 Output [2]: [d_date_sk#15, d_date#16]
 
-(25) BroadcastHashJoin [codegen id : 10]
+(27) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
 Join condition: None
 
-(26) Project [codegen id : 10]
+(28) Project [codegen id : 10]
 Output [2]: [cs_bill_customer_sk#13, d_date#16]
 Input [4]: [cs_bill_customer_sk#13, cs_sold_date_sk#14, d_date_sk#15, d_date#16]
 
-(27) Exchange
+(29) HashAggregate [codegen id : 10]
 Input [2]: [cs_bill_customer_sk#13, d_date#16]
+Keys [2]: [d_date#16, cs_bill_customer_sk#13]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [d_date#16, cs_bill_customer_sk#13]
+
+(30) Exchange
+Input [2]: [d_date#16, cs_bill_customer_sk#13]
 Arguments: hashpartitioning(cs_bill_customer_sk#13, 5), ENSURE_REQUIREMENTS, [id=#17]
 
-(28) Sort [codegen id : 11]
-Input [2]: [cs_bill_customer_sk#13, d_date#16]
+(31) Sort [codegen id : 11]
+Input [2]: [d_date#16, cs_bill_customer_sk#13]
 Arguments: [cs_bill_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(29) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#18, c_first_name#19, c_last_name#20]
+(32) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_last_name#18, c_first_name#19, c_customer_sk#20]
 
-(30) Sort [codegen id : 13]
-Input [3]: [c_customer_sk#18, c_first_name#19, c_last_name#20]
-Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+(33) Sort [codegen id : 13]
+Input [3]: [c_last_name#18, c_first_name#19, c_customer_sk#20]
+Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 
-(31) SortMergeJoin [codegen id : 14]
+(34) SortMergeJoin [codegen id : 14]
 Left keys [1]: [cs_bill_customer_sk#13]
-Right keys [1]: [c_customer_sk#18]
+Right keys [1]: [c_customer_sk#20]
 Join condition: None
 
-(32) Project [codegen id : 14]
-Output [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Input [5]: [cs_bill_customer_sk#13, d_date#16, c_customer_sk#18, c_first_name#19, c_last_name#20]
+(35) Project [codegen id : 14]
+Output [3]: [d_date#16, c_last_name#18, c_first_name#19]
+Input [5]: [d_date#16, cs_bill_customer_sk#13, c_last_name#18, c_first_name#19, c_customer_sk#20]
 
-(33) HashAggregate [codegen id : 14]
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
+(36) HashAggregate [codegen id : 14]
+Input [3]: [d_date#16, c_last_name#18, c_first_name#19]
+Keys [3]: [c_last_name#18, c_first_name#19, d_date#16]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#20, c_first_name#19, d_date#16]
+Results [3]: [c_last_name#18, c_first_name#19, d_date#16]
 
-(34) Exchange
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Arguments: hashpartitioning(c_last_name#20, c_first_name#19, d_date#16, 5), ENSURE_REQUIREMENTS, [id=#21]
+(37) Exchange
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Arguments: hashpartitioning(c_last_name#18, c_first_name#19, d_date#16, 5), ENSURE_REQUIREMENTS, [id=#21]
 
-(35) HashAggregate [codegen id : 15]
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
+(38) HashAggregate [codegen id : 15]
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Keys [3]: [c_last_name#18, c_first_name#19, d_date#16]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#20, c_first_name#19, d_date#16]
+Results [3]: [c_last_name#18, c_first_name#19, d_date#16]
 
-(36) Exchange
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Arguments: hashpartitioning(coalesce(c_last_name#20, ), isnull(c_last_name#20), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16), 5), ENSURE_REQUIREMENTS, [id=#22]
+(39) Exchange
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Arguments: hashpartitioning(coalesce(c_last_name#18, ), isnull(c_last_name#18), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16), 5), ENSURE_REQUIREMENTS, [id=#22]
 
-(37) Sort [codegen id : 16]
-Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
-Arguments: [coalesce(c_last_name#20, ) ASC NULLS FIRST, isnull(c_last_name#20) ASC NULLS FIRST, coalesce(c_first_name#19, ) ASC NULLS FIRST, isnull(c_first_name#19) ASC NULLS FIRST, coalesce(d_date#16, 1970-01-01) ASC NULLS FIRST, isnull(d_date#16) ASC NULLS FIRST], false, 0
+(40) Sort [codegen id : 16]
+Input [3]: [c_last_name#18, c_first_name#19, d_date#16]
+Arguments: [coalesce(c_last_name#18, ) ASC NULLS FIRST, isnull(c_last_name#18) ASC NULLS FIRST, coalesce(c_first_name#19, ) ASC NULLS FIRST, isnull(c_first_name#19) ASC NULLS FIRST, coalesce(d_date#16, 1970-01-01) ASC NULLS FIRST, isnull(d_date#16) ASC NULLS FIRST], false, 0
 
-(38) SortMergeJoin [codegen id : 17]
+(41) SortMergeJoin [codegen id : 17]
 Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#20, ), isnull(c_last_name#20), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16)]
+Right keys [6]: [coalesce(c_last_name#18, ), isnull(c_last_name#18), coalesce(c_first_name#19, ), isnull(c_first_name#19), coalesce(d_date#16, 1970-01-01), isnull(d_date#16)]
 Join condition: None
 
-(39) Scan parquet default.web_sales
+(42) Scan parquet default.web_sales
 Output [2]: [ws_bill_customer_sk#23, ws_sold_date_sk#24]
 Batched: true
 Location: InMemoryFileIndex []
@@ -243,96 +268,103 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#24), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_bill_customer_sk:int>
 
-(40) ColumnarToRow [codegen id : 19]
+(43) ColumnarToRow [codegen id : 19]
 Input [2]: [ws_bill_customer_sk#23, ws_sold_date_sk#24]
 
-(41) Filter [codegen id : 19]
+(44) Filter [codegen id : 19]
 Input [2]: [ws_bill_customer_sk#23, ws_sold_date_sk#24]
 Condition : isnotnull(ws_bill_customer_sk#23)
 
-(42) ReusedExchange [Reuses operator id: 65]
+(45) ReusedExchange [Reuses operator id: 69]
 Output [2]: [d_date_sk#25, d_date#26]
 
-(43) BroadcastHashJoin [codegen id : 19]
+(46) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#24]
 Right keys [1]: [d_date_sk#25]
 Join condition: None
 
-(44) Project [codegen id : 19]
+(47) Project [codegen id : 19]
 Output [2]: [ws_bill_customer_sk#23, d_date#26]
 Input [4]: [ws_bill_customer_sk#23, ws_sold_date_sk#24, d_date_sk#25, d_date#26]
 
-(45) Exchange
+(48) HashAggregate [codegen id : 19]
 Input [2]: [ws_bill_customer_sk#23, d_date#26]
+Keys [2]: [d_date#26, ws_bill_customer_sk#23]
+Functions: []
+Aggregate Attributes: []
+Results [2]: [d_date#26, ws_bill_customer_sk#23]
+
+(49) Exchange
+Input [2]: [d_date#26, ws_bill_customer_sk#23]
 Arguments: hashpartitioning(ws_bill_customer_sk#23, 5), ENSURE_REQUIREMENTS, [id=#27]
 
-(46) Sort [codegen id : 20]
-Input [2]: [ws_bill_customer_sk#23, d_date#26]
+(50) Sort [codegen id : 20]
+Input [2]: [d_date#26, ws_bill_customer_sk#23]
 Arguments: [ws_bill_customer_sk#23 ASC NULLS FIRST], false, 0
 
-(47) ReusedExchange [Reuses operator id: 12]
-Output [3]: [c_customer_sk#28, c_first_name#29, c_last_name#30]
+(51) ReusedExchange [Reuses operator id: 14]
+Output [3]: [c_last_name#28, c_first_name#29, c_customer_sk#30]
 
-(48) Sort [codegen id : 22]
-Input [3]: [c_customer_sk#28, c_first_name#29, c_last_name#30]
-Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
+(52) Sort [codegen id : 22]
+Input [3]: [c_last_name#28, c_first_name#29, c_customer_sk#30]
+Arguments: [c_customer_sk#30 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 23]
+(53) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#23]
-Right keys [1]: [c_customer_sk#28]
+Right keys [1]: [c_customer_sk#30]
 Join condition: None
 
-(50) Project [codegen id : 23]
-Output [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Input [5]: [ws_bill_customer_sk#23, d_date#26, c_customer_sk#28, c_first_name#29, c_last_name#30]
+(54) Project [codegen id : 23]
+Output [3]: [d_date#26, c_last_name#28, c_first_name#29]
+Input [5]: [d_date#26, ws_bill_customer_sk#23, c_last_name#28, c_first_name#29, c_customer_sk#30]
 
-(51) HashAggregate [codegen id : 23]
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
+(55) HashAggregate [codegen id : 23]
+Input [3]: [d_date#26, c_last_name#28, c_first_name#29]
+Keys [3]: [c_last_name#28, c_first_name#29, d_date#26]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#30, c_first_name#29, d_date#26]
+Results [3]: [c_last_name#28, c_first_name#29, d_date#26]
 
-(52) Exchange
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Arguments: hashpartitioning(c_last_name#30, c_first_name#29, d_date#26, 5), ENSURE_REQUIREMENTS, [id=#31]
+(56) Exchange
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Arguments: hashpartitioning(c_last_name#28, c_first_name#29, d_date#26, 5), ENSURE_REQUIREMENTS, [id=#31]
 
-(53) HashAggregate [codegen id : 24]
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
+(57) HashAggregate [codegen id : 24]
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Keys [3]: [c_last_name#28, c_first_name#29, d_date#26]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [c_last_name#30, c_first_name#29, d_date#26]
+Results [3]: [c_last_name#28, c_first_name#29, d_date#26]
 
-(54) Exchange
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Arguments: hashpartitioning(coalesce(c_last_name#30, ), isnull(c_last_name#30), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26), 5), ENSURE_REQUIREMENTS, [id=#32]
+(58) Exchange
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Arguments: hashpartitioning(coalesce(c_last_name#28, ), isnull(c_last_name#28), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26), 5), ENSURE_REQUIREMENTS, [id=#32]
 
-(55) Sort [codegen id : 25]
-Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
-Arguments: [coalesce(c_last_name#30, ) ASC NULLS FIRST, isnull(c_last_name#30) ASC NULLS FIRST, coalesce(c_first_name#29, ) ASC NULLS FIRST, isnull(c_first_name#29) ASC NULLS FIRST, coalesce(d_date#26, 1970-01-01) ASC NULLS FIRST, isnull(d_date#26) ASC NULLS FIRST], false, 0
+(59) Sort [codegen id : 25]
+Input [3]: [c_last_name#28, c_first_name#29, d_date#26]
+Arguments: [coalesce(c_last_name#28, ) ASC NULLS FIRST, isnull(c_last_name#28) ASC NULLS FIRST, coalesce(c_first_name#29, ) ASC NULLS FIRST, isnull(c_first_name#29) ASC NULLS FIRST, coalesce(d_date#26, 1970-01-01) ASC NULLS FIRST, isnull(d_date#26) ASC NULLS FIRST], false, 0
 
-(56) SortMergeJoin [codegen id : 26]
+(60) SortMergeJoin [codegen id : 26]
 Left keys [6]: [coalesce(c_last_name#9, ), isnull(c_last_name#9), coalesce(c_first_name#8, ), isnull(c_first_name#8), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
-Right keys [6]: [coalesce(c_last_name#30, ), isnull(c_last_name#30), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26)]
+Right keys [6]: [coalesce(c_last_name#28, ), isnull(c_last_name#28), coalesce(c_first_name#29, ), isnull(c_first_name#29), coalesce(d_date#26, 1970-01-01), isnull(d_date#26)]
 Join condition: None
 
-(57) Project [codegen id : 26]
+(61) Project [codegen id : 26]
 Output: []
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
-(58) HashAggregate [codegen id : 26]
+(62) HashAggregate [codegen id : 26]
 Input: []
 Keys: []
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#33]
 Results [1]: [count#34]
 
-(59) Exchange
+(63) Exchange
 Input [1]: [count#34]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [id=#35]
 
-(60) HashAggregate [codegen id : 27]
+(64) HashAggregate [codegen id : 27]
 Input [1]: [count#34]
 Keys: []
 Functions [1]: [count(1)]
@@ -342,37 +374,37 @@ Results [1]: [count(1)#36 AS count(1)#37]
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#2 IN dynamicpruning#3
-BroadcastExchange (65)
-+- * Project (64)
-   +- * Filter (63)
-      +- * ColumnarToRow (62)
-         +- Scan parquet default.date_dim (61)
+BroadcastExchange (69)
++- * Project (68)
+   +- * Filter (67)
+      +- * ColumnarToRow (66)
+         +- Scan parquet default.date_dim (65)
 
 
-(61) Scan parquet default.date_dim
+(65) Scan parquet default.date_dim
 Output [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1200), LessThanOrEqual(d_month_seq,1211), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_month_seq:int>
 
-(62) ColumnarToRow [codegen id : 1]
+(66) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 
-(63) Filter [codegen id : 1]
+(67) Filter [codegen id : 1]
 Input [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 Condition : (((isnotnull(d_month_seq#38) AND (d_month_seq#38 >= 1200)) AND (d_month_seq#38 <= 1211)) AND isnotnull(d_date_sk#4))
 
-(64) Project [codegen id : 1]
+(68) Project [codegen id : 1]
 Output [2]: [d_date_sk#4, d_date#5]
 Input [3]: [d_date_sk#4, d_date#5, d_month_seq#38]
 
-(65) BroadcastExchange
+(69) BroadcastExchange
 Input [2]: [d_date_sk#4, d_date#5]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#39]
 
-Subquery:2 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#3
+Subquery:2 Hosting operator id = 23 Hosting Expression = cs_sold_date_sk#14 IN dynamicpruning#3
 
-Subquery:3 Hosting operator id = 39 Hosting Expression = ws_sold_date_sk#24 IN dynamicpruning#3
+Subquery:3 Hosting operator id = 42 Hosting Expression = ws_sold_date_sk#24 IN dynamicpruning#3
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/simplified.txt
@@ -20,7 +20,7 @@ WholeStageCodegen (27)
                                       Exchange [c_last_name,c_first_name,d_date] #3
                                         WholeStageCodegen (6)
                                           HashAggregate [c_last_name,c_first_name,d_date]
-                                            Project [c_last_name,c_first_name,d_date]
+                                            Project [d_date,c_last_name,c_first_name]
                                               SortMergeJoin [ss_customer_sk,c_customer_sk]
                                                 InputAdapter
                                                   WholeStageCodegen (3)
@@ -28,32 +28,34 @@ WholeStageCodegen (27)
                                                       InputAdapter
                                                         Exchange [ss_customer_sk] #4
                                                           WholeStageCodegen (2)
-                                                            Project [ss_customer_sk,d_date]
-                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                Filter [ss_customer_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                        SubqueryBroadcast [d_date_sk] #1
-                                                                          BroadcastExchange #5
-                                                                            WholeStageCodegen (1)
-                                                                              Project [d_date_sk,d_date]
-                                                                                Filter [d_month_seq,d_date_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet default.date_dim [d_date_sk,d_date,d_month_seq]
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_date] #5
+                                                            HashAggregate [d_date,ss_customer_sk]
+                                                              Project [ss_customer_sk,d_date]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  Filter [ss_customer_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                          SubqueryBroadcast [d_date_sk] #1
+                                                                            BroadcastExchange #5
+                                                                              WholeStageCodegen (1)
+                                                                                Project [d_date_sk,d_date]
+                                                                                  Filter [d_month_seq,d_date_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet default.date_dim [d_date_sk,d_date,d_month_seq]
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_date] #5
                                                 InputAdapter
                                                   WholeStageCodegen (5)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
                                                         Exchange [c_customer_sk] #6
                                                           WholeStageCodegen (4)
-                                                            Filter [c_customer_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet default.customer [c_customer_sk,c_first_name,c_last_name]
+                                                            HashAggregate [c_last_name,c_first_name,c_customer_sk]
+                                                              Filter [c_customer_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet default.customer [c_customer_sk,c_first_name,c_last_name]
                       InputAdapter
                         WholeStageCodegen (16)
                           Sort [c_last_name,c_first_name,d_date]
@@ -65,7 +67,7 @@ WholeStageCodegen (27)
                                       Exchange [c_last_name,c_first_name,d_date] #8
                                         WholeStageCodegen (14)
                                           HashAggregate [c_last_name,c_first_name,d_date]
-                                            Project [c_last_name,c_first_name,d_date]
+                                            Project [d_date,c_last_name,c_first_name]
                                               SortMergeJoin [cs_bill_customer_sk,c_customer_sk]
                                                 InputAdapter
                                                   WholeStageCodegen (11)
@@ -73,20 +75,21 @@ WholeStageCodegen (27)
                                                       InputAdapter
                                                         Exchange [cs_bill_customer_sk] #9
                                                           WholeStageCodegen (10)
-                                                            Project [cs_bill_customer_sk,d_date]
-                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                Filter [cs_bill_customer_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet default.catalog_sales [cs_bill_customer_sk,cs_sold_date_sk]
-                                                                        ReusedSubquery [d_date_sk] #1
-                                                                InputAdapter
-                                                                  ReusedExchange [d_date_sk,d_date] #5
+                                                            HashAggregate [d_date,cs_bill_customer_sk]
+                                                              Project [cs_bill_customer_sk,d_date]
+                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                  Filter [cs_bill_customer_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.catalog_sales [cs_bill_customer_sk,cs_sold_date_sk]
+                                                                          ReusedSubquery [d_date_sk] #1
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk,d_date] #5
                                                 InputAdapter
                                                   WholeStageCodegen (13)
                                                     Sort [c_customer_sk]
                                                       InputAdapter
-                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                        ReusedExchange [c_last_name,c_first_name,c_customer_sk] #6
                 InputAdapter
                   WholeStageCodegen (25)
                     Sort [c_last_name,c_first_name,d_date]
@@ -98,7 +101,7 @@ WholeStageCodegen (27)
                                 Exchange [c_last_name,c_first_name,d_date] #11
                                   WholeStageCodegen (23)
                                     HashAggregate [c_last_name,c_first_name,d_date]
-                                      Project [c_last_name,c_first_name,d_date]
+                                      Project [d_date,c_last_name,c_first_name]
                                         SortMergeJoin [ws_bill_customer_sk,c_customer_sk]
                                           InputAdapter
                                             WholeStageCodegen (20)
@@ -106,17 +109,18 @@ WholeStageCodegen (27)
                                                 InputAdapter
                                                   Exchange [ws_bill_customer_sk] #12
                                                     WholeStageCodegen (19)
-                                                      Project [ws_bill_customer_sk,d_date]
-                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                          Filter [ws_bill_customer_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                  ReusedSubquery [d_date_sk] #1
-                                                          InputAdapter
-                                                            ReusedExchange [d_date_sk,d_date] #5
+                                                      HashAggregate [d_date,ws_bill_customer_sk]
+                                                        Project [ws_bill_customer_sk,d_date]
+                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                            Filter [ws_bill_customer_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                                    ReusedSubquery [d_date_sk] #1
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk,d_date] #5
                                           InputAdapter
                                             WholeStageCodegen (22)
                                               Sort [c_customer_sk]
                                                 InputAdapter
-                                                  ReusedExchange [c_customer_sk,c_first_name,c_last_name] #6
+                                                  ReusedExchange [c_last_name,c_first_name,c_customer_sk] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -18,57 +18,57 @@ TakeOrderedAndProject (99)
    :                 :     :  +- * Sort (59)
    :                 :     :     +- Exchange (58)
    :                 :     :        +- * Project (57)
-   :                 :     :           +- * BroadcastHashJoin Inner BuildRight (56)
-   :                 :     :              :- * Filter (8)
-   :                 :     :              :  +- * ColumnarToRow (7)
-   :                 :     :              :     +- Scan parquet default.item (6)
-   :                 :     :              +- BroadcastExchange (55)
-   :                 :     :                 +- * SortMergeJoin LeftSemi (54)
-   :                 :     :                    :- * Sort (42)
-   :                 :     :                    :  +- Exchange (41)
-   :                 :     :                    :     +- * HashAggregate (40)
-   :                 :     :                    :        +- Exchange (39)
-   :                 :     :                    :           +- * HashAggregate (38)
-   :                 :     :                    :              +- * Project (37)
-   :                 :     :                    :                 +- * BroadcastHashJoin Inner BuildRight (36)
-   :                 :     :                    :                    :- * Project (14)
-   :                 :     :                    :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-   :                 :     :                    :                    :     :- * Filter (11)
-   :                 :     :                    :                    :     :  +- * ColumnarToRow (10)
-   :                 :     :                    :                    :     :     +- Scan parquet default.store_sales (9)
-   :                 :     :                    :                    :     +- ReusedExchange (12)
-   :                 :     :                    :                    +- BroadcastExchange (35)
-   :                 :     :                    :                       +- * SortMergeJoin LeftSemi (34)
-   :                 :     :                    :                          :- * Sort (19)
-   :                 :     :                    :                          :  +- Exchange (18)
-   :                 :     :                    :                          :     +- * Filter (17)
-   :                 :     :                    :                          :        +- * ColumnarToRow (16)
-   :                 :     :                    :                          :           +- Scan parquet default.item (15)
-   :                 :     :                    :                          +- * Sort (33)
-   :                 :     :                    :                             +- Exchange (32)
-   :                 :     :                    :                                +- * Project (31)
-   :                 :     :                    :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-   :                 :     :                    :                                      :- * Project (25)
-   :                 :     :                    :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-   :                 :     :                    :                                      :     :- * Filter (22)
-   :                 :     :                    :                                      :     :  +- * ColumnarToRow (21)
-   :                 :     :                    :                                      :     :     +- Scan parquet default.catalog_sales (20)
-   :                 :     :                    :                                      :     +- ReusedExchange (23)
-   :                 :     :                    :                                      +- BroadcastExchange (29)
-   :                 :     :                    :                                         +- * Filter (28)
-   :                 :     :                    :                                            +- * ColumnarToRow (27)
-   :                 :     :                    :                                               +- Scan parquet default.item (26)
-   :                 :     :                    +- * Sort (53)
-   :                 :     :                       +- Exchange (52)
-   :                 :     :                          +- * Project (51)
-   :                 :     :                             +- * BroadcastHashJoin Inner BuildRight (50)
-   :                 :     :                                :- * Project (48)
-   :                 :     :                                :  +- * BroadcastHashJoin Inner BuildRight (47)
-   :                 :     :                                :     :- * Filter (45)
-   :                 :     :                                :     :  +- * ColumnarToRow (44)
-   :                 :     :                                :     :     +- Scan parquet default.web_sales (43)
-   :                 :     :                                :     +- ReusedExchange (46)
-   :                 :     :                                +- ReusedExchange (49)
+   :                 :     :           +- * BroadcastHashJoin Inner BuildLeft (56)
+   :                 :     :              :- BroadcastExchange (9)
+   :                 :     :              :  +- * Filter (8)
+   :                 :     :              :     +- * ColumnarToRow (7)
+   :                 :     :              :        +- Scan parquet default.item (6)
+   :                 :     :              +- * SortMergeJoin LeftSemi (55)
+   :                 :     :                 :- * Sort (43)
+   :                 :     :                 :  +- Exchange (42)
+   :                 :     :                 :     +- * HashAggregate (41)
+   :                 :     :                 :        +- Exchange (40)
+   :                 :     :                 :           +- * HashAggregate (39)
+   :                 :     :                 :              +- * Project (38)
+   :                 :     :                 :                 +- * BroadcastHashJoin Inner BuildRight (37)
+   :                 :     :                 :                    :- * Project (15)
+   :                 :     :                 :                    :  +- * BroadcastHashJoin Inner BuildRight (14)
+   :                 :     :                 :                    :     :- * Filter (12)
+   :                 :     :                 :                    :     :  +- * ColumnarToRow (11)
+   :                 :     :                 :                    :     :     +- Scan parquet default.store_sales (10)
+   :                 :     :                 :                    :     +- ReusedExchange (13)
+   :                 :     :                 :                    +- BroadcastExchange (36)
+   :                 :     :                 :                       +- * SortMergeJoin LeftSemi (35)
+   :                 :     :                 :                          :- * Sort (20)
+   :                 :     :                 :                          :  +- Exchange (19)
+   :                 :     :                 :                          :     +- * Filter (18)
+   :                 :     :                 :                          :        +- * ColumnarToRow (17)
+   :                 :     :                 :                          :           +- Scan parquet default.item (16)
+   :                 :     :                 :                          +- * Sort (34)
+   :                 :     :                 :                             +- Exchange (33)
+   :                 :     :                 :                                +- * Project (32)
+   :                 :     :                 :                                   +- * BroadcastHashJoin Inner BuildRight (31)
+   :                 :     :                 :                                      :- * Project (26)
+   :                 :     :                 :                                      :  +- * BroadcastHashJoin Inner BuildRight (25)
+   :                 :     :                 :                                      :     :- * Filter (23)
+   :                 :     :                 :                                      :     :  +- * ColumnarToRow (22)
+   :                 :     :                 :                                      :     :     +- Scan parquet default.catalog_sales (21)
+   :                 :     :                 :                                      :     +- ReusedExchange (24)
+   :                 :     :                 :                                      +- BroadcastExchange (30)
+   :                 :     :                 :                                         +- * Filter (29)
+   :                 :     :                 :                                            +- * ColumnarToRow (28)
+   :                 :     :                 :                                               +- Scan parquet default.item (27)
+   :                 :     :                 +- * Sort (54)
+   :                 :     :                    +- Exchange (53)
+   :                 :     :                       +- * Project (52)
+   :                 :     :                          +- * BroadcastHashJoin Inner BuildRight (51)
+   :                 :     :                             :- * Project (49)
+   :                 :     :                             :  +- * BroadcastHashJoin Inner BuildRight (48)
+   :                 :     :                             :     :- * Filter (46)
+   :                 :     :                             :     :  +- * ColumnarToRow (45)
+   :                 :     :                             :     :     +- Scan parquet default.web_sales (44)
+   :                 :     :                             :     +- ReusedExchange (47)
+   :                 :     :                             +- ReusedExchange (50)
    :                 :     +- ReusedExchange (61)
    :                 +- BroadcastExchange (72)
    :                    +- * SortMergeJoin LeftSemi (71)
@@ -130,232 +130,232 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 19]
+(7) ColumnarToRow [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 
-(8) Filter [codegen id : 19]
+(8) Filter [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(9) BroadcastExchange
+Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[2, int, false], input[3, int, false]),false), [id=#11]
+
+(10) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#13), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(11) ColumnarToRow [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(12) Filter [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
+Condition : isnotnull(ss_item_sk#12)
 
-(12) ReusedExchange [Reuses operator id: 132]
-Output [1]: [d_date_sk#14]
+(13) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#15]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(14) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_sold_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(15) Project [codegen id : 12]
+Output [1]: [ss_item_sk#12]
+Input [3]: [ss_item_sk#12, ss_sold_date_sk#13, d_date_sk#15]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(16) Scan parquet default.item
+Output [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(17) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(18) Filter [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Condition : (((isnotnull(i_item_sk#16) AND isnotnull(i_brand_id#17)) AND isnotnull(i_class_id#18)) AND isnotnull(i_category_id#19))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(19) Exchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: hashpartitioning(coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19), 5), ENSURE_REQUIREMENTS, [id=#20]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(20) Sort [codegen id : 6]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: [coalesce(i_brand_id#17, 0) ASC NULLS FIRST, isnull(i_brand_id#17) ASC NULLS FIRST, coalesce(i_class_id#18, 0) ASC NULLS FIRST, isnull(i_class_id#18) ASC NULLS FIRST, coalesce(i_category_id#19, 0) ASC NULLS FIRST, isnull(i_category_id#19) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(21) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#22), dynamicpruningexpression(cs_sold_date_sk#22 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(22) ColumnarToRow [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(23) Filter [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
+Condition : isnotnull(cs_item_sk#21)
 
-(23) ReusedExchange [Reuses operator id: 132]
-Output [1]: [d_date_sk#22]
+(24) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#23]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(25) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_sold_date_sk#22]
+Right keys [1]: [d_date_sk#23]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(26) Project [codegen id : 9]
+Output [1]: [cs_item_sk#21]
+Input [3]: [cs_item_sk#21, cs_sold_date_sk#22, d_date_sk#23]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(27) Scan parquet default.item
+Output [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(28) ColumnarToRow [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(29) Filter [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Condition : isnotnull(i_item_sk#24)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(30) BroadcastExchange
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(31) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_item_sk#21]
+Right keys [1]: [i_item_sk#24]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(32) Project [codegen id : 9]
+Output [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Input [5]: [cs_item_sk#21, i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(33) Exchange
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: hashpartitioning(coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27), 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 10]
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: [coalesce(i_brand_id#25, 0) ASC NULLS FIRST, isnull(i_brand_id#25) ASC NULLS FIRST, coalesce(i_class_id#26, 0) ASC NULLS FIRST, isnull(i_class_id#26) ASC NULLS FIRST, coalesce(i_category_id#27, 0) ASC NULLS FIRST, isnull(i_category_id#27) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(35) SortMergeJoin [codegen id : 11]
+Left keys [6]: [coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19)]
+Right keys [6]: [coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(36) BroadcastExchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(37) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_item_sk#12]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(38) Project [codegen id : 12]
+Output [3]: [i_brand_id#17 AS brand_id#31, i_class_id#18 AS class_id#32, i_category_id#19 AS category_id#33]
+Input [5]: [ss_item_sk#12, i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(39) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+(40) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(brand_id#31, class_id#32, category_id#33, 5), ENSURE_REQUIREMENTS, [id=#34]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(41) HashAggregate [codegen id : 13]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
+(42) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33), 5), ENSURE_REQUIREMENTS, [id=#35]
 
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
+(43) Sort [codegen id : 14]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: [coalesce(brand_id#31, 0) ASC NULLS FIRST, isnull(brand_id#31) ASC NULLS FIRST, coalesce(class_id#32, 0) ASC NULLS FIRST, isnull(class_id#32) ASC NULLS FIRST, coalesce(category_id#33, 0) ASC NULLS FIRST, isnull(category_id#33) ASC NULLS FIRST], false, 0
 
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(44) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#37), dynamicpruningexpression(ws_sold_date_sk#37 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(45) ColumnarToRow [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(46) Filter [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
+Condition : isnotnull(ws_item_sk#36)
 
-(46) ReusedExchange [Reuses operator id: 132]
-Output [1]: [d_date_sk#37]
+(47) ReusedExchange [Reuses operator id: 132]
+Output [1]: [d_date_sk#38]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(48) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#37]
+Right keys [1]: [d_date_sk#38]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(49) Project [codegen id : 17]
+Output [1]: [ws_item_sk#36]
+Input [3]: [ws_item_sk#36, ws_sold_date_sk#37, d_date_sk#38]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(50) ReusedExchange [Reuses operator id: 30]
+Output [4]: [i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(51) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#36]
+Right keys [1]: [i_item_sk#39]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(52) Project [codegen id : 17]
+Output [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Input [5]: [ws_item_sk#36, i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(53) Exchange
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: hashpartitioning(coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42), 5), ENSURE_REQUIREMENTS, [id=#43]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(54) Sort [codegen id : 18]
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: [coalesce(i_brand_id#40, 0) ASC NULLS FIRST, isnull(i_brand_id#40) ASC NULLS FIRST, coalesce(i_class_id#41, 0) ASC NULLS FIRST, isnull(i_class_id#41) ASC NULLS FIRST, coalesce(i_category_id#42, 0) ASC NULLS FIRST, isnull(i_category_id#42) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(55) SortMergeJoin
+Left keys [6]: [coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33)]
+Right keys [6]: [coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42)]
 Join condition: None
-
-(55) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+Right keys [3]: [brand_id#31, class_id#32, category_id#33]
 Join condition: None
 
 (57) Project [codegen id : 19]
 Output [1]: [i_item_sk#7 AS ss_item_sk#44]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#31, class_id#32, category_id#33]
 
 (58) Exchange
 Input [1]: [ss_item_sk#44]
@@ -573,7 +573,7 @@ Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquer
 Output [3]: [ss_quantity#91, ss_list_price#92, ss_sold_date_sk#93]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#93), dynamicpruningexpression(ss_sold_date_sk#93 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#93), dynamicpruningexpression(ss_sold_date_sk#93 IN dynamicpruning#14)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (101) ColumnarToRow [codegen id : 2]
@@ -595,7 +595,7 @@ Input [4]: [ss_quantity#91, ss_list_price#92, ss_sold_date_sk#93, d_date_sk#94]
 Output [3]: [cs_quantity#97, cs_list_price#98, cs_sold_date_sk#99]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#99), dynamicpruningexpression(cs_sold_date_sk#99 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#99), dynamicpruningexpression(cs_sold_date_sk#99 IN dynamicpruning#14)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (106) ColumnarToRow [codegen id : 4]
@@ -617,7 +617,7 @@ Input [4]: [cs_quantity#97, cs_list_price#98, cs_sold_date_sk#99, d_date_sk#100]
 Output [3]: [ws_quantity#103, ws_list_price#104, ws_sold_date_sk#105]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#105), dynamicpruningexpression(ws_sold_date_sk#105 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#105), dynamicpruningexpression(ws_sold_date_sk#105 IN dynamicpruning#14)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (111) ColumnarToRow [codegen id : 6]
@@ -655,11 +655,11 @@ Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#95 as decimal
 Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#95 as decimal(12,2))) * promote_precision(cast(list_price#96 as decimal(12,2)))), DecimalType(18,2)))#114]
 Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#95 as decimal(12,2))) * promote_precision(cast(list_price#96 as decimal(12,2)))), DecimalType(18,2)))#114 AS average_sales#115]
 
-Subquery:2 Hosting operator id = 100 Hosting Expression = ss_sold_date_sk#93 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 100 Hosting Expression = ss_sold_date_sk#93 IN dynamicpruning#14
 
-Subquery:3 Hosting operator id = 105 Hosting Expression = cs_sold_date_sk#99 IN dynamicpruning#13
+Subquery:3 Hosting operator id = 105 Hosting Expression = cs_sold_date_sk#99 IN dynamicpruning#14
 
-Subquery:4 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#105 IN dynamicpruning#13
+Subquery:4 Hosting operator id = 110 Hosting Expression = ws_sold_date_sk#105 IN dynamicpruning#14
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (123)
@@ -716,7 +716,7 @@ Condition : (((((isnotnull(d_year#121) AND isnotnull(d_moy#122)) AND isnotnull(d
 Output [1]: [d_week_seq#120]
 Input [4]: [d_week_seq#120, d_year#121, d_moy#122, d_dom#123]
 
-Subquery:7 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
+Subquery:7 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (132)
 +- * Project (131)
    +- * Filter (130)
@@ -725,30 +725,30 @@ BroadcastExchange (132)
 
 
 (128) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#124]
+Output [2]: [d_date_sk#15, d_year#124]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1998), LessThanOrEqual(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (129) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#124]
+Input [2]: [d_date_sk#15, d_year#124]
 
 (130) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#124]
-Condition : (((isnotnull(d_year#124) AND (d_year#124 >= 1998)) AND (d_year#124 <= 2000)) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#15, d_year#124]
+Condition : (((isnotnull(d_year#124) AND (d_year#124 >= 1998)) AND (d_year#124 <= 2000)) AND isnotnull(d_date_sk#15))
 
 (131) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#124]
+Output [1]: [d_date_sk#15]
+Input [2]: [d_date_sk#15, d_year#124]
 
 (132) BroadcastExchange
-Input [1]: [d_date_sk#14]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#125]
 
-Subquery:8 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#22 IN dynamicpruning#14
 
-Subquery:9 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:9 Hosting operator id = 44 Hosting Expression = ws_sold_date_sk#37 IN dynamicpruning#14
 
 Subquery:10 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#65, [id=#66]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
@@ -81,100 +81,100 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                       WholeStageCodegen (19)
                                         Project [i_item_sk]
                                           BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                            Filter [i_brand_id,i_class_id,i_category_id]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                             InputAdapter
                                               BroadcastExchange #5
-                                                WholeStageCodegen (18)
-                                                  SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                WholeStageCodegen (3)
+                                                  Filter [i_brand_id,i_class_id,i_category_id]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                            SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                              InputAdapter
+                                                WholeStageCodegen (14)
+                                                  Sort [brand_id,class_id,category_id]
                                                     InputAdapter
-                                                      WholeStageCodegen (13)
-                                                        Sort [brand_id,class_id,category_id]
-                                                          InputAdapter
-                                                            Exchange [brand_id,class_id,category_id] #6
-                                                              WholeStageCodegen (12)
-                                                                HashAggregate [brand_id,class_id,category_id]
-                                                                  InputAdapter
-                                                                    Exchange [brand_id,class_id,category_id] #7
-                                                                      WholeStageCodegen (11)
-                                                                        HashAggregate [brand_id,class_id,category_id]
-                                                                          Project [i_brand_id,i_class_id,i_category_id]
-                                                                            BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                              Project [ss_item_sk]
-                                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                  Filter [ss_item_sk]
-                                                                                    ColumnarToRow
-                                                                                      InputAdapter
-                                                                                        Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                          SubqueryBroadcast [d_date_sk] #3
-                                                                                            BroadcastExchange #8
-                                                                                              WholeStageCodegen (1)
-                                                                                                Project [d_date_sk]
-                                                                                                  Filter [d_year,d_date_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                  InputAdapter
-                                                                                    ReusedExchange [d_date_sk] #8
-                                                                              InputAdapter
-                                                                                BroadcastExchange #9
-                                                                                  WholeStageCodegen (10)
-                                                                                    SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                      InputAdapter
-                                                                                        WholeStageCodegen (5)
-                                                                                          Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                            InputAdapter
-                                                                                              Exchange [i_brand_id,i_class_id,i_category_id] #10
-                                                                                                WholeStageCodegen (4)
-                                                                                                  Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                      InputAdapter
-                                                                                        WholeStageCodegen (9)
-                                                                                          Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                            InputAdapter
-                                                                                              Exchange [i_brand_id,i_class_id,i_category_id] #11
-                                                                                                WholeStageCodegen (8)
-                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                      Project [cs_item_sk]
-                                                                                                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                          Filter [cs_item_sk]
-                                                                                                            ColumnarToRow
-                                                                                                              InputAdapter
-                                                                                                                Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                  ReusedSubquery [d_date_sk] #3
-                                                                                                          InputAdapter
-                                                                                                            ReusedExchange [d_date_sk] #8
-                                                                                                      InputAdapter
-                                                                                                        BroadcastExchange #12
-                                                                                                          WholeStageCodegen (7)
-                                                                                                            Filter [i_item_sk]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                    InputAdapter
-                                                      WholeStageCodegen (17)
-                                                        Sort [i_brand_id,i_class_id,i_category_id]
-                                                          InputAdapter
-                                                            Exchange [i_brand_id,i_class_id,i_category_id] #13
-                                                              WholeStageCodegen (16)
-                                                                Project [i_brand_id,i_class_id,i_category_id]
-                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                    Project [ws_item_sk]
-                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                        Filter [ws_item_sk]
-                                                                          ColumnarToRow
+                                                      Exchange [brand_id,class_id,category_id] #6
+                                                        WholeStageCodegen (13)
+                                                          HashAggregate [brand_id,class_id,category_id]
+                                                            InputAdapter
+                                                              Exchange [brand_id,class_id,category_id] #7
+                                                                WholeStageCodegen (12)
+                                                                  HashAggregate [brand_id,class_id,category_id]
+                                                                    Project [i_brand_id,i_class_id,i_category_id]
+                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                        Project [ss_item_sk]
+                                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                            Filter [ss_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                    SubqueryBroadcast [d_date_sk] #3
+                                                                                      BroadcastExchange #8
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [d_date_sk]
+                                                                                            Filter [d_year,d_date_sk]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet default.date_dim [d_date_sk,d_year]
                                                                             InputAdapter
-                                                                              Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                ReusedSubquery [d_date_sk] #3
+                                                                              ReusedExchange [d_date_sk] #8
                                                                         InputAdapter
-                                                                          ReusedExchange [d_date_sk] #8
-                                                                    InputAdapter
-                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
+                                                                          BroadcastExchange #9
+                                                                            WholeStageCodegen (11)
+                                                                              SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                InputAdapter
+                                                                                  WholeStageCodegen (6)
+                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                      InputAdapter
+                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #10
+                                                                                          WholeStageCodegen (5)
+                                                                                            Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                InputAdapter
+                                                                                  WholeStageCodegen (10)
+                                                                                    Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                      InputAdapter
+                                                                                        Exchange [i_brand_id,i_class_id,i_category_id] #11
+                                                                                          WholeStageCodegen (9)
+                                                                                            Project [i_brand_id,i_class_id,i_category_id]
+                                                                                              BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                Project [cs_item_sk]
+                                                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                    Filter [cs_item_sk]
+                                                                                                      ColumnarToRow
+                                                                                                        InputAdapter
+                                                                                                          Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                            ReusedSubquery [d_date_sk] #3
+                                                                                                    InputAdapter
+                                                                                                      ReusedExchange [d_date_sk] #8
+                                                                                                InputAdapter
+                                                                                                  BroadcastExchange #12
+                                                                                                    WholeStageCodegen (8)
+                                                                                                      Filter [i_item_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                              InputAdapter
+                                                WholeStageCodegen (18)
+                                                  Sort [i_brand_id,i_class_id,i_category_id]
+                                                    InputAdapter
+                                                      Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                        WholeStageCodegen (17)
+                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                              Project [ws_item_sk]
+                                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                  Filter [ws_item_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                          ReusedSubquery [d_date_sk] #3
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk] #8
+                                                              InputAdapter
+                                                                ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #12
                           InputAdapter
                             ReusedExchange [d_date_sk] #3
                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -25,57 +25,57 @@ TakeOrderedAndProject (143)
             :           :                 :     :  +- * Sort (59)
             :           :                 :     :     +- Exchange (58)
             :           :                 :     :        +- * Project (57)
-            :           :                 :     :           +- * BroadcastHashJoin Inner BuildRight (56)
-            :           :                 :     :              :- * Filter (8)
-            :           :                 :     :              :  +- * ColumnarToRow (7)
-            :           :                 :     :              :     +- Scan parquet default.item (6)
-            :           :                 :     :              +- BroadcastExchange (55)
-            :           :                 :     :                 +- * SortMergeJoin LeftSemi (54)
-            :           :                 :     :                    :- * Sort (42)
-            :           :                 :     :                    :  +- Exchange (41)
-            :           :                 :     :                    :     +- * HashAggregate (40)
-            :           :                 :     :                    :        +- Exchange (39)
-            :           :                 :     :                    :           +- * HashAggregate (38)
-            :           :                 :     :                    :              +- * Project (37)
-            :           :                 :     :                    :                 +- * BroadcastHashJoin Inner BuildRight (36)
-            :           :                 :     :                    :                    :- * Project (14)
-            :           :                 :     :                    :                    :  +- * BroadcastHashJoin Inner BuildRight (13)
-            :           :                 :     :                    :                    :     :- * Filter (11)
-            :           :                 :     :                    :                    :     :  +- * ColumnarToRow (10)
-            :           :                 :     :                    :                    :     :     +- Scan parquet default.store_sales (9)
-            :           :                 :     :                    :                    :     +- ReusedExchange (12)
-            :           :                 :     :                    :                    +- BroadcastExchange (35)
-            :           :                 :     :                    :                       +- * SortMergeJoin LeftSemi (34)
-            :           :                 :     :                    :                          :- * Sort (19)
-            :           :                 :     :                    :                          :  +- Exchange (18)
-            :           :                 :     :                    :                          :     +- * Filter (17)
-            :           :                 :     :                    :                          :        +- * ColumnarToRow (16)
-            :           :                 :     :                    :                          :           +- Scan parquet default.item (15)
-            :           :                 :     :                    :                          +- * Sort (33)
-            :           :                 :     :                    :                             +- Exchange (32)
-            :           :                 :     :                    :                                +- * Project (31)
-            :           :                 :     :                    :                                   +- * BroadcastHashJoin Inner BuildRight (30)
-            :           :                 :     :                    :                                      :- * Project (25)
-            :           :                 :     :                    :                                      :  +- * BroadcastHashJoin Inner BuildRight (24)
-            :           :                 :     :                    :                                      :     :- * Filter (22)
-            :           :                 :     :                    :                                      :     :  +- * ColumnarToRow (21)
-            :           :                 :     :                    :                                      :     :     +- Scan parquet default.catalog_sales (20)
-            :           :                 :     :                    :                                      :     +- ReusedExchange (23)
-            :           :                 :     :                    :                                      +- BroadcastExchange (29)
-            :           :                 :     :                    :                                         +- * Filter (28)
-            :           :                 :     :                    :                                            +- * ColumnarToRow (27)
-            :           :                 :     :                    :                                               +- Scan parquet default.item (26)
-            :           :                 :     :                    +- * Sort (53)
-            :           :                 :     :                       +- Exchange (52)
-            :           :                 :     :                          +- * Project (51)
-            :           :                 :     :                             +- * BroadcastHashJoin Inner BuildRight (50)
-            :           :                 :     :                                :- * Project (48)
-            :           :                 :     :                                :  +- * BroadcastHashJoin Inner BuildRight (47)
-            :           :                 :     :                                :     :- * Filter (45)
-            :           :                 :     :                                :     :  +- * ColumnarToRow (44)
-            :           :                 :     :                                :     :     +- Scan parquet default.web_sales (43)
-            :           :                 :     :                                :     +- ReusedExchange (46)
-            :           :                 :     :                                +- ReusedExchange (49)
+            :           :                 :     :           +- * BroadcastHashJoin Inner BuildLeft (56)
+            :           :                 :     :              :- BroadcastExchange (9)
+            :           :                 :     :              :  +- * Filter (8)
+            :           :                 :     :              :     +- * ColumnarToRow (7)
+            :           :                 :     :              :        +- Scan parquet default.item (6)
+            :           :                 :     :              +- * SortMergeJoin LeftSemi (55)
+            :           :                 :     :                 :- * Sort (43)
+            :           :                 :     :                 :  +- Exchange (42)
+            :           :                 :     :                 :     +- * HashAggregate (41)
+            :           :                 :     :                 :        +- Exchange (40)
+            :           :                 :     :                 :           +- * HashAggregate (39)
+            :           :                 :     :                 :              +- * Project (38)
+            :           :                 :     :                 :                 +- * BroadcastHashJoin Inner BuildRight (37)
+            :           :                 :     :                 :                    :- * Project (15)
+            :           :                 :     :                 :                    :  +- * BroadcastHashJoin Inner BuildRight (14)
+            :           :                 :     :                 :                    :     :- * Filter (12)
+            :           :                 :     :                 :                    :     :  +- * ColumnarToRow (11)
+            :           :                 :     :                 :                    :     :     +- Scan parquet default.store_sales (10)
+            :           :                 :     :                 :                    :     +- ReusedExchange (13)
+            :           :                 :     :                 :                    +- BroadcastExchange (36)
+            :           :                 :     :                 :                       +- * SortMergeJoin LeftSemi (35)
+            :           :                 :     :                 :                          :- * Sort (20)
+            :           :                 :     :                 :                          :  +- Exchange (19)
+            :           :                 :     :                 :                          :     +- * Filter (18)
+            :           :                 :     :                 :                          :        +- * ColumnarToRow (17)
+            :           :                 :     :                 :                          :           +- Scan parquet default.item (16)
+            :           :                 :     :                 :                          +- * Sort (34)
+            :           :                 :     :                 :                             +- Exchange (33)
+            :           :                 :     :                 :                                +- * Project (32)
+            :           :                 :     :                 :                                   +- * BroadcastHashJoin Inner BuildRight (31)
+            :           :                 :     :                 :                                      :- * Project (26)
+            :           :                 :     :                 :                                      :  +- * BroadcastHashJoin Inner BuildRight (25)
+            :           :                 :     :                 :                                      :     :- * Filter (23)
+            :           :                 :     :                 :                                      :     :  +- * ColumnarToRow (22)
+            :           :                 :     :                 :                                      :     :     +- Scan parquet default.catalog_sales (21)
+            :           :                 :     :                 :                                      :     +- ReusedExchange (24)
+            :           :                 :     :                 :                                      +- BroadcastExchange (30)
+            :           :                 :     :                 :                                         +- * Filter (29)
+            :           :                 :     :                 :                                            +- * ColumnarToRow (28)
+            :           :                 :     :                 :                                               +- Scan parquet default.item (27)
+            :           :                 :     :                 +- * Sort (54)
+            :           :                 :     :                    +- Exchange (53)
+            :           :                 :     :                       +- * Project (52)
+            :           :                 :     :                          +- * BroadcastHashJoin Inner BuildRight (51)
+            :           :                 :     :                             :- * Project (49)
+            :           :                 :     :                             :  +- * BroadcastHashJoin Inner BuildRight (48)
+            :           :                 :     :                             :     :- * Filter (46)
+            :           :                 :     :                             :     :  +- * ColumnarToRow (45)
+            :           :                 :     :                             :     :     +- Scan parquet default.web_sales (44)
+            :           :                 :     :                             :     +- ReusedExchange (47)
+            :           :                 :     :                             +- ReusedExchange (50)
             :           :                 :     +- ReusedExchange (61)
             :           :                 +- BroadcastExchange (72)
             :           :                    +- * SortMergeJoin LeftSemi (71)
@@ -174,232 +174,232 @@ Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(7) ColumnarToRow [codegen id : 19]
+(7) ColumnarToRow [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 
-(8) Filter [codegen id : 19]
+(8) Filter [codegen id : 3]
 Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
 Condition : ((isnotnull(i_brand_id#8) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10))
 
-(9) Scan parquet default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(9) BroadcastExchange
+Input [4]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10]
+Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[2, int, false], input[3, int, false]),false), [id=#11]
+
+(10) Scan parquet default.store_sales
+Output [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#12), dynamicpruningexpression(ss_sold_date_sk#12 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#13), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(10) ColumnarToRow [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(11) ColumnarToRow [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
 
-(11) Filter [codegen id : 11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : isnotnull(ss_item_sk#11)
+(12) Filter [codegen id : 12]
+Input [2]: [ss_item_sk#12, ss_sold_date_sk#13]
+Condition : isnotnull(ss_item_sk#12)
 
-(12) ReusedExchange [Reuses operator id: 177]
-Output [1]: [d_date_sk#14]
+(13) ReusedExchange [Reuses operator id: 177]
+Output [1]: [d_date_sk#15]
 
-(13) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#12]
-Right keys [1]: [d_date_sk#14]
+(14) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_sold_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join condition: None
 
-(14) Project [codegen id : 11]
-Output [1]: [ss_item_sk#11]
-Input [3]: [ss_item_sk#11, ss_sold_date_sk#12, d_date_sk#14]
+(15) Project [codegen id : 12]
+Output [1]: [ss_item_sk#12]
+Input [3]: [ss_item_sk#12, ss_sold_date_sk#13, d_date_sk#15]
 
-(15) Scan parquet default.item
-Output [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(16) Scan parquet default.item
+Output [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(16) ColumnarToRow [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(17) ColumnarToRow [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(17) Filter [codegen id : 4]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Condition : (((isnotnull(i_item_sk#15) AND isnotnull(i_brand_id#16)) AND isnotnull(i_class_id#17)) AND isnotnull(i_category_id#18))
+(18) Filter [codegen id : 5]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Condition : (((isnotnull(i_item_sk#16) AND isnotnull(i_brand_id#17)) AND isnotnull(i_class_id#18)) AND isnotnull(i_category_id#19))
 
-(18) Exchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: hashpartitioning(coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18), 5), ENSURE_REQUIREMENTS, [id=#19]
+(19) Exchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: hashpartitioning(coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19), 5), ENSURE_REQUIREMENTS, [id=#20]
 
-(19) Sort [codegen id : 5]
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: [coalesce(i_brand_id#16, 0) ASC NULLS FIRST, isnull(i_brand_id#16) ASC NULLS FIRST, coalesce(i_class_id#17, 0) ASC NULLS FIRST, isnull(i_class_id#17) ASC NULLS FIRST, coalesce(i_category_id#18, 0) ASC NULLS FIRST, isnull(i_category_id#18) ASC NULLS FIRST], false, 0
+(20) Sort [codegen id : 6]
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: [coalesce(i_brand_id#17, 0) ASC NULLS FIRST, isnull(i_brand_id#17) ASC NULLS FIRST, coalesce(i_class_id#18, 0) ASC NULLS FIRST, isnull(i_class_id#18) ASC NULLS FIRST, coalesce(i_category_id#19, 0) ASC NULLS FIRST, isnull(i_category_id#19) ASC NULLS FIRST], false, 0
 
-(20) Scan parquet default.catalog_sales
-Output [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(21) Scan parquet default.catalog_sales
+Output [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#21), dynamicpruningexpression(cs_sold_date_sk#21 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#22), dynamicpruningexpression(cs_sold_date_sk#22 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
+(22) ColumnarToRow [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
 
-(22) Filter [codegen id : 8]
-Input [2]: [cs_item_sk#20, cs_sold_date_sk#21]
-Condition : isnotnull(cs_item_sk#20)
+(23) Filter [codegen id : 9]
+Input [2]: [cs_item_sk#21, cs_sold_date_sk#22]
+Condition : isnotnull(cs_item_sk#21)
 
-(23) ReusedExchange [Reuses operator id: 177]
-Output [1]: [d_date_sk#22]
+(24) ReusedExchange [Reuses operator id: 177]
+Output [1]: [d_date_sk#23]
 
-(24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#21]
-Right keys [1]: [d_date_sk#22]
+(25) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_sold_date_sk#22]
+Right keys [1]: [d_date_sk#23]
 Join condition: None
 
-(25) Project [codegen id : 8]
-Output [1]: [cs_item_sk#20]
-Input [3]: [cs_item_sk#20, cs_sold_date_sk#21, d_date_sk#22]
+(26) Project [codegen id : 9]
+Output [1]: [cs_item_sk#21]
+Input [3]: [cs_item_sk#21, cs_sold_date_sk#22, d_date_sk#23]
 
-(26) Scan parquet default.item
-Output [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(27) Scan parquet default.item
+Output [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(27) ColumnarToRow [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(28) ColumnarToRow [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(28) Filter [codegen id : 7]
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Condition : isnotnull(i_item_sk#23)
+(29) Filter [codegen id : 8]
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Condition : isnotnull(i_item_sk#24)
 
-(29) BroadcastExchange
-Input [4]: [i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#27]
+(30) BroadcastExchange
+Input [4]: [i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#28]
 
-(30) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#20]
-Right keys [1]: [i_item_sk#23]
+(31) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_item_sk#21]
+Right keys [1]: [i_item_sk#24]
 Join condition: None
 
-(31) Project [codegen id : 8]
-Output [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Input [5]: [cs_item_sk#20, i_item_sk#23, i_brand_id#24, i_class_id#25, i_category_id#26]
+(32) Project [codegen id : 9]
+Output [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Input [5]: [cs_item_sk#21, i_item_sk#24, i_brand_id#25, i_class_id#26, i_category_id#27]
 
-(32) Exchange
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: hashpartitioning(coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26), 5), ENSURE_REQUIREMENTS, [id=#28]
+(33) Exchange
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: hashpartitioning(coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27), 5), ENSURE_REQUIREMENTS, [id=#29]
 
-(33) Sort [codegen id : 9]
-Input [3]: [i_brand_id#24, i_class_id#25, i_category_id#26]
-Arguments: [coalesce(i_brand_id#24, 0) ASC NULLS FIRST, isnull(i_brand_id#24) ASC NULLS FIRST, coalesce(i_class_id#25, 0) ASC NULLS FIRST, isnull(i_class_id#25) ASC NULLS FIRST, coalesce(i_category_id#26, 0) ASC NULLS FIRST, isnull(i_category_id#26) ASC NULLS FIRST], false, 0
+(34) Sort [codegen id : 10]
+Input [3]: [i_brand_id#25, i_class_id#26, i_category_id#27]
+Arguments: [coalesce(i_brand_id#25, 0) ASC NULLS FIRST, isnull(i_brand_id#25) ASC NULLS FIRST, coalesce(i_class_id#26, 0) ASC NULLS FIRST, isnull(i_class_id#26) ASC NULLS FIRST, coalesce(i_category_id#27, 0) ASC NULLS FIRST, isnull(i_category_id#27) ASC NULLS FIRST], false, 0
 
-(34) SortMergeJoin [codegen id : 10]
-Left keys [6]: [coalesce(i_brand_id#16, 0), isnull(i_brand_id#16), coalesce(i_class_id#17, 0), isnull(i_class_id#17), coalesce(i_category_id#18, 0), isnull(i_category_id#18)]
-Right keys [6]: [coalesce(i_brand_id#24, 0), isnull(i_brand_id#24), coalesce(i_class_id#25, 0), isnull(i_class_id#25), coalesce(i_category_id#26, 0), isnull(i_category_id#26)]
+(35) SortMergeJoin [codegen id : 11]
+Left keys [6]: [coalesce(i_brand_id#17, 0), isnull(i_brand_id#17), coalesce(i_class_id#18, 0), isnull(i_class_id#18), coalesce(i_category_id#19, 0), isnull(i_category_id#19)]
+Right keys [6]: [coalesce(i_brand_id#25, 0), isnull(i_brand_id#25), coalesce(i_class_id#26, 0), isnull(i_class_id#26), coalesce(i_category_id#27, 0), isnull(i_category_id#27)]
 Join condition: None
 
-(35) BroadcastExchange
-Input [4]: [i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#29]
+(36) BroadcastExchange
+Input [4]: [i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#30]
 
-(36) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_item_sk#11]
-Right keys [1]: [i_item_sk#15]
+(37) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_item_sk#12]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
-(37) Project [codegen id : 11]
-Output [3]: [i_brand_id#16 AS brand_id#30, i_class_id#17 AS class_id#31, i_category_id#18 AS category_id#32]
-Input [5]: [ss_item_sk#11, i_item_sk#15, i_brand_id#16, i_class_id#17, i_category_id#18]
+(38) Project [codegen id : 12]
+Output [3]: [i_brand_id#17 AS brand_id#31, i_class_id#18 AS class_id#32, i_category_id#19 AS category_id#33]
+Input [5]: [ss_item_sk#12, i_item_sk#16, i_brand_id#17, i_class_id#18, i_category_id#19]
 
-(38) HashAggregate [codegen id : 11]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(39) HashAggregate [codegen id : 12]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(39) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(brand_id#30, class_id#31, category_id#32, 5), ENSURE_REQUIREMENTS, [id=#33]
+(40) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(brand_id#31, class_id#32, category_id#33, 5), ENSURE_REQUIREMENTS, [id=#34]
 
-(40) HashAggregate [codegen id : 12]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Keys [3]: [brand_id#30, class_id#31, category_id#32]
+(41) HashAggregate [codegen id : 13]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Keys [3]: [brand_id#31, class_id#32, category_id#33]
 Functions: []
 Aggregate Attributes: []
-Results [3]: [brand_id#30, class_id#31, category_id#32]
+Results [3]: [brand_id#31, class_id#32, category_id#33]
 
-(41) Exchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: hashpartitioning(coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32), 5), ENSURE_REQUIREMENTS, [id=#34]
+(42) Exchange
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: hashpartitioning(coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33), 5), ENSURE_REQUIREMENTS, [id=#35]
 
-(42) Sort [codegen id : 13]
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: [coalesce(brand_id#30, 0) ASC NULLS FIRST, isnull(brand_id#30) ASC NULLS FIRST, coalesce(class_id#31, 0) ASC NULLS FIRST, isnull(class_id#31) ASC NULLS FIRST, coalesce(category_id#32, 0) ASC NULLS FIRST, isnull(category_id#32) ASC NULLS FIRST], false, 0
+(43) Sort [codegen id : 14]
+Input [3]: [brand_id#31, class_id#32, category_id#33]
+Arguments: [coalesce(brand_id#31, 0) ASC NULLS FIRST, isnull(brand_id#31) ASC NULLS FIRST, coalesce(class_id#32, 0) ASC NULLS FIRST, isnull(class_id#32) ASC NULLS FIRST, coalesce(category_id#33, 0) ASC NULLS FIRST, isnull(category_id#33) ASC NULLS FIRST], false, 0
 
-(43) Scan parquet default.web_sales
-Output [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(44) Scan parquet default.web_sales
+Output [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#36), dynamicpruningexpression(ws_sold_date_sk#36 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#37), dynamicpruningexpression(ws_sold_date_sk#37 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int>
 
-(44) ColumnarToRow [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
+(45) ColumnarToRow [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
 
-(45) Filter [codegen id : 16]
-Input [2]: [ws_item_sk#35, ws_sold_date_sk#36]
-Condition : isnotnull(ws_item_sk#35)
+(46) Filter [codegen id : 17]
+Input [2]: [ws_item_sk#36, ws_sold_date_sk#37]
+Condition : isnotnull(ws_item_sk#36)
 
-(46) ReusedExchange [Reuses operator id: 177]
-Output [1]: [d_date_sk#37]
+(47) ReusedExchange [Reuses operator id: 177]
+Output [1]: [d_date_sk#38]
 
-(47) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_sold_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(48) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#37]
+Right keys [1]: [d_date_sk#38]
 Join condition: None
 
-(48) Project [codegen id : 16]
-Output [1]: [ws_item_sk#35]
-Input [3]: [ws_item_sk#35, ws_sold_date_sk#36, d_date_sk#37]
+(49) Project [codegen id : 17]
+Output [1]: [ws_item_sk#36]
+Input [3]: [ws_item_sk#36, ws_sold_date_sk#37, d_date_sk#38]
 
-(49) ReusedExchange [Reuses operator id: 29]
-Output [4]: [i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(50) ReusedExchange [Reuses operator id: 30]
+Output [4]: [i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(50) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [ws_item_sk#35]
-Right keys [1]: [i_item_sk#38]
+(51) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_item_sk#36]
+Right keys [1]: [i_item_sk#39]
 Join condition: None
 
-(51) Project [codegen id : 16]
-Output [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Input [5]: [ws_item_sk#35, i_item_sk#38, i_brand_id#39, i_class_id#40, i_category_id#41]
+(52) Project [codegen id : 17]
+Output [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Input [5]: [ws_item_sk#36, i_item_sk#39, i_brand_id#40, i_class_id#41, i_category_id#42]
 
-(52) Exchange
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: hashpartitioning(coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41), 5), ENSURE_REQUIREMENTS, [id=#42]
+(53) Exchange
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: hashpartitioning(coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42), 5), ENSURE_REQUIREMENTS, [id=#43]
 
-(53) Sort [codegen id : 17]
-Input [3]: [i_brand_id#39, i_class_id#40, i_category_id#41]
-Arguments: [coalesce(i_brand_id#39, 0) ASC NULLS FIRST, isnull(i_brand_id#39) ASC NULLS FIRST, coalesce(i_class_id#40, 0) ASC NULLS FIRST, isnull(i_class_id#40) ASC NULLS FIRST, coalesce(i_category_id#41, 0) ASC NULLS FIRST, isnull(i_category_id#41) ASC NULLS FIRST], false, 0
+(54) Sort [codegen id : 18]
+Input [3]: [i_brand_id#40, i_class_id#41, i_category_id#42]
+Arguments: [coalesce(i_brand_id#40, 0) ASC NULLS FIRST, isnull(i_brand_id#40) ASC NULLS FIRST, coalesce(i_class_id#41, 0) ASC NULLS FIRST, isnull(i_class_id#41) ASC NULLS FIRST, coalesce(i_category_id#42, 0) ASC NULLS FIRST, isnull(i_category_id#42) ASC NULLS FIRST], false, 0
 
-(54) SortMergeJoin [codegen id : 18]
-Left keys [6]: [coalesce(brand_id#30, 0), isnull(brand_id#30), coalesce(class_id#31, 0), isnull(class_id#31), coalesce(category_id#32, 0), isnull(category_id#32)]
-Right keys [6]: [coalesce(i_brand_id#39, 0), isnull(i_brand_id#39), coalesce(i_class_id#40, 0), isnull(i_class_id#40), coalesce(i_category_id#41, 0), isnull(i_category_id#41)]
+(55) SortMergeJoin
+Left keys [6]: [coalesce(brand_id#31, 0), isnull(brand_id#31), coalesce(class_id#32, 0), isnull(class_id#32), coalesce(category_id#33, 0), isnull(category_id#33)]
+Right keys [6]: [coalesce(i_brand_id#40, 0), isnull(i_brand_id#40), coalesce(i_class_id#41, 0), isnull(i_class_id#41), coalesce(i_category_id#42, 0), isnull(i_category_id#42)]
 Join condition: None
-
-(55) BroadcastExchange
-Input [3]: [brand_id#30, class_id#31, category_id#32]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, true], input[2, int, true]),false), [id=#43]
 
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#8, i_class_id#9, i_category_id#10]
-Right keys [3]: [brand_id#30, class_id#31, category_id#32]
+Right keys [3]: [brand_id#31, class_id#32, category_id#33]
 Join condition: None
 
 (57) Project [codegen id : 19]
 Output [1]: [i_item_sk#7 AS ss_item_sk#44]
-Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#30, class_id#31, category_id#32]
+Input [7]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, brand_id#31, class_id#32, category_id#33]
 
 (58) Exchange
 Input [1]: [ss_item_sk#44]
@@ -841,7 +841,7 @@ Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquer
 Output [3]: [ss_quantity#177, ss_list_price#178, ss_sold_date_sk#179]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#179), dynamicpruningexpression(ss_sold_date_sk#179 IN dynamicpruning#13)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#179), dynamicpruningexpression(ss_sold_date_sk#179 IN dynamicpruning#14)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (145) ColumnarToRow [codegen id : 2]
@@ -923,7 +923,7 @@ Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#181 as decima
 Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#181 as decimal(12,2))) * promote_precision(cast(list_price#182 as decimal(12,2)))), DecimalType(18,2)))#201]
 Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#181 as decimal(12,2))) * promote_precision(cast(list_price#182 as decimal(12,2)))), DecimalType(18,2)))#201 AS average_sales#202]
 
-Subquery:2 Hosting operator id = 144 Hosting Expression = ss_sold_date_sk#179 IN dynamicpruning#13
+Subquery:2 Hosting operator id = 144 Hosting Expression = ss_sold_date_sk#179 IN dynamicpruning#14
 
 Subquery:3 Hosting operator id = 149 Hosting Expression = cs_sold_date_sk#185 IN dynamicpruning#186
 BroadcastExchange (167)
@@ -987,7 +987,7 @@ Input [3]: [d_date_sk#46, d_year#205, d_moy#206]
 Input [1]: [d_date_sk#46]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#207]
 
-Subquery:6 Hosting operator id = 9 Hosting Expression = ss_sold_date_sk#12 IN dynamicpruning#13
+Subquery:6 Hosting operator id = 10 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (177)
 +- * Project (176)
    +- * Filter (175)
@@ -996,30 +996,30 @@ BroadcastExchange (177)
 
 
 (173) Scan parquet default.date_dim
-Output [2]: [d_date_sk#14, d_year#208]
+Output [2]: [d_date_sk#15, d_year#208]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (174) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#208]
+Input [2]: [d_date_sk#15, d_year#208]
 
 (175) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#208]
-Condition : (((isnotnull(d_year#208) AND (d_year#208 >= 1999)) AND (d_year#208 <= 2001)) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#15, d_year#208]
+Condition : (((isnotnull(d_year#208) AND (d_year#208 >= 1999)) AND (d_year#208 <= 2001)) AND isnotnull(d_date_sk#15))
 
 (176) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#208]
+Output [1]: [d_date_sk#15]
+Input [2]: [d_date_sk#15, d_year#208]
 
 (177) BroadcastExchange
-Input [1]: [d_date_sk#14]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#209]
 
-Subquery:7 Hosting operator id = 20 Hosting Expression = cs_sold_date_sk#21 IN dynamicpruning#13
+Subquery:7 Hosting operator id = 21 Hosting Expression = cs_sold_date_sk#22 IN dynamicpruning#14
 
-Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#36 IN dynamicpruning#13
+Subquery:8 Hosting operator id = 44 Hosting Expression = ws_sold_date_sk#37 IN dynamicpruning#14
 
 Subquery:9 Hosting operator id = 96 Hosting Expression = ReusedSubquery Subquery scalar-subquery#65, [id=#66]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -96,100 +96,100 @@ TakeOrderedAndProject [channel,i_brand_id,i_class_id,i_category_id,sum_sales,num
                                                                     WholeStageCodegen (19)
                                                                       Project [i_item_sk]
                                                                         BroadcastHashJoin [i_brand_id,i_class_id,i_category_id,brand_id,class_id,category_id]
-                                                                          Filter [i_brand_id,i_class_id,i_category_id]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                                                           InputAdapter
                                                                             BroadcastExchange #7
-                                                                              WholeStageCodegen (18)
-                                                                                SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                              WholeStageCodegen (3)
+                                                                                Filter [i_brand_id,i_class_id,i_category_id]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                          SortMergeJoin [brand_id,class_id,category_id,i_brand_id,i_class_id,i_category_id]
+                                                                            InputAdapter
+                                                                              WholeStageCodegen (14)
+                                                                                Sort [brand_id,class_id,category_id]
                                                                                   InputAdapter
-                                                                                    WholeStageCodegen (13)
-                                                                                      Sort [brand_id,class_id,category_id]
-                                                                                        InputAdapter
-                                                                                          Exchange [brand_id,class_id,category_id] #8
-                                                                                            WholeStageCodegen (12)
-                                                                                              HashAggregate [brand_id,class_id,category_id]
-                                                                                                InputAdapter
-                                                                                                  Exchange [brand_id,class_id,category_id] #9
-                                                                                                    WholeStageCodegen (11)
-                                                                                                      HashAggregate [brand_id,class_id,category_id]
-                                                                                                        Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                          BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                                                            Project [ss_item_sk]
-                                                                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                                                                Filter [ss_item_sk]
-                                                                                                                  ColumnarToRow
-                                                                                                                    InputAdapter
-                                                                                                                      Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
-                                                                                                                        SubqueryBroadcast [d_date_sk] #2
-                                                                                                                          BroadcastExchange #10
-                                                                                                                            WholeStageCodegen (1)
-                                                                                                                              Project [d_date_sk]
-                                                                                                                                Filter [d_year,d_date_sk]
-                                                                                                                                  ColumnarToRow
-                                                                                                                                    InputAdapter
-                                                                                                                                      Scan parquet default.date_dim [d_date_sk,d_year]
-                                                                                                                InputAdapter
-                                                                                                                  ReusedExchange [d_date_sk] #10
-                                                                                                            InputAdapter
-                                                                                                              BroadcastExchange #11
-                                                                                                                WholeStageCodegen (10)
-                                                                                                                  SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
-                                                                                                                    InputAdapter
-                                                                                                                      WholeStageCodegen (5)
-                                                                                                                        Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                          InputAdapter
-                                                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #12
-                                                                                                                              WholeStageCodegen (4)
-                                                                                                                                Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                                  ColumnarToRow
-                                                                                                                                    InputAdapter
-                                                                                                                                      Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                                                    InputAdapter
-                                                                                                                      WholeStageCodegen (9)
-                                                                                                                        Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                                                          InputAdapter
-                                                                                                                            Exchange [i_brand_id,i_class_id,i_category_id] #13
-                                                                                                                              WholeStageCodegen (8)
-                                                                                                                                Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                                                                                                                    Project [cs_item_sk]
-                                                                                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                                                                                        Filter [cs_item_sk]
-                                                                                                                                          ColumnarToRow
-                                                                                                                                            InputAdapter
-                                                                                                                                              Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
-                                                                                                                                                ReusedSubquery [d_date_sk] #2
-                                                                                                                                        InputAdapter
-                                                                                                                                          ReusedExchange [d_date_sk] #10
-                                                                                                                                    InputAdapter
-                                                                                                                                      BroadcastExchange #14
-                                                                                                                                        WholeStageCodegen (7)
-                                                                                                                                          Filter [i_item_sk]
-                                                                                                                                            ColumnarToRow
-                                                                                                                                              InputAdapter
-                                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                                                                  InputAdapter
-                                                                                    WholeStageCodegen (17)
-                                                                                      Sort [i_brand_id,i_class_id,i_category_id]
-                                                                                        InputAdapter
-                                                                                          Exchange [i_brand_id,i_class_id,i_category_id] #15
-                                                                                            WholeStageCodegen (16)
-                                                                                              Project [i_brand_id,i_class_id,i_category_id]
-                                                                                                BroadcastHashJoin [ws_item_sk,i_item_sk]
-                                                                                                  Project [ws_item_sk]
-                                                                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                                                      Filter [ws_item_sk]
-                                                                                                        ColumnarToRow
+                                                                                    Exchange [brand_id,class_id,category_id] #8
+                                                                                      WholeStageCodegen (13)
+                                                                                        HashAggregate [brand_id,class_id,category_id]
+                                                                                          InputAdapter
+                                                                                            Exchange [brand_id,class_id,category_id] #9
+                                                                                              WholeStageCodegen (12)
+                                                                                                HashAggregate [brand_id,class_id,category_id]
+                                                                                                  Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                                                      Project [ss_item_sk]
+                                                                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                                                          Filter [ss_item_sk]
+                                                                                                            ColumnarToRow
+                                                                                                              InputAdapter
+                                                                                                                Scan parquet default.store_sales [ss_item_sk,ss_sold_date_sk]
+                                                                                                                  SubqueryBroadcast [d_date_sk] #2
+                                                                                                                    BroadcastExchange #10
+                                                                                                                      WholeStageCodegen (1)
+                                                                                                                        Project [d_date_sk]
+                                                                                                                          Filter [d_year,d_date_sk]
+                                                                                                                            ColumnarToRow
+                                                                                                                              InputAdapter
+                                                                                                                                Scan parquet default.date_dim [d_date_sk,d_year]
                                                                                                           InputAdapter
-                                                                                                            Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
-                                                                                                              ReusedSubquery [d_date_sk] #2
+                                                                                                            ReusedExchange [d_date_sk] #10
                                                                                                       InputAdapter
-                                                                                                        ReusedExchange [d_date_sk] #10
-                                                                                                  InputAdapter
-                                                                                                    ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14
+                                                                                                        BroadcastExchange #11
+                                                                                                          WholeStageCodegen (11)
+                                                                                                            SortMergeJoin [i_brand_id,i_class_id,i_category_id,i_brand_id,i_class_id,i_category_id]
+                                                                                                              InputAdapter
+                                                                                                                WholeStageCodegen (6)
+                                                                                                                  Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                                    InputAdapter
+                                                                                                                      Exchange [i_brand_id,i_class_id,i_category_id] #12
+                                                                                                                        WholeStageCodegen (5)
+                                                                                                                          Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                                            ColumnarToRow
+                                                                                                                              InputAdapter
+                                                                                                                                Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                                                              InputAdapter
+                                                                                                                WholeStageCodegen (10)
+                                                                                                                  Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                                                    InputAdapter
+                                                                                                                      Exchange [i_brand_id,i_class_id,i_category_id] #13
+                                                                                                                        WholeStageCodegen (9)
+                                                                                                                          Project [i_brand_id,i_class_id,i_category_id]
+                                                                                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                                                                              Project [cs_item_sk]
+                                                                                                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                                                                                                  Filter [cs_item_sk]
+                                                                                                                                    ColumnarToRow
+                                                                                                                                      InputAdapter
+                                                                                                                                        Scan parquet default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                                                                                                                                          ReusedSubquery [d_date_sk] #2
+                                                                                                                                  InputAdapter
+                                                                                                                                    ReusedExchange [d_date_sk] #10
+                                                                                                                              InputAdapter
+                                                                                                                                BroadcastExchange #14
+                                                                                                                                  WholeStageCodegen (8)
+                                                                                                                                    Filter [i_item_sk]
+                                                                                                                                      ColumnarToRow
+                                                                                                                                        InputAdapter
+                                                                                                                                          Scan parquet default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                                                            InputAdapter
+                                                                              WholeStageCodegen (18)
+                                                                                Sort [i_brand_id,i_class_id,i_category_id]
+                                                                                  InputAdapter
+                                                                                    Exchange [i_brand_id,i_class_id,i_category_id] #15
+                                                                                      WholeStageCodegen (17)
+                                                                                        Project [i_brand_id,i_class_id,i_category_id]
+                                                                                          BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                                            Project [ws_item_sk]
+                                                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                                                                Filter [ws_item_sk]
+                                                                                                  ColumnarToRow
+                                                                                                    InputAdapter
+                                                                                                      Scan parquet default.web_sales [ws_item_sk,ws_sold_date_sk]
+                                                                                                        ReusedSubquery [d_date_sk] #2
+                                                                                                InputAdapter
+                                                                                                  ReusedExchange [d_date_sk] #10
+                                                                                            InputAdapter
+                                                                                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #14
                                                         InputAdapter
                                                           ReusedExchange [d_date_sk] #5
                                                     InputAdapter

--- a/sql/core/src/test/scala/org/apache/spark/sql/ApproxCountDistinctForIntervalsQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ApproxCountDistinctForIntervalsQuerySuite.scala
@@ -46,7 +46,7 @@ class ApproxCountDistinctForIntervalsQuerySuite extends QueryTest with SharedSpa
       val aggFunc = ApproxCountDistinctForIntervals(attr, CreateArray(endpoints.map(Literal(_))))
       val aggExpr = aggFunc.toAggregateExpression()
       val namedExpr = Alias(aggExpr, aggExpr.toString)()
-      val ndvsRow = new QueryExecution(spark, Aggregate(Nil, Seq(namedExpr), relation))
+      val ndvsRow = new QueryExecution(spark, Aggregate(Nil, Seq(namedExpr), false, relation))
         .executedPlan.executeTake(1).head
       val ndvArray = ndvsRow.getArray(0).toLongArray()
       assert(endpoints.length == ndvArray.length + 1)
@@ -82,7 +82,8 @@ class ApproxCountDistinctForIntervalsQuerySuite extends QueryTest with SharedSpa
         ApproxCountDistinctForIntervals(dtAttr, CreateArray(endpoints.map(Literal(_))))
       val dtAggExpr = dtAggFunc.toAggregateExpression()
       val dtNamedExpr = Alias(dtAggExpr, dtAggExpr.toString)()
-      val result = Dataset.ofRows(spark, Aggregate(Nil, Seq(ymNamedExpr, dtNamedExpr), relation))
+      val result = Dataset.ofRows(spark,
+        Aggregate(Nil, Seq(ymNamedExpr, dtNamedExpr), false, relation))
       checkAnswer(result, Row(Array(1, 1, 1, 1, 1), Array(1, 1, 1, 1, 1)))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -269,7 +269,7 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
       case Filter(condition, _) => condition.collect {
         case subquery: org.apache.spark.sql.catalyst.expressions.ScalarSubquery
         => subquery.plan.collect {
-          case Aggregate(_, aggregateExpressions, _) =>
+          case Aggregate(_, aggregateExpressions, false, _) =>
             aggregateExpressions.map {
               case Alias(AggregateExpression(bfAgg : BloomFilterAggregate, _, _, _, _),
               _) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -344,6 +344,7 @@ class SparkSqlParserSuite extends AnalysisTest {
               UnresolvedAlias(
                 UnresolvedFunction("max", Seq(UnresolvedAttribute("c")), isDistinct = false), None)
             ),
+            false,
             UnresolvedRelation(TableIdentifier("testData")))),
         ioSchema))
 
@@ -411,6 +412,7 @@ class SparkSqlParserSuite extends AnalysisTest {
               UnresolvedAlias(
                 UnresolvedFunction("max", Seq(UnresolvedAttribute("c")), isDistinct = false), None)
             ),
+            false,
             Generate(
               UnresolvedGenerator(
                 FunctionIdentifier("explode"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add a new rule to push down the partial aggregation through join if it cannot be planned as broadcast hash join. For example:
```
set spark.sql.autoBroadcastJoinThreshold=-1;
CREATE TABLE t1 using parquet AS SELECT id AS a, id AS b, id AS c FROM range(10);
CREATE TABLE t2 using parquet AS SELECT id AS x, id AS y FROM range(8);
SELECT c, y FROM t1 JOIN t2 ON t1.a = t2.x GROUP BY c, y;
```

Before this pr:
```
== Optimized Logical Plan ==
Aggregate [c#19L, y#21L], [c#19L, y#21L], false
+- Project [c#19L, y#21L]
   +- Join Inner, (a#17L = x#20L)
      :- Project [a#17L, c#19L]
      :  +- Filter isnotnull(a#17L)
      :     +- Relation default.t1[a#17L,b#18L,c#19L] parquet
      +- Filter isnotnull(x#20L)
         +- Relation default.t2[x#20L,y#21L] parquet
```

After this pr:
```
== Optimized Logical Plan ==
Aggregate [c#19L, y#21L], [c#19L, y#21L], false
+- Project [c#19L, y#21L]
   +- Join Inner, (a#17L = x#20L)
      :- Aggregate [c#19L, a#17L], [c#19L, a#17L], true
      :  +- Project [a#17L, c#19L]
      :     +- Filter isnotnull(a#17L)
      :        +- Relation default.t1[a#17L,b#18L,c#19L] parquet
      +- Aggregate [y#21L, x#20L], [y#21L, x#20L], true
         +- Filter isnotnull(x#20L)
            +- Relation default.t2[x#20L,y#21L] parquet
```

### Why are the changes needed?

1. Reduce shuffle data to improve query performance.
2. Many databases have similar rules:
    Teradata: https://docs.teradata.com/r/Teradata-VantageTM-SQL-Request-and-Transaction-Processing/March-2019/Join-Planning-and-Optimization/Partial-GROUP-BY-Block-Optimization
    Calcite: https://issues.apache.org/jira/browse/CALCITE-366
    Hive: https://issues.apache.org/jira/browse/HIVE-10785
    Trino: https://github.com/trinodb/trino/blob/375/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
    Presto: https://github.com/prestodb/presto/blob/0.271/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and TPC-DS benchmark test.

SQL | Before this PR(Seconds) | After this PR(Seconds)
-- | -- | --
q37 | 31 | 14
q38 | 60 | 28
q54 | 10 | 12
q82 | 52 | 25
q87 | 46 | 41


