### PR TITLE
Revert "[SPARK-38750][SQL][TESTS] Test the error class: SECOND_FUNCTION_ARGUMENT_NOT_INTEGER"

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -310,17 +310,6 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
-
-  test("SECOND_FUNCTION_ARGUMENT_NOT_INTEGER: " +
-    "the second argument of 'date_add' function needs to be an integer") {
-    val e = intercept[AnalysisException] {
-      sql("select date_add('1982-08-15', 'x')").collect()
-    }
-    assert(e.getErrorClass === "SECOND_FUNCTION_ARGUMENT_NOT_INTEGER")
-    assert(e.getSqlState === "22023")
-    assert(e.getMessage ===
-      "The second argument of 'date_add' function needs to be an integer.")
-  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This reverts commit https://github.com/apache/spark/commit/7246d25cc9ec36dafe6b7df16c78b704c5934d84.

### Why are the changes needed?
The new test fails with the error in one of GAs:
```
[info] - SECOND_FUNCTION_ARGUMENT_NOT_INTEGER: the second argument of 'date_add' function needs to be an integer *** FAILED *** (22 milliseconds)
[info]   Expected exception org.apache.spark.sql.AnalysisException to be thrown, but java.lang.NumberFormatException was thrown (QueryCompilationErrorsSuite.scala:316)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By existing GAs.