### PR TITLE
[SPARK-38803][K8S][TESTS] Add `minio` tag for K8s IT

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -32,7 +32,7 @@ import org.scalatest.time.{Minutes, Span}
 
 import org.apache.spark.SparkException
 import org.apache.spark.deploy.k8s.integrationtest.DepsTestsSuite.{DEPS_TIMEOUT, FILE_CONTENTS, HOST_PATH}
-import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{INTERVAL, MinikubeTag, TIMEOUT}
+import org.apache.spark.deploy.k8s.integrationtest.KubernetesSuite.{INTERVAL, MinikubeTag, MinioTag, TIMEOUT}
 import org.apache.spark.deploy.k8s.integrationtest.Utils.getExamplesJarName
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.Minikube
 import org.apache.spark.internal.config.{ARCHIVES, PYSPARK_DRIVER_PYTHON, PYSPARK_PYTHON}
@@ -156,7 +156,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .delete()
   }
 
-  test("Launcher client dependencies", k8sTestTag, MinikubeTag) {
+  test("Launcher client dependencies", k8sTestTag, MinikubeTag, MinioTag) {
     tryDepsTest({
       val fileName = Utils.createTempFile(FILE_CONTENTS, HOST_PATH)
       sparkAppConf.set("spark.files", s"$HOST_PATH/$fileName")
@@ -167,7 +167,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     })
   }
 
-  test("SPARK-33615: Launcher client archives", k8sTestTag, MinikubeTag) {
+  test("SPARK-33615: Launcher client archives", k8sTestTag, MinikubeTag, MinioTag) {
     tryDepsTest {
       val fileName = Utils.createTempFile(FILE_CONTENTS, HOST_PATH)
       Utils.createTarGzFile(s"$HOST_PATH/$fileName", s"$HOST_PATH/$fileName.tar.gz")
@@ -179,8 +179,8 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     }
   }
 
-  test(
-    "SPARK-33748: Launcher python client respecting PYSPARK_PYTHON", k8sTestTag, MinikubeTag) {
+  test("SPARK-33748: Launcher python client respecting PYSPARK_PYTHON",
+    k8sTestTag, MinikubeTag, MinioTag) {
     val fileName = Utils.createTempFile(
       """
         |#!/usr/bin/env bash
@@ -201,7 +201,8 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
 
   test(
     "SPARK-33748: Launcher python client respecting " +
-      s"${PYSPARK_PYTHON.key} and ${PYSPARK_DRIVER_PYTHON.key}", k8sTestTag, MinikubeTag) {
+      s"${PYSPARK_PYTHON.key} and ${PYSPARK_DRIVER_PYTHON.key}",
+    k8sTestTag, MinikubeTag, MinioTag) {
     val fileName = Utils.createTempFile(
       """
         |#!/usr/bin/env bash
@@ -221,7 +222,8 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
         "Custom Python used on driver: False"))
   }
 
-  test("Launcher python client dependencies using a zip file", k8sTestTag, MinikubeTag) {
+  test("Launcher python client dependencies using a zip file",
+    k8sTestTag, MinikubeTag, MinioTag) {
     val pySparkFiles = Utils.getTestFileAbsolutePath("pyfiles.py", sparkHomeDir)
     val inDepsFile = Utils.getTestFileAbsolutePath("py_container_checks.py", sparkHomeDir)
     val outDepsFile = s"${inDepsFile.substring(0, inDepsFile.lastIndexOf("."))}.zip"

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesSuite.scala
@@ -614,6 +614,7 @@ private[spark] object KubernetesSuite {
   val schedulingTestTag = Tag("schedule")
   val rTestTag = Tag("r")
   val MinikubeTag = Tag("minikube")
+  val MinioTag = Tag("minio")
   val SPARK_PI_MAIN_CLASS: String = "org.apache.spark.examples.SparkPi"
   val SPARK_DFS_READ_WRITE_TEST = "org.apache.spark.examples.DFSReadWriteTest"
   val SPARK_MINI_READ_WRITE_TEST = "org.apache.spark.examples.MiniReadWriteTest"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add the `minio` tag. Skip minio related test only when specified `-Dtest.exclude.tags=minio`

### Why are the changes needed?
In some cases (such as resource limited case), we don't want to execute minio related test.

### Does this PR introduce _any_ user-facing change?
No, test only


### How was this patch tested?
IT passsed

```
$  build/sbt -Phadoop3 -Pvolcano -Pkubernetes -Pkubernetes-integration-tests -Dtest.include.tags=minio -Dspark.kubernetes.test.deployMode=minikube -Dspark.kubernetes.test.namespace=default "kubernetes-integration-tests/testOnly"
[info] KubernetesSuite:
[info] - Launcher client dependencies (47 seconds, 498 milliseconds)
[info] - SPARK-33615: Launcher client archives (50 seconds, 562 milliseconds)
[info] - SPARK-33748: Launcher python client respecting PYSPARK_PYTHON (52 seconds, 375 milliseconds)
[info] - SPARK-33748: Launcher python client respecting spark.pyspark.python and spark.pyspark.driver.python (54 seconds, 755 milliseconds)
[info] - Launcher python client dependencies using a zip file (52 seconds, 44 milliseconds)
[info] VolcanoSuite:
[info] - Launcher client dependencies (1 minute, 13 seconds)
[info] - SPARK-33615: Launcher client archives (49 seconds, 703 milliseconds)
[info] - SPARK-33748: Launcher python client respecting PYSPARK_PYTHON (51 seconds, 952 milliseconds)
[info] - SPARK-33748: Launcher python client respecting spark.pyspark.python and spark.pyspark.driver.python (1 minute, 3 seconds)
[info] - Launcher python client dependencies using a zip file (2 minutes, 10 seconds)
```