### PR TITLE
[SPARK-38867][SQL] Avoid OOM when bufferedPlan has a lot of duplicate keys in SortMergeJoin codegen 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2490,6 +2490,15 @@ object SQLConf {
       .intConf
       .createWithDefault(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD.defaultValue.get)
 
+  val SORT_MERGE_JOIN_EXEC_MAX_RECORD_PER_CYCLE =
+    buildConf("spark.sql.sortMergeJoinExec.codegen.maxRecordPerCycle")
+      .internal()
+      .doc("Every time so many records are output, check whether SortMergeJoin " +
+        "should be stopped, and then trigger parent to consume to avoid OOM.")
+      .version("3.4.0")
+      .intConf
+      .createWithDefault(1000)
+
   val CARTESIAN_PRODUCT_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.cartesianProductExec.buffer.in.memory.threshold")
       .internal()
@@ -4301,6 +4310,9 @@ class SQLConf extends Serializable with Logging {
 
   def sortMergeJoinExecBufferSpillThreshold: Int =
     getConf(SORT_MERGE_JOIN_EXEC_BUFFER_SPILL_THRESHOLD)
+
+  def sortMergeJoinExecMaxRecordPerCycle: Int =
+    getConf(SORT_MERGE_JOIN_EXEC_MAX_RECORD_PER_CYCLE)
 
   def cartesianProductExecBufferInMemoryThreshold: Int =
     getConf(CARTESIAN_PRODUCT_EXEC_BUFFER_IN_MEMORY_THRESHOLD)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -872,9 +872,7 @@ case class SortMergeJoinExec(
        |    InternalRow $bufferedRow = (InternalRow) $matchIterator.next();
        |    $conditionCheck
        |    $outputRow
-       |    if (++outputCount % $maxRecordPerCycle == 0 && shouldStop()) {
-       |      return
-       |    }
+       |    if (++outputCount % $maxRecordPerCycle == 0 && shouldStop()) return;
        |  }
        |  if (shouldStop()) return;
        |}
@@ -912,9 +910,7 @@ case class SortMergeJoinExec(
        |    $conditionCheck
        |    $hasOutputRow = true;
        |    $outputRow
-       |    if (++outputCount % $maxRecordPerCycle == 0 && shouldStop()) {
-       |      return
-       |    }
+       |    if (++outputCount % $maxRecordPerCycle == 0 && shouldStop()) return;
        |  }
        |  if (shouldStop()) return;
        |}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/SortMergeJoinExec.scala
@@ -689,7 +689,7 @@ case class SortMergeJoinExec(
                |    return false;
                |  }
                |  public UnsafeRow next() {
-               |    throw java.util.NoSuchElementException("next on empty iterator");
+               |    throw new java.util.NoSuchElementException("next on empty iterator");
                |  }
                |};
                |""".stripMargin,


### PR DESCRIPTION
### What changes were proposed in this pull request?
WholeStageCodegenExec is wrapped in BufferedRowIterator.

BufferedRowIterator uses a LinkedList to hold the output of WholeStageCodegenExec.

When the parent of SortMergeJoin cannot codegen, SortMergeJoin needs to append the output to this LinkedList.

SortMergeJoin processes a record in streamedPlan each time. If all records in bufferedPlan can match this record, all records in bufferedPlan will be saved in LinkedList, resulting in OOM.

The above situation is very common in our internal use, so it is best to add a configuration to the codegen code. If there are enough items in the LinkedList, stop SortMergeJoin and let the parent consume it first.

### benchmark case1: this test case is from JoinBenchmark
```scala
def sortMergeJoin(): Unit = {
  val N = 2 << 20
  codegenBenchmark("sort merge join", N) {
    val df1 = spark.range(N).selectExpr(s"id * 2 as k1")
    val df2 = spark.range(N).selectExpr(s"id * 3 as k2")
    val df = df1.join(df2, col("k1") === col("k2"))
    assert(df.queryExecution.sparkPlan.exists(_.isInstanceOf[SortMergeJoinExec]))
    df.noop()
  }
}
```
before pr:
```tex
[info] Running benchmark: sort merge join
[info]   Running case: sort merge join wholestage off
[info]   Stopped after 2 iterations, 1651 ms
[info]   Running case: sort merge join wholestage on
[info]   Stopped after 5 iterations, 3445 ms
[info] Java HotSpot(TM) 64-Bit Server VM 1.8.0_261-b12 on Mac OS X 10.15.6
[info] Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
[info] sort merge join:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] sort merge join wholestage off                      814            826          16          2.6         388.4       1.0X
[info] sort merge join wholestage on                       655            689          24          3.2         312.2       1.2X
```
after pr:
```tex
[info] Running benchmark: sort merge join
[info]   Running case: sort merge join wholestage off
[info]   Stopped after 2 iterations, 1637 ms
[info]   Running case: sort merge join wholestage on
[info]   Stopped after 5 iterations, 3498 ms
[info] Java HotSpot(TM) 64-Bit Server VM 1.8.0_261-b12 on Mac OS X 10.15.6
[info] Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
[info] sort merge join:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] sort merge join wholestage off                      814            819           7          2.6         388.1       1.0X
[info] sort merge join wholestage on                       662            700          60          3.2         315.7       1.2X
```

### benchmark case2: sort merge join bufferedPlan has a lot of duplicate keys
```scala
def joinBenchmarkWithDuplicateKeys(name: String, cardinality: Long)(f: => Unit): Unit = {
  val benchmark = new Benchmark(name, cardinality, output = output)
  Seq(1, 1000, Int.MaxValue).foreach { maxRecordPerCycle =>
    benchmark.addCase(s"maxRecordPerCycle=$maxRecordPerCycle", numIters = 5) { _ =>
      withSQLConf(SQLConf.SORT_MERGE_JOIN_EXEC_MAX_RECORD_PER_CYCLE.key
                  -> s"$maxRecordPerCycle") {
        f
      }
    }
  }
  benchmark.run()
}

def innerJoinWithDuplicateKeys(): Unit = {
	val N = 2 << 20
  withSQLConf(
    SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
    SQLConf.PREFER_SORTMERGEJOIN.key -> "true",
    SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true"
  ) {
    joinBenchmarkWithDuplicateKeys("sort merge join bufferedPlan has a lot of duplicate keys", N) {
      val df1 = spark.range(50)
      val df2 = spark.range(N).selectExpr(s"id % 50 as k2")
      val df = df1.join(df2, col("id") === col("k2"))
      assert(df.queryExecution.sparkPlan.exists(_.isInstanceOf[SortMergeJoinExec]))
      df.noop()
    }
  }
}
```
before pr:
```tex
[info] Running benchmark: sort merge join bufferedPlan has a lot of duplicate keys
[info]   Running case: before pr
[info]   Stopped after 5 iterations, 2787 ms
[info] Java HotSpot(TM) 64-Bit Server VM 1.8.0_261-b12 on Mac OS X 10.15.6
[info] Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
[info] sort merge join bufferedPlan has a lot of duplicate keys:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ----------------------------------------------------------------------------------------------------------------------------------------
[info] before pr                                                           512            557          56          4.1         244.3       1.0X
```
after pr:
```tex
[info] Running benchmark: sort merge join bufferedPlan has a lot of duplicate keys
[info]   Running case: maxRecordPerCycle=1
[info]   Stopped after 5 iterations, 2787 ms
[info]   Running case: maxRecordPerCycle=1000
[info]   Stopped after 5 iterations, 2689 ms
[info]   Running case: maxRecordPerCycle=2147483647
[info]   Stopped after 5 iterations, 2618 ms
[info] Java HotSpot(TM) 64-Bit Server VM 1.8.0_261-b12 on Mac OS X 10.15.6
[info] Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
[info] sort merge join bufferedPlan has a lot of duplicate keys:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ----------------------------------------------------------------------------------------------------------------------------------------
[info] maxRecordPerCycle=1                                                 528            558          50          4.0         251.8       1.0X
[info] maxRecordPerCycle=1000                                              501            538          39          4.2         239.1       1.1X
[info] maxRecordPerCycle=2147483647                                        515            524          15          4.1         245.7       1.0X
```

### Why are the changes needed?
Enhanced stability to avoid OOM interfering with users


### Does this PR introduce _any_ user-facing change?
yes, added a configuration spark.sql.sortMergeJoinExec.codegen.maxRecordPerCycle to ensure that the LinkedList length does not exceed the configuration value.


### How was this patch tested?
pass all current tests.
