### PR TITLE
[SPARK-38726][PYTHON] Support `how` parameter of `MultiIndex.dropna`

### DIFF
--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1141,9 +1141,20 @@ class Index(IndexOpsMixin):
         """
         return kind == self.inferred_type
 
-    def dropna(self) -> "Index":
+    def dropna(self, how: str = "any") -> "Index":
         """
         Return Index or MultiIndex without NA/NaN values
+
+        Parameters
+        ----------
+        how : {'any', 'all'}, default 'any'
+            If the Index is a MultiIndex, drop the value when any or all levels
+            are NaN.
+
+
+        Returns
+        -------
+        Index or MultiIndex
 
         Examples
         --------
@@ -1162,35 +1173,30 @@ class Index(IndexOpsMixin):
 
         Also support for MultiIndex
 
-        >>> midx = pd.MultiIndex([['lama', 'cow', 'falcon'],
-        ...                       [None, 'weight', 'length']],
-        ...                      [[0, 1, 1, 1, 1, 1, 2, 2, 2],
-        ...                       [0, 1, 1, 0, 1, 2, 1, 1, 2]])
-        >>> s = ps.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, None],
-        ...               index=midx)
-        >>> s
-        lama    NaN        45.0
-        cow     weight    200.0
-                weight      1.2
-                NaN        30.0
-                weight    250.0
-                length      1.5
-        falcon  weight    320.0
-                weight      1.0
-                length      NaN
-        dtype: float64
 
-        >>> s.index.dropna()  # doctest: +SKIP
-        MultiIndex([(   'cow', 'weight'),
-                    (   'cow', 'weight'),
-                    (   'cow', 'weight'),
-                    (   'cow', 'length'),
-                    ('falcon', 'weight'),
-                    ('falcon', 'weight'),
-                    ('falcon', 'length')],
+        >>> tuples = [(np.nan, 1.0), (2.0, 2.0), (np.nan, np.nan), (3.0, np.nan)]
+        >>> midx = ps.MultiIndex.from_tuples(tuples)
+        >>> midx  # doctest: +NORMALIZE_WHITESPACE
+        MultiIndex([(nan, 1.0),
+                    (2.0, 2.0),
+                    (nan, nan),
+                    (3.0, nan)],
+                   )
+
+        >>> midx.dropna()  # doctest: +NORMALIZE_WHITESPACE
+        MultiIndex([(2.0, 2.0)],
+                   )
+
+        >>> midx.dropna(how="all")  # doctest: +NORMALIZE_WHITESPACE
+        MultiIndex([(nan, 1.0),
+                    (2.0, 2.0),
+                    (3.0, nan)],
                    )
         """
-        sdf = self._internal.spark_frame.select(self._internal.index_spark_columns).dropna()
+        if how not in ("any", "all"):
+            raise ValueError("invalid how option: %s" % how)
+
+        sdf = self._internal.spark_frame.select(self._internal.index_spark_columns).dropna(how=how)
         internal = InternalFrame(
             spark_frame=sdf,
             index_spark_columns=[

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1151,7 +1151,6 @@ class Index(IndexOpsMixin):
             If the Index is a MultiIndex, drop the value when any or all levels
             are NaN.
 
-
         Returns
         -------
         Index or MultiIndex
@@ -1176,18 +1175,18 @@ class Index(IndexOpsMixin):
 
         >>> tuples = [(np.nan, 1.0), (2.0, 2.0), (np.nan, np.nan), (3.0, np.nan)]
         >>> midx = ps.MultiIndex.from_tuples(tuples)
-        >>> midx  # doctest: +NORMALIZE_WHITESPACE
+        >>> midx  # doctest: +SKIP
         MultiIndex([(nan, 1.0),
                     (2.0, 2.0),
                     (nan, nan),
                     (3.0, nan)],
                    )
 
-        >>> midx.dropna()  # doctest: +NORMALIZE_WHITESPACE
+        >>> midx.dropna()  # doctest: +SKIP
         MultiIndex([(2.0, 2.0)],
                    )
 
-        >>> midx.dropna(how="all")  # doctest: +NORMALIZE_WHITESPACE
+        >>> midx.dropna(how="all")  # doctest: +SKIP
         MultiIndex([(nan, 1.0),
                     (2.0, 2.0),
                     (3.0, nan)],

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -383,7 +383,9 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         self.assert_eq(psidx.dropna(how="any"), pidx.dropna(how="any"))
         self.assert_eq(psidx.dropna(how="all"), pidx.dropna(how="all"))
 
-        pmidx = pd.MultiIndex.from_tuples([(np.nan, 1.0), (2.0, 2.0), (np.nan, None), (3.0, np.nan)])
+        pmidx = pd.MultiIndex.from_tuples(
+            [(np.nan, 1.0), (2.0, 2.0), (np.nan, None), (3.0, np.nan)]
+        )
         psmidx = ps.from_pandas(pmidx)
         self.assert_eq(psmidx.dropna(), pmidx.dropna())
         self.assert_eq(psmidx.dropna(how="any"), pmidx.dropna(how="any"))

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -374,11 +374,20 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         )
 
     def test_dropna(self):
-        pidx = pd.Index([np.nan, 2, 4, 1, np.nan, 3])
+        pidx = pd.Index([np.nan, 2, 4, 1, None, 3])
         psidx = ps.from_pandas(pidx)
 
         self.assert_eq(psidx.dropna(), pidx.dropna())
         self.assert_eq((psidx + 1).dropna(), (pidx + 1).dropna())
+
+        self.assert_eq(psidx.dropna(how="any"), pidx.dropna(how="any"))
+        self.assert_eq(psidx.dropna(how="all"), pidx.dropna(how="all"))
+
+        pmidx = pd.MultiIndex.from_tuples([(np.nan, 1.0), (2.0, 2.0), (np.nan, None), (3.0, np.nan)])
+        psmidx = ps.from_pandas(pmidx)
+        self.assert_eq(psmidx.dropna(), pmidx.dropna())
+        self.assert_eq(psmidx.dropna(how="any"), pmidx.dropna(how="any"))
+        self.assert_eq(psmidx.dropna(how="all"), pmidx.dropna(how="all"))
 
     def test_index_symmetric_difference(self):
         pidx1 = pd.Index([1, 2, 3, 4])

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -391,6 +391,10 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         self.assert_eq(psmidx.dropna(how="any"), pmidx.dropna(how="any"))
         self.assert_eq(psmidx.dropna(how="all"), pmidx.dropna(how="all"))
 
+        invalid_how = "none"
+        with self.assertRaisesRegex(ValueError, "invalid how option: %s" % invalid_how):
+            psmidx.dropna(invalid_how)
+
     def test_index_symmetric_difference(self):
         pidx1 = pd.Index([1, 2, 3, 4])
         pidx2 = pd.Index([2, 3, 4, 5])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support `how` parameter of `MultiIndex.dropna` to specify drop the value when any or all levels are NaN.


### Why are the changes needed?
To reach parity with pandas.

### Does this PR introduce _any_ user-facing change?
Yes.`how` parameter of `MultiIndex.dropna` is supported
```py
        >>> tuples = [(np.nan, 1.0), (2.0, 2.0), (np.nan, np.nan), (3.0, np.nan)]
        >>> midx = ps.MultiIndex.from_tuples(tuples)
        >>> midx
        MultiIndex([(nan, 1.0),
                    (2.0, 2.0),
                    (nan, nan),
                    (3.0, nan)],
                   )

        >>> midx.dropna(how="any")
        MultiIndex([(2.0, 2.0)],
                   )

        >>> midx.dropna(how="all")
        MultiIndex([(nan, 1.0),
                    (2.0, 2.0),
                    (3.0, nan)],
                   )
```

### How was this patch tested?
Unit tests.
