### PR TITLE
[SPARK-38868][SQL] Don't propagate exceptions from filter predicate when optimizing outer joins

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -144,6 +144,8 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
     val emptyRow = new GenericInternalRow(attributes.length)
     val boundE = BindReferences.bindReference(e, attributes)
     if (boundE.exists(_.isInstanceOf[Unevaluable])) return false
+    // don't evaluate an expression that might purposefully throw an exception
+    if (boundE.exists(_.isInstanceOf[RaiseError])) return false
     val v = boundE.eval(emptyRow)
     v == null || v == false
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import scala.annotation.tailrec
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.planning.ExtractFiltersAndInnerJoins
@@ -151,7 +152,7 @@ object EliminateOuterJoin extends Rule[LogicalPlan] with PredicateHelper {
       val v = boundE.eval(emptyRow)
       v == null || v == false
     } catch {
-      case e: Exception =>
+      case NonFatal(e) =>
         // cannot filter out null if `where` expression throws an exception with null input
         false
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
@@ -255,8 +255,7 @@ class OuterJoinEliminationSuite extends PlanTest {
     }
   }
 
-  // evaluating if assert_true/raised in filter predicate will cause exception
-  test("SPARK-38868: assert_true/raised in filter predicate does not throw exception") {
+  test("SPARK-38868: exception thrown from filter predicate does not propagate") {
     val x = testRelation.subquery(Symbol("x"))
     val y = testRelation1.subquery(Symbol("y"))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
@@ -259,7 +259,7 @@ class OuterJoinEliminationSuite extends PlanTest {
     val x = testRelation.subquery(Symbol("x"))
     val y = testRelation1.subquery(Symbol("y"))
 
-    val message = Literal(UTF8String fromString("Bad value"), StringType)
+    val message = Literal(UTF8String.fromString("Bad value"), StringType)
     val originalQuery =
       x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
         .where(If("y.d".attr > 0, true, RaiseError(message)).isNull)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
@@ -20,11 +20,13 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{Coalesce, IsNotNull}
+import org.apache.spark.sql.catalyst.expressions.{Coalesce, If, IsNotNull, Literal, RaiseError}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
 
 class OuterJoinEliminationSuite extends PlanTest {
   object Optimize extends RuleExecutor[LogicalPlan] {
@@ -251,5 +253,20 @@ class OuterJoinEliminationSuite extends PlanTest {
 
       comparePlans(optimized, originalQuery.analyze)
     }
+  }
+
+  // evaluating if assert_true/raised in filter predicate will cause exception
+  test("SPARK-38868: assert_true/raised in filter predicate does not throw exception") {
+    val x = testRelation.subquery(Symbol("x"))
+    val y = testRelation1.subquery(Symbol("y"))
+
+    val message = Literal(UTF8String fromString("Bad value"), StringType)
+    val originalQuery =
+      x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
+        .where(If("y.d".attr > 0, true, RaiseError(message)).isNull)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+
+    comparePlans(optimized, originalQuery.analyze)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `EliminateOuterJoin#canFilterOutNull` to return `false` when a `where` condition throws an exception.

### Why are the changes needed?

Consider this query:
```
select *
from (select id, id as b from range(0, 10)) l
left outer join (select id, id + 1 as c from range(0, 10)) r
on l.id = r.id
where assert_true(c > 0) is null;
```
The query should succeed, but instead fails with
```
java.lang.RuntimeException: '(c#1L > cast(0 as bigint))' is not true!
```
This happens even though there is no row where `c > 0` is false. 

The `EliminateOuterJoin` rule checks if it can convert the outer join to a inner join based on the expression in the where clause, which in this case is
```
assert_true(c > 0) is null
```
`EliminateOuterJoin#canFilterOutNull` evaluates that expression with `c` set to `null` to see if the result is `null` or `false`. That rule doesn't expect the result to be a `RuntimeException`, but in this case it always is.

That is, the assertion is failing during optimization, not at run time.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit test.
