### PR TITLE
[SPARK-38747][SQL][TESTS] Move the tests for `PARSE_SYNTAX_ERROR` to QueryParsingErrorsSuite

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ErrorParserSuite.scala
@@ -88,17 +88,6 @@ class ErrorParserSuite extends AnalysisTest {
     intercept("select *\nfrom r as q t", 2, 12, 13, "Syntax error at or near", "------------^^^")
   }
 
-  test("mismatched input") {
-    intercept("select * from r order by q from t", "PARSE_SYNTAX_ERROR",
-      1, 27, 31,
-      "Syntax error at or near",
-      "---------------------------^^^"
-    )
-    intercept("select *\nfrom r\norder by q\nfrom t", "PARSE_SYNTAX_ERROR",
-      4, 0, 4,
-      "Syntax error at or near", "^^^")
-  }
-
   test("empty input") {
     val expectedErrMsg = SparkThrowableHelper.getMessage("PARSE_EMPTY_STATEMENT", Array[String]())
     intercept("", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
@@ -106,27 +95,10 @@ class ErrorParserSuite extends AnalysisTest {
     intercept(" \n", Some("PARSE_EMPTY_STATEMENT"), expectedErrMsg)
   }
 
-  test("jargon token substitute to user-facing language") {
-    // '<EOF>' -> end of input
-    intercept("select count(*", "PARSE_SYNTAX_ERROR",
-      1, 14, 14, "Syntax error at or near end of input")
-    intercept("select 1 as a from", "PARSE_SYNTAX_ERROR",
-      1, 18, 18, "Syntax error at or near end of input")
-  }
-
   test("semantic errors") {
     intercept("select *\nfrom r\norder by q\ncluster by q", 3, 0, 11,
       "Combination of ORDER BY/SORT BY/DISTRIBUTE BY/CLUSTER BY is not supported",
       "^^^")
-  }
-
-  test("SPARK-21136: misleading error message due to problematic antlr grammar") {
-    intercept("select * from a left join_ b on a.id = b.id", None,
-      "Syntax error at or near 'join_': missing 'JOIN'")
-    intercept("select * from test where test.t is like 'test'", Some("PARSE_SYNTAX_ERROR"),
-      SparkThrowableHelper.getMessage("PARSE_SYNTAX_ERROR", Array("'is'", "")))
-    intercept("SELECT * FROM test WHERE x NOT NULL", Some("PARSE_SYNTAX_ERROR"),
-      SparkThrowableHelper.getMessage("PARSE_SYNTAX_ERROR", Array("'NOT'", "")))
   }
 
   test("hyphen in identifier - DDL tests") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -405,4 +405,106 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
           |-----------------------------^^^
           |""".stripMargin)
   }
+
+  test("PARSE_SYNTAX_ERROR: mismatched input") {
+    validateParsingError(
+      sqlText = "select * from r order by q from t",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near 'from'(line 1, pos 27)
+          |
+          |== SQL ==
+          |select * from r order by q from t
+          |---------------------------^^^
+          |""".stripMargin)
+
+    validateParsingError(
+      sqlText = "select *\nfrom r\norder by q\nfrom t",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near 'from'(line 4, pos 0)
+          |
+          |== SQL ==
+          |select *
+          |from r
+          |order by q
+          |from t
+          |^^^
+          |""".stripMargin)
+  }
+
+  test("PARSE_SYNTAX_ERROR: jargon token substitute to user-facing language") {
+    // '<EOF>' -> end of input
+    validateParsingError(
+      sqlText = "select count(*",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near end of input(line 1, pos 14)
+          |
+          |== SQL ==
+          |select count(*
+          |--------------^^^
+          |""".stripMargin)
+
+    validateParsingError(
+      sqlText = "select 1 as a from",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near end of input(line 1, pos 18)
+          |
+          |== SQL ==
+          |select 1 as a from
+          |------------------^^^
+          |""".stripMargin)
+  }
+
+  test("PARSE_SYNTAX_ERROR - SPARK-21136: " +
+    "misleading error message due to problematic antlr grammar") {
+    validateParsingError(
+      sqlText = "select * from a left join_ b on a.id = b.id",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near 'join_': missing 'JOIN'(line 1, pos 21)
+          |
+          |== SQL ==
+          |select * from a left join_ b on a.id = b.id
+          |---------------------^^^
+          |""".stripMargin)
+
+    validateParsingError(
+      sqlText = "select * from test where test.t is like 'test'",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near 'is'(line 1, pos 32)
+          |
+          |== SQL ==
+          |select * from test where test.t is like 'test'
+          |--------------------------------^^^
+          |""".stripMargin)
+
+    validateParsingError(
+      sqlText = "SELECT * FROM test WHERE x NOT NULL",
+      errorClass = "PARSE_SYNTAX_ERROR",
+      sqlState = "42000",
+      message =
+        """
+          |Syntax error at or near 'NOT'(line 1, pos 27)
+          |
+          |== SQL ==
+          |SELECT * FROM test WHERE x NOT NULL
+          |---------------------------^^^
+          |""".stripMargin)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to Move tests for the error class PARSE_SYNTAX_ERROR from ErrorParserSuite to QueryParsingErrorsSuite., it's a followup of [SPARK-37935](https://issues.apache.org/jira/browse/SPARK-37935).

### Why are the changes needed?
Move tests for the error class PARSE_SYNTAX_ERROR from ErrorParserSuite to QueryParsingErrorsSuite

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
- Manual test：

```
./build/sbt "sql/testOnly *QueryParsingErrorsSuite*"
```

All tests passed.