### PR TITLE
[SPARK-38750][SQL][TESTS] Test the error class: SECOND_FUNCTION_ARGUMENT_NOT_INTEGER

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -311,7 +311,8 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SECOND_FUNCTION_ARGUMENT_NOT_INTEGER: data_add's second argument must be integer") {
+  test("SECOND_FUNCTION_ARGUMENT_NOT_INTEGER: " +
+    "the second argument of 'date_add' function needs to be an integer") {
     val e = intercept[AnalysisException] {
       sql("select date_add('1982-08-15', 'x')").collect()
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -318,8 +318,8 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     }
     assert(e.getErrorClass === "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER")
     assert(e.getSqlState === "22023")
-    assert(e.getMessage.matches(
-      "The second argument of 'date_add' function needs to be an integer."))
+    assert(e.getMessage ===
+      "The second argument of 'date_add' function needs to be an integer.")
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -310,6 +310,16 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
+
+  test("SECOND_FUNCTION_ARGUMENT_NOT_INTEGER: data_add's second argument must be integer") {
+    val e = intercept[AnalysisException] {
+      sql("select date_add('1982-08-15', 'x')").collect()
+    }
+    assert(e.getErrorClass === "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER")
+    assert(e.getSqlState === "22023")
+    assert(e.getMessage.matches(
+      "The second argument of 'date_add' function needs to be an integer."))
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR aims to add a test for the error class SECOND_FUNCTION_ARGUMENT_NOT_INTEGER to `QueryCompilationErrorsSuite`.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryCompilationErrorsSuite*"
```