### PR TITLE
[SPARK-38933][SQL][DOCS] Add examples of window functions into SQL docs

### DIFF
--- a/docs/sql-ref-functions-builtin.md
+++ b/docs/sql-ref-functions-builtin.md
@@ -31,6 +31,8 @@ license: |
     {% if static_file.name == 'generated-window-funcs-table.html' %}
 ### Window Functions
 {% include_relative generated-window-funcs-table.html %}
+#### Examples
+{% include_relative generated-window-funcs-examples.html %}
         {% break %}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark SQL docs display the window functions without examples.

![image](https://user-images.githubusercontent.com/8486025/163788857-38313a9c-48b2-4b72-bc60-38056d91124e.png)

In fact, Mkdocs also generates the doc `generated-window-funcs-examples.html`
This PR just updates the `sql-ref-functions-builtin.md`

![image](https://user-images.githubusercontent.com/8486025/163789775-17255e1a-7f7e-4b79-b780-3b04ba55dde7.png)


### Why are the changes needed?
Let SQL docs display the examples of window functions.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update docs.


### How was this patch tested?
Manual tests.
