### PR TITLE
[SPARK-38679][SQL][TESTS][FOLLOW-UP]Add numPartitions parameter to TaskContextImpl at SubexpressionEliminationSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -423,7 +423,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
   test("SPARK-38333: PlanExpression expression should skip addExprTree function in Executor") {
     try {
       // suppose we are in executor
-      val context1 = new TaskContextImpl(0, 0, 0, 0, 0, null, null, null, cpus = 0)
+      val context1 = new TaskContextImpl(0, 0, 0, 0, 0, 1, null, null, null, cpus = 0)
       TaskContext.setTaskContext(context1)
 
       val equivalence = new EquivalentExpressions


### PR DESCRIPTION
### What changes were proposed in this pull request?

There was a logical conflict between https://github.com/apache/spark/pull/36012 and https://github.com/apache/spark/pull/35995. This PR fixes it up by providing `numPartitions` paramter to `TaskContextImpl` at `SubexpressionEliminationSuite`.

### Why are the changes needed?

To fix the build up.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.