### PR TITLE
[WIP] Update to_number and try_to_number functions to restrict MI sequence to start or end only

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
@@ -244,9 +244,11 @@ class ToNumberParser(numberFormat: String, errorOnFail: Boolean) extends Seriali
     def multipleSignInNumberFormatError(message: String) = {
       s"At most one $message is allowed in the number format: '$numberFormat'"
     }
-
     def notAtEndOfNumberFormatError(message: String) = {
       s"$message must be at the end of the number format: '$numberFormat'"
+    }
+    def notAtBeginningOrEndOfNumberFormatError(message: String) = {
+      s"$message must be at the beginning or end of the number format: '$numberFormat'"
     }
 
     val inputTokenCounts = formatTokens.groupBy(identity).mapValues(_.size)
@@ -309,6 +311,12 @@ class ToNumberParser(numberFormat: String, errorOnFail: Boolean) extends Seriali
     // Make sure the format string contains at most one "MI" sequence.
     else if (inputTokenCounts.getOrElse(OptionalMinusSign(), 0) > 1) {
       multipleSignInNumberFormatError(s"'$OPTIONAL_MINUS_STRING'")
+    }
+    // Make sure that any "MI" sequence is at the start or end of the format string only.
+    else if (inputTokenCounts.getOrElse(OptionalMinusSign(), 0) == 1 &&
+      formatTokens.head != OptionalMinusSign() &&
+      formatTokens.last != OptionalMinusSign()) {
+      notAtBeginningOrEndOfNumberFormatError(s"'$OPTIONAL_MINUS_STRING'")
     }
     // Make sure the format string contains at most one closing angle bracket at the end.
     else if (inputTokenCounts.getOrElse(ClosingAngleBracket(), 0) > 1 ||

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
@@ -244,6 +244,7 @@ class ToNumberParser(numberFormat: String, errorOnFail: Boolean) extends Seriali
     def multipleSignInNumberFormatError(message: String) = {
       s"At most one $message is allowed in the number format: '$numberFormat'"
     }
+
     def notAtEndOfNumberFormatError(message: String) = {
       s"$message must be at the end of the number format: '$numberFormat'"
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -917,7 +917,6 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       ("<454>", "999PR") -> Decimal(-454),
       ("454-", "999MI") -> Decimal(-454),
       ("-$54", "MI$99") -> Decimal(-54),
-      ("$4-4", "$9MI9") -> Decimal(-44),
       // The input string contains more digits than fit in a long integer.
       ("123,456,789,123,456,789,123", "999,999,999,999,999,999,999") ->
         Decimal(new JavaBigDecimal("123456789123456789123"))
@@ -972,7 +971,8 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       ("454", "99.99.99") -> atMostOne,
       // Make sure the format string contains at most one dollar sign.
       ("454", "$$99") -> atMostOne,
-      // Make sure the format string contains at most one minus sign at the end.
+      // Make sure the format string contains at most one minus sign at the beginning or end.
+      ("$4-4", "$9MI9") -> "must be at the beginning or end of the number format",
       ("--$54", "SS$99") -> atMostOne,
       ("-$54", "MI$99MI") -> atMostOne,
       ("$4-4", "$9MI9MI") -> atMostOne,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `to_number` and `try_to_number` functions to restrict MI sequence to start or end only.

### Why are the changes needed?

After reviewing the specification, this behavior makes the most sense.

### Does this PR introduce _any_ user-facing change?

Yes, a slight change in the behavior of the format string.

### How was this patch tested?

Existing and updated unit test coverage.