### PR TITLE
[SPARK-38880][PYTHON] Implement `numeric_only` parameter of `GroupBy.max/min`

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2652,7 +2652,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             for psser in self._agg_columns
             if (
                 isinstance(psser.spark.data_type, NumericType)
-                or (isinstance(psser.spark.data_type, BooleanType) and bool_as_numeric)
+                or (bool_as_numeric and isinstance(psser.spark.data_type, BooleanType))
                 or not only_numeric
             )
         ]

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -55,6 +55,7 @@ else:
 
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.types import (
+    BooleanType,
     NumericType,
     StructField,
     StructType,
@@ -426,16 +427,24 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             lambda col: F.last(col, ignorenulls=True), only_numeric=False
         )
 
-    def max(self) -> FrameLike:
+    def max(self, numeric_only: Optional[bool] = False) -> FrameLike:
         """
         Compute max of group values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default False
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data.
 
         See Also
         --------
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
-        return self._reduce_for_stat_function(F.max, only_numeric=False)
+        return self._reduce_for_stat_function(
+            F.max, only_numeric=numeric_only, bool_as_numeric=True
+        )
 
     # TODO: examples should be updated.
     def mean(self) -> FrameLike:
@@ -469,16 +478,24 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         return self._reduce_for_stat_function(F.mean, only_numeric=True)
 
-    def min(self) -> FrameLike:
+    def min(self, numeric_only: Optional[bool] = False) -> FrameLike:
         """
         Compute min of group values.
+
+        Parameters
+        ----------
+        numeric_only : bool, default False
+            Include only float, int, boolean columns. If None, will attempt to use
+            everything, then use only numeric data.
 
         See Also
         --------
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
-        return self._reduce_for_stat_function(F.min, only_numeric=False)
+        return self._reduce_for_stat_function(
+            F.min, only_numeric=numeric_only, bool_as_numeric=True
+        )
 
     # TODO: sync the doc.
     def std(self, ddof: int = 1) -> FrameLike:
@@ -2573,15 +2590,30 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         return self._reduce_for_stat_function(stat_function, only_numeric=numeric_only)
 
     def _reduce_for_stat_function(
-        self, sfun: Callable[[Column], Column], only_numeric: bool
+        self,
+        sfun: Callable[[Column], Column],
+        only_numeric: Optional[bool] = None,
+        bool_as_numeric: bool = False,
     ) -> FrameLike:
+        """Apply an aggregate function `sfun` per column and reduce to a FrameLike.
+
+        Parameters
+        ----------
+        sfun : The aggregate function to apply per column
+        only_numeric: If True, only numeric columns are involved
+        bool_as_numeric: If True, boolean columns are seen as numeric columns (following pandas)
+        """
         groupkey_names = [SPARK_INDEX_NAME_FORMAT(i) for i in range(len(self._groupkeys))]
         groupkey_scols = [s.alias(name) for s, name in zip(self._groupkeys_scols, groupkey_names)]
 
         agg_columns = [
             psser
             for psser in self._agg_columns
-            if isinstance(psser.spark.data_type, NumericType) or not only_numeric
+            if (
+                isinstance(psser.spark.data_type, NumericType)
+                or (isinstance(psser.spark.data_type, BooleanType) and bool_as_numeric)
+                or not only_numeric
+            )
         ]
 
         sdf = self._psdf._internal.spark_frame.select(

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -437,6 +437,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data.
 
+            .. versionadded:: 3.4.0
+
         See Also
         --------
         pyspark.pandas.Series.groupby
@@ -506,6 +508,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         numeric_only : bool, default False
             Include only float, int, boolean columns. If None, will attempt to use
             everything, then use only numeric data.
+
+            .. versionadded:: 3.4.0
 
         See Also
         --------

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -441,6 +441,25 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         --------
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
+
+        Examples
+        --------
+        >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
+        ...                    "C": [3, 4, 3, 4], "D": ["a", "b", "b", "a"]})
+
+        >>> df.groupby("A").max().sort_index()
+              B  C  D
+        A
+        1  True  3  b
+        2  True  4  b
+
+        Include only float, int, boolean columns when set numeric_only True.
+
+        >>> df.groupby("A").max(numeric_only=True).sort_index()
+              B  C
+        A
+        1  True  3
+        2  True  4
         """
         return self._reduce_for_stat_function(
             F.max, only_numeric=numeric_only, bool_as_numeric=True
@@ -492,6 +511,24 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         --------
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
+
+        Examples
+        --------
+        >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
+        ...                    "C": [3, 4, 3, 4], "D": ["a", "b", "b", "a"]})
+        >>> df.groupby("A").min().sort_index()
+               B  C  D
+        A
+        1  False  3  a
+        2  False  4  a
+
+        Include only float, int, boolean columns when set numeric_only True.
+
+        >>> df.groupby("A").min(numeric_only=True).sort_index()
+               B  C
+        A
+        1  False  3
+        2  False  4
         """
         return self._reduce_for_stat_function(
             F.min, only_numeric=numeric_only, bool_as_numeric=True

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1242,6 +1242,54 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             pdf.groupby([("x", "a"), ("x", "b")]).rank().sort_index(),
         )
 
+    def test_min(self):
+        pdf = pd.DataFrame(
+            {
+                "A": [1, 2, 1, 2],
+                "B": [3, 4, 4, 3],
+                "C": ["a", "b", "b", "a"],
+                "D": [True, False, False, True],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        for p_groupby_obj, ps_groupby_obj in [
+            (pdf.groupby("A"), psdf.groupby("A")),
+            (pdf.groupby("A")[["C"]], psdf.groupby("A")[["C"]]),
+        ]:
+            self.assert_eq(p_groupby_obj.min().sort_index(), ps_groupby_obj.min().sort_index())
+            self.assert_eq(
+                p_groupby_obj.min(numeric_only=None).sort_index(),
+                ps_groupby_obj.min(numeric_only=None).sort_index(),
+            )
+            self.assert_eq(
+                p_groupby_obj.min(numeric_only=True).sort_index(),
+                ps_groupby_obj.min(numeric_only=True).sort_index(),
+            )
+
+    def test_max(self):
+        pdf = pd.DataFrame(
+            {
+                "A": [1, 2, 1, 2],
+                "B": [3, 4, 4, 3],
+                "C": ["a", "b", "b", "a"],
+                "D": [True, False, False, True],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        for p_groupby_obj, ps_groupby_obj in [
+            (pdf.groupby("A"), psdf.groupby("A")),
+            (pdf.groupby("A")[["C"]], psdf.groupby("A")[["C"]]),
+        ]:
+            self.assert_eq(p_groupby_obj.max().sort_index(), ps_groupby_obj.max().sort_index())
+            self.assert_eq(
+                p_groupby_obj.max(numeric_only=None).sort_index(),
+                ps_groupby_obj.max(numeric_only=None).sort_index(),
+            )
+            self.assert_eq(
+                p_groupby_obj.max(numeric_only=True).sort_index(),
+                ps_groupby_obj.max(numeric_only=True).sort_index(),
+            )
+
     def test_cumcount(self):
         pdf = pd.DataFrame(
             {

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1246,7 +1246,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         pdf = pd.DataFrame(
             {
                 "A": [1, 2, 1, 2],
-                "B": [3, 4, 4, 3],
+                "B": [3.1, 4.1, 4.1, 3.1],
                 "C": ["a", "b", "b", "a"],
                 "D": [True, False, False, True],
             }
@@ -1270,7 +1270,7 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         pdf = pd.DataFrame(
             {
                 "A": [1, 2, 1, 2],
-                "B": [3, 4, 4, 3],
+                "B": [3.1, 4.1, 4.1, 3.1],
                 "C": ["a", "b", "b", "a"],
                 "D": [True, False, False, True],
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `numeric_only` parameter of `GroupBy.max/min` to include only float, int, boolean columns.

### Why are the changes needed?
To reach parity with pandas API.


### Does this PR introduce _any_ user-facing change?
Yes. `numeric_only` parameter is supported in `GroupBy.max/min`.
```py
        >>> df = ps.DataFrame({"A": [1, 2, 1, 2], "B": [True, False, False, True],
        ...                    "C": [3, 4, 3, 4], "D": ["a", "b", "b", "a"]})

        >>> df.groupby("A").min(numeric_only=True).sort_index()
               B  C
        A          
        1  False  3
        2  False  4
        
        >>> df.groupby("A").max(numeric_only=True).sort_index()
              B  C
        A         
        1  True  3
        2  True  4

```

### How was this patch tested?
Unit tests.