### PR TITLE
[SPARK-38755][PYTHON][TEST] Add file to address missing pandas general functions

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/general_functions.rst
+++ b/python/docs/source/reference/pyspark.pandas/general_functions.rst
@@ -41,6 +41,7 @@ Data manipulations and SQL
 
    melt
    merge
+   merge_asof
    get_dummies
    concat
    sql
@@ -52,14 +53,21 @@ Top-level missing data
 .. autosummary::
    :toctree: api/
 
-   to_numeric
    isna
    isnull
    notna
    notnull
 
-Top-level dealing with datetimelike
+Top-level dealing with numeric data
 -----------------------------------
+
+.. autosummary::
+   :toctree: api/
+
+   to_numeric
+
+Top-level dealing with datetimelike data
+----------------------------------------
 .. autosummary::
    :toctree: api/
 

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -22,9 +22,12 @@
 
 import os
 import sys
-from distutils.version import LooseVersion
 import warnings
+from distutils.version import LooseVersion
+from functools import partial
+from typing import Any
 
+from pyspark.pandas.missing.general_functions import _MissingPandasLikeGeneralFunctions
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
 
 try:
@@ -151,3 +154,13 @@ _auto_patch_pandas()
 from pyspark.pandas.config import get_option, options, option_context, reset_option, set_option
 from pyspark.pandas.namespace import *  # noqa: F403
 from pyspark.pandas.sql_formatter import sql
+
+
+def __getattr__(key: str) -> Any:
+    if key.startswith("__"):
+        raise AttributeError(key)
+    if hasattr(_MissingPandasLikeGeneralFunctions, key):
+        func = getattr(_MissingPandasLikeGeneralFunctions, key)
+        return partial(func)
+    else:
+        raise AttributeError("module 'pyspark.pandas' has no attribute '%s'" % (key))

--- a/python/pyspark/pandas/__init__.py
+++ b/python/pyspark/pandas/__init__.py
@@ -24,7 +24,6 @@ import os
 import sys
 import warnings
 from distutils.version import LooseVersion
-from functools import partial
 from typing import Any
 
 from pyspark.pandas.missing.general_functions import _MissingPandasLikeGeneralFunctions
@@ -160,7 +159,6 @@ def __getattr__(key: str) -> Any:
     if key.startswith("__"):
         raise AttributeError(key)
     if hasattr(_MissingPandasLikeGeneralFunctions, key):
-        func = getattr(_MissingPandasLikeGeneralFunctions, key)
-        return partial(func)
+        return getattr(_MissingPandasLikeGeneralFunctions, key)
     else:
         raise AttributeError("module 'pyspark.pandas' has no attribute '%s'" % (key))

--- a/python/pyspark/pandas/missing/general_functions.py
+++ b/python/pyspark/pandas/missing/general_functions.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyspark.pandas.missing import unsupported_function
+
+
+def _unsupported_function(method_name, deprecated=False, reason=""):
+    return unsupported_function(
+        class_name="pd", method_name=method_name, deprecated=deprecated, reason=reason
+    )
+
+
+class _MissingPandasLikeGeneralFunctions:
+
+    pivot = _unsupported_function("pivot")
+    pivot_table = _unsupported_function("pivot_table")
+    crosstab = _unsupported_function("crosstab")
+    cut = _unsupported_function("cut")
+    qcut = _unsupported_function("qcut")
+    merge_ordered = _unsupported_function("merge_ordered")
+    factorize = _unsupported_function("factorize")
+    unique = _unsupported_function("unique")
+    wide_to_long = _unsupported_function("wide_to_long")
+    bdate_range = _unsupported_function("bdate_range")
+    period_range = _unsupported_function("period_range")
+    infer_freq = _unsupported_function("infer_freq")
+    interval_range = _unsupported_function("interval_range")
+    eval = _unsupported_function("eval")

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -31,6 +31,7 @@ from pyspark.pandas.indexes.datetimes import DatetimeIndex
 from pyspark.pandas.indexes.multi import MultiIndex
 from pyspark.pandas.indexes.numeric import Float64Index, Int64Index
 from pyspark.pandas.missing.frame import _MissingPandasLikeDataFrame
+from pyspark.pandas.missing.general_functions import _MissingPandasLikeGeneralFunctions
 from pyspark.pandas.missing.groupby import (
     MissingPandasLikeDataFrameGroupBy,
     MissingPandasLikeSeriesGroupBy,
@@ -109,6 +110,7 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
     modules.append(sql_formatter)
 
     missings = [
+        (pd, _MissingPandasLikeGeneralFunctions),
         (pd.DataFrame, _MissingPandasLikeDataFrame),
         (pd.Series, MissingPandasLikeSeries),
         (pd.Index, MissingPandasLikeIndex),

--- a/python/pyspark/pandas/usage_logging/__init__.py
+++ b/python/pyspark/pandas/usage_logging/__init__.py
@@ -124,4 +124,4 @@ def attach(logger_module: Union[str, ModuleType]) -> None:
         (pd.core.window.RollingGroupby, MissingPandasLikeRollingGroupby),
     ]
 
-    _attach(logger_module, modules, classes, missings)
+    _attach(logger_module, modules, classes, missings)  # type: ignore[arg-type]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `python/pyspark/pandas/missing/general_functions.py` to track the missing [pandas general functions](https://pandas.pydata.org/docs/reference/general_functions.html) API.


### Why are the changes needed?

We have scripts in `missing` directory to track & address the missing pandas APIs, but one for general functions is missing.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

The existing tests should cover