### PR TITLE
[SPARK-38804][PYTHON][SS] Add StreamingQueryManager.removeListener in PySpark

### DIFF
--- a/python/pyspark/sql/streaming/listener.py
+++ b/python/pyspark/sql/streaming/listener.py
@@ -67,7 +67,7 @@ class StreamingQueryListener(ABC):
         -----
         This is called synchronously with :py:meth:`~pyspark.sql.streaming.DataStreamWriter.start`,
         that is, `onQueryStart` will be called on all listeners before `DataStreamWriter.start()`
-        returns the corresponding :class:`~pyspark.streaming.StreamingQuery`.
+        returns the corresponding :class:`~pyspark.sql.streaming.StreamingQuery`.
         Please don't block this method as it will block your query.
         """
         pass
@@ -79,11 +79,11 @@ class StreamingQueryListener(ABC):
 
         Notes
         -----
-        This method is asynchronous. The status in :class:`~pyspark.streaming.StreamingQuery`
+        This method is asynchronous. The status in :class:`~pyspark.sql.streaming.StreamingQuery`
         will always be latest no matter when this method is called. Therefore, the status of
-        :class:`~pyspark.streaming.StreamingQuery`.
+        :class:`~pyspark.sql.streaming.StreamingQuery`.
         may be changed before/when you process the event. E.g., you may find
-        :class:`~pyspark.streaming.StreamingQuery` is terminated when you are
+        :class:`~pyspark.sql.streaming.StreamingQuery` is terminated when you are
         processing `QueryProgressEvent`.
         """
         pass
@@ -94,6 +94,20 @@ class StreamingQueryListener(ABC):
         Called when a query is stopped, with or without error.
         """
         pass
+
+    @property
+    def _jlistener(self) -> JavaObject:
+        from pyspark import SparkContext
+
+        if hasattr(self, "_jlistenerobj"):
+            return self._jlistenerobj
+
+        self._jlistenerobj: JavaObject = (
+            SparkContext._jvm.PythonStreamingQueryListenerWrapper(  # type: ignore[union-attr]
+                JStreamingQueryListener(self)
+            )
+        )
+        return self._jlistenerobj
 
 
 class JStreamingQueryListener:
@@ -138,7 +152,7 @@ class QueryStartedEvent:
     def id(self) -> uuid.UUID:
         """
         A unique query id that persists across restarts. See
-        py:meth:`~pyspark.streaming.StreamingQuery.id`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.id`.
         """
         return self._id
 
@@ -146,7 +160,7 @@ class QueryStartedEvent:
     def runId(self) -> uuid.UUID:
         """
         A query id that is unique for every start/restart. See
-        py:meth:`~pyspark.streaming.StreamingQuery.runId`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.runId`.
         """
         return self._runId
 
@@ -208,7 +222,7 @@ class QueryTerminatedEvent:
     def id(self) -> uuid.UUID:
         """
         A unique query id that persists across restarts. See
-        py:meth:`~pyspark.streaming.StreamingQuery.id`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.id`.
         """
         return self._id
 
@@ -216,7 +230,7 @@ class QueryTerminatedEvent:
     def runId(self) -> uuid.UUID:
         """
         A query id that is unique for every start/restart. See
-        py:meth:`~pyspark.streaming.StreamingQuery.runId`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.runId`.
         """
         return self._runId
 
@@ -268,7 +282,7 @@ class StreamingQueryProgress:
     def id(self) -> uuid.UUID:
         """
         A unique query id that persists across restarts. See
-        py:meth:`~pyspark.streaming.StreamingQuery.id`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.id`.
         """
         return self._id
 
@@ -276,7 +290,7 @@ class StreamingQueryProgress:
     def runId(self) -> uuid.UUID:
         """
         A query id that is unique for every start/restart. See
-        py:meth:`~pyspark.streaming.StreamingQuery.runId`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.runId`.
         """
         return self._runId
 
@@ -354,7 +368,7 @@ class StreamingQueryProgress:
     def sink(self) -> "SinkProgress":
         """
         A unique query id that persists across restarts. See
-        py:meth:`~pyspark.streaming.StreamingQuery.id`.
+        py:meth:`~pyspark.sql.streaming.StreamingQuery.id`.
         """
         return self._sink
 

--- a/python/pyspark/sql/streaming/query.py
+++ b/python/pyspark/sql/streaming/query.py
@@ -23,7 +23,7 @@ from py4j.java_gateway import JavaObject, java_import
 
 from pyspark import since
 from pyspark.sql.utils import StreamingQueryException
-from pyspark.sql.streaming.listener import StreamingQueryListener, JStreamingQueryListener
+from pyspark.sql.streaming.listener import StreamingQueryListener
 
 __all__ = ["StreamingQuery", "StreamingQueryManager"]
 
@@ -309,11 +309,15 @@ class StreamingQueryManager:
         java_import(gw.jvm, "org.apache.spark.sql.streaming.*")
         ensure_callback_server_started(gw)
 
-        self._jsqm.addListener(
-            SparkContext._jvm.PythonStreamingQueryListenerWrapper(  # type: ignore[union-attr]
-                JStreamingQueryListener(listener)
-            )
-        )
+        self._jsqm.addListener(listener._jlistener)
+
+    def removeListener(self, listener: StreamingQueryListener) -> None:
+        """
+        Deregister a :class:`StreamingQueryListener`.
+
+        .. versionadded:: 3.4.0
+        """
+        self._jsqm.removeListener(listener._jlistener)
 
 
 def _test() -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

SPARK-38759 added `StreamingQueryManager.addListener`. This PR adds the ability to remove it back.

### Why are the changes needed?

To be able to remove the listener added.

### Does this PR introduce _any_ user-facing change?

Yes, now users can remove the listener added in PySpark via `spark.streams.removeListener(...)`

### How was this patch tested?

Manually tested, and unittest was added.
