### PR TITLE
[SPARK-38720][SQL][TESTS] Test the error class: CANNOT_CHANGE_DECIMAL_PRECISION

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -411,11 +411,11 @@ class QueryExecutionErrorsSuite extends QueryTest
       assert(e.getMessage ===
         "Decimal(expanded,66666666666666.666,17,3}) cannot be represented as Decimal(8, 1). " +
         "If necessary set spark.sql.ansi.enabled to false to bypass this error." +
-          """
-            |== SQL(line 1, position 7) ==
-            |select CAST('66666666666666.666' AS DECIMAL(8, 1))
-            |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            |""".stripMargin)
+        """
+          |== SQL(line 1, position 7) ==
+          |select CAST('66666666666666.666' AS DECIMAL(8, 1))
+          |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          |""".stripMargin)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -404,14 +404,13 @@ class QueryExecutionErrorsSuite extends QueryTest
   test("CANNOT_CHANGE_DECIMAL_PRECISION: cast string to decimal") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
       val e = intercept[SparkArithmeticException] {
-        sql("select CAST('66666666666666.666' " +
-          "AS DECIMAL(8, 1))").collect()
+        sql("select CAST('66666666666666.666' AS DECIMAL(8, 1))").collect()
       }
       assert(e.getErrorClass === "CANNOT_CHANGE_DECIMAL_PRECISION")
       assert(e.getSqlState === "22005")
       assert(e.getMessage ===
         "Decimal(expanded,66666666666666.666,17,3}) cannot be represented as Decimal(8, 1). " +
-          "If necessary set spark.sql.ansi.enabled to false to bypass this error." +
+        "If necessary set spark.sql.ansi.enabled to false to bypass this error." +
           """
             |== SQL(line 1, position 7) ==
             |select CAST('66666666666666.666' AS DECIMAL(8, 1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -400,4 +400,23 @@ class QueryExecutionErrorsSuite extends QueryTest
         "If necessary set spark.sql.ansi.enabled to false to bypass this error. ")
     }
   }
+
+  test("CANNOT_CHANGE_DECIMAL_PRECISION: cast string to decimal") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      val e = intercept[SparkArithmeticException] {
+        sql("select CAST('66666666666666.666' " +
+          "AS DECIMAL(8, 1))").collect()
+      }
+      assert(e.getErrorClass === "CANNOT_CHANGE_DECIMAL_PRECISION")
+      assert(e.getSqlState === "22005")
+      assert(e.getMessage ===
+        "Decimal(expanded,66666666666666.666,17,3}) cannot be represented as Decimal(8, 1). " +
+          "If necessary set spark.sql.ansi.enabled to false to bypass this error." +
+          """
+            |== SQL(line 1, position 7) ==
+            |select CAST('66666666666666.666' AS DECIMAL(8, 1))
+            |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            |""".stripMargin)
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR aims to add a test for the error class CANNOT_CHANGE_DECIMAL_PRECISION to `QueryExecutionErrorsSuite`.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryExecutionErrorsSuite*"
```