### PR TITLE
[SPARK-38920][SQL][TEST] Add ORC blockSize tests to BloomFilterBenchmark

### DIFF
--- a/sql/core/benchmarks/BloomFilterBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/BloomFilterBenchmark-jdk11-results.txt
@@ -6,8 +6,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              20453          20495          60          4.9         204.5       1.0X
-With bloom filter                                 22539          22694         218          4.4         225.4       0.9X
+Without bloom filter                              15642          15783         200          6.4         156.4       1.0X
+With bloom filter                                 18117          18282         234          5.5         181.2       0.9X
 
 
 ================================================================================================
@@ -18,8 +18,80 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                               1708           1800         129         58.5          17.1       1.0X
-With bloom filter                                  1324           1357          47         75.5          13.2       1.3X
+Without bloom filter, blocksize: 2097152           1936           1975          55         51.7          19.4       1.0X
+With bloom filter, blocksize: 2097152              1188           1263         106         84.2          11.9       1.6X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 4194304           1400           1459          83         71.4          14.0       1.0X
+With bloom filter, blocksize: 4194304              1047           1069          32         95.5          10.5       1.3X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 6291456           1486           1528          60         67.3          14.9       1.0X
+With bloom filter, blocksize: 6291456              1059           1131         101         94.4          10.6       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 8388608           1532           1578          66         65.3          15.3       1.0X
+With bloom filter, blocksize: 8388608              1113           1125          17         89.8          11.1       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 12582912           1430           1455          36         70.0          14.3       1.0X
+With bloom filter, blocksize: 12582912              1080           1088          12         92.6          10.8       1.3X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 16777216           1481           1523          59         67.5          14.8       1.0X
+With bloom filter, blocksize: 16777216              1087           1103          22         92.0          10.9       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 33554432           1526           1540          20         65.5          15.3       1.0X
+With bloom filter, blocksize: 33554432              1066           1087          30         93.8          10.7       1.4X
 
 
 ================================================================================================
@@ -30,8 +102,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              17586          17666         112          5.7         175.9       1.0X
-With bloom filter                                 21429          21507         111          4.7         214.3       0.8X
+Without bloom filter                              15472          15571         140          6.5         154.7       1.0X
+With bloom filter                                 19960          20211         354          5.0         199.6       0.8X
 
 
 ================================================================================================
@@ -42,8 +114,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152           1219           1246          39         82.1          12.2       1.0X
-With bloom filter, blocksize: 2097152               379            420          48        264.0           3.8       3.2X
+Without bloom filter, blocksize: 2097152            982           1039          80        101.8           9.8       1.0X
+With bloom filter, blocksize: 2097152               340            384          32        294.5           3.4       2.9X
 
 
 ================================================================================================
@@ -54,8 +126,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304           1015           1023          11         98.5          10.2       1.0X
-With bloom filter, blocksize: 4194304               237            267          25        422.1           2.4       4.3X
+Without bloom filter, blocksize: 4194304            903            956          61        110.7           9.0       1.0X
+With bloom filter, blocksize: 4194304               257            308          57        389.6           2.6       3.5X
 
 
 ================================================================================================
@@ -66,8 +138,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456            997           1008          16        100.3          10.0       1.0X
-With bloom filter, blocksize: 6291456               268            290          11        372.6           2.7       3.7X
+Without bloom filter, blocksize: 6291456            993            998           4        100.7           9.9       1.0X
+With bloom filter, blocksize: 6291456               327            345          19        306.0           3.3       3.0X
 
 
 ================================================================================================
@@ -78,8 +150,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608            957           1014          81        104.5           9.6       1.0X
-With bloom filter, blocksize: 8388608               361            401          33        277.0           3.6       2.6X
+Without bloom filter, blocksize: 8388608            981           1026          62        101.9           9.8       1.0X
+With bloom filter, blocksize: 8388608               319            345          23        313.0           3.2       3.1X
 
 
 ================================================================================================
@@ -90,8 +162,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912           1015           1033          26         98.5          10.1       1.0X
-With bloom filter, blocksize: 12582912               606            635          29        165.2           6.1       1.7X
+Without bloom filter, blocksize: 12582912            903            951          45        110.7           9.0       1.0X
+With bloom filter, blocksize: 12582912               630            653          26        158.7           6.3       1.4X
 
 
 ================================================================================================
@@ -102,8 +174,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216           1038           1055          23         96.3          10.4       1.0X
-With bloom filter, blocksize: 16777216               901            905           4        111.0           9.0       1.2X
+Without bloom filter, blocksize: 16777216            944            970          38        106.0           9.4       1.0X
+With bloom filter, blocksize: 16777216               849            882          28        117.8           8.5       1.1X
 
 
 ================================================================================================
@@ -114,7 +186,7 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432            941            955          13        106.3           9.4       1.0X
-With bloom filter, blocksize: 33554432               888            930          39        112.6           8.9       1.1X
+Without bloom filter, blocksize: 33554432            917            929          11        109.0           9.2       1.0X
+With bloom filter, blocksize: 33554432               913            955          41        109.6           9.1       1.0X
 
 

--- a/sql/core/benchmarks/BloomFilterBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/BloomFilterBenchmark-jdk11-results.txt
@@ -6,8 +6,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              15642          15783         200          6.4         156.4       1.0X
-With bloom filter                                 18117          18282         234          5.5         181.2       0.9X
+Without bloom filter                              15574          15579           6          6.4         155.7       1.0X
+With bloom filter                                 17915          17972          80          5.6         179.2       0.9X
 
 
 ================================================================================================
@@ -18,8 +18,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152           1936           1975          55         51.7          19.4       1.0X
-With bloom filter, blocksize: 2097152              1188           1263         106         84.2          11.9       1.6X
+Without bloom filter, blocksize: 2097152           1667           1675          11         60.0          16.7       1.0X
+With bloom filter, blocksize: 2097152              1098           1134          50         91.1          11.0       1.5X
 
 
 ================================================================================================
@@ -30,8 +30,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304           1400           1459          83         71.4          14.0       1.0X
-With bloom filter, blocksize: 4194304              1047           1069          32         95.5          10.5       1.3X
+Without bloom filter, blocksize: 4194304           1446           1514          97         69.2          14.5       1.0X
+With bloom filter, blocksize: 4194304              1069           1145         108         93.6          10.7       1.4X
 
 
 ================================================================================================
@@ -42,8 +42,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456           1486           1528          60         67.3          14.9       1.0X
-With bloom filter, blocksize: 6291456              1059           1131         101         94.4          10.6       1.4X
+Without bloom filter, blocksize: 6291456           1436           1468          46         69.6          14.4       1.0X
+With bloom filter, blocksize: 6291456              1035           1060          36         96.6          10.3       1.4X
 
 
 ================================================================================================
@@ -54,8 +54,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608           1532           1578          66         65.3          15.3       1.0X
-With bloom filter, blocksize: 8388608              1113           1125          17         89.8          11.1       1.4X
+Without bloom filter, blocksize: 8388608           1451           1488          52         68.9          14.5       1.0X
+With bloom filter, blocksize: 8388608              1016           1027          15         98.4          10.2       1.4X
 
 
 ================================================================================================
@@ -66,8 +66,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912           1430           1455          36         70.0          14.3       1.0X
-With bloom filter, blocksize: 12582912              1080           1088          12         92.6          10.8       1.3X
+Without bloom filter, blocksize: 12582912           1463           1463           1         68.4          14.6       1.0X
+With bloom filter, blocksize: 12582912              1023           1041          24         97.7          10.2       1.4X
 
 
 ================================================================================================
@@ -78,8 +78,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216           1481           1523          59         67.5          14.8       1.0X
-With bloom filter, blocksize: 16777216              1087           1103          22         92.0          10.9       1.4X
+Without bloom filter, blocksize: 16777216           1473           1505          46         67.9          14.7       1.0X
+With bloom filter, blocksize: 16777216               997           1016          26        100.3          10.0       1.5X
 
 
 ================================================================================================
@@ -90,8 +90,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432           1526           1540          20         65.5          15.3       1.0X
-With bloom filter, blocksize: 33554432              1066           1087          30         93.8          10.7       1.4X
+Without bloom filter, blocksize: 33554432           1440           1482          59         69.4          14.4       1.0X
+With bloom filter, blocksize: 33554432              1037           1065          40         96.4          10.4       1.4X
 
 
 ================================================================================================
@@ -102,8 +102,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              15472          15571         140          6.5         154.7       1.0X
-With bloom filter                                 19960          20211         354          5.0         199.6       0.8X
+Without bloom filter                              16645          16907         371          6.0         166.4       1.0X
+With bloom filter                                 20968          21145         250          4.8         209.7       0.8X
 
 
 ================================================================================================
@@ -114,8 +114,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152            982           1039          80        101.8           9.8       1.0X
-With bloom filter, blocksize: 2097152               340            384          32        294.5           3.4       2.9X
+Without bloom filter, blocksize: 2097152           1101           1106           7         90.8          11.0       1.0X
+With bloom filter, blocksize: 2097152               308            365          37        325.2           3.1       3.6X
 
 
 ================================================================================================
@@ -126,8 +126,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304            903            956          61        110.7           9.0       1.0X
-With bloom filter, blocksize: 4194304               257            308          57        389.6           2.6       3.5X
+Without bloom filter, blocksize: 4194304            933            970          33        107.2           9.3       1.0X
+With bloom filter, blocksize: 4194304               269            302          32        371.1           2.7       3.5X
 
 
 ================================================================================================
@@ -138,8 +138,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456            993            998           4        100.7           9.9       1.0X
-With bloom filter, blocksize: 6291456               327            345          19        306.0           3.3       3.0X
+Without bloom filter, blocksize: 6291456            977           1026          69        102.3           9.8       1.0X
+With bloom filter, blocksize: 6291456               358            379          14        279.6           3.6       2.7X
 
 
 ================================================================================================
@@ -150,8 +150,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608            981           1026          62        101.9           9.8       1.0X
-With bloom filter, blocksize: 8388608               319            345          23        313.0           3.2       3.1X
+Without bloom filter, blocksize: 8388608           1009           1026          24         99.2          10.1       1.0X
+With bloom filter, blocksize: 8388608               371            395          28        269.3           3.7       2.7X
 
 
 ================================================================================================
@@ -162,8 +162,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912            903            951          45        110.7           9.0       1.0X
-With bloom filter, blocksize: 12582912               630            653          26        158.7           6.3       1.4X
+Without bloom filter, blocksize: 12582912            972            977           6        102.9           9.7       1.0X
+With bloom filter, blocksize: 12582912               695            725          30        143.9           6.9       1.4X
 
 
 ================================================================================================
@@ -174,8 +174,8 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216            944            970          38        106.0           9.4       1.0X
-With bloom filter, blocksize: 16777216               849            882          28        117.8           8.5       1.1X
+Without bloom filter, blocksize: 16777216            938            946           8        106.6           9.4       1.0X
+With bloom filter, blocksize: 16777216               833            870          45        120.0           8.3       1.1X
 
 
 ================================================================================================
@@ -186,7 +186,7 @@ OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432            917            929          11        109.0           9.2       1.0X
-With bloom filter, blocksize: 33554432               913            955          41        109.6           9.1       1.0X
+Without bloom filter, blocksize: 33554432            929            955          24        107.6           9.3       1.0X
+With bloom filter, blocksize: 33554432              1003           1010          10         99.7          10.0       0.9X
 
 

--- a/sql/core/benchmarks/BloomFilterBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/BloomFilterBenchmark-jdk17-results.txt
@@ -3,11 +3,11 @@ ORC Write
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              19097          19523         602          5.2         191.0       1.0X
-With bloom filter                                 22213          22402         267          4.5         222.1       0.9X
+Without bloom filter                              15254          15831         816          6.6         152.5       1.0X
+With bloom filter                                 18586          18608          32          5.4         185.9       0.8X
 
 
 ================================================================================================
@@ -15,11 +15,83 @@ ORC Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                               1528           1628         142         65.4          15.3       1.0X
-With bloom filter                                  1370           1391          29         73.0          13.7       1.1X
+Without bloom filter, blocksize: 2097152           1199           1225          37         83.4          12.0       1.0X
+With bloom filter, blocksize: 2097152               886            894          11        112.8           8.9       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 4194304           1202           1208           8         83.2          12.0       1.0X
+With bloom filter, blocksize: 4194304               874            893          30        114.4           8.7       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 6291456           1241           1251          15         80.6          12.4       1.0X
+With bloom filter, blocksize: 6291456               852            857           6        117.4           8.5       1.5X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 8388608           1182           1183           2         84.6          11.8       1.0X
+With bloom filter, blocksize: 8388608               852            859           7        117.3           8.5       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 12582912           1185           1187           2         84.4          11.8       1.0X
+With bloom filter, blocksize: 12582912               857            883          23        116.6           8.6       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 16777216           1194           1197           5         83.8          11.9       1.0X
+With bloom filter, blocksize: 16777216               837            848          10        119.4           8.4       1.4X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 33554432           1149           1151           4         87.0          11.5       1.0X
+With bloom filter, blocksize: 33554432               841            850           8        119.0           8.4       1.4X
 
 
 ================================================================================================
@@ -27,11 +99,11 @@ Parquet Write
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              17846          17981         191          5.6         178.5       1.0X
-With bloom filter                                 22883          22982         140          4.4         228.8       0.8X
+Without bloom filter                              16009          16144         191          6.2         160.1       1.0X
+With bloom filter                                 19576          19850         387          5.1         195.8       0.8X
 
 
 ================================================================================================
@@ -39,11 +111,11 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152            947           1012          92        105.6           9.5       1.0X
-With bloom filter, blocksize: 2097152               311            325          12        322.0           3.1       3.0X
+Without bloom filter, blocksize: 2097152            712            754          43        140.5           7.1       1.0X
+With bloom filter, blocksize: 2097152               227            236           9        440.9           2.3       3.1X
 
 
 ================================================================================================
@@ -51,11 +123,11 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304            824            837          15        121.3           8.2       1.0X
-With bloom filter, blocksize: 4194304               210            222          10        475.8           2.1       3.9X
+Without bloom filter, blocksize: 4194304            674            677           3        148.3           6.7       1.0X
+With bloom filter, blocksize: 4194304               160            167           5        625.3           1.6       4.2X
 
 
 ================================================================================================
@@ -63,11 +135,11 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456           1210           1327         166         82.6          12.1       1.0X
-With bloom filter, blocksize: 6291456               302            315           9        331.1           3.0       4.0X
+Without bloom filter, blocksize: 6291456            675            680           7        148.2           6.7       1.0X
+With bloom filter, blocksize: 6291456               185            190           5        540.9           1.8       3.6X
 
 
 ================================================================================================
@@ -75,11 +147,11 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608           1244           1251          10         80.4          12.4       1.0X
-With bloom filter, blocksize: 8388608               504            513           8        198.4           5.0       2.5X
+Without bloom filter, blocksize: 8388608            673            695          28        148.5           6.7       1.0X
+With bloom filter, blocksize: 8388608               306            310           3        327.2           3.1       2.2X
 
 
 ================================================================================================
@@ -87,11 +159,11 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912           1384           1408          34         72.3          13.8       1.0X
-With bloom filter, blocksize: 12582912               900            955          49        111.1           9.0       1.5X
+Without bloom filter, blocksize: 12582912            678            681           4        147.4           6.8       1.0X
+With bloom filter, blocksize: 12582912               497            501           5        201.0           5.0       1.4X
 
 
 ================================================================================================
@@ -99,11 +171,11 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216           1468           1482          19         68.1          14.7       1.0X
-With bloom filter, blocksize: 16777216              1302           1313          15         76.8          13.0       1.1X
+Without bloom filter, blocksize: 16777216            675            738         102        148.2           6.7       1.0X
+With bloom filter, blocksize: 16777216              1071           1075           5         93.4          10.7       0.6X
 
 
 ================================================================================================
@@ -111,10 +183,10 @@ Parquet Read
 ================================================================================================
 
 OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432           1444           1451           9         69.2          14.4       1.0X
-With bloom filter, blocksize: 33554432              1458           1461           3         68.6          14.6       1.0X
+Without bloom filter, blocksize: 33554432           1116           1165          69         89.6          11.2       1.0X
+With bloom filter, blocksize: 33554432              1123           1128           7         89.1          11.2       1.0X
 
 

--- a/sql/core/benchmarks/BloomFilterBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/BloomFilterBenchmark-jdk17-results.txt
@@ -6,8 +6,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              15254          15831         816          6.6         152.5       1.0X
-With bloom filter                                 18586          18608          32          5.4         185.9       0.8X
+Without bloom filter                              15778          15792          19          6.3         157.8       1.0X
+With bloom filter                                 17951          18076         178          5.6         179.5       0.9X
 
 
 ================================================================================================
@@ -18,8 +18,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152           1199           1225          37         83.4          12.0       1.0X
-With bloom filter, blocksize: 2097152               886            894          11        112.8           8.9       1.4X
+Without bloom filter, blocksize: 2097152           1327           1404         109         75.4          13.3       1.0X
+With bloom filter, blocksize: 2097152               929            943          24        107.6           9.3       1.4X
 
 
 ================================================================================================
@@ -30,8 +30,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304           1202           1208           8         83.2          12.0       1.0X
-With bloom filter, blocksize: 4194304               874            893          30        114.4           8.7       1.4X
+Without bloom filter, blocksize: 4194304           1342           1348           8         74.5          13.4       1.0X
+With bloom filter, blocksize: 4194304              1085           1087           2         92.1          10.9       1.2X
 
 
 ================================================================================================
@@ -42,8 +42,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456           1241           1251          15         80.6          12.4       1.0X
-With bloom filter, blocksize: 6291456               852            857           6        117.4           8.5       1.5X
+Without bloom filter, blocksize: 6291456           1325           1332          10         75.5          13.3       1.0X
+With bloom filter, blocksize: 6291456              1115           1117           3         89.7          11.1       1.2X
 
 
 ================================================================================================
@@ -54,8 +54,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608           1182           1183           2         84.6          11.8       1.0X
-With bloom filter, blocksize: 8388608               852            859           7        117.3           8.5       1.4X
+Without bloom filter, blocksize: 8388608           1203           1213          14         83.1          12.0       1.0X
+With bloom filter, blocksize: 8388608              1168           1171           4         85.6          11.7       1.0X
 
 
 ================================================================================================
@@ -66,8 +66,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912           1185           1187           2         84.4          11.8       1.0X
-With bloom filter, blocksize: 12582912               857            883          23        116.6           8.6       1.4X
+Without bloom filter, blocksize: 12582912           1774           1781          10         56.4          17.7       1.0X
+With bloom filter, blocksize: 12582912              1171           1182          15         85.4          11.7       1.5X
 
 
 ================================================================================================
@@ -78,8 +78,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216           1194           1197           5         83.8          11.9       1.0X
-With bloom filter, blocksize: 16777216               837            848          10        119.4           8.4       1.4X
+Without bloom filter, blocksize: 16777216           1723           1728           7         58.0          17.2       1.0X
+With bloom filter, blocksize: 16777216              1329           1344          20         75.2          13.3       1.3X
 
 
 ================================================================================================
@@ -90,8 +90,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432           1149           1151           4         87.0          11.5       1.0X
-With bloom filter, blocksize: 33554432               841            850           8        119.0           8.4       1.4X
+Without bloom filter, blocksize: 33554432           1847           1858          15         54.1          18.5       1.0X
+With bloom filter, blocksize: 33554432              1222           1312         126         81.8          12.2       1.5X
 
 
 ================================================================================================
@@ -102,8 +102,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              16009          16144         191          6.2         160.1       1.0X
-With bloom filter                                 19576          19850         387          5.1         195.8       0.8X
+Without bloom filter                              16902          16907           8          5.9         169.0       1.0X
+With bloom filter                                 28237          28266          41          3.5         282.4       0.6X
 
 
 ================================================================================================
@@ -114,8 +114,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152            712            754          43        140.5           7.1       1.0X
-With bloom filter, blocksize: 2097152               227            236           9        440.9           2.3       3.1X
+Without bloom filter, blocksize: 2097152            763            796          31        131.1           7.6       1.0X
+With bloom filter, blocksize: 2097152               248            261          13        403.2           2.5       3.1X
 
 
 ================================================================================================
@@ -126,8 +126,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304            674            677           3        148.3           6.7       1.0X
-With bloom filter, blocksize: 4194304               160            167           5        625.3           1.6       4.2X
+Without bloom filter, blocksize: 4194304           1020           1020           0         98.0          10.2       1.0X
+With bloom filter, blocksize: 4194304               193            201          11        517.5           1.9       5.3X
 
 
 ================================================================================================
@@ -138,8 +138,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456            675            680           7        148.2           6.7       1.0X
-With bloom filter, blocksize: 6291456               185            190           5        540.9           1.8       3.6X
+Without bloom filter, blocksize: 6291456           1023           1023           1         97.8          10.2       1.0X
+With bloom filter, blocksize: 6291456               298            306           8        336.0           3.0       3.4X
 
 
 ================================================================================================
@@ -150,8 +150,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608            673            695          28        148.5           6.7       1.0X
-With bloom filter, blocksize: 8388608               306            310           3        327.2           3.1       2.2X
+Without bloom filter, blocksize: 8388608           1033           1038           6         96.8          10.3       1.0X
+With bloom filter, blocksize: 8388608               459            467           4        217.7           4.6       2.2X
 
 
 ================================================================================================
@@ -162,8 +162,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912            678            681           4        147.4           6.8       1.0X
-With bloom filter, blocksize: 12582912               497            501           5        201.0           5.0       1.4X
+Without bloom filter, blocksize: 12582912           1077           1084          11         92.9          10.8       1.0X
+With bloom filter, blocksize: 12582912               734            741           9        136.2           7.3       1.5X
 
 
 ================================================================================================
@@ -174,8 +174,8 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216            675            738         102        148.2           6.7       1.0X
-With bloom filter, blocksize: 16777216              1071           1075           5         93.4          10.7       0.6X
+Without bloom filter, blocksize: 16777216           1044           1047           4         95.7          10.4       1.0X
+With bloom filter, blocksize: 16777216               825            835          11        121.2           8.2       1.3X
 
 
 ================================================================================================
@@ -186,7 +186,7 @@ OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432           1116           1165          69         89.6          11.2       1.0X
-With bloom filter, blocksize: 33554432              1123           1128           7         89.1          11.2       1.0X
+Without bloom filter, blocksize: 33554432           1232           1237           6         81.2          12.3       1.0X
+With bloom filter, blocksize: 33554432              1152           1199          67         86.8          11.5       1.1X
 
 

--- a/sql/core/benchmarks/BloomFilterBenchmark-results.txt
+++ b/sql/core/benchmarks/BloomFilterBenchmark-results.txt
@@ -6,8 +6,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              17889          18038         211          5.6         178.9       1.0X
-With bloom filter                                 20780          20941         228          4.8         207.8       0.9X
+Without bloom filter                              20928          21034         149          4.8         209.3       1.0X
+With bloom filter                                 23707          23716          12          4.2         237.1       0.9X
 
 
 ================================================================================================
@@ -18,8 +18,80 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                               1690           1694           6         59.2          16.9       1.0X
-With bloom filter                                  1274           1291          24         78.5          12.7       1.3X
+Without bloom filter, blocksize: 2097152           1464           1477          19         68.3          14.6       1.0X
+With bloom filter, blocksize: 2097152              1109           1131          31         90.2          11.1       1.3X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 4194304           1435           1446          15         69.7          14.4       1.0X
+With bloom filter, blocksize: 4194304              1087           1092           7         92.0          10.9       1.3X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 6291456           1312           1395         116         76.2          13.1       1.0X
+With bloom filter, blocksize: 6291456              1059           1062           4         94.4          10.6       1.2X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 8388608           1324           1337          19         75.6          13.2       1.0X
+With bloom filter, blocksize: 8388608              1086           1144          82         92.1          10.9       1.2X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 12582912           1316           1333          25         76.0          13.2       1.0X
+With bloom filter, blocksize: 12582912              1019           1055          50         98.1          10.2       1.3X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 16777216           1301           1320          27         76.9          13.0       1.0X
+With bloom filter, blocksize: 16777216              1031           1039          11         97.0          10.3       1.3X
+
+
+================================================================================================
+ORC Read
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Without bloom filter, blocksize: 33554432           1328           1331           5         75.3          13.3       1.0X
+With bloom filter, blocksize: 33554432              1017           1042          35         98.3          10.2       1.3X
 
 
 ================================================================================================
@@ -30,8 +102,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              15998          16218         311          6.3         160.0       1.0X
-With bloom filter                                 29974          30180         291          3.3         299.7       0.5X
+Without bloom filter                              17756          17782          37          5.6         177.6       1.0X
+With bloom filter                                 27591          27805         303          3.6         275.9       0.6X
 
 
 ================================================================================================
@@ -42,8 +114,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152           1032           1039          10         96.9          10.3       1.0X
-With bloom filter, blocksize: 2097152               285            302          22        350.7           2.9       3.6X
+Without bloom filter, blocksize: 2097152           1011           1016           8         98.9          10.1       1.0X
+With bloom filter, blocksize: 2097152               274            299          30        364.7           2.7       3.7X
 
 
 ================================================================================================
@@ -54,8 +126,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304            927            939          11        107.9           9.3       1.0X
-With bloom filter, blocksize: 4194304               239            263          27        418.3           2.4       3.9X
+Without bloom filter, blocksize: 4194304            936            966          27        106.8           9.4       1.0X
+With bloom filter, blocksize: 4194304               203            215          18        493.2           2.0       4.6X
 
 
 ================================================================================================
@@ -66,8 +138,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456            958            968          11        104.3           9.6       1.0X
-With bloom filter, blocksize: 6291456               279            302          17        357.9           2.8       3.4X
+Without bloom filter, blocksize: 6291456            923            940          25        108.3           9.2       1.0X
+With bloom filter, blocksize: 6291456               325            334           8        307.9           3.2       2.8X
 
 
 ================================================================================================
@@ -78,8 +150,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608            898            930          31        111.4           9.0       1.0X
-With bloom filter, blocksize: 8388608               360            380          13        278.0           3.6       2.5X
+Without bloom filter, blocksize: 8388608            913            925          12        109.5           9.1       1.0X
+With bloom filter, blocksize: 8388608               365            386          18        274.1           3.6       2.5X
 
 
 ================================================================================================
@@ -90,8 +162,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912            937            954          25        106.7           9.4       1.0X
-With bloom filter, blocksize: 12582912               650            696          40        153.9           6.5       1.4X
+Without bloom filter, blocksize: 12582912            901            924          21        111.0           9.0       1.0X
+With bloom filter, blocksize: 12582912               659            681          24        151.7           6.6       1.4X
 
 
 ================================================================================================
@@ -102,8 +174,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216            934            949          14        107.1           9.3       1.0X
-With bloom filter, blocksize: 16777216               925            935           9        108.2           9.2       1.0X
+Without bloom filter, blocksize: 16777216            900            917          15        111.1           9.0       1.0X
+With bloom filter, blocksize: 16777216               810            824          21        123.5           8.1       1.1X
 
 
 ================================================================================================
@@ -114,7 +186,7 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432            910            931          18        109.8           9.1       1.0X
-With bloom filter, blocksize: 33554432               910            927          15        109.9           9.1       1.0X
+Without bloom filter, blocksize: 33554432            891            911          18        112.3           8.9       1.0X
+With bloom filter, blocksize: 33554432               921            932          14        108.6           9.2       1.0X
 
 

--- a/sql/core/benchmarks/BloomFilterBenchmark-results.txt
+++ b/sql/core/benchmarks/BloomFilterBenchmark-results.txt
@@ -6,8 +6,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              20928          21034         149          4.8         209.3       1.0X
-With bloom filter                                 23707          23716          12          4.2         237.1       0.9X
+Without bloom filter                              18682          18792         156          5.4         186.8       1.0X
+With bloom filter                                 21347          21396          69          4.7         213.5       0.9X
 
 
 ================================================================================================
@@ -18,8 +18,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152           1464           1477          19         68.3          14.6       1.0X
-With bloom filter, blocksize: 2097152              1109           1131          31         90.2          11.1       1.3X
+Without bloom filter, blocksize: 2097152           1656           1666          14         60.4          16.6       1.0X
+With bloom filter, blocksize: 2097152              1203           1230          37         83.1          12.0       1.4X
 
 
 ================================================================================================
@@ -30,8 +30,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304           1435           1446          15         69.7          14.4       1.0X
-With bloom filter, blocksize: 4194304              1087           1092           7         92.0          10.9       1.3X
+Without bloom filter, blocksize: 4194304           1625           1632          10         61.6          16.2       1.0X
+With bloom filter, blocksize: 4194304              1224           1284          85         81.7          12.2       1.3X
 
 
 ================================================================================================
@@ -42,8 +42,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456           1312           1395         116         76.2          13.1       1.0X
-With bloom filter, blocksize: 6291456              1059           1062           4         94.4          10.6       1.2X
+Without bloom filter, blocksize: 6291456           1599           1601           3         62.5          16.0       1.0X
+With bloom filter, blocksize: 6291456              1162           1179          24         86.0          11.6       1.4X
 
 
 ================================================================================================
@@ -54,8 +54,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608           1324           1337          19         75.6          13.2       1.0X
-With bloom filter, blocksize: 8388608              1086           1144          82         92.1          10.9       1.2X
+Without bloom filter, blocksize: 8388608           1623           1638          21         61.6          16.2       1.0X
+With bloom filter, blocksize: 8388608              1181           1197          23         84.7          11.8       1.4X
 
 
 ================================================================================================
@@ -66,8 +66,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912           1316           1333          25         76.0          13.2       1.0X
-With bloom filter, blocksize: 12582912              1019           1055          50         98.1          10.2       1.3X
+Without bloom filter, blocksize: 12582912           1631           1643          18         61.3          16.3       1.0X
+With bloom filter, blocksize: 12582912              1159           1183          34         86.3          11.6       1.4X
 
 
 ================================================================================================
@@ -78,8 +78,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216           1301           1320          27         76.9          13.0       1.0X
-With bloom filter, blocksize: 16777216              1031           1039          11         97.0          10.3       1.3X
+Without bloom filter, blocksize: 16777216           1586           1597          16         63.0          15.9       1.0X
+With bloom filter, blocksize: 16777216              1170           1175           7         85.5          11.7       1.4X
 
 
 ================================================================================================
@@ -90,8 +90,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432           1328           1331           5         75.3          13.3       1.0X
-With bloom filter, blocksize: 33554432              1017           1042          35         98.3          10.2       1.3X
+Without bloom filter, blocksize: 33554432           1646           1649           4         60.8          16.5       1.0X
+With bloom filter, blocksize: 33554432              1186           1187           1         84.3          11.9       1.4X
 
 
 ================================================================================================
@@ -102,8 +102,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Write 100M rows:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter                              17756          17782          37          5.6         177.6       1.0X
-With bloom filter                                 27591          27805         303          3.6         275.9       0.6X
+Without bloom filter                              16633          16773         197          6.0         166.3       1.0X
+With bloom filter                                 23442          23538         136          4.3         234.4       0.7X
 
 
 ================================================================================================
@@ -114,8 +114,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 2097152           1011           1016           8         98.9          10.1       1.0X
-With bloom filter, blocksize: 2097152               274            299          30        364.7           2.7       3.7X
+Without bloom filter, blocksize: 2097152            955            965          13        104.7           9.6       1.0X
+With bloom filter, blocksize: 2097152               271            289          17        368.8           2.7       3.5X
 
 
 ================================================================================================
@@ -126,8 +126,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 4194304            936            966          27        106.8           9.4       1.0X
-With bloom filter, blocksize: 4194304               203            215          18        493.2           2.0       4.6X
+Without bloom filter, blocksize: 4194304            897            907           9        111.4           9.0       1.0X
+With bloom filter, blocksize: 4194304               242            255          19        412.6           2.4       3.7X
 
 
 ================================================================================================
@@ -138,8 +138,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 6291456            923            940          25        108.3           9.2       1.0X
-With bloom filter, blocksize: 6291456               325            334           8        307.9           3.2       2.8X
+Without bloom filter, blocksize: 6291456            923            934          11        108.3           9.2       1.0X
+With bloom filter, blocksize: 6291456               271            283          11        369.0           2.7       3.4X
 
 
 ================================================================================================
@@ -150,8 +150,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 8388608            913            925          12        109.5           9.1       1.0X
-With bloom filter, blocksize: 8388608               365            386          18        274.1           3.6       2.5X
+Without bloom filter, blocksize: 8388608            916            920           3        109.1           9.2       1.0X
+With bloom filter, blocksize: 8388608               442            448           9        226.4           4.4       2.1X
 
 
 ================================================================================================
@@ -162,8 +162,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 12582912            901            924          21        111.0           9.0       1.0X
-With bloom filter, blocksize: 12582912               659            681          24        151.7           6.6       1.4X
+Without bloom filter, blocksize: 12582912            899            917          15        111.2           9.0       1.0X
+With bloom filter, blocksize: 12582912               676            682           7        148.0           6.8       1.3X
 
 
 ================================================================================================
@@ -174,8 +174,8 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 16777216            900            917          15        111.1           9.0       1.0X
-With bloom filter, blocksize: 16777216               810            824          21        123.5           8.1       1.1X
+Without bloom filter, blocksize: 16777216            894            913          17        111.8           8.9       1.0X
+With bloom filter, blocksize: 16777216               866            890          26        115.4           8.7       1.0X
 
 
 ================================================================================================
@@ -186,7 +186,7 @@ OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
 Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
 Read a row from 100M rows:                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Without bloom filter, blocksize: 33554432            891            911          18        112.3           8.9       1.0X
-With bloom filter, blocksize: 33554432               921            932          14        108.6           9.2       1.0X
+Without bloom filter, blocksize: 33554432            896            921          22        111.6           9.0       1.0X
+With bloom filter, blocksize: 33554432               909            924          20        110.1           9.1       1.0X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/BloomFilterBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/BloomFilterBenchmark.scala
@@ -61,21 +61,27 @@ object BloomFilterBenchmark extends SqlBasedBenchmark {
   }
 
   private def readORCBenchmark(): Unit = {
-    withTempPath { dir =>
-      val path = dir.getCanonicalPath
+    val blockSizes = Seq(2 * 1024 * 1024, 4 * 1024 * 1024, 6 * 1024 * 1024, 8 * 1024 * 1024,
+      12 * 1024 * 1024, 16 * 1024 * 1024, 32 * 1024 * 1024)
+    for (blocksize <- blockSizes) {
+      withTempPath { dir =>
+        val path = dir.getCanonicalPath
 
-      df.write.orc(path + "/withoutBF")
-      df.write.option("orc.bloom.filter.columns", "value").orc(path + "/withBF")
+        df.write.option("orc.block.size", blocksize).orc(path + "/withoutBF")
+        df.write
+          .option("orc.block.size", blocksize)
+          .option("orc.bloom.filter.columns", "value").orc(path + "/withBF")
 
-      runBenchmark(s"ORC Read") {
-        val benchmark = new Benchmark(s"Read a row from ${scaleFactor}M rows", N, output = output)
-        benchmark.addCase("Without bloom filter") { _ =>
-          spark.read.orc(path + "/withoutBF").where("value = 0").noop()
+        runBenchmark(s"ORC Read") {
+          val benchmark = new Benchmark(s"Read a row from ${scaleFactor}M rows", N, output = output)
+          benchmark.addCase("Without bloom filter, blocksize: " + blocksize) { _ =>
+            spark.read.orc(path + "/withoutBF").where("value = 0").noop()
+          }
+          benchmark.addCase("With bloom filter, blocksize: " + blocksize) { _ =>
+            spark.read.orc(path + "/withBF").where("value = 0").noop()
+          }
+          benchmark.run()
         }
-        benchmark.addCase("With bloom filter") { _ =>
-          spark.read.orc(path + "/withBF").where("value = 0").noop()
-        }
-        benchmark.run()
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `BloomFilterBenchmark` by adding more `blockSize` combination tests for ORC.

- Java 8: https://github.com/dongjoon-hyun/spark/actions/runs/2178431204
- Java 11: https://github.com/dongjoon-hyun/spark/actions/runs/2178432284
- Java 17: https://github.com/dongjoon-hyun/spark/actions/runs/2178432661

### Why are the changes needed?

For Parquet, we had the benchmark already. This will provide a feature parity of the comparison.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test because this is a benchmark.