### PR TITLE
[SPARK-38786][SQL][TEST] Bug in StatisticsSuite 'change stats after add/drop partition command'

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -976,7 +976,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
               s"""
                  |ALTER TABLE $table ADD
                  |PARTITION (ds='2008-04-09', hr='11') LOCATION '${partDir1.toURI.toString}'
-                 |PARTITION (ds='2008-04-09', hr='12') LOCATION '${partDir1.toURI.toString}'
+                 |PARTITION (ds='2008-04-09', hr='12') LOCATION '${partDir2.toURI.toString}'
             """.stripMargin)
             if (autoUpdate) {
               val fetched2 = checkTableStats(table, hasSizeInBytes = true, expectedRowCounts = None)
@@ -999,6 +999,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
             sql(s"ALTER TABLE $table DROP PARTITION (ds='2008-04-08'), PARTITION (hr='12')")
             assert(spark.sessionState.catalog.listPartitions(TableIdentifier(table))
               .map(_.spec).toSet == Set(Map("ds" -> "2008-04-09", "hr" -> "11")))
+            assert(partDir1.exists())
             // only one partition left
             if (autoUpdate) {
               val fetched4 = checkTableStats(table, hasSizeInBytes = true, expectedRowCounts = None)


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/blob/cbffc12f90e45d33e651e38cf886d7ab4bcf96da/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala#L979
It should be `partDir2` instead of `partDir1`. Looks like it is a copy paste bug.


### Why are the changes needed?
Due to this test bug, the drop command was dropping a wrong (`partDir1`) underlying file in the test.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added extra underlying file location check.
