### PR TITLE
[SPARK-38805][SHUFFLE] Automatically remove an expired indexFilePath from the ESS shuffleIndexCache or the PBS indexCache to save memory.

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -45,6 +45,7 @@ public class TransportConf {
   private final String SPARK_NETWORK_IO_LAZYFD_KEY;
   private final String SPARK_NETWORK_VERBOSE_METRICS;
   private final String SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY;
+  private final String SPARK_SHUFFLEINDEXCACHE_EXPIRE_TIME_KEY;
 
   private final ConfigProvider conf;
 
@@ -69,6 +70,7 @@ public class TransportConf {
     SPARK_NETWORK_IO_LAZYFD_KEY = getConfKey("io.lazyFD");
     SPARK_NETWORK_VERBOSE_METRICS = getConfKey("io.enableVerboseMetrics");
     SPARK_NETWORK_IO_ENABLETCPKEEPALIVE_KEY = getConfKey("io.enableTcpKeepAlive");
+    SPARK_SHUFFLEINDEXCACHE_EXPIRE_TIME_KEY = getConfKey("indexCache.expireTimeSeconds");
   }
 
   public int getInt(String name, int defaultValue) {
@@ -331,6 +333,10 @@ public class TransportConf {
    */
   public boolean useOldFetchProtocol() {
     return conf.getBoolean("spark.shuffle.useOldFetchProtocol", false);
+  }
+
+  public int shuffleIndexCacheExpireTimeSeconds() {
+    return (int) JavaUtils.timeStringAsSec(conf.get(SPARK_SHUFFLEINDEXCACHE_EXPIRE_TIME_KEY, "0s"));
   }
 
   /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 
@@ -119,11 +120,17 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           return new ShuffleIndexInformation(filePath);
         }
     };
-    indexCache = CacheBuilder.newBuilder()
-      .maximumWeight(conf.mergedIndexCacheSize())
-      .weigher((Weigher<String, ShuffleIndexInformation>)
-        (filePath, indexInfo) -> indexInfo.getRetainedMemorySize())
-      .build(indexCacheLoader);
+    CacheBuilder cacheBuilder = CacheBuilder.newBuilder()
+        .maximumWeight(conf.mergedIndexCacheSize())
+        .weigher((Weigher<String, ShuffleIndexInformation>)
+            (filePath, indexInfo) -> indexInfo.getRetainedMemorySize());
+    int expireTimeSeconds = conf.shuffleIndexCacheExpireTimeSeconds();
+    if (expireTimeSeconds > 0) {
+      indexCache = cacheBuilder.expireAfterAccess(expireTimeSeconds, TimeUnit.SECONDS)
+          .build(indexCacheLoader);
+    } else {
+      indexCache = cacheBuilder.build(indexCacheLoader);
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, we use Guava Cache  in ExternalShuffleBlockResolver and RemoteBlockPushResolver to cache index file information so that we can avoid open/close the index files for each request. However, it will take up a fixed amount of memory, even though we no longer need any cached index files, which is a waste of memory.

In our production，we  set spark.shuffle.service.index.cache.size to be 400m，and found  above problem.  So, we should automatically remove an expired indexFilePath from the ESS shuffleIndexCache or the PBS indexCache to save memory.

![image](https://user-images.githubusercontent.com/39684231/161970656-d86b3c16-47e4-49a8-8749-54c6d5e30e5a.png)

### Why are the changes needed?
To save memory

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Existing unittests and Passed CI. 
