### PR TITLE
[SPARK-38730][SPARK-38731][SQL][TESTS] Move tests for error classes of grouping

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -197,15 +197,6 @@ class DataFrameAggregateSuite extends QueryTest
     intercept[AnalysisException] {
       courseSales.groupBy().agg(grouping_id("course")).explain()
     }
-
-    val groupingIdColMismatchEx = intercept[AnalysisException] {
-      courseSales.cube("course", "year").agg(grouping_id("earnings")).explain()
-    }
-    assert(groupingIdColMismatchEx.getErrorClass == "GROUPING_ID_COLUMN_MISMATCH")
-    assert(groupingIdColMismatchEx.getMessage.matches(
-      "Columns of grouping_id \\(earnings.*\\) does not match " +
-        "grouping columns \\(course.*,year.*\\)"),
-      groupingIdColMismatchEx.getMessage)
   }
 
   test("grouping/grouping_id inside window function") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -198,14 +198,6 @@ class DataFrameAggregateSuite extends QueryTest
       courseSales.groupBy().agg(grouping_id("course")).explain()
     }
 
-    val groupingColMismatchEx = intercept[AnalysisException] {
-      courseSales.cube("course", "year").agg(grouping("earnings")).explain()
-    }
-    assert(groupingColMismatchEx.getErrorClass == "GROUPING_COLUMN_MISMATCH")
-    assert(groupingColMismatchEx.getMessage.matches(
-      "Column of grouping \\(earnings.*\\) can't be found in grouping columns course.*,year.*"))
-
-
     val groupingIdColMismatchEx = intercept[AnalysisException] {
       courseSales.cube("course", "year").agg(grouping_id("earnings")).explain()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -3417,20 +3417,10 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
       withSQLConf(SQLConf.LEGACY_INTEGER_GROUPING_ID.key -> "true") {
         testGroupingIDs(32, Seq(0, 1))
-        val ex = intercept[AnalysisException] {
-          testGroupingIDs(33)
-        }
-        assert(ex.getMessage.contains("Grouping sets size cannot be greater than 32"))
-        assert(ex.getErrorClass == "GROUPING_SIZE_LIMIT_EXCEEDED")
       }
 
       withSQLConf(SQLConf.LEGACY_INTEGER_GROUPING_ID.key -> "false") {
         testGroupingIDs(64, Seq(0L, 1L))
-        val ex = intercept[AnalysisException] {
-          testGroupingIDs(65)
-        }
-        assert(ex.getMessage.contains("Grouping sets size cannot be greater than 64"))
-        assert(ex.getErrorClass == "GROUPING_SIZE_LIMIT_EXCEEDED")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -254,6 +254,16 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     assert(e.getSqlState === "0A000")
     assert(e.message === "The feature is not supported: UDF class with 24 type arguments")
   }
+
+  test("GROUPING_COLUMN_MISMATCH: not found the grouping column") {
+    val groupingColMismatchEx = intercept[AnalysisException] {
+      courseSales.cube("course", "year").agg(grouping("earnings")).explain()
+    }
+    assert(groupingColMismatchEx.getErrorClass === "GROUPING_COLUMN_MISMATCH")
+    assert(groupingColMismatchEx.getSqlState === "42000")
+    assert(groupingColMismatchEx.getMessage.matches(
+      "Column of grouping \\(earnings.*\\) can't be found in grouping columns course.*,year.*"))
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -264,6 +264,18 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     assert(groupingColMismatchEx.getMessage.matches(
       "Column of grouping \\(earnings.*\\) can't be found in grouping columns course.*,year.*"))
   }
+
+  test("GROUPING_ID_COLUMN_MISMATCH: columns of grouping_id does not match") {
+    val groupingIdColMismatchEx = intercept[AnalysisException] {
+      courseSales.cube("course", "year").agg(grouping_id("earnings")).explain()
+    }
+    assert(groupingIdColMismatchEx.getErrorClass === "GROUPING_ID_COLUMN_MISMATCH")
+    assert(groupingIdColMismatchEx.getSqlState === "42000")
+    assert(groupingIdColMismatchEx.getMessage.matches(
+      "Columns of grouping_id \\(earnings.*\\) does not match " +
+        "grouping columns \\(course.*,year.*\\)"),
+      groupingIdColMismatchEx.getMessage)
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to get together all tests for error classes related to grouping and move them to `QueryCompilationErrorsSuite`.

### Why are the changes needed?
To improve code maintenance - all tests for error classes are placed to Query.*ErrorsSuite. Also exception are raised from `QueryCompilationErrors`, so, tests should be in `QueryCompilationErrorsSuite` for consistency.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By the affected test suites:
```
$ build/sbt "test:testOnly *SQLQuerySuite"
$ build/sbt "test:testOnly *DataFrameAggregateSuite"
$ build/sbt "test:testOnly *QueryCompilationErrorsSuite"
```