### PR TITLE
[SPARK-38898][PYTHON][K8S] Force to remove pip .cache in python dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
     apt install -y python3 python3-pip && \
     pip3 install --upgrade pip setuptools && \
     # Removed the .cache to save space
-    rm -r /root/.cache && rm -rf /var/cache/apt/*
+    rm -rf /root/.cache && rm -rf /var/cache/apt/*
 
 COPY python/pyspark ${SPARK_HOME}/python/pyspark
 COPY python/lib ${SPARK_HOME}/python/lib


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add force flag to remove `.cache`

### Why are the changes needed?
There are some [flaky error](https://github.com/volcano-sh/volcano/runs/6020604500?check_suite_focus=true#step:10:2381) when build spark python docker images due to  `rm: cannot remove '/root/.cache': No such file or directory`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
K8s IT passed