### PR TITLE
[SPARK-38763][PYTHON] Support lambda `column` parameter of `DataFrame.rename`

### DIFF
--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -817,11 +817,20 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             pdf1.rename(columns=str_lower, index={1: 10, 2: 20}),
         )
 
+        self.assert_eq(
+            psdf1.rename(columns=lambda x: str.lower(x)),
+            pdf1.rename(columns=lambda x: str.lower(x)),
+        )
+
         idx = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Y", "D")])
         pdf2 = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]], columns=idx)
         psdf2 = ps.from_pandas(pdf2)
 
         self.assert_eq(psdf2.rename(columns=str_lower), pdf2.rename(columns=str_lower))
+        self.assert_eq(
+            psdf2.rename(columns=lambda x: str.lower(x)),
+            pdf2.rename(columns=lambda x: str.lower(x)),
+        )
 
         self.assert_eq(
             psdf2.rename(columns=str_lower, level=0), pdf2.rename(columns=str_lower, level=0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support lambda `column` parameter of `DataFrame.rename`.

We may want to backport this to 3.3 since this is a regression.

### Why are the changes needed?
To reach parity with Pandas.

### Does this PR introduce _any_ user-facing change?
Yes. The regression is fixed; lambda `column` is supported again.

```py
>>> psdf = ps.DataFrame({'x': [1, 2], 'y': [3, 4]})

>>> psdf.rename(columns=lambda x: x + 'o')
   xo  yo
0   1   3
1   2   4
```

### How was this patch tested?
Unit tests.