### PR TITLE
[SPARK-38780][PYTHON][DOCS] PySpark docs build should fail when there is warning.

### DIFF
--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -16,7 +16,7 @@
 # Minimal makefile for Sphinx documentation
 
 # You can set these variables from the command line.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= "-W"
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     ?= source
 BUILDDIR      ?= build


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add option "-W" when running PySpark documentation build via Sphinx.


### Why are the changes needed?

To make documentation build failing when the documentation violates the Sphinx warning rules.

So far, the docs build is passed although the docs has warnings as below:
```
…
build succeeded, 14 warnings.
```

With this change, the warnings treated as error, so the build should be failed as below for an example:
```
Warning, treated as error:
…:153:Malformed table.
Text in column margin in table line 38.
…
make: *** [html] Error 2
```

### Does this PR introduce _any_ user-facing change?

This would make docs a bit more prettier.


### How was this patch tested?

The existing build & tests should be passed.