### PR TITLE
[SPARK-38666][SQL] Add missing aggregate filter checks

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2231,6 +2231,9 @@ class Analyzer(override val catalogManager: CatalogManager)
             if (u.filter.get.exists(_.isInstanceOf[AggregateExpression])) {
               throw QueryCompilationErrors.aggregateInAggregateFilterError
             }
+            if (u.filter.get.exists(_.isInstanceOf[WindowFunction])) {
+              throw QueryCompilationErrors.windowFunctionInAggregateFilterError
+            }
           }
           if (u.ignoreNulls) {
             val aggFunc = agg match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2225,7 +2225,7 @@ class Analyzer(override val catalogManager: CatalogManager)
             throw QueryCompilationErrors.nonDeterministicFilterInAggregateError
           }
           if (u.filter.isDefined &&
-            u.filter.get.children.exists(_.isInstanceOf[AggregateExpression])) {
+            u.filter.get.exists(_.isInstanceOf[AggregateExpression])) {
             throw QueryCompilationErrors.aggregateInAggregateFilterError
           }
           if (u.ignoreNulls) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2221,19 +2221,16 @@ class Analyzer(override val catalogManager: CatalogManager)
           }
         // We get an aggregate function, we need to wrap it in an AggregateExpression.
         case agg: AggregateFunction =>
-          if (u.filter.isDefined) {
-            if (!u.filter.get.deterministic) {
+          u.filter match {
+            case Some(filter) if !filter.deterministic =>
               throw QueryCompilationErrors.nonDeterministicFilterInAggregateError
-            }
-            if (u.filter.get.dataType != BooleanType) {
-              throw QueryCompilationErrors.nonBooleanAggregateFilterError
-            }
-            if (u.filter.get.exists(_.isInstanceOf[AggregateExpression])) {
+            case Some(filter) if filter.dataType != BooleanType =>
+              throw QueryCompilationErrors.nonBooleanFilterInAggregateError
+            case Some(filter) if filter.exists(_.isInstanceOf[AggregateExpression]) =>
               throw QueryCompilationErrors.aggregateInAggregateFilterError
-            }
-            if (u.filter.get.exists(_.isInstanceOf[WindowExpression])) {
+            case Some(filter) if filter.exists(_.isInstanceOf[WindowExpression]) =>
               throw QueryCompilationErrors.windowFunctionInAggregateFilterError
-            }
+            case _ =>
           }
           if (u.ignoreNulls) {
             val aggFunc = agg match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2231,7 +2231,7 @@ class Analyzer(override val catalogManager: CatalogManager)
             if (u.filter.get.exists(_.isInstanceOf[AggregateExpression])) {
               throw QueryCompilationErrors.aggregateInAggregateFilterError
             }
-            if (u.filter.get.exists(_.isInstanceOf[WindowFunction])) {
+            if (u.filter.get.exists(_.isInstanceOf[WindowExpression])) {
               throw QueryCompilationErrors.windowFunctionInAggregateFilterError
             }
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2224,6 +2224,10 @@ class Analyzer(override val catalogManager: CatalogManager)
           if (u.filter.isDefined && !u.filter.get.deterministic) {
             throw QueryCompilationErrors.nonDeterministicFilterInAggregateError
           }
+          if (u.filter.isDefined &&
+            u.filter.get.children.exists(_.isInstanceOf[AggregateExpression])) {
+            throw QueryCompilationErrors.aggregateInAggregateFilterError
+          }
           if (u.ignoreNulls) {
             val aggFunc = agg match {
               case first: First => first.copy(ignoreNulls = u.ignoreNulls)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2221,12 +2221,16 @@ class Analyzer(override val catalogManager: CatalogManager)
           }
         // We get an aggregate function, we need to wrap it in an AggregateExpression.
         case agg: AggregateFunction =>
-          if (u.filter.isDefined && !u.filter.get.deterministic) {
-            throw QueryCompilationErrors.nonDeterministicFilterInAggregateError
-          }
-          if (u.filter.isDefined &&
-            u.filter.get.exists(_.isInstanceOf[AggregateExpression])) {
-            throw QueryCompilationErrors.aggregateInAggregateFilterError
+          if (u.filter.isDefined) {
+            if (!u.filter.get.deterministic) {
+              throw QueryCompilationErrors.nonDeterministicFilterInAggregateError
+            }
+            if (u.filter.get.dataType != BooleanType) {
+              throw QueryCompilationErrors.nonBooleanAggregateFilterError
+            }
+            if (u.filter.get.exists(_.isInstanceOf[AggregateExpression])) {
+              throw QueryCompilationErrors.aggregateInAggregateFilterError
+            }
           }
           if (u.ignoreNulls) {
             val aggFunc = agg match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -335,7 +335,7 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def nonBooleanAggregateFilterError(): Throwable = {
-    new AnalysisException("FILTER expression does not return true or false. " +
+    new AnalysisException("FILTER expression is not of type boolean. " +
       "It cannot be used in an aggregate function")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -334,7 +334,7 @@ object QueryCompilationErrors extends QueryErrorsBase {
       "it cannot be used in aggregate functions")
   }
 
-  def nonBooleanAggregateFilterError(): Throwable = {
+  def nonBooleanFilterInAggregateError(): Throwable = {
     new AnalysisException("FILTER expression is not of type boolean. " +
       "It cannot be used in an aggregate function")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -334,6 +334,11 @@ object QueryCompilationErrors extends QueryErrorsBase {
       "it cannot be used in aggregate functions")
   }
 
+  def aggregateInAggregateFilterError(): Throwable = {
+    new AnalysisException("FILTER expression contains aggregate, " +
+      "it cannot be used in aggregate functions")
+  }
+
   def aliasNumberNotMatchColumnNumberError(
       columnSize: Int, outputSize: Int, t: TreeNode[_]): Throwable = {
     new AnalysisException("Number of column aliases does not match number of columns. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -344,6 +344,11 @@ object QueryCompilationErrors extends QueryErrorsBase {
       "It cannot be used in an aggregate function")
   }
 
+  def windowFunctionInAggregateFilterError(): Throwable = {
+    new AnalysisException("FILTER expression contains window function. " +
+      "It cannot be used in an aggregate function")
+  }
+
   def aliasNumberNotMatchColumnNumberError(
       columnSize: Int, outputSize: Int, t: TreeNode[_]): Throwable = {
     new AnalysisException("Number of column aliases does not match number of columns. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -334,9 +334,14 @@ object QueryCompilationErrors extends QueryErrorsBase {
       "it cannot be used in aggregate functions")
   }
 
+  def nonBooleanAggregateFilterError(): Throwable = {
+    new AnalysisException("FILTER expression does not return true or false. " +
+      "It cannot be used in an aggregate function")
+  }
+
   def aggregateInAggregateFilterError(): Throwable = {
-    new AnalysisException("FILTER expression contains aggregate, " +
-      "it cannot be used in aggregate functions")
+    new AnalysisException("FILTER expression contains aggregate. " +
+      "It cannot be used in an aggregate function")
   }
 
   def aliasNumberNotMatchColumnNumberError(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -592,6 +592,12 @@ class AnalysisErrorSuite extends AnalysisTest {
       "explode(array(min(a))), explode(array(max(a)))" :: Nil
   )
 
+  errorTest(
+    "aggregate in aggregate filter",
+    CatalystSqlParser.parsePlan("SELECT sum(c) filter (where max(e) > 1) FROM TaBlE2"),
+    "FILTER expression contains aggregate, " +
+      "it cannot be used in aggregate functions" :: Nil)
+
   test("SPARK-6452 regression test") {
     // CheckAnalysis should throw AnalysisException when Aggregate contains missing attribute(s)
     // Since we manually construct the logical plan at here and Sum only accept

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -593,17 +593,17 @@ class AnalysisErrorSuite extends AnalysisTest {
   )
 
   errorTest(
-    "non-boolean aggregate filter",
+    "SPARK-38666: non-boolean aggregate filter",
     CatalystSqlParser.parsePlan("SELECT sum(c) filter (where e) FROM TaBlE2"),
     "FILTER expression does not return true or false" :: Nil)
 
   errorTest(
-    "aggregate in aggregate filter",
+    "SPARK-38666: aggregate in aggregate filter",
     CatalystSqlParser.parsePlan("SELECT sum(c) filter (where max(e) > 1) FROM TaBlE2"),
     "FILTER expression contains aggregate" :: Nil)
 
   errorTest(
-    "window function in aggregate filter",
+    "SPARK-38666: window function in aggregate filter",
     CatalystSqlParser.parsePlan("SELECT sum(c) " +
        "filter (where nth_value(e, 2) over(order by b) > 1) FROM TaBlE2"),
     "FILTER expression contains window function" :: Nil)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -593,10 +593,14 @@ class AnalysisErrorSuite extends AnalysisTest {
   )
 
   errorTest(
+    "non-boolean aggregate filter",
+    CatalystSqlParser.parsePlan("SELECT sum(c) filter (where e) FROM TaBlE2"),
+    "FILTER expression does not return true or false" :: Nil)
+
+  errorTest(
     "aggregate in aggregate filter",
     CatalystSqlParser.parsePlan("SELECT sum(c) filter (where max(e) > 1) FROM TaBlE2"),
-    "FILTER expression contains aggregate, " +
-      "it cannot be used in aggregate functions" :: Nil)
+    "FILTER expression contains aggregate" :: Nil)
 
   test("SPARK-6452 regression test") {
     // CheckAnalysis should throw AnalysisException when Aggregate contains missing attribute(s)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -602,6 +602,12 @@ class AnalysisErrorSuite extends AnalysisTest {
     CatalystSqlParser.parsePlan("SELECT sum(c) filter (where max(e) > 1) FROM TaBlE2"),
     "FILTER expression contains aggregate" :: Nil)
 
+  errorTest(
+    "window function in aggregate filter",
+    CatalystSqlParser.parsePlan("SELECT sum(c) " +
+       "filter (where nth_value(e, 2) over(order by b) > 1) FROM TaBlE2"),
+    "FILTER expression contains window function" :: Nil)
+
   test("SPARK-6452 regression test") {
     // CheckAnalysis should throw AnalysisException when Aggregate contains missing attribute(s)
     // Since we manually construct the logical plan at here and Sum only accept

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -595,7 +595,7 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorTest(
     "SPARK-38666: non-boolean aggregate filter",
     CatalystSqlParser.parsePlan("SELECT sum(c) filter (where e) FROM TaBlE2"),
-    "FILTER expression does not return true or false" :: Nil)
+    "FILTER expression is not of type boolean" :: Nil)
 
   errorTest(
     "SPARK-38666: aggregate in aggregate filter",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add checks in `ResolveFunctions#validateFunction` to ensure the following about each aggregate filter:

- has a datatype of boolean
- doesn't contain an aggregate expression
- doesn't contain a window expression

`ExtractGenerator` already handles the case of a generator in an aggregate filter.

### Why are the changes needed?

There are three cases where a query with an aggregate filter produces non-helpful error messages.

1) Window expression in aggregate filter

```
select sum(a) filter (where nth_value(a, 2) over (order by b) > 1)
from (select 1 a, '2' b);
```
The above query should produce an analysis error, but instead produces a stack overflow:
```
java.lang.StackOverflowError: null
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:62) ~[scala-library.jar:?]
	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:53) ~[scala-library.jar:?]
	at scala.collection.immutable.VectorBuilder.$plus$plus$eq(Vector.scala:668) ~[scala-library.jar:?]
	at scala.collection.immutable.VectorBuilder.$plus$plus$eq(Vector.scala:645) ~[scala-library.jar:?]
	at scala.collection.generic.GenericCompanion.apply(GenericCompanion.scala:56) ~[scala-library.jar:?]
	at org.apache.spark.sql.catalyst.trees.UnaryLike.children(TreeNode.scala:1172) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.trees.UnaryLike.children$(TreeNode.scala:1172) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.UnaryExpression.children$lzycompute(Expression.scala:494) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.UnaryExpression.children(Expression.scala:494) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.Expression.childrenResolved(Expression.scala:223) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.Alias.resolved$lzycompute(namedExpressions.scala:155) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.Alias.resolved(namedExpressions.scala:155) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
```
With this PR, the query will instead produce
```
org.apache.spark.sql.AnalysisException: FILTER expression contains window function. It cannot be used in an aggregate function; line 1 pos 7
```

2) Non-boolean filter expression

```
select sum(a) filter (where a) from (select 1 a, '2' b);
```
This query should produce an analysis error, but instead causes a projection compilation error or whole-stage codegen error (depending on the datatype of the expression):
````
org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 50, Column 6: Not a boolean expression
	at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:12021) ~[janino-3.0.16.jar:?]
	at org.codehaus.janino.UnitCompiler.compileBoolean2(UnitCompiler.java:4049) ~[janino-3.0.16.jar:?]
	at org.codehaus.janino.UnitCompiler.access$6300(UnitCompiler.java:226) ~[janino-3.0.16.jar:?]
	at org.codehaus.janino.UnitCompiler$14.visitIntegerLiteral(UnitCompiler.java:4016) ~[janino-3.0.16.jar:?]
	at org.codehaus.janino.UnitCompiler$14.visitIntegerLiteral(UnitCompiler.java:3986) ~[janino-3.0.16.jar:?]
...
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3599) ~[guava-14.0.1.jar:?]
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2379) ~[guava-14.0.1.jar:?]
	... 37 more
NULL
Time taken: 6.132 seconds, Fetched 1 row(s)
````
After the compilation error, _the query returns a result as if `a` was a boolean `false`_.

With this PR, the query will instead produce
```
org.apache.spark.sql.AnalysisException: FILTER expression is not of type boolean. It cannot be used in an aggregate function; line 1 pos 7
```

3) Aggregate expression in filter expression

```
select max(b) filter (where max(a) > 1) from (select 1 a, '2' b);
```
The above query should produce an analysis error, but instead causes a projection compilation error or whole-stage codegen error (depending on the datatype of the expression being aggregated):
```
org.apache.spark.SparkUnsupportedOperationException: Cannot generate code for expression: max(1)
	at org.apache.spark.sql.errors.QueryExecutionErrors$.cannotGenerateCodeForExpressionError(QueryExecutionErrors.scala:84) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.Unevaluable.doGenCode(Expression.scala:347) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.Unevaluable.doGenCode$(Expression.scala:346) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
	at org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression.doGenCode(interfaces.scala:99) ~[spark-catalyst_2.12-3.4.0-SNAPSHOT.jar:3.4.0-SNAPSHOT]
```
With this PR, the query will instead produce
```
org.apache.spark.sql.AnalysisException: FILTER expression contains aggregate. It cannot be used in an aggregate function; line 1 pos 7
```

### Does this PR introduce _any_ user-facing change?

No, except in error conditions.


### How was this patch tested?

New unit tests.
