### PR TITLE
[SPARK-38892][SQL][TESTS] Fix a test case schema assertion of ParquetPartitionDiscoverySuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetPartitionDiscoverySuite.scala
@@ -1076,7 +1076,7 @@ abstract class ParquetPartitionDiscoverySuite
       val input = spark.read.parquet(path.getAbsolutePath).select("id",
         "date_month", "date_hour", "date_t_hour", "data")
 
-      assert(input.schema.sameType(input.schema))
+      assert(data.schema.sameType(input.schema))
       checkAnswer(input, data)
     }
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
in ParquetPartitionDiscoverySuite, thare are some assert have no parctical significance.
`assert(input.schema.sameType(input.schema))`

### Why are the changes needed?
fix this to assert the actual result.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
updated testsuites
