### PR TITLE
[SPARK-38843][SQL] Fix translate metadata col filters

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -369,16 +369,7 @@ case class FileSourceScanExec(
   }
 
   @transient
-  private lazy val pushedDownFilters = {
-    val supportNestedPredicatePushdown = DataSourceUtils.supportNestedPredicatePushdown(relation)
-    // `dataFilters` should not include any metadata col filters
-    // because the metadata struct has been flatted in FileSourceStrategy
-    // and thus metadata col filters are invalid to be pushed down
-    dataFilters.filterNot(_.references.exists {
-      case FileSourceMetadataAttribute(_) => true
-      case _ => false
-    }).flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
-  }
+  private lazy val pushedDownFilters = DataSourceStrategy.pushedDownFilters(dataFilters, relation)
 
   override lazy val metadata: Map[String, String] = {
     def seqToString(seq: Seq[Any]) = seq.mkString("[", ", ", "]")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -564,13 +564,29 @@ object DataSourceStrategy
   }
 
   /**
-   * Tries to translate a Catalyst [[Expression]] into data source [[Filter]].
+   * Tries to translate a pushable Catalyst [[Expression]] into data source [[Filter]].
    *
    * @return a `Some[Filter]` if the input [[Expression]] is convertible, otherwise a `None`.
    */
   protected[sql] def translateFilter(
       predicate: Expression, supportNestedPredicatePushdown: Boolean): Option[Filter] = {
-    translateFilterWithMapping(predicate, None, supportNestedPredicatePushdown)
+    // `predicate` should not include any metadata col filters
+    // because the metadata struct has been flatted in FileSourceStrategy
+    Option(predicate).filterNot(_.references.exists {
+      case FileSourceMetadataAttribute(_) => true
+      case _ => false
+    }).flatMap(translateFilterWithMapping(_, None, supportNestedPredicatePushdown))
+  }
+
+  /**
+   * Translate a Seq of pushable Catalyst [[Expression]]s into data source [[Filter]]s.
+   *
+   * @return a Seq of pushed down `Filter`s.
+   */
+  protected[sql] def pushedDownFilters(
+      dataFilters: Seq[Expression], relation: HadoopFsRelation): Seq[Filter] = {
+    val supportNestedPredicatePushdown = DataSourceUtils.supportNestedPredicatePushdown(relation)
+    dataFilters.flatMap(translateFilter(_, supportNestedPredicatePushdown))
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -192,10 +192,7 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
           Some(f)
         }
       }
-      val supportNestedPredicatePushdown =
-        DataSourceUtils.supportNestedPredicatePushdown(fsRelation)
-      val pushedFilters = dataFilters
-        .flatMap(DataSourceStrategy.translateFilter(_, supportNestedPredicatePushdown))
+      val pushedFilters = DataSourceStrategy.pushedDownFilters(dataFilters, fsRelation)
       logInfo(s"Pushed Filters: ${pushedFilters.mkString(",")}")
 
       // Predicates with both partition keys and attributes need to be evaluated after the scan.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix translate metadata col filters because it can't be pushed down.

1. The [FileSourceStrategy](https://github.com/apache/spark/blob/6bc001ff5ae5f2f2321b3cd999fa1ef879d3a922/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala#L196) log is incorrect:
    Before this PR:
    ```
    07:24:45.131 ERROR org.apache.spark.sql.execution.datasources.FileSourceStrategy: Pushed Filters: 
    IsNotNull(_metadata.file_path),StringContains(_metadata.file_path,data/f0)
    ```
    After this PR:
    ```
    07:24:45.144 ERROR org.apache.spark.sql.execution.datasources.FileSourceStrategy: Pushed Filters: 
    ```
2. It should be also pushable in other places:
https://github.com/apache/spark/blob/128168d8c4019a1e10a9f1be734868524f6a09f0/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScanBuilder.scala#L78
https://github.com/apache/spark/blob/ac4f2af8d9184db3962427133ef2940c8b515c26/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala#L705


### Why are the changes needed?

Fix bug.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT.