### PR TITLE
[SPARK-38837][PYTHON] Implement `dropna` parameter of `SeriesGroupBy.value_counts`

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3248,7 +3248,7 @@ class SeriesGroupBy(GroupBy[Series]):
         sdf = sdf.groupby(*groupkey_cols).count().withColumnRenamed("count", agg_column)
 
         if dropna:
-            _agg_columns_names = groupkey_names[len(self._groupkeys):]
+            _agg_columns_names = groupkey_names[len(self._groupkeys) :]
             sdf = sdf.dropna(subset=_agg_columns_names)
         if sort:
             if ascending:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3205,23 +3205,34 @@ class SeriesGroupBy(GroupBy[Series]):
         Examples
         --------
         >>> df = ps.DataFrame({'A': [1, 2, 2, 3, 3, 3],
-        ...                    'B': [1, 1, 2, 3, 3, 3]},
+        ...                    'B': [1, 1, 2, 3, 3, np.nan]},
         ...                   columns=['A', 'B'])
         >>> df
-           A  B
-        0  1  1
-        1  2  1
-        2  2  2
-        3  3  3
-        4  3  3
-        5  3  3
+           A    B
+        0  1  1.0
+        1  2  1.0
+        2  2  2.0
+        3  3  3.0
+        4  3  3.0
+        5  3  NaN
 
         >>> df.groupby('A')['B'].value_counts().sort_index()  # doctest: +NORMALIZE_WHITESPACE
         A  B
-        1  1    1
-        2  1    1
-           2    1
-        3  3    3
+        1  1.0    1
+        2  1.0    1
+           2.0    1
+        3  3.0    2
+        Name: B, dtype: int64
+
+        Don't include counts of NaN when dropna is False.
+
+        >>> df.groupby('A')['B'].value_counts(dropna=False).sort_index()  # doctest: +NORMALIZE_WHITESPACE
+        A  B
+        1  1.0    1
+        2  1.0    1
+           2.0    1
+        3  3.0    2
+           NaN    1
         Name: B, dtype: int64
         """
         groupkeys = self._groupkeys + self._agg_columns
@@ -3229,6 +3240,9 @@ class SeriesGroupBy(GroupBy[Series]):
         groupkey_cols = [s.spark.column.alias(name) for s, name in zip(groupkeys, groupkey_names)]
 
         sdf = self._psdf._internal.spark_frame
+        if dropna:
+            sdf = sdf.dropna()
+
         agg_column = self._agg_columns[0]._internal.data_spark_column_names[0]
         sdf = sdf.groupby(*groupkey_cols).count().withColumnRenamed("count", agg_column)
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3248,9 +3248,14 @@ class SeriesGroupBy(GroupBy[Series]):
         agg_column = self._agg_columns[0]._internal.data_spark_column_names[0]
         sdf = sdf.groupby(*groupkey_cols).count().withColumnRenamed("count", agg_column)
 
+        if self._dropna:
+            _groupkey_column_names = groupkey_names[: len(self._groupkeys)]
+            sdf = sdf.dropna(subset=_groupkey_column_names)
+
         if dropna:
             _agg_columns_names = groupkey_names[len(self._groupkeys) :]
             sdf = sdf.dropna(subset=_agg_columns_names)
+
         if sort:
             if ascending:
                 sdf = sdf.orderBy(scol_for(sdf, agg_column).asc())

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3240,12 +3240,13 @@ class SeriesGroupBy(GroupBy[Series]):
         groupkey_cols = [s.spark.column.alias(name) for s, name in zip(groupkeys, groupkey_names)]
 
         sdf = self._psdf._internal.spark_frame
-        if dropna:
-            sdf = sdf.dropna()
 
         agg_column = self._agg_columns[0]._internal.data_spark_column_names[0]
         sdf = sdf.groupby(*groupkey_cols).count().withColumnRenamed("count", agg_column)
 
+        if dropna:
+            _agg_columns_names = groupkey_names[len(self._groupkeys) :]
+            sdf = sdf.dropna(subset=_agg_columns_names)
         if sort:
             if ascending:
                 sdf = sdf.orderBy(scol_for(sdf, agg_column).asc())

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3188,6 +3188,9 @@ class SeriesGroupBy(GroupBy[Series]):
         """
         Compute group sizes.
 
+        .. note:: Unlike pandas, the method doesn't drop NaNs of groupby column.
+          See more https://github.com/pandas-dev/pandas/issues/46676.
+
         Parameters
         ----------
         sort : boolean, default None
@@ -3245,7 +3248,7 @@ class SeriesGroupBy(GroupBy[Series]):
         sdf = sdf.groupby(*groupkey_cols).count().withColumnRenamed("count", agg_column)
 
         if dropna:
-            _agg_columns_names = groupkey_names[len(self._groupkeys) :]
+            _agg_columns_names = groupkey_names[len(self._groupkeys):]
             sdf = sdf.dropna(subset=_agg_columns_names)
         if sort:
             if ascending:

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3229,7 +3229,8 @@ class SeriesGroupBy(GroupBy[Series]):
 
         Don't include counts of NaN when dropna is False.
 
-        >>> df.groupby('A')['B'].value_counts(dropna=False).sort_index()  # doctest: +NORMALIZE_WHITESPACE
+        >>> df.groupby('A')['B'].value_counts(
+        ...   dropna=False).sort_index()  # doctest: +NORMALIZE_WHITESPACE
         A  B
         1  1.0    1
         2  1.0    1

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3188,9 +3188,6 @@ class SeriesGroupBy(GroupBy[Series]):
         """
         Compute group sizes.
 
-        .. note:: Unlike pandas, the method doesn't drop NaNs of groupby column.
-          See more https://github.com/pandas-dev/pandas/issues/46676.
-
         Parameters
         ----------
         sort : boolean, default None

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1055,7 +1055,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
 
     def test_value_counts(self):
         pdf = pd.DataFrame(
-            {"A": [1, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, np.nan]}, columns=["A", "B"]
+            {"A": [np.nan, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, np.nan]}, columns=["A", "B"]
         )
         psdf = ps.from_pandas(pdf)
         self.assert_eq(
@@ -1065,6 +1065,13 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         self.assert_eq(
             psdf.groupby("A")["B"].value_counts(dropna=False).sort_index(),
             pdf.groupby("A")["B"].value_counts(dropna=False).sort_index(),
+        )
+        self.assert_eq(
+            psdf.groupby("A", dropna=False)["B"].value_counts(dropna=False).sort_index(),
+            pdf.groupby("A", dropna=False)["B"].value_counts(dropna=False).sort_index(),
+            # Returns are the same considering values and types,
+            # disable check_exact to pass the assert_eq
+            check_exact=False,
         )
         self.assert_eq(
             psdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index(),

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1054,19 +1054,37 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
                     self.assertTrue(sorted(act) == sorted(exp))
 
     def test_value_counts(self):
-        pdf = pd.DataFrame({"A": [1, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, 3]}, columns=["A", "B"])
+        pdf = pd.DataFrame(
+            {"A": [1, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, np.nan]}, columns=["A", "B"]
+        )
         psdf = ps.from_pandas(pdf)
         self.assert_eq(
             psdf.groupby("A")["B"].value_counts().sort_index(),
             pdf.groupby("A")["B"].value_counts().sort_index(),
         )
         self.assert_eq(
+            psdf.groupby("A")["B"].value_counts(dropna=False).sort_index(),
+            pdf.groupby("A")["B"].value_counts(dropna=False).sort_index(),
+        )
+        self.assert_eq(
             psdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index(),
             pdf.groupby("A")["B"].value_counts(sort=True, ascending=False).sort_index(),
         )
         self.assert_eq(
-            psdf.groupby("A")["B"].value_counts(sort=True, ascending=True).sort_index(),
-            pdf.groupby("A")["B"].value_counts(sort=True, ascending=True).sort_index(),
+            psdf.groupby("A")["B"]
+            .value_counts(sort=True, ascending=False, dropna=False)
+            .sort_index(),
+            pdf.groupby("A")["B"]
+            .value_counts(sort=True, ascending=False, dropna=False)
+            .sort_index(),
+        )
+        self.assert_eq(
+            psdf.groupby("A")["B"]
+            .value_counts(sort=True, ascending=True, dropna=False)
+            .sort_index(),
+            pdf.groupby("A")["B"]
+            .value_counts(sort=True, ascending=True, dropna=False)
+            .sort_index(),
         )
         self.assert_eq(
             psdf.B.rename().groupby(psdf.A).value_counts().sort_index(),

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1098,6 +1098,13 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             pdf.B.rename().groupby(pdf.A).value_counts().sort_index(),
         )
         self.assert_eq(
+            psdf.B.rename().groupby(psdf.A, dropna=False).value_counts().sort_index(),
+            pdf.B.rename().groupby(pdf.A, dropna=False).value_counts().sort_index(),
+            # Returns are the same considering values and types,
+            # disable check_exact to pass the assert_eq
+            check_exact=False,
+        )
+        self.assert_eq(
             psdf.B.groupby(psdf.A.rename()).value_counts().sort_index(),
             pdf.B.groupby(pdf.A.rename()).value_counts().sort_index(),
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `dropna` parameter of `SeriesGroupBy.value_counts` to exclude counts of NaN.

It also fixes the behavior of `self._dropna` in the context of `SeriesGroupBy.value_counts`.

### Why are the changes needed?
To reach parity with pandas.


### Does this PR introduce _any_ user-facing change?
Yes. `dropna` parameter of `SeriesGroupBy.value_counts` is supported.

```py
>>> psdf = ps.DataFrame(
...             {"A": [np.nan, 2, 2, 3, 3, 3], "B": [1, 1, 2, 3, 3, np.nan]}, columns=["A", "B"]
...         )

>>> psdf.groupby("A")["B"].value_counts(dropna=False).sort_index()
A    B  
2.0  1.0    1
     2.0    1
3.0  3.0    2
     NaN    1
Name: B, dtype: int64

>>> psdf.groupby("A", dropna=False)["B"].value_counts(dropna=False).sort_index()   # self.dropna=False
A    B  
2.0  1.0    1
     2.0    1
3.0  3.0    2
     NaN    1
NaN  1.0    1
Name: B, dtype: int64


>>> psdf.groupby("A")["B"].value_counts(dropna=True).sort_index()
A    B  
2.0  1.0    1
     2.0    1
3.0  3.0    2
Name: B, dtype: int64
```

### How was this patch tested?
Unit tests.