### PR TITLE
[SPARK-38803][K8S][TESTS] Lower minio cpu to 250m (0.25) from 1 in K8s IT

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -58,7 +58,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
     ).toArray
 
     val resources = Map(
-      "cpu" -> new Quantity("1"),
+      "cpu" -> new Quantity("250m"),
       "memory" -> new Quantity("512M")
     ).asJava
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to set minio request cpu to `250m` (0.25).
- This value also recommand in [link](https://docs.gitlab.com/charts/charts/minio/#installation-command-line-options).
- There are [no cpu request limitation](https://github.com/minio/minio/blob/a3e317773a2b90a433136e1ff2a8394bc5017c75/helm/minio/values.yaml#L251) on current minio.

### Why are the changes needed?
In some cases (such as resource limited case), we reduce request cpu of minio.
See also: https://github.com/apache/spark/pull/35830#pullrequestreview-929597027

### Does this PR introduce _any_ user-facing change?
No, test only


### How was this patch tested?
IT passsed