### PR TITLE
Draft: [SPARK-38715] Configurable client ID for Kafka Spark SQL producer

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/package.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/package.scala
@@ -89,4 +89,12 @@ package object kafka010 {   // scalastyle:ignore
       .version("3.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("1m")
+
+  private[kafka010] val CLIENT_ID_PREFIX =
+    ConfigBuilder("spark.kafka.clientIdPrefix")
+      .doc("The custom prefix for generated client ID.")
+      .version("3.3.0")
+      .stringConf
+      .createWithDefault("spark-kafka-")
+
 }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/producer/CachedKafkaProducer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/producer/CachedKafkaProducer.scala
@@ -27,8 +27,14 @@ import org.apache.spark.internal.Logging
 
 private[kafka010] class CachedKafkaProducer(
     val cacheKey: Seq[(String, Object)],
-    val producer: KafkaProducer[Array[Byte], Array[Byte]]) extends Logging {
-  val id: String = ju.UUID.randomUUID().toString
+    val producer: KafkaProducer[Array[Byte], Array[Byte]],
+    val id: String) extends Logging {
+
+  @deprecated("Please the constructor with 'id' parameter.", "3.0.0")
+  def this(
+    cacheKey: Seq[(String, Object)],
+    producer: KafkaProducer[Array[Byte], Array[Byte]]) =
+    this(cacheKey, producer, ju.UUID.randomUUID().toString)
 
   private[producer] def close(): Unit = {
     try {


### PR DESCRIPTION
By default Kafka client automatically generated a unique client ID.
Client ID is used by many data lineage tool to gather consumer/producer (for consumer the consumer group is also used, but only client ID can be used for producer).

Setting the [client.id](https://kafka.apache.org/documentation/#producerconfigs_client.id) is options passed to Spark Kafka read or write is not possible, as it would force the same client.id on at east both the driver and the executor.

What could be done is to be able to passed Spark specific option, maybe named `clientIdPrefix`.

e.g.

```scala
val df = spark
.read
.format("kafka")
.option("kafka.bootstrap.servers", "host1:port1,host2:port2")
.option("subscribePattern", "topic.*")
.option("startingOffsets", "earliest")
.option("endingOffsets", "latest")
.option("clientIdPrefix", "my-workflow-")
.load()
```

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?

- A new client ID prefix setting in Sparl SQL

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
