### PR TITLE
[SPARK-38830][CORE] Warn on corrupted block messages

### DIFF
--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockRpcServer.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.network.netty
 
+import java.lang.IndexOutOfBoundsException
 import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
@@ -50,7 +51,17 @@ class NettyBlockRpcServer(
       client: TransportClient,
       rpcMessage: ByteBuffer,
       responseContext: RpcResponseCallback): Unit = {
-    val message = BlockTransferMessage.Decoder.fromByteBuffer(rpcMessage)
+    val message = try {
+      BlockTransferMessage.Decoder.fromByteBuffer(rpcMessage)
+    } catch {
+      case _: IndexOutOfBoundsException =>
+        // Netty throws IndexOutOfBoundsException for corrupted buffers. In this case, we ignore
+        // the entire message with warnings because we cannot trust any contents.
+        logWarning(s"Ignored a corrupted RPC message (capacity: ${rpcMessage.capacity()}) " +
+          s"from ${client.getSocketAddress}. Please use `spark.authenticate.*` configurations " +
+          "in case of security incidents.")
+        return
+    }
     logTrace(s"Received request: $message")
 
     message match {

--- a/core/src/test/scala/org/apache/spark/network/netty/NettyBlockRpcServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/network/netty/NettyBlockRpcServerSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.netty
+
+import java.nio.ByteBuffer
+
+import org.mockito.Mockito.mock
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.network.client.TransportClient
+import org.apache.spark.serializer.JavaSerializer
+
+class NettyBlockRpcServerSuite extends SparkFunSuite {
+
+  test("SPARK-38830: Warn corrupted Netty messages") {
+    val serializer = new JavaSerializer(new SparkConf)
+    val server = new NettyBlockRpcServer("enhanced-rpc-server", serializer, null)
+    val bytes = Array[Byte](1.toByte)
+    val message = ByteBuffer.wrap(bytes)
+    val client = mock(classOf[TransportClient])
+    server.receive(client, message)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to warn when `NettyBlockRpcServer` received a corrupted block RPC message or under attack.

- `IllegalArgumentException`: When the type is unknown/invalid when decoding. This fails at Spark layer.
- `NegativeArraySizeException`: When the size read is negative. This fails at Spark layer during buffer creation.
- `IndexOutOfBoundsException`: When the data field isn't matched with the size. This fails at Netty later.

### Why are the changes needed?

When the RPC messages are corrupted or the servers are under attack, Spark shows `IndexOutOfBoundsException` due to the failure from `Decoder`. Instead of `Exception`, we had better ignore the message with a directional warning message.
```
java.lang.IndexOutOfBoundsException:
    readerIndex(5) + length(602416) exceeds writerIndex(172):
UnpooledUnsafeDirectByteBuf(ridx: 5, widx: 172, cap: 172/172)
    at io.netty.buffer.AbstractByteBuf.checkReadableBytes0(AbstractByteBuf.java:1477)
    at io.netty.buffer.AbstractByteBuf.checkReadableBytes(AbstractByteBuf.java:1463)
    at io.netty.buffer.UnpooledDirectByteBuf.readBytes(UnpooledDirectByteBuf.java:316)
    at io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:904)
    at org.apache.spark.network.protocol.Encoders$Strings.decode(Encoders.java:45)
    at org.apache.spark.network.shuffle.protocol.UploadBlock.decode(UploadBlock.java:112)
    at org.apache.spark.network.shuffle.protocol.BlockTransferMessage$Decoder.fromByteBuffer(BlockTransferMessage.java:71)
    at org.apache.spark.network.netty.NettyBlockRpcServer.receive(NettyBlockRpcServer.scala:53)
    at org.apache.spark.network.server.TransportRequestHandler.processRpcRequest(TransportRequestHandler.java:161)
    at org.apache.spark.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:109)
    at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:140)
    at org.apache.spark.network.server.TransportChannelHandler.channelRead0(TransportChannelHandler.java:53)

```

### Does this PR introduce _any_ user-facing change?

Yes, but this clarify the log messages from exceptions, `IndexOutOfBoundsException`.

### How was this patch tested?

Pass the CIs with newly added test suite.