### PR TITLE
[SPARK-38827][PYTHON][TESTS] Add the test for pyspark/find_spark_home.py

### DIFF
--- a/python/pyspark/tests/test_util.py
+++ b/python/pyspark/tests/test_util.py
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import unittest
 
 from py4j.protocol import Py4JJavaError
 
 from pyspark import keyword_only
 from pyspark.testing.utils import PySparkTestCase
+from pyspark.find_spark_home import _find_spark_home
 
 
 class KeywordOnlyTests(unittest.TestCase):
@@ -72,6 +74,15 @@ class UtilTests(PySparkTestCase):
         from pyspark.util import VersionUtils
 
         self.assertRaises(ValueError, lambda: VersionUtils.majorMinorVersion("abced"))
+
+    def test_find_spark_home(self):
+        # SPARK-38827: Test find_spark_home without `SPARK_HOME` environment variable set.
+        origin = os.environ["SPARK_HOME"]
+        try:
+            del os.environ["SPARK_HOME"]
+            self.assertEquals(origin, _find_spark_home())
+        finally:
+            os.environ["SPARK_HOME"] = origin
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test for the case when `SPARK_HOME` environment variable is not set (see https://app.codecov.io/gh/apache/spark/blob/master/python/pyspark/find_spark_home.py)

### Why are the changes needed?

To keep the test coverage.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test it out.
