### PR TITLE
[SPARK-38807][CORE] Fix the startup error of spark shell on Windows S…

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.rpc
 
 import java.io.File
+import java.net.URI
 import java.nio.channels.ReadableByteChannel
 
 import scala.concurrent.Future
@@ -25,7 +26,8 @@ import scala.concurrent.Future
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.rpc.netty.NettyRpcEnvFactory
 import org.apache.spark.util.RpcUtils
-import org.apache.spark.util.Utils
+
+
 
 
 /**
@@ -188,10 +190,7 @@ private[spark] trait RpcEnvFileServer {
 
   /** Validates and normalizes the base URI for directories. */
   protected def validateDirectoryUri(baseUri: String): String = {
-    var baseCanonicalUri = new File(baseUri).getCanonicalPath
-    if(Utils.isWindows) {
-      baseCanonicalUri = baseCanonicalUri.replaceFirst("^[A-Z]:", "").replaceAll("\\\\", "/")
-    }
+    val baseCanonicalUri = new URI(baseUri).normalize().getPath.replaceFirst("^/[A-Z]:", "")
     val fixedBaseUri = "/" + baseCanonicalUri.stripPrefix("/").stripSuffix("/")
     require(fixedBaseUri != "/files" && fixedBaseUri != "/jars",
       "Directory URI cannot be /files nor /jars.")

--- a/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
@@ -190,7 +190,7 @@ private[spark] trait RpcEnvFileServer {
 
   /** Validates and normalizes the base URI for directories. */
   protected def validateDirectoryUri(baseUri: String): String = {
-    val baseCanonicalUri = new URI(baseUri).normalize().getPath.replaceFirst("^/[A-Z]:", "")
+    val baseCanonicalUri = new URI(baseUri).normalize().getPath
     val fixedBaseUri = "/" + baseCanonicalUri.stripPrefix("/").stripSuffix("/")
     require(fixedBaseUri != "/files" && fixedBaseUri != "/jars",
       "Directory URI cannot be /files nor /jars.")

--- a/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcEnv.scala
@@ -25,6 +25,7 @@ import scala.concurrent.Future
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.rpc.netty.NettyRpcEnvFactory
 import org.apache.spark.util.RpcUtils
+import org.apache.spark.util.Utils
 
 
 /**
@@ -187,7 +188,10 @@ private[spark] trait RpcEnvFileServer {
 
   /** Validates and normalizes the base URI for directories. */
   protected def validateDirectoryUri(baseUri: String): String = {
-    val baseCanonicalUri = new File(baseUri).getCanonicalPath
+    var baseCanonicalUri = new File(baseUri).getCanonicalPath
+    if(Utils.isWindows) {
+      baseCanonicalUri = baseCanonicalUri.replaceFirst("^[A-Z]:", "").replaceAll("\\\\", "/")
+    }
     val fixedBaseUri = "/" + baseCanonicalUri.stripPrefix("/").stripSuffix("/")
     require(fixedBaseUri != "/files" && fixedBaseUri != "/jars",
       "Directory URI cannot be /files nor /jars.")


### PR DESCRIPTION
What changes were proposed in this pull request?
The File.getCanonicalPath method will return the drive letter in the windows system. The RpcEnvFileServer.validateDirectoryUri method uses the File.getCanonicalPath method to process the baseuri, which will cause the baseuri not to comply with the URI verification rules. For example, the / classes is processed into F: \ classes.
This PR modified the RpcEnvFileServer.validateDirectoryUri method to increase the conversion to Windows system, so that baseUri conforms to the URI check rule.


Why are the changes needed?
Fix the startup error of spark shell on Windows system
[SPARK-35691]  introduced this regression.

Does this PR introduce any user-facing change?
No

How was this patch tested?
Manually tested in local,  Rpcenvsuite failed before modification, but it can succeed after modification
It can run on windows, and the basic functions are normal
