### PR TITLE
[SPARK-38698][SQL] Provide query context in runtime error of Divide/Div/Reminder/Pmod

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -33,7 +33,7 @@
     "sqlState" : "22008"
   },
   "DIVIDE_BY_ZERO" : {
-    "message" : [ "divide by zero. To return NULL instead, use 'try_divide'. If necessary set %s to false (except for ANSI interval type) to bypass this error." ],
+    "message" : [ "divide by zero. To return NULL instead, use 'try_divide'. If necessary set %s to false (except for ANSI interval type) to bypass this error.%s" ],
     "sqlState" : "22012"
   },
   "DUPLICATE_KEY" : {

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -124,9 +124,9 @@ class SparkThrowableSuite extends SparkFunSuite {
     }
 
     // Does not fail with too many args (expects 0 args)
-    assert(getMessage("DIVIDE_BY_ZERO", Array("foo", "bar")) ==
+    assert(getMessage("DIVIDE_BY_ZERO", Array("foo", "bar", "baz")) ==
       "divide by zero. To return NULL instead, use 'try_divide'. If necessary set foo to false " +
-        "(except for ANSI interval type) to bypass this error.")
+        "(except for ANSI interval type) to bypass this error.bar")
   }
 
   test("Error message is formatted") {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -749,7 +749,7 @@ case class DivideDTInterval(
         val checkIntegralDivideOverflow =
           s"""
              |if (${micros.value} == ${Long.MinValue}L && ${num.value} == -1L)
-             |  throw QueryExecutionErrors.overflowInIntegralDivideError();
+             |  throw QueryExecutionErrors.overflowInIntegralDivideError($errorContext);
              |""".stripMargin
         nullSafeCodeGen(ctx, ev, (m, n) =>
           s"""

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -598,23 +598,33 @@ case class MultiplyDTInterval(
 }
 
 trait IntervalDivide {
-  def checkDivideOverflow(value: Any, minValue: Any, num: Expression, numValue: Any): Unit = {
+  def checkDivideOverflow(
+      value: Any,
+      minValue: Any,
+      num: Expression,
+      numValue: Any,
+      context: String): Unit = {
     if (value == minValue && num.dataType.isInstanceOf[IntegralType]) {
       if (numValue.asInstanceOf[Number].longValue() == -1) {
-        throw QueryExecutionErrors.overflowInIntegralDivideError()
+        throw QueryExecutionErrors.overflowInIntegralDivideError(context)
       }
     }
   }
 
-  def divideByZeroCheck(dataType: DataType, num: Any): Unit = dataType match {
+  def divideByZeroCheck(dataType: DataType, num: Any, context: String): Unit = dataType match {
     case _: DecimalType =>
-      if (num.asInstanceOf[Decimal].isZero) throw QueryExecutionErrors.divideByZeroError()
-    case _ => if (num == 0) throw QueryExecutionErrors.divideByZeroError()
+      if (num.asInstanceOf[Decimal].isZero) throw QueryExecutionErrors.divideByZeroError(context)
+    case _ => if (num == 0) throw QueryExecutionErrors.divideByZeroError(context)
   }
 
-  def divideByZeroCheckCodegen(dataType: DataType, value: String): String = dataType match {
-    case _: DecimalType => s"if ($value.isZero()) throw QueryExecutionErrors.divideByZeroError();"
-    case _ => s"if ($value == 0) throw QueryExecutionErrors.divideByZeroError();"
+  def divideByZeroCheckCodegen(
+      dataType: DataType,
+      value: String,
+      errorContextReference: String): String = dataType match {
+    case _: DecimalType =>
+      s"if ($value.isZero()) throw QueryExecutionErrors.divideByZeroError($errorContextReference);"
+    case _ =>
+      s"if ($value == 0) throw QueryExecutionErrors.divideByZeroError($errorContextReference);"
   }
 }
 
@@ -646,47 +656,50 @@ case class DivideYMInterval(
   }
 
   override def nullSafeEval(interval: Any, num: Any): Any = {
-    checkDivideOverflow(interval.asInstanceOf[Int], Int.MinValue, right, num)
-    divideByZeroCheck(right.dataType, num)
+    checkDivideOverflow(interval.asInstanceOf[Int], Int.MinValue, right, num, origin.context)
+    divideByZeroCheck(right.dataType, num, origin.context)
     evalFunc(interval.asInstanceOf[Int], num)
   }
 
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = right.dataType match {
-    case t: IntegralType =>
-      val math = t match {
-        case LongType => classOf[LongMath].getName
-        case _ => classOf[IntMath].getName
-      }
-      val javaType = CodeGenerator.javaType(dataType)
-      val months = left.genCode(ctx)
-      val num = right.genCode(ctx)
-      val checkIntegralDivideOverflow =
-        s"""
-           |if (${months.value} == ${Int.MinValue} && ${num.value} == -1)
-           |  throw QueryExecutionErrors.overflowInIntegralDivideError();
-           |""".stripMargin
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit to `Int`.
-        // Casting to `Int` is safe here.
-        s"""
-           |${divideByZeroCheckCodegen(right.dataType, n)}
-           |$checkIntegralDivideOverflow
-           |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
-        """.stripMargin)
-    case _: DecimalType =>
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        s"""
-           |${divideByZeroCheckCodegen(right.dataType, n)}
-           |${ev.value} = ((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()
-           |  .setScale(0, java.math.RoundingMode.HALF_UP).intValueExact();
-         """.stripMargin)
-    case _: FractionalType =>
-      val math = classOf[DoubleMath].getName
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        s"""
-           |${divideByZeroCheckCodegen(right.dataType, n)}
-           |${ev.value} = $math.roundToInt($m / (double)$n, java.math.RoundingMode.HALF_UP);
-         """.stripMargin)
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val errorContext = ctx.addReferenceObj("errCtx", origin.context)
+    right.dataType match {
+      case t: IntegralType =>
+        val math = t match {
+          case LongType => classOf[LongMath].getName
+          case _ => classOf[IntMath].getName
+        }
+        val javaType = CodeGenerator.javaType(dataType)
+        val months = left.genCode(ctx)
+        val num = right.genCode(ctx)
+        val checkIntegralDivideOverflow =
+          s"""
+             |if (${months.value} == ${Int.MinValue} && ${num.value} == -1)
+             |  throw QueryExecutionErrors.overflowInIntegralDivideError($errorContext);
+             |""".stripMargin
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit
+          // to `Int`. Casting to `Int` is safe here.
+          s"""
+             |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
+             |$checkIntegralDivideOverflow
+             |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
+          """.stripMargin)
+      case _: DecimalType =>
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
+             |${ev.value} = ((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()
+             |  .setScale(0, java.math.RoundingMode.HALF_UP).intValueExact();
+          """.stripMargin)
+      case _: FractionalType =>
+        val math = classOf[DoubleMath].getName
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
+             |${ev.value} = $math.roundToInt($m / (double)$n, java.math.RoundingMode.HALF_UP);
+          """.stripMargin)
+    }
   }
 
   override def toString: String = s"($left / $right)"
@@ -721,41 +734,44 @@ case class DivideDTInterval(
   }
 
   override def nullSafeEval(interval: Any, num: Any): Any = {
-    checkDivideOverflow(interval.asInstanceOf[Long], Long.MinValue, right, num)
-    divideByZeroCheck(right.dataType, num)
+    checkDivideOverflow(interval.asInstanceOf[Long], Long.MinValue, right, num, origin.context)
+    divideByZeroCheck(right.dataType, num, origin.context)
     evalFunc(interval.asInstanceOf[Long], num)
   }
 
-  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = right.dataType match {
-    case _: IntegralType =>
-      val math = classOf[LongMath].getName
-      val micros = left.genCode(ctx)
-      val num = right.genCode(ctx)
-      val checkIntegralDivideOverflow =
-        s"""
-           |if (${micros.value} == ${Long.MinValue}L && ${num.value} == -1L)
-           |  throw QueryExecutionErrors.overflowInIntegralDivideError();
-           |""".stripMargin
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        s"""
-           |${divideByZeroCheckCodegen(right.dataType, n)}
-           |$checkIntegralDivideOverflow
-           |${ev.value} = $math.divide($m, $n, java.math.RoundingMode.HALF_UP);
-        """.stripMargin)
-    case _: DecimalType =>
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        s"""
-           |${divideByZeroCheckCodegen(right.dataType, n)}
-           |${ev.value} = ((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()
-           |  .setScale(0, java.math.RoundingMode.HALF_UP).longValueExact();
-         """.stripMargin)
-    case _: FractionalType =>
-      val math = classOf[DoubleMath].getName
-      nullSafeCodeGen(ctx, ev, (m, n) =>
-        s"""
-           |${divideByZeroCheckCodegen(right.dataType, n)}
-           |${ev.value} = $math.roundToLong($m / (double)$n, java.math.RoundingMode.HALF_UP);
-         """.stripMargin)
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val errorContext = ctx.addReferenceObj("errCtx", origin.context)
+    right.dataType match {
+      case _: IntegralType =>
+        val math = classOf[LongMath].getName
+        val micros = left.genCode(ctx)
+        val num = right.genCode(ctx)
+        val checkIntegralDivideOverflow =
+          s"""
+             |if (${micros.value} == ${Long.MinValue}L && ${num.value} == -1L)
+             |  throw QueryExecutionErrors.overflowInIntegralDivideError();
+             |""".stripMargin
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
+             |$checkIntegralDivideOverflow
+             |${ev.value} = $math.divide($m, $n, java.math.RoundingMode.HALF_UP);
+          """.stripMargin)
+      case _: DecimalType =>
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
+             |${ev.value} = ((new Decimal()).set($m).$$div($n)).toJavaBigDecimal()
+             |  .setScale(0, java.math.RoundingMode.HALF_UP).longValueExact();
+          """.stripMargin)
+      case _: FractionalType =>
+        val math = classOf[DoubleMath].getName
+        nullSafeCodeGen(ctx, ev, (m, n) =>
+          s"""
+             |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
+             |${ev.value} = $math.roundToLong($m / (double)$n, java.math.RoundingMode.HALF_UP);
+          """.stripMargin)
+    }
   }
 
   override def toString: String = s"($left / $right)"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -733,7 +733,7 @@ object IntervalUtils {
    * @throws ArithmeticException if the result overflows any field value or divided by zero
    */
   def divideExact(interval: CalendarInterval, num: Double): CalendarInterval = {
-    if (num == 0) throw QueryExecutionErrors.divideByZeroError()
+    if (num == 0) throw QueryExecutionErrors.divideByZeroError("")
     fromDoubles(interval.months / num, interval.days / num, interval.microseconds / num)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -137,9 +137,9 @@ object QueryExecutionErrors {
       messageParameters = Array(funcCls, inputTypes, outputType), e)
   }
 
-  def divideByZeroError(): ArithmeticException = {
+  def divideByZeroError(context: String): ArithmeticException = {
     new SparkArithmeticException(
-      errorClass = "DIVIDE_BY_ZERO", messageParameters = Array(SQLConf.ANSI_ENABLED.key))
+      errorClass = "DIVIDE_BY_ZERO", messageParameters = Array(SQLConf.ANSI_ENABLED.key, context))
   }
 
   def invalidArrayIndexError(index: Int, numElements: Int): ArrayIndexOutOfBoundsException = {
@@ -212,8 +212,8 @@ object QueryExecutionErrors {
     arithmeticOverflowError("Overflow in sum of decimals")
   }
 
-  def overflowInIntegralDivideError(): ArithmeticException = {
-    arithmeticOverflowError("Overflow in integral divide", "try_divide")
+  def overflowInIntegralDivideError(context: String): ArithmeticException = {
+    arithmeticOverflowError("Overflow in integral divide", "try_divide", context)
   }
 
   def mapSizeExceedArraySizeWhenZipMapError(size: Int): RuntimeException = {

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -211,6 +211,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select interval '2 seconds' / 0
+       ^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -244,6 +247,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select interval '2' year / 0
+       ^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -1998,6 +2004,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -2007,6 +2016,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -2050,6 +2062,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -2059,6 +2074,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -205,6 +205,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select interval '2 seconds' / 0
+       ^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -238,6 +241,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select interval '2' year / 0
+       ^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -1987,6 +1993,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -1996,6 +2005,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-178956970-8' YEAR TO MONTH) / -1L
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -2039,6 +2051,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -2048,6 +2063,9 @@ struct<>
 -- !query output
 java.lang.ArithmeticException
 Overflow in integral divide. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+SELECT (INTERVAL '-106751991 04:00:54.775808' DAY TO SECOND) / -1L
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/case.sql.out
@@ -180,6 +180,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 26) ==
+SELECT CASE WHEN 1=0 THEN 1/0 WHEN 1=1 THEN 1 ELSE 2/0 END
+                          ^^^
 
 
 -- !query
@@ -189,6 +192,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 26) ==
+SELECT CASE 1 WHEN 0 THEN 1/0 WHEN 1 THEN 1 ELSE 2/0 END
+                          ^^^
 
 
 -- !query
@@ -198,6 +204,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 30) ==
+SELECT CASE WHEN i > 100 THEN 1/0 ELSE 0 END FROM case_tbl
+                              ^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out
@@ -576,6 +576,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select bigint('9223372036854775800') / bigint('0')
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -585,6 +588,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select bigint('-9223372036854775808') / smallint('0')
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query
@@ -594,6 +600,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 7) ==
+select smallint('100') / bigint('0')
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/select_having.sql.out
@@ -178,6 +178,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 39) ==
+...1 AS one FROM test_having WHERE 1/a = 1 HAVING 1 < 2
+                                   ^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-case.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-case.sql.out
@@ -180,6 +180,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 31) ==
+SELECT CASE WHEN udf(1=0) THEN 1/0 WHEN 1=1 THEN 1 ELSE 2/0 END
+                               ^^^
 
 
 -- !query
@@ -189,6 +192,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 54) ==
+...HEN 1/udf(0) WHEN 1 THEN 1 ELSE 2/0 END
+                                   ^^^
 
 
 -- !query
@@ -198,6 +204,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 34) ==
+...LECT CASE WHEN i > 100 THEN udf(1/0) ELSE udf(0) END FROM case_tbl
+                                   ^^^
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/postgreSQL/udf-select_having.sql.out
@@ -178,6 +178,9 @@ struct<>
 -- !query output
 org.apache.spark.SparkArithmeticException
 divide by zero. To return NULL instead, use 'try_divide'. If necessary set spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error.
+== SQL(line 1, position 39) ==
+...1 AS one FROM test_having WHERE 1/udf(a) = 1 HAVING 1 < 2
+                                   ^^^^^^^^
 
 
 -- !query


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Provide SQL query context in the following runtime error:

- Divide: divide by 0 error, including numeric types and ANSI interval types
- Integral Divide: divide by 0 error and overflow error
- Reminder: divide by 0 error
- Pmod: divide by 0 error

Example1:
```
== SQL(line 1, position 7) ==
select smallint('100') / bigint('0')
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Example 2:
```
== SQL(line 1, position 7) ==
select interval '2' year / 0
       ^^^^^^^^^^^^^^^^^^^^^
```
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Provide SQL query context of runtime errors to users, so that they can understand it better.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, improve the runtime error message of Divide/Div/Reminder/Pmod
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT