### PR TITLE
[SPARK-38905][BUILD][3.2] Upgrade ORC to 1.6.14

### DIFF
--- a/dev/deps/spark-deps-hadoop-2.7-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2.7-hive-2.3
@@ -195,9 +195,9 @@ objenesis/2.6//objenesis-2.6.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.6.13//orc-core-1.6.13.jar
-orc-mapreduce/1.6.13//orc-mapreduce-1.6.13.jar
-orc-shims/1.6.13//orc-shims-1.6.13.jar
+orc-core/1.6.14//orc-core-1.6.14.jar
+orc-mapreduce/1.6.14//orc-mapreduce-1.6.14.jar
+orc-shims/1.6.14//orc-shims-1.6.14.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3.2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3.2-hive-2.3
@@ -166,9 +166,9 @@ objenesis/2.6//objenesis-2.6.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.6.13//orc-core-1.6.13.jar
-orc-mapreduce/1.6.13//orc-mapreduce-1.6.13.jar
-orc-shims/1.6.13//orc-shims-1.6.13.jar
+orc-core/1.6.14//orc-core-1.6.14.jar
+orc-mapreduce/1.6.14//orc-mapreduce-1.6.14.jar
+orc-shims/1.6.14//orc-shims-1.6.14.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>
-    <orc.version>1.6.13</orc.version>
+    <orc.version>1.6.14</orc.version>
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC dependency to 1.6.14.

### Why are the changes needed?

Apache ORC 1.6.14 is a maintenance release with 5 patches. Apache ORC community recommends to upgrade it. Here is the release note, https://orc.apache.org/news/2022/04/14/ORC-1.6.14/

- [ORC-1121](https://issues.apache.org/jira/browse/ORC-1121) Fix column coversion check bug which causes column filters don’t work
- [ORC-1146](https://issues.apache.org/jira/browse/ORC-1146) Float category missing check if the statistic sum is a finite value
- [ORC-1147](https://issues.apache.org/jira/browse/ORC-1147) Use isNaN instead of isFinite to determine the contain NaN values

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI.