### PR TITLE
[SPARK-38725][SQL][TESTS] Test the error class: DUPLICATE_KEY

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -390,4 +390,19 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |^^^
           |""".stripMargin)
   }
+
+  test("DUPLICATE_KEY: Found duplicate partition keys") {
+    validateParsingError(
+      sqlText = "INSERT OVERWRITE TABLE table PARTITION(p1='1', p1='1') SELECT 'col1', 'col2'",
+      errorClass = "DUPLICATE_KEY",
+      sqlState = "23000",
+      message =
+        """
+          |Found duplicate keys 'p1'(line 1, pos 29)
+          |
+          |== SQL ==
+          |INSERT OVERWRITE TABLE table PARTITION(p1='1', p1='1') SELECT 'col1', 'col2'
+          |-----------------------------^^^
+          |""".stripMargin)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to Add one test for the error class DUPLICATE_KEY to QueryParsingErrorsSuite, it's a followup of [SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Why are the changes needed?
Add one test for the error class DUPLICATE_KEY to QueryParsingErrorsSuite

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
- Manual test：

```
./build/sbt "sql/testOnly *QueryParsingErrorsSuite*"
```

All tests passed.