### PR TITLE
[SPARK-38800][DOCS][PYTHON][3.3] Explicitly document the supported pandas version.

### DIFF
--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -22,7 +22,7 @@ API Reference
 
 This page lists an overview of all public PySpark modules, classes, functions and methods.
 
-Pandas API on Spark follows the API specifications of pandas 1.4.
+Pandas API on Spark follows the API specifications of pandas 1.3.
 
 .. toctree::
    :maxdepth: 2

--- a/python/docs/source/reference/index.rst
+++ b/python/docs/source/reference/index.rst
@@ -22,6 +22,8 @@ API Reference
 
 This page lists an overview of all public PySpark modules, classes, functions and methods.
 
+Pandas API on Spark follows the API specifications of pandas 1.4.
+
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to document the supported pandas version for pandas API on Spark.

https://github.com/apache/spark/pull/36095 is corresponding PR for master branch.

### Why are the changes needed?

Since the behavior of pandas is different per its version, it would be better explicitly documenting the supported pandas version so that users won't confuse.

pandas API on Spark aims matching behavior to pandas 1.3.


### Does this PR introduce _any_ user-facing change?

Yes, now the supported pandas version is mentioned to the PySpark API reference page.


### How was this patch tested?

This existing doc build should cover
