### PR TITLE
[SPARK-38870][SQL][PYSPARK] Make SparkSession.builder return new builder

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -104,8 +104,14 @@ def _monkey_patch_RDD(sparkSession: "SparkSession") -> None:
     RDD.toDF = toDF  # type: ignore[assignment]
 
 
+# TODO(SPARK-38912): This method can be dropped once support for Python 3.8 is dropped
+# In Python 3.9, the @property decorator has been made compatible with the @classmethod decorator.
+# https://docs.python.org/3.9/library/functions.html#classmethod
+#
+# @classmethod + @property is also affected by a bug in Python's docstring which was backported
+# to Python 3.9.6 (https://github.com/python/cpython/pull/28838)
 class classproperty(property):
-    """Same as Python's @property annotation, but for class attributes.
+    """Same as Python's @property decorator, but for class attributes.
 
     Example:
 
@@ -129,6 +135,7 @@ class classproperty(property):
     >>> isinstance(c1.build(), MyClass)
     True
     """
+
     def __get__(self, cls, owner):
         return classmethod(self.fget).__get__(None, owner)()
 
@@ -312,6 +319,14 @@ class SparkSession(SparkConversionMixin):
                     ).applyModifiableSettings(session._jsparkSession, self._options)
                 return session
 
+    # TODO(SPARK-38912): Replace @classproperty with @classmethod + @property once support for
+    # Python 3.8 is dropped.
+    #
+    # In Python 3.9, the @property decorator has been made compatible with the @classmethod decorator.
+    # https://docs.python.org/3.9/library/functions.html#classmethod
+    #
+    # @classmethod + @property is also affected by a bug in Python's docstring which was backported
+    # to Python 3.9.6 (https://github.com/python/cpython/pull/28838)
     @classproperty
     def builder(cls):
         """A class attribute having a :class:`Builder` to construct :class:`SparkSession` instances."""

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -136,8 +136,12 @@ class classproperty(property):
     True
     """
 
-    def __get__(self, cls, owner):
-        return classmethod(self.fget).__get__(None, owner)()
+    def __get__(self, instance: Any, owner: Any = None) -> "SparkSession.Builder":
+        # The "type: ignore" below silences the following error from mypy:
+        # error: Argument 1 to "classmethod" has incompatible
+        # type "Optional[Callable[[Any], Any]]";
+        # expected "Callable[..., Any]"  [arg-type]
+        return classmethod(self.fget).__get__(None, owner)()  # type: ignore
 
 
 class SparkSession(SparkConversionMixin):
@@ -179,7 +183,7 @@ class SparkSession(SparkConversionMixin):
 
         _lock = RLock()
 
-        def __init__(self):
+        def __init__(self) -> None:
             self._options: Dict[str, Any] = {}
 
         @overload
@@ -328,7 +332,7 @@ class SparkSession(SparkConversionMixin):
     # @classmethod + @property is also affected by a bug in Python's docstring which was backported
     # to Python 3.9.6 (https://github.com/python/cpython/pull/28838)
     @classproperty
-    def builder(cls):
+    def builder(cls) -> Builder:
         """Creates a :class:`Builder` for constructing a :class:`SparkSession`."""
         return cls.Builder()
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -105,8 +105,8 @@ def _monkey_patch_RDD(sparkSession: "SparkSession") -> None:
 
 
 # TODO(SPARK-38912): This method can be dropped once support for Python 3.8 is dropped
-# In Python 3.9, the @property decorator has been made compatible with the @classmethod decorator.
-# https://docs.python.org/3.9/library/functions.html#classmethod
+# In Python 3.9, the @property decorator has been made compatible with the
+# @classmethod decorator (https://docs.python.org/3.9/library/functions.html#classmethod)
 #
 # @classmethod + @property is also affected by a bug in Python's docstring which was backported
 # to Python 3.9.6 (https://github.com/python/cpython/pull/28838)
@@ -322,14 +322,14 @@ class SparkSession(SparkConversionMixin):
     # TODO(SPARK-38912): Replace @classproperty with @classmethod + @property once support for
     # Python 3.8 is dropped.
     #
-    # In Python 3.9, the @property decorator has been made compatible with the @classmethod decorator.
-    # https://docs.python.org/3.9/library/functions.html#classmethod
+    # In Python 3.9, the @property decorator has been made compatible with the
+    # @classmethod decorator (https://docs.python.org/3.9/library/functions.html#classmethod)
     #
     # @classmethod + @property is also affected by a bug in Python's docstring which was backported
     # to Python 3.9.6 (https://github.com/python/cpython/pull/28838)
     @classproperty
     def builder(cls):
-        """A class attribute having a :class:`Builder` to construct :class:`SparkSession` instances."""
+        """Creates a :class:`Builder` for constructing a :class:`SparkSession`."""
         return cls.Builder()
 
     _instantiatedSession: ClassVar[Optional["SparkSession"]] = None


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Scala, SparkSession.builder returns a new builder each time,
but in Python, it returns the same builder every time, with the
same static options.

Because of this, whenever SparkSession.builder.getOrCreate() is called,
the options set in the very first builder are reapplied.

To fix this, I introduce a @classproperty decorator, that is similar
to the @property decorator, except that it works with class methods.
Now, whenever `SparkSession.builder` is called, a new builder is
returned as expected.

I also made the parameter `Builder._options` non-static, and I removed
`Builder._sc` which didn't seem used anymore.

`Builder._sc` was introduced in this commit:
58419b92673c46911c25bc6c6b13397f880c6424

And it's only use seems to have been removed by this commit:
88696ebcb72fd3057b1546831f653b29b7e0abb2

## How was this patch tested?

I updated the Doctests for SparkSession.Builder.getOrCreate and added
Doctests on the classproperty decorator as well.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
