### PR TITLE
[SPARK-38800][DOCS][PYTHON] Explicitly document the supported pandas version.

### DIFF
--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -47,6 +47,8 @@ With this package, you can:
 * Have a single codebase that works both with pandas (tests, smaller datasets) and with Spark (distributed datasets).
 * Switch to pandas API and PySpark API contexts easily without any overhead.
 
+Note that pandas has different behavior per its version, and pandas API on Spark tries to match the behavior of pandas 1.4.
+
 **Streaming**
 
 Running on top of Spark, the streaming feature in Apache Spark enables powerful

--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -47,8 +47,6 @@ With this package, you can:
 * Have a single codebase that works both with pandas (tests, smaller datasets) and with Spark (distributed datasets).
 * Switch to pandas API and PySpark API contexts easily without any overhead.
 
-Note that pandas has different behavior per its version, and pandas API on Spark tries to match the behavior of pandas 1.4.
-
 **Streaming**
 
 Running on top of Spark, the streaming feature in Apache Spark enables powerful

--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -22,7 +22,7 @@ API Reference
 
 This page lists an overview of all public PySpark modules, classes, functions and methods.
 
-Note that pandas has different behavior per its version, and pandas API on Spark tries to match the behavior of latest pandas release.
+Note that pandas has different behavior per its version, and pandas API on Spark tries to match the behavior of the latest pandas release.
 
 .. toctree::
    :maxdepth: 2

--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -22,6 +22,8 @@ API Reference
 
 This page lists an overview of all public PySpark modules, classes, functions and methods.
 
+Note that pandas has different behavior per its version, and pandas API on Spark tries to match the behavior of latest pandas release.
+
 .. toctree::
    :maxdepth: 2
 

--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -22,7 +22,7 @@ API Reference
 
 This page lists an overview of all public PySpark modules, classes, functions and methods.
 
-Note that pandas has different behavior per its version, and pandas API on Spark tries to match the behavior of the latest pandas release.
+Pandas API on Spark follows the API specifications of latest pandas release.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to document the supported pandas version for pandas API on Spark.

### Why are the changes needed?

Since the behavior of pandas is different per its version, it would be better explicitly documenting the supported pandas version so that users won't confuse.


### Does this PR introduce _any_ user-facing change?

Yes, now the supported pandas version is mentioned to the PySpark API reference page as below:

<img width="1109" alt="Screen Shot 2022-04-08 at 10 35 28 AM" src="https://user-images.githubusercontent.com/44108233/162345946-87d5168c-8ff2-40f3-a0d3-2979332e67b7.png">


### How was this patch tested?

This existing doc build should cover
