### PR TITLE
[SPARK-38804][PYTHON][SS][DOCS][FOLLOW-UP] Document StreamingQueryManager.removeListener

### DIFF
--- a/python/docs/source/reference/pyspark.ss.rst
+++ b/python/docs/source/reference/pyspark.ss.rst
@@ -87,4 +87,5 @@ Query Management
     StreamingQueryManager.addListener
     StreamingQueryManager.awaitAnyTermination
     StreamingQueryManager.get
+    StreamingQueryManager.removeListener
     StreamingQueryManager.resetTerminated


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/36086 which mistakenly did not document the feature added.

### Why are the changes needed?

To show the supported features to the end users.

### Does this PR introduce _any_ user-facing change?

Yes, it shows the documentation of `StreamingQueryManager.removeListener` to the end users.

### How was this patch tested?

Manually build the documentation and checked.