### PR TITLE
[SPARK-38784][CORE] Upgrade Jetty to 9.4.46

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -146,7 +146,7 @@ jersey-hk2/2.35//jersey-hk2-2.35.jar
 jersey-server/2.35//jersey-server-2.35.jar
 jetty-sslengine/6.1.26//jetty-sslengine-6.1.26.jar
 jetty-util/6.1.26//jetty-util-6.1.26.jar
-jetty-util/9.4.44.v20210927//jetty-util-9.4.44.v20210927.jar
+jetty-util/9.4.46.v20220331//jetty-util-9.4.46.v20220331.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.13//joda-time-2.10.13.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -133,8 +133,8 @@ jersey-container-servlet/2.35//jersey-container-servlet-2.35.jar
 jersey-hk2/2.35//jersey-hk2-2.35.jar
 jersey-server/2.35//jersey-server-2.35.jar
 jettison/1.1//jettison-1.1.jar
-jetty-util-ajax/9.4.44.v20210927//jetty-util-ajax-9.4.44.v20210927.jar
-jetty-util/9.4.44.v20210927//jetty-util-9.4.44.v20210927.jar
+jetty-util-ajax/9.4.46.v20220331//jetty-util-ajax-9.4.46.v20220331.jar
+jetty-util/9.4.46.v20220331//jetty-util-9.4.46.v20220331.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.13//joda-time-2.10.13.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>
     <orc.version>1.7.4</orc.version>
-    <jetty.version>9.4.44.v20210927</jetty.version>
+    <jetty.version>9.4.46.v20220331</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <ivy.version>2.5.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade Jetty to 9.4.46

### Why are the changes needed?

Three CVEs, which don't necessarily appear to affect Spark, are fixed in this version. Just housekeeping.
CVE-2021-28169
CVE-2021-34428
CVE-2021-34429

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests