### PR TITLE
[SPARK-3723][FOLLOW-UP][PYTHON][MLLIB] Rename method type and dist name literals

### DIFF
--- a/python/pyspark/mllib/_typing.pyi
+++ b/python/pyspark/mllib/_typing.pyi
@@ -28,6 +28,6 @@ VectorLike = Union[ndarray, Vector, List[float], Tuple[float, ...]]
 C = TypeVar("C", bound=type)
 JavaObjectOrPickleDump = Union[JavaObject, bytearray, bytes]
 
-CorrelationMethod = Union[Literal["spearman"], Literal["pearson"]]
-DistName = Literal["norm"]
+CorrMethodType = Union[Literal["spearman"], Literal["pearson"]]
+KolmogorovSmirnovTestDistNameType = Literal["norm"]
 NormType = Union[None, float, Literal["fro"], Literal["nuc"]]

--- a/python/pyspark/mllib/stat/_statistics.py
+++ b/python/pyspark/mllib/stat/_statistics.py
@@ -28,7 +28,7 @@ from pyspark.mllib.regression import LabeledPoint
 from pyspark.mllib.stat.test import ChiSqTestResult, KolmogorovSmirnovTestResult
 
 if TYPE_CHECKING:
-    from pyspark.mllib._typing import CorrelationMethod, DistName
+    from pyspark.mllib._typing import CorrMethodType, KolmogorovSmirnovTestDistNameType
 
 __all__ = ["MultivariateStatisticalSummary", "Statistics"]
 
@@ -106,19 +106,19 @@ class Statistics:
 
     @overload
     @staticmethod
-    def corr(x: RDD[Vector], *, method: Optional["CorrelationMethod"] = ...) -> Matrix:
+    def corr(x: RDD[Vector], *, method: Optional["CorrMethodType"] = ...) -> Matrix:
         ...
 
     @overload
     @staticmethod
-    def corr(x: RDD[float], y: RDD[float], method: Optional["CorrelationMethod"] = ...) -> float:
+    def corr(x: RDD[float], y: RDD[float], method: Optional["CorrMethodType"] = ...) -> float:
         ...
 
     @staticmethod
     def corr(
         x: Union[RDD[Vector], RDD[float]],
         y: Optional[RDD[float]] = None,
-        method: Optional["CorrelationMethod"] = None,
+        method: Optional["CorrMethodType"] = None,
     ) -> Union[float, Matrix]:
         """
         Compute the correlation (matrix) for the input RDD(s) using the
@@ -313,7 +313,7 @@ class Statistics:
 
     @staticmethod
     def kolmogorovSmirnovTest(
-        data: RDD[float], distName: "DistName" = "norm", *params: float
+        data: RDD[float], distName: "KolmogorovSmirnovTestDistNameType" = "norm", *params: float
     ) -> KolmogorovSmirnovTestResult:
         """
         Performs the Kolmogorov-Smirnov (KS) test for data sampled from


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR renames the following literal types:

- `CorrelationMethod` -> `CorrMethodType`
- `DistName`-> `KolmogorovSmirnovTestDistNameType`

in  `pyspark.mllib._typing`

### Why are the changes needed?

Consistency with existing codebase.

### Does this PR introduce _any_ user-facing change?

No, this feature hasn't been released yet.


### How was this patch tested?

Existing tests.