### PR TITLE
[SPARK-38911][CORE] Fix the potential resource profile id mess up issue

### DIFF
--- a/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
+++ b/core/src/main/scala/org/apache/spark/resource/ResourceProfile.scala
@@ -290,7 +290,7 @@ object ResourceProfile extends Logging {
 
   private[spark] val MEMORY_OVERHEAD_MIN_MIB = 384L
 
-  private lazy val nextProfileId = new AtomicInteger(0)
+  private lazy val nextProfileId = new AtomicInteger(DEFAULT_RESOURCE_PROFILE_ID + 1)
   private val DEFAULT_PROFILE_LOCK = new Object()
 
   // The default resource profile uses the application level configs.

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3256,12 +3256,12 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   }
 
   test("test 1 resource profile") {
-    val sparkContext = sc
     val ereqs = new ExecutorResourceRequests().cores(4)
     val treqs = new TaskResourceRequests().cpus(1)
     val rp1 = new ResourceProfileBuilder().require(ereqs).require(treqs).build
+    assert(rp1.id == 1)
 
-    val rdd = sparkContext.parallelize(1 to 10).map(x => (x, x)).withResources(rp1)
+    val rdd = sc.parallelize(1 to 10).map(x => (x, x)).withResources(rp1)
     val (shuffledeps, resourceprofiles) = scheduler.getShuffleDependenciesAndResourceProfiles(rdd)
     val rpMerged = scheduler.mergeResourceProfilesForStage(resourceprofiles)
     val expectedid = Option(rdd.getResourceProfile).map(_.id)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3256,11 +3256,12 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   }
 
   test("test 1 resource profile") {
+    val sparkContext = sc
     val ereqs = new ExecutorResourceRequests().cores(4)
     val treqs = new TaskResourceRequests().cpus(1)
     val rp1 = new ResourceProfileBuilder().require(ereqs).require(treqs).build
 
-    val rdd = sc.parallelize(1 to 10).map(x => (x, x)).withResources(rp1)
+    val rdd = sparkContext.parallelize(1 to 10).map(x => (x, x)).withResources(rp1)
     val (shuffledeps, resourceprofiles) = scheduler.getShuffleDependenciesAndResourceProfiles(rdd)
     val rpMerged = scheduler.mergeResourceProfilesForStage(resourceprofiles)
     val expectedid = Option(rdd.getResourceProfile).map(_.id)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3259,7 +3259,6 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     val ereqs = new ExecutorResourceRequests().cores(4)
     val treqs = new TaskResourceRequests().cpus(1)
     val rp1 = new ResourceProfileBuilder().require(ereqs).require(treqs).build
-    assert(rp1.id == 1)
 
     val rdd = sc.parallelize(1 to 10).map(x => (x, x)).withResources(rp1)
     val (shuffledeps, resourceprofiles) = scheduler.getShuffleDependenciesAndResourceProfiles(rdd)


### PR DESCRIPTION
### What changes were proposed in this pull request?

The test `test 1 resource profile` of DAGSchedulerSuite will fail if I run it in IDEA separately.

The exception is like below,

```
0 equaled 0
ScalaTestFailureLocation: org.apache.spark.scheduler.DAGSchedulerSuite at (DAGSchedulerSuite.scala:3269)
org.scalatest.exceptions.TestFailedException: 0 equaled 0
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
	at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
	at org.scalatest.Assertions$.newAssertionFailedException(Assertions.scala:1231)
	at org.scalatest.Assertions$AssertionsHelper.macroAssert(Assertions.scala:1295)
	at org.apache.spark.scheduler.DAGSchedulerSuite.$anonfun$new$191(DAGSchedulerSuite.scala:3269)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
```

This issue does not exist when running all DAGSchedulerSuite one by one, since the SparkContext
will be initialized at the very beginning.

The root cause is the requested ResourceProfile is initialized before SparkContext,  consider below scenario

```
val ereqs = new ExecutorResourceRequests().cores(4)
val treqs = new TaskResourceRequests().cpus(1)
val rp1 = new ResourceProfileBuilder().require(ereqs).require(treqs).build

val sc = new SparkContext(master, appName) 
```

rp1 will take 0 as the resource profile id. But when SparkContext is initializing,
the default profile will also force the profile id to DEFAULT_RESOURCE_PROFILE_ID (0) which results in
two different ResourceProfiles have the same id ( DEFAULT_RESOURCE_PROFILE_ID ).

### Why are the changes needed?

To make the ResourceProfile robust. and to fix the potential issues

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

1. monitor CI
2. run `test 1 resource profile` in DAGSchedulerSuite manually  in IDEA



