### PR TITLE
[SPARK-38771][SQL] Adaptive Bloom filter Join

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -756,6 +756,13 @@ jobs:
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.forceApplyShuffledHashJoin=true
+    - name: Run TPC-DS queries (Test AdaptiveBloomFilterJoin)
+      run: |
+        SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
+      env:
+        SPARK_TPCDS_JOIN_CONF: |
+          spark.memory.storageFraction=0.99999999
+          spark.sql.autoBroadcastJoinThreshold=-1
     - name: Upload test results to report
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -756,13 +756,6 @@ jobs:
         SPARK_TPCDS_JOIN_CONF: |
           spark.sql.autoBroadcastJoinThreshold=-1
           spark.sql.join.forceApplyShuffledHashJoin=true
-    - name: Run TPC-DS queries (Test AdaptiveBloomFilterJoin)
-      run: |
-        SPARK_TPCDS_DATA=`pwd`/tpcds-sf-1 build/sbt "sql/testOnly org.apache.spark.sql.TPCDSQueryTestSuite"
-      env:
-        SPARK_TPCDS_JOIN_CONF: |
-          spark.memory.storageFraction=0.99999999
-          spark.sql.autoBroadcastJoinThreshold=-1
     - name: Upload test results to report
       if: always()
       uses: actions/upload-artifact@v2

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveBloomFilterJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveBloomFilterJoin.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.internal.config
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Alias, BloomFilterMightContain, Expression, Literal, ScalarSubquery, XxHash64}
+import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
+import org.apache.spark.sql.catalyst.optimizer.ConstantFolding
+import org.apache.spark.sql.catalyst.optimizer.JoinSelectionHelper
+import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * Insert a bloom filter on one side of the join if it may be spill when sorting and
+ * the other side less than 100000000L rows.
+ */
+case class AdaptiveBloomFilterJoin(sparkSession: SparkSession)
+    extends Rule[LogicalPlan] with JoinSelectionHelper {
+
+  // Larger number of items may take a long time to build bloom filter.
+  private final val maxNumItems = 100000000L
+  // The factor of raw data to Java objects.
+  private final val factor = 2
+
+  private val sc = sparkSession.sparkContext
+  private val fraction = sc.conf.get(config.MEMORY_FRACTION)
+  private val storageFraction = sc.conf.get(config.MEMORY_STORAGE_FRACTION)
+  private val executorCores = sc.conf.get(config.EXECUTOR_CORES)
+
+  private val memoryPerTask =
+    (sc.executorMemory * fraction * (1 - storageFraction) * (1L << 20)).toFloat / executorCores
+
+  private def canPruneLeft(joinType: JoinType): Boolean = joinType match {
+    case Inner | LeftSemi | RightOuter => true
+    case _ => false
+  }
+
+  private def canPruneRight(joinType: JoinType): Boolean = joinType match {
+    case Inner | LeftSemi | LeftOuter => true
+    case _ => false
+  }
+
+  private def avgShuffleSizePerPartition(logicalPlan: LogicalPlan): Option[Long] = {
+    logicalPlan match {
+      case LogicalQueryStage(_, stage: ShuffleQueryStageExec) =>
+        stage.mapStats.map(s => s.bytesByPartitionId.sum / s.bytesByPartitionId.length)
+      case _ => None
+    }
+  }
+
+  private def nonBroadcastHashJoin(join: Join): Boolean = {
+    !canPlanAsBroadcastHashJoin(join, conf) && join.children.forall {
+      case LogicalQueryStage(_, stage: ShuffleQueryStageExec) => stage.isMaterialized
+      case _ => false
+    }
+  }
+
+  private def insertPredicate(
+      pruningKeys: Seq[Expression],
+      pruningPlan: LogicalPlan,
+      filteringKey: Seq[Expression],
+      filteringPlan: LogicalPlan): LogicalPlan = {
+    val filteringRowCount = filteringPlan.stats.rowCount.get
+    // To improve build bloom filter performance.
+    val coalesceNum = scala.math.ceil(filteringRowCount.toDouble / 4000000).toInt
+
+    val bloomFilterAgg =
+      new BloomFilterAggregate(new XxHash64(filteringKey), Literal(filteringRowCount.toLong))
+    val alias = Alias(bloomFilterAgg.toAggregateExpression(), "bloomFilter")()
+    val aggregate = ConstantFolding(Aggregate(Nil, Seq(alias),
+      Repartition(coalesceNum, false, filteringPlan)))
+
+    logWarning("Adaptive insert bloom filter join")
+    val bloomFilterSubquery = ScalarSubquery(aggregate, Nil)
+    Filter(BloomFilterMightContain(bloomFilterSubquery, new XxHash64(pruningKeys)), pruningPlan)
+  }
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
+    case join @ ExtractEquiJoinKeys(joinType, leftKeys, rightKeys, _, _, left, right, _)
+        if left.stats.isRuntime && right.stats.isRuntime && nonBroadcastHashJoin(join) =>
+      val leftRowCnt = left.stats.rowCount.get
+      val rightRowCnt = right.stats.rowCount.get
+
+      if (canPruneLeft(joinType) && rightRowCnt < maxNumItems && rightRowCnt < leftRowCnt &&
+        avgShuffleSizePerPartition(left).exists(_ * factor > memoryPerTask)) {
+        join.copy(left = insertPredicate(leftKeys, left, rightKeys, right))
+      } else if (canPruneRight(joinType) && leftRowCnt < maxNumItems && leftRowCnt < rightRowCnt &&
+        avgShuffleSizePerPartition(right).exists(_ * factor > memoryPerTask)) {
+        join.copy(right = insertPredicate(rightKeys, right, leftKeys, left))
+      } else {
+        join
+      }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -84,7 +84,7 @@ case class AdaptiveSparkPlanExec(
   @transient private val planChangeLogger = new PlanChangeLogger[SparkPlan]()
 
   // The logical plan optimizer for re-optimizing the current logical plan.
-  @transient private val optimizer = new AQEOptimizer(conf)
+  @transient private val optimizer = new AQEOptimizer(context.session)
 
   // `EnsureRequirements` may remove user-specified repartition and assume the query plan won't
   // change its output partitioning. This assumption is not true in AQE. Here we check the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanHelper.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.adaptive
 
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 
 /**
  * This class provides utility methods related to tree traversal of an [[AdaptiveSparkPlanExec]]
@@ -26,6 +27,18 @@ import org.apache.spark.sql.execution.SparkPlan
  * adaptive plans, i.e., [[AdaptiveSparkPlanExec]] and [[QueryStageExec]].
  */
 trait AdaptiveSparkPlanHelper {
+
+  def findTopLevelBroadcastHashJoin(plan: SparkPlan): Seq[BroadcastHashJoinExec] = {
+    collect(plan) {
+      case j: BroadcastHashJoinExec => j
+    }
+  }
+
+  def findTopLevelSortMergeJoin(plan: SparkPlan): Seq[SortMergeJoinExec] = {
+    collect(plan) {
+      case j: SortMergeJoinExec => j
+    }
+  }
 
   /**
    * Find the first [[SparkPlan]] that satisfies the condition specified by `f`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanHelper.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanHelper.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.adaptive
 
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHashJoinExec, SortMergeJoinExec}
 
 /**
  * This class provides utility methods related to tree traversal of an [[AdaptiveSparkPlanExec]]
@@ -37,6 +37,12 @@ trait AdaptiveSparkPlanHelper {
   def findTopLevelSortMergeJoin(plan: SparkPlan): Seq[SortMergeJoinExec] = {
     collect(plan) {
       case j: SortMergeJoinExec => j
+    }
+  }
+
+  def findTopLevelShuffledHashJoin(plan: SparkPlan): Seq[ShuffledHashJoinExec] = {
+    collect(plan) {
+      case j: ShuffledHashJoinExec => j
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -54,7 +54,7 @@ case class InsertAdaptiveSparkPlan(
           // Plan sub-queries recursively and pass in the shared stage cache for exchange reuse.
           // Fall back to non-AQE mode if AQE is not supported in any of the sub-queries.
           val subqueryMap = buildSubqueryMap(plan)
-          val planSubqueriesRule = PlanAdaptiveSubqueries(subqueryMap)
+          val planSubqueriesRule = PlanAdaptiveSubqueries(adaptiveExecutionContext, subqueryMap)
           val preprocessingRules = Seq(
             planSubqueriesRule)
           // Run pre-processing rules.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveBloomFilterJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveBloomFilterJoinSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.scalatest.PrivateMethodTester
+
+import org.apache.spark.internal.config
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.expressions.BloomFilterMightContain
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AdaptiveBloomFilterJoinSuite
+  extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper
+  with PrivateMethodTester {
+
+  protected override def sparkConf = {
+    super.sparkConf
+      .set(config.MEMORY_STORAGE_FRACTION, 0.99999999)
+  }
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches = Batch("Adaptive Bloom Filter Join", FixedPoint(10),
+      AdaptiveBloomFilterJoin(spark)) :: Nil
+  }
+
+  setupTestData()
+
+  private def hasBloomFilterJoin(plan: SparkPlan): Seq[FilterExec] = {
+    collectWithSubqueries(plan) {
+      case f @ FilterExec(e, _) if e.isInstanceOf[BloomFilterMightContain] => f
+    }
+  }
+
+  test("Adaptive add Bloom filter") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1") {
+      val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
+        "SELECT * FROM testData join testData2 ON key = a where value = 1")
+
+      assert(findTopLevelSortMergeJoin(plan).size === 1)
+      assert(hasBloomFilterJoin(plan).size === 0)
+      assert(findTopLevelSortMergeJoin(adaptivePlan).size === 1)
+      assert(hasBloomFilterJoin(adaptivePlan).size === 1)
+    }
+  }
+
+  test("Do not add Bloom filter if convert to BroadcastHashJoin") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "80") {
+      val (plan, adaptivePlan) = runAdaptiveAndVerifyResult(
+        "SELECT * FROM testData join testData2 ON key = a where value = 1")
+
+      assert(findTopLevelSortMergeJoin(plan).size === 1)
+      assert(hasBloomFilterJoin(plan).size === 0)
+      assert(findTopLevelBroadcastHashJoin(adaptivePlan).size == 1)
+      assert(findTopLevelSortMergeJoin(adaptivePlan).size === 0)
+      assert(hasBloomFilterJoin(adaptivePlan).size === 0)
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.command.DataWritingCommandExec
 import org.apache.spark.sql.execution.datasources.noop.NoopDataSource
 import org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec
 import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ENSURE_REQUIREMENTS, REPARTITION_BY_COL, REPARTITION_BY_NUM, ReusedExchangeExec, ShuffleExchangeExec, ShuffleExchangeLike, ShuffleOrigin}
-import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, ShuffledHashJoinExec, ShuffledJoin, SortMergeJoinExec}
+import org.apache.spark.sql.execution.joins.{BaseJoinExec, BroadcastHashJoinExec, ShuffledJoin, SortMergeJoinExec}
 import org.apache.spark.sql.execution.metric.SQLShuffleReadMetricsReporter
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
 import org.apache.spark.sql.functions._
@@ -54,12 +54,6 @@ class AdaptiveQueryExecSuite
   import testImplicits._
 
   setupTestData()
-
-  private def findTopLevelShuffledHashJoin(plan: SparkPlan): Seq[ShuffledHashJoinExec] = {
-    collect(plan) {
-      case j: ShuffledHashJoinExec => j
-    }
-  }
 
   private def findTopLevelBaseJoin(plan: SparkPlan): Seq[BaseJoinExec] = {
     collect(plan) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR introduces an adaptive Bloom filter Join rule for `AQEOptimizer`.
It has two benefit:
1. It reduces spilling data when sorting.
2. It improves join performance, especially join keys may be skewed.

It only works:
1. AQE is enabled and can't be convert to BroadcastHashJoin.
2. The filtering side rows should be less than 100,000,000 rows.
3. The pruning side should be large and must spill data to disk when sorting(Larger than `spark.executor.memory(mb) * spark.memory.fraction * (1 - spark.memory.storageFraction) * 1024 * 1024 / spark.executor.cores  / factor * spark.sql.shuffle.partitions`). For example:
     Default config: `spark.executor.memory` = 1g,`spark.memory.fraction` = 0.6, `spark.memory.storageFraction` = 0.5, `spark.executor.cores` = 1 and `spark.sql.shuffle.partitions` = 200. The pruning side should larger than 30gb.
     Our production config: `spark.executor.memory` = 45g,`spark.memory.fraction` = 0.75, `spark.memory.storageFraction` = 0.5, `spark.executor.cores` = 18 and `spark.sql.shuffle.partitions` = 10000. The pruning side should larger than 4687gb.

How to disable this rule:
```
set spark.sql.adaptive.optimizer.excludedRules=org.apache.spark.sql.execution.adaptive.AdaptiveBloomFilterJoin
```

### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and benchmark test.
 Before | After
-- | --
![image](https://user-images.githubusercontent.com/5399861/161379061-629b8031-3919-4078-96de-e8eb7d72428c.png) | ![image](https://user-images.githubusercontent.com/5399861/161379140-c72102ca-e94a-4962-8160-e80f22e6899e.png)
