### PR TITLE
[SPARK-38588][ML][FOLLOWUP] fix ga failed at `Bernoulli: check vectors`

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/NaiveBayesSuite.scala
@@ -345,7 +345,7 @@ class NaiveBayesSuite extends MLTest with DefaultReadWriteTest {
 
   test("Bernoulli: check vectors") {
     val df1 = sc.parallelize(Seq(
-      (1.0, 1.0, Vectors.dense(1.0, 2.0)),
+      (1.0, 1.0, Vectors.dense(1.0)),
       (0.0, 1.0, null)
     )).toDF("label", "weight", "features")
     val e1 = intercept[Exception] {


### PR DESCRIPTION
### Why are the changes needed?
GA failed at `Bernoulli: check vectors` in `NaiveBayesSuite`.
The first case in `Bernoulli: check vectors` tried to check Exception while value is null, however the other given value is not valid to this case, thus we got the error message of `Vector values MUST be in {0, 1}, but got [1.0,2.0]`.
The relevant code can be found [here](https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala#L183), we check for null first, and then check if the data is reasonable

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
GA passed.