### PR TITLE
[SPARK-38844][PYTHON][SQL] Implement linear interpolate

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -218,6 +218,7 @@ Missing data handling
    DataFrame.replace
    DataFrame.bfill
    DataFrame.ffill
+   DataFrame.interpolate
 
 Reshaping, sorting, transposing
 -------------------------------

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -221,6 +221,7 @@ Missing data handling
    Series.pad
    Series.dropna
    Series.fillna
+   Series.interpolate
 
 Reshaping, sorting, transposing
 -------------------------------

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -5500,6 +5500,23 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return psdf
 
+    def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None):
+        if (method is not None) and (method not in ["linear"]):
+            raise ValueError("Expecting 'linear'.")
+        if (limit is not None) and (not limit > 0):
+            raise ValueError("limit must be > 0.")
+
+        numeric_col_names = []
+        for label in self._internal.column_labels:
+            psser = self._psser_for(label)
+            if isinstance(psser.spark.data_type, (NumericType, BooleanType)):
+                numeric_col_names.append(psser.name)
+
+        psdf = self[numeric_col_names]
+        return psdf._apply_series_op(
+            lambda psser: psser._interpolate(method=method, limit=limit), should_resolve=True
+        )
+
     def replace(
         self,
         to_replace: Optional[Union[Any, List, Tuple, Dict]] = None,

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -5500,11 +5500,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return psdf
 
-    def interpolate(
-        self, method: Optional[str] = None, limit: Optional[int] = None
-    ) -> Optional["DataFrame"]:
+    def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None) -> "DataFrame":
         if (method is not None) and (method not in ["linear"]):
-            raise ValueError("Expecting 'linear'.")
+            raise NotImplementedError("interpolate currently works only for method='linear'")
         if (limit is not None) and (not limit > 0):
             raise ValueError("limit must be > 0.")
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -5500,7 +5500,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         else:
             return psdf
 
-    def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None):
+    def interpolate(
+        self, method: Optional[str] = None, limit: Optional[int] = None
+    ) -> Optional["DataFrame"]:
         if (method is not None) and (method not in ["linear"]):
             raise ValueError("Expecting 'linear'.")
         if (limit is not None) and (not limit > 0):

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3240,6 +3240,13 @@ class Frame(object, metaclass=ABCMeta):
         """
         Fill NaN values using an interpolation method.
 
+        .. note:: the current implementation of rank uses Spark's Window without
+            specifying partition specification. This leads to move all data into
+            single partition in single machine and could cause serious
+            performance degradation. Avoid this method against very large dataset.
+
+        .. versionadded:: 3.4.0
+
         Parameters
         ----------
         method : str, default 'linear'

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3231,6 +3231,14 @@ class Frame(object, metaclass=ABCMeta):
 
     pad = ffill
 
+    # TODO: add 'axis', 'inplace', 'limit_direction', 'limit_area', 'downcast'
+    def interpolate(
+        self: FrameLike,
+        method: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> FrameLike:
+        return self.interpolate(method=method, limit=limit)
+
     @property
     def at(self) -> AtIndexer:
         return AtIndexer(self)

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -3237,6 +3237,75 @@ class Frame(object, metaclass=ABCMeta):
         method: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> FrameLike:
+        """
+        Fill NaN values using an interpolation method.
+
+        Parameters
+        ----------
+        method : str, default 'linear'
+            Interpolation technique to use. One of:
+
+            * 'linear': Ignore the index and treat the values as equally
+              spaced.
+
+        limit : int, optional
+            Maximum number of consecutive NaNs to fill. Must be greater than
+            0.
+
+        Returns
+        -------
+        Series or DataFrame or None
+            Returns the same object type as the caller, interpolated at
+            some or all NA values.
+
+        See Also
+        --------
+        fillna : Fill missing values using different methods.
+
+        Examples
+        --------
+        Filling in NA via linear interpolation.
+
+        >>> s = ps.Series([0, 1, np.nan, 3])
+        >>> s
+        0    0.0
+        1    1.0
+        2    NaN
+        3    3.0
+        dtype: float64
+        >>> s.interpolate()
+        0    0.0
+        1    1.0
+        2    2.0
+        3    3.0
+        dtype: float64
+
+        Fill the DataFrame forward (that is, going down) along each column
+        using linear interpolation.
+
+        Note how the last entry in column 'a' is interpolated differently,
+        because there is no entry after it to use for interpolation.
+        Note how the first entry in column 'b' remains NA, because there
+        is no entry before it to use for interpolation.
+
+        >>> df = ps.DataFrame([(0.0, np.nan, -1.0, 1.0),
+        ...                    (np.nan, 2.0, np.nan, np.nan),
+        ...                    (2.0, 3.0, np.nan, 9.0),
+        ...                    (np.nan, 4.0, -4.0, 16.0)],
+        ...                   columns=list('abcd'))
+        >>> df
+             a    b    c     d
+        0  0.0  NaN -1.0   1.0
+        1  NaN  2.0  NaN   NaN
+        2  2.0  3.0  NaN   9.0
+        3  NaN  4.0 -4.0  16.0
+        >>> df.interpolate(method='linear')
+             a    b    c     d
+        0  0.0  NaN -1.0   1.0
+        1  1.0  2.0 -2.0   5.0
+        2  2.0  3.0 -3.0   9.0
+        3  2.0  4.0 -4.0  16.0
+        """
         return self.interpolate(method=method, limit=limit)
 
     @property

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -40,7 +40,6 @@ class _MissingPandasLikeDataFrame:
     convert_dtypes = _unsupported_function("convert_dtypes")
     corrwith = _unsupported_function("corrwith")
     infer_objects = _unsupported_function("infer_objects")
-    interpolate = _unsupported_function("interpolate")
     mode = _unsupported_function("mode")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -37,7 +37,6 @@ class MissingPandasLikeSeries:
     combine = _unsupported_function("combine")
     convert_dtypes = _unsupported_function("convert_dtypes")
     infer_objects = _unsupported_function("infer_objects")
-    interpolate = _unsupported_function("interpolate")
     reorder_levels = _unsupported_function("reorder_levels")
     resample = _unsupported_function("resample")
     searchsorted = _unsupported_function("searchsorted")

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2164,7 +2164,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             scol = F.when(cond, func(scol, True).over(window)).otherwise(scol)
 
         return DataFrame(
-            self._psdf._internal.with_new_spark_column(self._column_label, scol)  # TODO: dtype?
+            self._psdf._internal.with_new_spark_column(
+                self._column_label, scol.alias(name_like_string(self.name))  # TODO: dtype?
+            )
         )._psser_for(self._column_label)
 
     def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None) -> "Series":

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2169,7 +2169,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             )
         )._psser_for(self._column_label)
 
-    def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None):
+    def interpolate(
+        self, method: Optional[str] = None, limit: Optional[int] = None
+    ) -> Optional["Series"]:
         return self._interpolate(method=method, limit=limit)
 
     def _interpolate(

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2164,14 +2164,12 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             scol = F.when(cond, func(scol, True).over(window)).otherwise(scol)
 
         return DataFrame(
-            self._psdf._internal.with_new_spark_column(
-                self._column_label, scol.alias(name_like_string(self.name))  # TODO: dtype?
-            )
+            self._psdf._internal.with_new_spark_column(self._column_label, scol)  # TODO: dtype?
         )._psser_for(self._column_label)
 
     def interpolate(
         self, method: Optional[str] = None, limit: Optional[int] = None
-    ) -> Optional["Series"]:
+    ) -> "Series":
         return self._interpolate(method=method, limit=limit)
 
     def _interpolate(
@@ -2180,7 +2178,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         limit: Optional[int] = None,
     ) -> "Series":
         if (method is not None) and (method not in ["linear"]):
-            raise ValueError("Expecting 'linear'.")
+            raise NotImplementedError("interpolate currently works only for method='linear'")
         if (limit is not None) and (not limit > 0):
             raise ValueError("limit must be > 0.")
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -54,6 +54,7 @@ from pandas.api.types import (  # type: ignore[attr-defined]
     CategoricalDtype,
 )
 from pandas.tseries.frequencies import DateOffset
+from pyspark import SparkContext
 from pyspark.sql import functions as F, Column, DataFrame as SparkDataFrame
 from pyspark.sql.types import (
     ArrayType,
@@ -2161,6 +2162,64 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 .rowsBetween(begin, end)
             )
             scol = F.when(cond, func(scol, True).over(window)).otherwise(scol)
+
+        return DataFrame(
+            self._psdf._internal.with_new_spark_column(
+                self._column_label, scol.alias(name_like_string(self.name))  # TODO: dtype?
+            )
+        )._psser_for(self._column_label)
+
+    def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None):
+        return self._interpolate(method=method, limit=limit)
+
+    def _interpolate(
+        self,
+        method: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> "Series":
+        if (method is not None) and (method not in ["linear"]):
+            raise ValueError("Expecting 'linear'.")
+        if (limit is not None) and (not limit > 0):
+            raise ValueError("limit must be > 0.")
+
+        if not self.spark.nullable and not isinstance(
+            self.spark.data_type, (FloatType, DoubleType)
+        ):
+            return self._psdf.copy()._psser_for(self._column_label)
+
+        scol = self.spark.column
+        sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
+        last_non_null = Column(sql_utils.lastNonNull(scol._jc))
+        null_index = Column(sql_utils.nullIndex(scol._jc))
+
+        window_forward = Window.orderBy(NATURAL_ORDER_COLUMN_NAME).rowsBetween(
+            Window.unboundedPreceding, Window.currentRow
+        )
+        last_non_null_forward = last_non_null.over(window_forward)
+        null_index_forward = null_index.over(window_forward)
+
+        window_backward = Window.orderBy(F.desc(NATURAL_ORDER_COLUMN_NAME)).rowsBetween(
+            Window.unboundedPreceding, Window.currentRow
+        )
+        last_non_null_backward = last_non_null.over(window_backward)
+        null_index_backward = null_index.over(window_backward)
+
+        fill = (last_non_null_backward - last_non_null_forward) / (
+            null_index_backward + null_index_forward
+        ) * null_index_forward + last_non_null_forward
+
+        fill_cond = ~F.isnull(last_non_null_backward) & ~F.isnull(last_non_null_forward)
+        pad_cond = F.isnull(last_non_null_backward) & ~F.isnull(last_non_null_forward)
+        if limit is not None:
+            fill_cond = fill_cond & (null_index_forward <= F.lit(limit))
+            pad_cond = pad_cond & (null_index_forward <= F.lit(limit))
+
+        cond = self.isnull().spark.column
+        scol = (
+            F.when(cond & fill_cond, fill)
+            .when(cond & pad_cond, last_non_null_forward)
+            .otherwise(scol)
+        )
 
         return DataFrame(
             self._psdf._internal.with_new_spark_column(

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2220,9 +2220,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         )
 
         return DataFrame(
-            self._psdf._internal.with_new_spark_column(
-                self._column_label, scol.alias(name_like_string(self.name))  # TODO: dtype?
-            )
+            self._psdf._internal.with_new_spark_column(self._column_label, scol)  # TODO: dtype?
         )._psser_for(self._column_label)
 
     def dropna(self, axis: Axis = 0, inplace: bool = False, **kwargs: Any) -> Optional["Series"]:

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2167,9 +2167,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             self._psdf._internal.with_new_spark_column(self._column_label, scol)  # TODO: dtype?
         )._psser_for(self._column_label)
 
-    def interpolate(
-        self, method: Optional[str] = None, limit: Optional[int] = None
-    ) -> "Series":
+    def interpolate(self, method: Optional[str] = None, limit: Optional[int] = None) -> "Series":
         return self._interpolate(method=method, limit=limit)
 
     def _interpolate(

--- a/python/pyspark/pandas/tests/test_generic_functions.py
+++ b/python/pyspark/pandas/tests/test_generic_functions.py
@@ -21,11 +21,13 @@ import pyspark.pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
 
 
-class InterpolateTest(PandasOnSparkTestCase, TestUtils):
+class GenericFunctionsTest(PandasOnSparkTestCase, TestUtils):
     def test_interpolate_error(self):
         psdf = ps.range(10)
 
-        with self.assertRaisesRegex(ValueError, "Expecting 'linear'"):
+        with self.assertRaisesRegex(
+            NotImplementedError, "interpolate currently works only for method='linear'"
+        ):
             psdf.interpolate(method="quadratic")
 
         with self.assertRaisesRegex(ValueError, "limit must be > 0"):
@@ -111,7 +113,7 @@ class InterpolateTest(PandasOnSparkTestCase, TestUtils):
 
 if __name__ == "__main__":
     import unittest
-    from pyspark.pandas.tests.test_interpolate import *  # noqa: F401
+    from pyspark.pandas.tests.test_generic_functions import *  # noqa: F401
 
     try:
         import xmlrunner  # type: ignore[import]

--- a/python/pyspark/pandas/tests/test_interpolate.py
+++ b/python/pyspark/pandas/tests/test_interpolate.py
@@ -92,7 +92,7 @@ class InterpolateTest(PandasOnSparkTestCase, TestUtils):
                 (4, np.nan, 4.0),
                 (5, np.nan, 1.0),
             ],
-            columns=list("abcd"),
+            columns=list("abc"),
         )
         self._test_dataframe_interpolate(pdf)
 

--- a/python/pyspark/pandas/tests/test_interpolate.py
+++ b/python/pyspark/pandas/tests/test_interpolate.py
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+import pandas as pd
+
+import pyspark.pandas as ps
+from pyspark.testing.pandasutils import PandasOnSparkTestCase, TestUtils
+
+
+class InterpolateTest(PandasOnSparkTestCase, TestUtils):
+    def test_interpolate_error(self):
+        psdf = ps.range(10)
+
+        with self.assertRaisesRegex(ValueError, "Expecting 'linear'"):
+            psdf.interpolate(method="quadratic")
+
+        with self.assertRaisesRegex(ValueError, "limit must be > 0"):
+            psdf.interpolate(limit=0)
+
+    def _test_series_interpolate(self, pser):
+        psser = ps.from_pandas(pser)
+        self.assert_eq(psser.interpolate(), pser.interpolate())
+        for l1 in range(1, 5):
+            self.assert_eq(psser.interpolate(limit=l1), pser.interpolate(limit=l1))
+
+    def _test_dataframe_interpolate(self, pdf):
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(psdf.interpolate(), pdf.interpolate())
+        for l2 in range(1, 5):
+            self.assert_eq(psdf.interpolate(limit=l2), pdf.interpolate(limit=l2))
+
+    def test_interpolate(self):
+        pser = pd.Series(
+            [
+                1,
+                np.nan,
+                3,
+            ],
+            name="a",
+        )
+        self._test_series_interpolate(pser)
+
+        pser = pd.Series(
+            [
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            name="a",
+        )
+        self._test_series_interpolate(pser)
+
+        pser = pd.Series(
+            [
+                np.nan,
+                np.nan,
+                np.nan,
+                0,
+                1,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                3,
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            name="a",
+        )
+        self._test_series_interpolate(pser)
+
+        pdf = pd.DataFrame(
+            [
+                (1, 0.0, np.nan),
+                (2, np.nan, 2.0),
+                (3, 2.0, 3.0),
+                (4, np.nan, 4.0),
+                (5, np.nan, 1.0),
+            ],
+            columns=list("abcd"),
+        )
+        self._test_dataframe_interpolate(pdf)
+
+        pdf = pd.DataFrame(
+            [
+                (0.0, np.nan, -1.0, 1.0, np.nan),
+                (np.nan, 2.0, np.nan, np.nan, np.nan),
+                (2.0, 3.0, np.nan, 9.0, np.nan),
+                (np.nan, 4.0, -4.0, 16.0, np.nan),
+                (np.nan, 1.0, np.nan, 7.0, np.nan),
+            ],
+            columns=list("abcde"),
+        )
+        self._test_dataframe_interpolate(pdf)
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.pandas.tests.test_interpolate import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -29,7 +29,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.expressions.{CastTimestampNTZToLong, EWM, ExpressionInfo, GenericRowWithSchema}
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.execution.{ExplainMode, QueryExecution}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
@@ -96,6 +96,10 @@ private[sql] object PythonSQLUtils extends Logging {
   def castTimestampNTZToLong(c: Column): Column = Column(CastTimestampNTZToLong(c.expr))
 
   def ewm(e: Column, alpha: Double): Column = Column(EWM(e.expr, alpha))
+
+  def lastNonNull(e: Column): Column = Column(LastNonNull(e.expr))
+
+  def nullIndex(e: Column): Column = Column(NullIndex(e.expr))
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement linear interpolate, see [SPARK-38844](https://issues.apache.org/jira/browse/SPARK-38844) 

### Why are the changes needed?
Increase pandas API coverage in PySpark


### Does this PR introduce _any_ user-facing change?
yes, new function was added:

```
In [3]: df = ps.DataFrame({'s1': [-1, .2, np.nan, np.nan, np.nan, .6, .2, .4, .5, .6, np.nan, np.nan], 's2': [np.nan, 2, np.nan, 1, 3, 1, np.nan, np.nan, 0, 0, np.nan, 2]})

In [4]: df.interpolate(method='linear')
                                                                                
     s1        s2
0  -1.0       NaN
1   0.2  2.000000
2   0.3  1.500000
3   0.4  1.000000
4   0.5  3.000000
5   0.6  1.000000
6   0.2  0.666667
7   0.4  0.333333
8   0.5  0.000000
9   0.6  0.000000
10  0.6  1.000000
11  0.6  2.000000


```


### How was this patch tested?
added UT