### PR TITLE
[SPARK-38747][SQL][TESTS] Move the tests for `PARSE_SYNTAX_ERROR` to …

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
@@ -99,13 +99,6 @@ class ErrorParserSuite extends AnalysisTest {
       "Syntax error at or near", "^^^")
   }
 
-  test("empty input") {
-    val expectedErrMsg = SparkThrowableHelper.getMessage("PARSE_EMPTY_STATEMENT", Array[String]())
-    intercept("", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
-    intercept("   ", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
-    intercept(" \n", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
-  }
-
   test("jargon token substitute to user-facing language") {
     // '<EOF>' -> end of input
     intercept("select count(*", "PARSE_SYNTAX_ERROR",

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -405,4 +405,47 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |-----------------------------^^^
           |""".stripMargin)
   }
+
+  test("PARSE_EMPTY_STATEMENT: ") {
+    validateParsingError(
+      sqlText = "",
+      errorClass = "PARSE_EMPTY_STATEMENT",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error, unexpected empty statement(line 1, pos 0)
+          |
+          |== SQL ==
+          |
+          |^^^
+          |""".stripMargin)
+
+    validateParsingError(
+      sqlText = "   ",
+      errorClass = "PARSE_EMPTY_STATEMENT",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error, unexpected empty statement(line 1, pos 3)
+          |
+          |== SQL ==
+          |   """.stripMargin +
+        """
+          |---^^^
+          |""".stripMargin)
+
+    validateParsingError(
+      sqlText = " \n",
+      errorClass = "PARSE_EMPTY_STATEMENT",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error, unexpected empty statement(line 2, pos 0)
+          |
+          |== SQL ==
+          | """.stripMargin +
+        """
+          |^^^
+          |""".stripMargin)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to Move tests for the error class PARSE_SYNTAX_ERROR from ErrorParserSuite to QueryParsingErrorsSuite., it's a followup of [SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Why are the changes needed?
Move tests for the error class PARSE_SYNTAX_ERROR from ErrorParserSuite to QueryParsingErrorsSuite

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
- Manual test：

```
./build/sbt "sql/testOnly *QueryParsingErrorsSuite*"
```

All tests passed.