### PR TITLE
[SPARK-38780][FOLLOWUP][PYTHON][DOCS] PySpark docs build should fail when there is warning.

### DIFF
--- a/python/docs/source/reference/pyspark.ss.rst
+++ b/python/docs/source/reference/pyspark.ss.rst
@@ -30,9 +30,7 @@ Core Classes
 
     DataStreamReader
     DataStreamWriter
-    ForeachBatchFunction
     StreamingQuery
-    StreamingQueryException
     StreamingQueryManager
 
 Input and Output


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove `ForeachBatchFunction` and `StreamingQueryException` from `python/docs/source/reference/pyspark.ss.rst` since they're not API so the doc build is failed.


### Why are the changes needed?

To fix the document build failure.


### Does this PR introduce _any_ user-facing change?

`ForeachBatchFunction` and `StreamingQueryException` are removed from the documents since they're not actually APIs.


### How was this patch tested?

The existing doc build should be passed.
