### PR TITLE
[MINOR][DOCS] Remove PySpark doc build warnings

### DIFF
--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -53,7 +53,7 @@ This can be controlled by ``spark.sql.execution.arrow.pyspark.fallback.enabled``
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 35-48
+    :lines: 37-52
     :dedent: 4
 
 Using the above optimizations with Arrow will produce the same results as when Arrow is not
@@ -90,7 +90,7 @@ specify the type hints of ``pandas.Series`` and ``pandas.DataFrame`` as below:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 54-78
+    :lines: 56-80
     :dedent: 4
 
 In the following sections, it describes the combinations of the supported type hints. For simplicity,
@@ -113,7 +113,7 @@ The following example shows how to create this Pandas UDF that computes the prod
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 82-112
+    :lines: 84-114
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -152,7 +152,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 116-138
+    :lines: 118-140
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -174,7 +174,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 142-165
+    :lines: 144-167
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -205,7 +205,7 @@ and window operations:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 169-210
+    :lines: 171-212
     :dedent: 4
 
 .. currentmodule:: pyspark.sql.functions
@@ -270,7 +270,7 @@ in the group.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 214-232
+    :lines: 216-234
     :dedent: 4
 
 For detailed usage, please see  please see :meth:`GroupedData.applyInPandas`
@@ -288,7 +288,7 @@ The following example shows how to use :meth:`DataFrame.mapInPandas`:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 236-247
+    :lines: 238-249
     :dedent: 4
 
 For detailed usage, please see :meth:`DataFrame.mapInPandas`.
@@ -327,7 +327,7 @@ The following example shows how to use ``DataFrame.groupby().cogroup().applyInPa
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 251-273
+    :lines: 253-275
     :dedent: 4
 
 

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -952,7 +952,7 @@ class Frame(object, metaclass=ABCMeta):
             This parameter only works when `path` is specified.
 
         Returns
-        --------
+        -------
         str or None
 
         Examples
@@ -2317,7 +2317,7 @@ class Frame(object, metaclass=ABCMeta):
         the object does not have exactly 1 element, or that element is not boolean
 
         Returns
-        --------
+        -------
         bool
 
         Examples

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1313,7 +1313,7 @@ class Index(IndexOpsMixin):
         """
         Return Index if a valid level is given.
 
-        Examples:
+        Examples
         --------
         >>> psidx = ps.Index(['a', 'b', 'c'], name='ks')
         >>> psidx.get_level_values(0)

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -1704,10 +1704,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         ----------
         keep : {'first', 'last', False}, default 'first'
             Method to handle marking duplicates:
-            - 'first' : Mark duplicates as ``True`` except for the first
-              occurrence.
-            - 'last' : Mark duplicates as ``True`` except for the last
-              occurrence.
+            - 'first' : Mark duplicates as ``True`` except for the first occurrence.
+            - 'last' : Mark duplicates as ``True`` except for the last occurrence.
             - ``False`` : Mark all duplicates as ``True``.
 
         Returns

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -555,7 +555,7 @@ class DataStreamReader(OptionUtils):
             string, for the name of the table.
 
         Returns
-        --------
+        -------
         :class:`DataFrame`
 
         Notes


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a various documentation build warnings in PySpark documentation

### Why are the changes needed?

To render the docs better.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the documentation to be prettier. Pretty minor though.

### How was this patch tested?

I manually tested it by building the PySpark documentation