### PR TITLE
[SPARK-38774][PYTHON] Implement Series.autocorr

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -134,6 +134,7 @@ Computations / Descriptive Stats
    Series.abs
    Series.all
    Series.any
+   Series.autocorr
    Series.between
    Series.clip
    Series.corr

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -33,7 +33,6 @@ class MissingPandasLikeSeries:
 
     # Functions
     asfreq = _unsupported_function("asfreq")
-    autocorr = _unsupported_function("autocorr")
     combine = _unsupported_function("combine")
     convert_dtypes = _unsupported_function("convert_dtypes")
     infer_objects = _unsupported_function("infer_objects")

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3052,6 +3052,11 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         This method computes the Pearson correlation between
         the Series and its shifted self.
 
+        .. note:: the current implementation of rank uses Spark's Window without
+            specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
         .. versionadded:: 3.4.0
 
         Parameters

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3099,17 +3099,19 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if not isinstance(periods, int):
             raise TypeError("periods should be an int; however, got [%s]" % type(periods).__name__)
 
-        scol = self.spark.column.alias("__tmp_col__")
+        tmp_col = "__tmp_col__"
+        tmp_lag_col = "__tmp_lag_col__"
+        scol = self.spark.column.alias(tmp_col)
         if periods == 0:
-            lag_col = scol.alias("__tmp_lag_col__")
+            lag_col = scol.alias(tmp_lag_col)
         else:
             window = Window.orderBy(NATURAL_ORDER_COLUMN_NAME)
-            lag_col = F.lag(scol, periods).over(window).alias("__tmp_lag_col__")
+            lag_col = F.lag(scol, periods).over(window).alias(tmp_lag_col)
 
         return (
             self._internal.spark_frame.select([scol, lag_col])
             .dropna("any")
-            .corr("__tmp_col__", "__tmp_lag_col__")
+            .corr(tmp_col, tmp_lag_col)
         )
 
     def corr(self, other: "Series", method: str = "pearson") -> float:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3052,6 +3052,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         This method computes the Pearson correlation between
         the Series and its shifted self.
 
+        .. versionadded:: 3.4.0
+
         Parameters
         ----------
         periods : int, default 1

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -3104,6 +3104,23 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
         self.assert_eq(psser1.combine_first(psser2), pser1.combine_first(pser2))
 
+    def test_autocorr(self):
+        pdf = pd.DataFrame({"s1": [0.90010907, 0.13484424, 0.62036035]})
+        self._test_autocorr(pdf)
+
+        pdf = pd.DataFrame({"s1": [0.90010907, np.nan, 0.13484424, 0.62036035]})
+        self._test_autocorr(pdf)
+
+        pdf = pd.DataFrame({"s1": [0.2, 0.0, 0.6, 0.2, np.nan, 0.5, 0.6]})
+        self._test_autocorr(pdf)
+
+    def _test_autocorr(self, pdf):
+        psdf = ps.from_pandas(pdf)
+        for lag in range(-10, 10):
+            p_autocorr = pdf["s1"].autocorr(lag)
+            ps_autocorr = psdf["s1"].autocorr(lag)
+            self.assert_eq(p_autocorr, ps_autocorr, almost=True)
+
     def test_cov(self):
         pdf = pd.DataFrame(
             {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement Series.autocorr


### Why are the changes needed?
for API coverage


### Does this PR introduce _any_ user-facing change?
yes, Series now support function `autocorr`

```
In [86]: s = pd.Series([.2, .0, .6, .2, np.nan, .5, .6])

In [87]: s.autocorr()
Out[87]: -0.14121975762272054
```


### How was this patch tested?
added doctest
