### PR TITLE
[SPARK-38936][SQL] Script transform feed thread should have name

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -262,8 +262,7 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
       }
 }
 
-abstract class BaseScriptTransformationWriterThread
-  extends Thread("Thread-ScriptTransformation-Feed") with Logging {
+abstract class BaseScriptTransformationWriterThread extends Thread with Logging {
 
   def iter: Iterator[InternalRow]
   def inputSchema: Seq[DataType]
@@ -274,6 +273,7 @@ abstract class BaseScriptTransformationWriterThread
   def taskContext: TaskContext
   def conf: Configuration
 
+  setName(s"Thread-${this.getClass.getSimpleName}-Feed")
   setDaemon(true)
 
   @volatile protected var _exception: Throwable = null
@@ -329,7 +329,7 @@ abstract class BaseScriptTransformationWriterThread
         // Javadoc this call will not throw an exception:
         _exception = t
         proc.destroy()
-        logError("Thread-ScriptTransformation-Feed exit cause by: ", t)
+        logError(s"Thread-${this.getClass.getSimpleName}-Feed exit cause by: ", t)
     } finally {
       try {
         Utils.tryLogNonFatalError(outputStream.close())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/BaseScriptTransformationExec.scala
@@ -262,7 +262,8 @@ trait BaseScriptTransformationExec extends UnaryExecNode {
       }
 }
 
-abstract class BaseScriptTransformationWriterThread extends Thread with Logging {
+abstract class BaseScriptTransformationWriterThread
+  extends Thread("Thread-ScriptTransformation-Feed") with Logging {
 
   def iter: Iterator[InternalRow]
   def inputSchema: Seq[DataType]


### PR DESCRIPTION
### What changes were proposed in this pull request?
re-add thread name(`Thread-ScriptTransformation-Feed`).

### Why are the changes needed?
Lost feed thread name after [SPARK-32105](https://issues.apache.org/jira/browse/SPARK-32105) refactoring.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exist UT
