### PR TITLE
[SPARK-38760][PYTHON][SQL][SS] Add DataFrame.observe(str, ...) for Structured Streaming in PySpark

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2204,19 +2204,42 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         return self.groupBy().agg(*exprs)  # type: ignore[arg-type]
 
-    @since(3.3)
-    def observe(self, observation: "Observation", *exprs: Column) -> "DataFrame":
-        """Observe (named) metrics through an :class:`Observation` instance.
+    def observe(
+        self,
+        observation: Union["Observation", str],
+        *exprs: Column,
+    ) -> "DataFrame":
+        """Define (named) metrics to observe on the DataFrame. This method returns an 'observed'
+        DataFrame that returns the same result as the input, with the following guarantees:
 
-        A user can retrieve the metrics by accessing `Observation.get`.
+        * It will compute the defined aggregates (metrics) on all the data that is flowing through
+            the Dataset at that point.
+
+        * It will report the value of the defined aggregate columns as soon as we reach a completion
+            point. A completion point is either the end of a query (batch mode) or the end of a
+            streaming epoch. The value of the aggregates only reflects the data processed since
+            the previous completion point.
+
+        The metrics columns must either contain a literal (e.g. lit(42)), or should contain one or
+        more aggregate functions (e.g. sum(a) or sum(a + b) + avg(c) - lit(1)). Expressions that
+        contain references to the input Dataset's columns must always be wrapped in an aggregate
+        function.
+
+        A user can observe these metrics by adding
+        Python's :class:`~pyspark.sql.streaming.StreamingQueryListener`,
+        Scala/Java's ``org.apache.spark.sql.streaming.StreamingQueryListener`` or Scala/Java's
+        ``org.apache.spark.sql.util.QueryExecutionListener`` to the spark session.
 
         .. versionadded:: 3.3.0
 
         Parameters
         ----------
-        observation : :class:`Observation`
-            an :class:`Observation` instance to obtain the metric.
-        exprs : list of :class:`Column`
+        observation : :class:`Observation` or str
+            `str` to specify the name, or an :class:`Observation` instance to obtain the metric.
+
+            .. versionchanged:: 3.4.0
+               Added support for `str` in this parameter.
+        exprs : :class:`Column`
             column expressions (:class:`Column`).
 
         Returns
@@ -2226,10 +2249,14 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Notes
         -----
-        This method does not support streaming datasets.
+        When ``observation`` is :class:`Observation`, this method only supports batch queries.
+        When ``observation`` is a string, this method works for both batch and streaming queries.
+        Continuous execution is currently not supported yet.
 
         Examples
         --------
+        When ``observation`` is :class:`Observation`, only batch queries works as below.
+
         >>> from pyspark.sql.functions import col, count, lit, max
         >>> from pyspark.sql import Observation
         >>> observation = Observation("my metrics")
@@ -2238,11 +2265,53 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         2
         >>> observation.get
         {'count': 2, 'max(age)': 5}
+
+        When ``observation`` is a string, streaming queries also work as below.
+
+        >>> from pyspark.sql.streaming import StreamingQueryListener
+        >>> class MyErrorListener(StreamingQueryListener):
+        ...    def onQueryStarted(self, event):
+        ...        pass
+        ...
+        ...    def onQueryProgress(self, event):
+        ...        row = event.progress.observedMetrics.get("my_event")
+        ...        # Trigger if the number of errors exceeds 5 percent
+        ...        num_rows = row.rc
+        ...        num_error_rows = row.erc
+        ...        ratio = num_error_rows / num_rows
+        ...        if ratio > 0.05:
+        ...            # Trigger alert
+        ...            pass
+        ...
+        ...    def onQueryTerminated(self, event):
+        ...        pass
+        ...
+        >>> spark.streams.addListener(MyErrorListener())
+        >>> # Observe row count (rc) and error row count (erc) in the streaming Dataset
+        ... observed_ds = df.observe(
+        ...     "my_event",
+        ...     count(lit(1)).alias("rc"),
+        ...     count(col("error")).alias("erc"))  # doctest: +SKIP
+        >>> observed_ds.writeStream.format("console").start()  # doctest: +SKIP
         """
         from pyspark.sql import Observation
 
-        assert isinstance(observation, Observation), "observation should be Observation"
-        return observation._on(self, *exprs)
+        if len(exprs) == 0:
+            raise ValueError("'exprs' should not be empty")
+        if not all(isinstance(c, Column) for c in exprs):
+            raise ValueError("all 'exprs' should be Column")
+
+        if isinstance(observation, Observation):
+            return observation._on(self, *exprs)
+        elif isinstance(observation, str):
+            return DataFrame(
+                self._jdf.observe(
+                    observation, exprs[0]._jc, _to_seq(self._sc, [c._jc for c in exprs[1:]])
+                ),
+                self.sparkSession,
+            )
+        else:
+            raise ValueError("'observation' should be either `Observation` or `str`.")
 
     @since(2.0)
     def union(self, other: "DataFrame") -> "DataFrame":

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -98,8 +98,6 @@ class Observation:
         :class:`DataFrame`
             the observed :class:`DataFrame`.
         """
-        assert exprs, "exprs should not be empty"
-        assert all(isinstance(c, Column) for c in exprs), "all exprs should be Column"
         assert self._jo is None, "an Observation can be used with a DataFrame only once"
 
         self._jvm = df._sc._jvm

--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pickle
 import uuid
 from typing import Optional, Dict, List
 from abc import ABC, abstractmethod
@@ -22,7 +21,7 @@ from abc import ABC, abstractmethod
 from py4j.java_gateway import JavaObject
 
 from pyspark.sql import Row
-
+from pyspark import cloudpickle
 
 __all__ = ["StreamingQueryListener"]
 
@@ -256,9 +255,8 @@ class StreamingQueryProgress:
         self._sources: List[SourceProgress] = [SourceProgress(js) for js in jprogress.sources()]
         self._sink: SinkProgress = SinkProgress(jprogress.sink())
 
-        # TODO(SPARK-38760): Write a test with DataFrame.observe API implementation.
         self._observedMetrics: Dict[str, Row] = {
-            k: pickle.loads(
+            k: cloudpickle.loads(
                 SparkContext._jvm.PythonSQLUtils.toPyRow(jr)  # type: ignore[union-attr]
             )
             for k, jr in dict(jprogress.observedMetrics()).items()

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
 
 private[sql] object PythonSQLUtils extends Logging {
-  private lazy val internalrowPickler = {
+  private lazy val internalRowPickler = {
     EvaluatePython.registerPicklers()
     new Pickler(true, false)
   }
@@ -89,7 +89,7 @@ private[sql] object PythonSQLUtils extends Logging {
 
   def toPyRow(row: Row): Array[Byte] = {
     assert(row.isInstanceOf[GenericRowWithSchema])
-    internalrowPickler.dumps(EvaluatePython.toJava(
+    internalRowPickler.dumps(EvaluatePython.toJava(
       CatalystTypeConverters.convertToCatalyst(row), row.schema))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -27,6 +27,7 @@ import org.apache.spark.api.python.PythonRDDServer
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.catalyst.expressions.{CastTimestampNTZToLong, ExpressionInfo, GenericRowWithSchema}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
@@ -37,7 +38,10 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
 
 private[sql] object PythonSQLUtils extends Logging {
-  private lazy val rowPickler = new Pickler(true, false)
+  private lazy val internalrowPickler = {
+    EvaluatePython.registerPicklers()
+    new Pickler(true, false)
+  }
 
   def parseDataType(typeText: String): DataType = CatalystSqlParser.parseDataType(typeText)
 
@@ -85,7 +89,8 @@ private[sql] object PythonSQLUtils extends Logging {
 
   def toPyRow(row: Row): Array[Byte] = {
     assert(row.isInstanceOf[GenericRowWithSchema])
-    rowPickler.dumps(EvaluatePython.toJava(row, row.schema))
+    internalrowPickler.dumps(EvaluatePython.toJava(
+      CatalystTypeConverters.convertToCatalyst(row), row.schema))
   }
 
   def castTimestampNTZToLong(c: Column): Column = Column(CastTimestampNTZToLong(c.expr))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the support of Structured Streaming at `DataFrame.observe` in PySpark. This is the same support with the Scala side.

### Why are the changes needed?

For SS users in PySpark to easily monitor their streaming queries.

### Does this PR introduce _any_ user-facing change?

Yes. After this PR, PySpark users can do:

```python
from pyspark.sql.functions import count, col, sum, lit
from pyspark.sql.streaming import StreamingQueryListener

class MyListener(StreamingQueryListener):
    def onQueryStarted(self, event):
        pass
    def onQueryProgress(self, event):
        row = event.progress.observedMetrics.get("metric")
        # Do something with the metric, e.g.) row.cnt and row.sum
        print("Count: %s" % row.cnt)
    def onQueryTerminated(self, event):
        pass

spark.streams.addListener(MyListener())

df = spark.readStream.format("rate").option("rowsPerSecond", 10).load()
observed_df = df.observe("metric", count(lit(1)).alias("cnt"), sum(col("value")).alias("sum"))
observed_df.writeStream.format("noop").queryName("test").start()
```

### How was this patch tested?

Manually tested with the example above, and unit test was added.