### PR TITLE
[SPARK-38942][TESTS][SQL][3.3] Skip RocksDB-based test case in FlatMapGroupsWithStateSuite on Apple Silicon

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
@@ -1521,6 +1521,7 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
   }
 
   test("SPARK-38320 - flatMapGroupsWithState state with data should not timeout") {
+    assume(!Utils.isMacOnAppleSilicon)
     withTempDir { dir =>
       withSQLConf(
         (SQLConf.STREAMING_NO_DATA_MICRO_BATCHES_ENABLED.key -> "false"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to skip RocksDB-based test case in FlatMapGroupsWithStateSuite on Apple Silicon.

### Why are the changes needed?
Currently, it is broken on Apple Silicon. 

**BEFORE**
```
$ build/sbt "sql/testOnly org.apache.spark.sql.streaming.FlatMapGroupsWithStateSuite"
...
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error] 	org.apache.spark.sql.streaming.FlatMapGroupsWithStateSuite
[error] (sql / Test / testOnly) sbt.TestsFailedException: Tests unsuccessful
```

**AFTER**
```
$ build/sbt "sql/testOnly org.apache.spark.sql.streaming.FlatMapGroupsWithStateSuite"
...
[info] Run completed in 32 seconds, 692 milliseconds.
[info] Total number of tests run: 105
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 105, failed 0, canceled 1, ignored 0, pending 0
[info] All tests passed.
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test manually on Apple Silicon.