### PR TITLE
 [SPARK-38854][PYTHON][TEST] Improve the test coverage for pyspark/statcounter.py

### DIFF
--- a/python/pyspark/tests/test_statcounter.py
+++ b/python/pyspark/tests/test_statcounter.py
@@ -16,6 +16,7 @@
 #
 from pyspark.statcounter import StatCounter
 from pyspark.testing.utils import ReusedPySparkTestCase
+import math
 
 
 class StatCounterTests(ReusedPySparkTestCase):
@@ -92,7 +93,6 @@ class StatCounterTests(ReusedPySparkTestCase):
         # SPARK-38854: Test case to improve test coverage when
         # StatCounter argument is empty list or None
         arguments = [[], None]
-        import math
 
         for arg in arguments:
             stats = StatCounter(arg)

--- a/python/pyspark/tests/test_statcounter.py
+++ b/python/pyspark/tests/test_statcounter.py
@@ -76,10 +76,11 @@ class StatCounterTests(ReusedPySparkTestCase):
         self.assertEqual(stats.sum(), 20.0)
         self.assertAlmostEqual(stats.variance(), 1.25)
         self.assertAlmostEqual(stats.sampleVariance(), 1.4285714285714286)
-        for idx in range(2):
-            stats1 = StatCounter([1.0, 2.0])
-            stats2 = StatCounter(range(1, 301))
-            stats = stats1.mergeStats(stats2) if idx == 1 else stats2.mergeStats(stats1)
+        execution_statements = [
+            StatCounter([1.0, 2.0]).mergeStats(StatCounter(range(1, 301))),
+            StatCounter(range(1, 301)).mergeStats(StatCounter([1.0, 2.0])),
+        ]
+        for stats in execution_statements:
             self.assertEqual(stats.count(), 302)
             self.assertEqual(stats.max(), 300.0)
             self.assertEqual(stats.min(), 1.0)

--- a/python/pyspark/tests/test_statcounter.py
+++ b/python/pyspark/tests/test_statcounter.py
@@ -88,7 +88,7 @@ class StatCounterTests(ReusedPySparkTestCase):
             self.assertAlmostEqual(stats.sampleVariance(), 7621.539691095905)
 
     def test_variance_when_size_zero(self):
-        # SPARK-38854 : Test case to improve test coverage when
+        # SPARK-38854: Test case to improve test coverage when
         # StatCounter argument is empty list or None
         arguments = [[], None]
         import math

--- a/python/pyspark/tests/test_statcounter.py
+++ b/python/pyspark/tests/test_statcounter.py
@@ -76,6 +76,31 @@ class StatCounterTests(ReusedPySparkTestCase):
         self.assertEqual(stats.sum(), 20.0)
         self.assertAlmostEqual(stats.variance(), 1.25)
         self.assertAlmostEqual(stats.sampleVariance(), 1.4285714285714286)
+        for idx in range(2):
+            stats1 = StatCounter([1.0, 2.0])
+            stats2 = StatCounter(range(1, 301))
+            stats = stats1.mergeStats(stats2) if idx == 1 else stats2.mergeStats(stats1)
+            self.assertEqual(stats.count(), 302)
+            self.assertEqual(stats.max(), 300.0)
+            self.assertEqual(stats.min(), 1.0)
+            self.assertAlmostEqual(stats.mean(), 149.51324503311)
+            self.assertAlmostEqual(stats.variance(), 7596.302804701549)
+            self.assertAlmostEqual(stats.sampleVariance(), 7621.539691095905)
+
+    def test_variance_when_size_zero(self):
+        # SPARK-38854 : Test case to improve test coverage when
+        # StatCounter argument is empty list or None
+        arguments = [[], None]
+        import math
+
+        for arg in arguments:
+            stats = StatCounter(arg)
+            self.assertTrue(math.isnan(stats.variance()))
+            self.assertTrue(math.isnan(stats.sampleVariance()))
+            self.assertEqual(stats.count(), 0)
+            self.assertTrue(math.isinf(stats.max()))
+            self.assertTrue(math.isinf(stats.min()))
+            self.assertEqual(stats.mean(), 0.0)
 
     def test_merge_stats_with_self(self):
         stats = StatCounter([1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a test for the case to check merge_stats when 

- One StatCounter size largely greater than the other . 
- NA, None is passed to StatCounter  


### Why are the changes needed?
To cover corner test cases and increase coverage 


### Does this PR introduce _any_ user-facing change?
No - test only 

### How was this patch tested?
CI in this PR should test it out
