### PR TITLE
[SPARK-38941][TESTS][SQL][3.3] Skip RocksDB-based test case in StreamingJoinSuite on Apple Silicon

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -1356,6 +1356,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
 
   test("SPARK-38684: outer join works correctly even if processing input rows and " +
     "evicting state rows for same grouping key happens in the same micro-batch") {
+    assume(!Utils.isMacOnAppleSilicon)
 
     // The test is to demonstrate the correctness issue in outer join before SPARK-38684.
     withSQLConf(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR aims to skip RocksDB-based test case in `StreamingJoinSuite` on Apple Silicon.


### Why are the changes needed?
Currently, it is broken on Apple Silicon. 


**BEFORE**
```
$ build/sbt "sql/testOnly org.apache.spark.sql.streaming.Streaming*JoinSuite"
...
[info] Run completed in 2 minutes, 47 seconds.
[info] Total number of tests run: 43
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 42, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.sql.streaming.StreamingOuterJoinSuite
[error] (sql / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
```

**AFTER**
```
$ build/sbt "sql/testOnly org.apache.spark.sql.streaming.Streaming*JoinSuite"
...
[info] Run completed in 2 minutes, 52 seconds.
[info] Total number of tests run: 42
[info] Suites: completed 4, aborted 0
[info] Tests: succeeded 42, failed 0, canceled 1, ignored 0, pending 0
[info] All tests passed.
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually test on Apple Silicon. 
