### PR TITLE
[SPARK-38107][SQL][FOLLOWUP] Refine the error-class name and message for grouped agg pandas UDF

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -22,9 +22,6 @@
   "CANNOT_UP_CAST_DATATYPE" : {
     "message" : [ "Cannot up cast %s from %s to %s.\n%s" ]
   },
-  "CANNOT_USE_MIXTURE" : {
-    "message" : [ "Cannot use a mixture of aggregate function and group aggregate pandas UDF" ]
-  },
   "CAST_CAUSES_OVERFLOW" : {
     "message" : [ "Casting %s to %s causes overflow. To return NULL instead, use 'try_cast'. If necessary set %s to false to bypass this error." ],
     "sqlState" : "22005"
@@ -111,6 +108,9 @@
   },
   "INVALID_JSON_SCHEMA_MAPTYPE" : {
     "message" : [ "Input schema %s can only contain StringType as a key type for a MapType." ]
+  },
+  "INVALID_PANDAS_UDF_PLACEMENT" : {
+    "message" : [ "The group aggregate pandas UDF %s cannot be invoked together with as other, non-pandas aggregate functions." ]
   },
   "INVALID_PARAMETER_VALUE" : {
     "message" : [ "The value of parameter(s) '%s' in %s is invalid: %s" ],

--- a/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
@@ -487,7 +487,7 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
                 AnalysisException,
-                "The group aggregate pandas UDF 'avg' cannot be invoked together with as other, " +
+                "The group aggregate pandas UDF 'avg' cannot be invoked together with as other, "
                 "non-pandas aggregate functions.",
             ):
                 df.groupby(df.id).agg(mean_udf(df.v), mean(df.v)).collect()

--- a/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_grouped_agg.py
@@ -486,7 +486,9 @@ class GroupedAggPandasUDFTests(ReusedSQLTestCase):
 
         with QuietTest(self.sc):
             with self.assertRaisesRegex(
-                AnalysisException, "mixture.*aggregate function.*group aggregate pandas UDF"
+                AnalysisException,
+                "The group aggregate pandas UDF 'avg' cannot be invoked together with as other, " +
+                "non-pandas aggregate functions.",
             ):
                 df.groupby(df.id).agg(mean_udf(df.v), mean(df.v)).collect()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1338,10 +1338,11 @@ object QueryCompilationErrors {
       "Stream-stream join without equality predicate is not supported", plan = Some(plan))
   }
 
-  def cannotUseMixtureOfAggFunctionAndGroupAggPandasUDFError(): Throwable = {
+  def invalidPandasUDFPlacementError(
+      groupAggPandasUDFNames: Seq[String]): Throwable = {
     new AnalysisException(
-      errorClass = "CANNOT_USE_MIXTURE",
-      messageParameters = Array.empty)
+      errorClass = "INVALID_PANDAS_UDF_PLACEMENT",
+      messageParameters = Array(groupAggPandasUDFNames.map(name => s"'$name'").mkString(", ")))
   }
 
   def ambiguousAttributesInSelfJoinError(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -571,9 +571,12 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           resultExpressions,
           planLater(child)))
 
-      case PhysicalAggregation(_, _, _, _) =>
+      case PhysicalAggregation(_, aggExpressions, _, _) =>
+        val groupAggPandasUDFNames = aggExpressions
+          .filter(_.isInstanceOf[PythonUDF])
+          .map(_.asInstanceOf[PythonUDF].name)
         // If cannot match the two cases above, then it's an error
-        throw QueryCompilationErrors.cannotUseMixtureOfAggFunctionAndGroupAggPandasUDFError()
+        throw QueryCompilationErrors.invalidPandasUDFPlacementError(groupAggPandasUDFNames.distinct)
 
       case _ => Nil
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR follow-up https://github.com/apache/spark/pull/35656 to make error-class name and error message better.

### Why are the changes needed?

The existing class name `CANNOT_USE_MIXTURE ` and its message `"Cannot use a mixture of aggregate function and group aggregate pandas UDF"` don't seem to clearly elaborate why the error is occurred.


### Does this PR introduce _any_ user-facing change?

Yes, the error message is changed from `"The group aggregate pandas UDF %s cannot be invoked in the same SELECT list as other, non-pandas aggregate functions."` to `"The group aggregate pandas UDF <pandas_udf_name> cannot be invoked in the same SELECT list as other, non-pandas aggregate functions."`


### How was this patch tested?

The existing test should cover.
