### PR TITLE
[SPARK-38765][PYTHON] Implement `inplace` parameter of `Series.clip`

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2210,18 +2210,18 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 scol = F.when(scol < lower, lower).otherwise(scol)
             if upper is not None:
                 scol = F.when(scol > upper, upper).otherwise(scol)
-            if not inplace:
-                return self._with_new_scol(
-                    scol.alias(self._internal.data_spark_column_names[0]),
-                    field=self._internal.data_fields[0],
-                )
-            else:
+            if inplace:
                 internal = self._internal.copy(
                     data_spark_columns=[scol.alias(self._internal.data_spark_column_names[0])],
                     data_fields=[self._internal.data_fields[0]],
                 )
                 self._psdf._update_internal_frame(internal, requires_same_anchor=False)
                 return None
+            else:
+                return self._with_new_scol(
+                    scol.alias(self._internal.data_spark_column_names[0]),
+                    field=self._internal.data_fields[0],
+                )
         else:
             return self
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2182,6 +2182,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    3
         dtype: int64
 
+        Clip can be performed in-place.
+
         >>> psser.clip(2, 3, inplace=True)
         >>> psser
         0    2

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1080,9 +1080,9 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
                 getattr(psser, name)
 
     def test_clip(self):
-        pser = pd.Series([0, 2, 4], index=np.random.rand(3))
+        pser = pd.Series([0, 2, 4], index=np.random.rand(3), name='x')
         psser = ps.from_pandas(pser)
-        psser.clip(1, 3)
+
         # Assert list-like values are not accepted for 'lower' and 'upper'
         msg = "List-like value are not supported for 'lower' and 'upper' at the moment"
         with self.assertRaises(TypeError, msg=msg):

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1080,7 +1080,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
                 getattr(psser, name)
 
     def test_clip(self):
-        pser = pd.Series([0, 2, 4], index=np.random.rand(3), name='x')
+        pser = pd.Series([0, 2, 4], index=np.random.rand(3), name="x")
         psser = ps.from_pandas(pser)
 
         # Assert list-like values are not accepted for 'lower' and 'upper'

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1082,7 +1082,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
     def test_clip(self):
         pser = pd.Series([0, 2, 4], index=np.random.rand(3))
         psser = ps.from_pandas(pser)
-
+        psser.clip(1, 3)
         # Assert list-like values are not accepted for 'lower' and 'upper'
         msg = "List-like value are not supported for 'lower' and 'upper' at the moment"
         with self.assertRaises(TypeError, msg=msg):
@@ -1098,6 +1098,13 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.clip(upper=3), pser.clip(upper=3))
         # Assert lower and upper
         self.assert_eq(psser.clip(1, 3), pser.clip(1, 3))
+        self.assert_eq((psser + 1).clip(1, 3), (pser + 1).clip(1, 3))
+
+        # Assert inplace is True
+        psser = ps.from_pandas(pser)
+        pser.clip(1, 3, inplace=True)
+        psser.clip(1, 3, inplace=True)
+        self.assert_eq(psser, pser)
 
         # Assert behavior on string values
         str_psser = ps.Series(["a", "b", "c"])


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `inplace` parameter of `Series.clip`.

### Why are the changes needed?
To reach parity with pandas.

### Does this PR introduce _any_ user-facing change?
Yes.

`inplace` parameter of `Series.clip` is supported as below:
```py
        >>> psser = ps.Series([0, 2, 4])
        >>> psser
        0    0
        1    2
        2    4
        dtype: int64

        >>> psser.clip(2, 3, inplace=True)
        >>> psser
        0    2
        1    2
        2    3
        dtype: int64
```
### How was this patch tested?
Unit tests.