### PR TITLE
[SPARK-34659][UI] Fix wrong application ID when reverse proxy URL contains "proxy" or "history"

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -96,19 +96,24 @@ function formatLogsCells(execLogs, type) {
 }
 
 function getStandAloneAppId(cb) {
-  var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
-  var appId;
-  if (ind > 0) {
-    appId = words[ind + 1];
-    cb(appId);
-    return;
-  }
-  ind = words.indexOf("history");
-  if (ind > 0) {
-    appId = words[ind + 1];
-    cb(appId);
-    return;
+  let proxyWords = reverseProxyURL.split('/');
+  // If the configured proxy base URL doesn't contain "proxy" or "history", we can get the APP id
+  // from the current base URI.
+  if (proxyWords.indexOf("proxy") < 0 && proxyWords.indexOf("history") < 0) {
+    var words = getBaseURI().split('/');
+    var ind = words.indexOf("proxy");
+    var appId;
+    if (ind > 0) {
+      appId = words[ind + 1];
+      cb(appId);
+      return;
+    }
+    ind = words.indexOf("history");
+    if (ind > 0) {
+      appId = words[ind + 1];
+      cb(appId);
+      return;
+    }
   }
   // Looks like Web UI is running in standalone mode
   // Let's get application-id using REST End Point
@@ -149,13 +154,7 @@ function ConvertDurationString(data) {
 
 function createTemplateURI(appId, templateName) {
   var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
-  var baseURI;
-  if (ind > 0) {
-    baseURI = words.slice(0, ind + 1).join('/') + '/' + appId + '/static/' + templateName + '-template.html';
-    return baseURI;
-  }
-  ind = words.indexOf("history");
+  ind = words.lastIndexOf("history");
   if(ind > 0) {
     baseURI = words.slice(0, ind).join('/') + '/static/' + templateName + '-template.html';
     return baseURI;
@@ -184,14 +183,7 @@ function formatDate(date) {
 
 function createRESTEndPointForExecutorsPage(appId) {
   var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
-  var newBaseURI;
-  if (ind > 0) {
-    appId = words[ind + 1];
-    newBaseURI = words.slice(0, ind + 2).join('/');
-    return newBaseURI + "/api/v1/applications/" + appId + "/allexecutors";
-  }
-  ind = words.indexOf("history");
+  ind = words.lastIndexOf("history");
   if (ind > 0) {
     appId = words[ind + 1];
     var attemptId = words[ind + 2];

--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -19,6 +19,7 @@
 /* eslint-disable no-unused-vars */
 var uiRoot = "";
 var appBasePath = "";
+var reverseProxyURL = "";
 
 function setUIRoot(val) {
   uiRoot = val;
@@ -27,6 +28,11 @@ function setUIRoot(val) {
 function setAppBasePath(path) {
   appBasePath = path;
 }
+
+function setReverseProxyURL(base) {
+  reverseProxyURL = base;
+}
+
 /* eslint-enable no-unused-vars */
 
 function collapseTablePageLoad(name, table){

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -592,9 +592,10 @@ class SparkContext(config: SparkConf) extends Logging {
       _env.blockManager.blockStoreClient.setAppAttemptId(attemptId)
     }
     if (_conf.get(UI_REVERSE_PROXY)) {
-      val proxyUrl = _conf.get(UI_REVERSE_PROXY_URL.key, "").stripSuffix("/") +
-        "/proxy/" + _applicationId
+      val reverseProxyURL = _conf.get(UI_REVERSE_PROXY_URL.key, "").stripSuffix("/")
+      val proxyUrl = reverseProxyURL + "/proxy/" + _applicationId
       System.setProperty("spark.ui.proxyBase", proxyUrl)
+      System.setProperty("spark.ui.reverseProxyURL", reverseProxyURL)
     }
     _ui.foreach(_.setAppId(_applicationId))
     _env.blockManager.initialize(_applicationId)

--- a/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/UIUtils.scala
@@ -240,6 +240,7 @@ private[spark] object UIUtils extends Logging {
     <script src={prependBaseUri(request, "/static/log-view.js")}></script>
     <script src={prependBaseUri(request, "/static/webui.js")}></script>
     <script>setUIRoot('{UIUtils.uiRoot(request)}')</script>
+    <script>setReverseProxyURL('{sys.props.getOrElse("spark.ui.reverseProxyURL", "")}')</script>
   }
 
   def vizHeaderNodes(request: HttpServletRequest): Seq[Node] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->
This PR is to show how tricky it is to allow keywords "proxy" or "history" in reverse proxy URL. I suggest to forbid the keywords instead of support it. See PR https://github.com/apache/spark/pull/36176
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When the reverse proxy URL contains "proxy" or "history", the application ID in UI is wrongly parsed.
For example, if we set `spark.ui.reverseProxyURL` as "/test/proxy/prefix" or "/test/history/prefix", the application ID is parsed as "prefix" and the related API calls will fail in stages/executors pages.



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
