### PR TITLE
[SPARK-38409][CORE] Do not export gauges with null values in prometheus metric snapshots

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusServlet.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusServlet.scala
@@ -33,8 +33,8 @@ import org.apache.spark.ui.JettyUtils._
  * and with the previous result of Spark JMX Sink + Prometheus JMX Converter combination
  * in terms of key string format.
  */
-private[spark] class PrometheusServlet(
-    val property: Properties, val registry: MetricRegistry) extends Sink {
+private[spark] class PrometheusServlet(val property: Properties, val registry: MetricRegistry)
+    extends Sink {
 
   val SERVLET_KEY_PATH = "path"
 
@@ -42,9 +42,10 @@ private[spark] class PrometheusServlet(
 
   def getHandlers(conf: SparkConf): Array[ServletContextHandler] = {
     Array[ServletContextHandler](
-      createServletHandler(servletPath,
-        new ServletParams(request => getMetricsSnapshot(request), "text/plain"), conf)
-    )
+      createServletHandler(
+        servletPath,
+        new ServletParams(request => getMetricsSnapshot(request), "text/plain"),
+        conf))
   }
 
   def getMetricsSnapshot(request: HttpServletRequest): String = {
@@ -57,29 +58,32 @@ private[spark] class PrometheusServlet(
     val timersLabels = """{type="timers"}"""
 
     val sb = new StringBuilder()
-    registry.getGauges.asScala.foreach { case (k, v) =>
-      if (!v.getValue.isInstanceOf[String] && !(v.getValue == null)) {
-        sb.append(s"${normalizeKey(k)}Number$gaugesLabel ${v.getValue}\n")
-        sb.append(s"${normalizeKey(k)}Value$gaugesLabel ${v.getValue}\n")
-      }
+    registry.getGauges.asScala.foreach {
+      case (k, v) =>
+        if (!v.getValue.isInstanceOf[String] && !(v.getValue == null)) {
+          sb.append(s"${normalizeKey(k)}Number$gaugesLabel ${v.getValue}\n")
+          sb.append(s"${normalizeKey(k)}Value$gaugesLabel ${v.getValue}\n")
+        }
     }
-    registry.getCounters.asScala.foreach { case (k, v) =>
-      sb.append(s"${normalizeKey(k)}Count$countersLabel ${v.getCount}\n")
+    registry.getCounters.asScala.foreach {
+      case (k, v) =>
+        sb.append(s"${normalizeKey(k)}Count$countersLabel ${v.getCount}\n")
     }
-    registry.getHistograms.asScala.foreach { case (k, h) =>
-      val snapshot = h.getSnapshot
-      val prefix = normalizeKey(k)
-      sb.append(s"${prefix}Count$histogramslabels ${h.getCount}\n")
-      sb.append(s"${prefix}Max$histogramslabels ${snapshot.getMax}\n")
-      sb.append(s"${prefix}Mean$histogramslabels ${snapshot.getMean}\n")
-      sb.append(s"${prefix}Min$histogramslabels ${snapshot.getMin}\n")
-      sb.append(s"${prefix}50thPercentile$histogramslabels ${snapshot.getMedian}\n")
-      sb.append(s"${prefix}75thPercentile$histogramslabels ${snapshot.get75thPercentile}\n")
-      sb.append(s"${prefix}95thPercentile$histogramslabels ${snapshot.get95thPercentile}\n")
-      sb.append(s"${prefix}98thPercentile$histogramslabels ${snapshot.get98thPercentile}\n")
-      sb.append(s"${prefix}99thPercentile$histogramslabels ${snapshot.get99thPercentile}\n")
-      sb.append(s"${prefix}999thPercentile$histogramslabels ${snapshot.get999thPercentile}\n")
-      sb.append(s"${prefix}StdDev$histogramslabels ${snapshot.getStdDev}\n")
+    registry.getHistograms.asScala.foreach {
+      case (k, h) =>
+        val snapshot = h.getSnapshot
+        val prefix = normalizeKey(k)
+        sb.append(s"${prefix}Count$histogramslabels ${h.getCount}\n")
+        sb.append(s"${prefix}Max$histogramslabels ${snapshot.getMax}\n")
+        sb.append(s"${prefix}Mean$histogramslabels ${snapshot.getMean}\n")
+        sb.append(s"${prefix}Min$histogramslabels ${snapshot.getMin}\n")
+        sb.append(s"${prefix}50thPercentile$histogramslabels ${snapshot.getMedian}\n")
+        sb.append(s"${prefix}75thPercentile$histogramslabels ${snapshot.get75thPercentile}\n")
+        sb.append(s"${prefix}95thPercentile$histogramslabels ${snapshot.get95thPercentile}\n")
+        sb.append(s"${prefix}98thPercentile$histogramslabels ${snapshot.get98thPercentile}\n")
+        sb.append(s"${prefix}99thPercentile$histogramslabels ${snapshot.get99thPercentile}\n")
+        sb.append(s"${prefix}999thPercentile$histogramslabels ${snapshot.get999thPercentile}\n")
+        sb.append(s"${prefix}StdDev$histogramslabels ${snapshot.getStdDev}\n")
     }
     registry.getMeters.entrySet.iterator.asScala.foreach { kv =>
       val prefix = normalizeKey(kv.getKey)
@@ -117,9 +121,9 @@ private[spark] class PrometheusServlet(
     s"metrics_${key.replaceAll("[^a-zA-Z0-9]", "_")}_"
   }
 
-  override def start(): Unit = { }
+  override def start(): Unit = {}
 
-  override def stop(): Unit = { }
+  override def stop(): Unit = {}
 
-  override def report(): Unit = { }
+  override def report(): Unit = {}
 }

--- a/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusServlet.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusServlet.scala
@@ -58,7 +58,7 @@ private[spark] class PrometheusServlet(
 
     val sb = new StringBuilder()
     registry.getGauges.asScala.foreach { case (k, v) =>
-      if (!v.getValue.isInstanceOf[String]) {
+      if (!v.getValue.isInstanceOf[String] && !(v.getValue == null)) {
         sb.append(s"${normalizeKey(k)}Number$gaugesLabel ${v.getValue}\n")
         sb.append(s"${normalizeKey(k)}Value$gaugesLabel ${v.getValue}\n")
       }

--- a/core/src/test/scala/org/apache/spark/metrics/sink/PrometheusServletSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/sink/PrometheusServletSuite.scala
@@ -43,11 +43,13 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     sink.registry.register("counter1", counter)
 
     val metricGaugeKeys = sink.registry.getGauges.keySet.asScala
-    assert(metricGaugeKeys.equals(Set("gauge1", "gauge2")),
+    assert(
+      metricGaugeKeys.equals(Set("gauge1", "gauge2")),
       "Should contain 2 gauges metrics registered")
 
     val metricCounterKeys = sink.registry.getCounters.keySet.asScala
-    assert(metricCounterKeys.equals(Set("counter1")),
+    assert(
+      metricCounterKeys.equals(Set("counter1")),
       "Should contain 1 counter metric registered")
 
     val gaugeValues = sink.registry.getGauges.values.asScala
@@ -64,10 +66,10 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
       "listenerProcessingTime.org.apache.spark.HeartbeatReceiver"
     val sink = createPrometheusServlet()
     val suffix = sink invokePrivate PrivateMethod[String](Symbol("normalizeKey"))(key)
-    assert(suffix == "metrics_local_1592132938718_driver_LiveListenerBus_" +
-      "listenerProcessingTime_org_apache_spark_HeartbeatReceiver_")
+    assert(
+      suffix == "metrics_local_1592132938718_driver_LiveListenerBus_" +
+        "listenerProcessingTime_org_apache_spark_HeartbeatReceiver_")
   }
-
 
   test("do not export null values in metric snapshots") {
     val sink = createPrometheusServlet()
@@ -87,7 +89,8 @@ class PrometheusServletSuite extends SparkFunSuite with PrivateMethodTester {
     sink.registry.register("counter1", counter)
 
     val metricGaugeKeys = sink.registry.getGauges.keySet.asScala
-    assert(metricGaugeKeys.equals(Set("gauge1", "gauge2")),
+    assert(
+      metricGaugeKeys.equals(Set("gauge1", "gauge2")),
       "Should contain 2 gauges metrics registered")
 
     val expectedResult =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR changes the PrometheusServlet to not export gauges (or counters) with null values in the metric snapshot. Currently, we do export these gauges using the value `null` in the metric snapshot. This can cause Prometheus to fail when scraping the servlet, as null is not a valid floating point value.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Null values are not valid floating point values. Prometheus will fail to scrape any metrics if a null value is part of the metrics snapshot. Such gauges can for instance be created with an uninitialized [DefaultSettableGauge](https://www.javadoc.io/static/io.dropwizard.metrics/metrics-core/4.2.0-beta.3/com/codahale/metrics/DefaultSettableGauge.html).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, gauges which are null are no longer exported. This is positive, as consumers of the metrics snapshots probably expect the snapshot to follow the [Prometheus text format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details).


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I've run the PrometheusServletSuite tests, and added a new test to verify that a gauge with a null value is not part of the metric snapshot.