### PR TITLE
[SPARK-38828][PYTHON] Remove TimestampNTZ type Python support in Spark 3.3

### DIFF
--- a/python/docs/source/reference/pyspark.sql.rst
+++ b/python/docs/source/reference/pyspark.sql.rst
@@ -302,7 +302,6 @@ Data Types
     StringType
     StructField
     StructType
-    TimestampNTZType
     TimestampType
     DayTimeIntervalType
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -59,7 +59,6 @@ __all__ = [
     "BooleanType",
     "DateType",
     "TimestampType",
-    "TimestampNTZType",
     "DecimalType",
     "DoubleType",
     "FloatType",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove `TimestampNTZ` type Python support in Spark 3.3 from documentation and `pyspark.sql.types` module.

The purpose of this PR is just hide `TimestampNTZ` type from end-users.

### Why are the changes needed?

Because the `TimestampNTZ` project is not finished yet:

- Lack Hive metastore support
- Lack JDBC support
- Need to spend time scanning the codebase to find out any missing support. The current code usages of TimestampType are larger than TimestampNTZType

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests should cover.
