### PR TITLE
[SPARK-38826][SQL][DOCS] dropFieldIfAllNull option does not work for empty JSON struct

### DIFF
--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -235,7 +235,7 @@ Data source options of JSON can be set via:
   <tr>
     <td><code>dropFieldIfAllNull</code></td>
     <td><code>false</code></td>
-    <td>Whether to ignore column of all null values or empty array/struct during schema inference.</td>
+    <td>Whether to ignore column of all null values or empty array during schema inference.</td>
     <td>read</td>
   </tr>
   <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make a minor correction for the documentation of json option `dropFieldIfAllNull`

### Why are the changes needed?
The `dropFieldIfAllNull` option actually does not work for empty json struct due to [SPARK-8093](https://issues.apache.org/jira/browse/SPARK-8093), the empty struct will be dropped anyway.
We should update the doc, otherwise it would be confusing.

### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
I've built the documentation locally and tested my change.
