### PR TITLE
[SPARK-38745][SQL][TESTS] Move the tests for `NON_PARTITION_COLUMN` to `QueryCompilationErrorsDSv2Suite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/InsertIntoTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/InsertIntoTests.scala
@@ -198,7 +198,7 @@ trait InsertIntoSQLOnlyTests
   /** Whether to include the SQL specific tests in this trait within the extending test suite. */
   protected val includeSQLOnlyTests: Boolean
 
-  private def withTableAndData(tableName: String)(testFn: String => Unit): Unit = {
+  protected def withTableAndData(tableName: String)(testFn: String => Unit): Unit = {
     withTable(tableName) {
       val viewName = "tmp_view"
       val df = spark.createDataFrame(Seq((1L, "a"), (2L, "b"), (3L, "c"))).toDF("id", "data")
@@ -245,40 +245,6 @@ trait InsertIntoSQLOnlyTests
         sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (id)")
         sql(s"INSERT INTO $t1 PARTITION (id = 23) SELECT data FROM $view")
         verifyTable(t1, sql(s"SELECT 23, data FROM $view"))
-      }
-    }
-
-    test("InsertInto: static PARTITION clause fails with non-partition column") {
-      val t1 = s"${catalogAndNamespace}tbl"
-      withTableAndData(t1) { view =>
-        sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (data)")
-
-        val exc = intercept[AnalysisException] {
-          sql(s"INSERT INTO TABLE $t1 PARTITION (id=1) SELECT data FROM $view")
-        }
-
-        verifyTable(t1, spark.emptyDataFrame)
-        assert(exc.getMessage.contains(
-          "PARTITION clause cannot contain a non-partition column name"))
-        assert(exc.getMessage.contains("id"))
-        assert(exc.getErrorClass == "NON_PARTITION_COLUMN")
-      }
-    }
-
-    test("InsertInto: dynamic PARTITION clause fails with non-partition column") {
-      val t1 = s"${catalogAndNamespace}tbl"
-      withTableAndData(t1) { view =>
-        sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (id)")
-
-        val exc = intercept[AnalysisException] {
-          sql(s"INSERT INTO TABLE $t1 PARTITION (data) SELECT * FROM $view")
-        }
-
-        verifyTable(t1, spark.emptyDataFrame)
-        assert(exc.getMessage.contains(
-          "PARTITION clause cannot contain a non-partition column name"))
-        assert(exc.getMessage.contains("data"))
-        assert(exc.getErrorClass == "NON_PARTITION_COLUMN")
       }
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsDSv2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsDSv2Suite.scala
@@ -64,13 +64,13 @@ class QueryCompilationErrorsDSv2Suite
     withTableAndData(t1) { view =>
       sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (data)")
 
-      val exc = intercept[AnalysisException] {
+      val e = intercept[AnalysisException] {
         sql(s"INSERT INTO TABLE $t1 PARTITION (id=1) SELECT data FROM $view")
       }
 
       verifyTable(t1, spark.emptyDataFrame)
-      assert(exc.getMessage === "PARTITION clause cannot contain a non-partition column name: id")
-      assert(exc.getErrorClass == "NON_PARTITION_COLUMN")
+      assert(e.getMessage === "PARTITION clause cannot contain a non-partition column name: id")
+      assert(e.getErrorClass === "NON_PARTITION_COLUMN")
     }
   }
 
@@ -79,13 +79,13 @@ class QueryCompilationErrorsDSv2Suite
     withTableAndData(t1) { view =>
       sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (id)")
 
-      val exc = intercept[AnalysisException] {
+      val e = intercept[AnalysisException] {
         sql(s"INSERT INTO TABLE $t1 PARTITION (data) SELECT * FROM $view")
       }
 
       verifyTable(t1, spark.emptyDataFrame)
-      assert(exc.getMessage === "PARTITION clause cannot contain a non-partition column name: data")
-      assert(exc.getErrorClass == "NON_PARTITION_COLUMN")
+      assert(e.getMessage === "PARTITION clause cannot contain a non-partition column name: data")
+      assert(e.getErrorClass === "NON_PARTITION_COLUMN")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsDSv2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsDSv2Suite.scala
@@ -17,18 +17,27 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.connector.{DatasourceV2SQLBase, FakeV2Provider}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest}
+import org.apache.spark.sql.connector.{DatasourceV2SQLBase, FakeV2Provider, InsertIntoSQLOnlyTests}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class QueryCompilationErrorsDSv2Suite
   extends QueryTest
   with SharedSparkSession
-  with DatasourceV2SQLBase {
+  with DatasourceV2SQLBase
+  with InsertIntoSQLOnlyTests {
+
+  private val v2Source = classOf[FakeV2Provider].getName
+  override protected val v2Format = v2Source
+  override protected val catalogAndNamespace = "testcat.ns1.ns2."
+  override protected val supportsDynamicOverwrite: Boolean = false
+  override protected val includeSQLOnlyTests: Boolean = false
+  override def verifyTable(tableName: String, expected: DataFrame): Unit = {
+    checkAnswer(spark.table(tableName), expected)
+  }
 
   test("UNSUPPORTED_FEATURE: IF PARTITION NOT EXISTS not supported by INSERT") {
-    val v2Format = classOf[FakeV2Provider].getName
-    val tbl = "testcat.ns1.ns2.tbl"
+    val tbl = s"${catalogAndNamespace}tbl"
 
     withTable(tbl) {
       val view = "tmp_view"
@@ -47,6 +56,36 @@ class QueryCompilationErrorsDSv2Suite
         assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
         assert(e.getSqlState === "0A000")
       }
+    }
+  }
+
+  test("NON_PARTITION_COLUMN: static PARTITION clause fails with non-partition column") {
+    val t1 = s"${catalogAndNamespace}tbl"
+    withTableAndData(t1) { view =>
+      sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (data)")
+
+      val exc = intercept[AnalysisException] {
+        sql(s"INSERT INTO TABLE $t1 PARTITION (id=1) SELECT data FROM $view")
+      }
+
+      verifyTable(t1, spark.emptyDataFrame)
+      assert(exc.getMessage === "PARTITION clause cannot contain a non-partition column name: id")
+      assert(exc.getErrorClass == "NON_PARTITION_COLUMN")
+    }
+  }
+
+  test("NON_PARTITION_COLUMN: dynamic PARTITION clause fails with non-partition column") {
+    val t1 = s"${catalogAndNamespace}tbl"
+    withTableAndData(t1) { view =>
+      sql(s"CREATE TABLE $t1 (id bigint, data string) USING $v2Format PARTITIONED BY (id)")
+
+      val exc = intercept[AnalysisException] {
+        sql(s"INSERT INTO TABLE $t1 PARTITION (data) SELECT * FROM $view")
+      }
+
+      verifyTable(t1, spark.emptyDataFrame)
+      assert(exc.getMessage === "PARTITION clause cannot contain a non-partition column name: data")
+      assert(exc.getErrorClass == "NON_PARTITION_COLUMN")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move test for the error class `NON_PARTITION_COLUMN` from `InsertIntoSQLOnlyTests` to `QueryCompilationErrorsDSv2Suite`.

### Why are the changes needed?
To improve code maintenance - all tests for error classes are placed to Query.*ErrorsSuite. Also exception are raised from [QueryCompilationErrors](https://github.com/apache/spark/blob/bf75b495e18ed87d0c118bfd5f1ceb52d720cad9/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala#L100-L104), so, tests should be in `QueryCompilationErrorsDSv2Suite` for consistency.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the moved tests:
```
$ build/sbt "test:testOnly *QueryCompilationErrorsDSv2Suite"
```