### PR TITLE
[SPARK-38548][SQL][FOLLOWUP] try_sum: return null if overflow happens before merging

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -32,6 +32,8 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
 
   def failOnError: Boolean
 
+  protected def shouldTrackIsEmpty: Boolean
+
   override def nullable: Boolean = true
 
   // Return data type.
@@ -45,7 +47,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
 
   final override val nodePatterns: Seq[TreePattern] = Seq(SUM)
 
-  private lazy val resultType = child.dataType match {
+  protected lazy val resultType = child.dataType match {
     case DecimalType.Fixed(precision, scale) =>
       DecimalType.bounded(precision + 10, scale)
     case _: IntegralType => LongType
@@ -60,46 +62,46 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
 
   private lazy val zero = Literal.default(resultType)
 
-  override lazy val aggBufferAttributes = resultType match {
-    case _: DecimalType => sum :: isEmpty :: Nil
-    case _ => sum :: Nil
+  override lazy val aggBufferAttributes = if (shouldTrackIsEmpty) {
+    sum :: isEmpty :: Nil
+  } else {
+    sum :: Nil
   }
 
-  override lazy val initialValues: Seq[Expression] = resultType match {
-    case _: DecimalType => Seq(zero, Literal(true, BooleanType))
-    case _ => Seq(Literal(null, resultType))
-  }
+  override lazy val initialValues: Seq[Expression] =
+    if (shouldTrackIsEmpty) {
+      Seq(zero, Literal(true, BooleanType))
+    } else {
+      Seq(Literal(null, resultType))
+    }
 
-  protected def getUpdateExpressions: Seq[Expression] = {
-    resultType match {
-      case _: DecimalType =>
-        // For decimal type, the initial value of `sum` is 0. We need to keep `sum` unchanged if
-        // the input is null, as SUM function ignores null input. The `sum` can only be null if
-        // overflow happens under non-ansi mode.
-        val sumExpr = if (child.nullable) {
-          If(child.isNull, sum,
-            Add(sum, KnownNotNull(child).cast(resultType), failOnError = failOnError))
-        } else {
-          Add(sum, child.cast(resultType), failOnError = failOnError)
-        }
-        // The buffer becomes non-empty after seeing the first not-null input.
-        val isEmptyExpr = if (child.nullable) {
-          isEmpty && child.isNull
-        } else {
-          Literal(false, BooleanType)
-        }
-        Seq(sumExpr, isEmptyExpr)
-      case _ =>
-        // For non-decimal type, the initial value of `sum` is null, which indicates no value.
-        // We need `coalesce(sum, zero)` to start summing values. And we need an outer `coalesce`
-        // in case the input is nullable. The `sum` can only be null if there is no value, as
-        // non-decimal type can produce overflowed value under non-ansi mode.
-        if (child.nullable) {
-          Seq(coalesce(Add(coalesce(sum, zero), child.cast(resultType), failOnError = failOnError),
-            sum))
-        } else {
-          Seq(Add(coalesce(sum, zero), child.cast(resultType), failOnError = failOnError))
-        }
+  protected def getUpdateExpressions: Seq[Expression] = if (shouldTrackIsEmpty) {
+    // For decimal type, the initial value of `sum` is 0. We need to keep `sum` unchanged if
+    // the input is null, as SUM function ignores null input. The `sum` can only be null if
+    // overflow happens under non-ansi mode.
+    val sumExpr = if (child.nullable) {
+      If(child.isNull, sum,
+        Add(sum, KnownNotNull(child).cast(resultType), failOnError = failOnError))
+    } else {
+      Add(sum, child.cast(resultType), failOnError = failOnError)
+    }
+    // The buffer becomes non-empty after seeing the first not-null input.
+    val isEmptyExpr = if (child.nullable) {
+      isEmpty && child.isNull
+    } else {
+      Literal(false, BooleanType)
+    }
+    Seq(sumExpr, isEmptyExpr)
+  } else {
+    // For non-decimal type, the initial value of `sum` is null, which indicates no value.
+    // We need `coalesce(sum, zero)` to start summing values. And we need an outer `coalesce`
+    // in case the input is nullable. The `sum` can only be null if there is no value, as
+    // non-decimal type can produce overflowed value under non-ansi mode.
+    if (child.nullable) {
+      Seq(coalesce(Add(coalesce(sum, zero), child.cast(resultType), failOnError = failOnError),
+        sum))
+    } else {
+      Seq(Add(coalesce(sum, zero), child.cast(resultType), failOnError = failOnError))
     }
   }
 
@@ -115,24 +117,22 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
    * isEmpty:  Set to false if either one of the left or right is set to false. This
    * means we have seen atleast a value that was not null.
    */
-  protected def getMergeExpressions: Seq[Expression] = {
-    resultType match {
-      case _: DecimalType =>
-        val bufferOverflow = !isEmpty.left && sum.left.isNull
-        val inputOverflow = !isEmpty.right && sum.right.isNull
-        Seq(
-          If(
-            bufferOverflow || inputOverflow,
-            Literal.create(null, resultType),
-            // If both the buffer and the input do not overflow, just add them, as they can't be
-            // null. See the comments inside `updateExpressions`: `sum` can only be null if
-            // overflow happens.
-            KnownNotNull(sum.left) + KnownNotNull(sum.right)),
-          isEmpty.left && isEmpty.right)
-      case _ => Seq(coalesce(
-        Add(coalesce(sum.left, zero), sum.right, failOnError = failOnError),
-        sum.left))
-    }
+  protected def getMergeExpressions: Seq[Expression] = if (shouldTrackIsEmpty) {
+    val bufferOverflow = !isEmpty.left && sum.left.isNull
+    val inputOverflow = !isEmpty.right && sum.right.isNull
+    Seq(
+      If(
+        bufferOverflow || inputOverflow,
+        Literal.create(null, resultType),
+        // If both the buffer and the input do not overflow, just add them, as they can't be
+        // null. See the comments inside `updateExpressions`: `sum` can only be null if
+        // overflow happens.
+        Add(KnownNotNull(sum.left), KnownNotNull(sum.right), failOnError)),
+      isEmpty.left && isEmpty.right)
+  } else {
+    Seq(coalesce(
+      Add(coalesce(sum.left, zero), sum.right, failOnError = failOnError),
+      sum.left))
   }
 
   /**
@@ -146,6 +146,8 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
     case d: DecimalType =>
       If(isEmpty, Literal.create(null, resultType),
         CheckOverflowInSum(sum, d, !failOnError))
+    case _ if shouldTrackIsEmpty =>
+      If(isEmpty, Literal.create(null, resultType), sum)
     case _ => sum
   }
 
@@ -171,6 +173,11 @@ case class Sum(
     failOnError: Boolean = SQLConf.get.ansiEnabled)
   extends SumBase(child) {
   def this(child: Expression) = this(child, failOnError = SQLConf.get.ansiEnabled)
+
+  override def shouldTrackIsEmpty: Boolean = resultType match {
+    case _: DecimalType => true
+    case _ => false
+  }
 
   override protected def withNewChildInternal(newChild: Expression): Sum = copy(child = newChild)
 
@@ -206,6 +213,14 @@ case class TrySum(child: Expression) extends SumBase(child) {
     // `failOnError` is false.
     case _: DoubleType | _: DecimalType => false
     case _ => true
+  }
+
+  override def shouldTrackIsEmpty: Boolean = resultType match {
+    // The sum of following data types can cause overflow.
+    case _: DecimalType | _: IntegralType | _: YearMonthIntervalType | _: DayTimeIntervalType =>
+      true
+    case _ =>
+      false
   }
 
   override lazy val updateExpressions: Seq[Expression] =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -76,9 +76,9 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
     }
 
   protected def getUpdateExpressions: Seq[Expression] = if (shouldTrackIsEmpty) {
-    // If shouldTrackIsEmpty is true, the initial value of `sum` is 0. We need to keep `sum` unchanged if
-    // the input is null, as SUM function ignores null input. The `sum` can only be null if
-    // overflow happens under non-ansi mode.
+    // If shouldTrackIsEmpty is true, the initial value of `sum` is 0. We need to keep `sum`
+    // unchanged if the input is null, as SUM function ignores null input. The `sum` can only be
+    // null if overflow happens under non-ansi mode.
     val sumExpr = if (child.nullable) {
       If(child.isNull, sum,
         Add(sum, KnownNotNull(child).cast(resultType), failOnError = failOnError))
@@ -106,7 +106,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
   }
 
   /**
-   * For decimal type:
+   * When shouldTrackIsEmpty is true:
    * If isEmpty is false and if sum is null, then it means we have had an overflow.
    *
    * update of the sum is as follows:
@@ -115,7 +115,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
    * If it did not have overflow, then add the sum.left and sum.right
    *
    * isEmpty:  Set to false if either one of the left or right is set to false. This
-   * means we have seen atleast a value that was not null.
+   * means we have seen at least a value that was not null.
    */
   protected def getMergeExpressions: Seq[Expression] = if (shouldTrackIsEmpty) {
     val bufferOverflow = !isEmpty.left && sum.left.isNull

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -76,7 +76,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
     }
 
   protected def getUpdateExpressions: Seq[Expression] = if (shouldTrackIsEmpty) {
-    // For decimal type, the initial value of `sum` is 0. We need to keep `sum` unchanged if
+    // If shouldTrackIsEmpty is true, the initial value of `sum` is 0. We need to keep `sum` unchanged if
     // the input is null, as SUM function ignores null input. The `sum` can only be null if
     // overflow happens under non-ansi mode.
     val sumExpr = if (child.nullable) {
@@ -93,7 +93,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
     }
     Seq(sumExpr, isEmptyExpr)
   } else {
-    // For non-decimal type, the initial value of `sum` is null, which indicates no value.
+    // If shouldTrackIsEmpty is false, the initial value of `sum` is null, which indicates no value.
     // We need `coalesce(sum, zero)` to start summing values. And we need an outer `coalesce`
     // in case the input is nullable. The `sum` can only be null if there is no value, as
     // non-decimal type can produce overflowed value under non-ansi mode.

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4332,12 +4332,11 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   test("SPARK-38548: try_sum should return null if overflow happens before merging") {
     val longDf = Seq(Long.MaxValue, Long.MaxValue, 2).toDF("v")
     val yearMonthDf = Seq(Int.MaxValue, Int.MaxValue, 2)
+      .map(Period.ofMonths)
       .toDF("v")
-      .select(col("v").cast("year to month interval").as("v"))
-
-    val dayTimeDf = Seq(Long.MaxValue, Long.MaxValue, 2)
+    val dayTimeDf = Seq(106751991L, 106751991L, 2L)
+      .map(Duration.ofDays)
       .toDF("v")
-      .select(col("v").cast("day time interval").as("v"))
     Seq(longDf, yearMonthDf, dayTimeDf).foreach { df =>
       checkAnswer(df.repartitionByRange(2, col("v")).selectExpr("try_sum(v)"), Row(null))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4342,7 +4342,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       checkAnswer(df.repartitionByRange(2, col("v")).selectExpr("try_sum(v)"), Row(null))
     }
   }
-
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is to fix a bug in the new function `try_sum`. It should return null if overflow happens before merging the sums from map tasks.
For example: 
MAP TASK 1: partial aggregation TRY_SUM(large_numbers_column) -> overflows, turns into NULL
MAP TASK 2: partial aggregation TRY_SUM(large_numbers_column) -> succeeds, returns 12345
REDUCE TASK: merge TRY_SUM(NULL, 12345) -> returns 12345

We should use a new slot buffer `isEmpty` to track if there is a non-empty value in partial aggregation. If the partial result is null and there is non-empty value, the merge result should be `NULL`.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the new function is not release yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT