### PR TITLE
[SPARK-38940][PYTHON] Test Series' anchor frame for in-place updates on Series

### DIFF
--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -175,8 +175,9 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
 
     def test_rename_method(self):
         # Series name
-        pser = pd.Series([1, 2, 3, 4, 5, 6, 7], name="x")
-        psser = ps.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7]})
+        psdf = ps.from_pandas(pdf)
+        pser, psser = pdf.x, psdf.x
 
         self.assert_eq(psser.rename("y"), pser.rename("y"))
         self.assertEqual(psser.name, "x")  # no mutation
@@ -188,6 +189,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser.rename("z", inplace=True)
         self.assertEqual(psser.name, "z")
         self.assert_eq(psser, pser)
+        self.assert_eq(psdf, pdf)
 
         expected_error_message = "Series.name must be a hashable type"
         with self.assertRaisesRegex(TypeError, expected_error_message):
@@ -548,12 +550,14 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         psser.fillna(0, inplace=True)
         pser.fillna(0, inplace=True)
         self.assert_eq(psser, pser)
+        self.assert_eq(psdf, pdf)
 
         psser = psdf.x.rename("y")
         pser = pdf.x.rename("y")
         psser.fillna(0, inplace=True)
         pser.fillna(0, inplace=True)
         self.assert_eq(psser.head(), pser.head())
+        self.assert_eq(psdf, pdf)
 
         pser = pd.Series([1, 2, 3, 4, 5, 6], name="x")
         psser = ps.from_pandas(pser)
@@ -1106,8 +1110,9 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
                 getattr(psser, name)
 
     def test_clip(self):
-        pser = pd.Series([0, 2, 4], index=np.random.rand(3), name="x")
-        psser = ps.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [0, 2, 4]}, index=np.random.rand(3))
+        psdf = ps.from_pandas(pdf)
+        pser, psser = pdf.x, psdf.x
 
         # Assert list-like values are not accepted for 'lower' and 'upper'
         msg = "List-like value are not supported for 'lower' and 'upper' at the moment"
@@ -1127,10 +1132,10 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq((psser + 1).clip(1, 3), (pser + 1).clip(1, 3))
 
         # Assert inplace is True
-        psser = ps.from_pandas(pser)
         pser.clip(1, 3, inplace=True)
         psser.clip(1, 3, inplace=True)
         self.assert_eq(psser, pser)
+        self.assert_eq(psdf, pdf)
 
         # Assert behavior on string values
         str_psser = ps.Series(["a", "b", "c"])
@@ -2802,8 +2807,9 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             self.assert_eq(puniques, kuniques)
 
     def test_pad(self):
-        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
-        psser = ps.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6]})
+        psdf = ps.from_pandas(pdf)
+        pser, psser = pdf.x, psdf.x
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
             self.assert_eq(pser.pad(), psser.pad())
@@ -2812,6 +2818,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             pser.pad(inplace=True)
             psser.pad(inplace=True)
             self.assert_eq(pser, psser)
+            self.assert_eq(pdf, psdf)
         else:
             expected = ps.Series([np.nan, 2, 3, 4, 4, 6], name="x")
             self.assert_eq(expected, psser.pad())
@@ -2963,8 +2970,9 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             ps.Series([]).argmax()
 
     def test_backfill(self):
-        pser = pd.Series([np.nan, 2, 3, 4, np.nan, 6], name="x")
-        psser = ps.from_pandas(pser)
+        pdf = pd.DataFrame({"x": [np.nan, 2, 3, 4, np.nan, 6]})
+        psdf = ps.from_pandas(pdf)
+        pser, psser = pdf.x, psdf.x
 
         if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
             self.assert_eq(pser.backfill(), psser.backfill())
@@ -2973,6 +2981,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
             pser.backfill(inplace=True)
             psser.backfill(inplace=True)
             self.assert_eq(pser, psser)
+            self.assert_eq(pdf, psdf)
         else:
             expected = ps.Series([2.0, 2.0, 3.0, 4.0, 6.0, 6.0], name="x")
             self.assert_eq(expected, psser.backfill())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Test Series' anchor DataFrame for in-place updates on Series.

### Why are the changes needed?
In pandas, some in-place updates on Series change its anchor frame (e.g. `Series.clip`), while others don't.
We should test that to ensure parity with pandas.

#### Example on changed anchor DataFrame
```py
>>> df = pd.DataFrame({'x': [1, 2, 3]})
>>> ser = df.x

>>> ser.clip(2, 2, inplace=True)
>>> ser
0    2
1    2
2    2
Name: x, dtype: int64
>>> df
   x
0  2
1  2
2  2
```

#### Example on unchanged anchor DataFrame
```py
>>> df = pd.DataFrame({'x': [1, 2, 3]})
>>> ser = df.x

>>> ser.drop(1, inplace=True)
>>> ser
0    1
2    3
Name: x, dtype: int64
>>> df
   x
0  1
1  2
2  3
```
### Does this PR introduce _any_ user-facing change?
No. Test only.

### How was this patch tested?
Unit tests.