### PR TITLE
[SPARK-38932][SQL] Datasource v2 support report distinct keys

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsReportDistinctKeys.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsReportDistinctKeys.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read;
+
+import java.util.Set;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+
+/**
+ * A mix in interface for {@link Scan}. Data sources can implement this interface to
+ * report unique keys set to Spark.
+ * <p>
+ * Spark will optimize the query plan according to the given unique keys.
+ * For example, Spark will eliminate the `Distinct` if the v2 relation only output the unique
+ * attributes.
+ * <pre>
+ *   Distinct
+ *     +- RelationV2[unique_key#1]
+ * </pre>
+ * <p>
+ * Note that, Spark doest not validate whether the value is unique or not. The implementation
+ * should guarantee this.
+ *
+ * @since 3.4.0
+ */
+@Evolving
+public interface SupportsReportDistinctKeys extends Scan {
+    /**
+     * Returns a set of unique keys. Each unique keys can consist of multiple attributes.
+     */
+    Set<Set<NamedReference>> distinctKeysSet();
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/V2ExpressionUtils.scala
@@ -49,6 +49,10 @@ object V2ExpressionUtils extends SQLConfHelper with Logging {
     refs.map(ref => resolveRef[T](ref, plan))
   }
 
+  def resolveRefs[T <: NamedExpression](refs: Set[NamedReference], plan: LogicalPlan): Set[T] = {
+    refs.map(ref => resolveRef[T](ref, plan))
+  }
+
   /**
    * Converts the array of input V2 [[V2SortOrder]] into their counterparts in catalyst.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitor.scala
@@ -62,7 +62,10 @@ object DistinctKeyVisitor extends LogicalPlanVisitor[Set[ExpressionSet]] {
     }
   }
 
-  override def default(p: LogicalPlan): Set[ExpressionSet] = Set.empty[ExpressionSet]
+  override def default(p: LogicalPlan): Set[ExpressionSet] = p match {
+    case leaf: LeafNode => leaf.reportDistinctKeysSet()
+    case _ => Set.empty[ExpressionSet]
+  }
 
   override def visitAggregate(p: Aggregate): Set[ExpressionSet] = {
     // handle group by a, a and global aggregate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -167,6 +167,9 @@ abstract class LogicalPlan
 trait LeafNode extends LogicalPlan with LeafLike[LogicalPlan] {
   override def producedAttributes: AttributeSet = outputSet
 
+  /** Return a set of unique keys. */
+  def reportDistinctKeysSet(): Set[ExpressionSet] = Set.empty[ExpressionSet]
+
   /** Leaf nodes that can survive analysis must define their own statistics. */
   def computeStats(): Statistics = throw new UnsupportedOperationException
 }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaReportDistinctKeysDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaReportDistinctKeysDataSource.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.apache.spark.sql.connector;
+
+import com.google.common.collect.Sets;
+import org.apache.spark.sql.connector.TestingV2Source;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.*;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.util.Set;
+
+public class JavaReportDistinctKeysDataSource implements TestingV2Source {
+    static class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportDistinctKeys {
+        @Override
+        public Set<Set<NamedReference>> distinctKeysSet() {
+            return Sets.newHashSet(
+                    Sets.newHashSet(FieldReference.apply("i")),
+                    Sets.newHashSet(FieldReference.apply("j")));
+        }
+
+        @Override
+        public InputPartition[] planInputPartitions() {
+            InputPartition[] partitions = new InputPartition[1];
+            partitions[0] = new JavaRangeInputPartition(0, 1);
+            return partitions;
+        }
+    }
+
+    @Override
+    public Table getTable(CaseInsensitiveStringMap options) {
+        return new JavaSimpleBatchTable() {
+            @Override
+            public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+                return new JavaReportDistinctKeysDataSource.MyScanBuilder();
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- Add a new mix in interface `SupportsReportDistinctKeys` for datasource v2
- Add a new method `reportDistinctKeysSet` in `LeafNode`
- Override `reportDistinctKeysSet` in datasource v2 relation
- Propagate `reportDistinctKeysSet` at `DistinctKeysVisitor`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Datasource v2 can be used to connect to some databases who support [unique key](https://en.wikipedia.org/wiki/Unique_key).

Spark catalyst optimizer support do further optimization through distinct keys. So it can improve the performance if the Scan reports its distinct keys to Spark.

We already have several optimizer rules for distinct keys, for example:
- https://github.com/apache/spark/pull/35779
- https://github.com/apache/spark/pull/36117
- https://github.com/apache/spark/pull/36530

We also have some prs which is in progress related distinct keys,  for example:
- https://github.com/apache/spark/pull/37267
- https://github.com/apache/spark/pull/36180

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, a new interface added for developer

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test 