### PR TITLE
[SPARK-38679][SQL][TESTS][FOLLOW-UP]Add numPartitions parameter to TaskContextImpl at SubexpressionEliminationSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -423,7 +423,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
   test("SPARK-38333: PlanExpression expression should skip addExprTree function in Executor") {
     try {
       // suppose we are in executor
-      val context1 = new TaskContextImpl(0, 0, 0, 0, 0, null, null, null, cpus = 0)
+      val context1 = new TaskContextImpl(0, 0, 0, 0, 0, 1, null, null, null, cpus = 0)
       TaskContext.setTaskContext(context1)
 
       val equivalence = new EquivalentExpressions


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds missing `numPartitions` parameter for `TaskContextImpl` ctor.

### Why are the changes needed?
This PR fixes build error:

```
spark/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala:426: not enough arguments for constructor TaskContextImpl: (stageId: Int, stageAttemptNumber: Int, partitionId: Int, taskAttemptId: Long, attemptNumber: Int, numPartitions: Int, taskMemoryManager: org.apache.spark.memory.TaskMemoryManager, localProperties: java.util.Properties, metricsSystem: org.apache.spark.metrics.MetricsSystem, taskMetrics: org.apache.spark.executor.TaskMetrics, cpus: Int, resources: Map[String,org.apache.spark.resource.ResourceInformation])org.apache.spark.TaskContextImpl.
Unspecified value parameter metricsSystem.
```
This was due to commit a40acd4392a8611062763ce6ec7bc853d401c646 not being updated with latest TaskContextImpl ctor before merging.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
```
./build/mvn install -Phive -Phive-thriftserver -DskipTests
```