### PR TITLE
[SPARK-38928][TESTS][SQL] Skip Pandas UDF test in `QueryCompilationErrorsSuite` if not available

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -110,6 +110,7 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
 
   test("INVALID_PANDAS_UDF_PLACEMENT: Using aggregate function with grouped aggregate pandas UDF") {
     import IntegratedUDFTestUtils._
+    assume(shouldTestGroupedAggPandasUDFs)
 
     val df = Seq(
       (536361, "85123A", 2, 17850),
@@ -159,6 +160,7 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
 
   test("UNSUPPORTED_FEATURE: Using pandas UDF aggregate expression with pivot") {
     import IntegratedUDFTestUtils._
+    assume(shouldTestGroupedAggPandasUDFs)
 
     val df = Seq(
       (536361, "85123A", 2, 17850),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to skip Pandas UDF tests in `QueryCompilationErrorsSuite` if not available. 


### Why are the changes needed?
The tests should be skipped instead of showing failure. 

**BEFORE**
```
$ build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryCompilationErrorsSuite"
...
[info] *** 2 TESTS FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.sql.errors.QueryCompilationErrorsSuite
[error] (sql / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
```

**AFTER**
```
$ build/sbt "sql/testOnly org.apache.spark.sql.errors.QueryCompilationErrorsSuite"
...
[info] Tests: succeeded 13, failed 0, canceled 2, ignored 0, pending 0
[info] All tests passed.
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass the CIs. 