### PR TITLE
[SPARK-38894][PYTHON][TESTS] Exclude pyspark.cloudpickle in test coverage report

### DIFF
--- a/python/run-tests-with-coverage
+++ b/python/run-tests-with-coverage
@@ -60,10 +60,10 @@ find $COVERAGE_DIR/coverage_data -size 0 -print0 | xargs -0 rm -fr
 echo "Combining collected coverage data under $COVERAGE_DIR/coverage_data"
 $COV_EXEC combine
 echo "Creating XML report file at python/coverage.xml"
-$COV_EXEC xml --ignore-errors --include "pyspark/*"
+$COV_EXEC xml --ignore-errors --include "pyspark/*" --omit "pyspark/cloudpickle/*"
 echo "Reporting the coverage data at $COVERAGE_DIR/coverage_data/coverage"
-$COV_EXEC report --include "pyspark/*"
+$COV_EXEC report --include "pyspark/*" --omit "pyspark/cloudpickle/*"
 echo "Generating HTML files for PySpark coverage under $COVERAGE_DIR/htmlcov"
-$COV_EXEC html --ignore-errors --include "pyspark/*" --directory "$COVERAGE_DIR/htmlcov"
+$COV_EXEC html --ignore-errors --include "pyspark/*" --directory "$COVERAGE_DIR/htmlcov" --omit "pyspark/cloudpickle/*"
 
 popd


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove the test coverage report for `pyspark.cloudpickle` (https://codecov.io/gh/apache/spark/tree/master/python/pyspark/cloudpickle).

### Why are the changes needed?

`pyspark.cloudpickle` is actually a copy from [cloudpickle](https://github.com/cloudpipe/cloudpickle) as is. We don't need to check test coverage duplicately here.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested, and verified the site and console output:

```bash
cd python
./run-tests-with-coverage --python-executables=python3 --modules=pyspark-sql
```

and

```
open test_coverage/htmlcov/index.html
```