### PR TITLE
[SPARK-38943][PYTHON] EWM support ignore_na

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2626,8 +2626,8 @@ class Frame(object, metaclass=ABCMeta):
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
-        ignore_na: bool_type = False,
         min_periods: Optional[int] = None,
+        ignore_na: bool_type = False,
     ) -> "ExponentialMoving[FrameLike]":
         """
         Provide exponentially weighted window transformations.
@@ -2660,6 +2660,21 @@ class Frame(object, metaclass=ABCMeta):
             Minimum number of observations in window required to have a value
             (otherwise result is NA).
 
+        ignore_na : bool, default False
+            Ignore missing values when calculating weights.
+
+            - When ``ignore_na=False`` (default), weights are based on absolute positions.
+              For example, the weights of :math:`x_0` and :math:`x_2` used in calculating
+              the final weighted average of [:math:`x_0`, None, :math:`x_2`] are
+              :math:`(1-\alpha)^2` and :math:`1` if ``adjust=True``, and
+              :math:`(1-\alpha)^2` and :math:`\alpha` if ``adjust=False``.
+
+            - When ``ignore_na=True``, weights are based
+              on relative positions. For example, the weights of :math:`x_0` and :math:`x_2`
+              used in calculating the final weighted average of
+              [:math:`x_0`, None, :math:`x_2`] are :math:`1-\alpha` and :math:`1` if
+              ``adjust=True``, and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
+
         Returns
         -------
         a Window sub-classed for the particular operation
@@ -2672,8 +2687,8 @@ class Frame(object, metaclass=ABCMeta):
             span=span,
             halflife=halflife,
             alpha=alpha,
-            ignore_na=ignore_na,
             min_periods=min_periods,
+            ignore_na=ignore_na,
         )
 
     def get(self, key: Any, default: Optional[Any] = None) -> Any:

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2619,13 +2619,14 @@ class Frame(object, metaclass=ABCMeta):
 
         return Expanding(self, min_periods=min_periods)
 
-    # TODO: 'adjust', 'ignore_na', 'axis', 'method' parameter should be implemented.
+    # TODO: 'adjust', 'axis', 'method' parameter should be implemented.
     def ewm(
         self: FrameLike,
         com: Optional[float] = None,
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
+        ignore_na: bool = False,
         min_periods: Optional[int] = None,
     ) -> "ExponentialMoving[FrameLike]":
         """
@@ -2666,7 +2667,13 @@ class Frame(object, metaclass=ABCMeta):
         from pyspark.pandas.window import ExponentialMoving
 
         return ExponentialMoving(
-            self, com=com, span=span, halflife=halflife, alpha=alpha, min_periods=min_periods
+            self,
+            com=com,
+            span=span,
+            halflife=halflife,
+            alpha=alpha,
+            ignore_na=ignore_na,
+            min_periods=min_periods,
         )
 
     def get(self, key: Any, default: Optional[Any] = None) -> Any:

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2626,7 +2626,7 @@ class Frame(object, metaclass=ABCMeta):
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
-        ignore_na: bool = False,
+        ignore_na: bool_type = False,
         min_periods: Optional[int] = None,
     ) -> "ExponentialMoving[FrameLike]":
         """

--- a/python/pyspark/pandas/missing/window.py
+++ b/python/pyspark/pandas/missing/window.py
@@ -152,6 +152,5 @@ class MissingPandasLikeExponentialMoving:
     corr = _unsupported_function_exponential_moving("corr")
 
     adjust = _unsupported_property_exponential_moving("adjust")
-    ignore_na = _unsupported_property_exponential_moving("ignore_na")
     axis = _unsupported_property_exponential_moving("axis")
     method = _unsupported_property_exponential_moving("method")

--- a/python/pyspark/pandas/tests/test_ewm.py
+++ b/python/pyspark/pandas/tests/test_ewm.py
@@ -109,6 +109,98 @@ class EWMTest(PandasOnSparkTestCase, TestUtils):
             getattr(pdf.ewm(alpha=0.7, min_periods=2), f)().sum(),
         )
 
+        pdf = pd.DataFrame(
+            {
+                "s1": [None, 2, 3, 4],
+                "s2": [1, None, 3, 4],
+                "s3": [1, 3, 4, 5],
+                "s4": [1, 0, 3, 4],
+                "s5": [None, None, 1, None],
+                "s6": [None, None, None, None],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(
+            getattr(psdf.ewm(com=0.2, ignore_na=True), f)(),
+            getattr(pdf.ewm(com=0.2, ignore_na=True), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(com=0.2, ignore_na=True), f)().sum(),
+            getattr(pdf.ewm(com=0.2, ignore_na=True), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(com=0.2, ignore_na=False), f)(),
+            getattr(pdf.ewm(com=0.2, ignore_na=False), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(com=0.2, ignore_na=False), f)().sum(),
+            getattr(pdf.ewm(com=0.2, ignore_na=False), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(span=1.7, ignore_na=True), f)(),
+            getattr(pdf.ewm(span=1.7, ignore_na=True), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(span=1.7, ignore_na=True), f)().sum(),
+            getattr(pdf.ewm(span=1.7, ignore_na=True), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(span=1.7, ignore_na=False), f)(),
+            getattr(pdf.ewm(span=1.7, ignore_na=False), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(span=1.7, ignore_na=False), f)().sum(),
+            getattr(pdf.ewm(span=1.7, ignore_na=False), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(halflife=0.5, ignore_na=True), f)(),
+            getattr(pdf.ewm(halflife=0.5, ignore_na=True), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(halflife=0.5, ignore_na=True), f)().sum(),
+            getattr(pdf.ewm(halflife=0.5, ignore_na=True), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(halflife=0.5, ignore_na=False), f)(),
+            getattr(pdf.ewm(halflife=0.5, ignore_na=False), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(halflife=0.5, ignore_na=False), f)().sum(),
+            getattr(pdf.ewm(halflife=0.5, ignore_na=False), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=True), f)(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=True), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=True), f)().sum(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=True), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=False), f)(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=False), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=False), f)().sum(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=False), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=True, min_periods=2), f)(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=True, min_periods=2), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=True, min_periods=2), f)().sum(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=True, min_periods=2), f)().sum(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=False, min_periods=2), f)(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=False, min_periods=2), f)(),
+        )
+        self.assert_eq(
+            getattr(psdf.ewm(alpha=0.7, ignore_na=False, min_periods=2), f)().sum(),
+            getattr(pdf.ewm(alpha=0.7, ignore_na=False, min_periods=2), f)().sum(),
+        )
+
     def test_ewm_mean(self):
         self._test_ewm_func("mean")
 

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -1761,8 +1761,8 @@ class ExponentialMovingLike(Generic[FrameLike], metaclass=ABCMeta):
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
-        ignore_na: bool = False,
         min_periods: Optional[int] = None,
+        ignore_na: bool = False,
     ):
         if (min_periods is not None) and (min_periods < 0):
             raise ValueError("min_periods must be >= 0")
@@ -1848,8 +1848,8 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
-        ignore_na: bool = False,
         min_periods: Optional[int] = None,
+        ignore_na: bool = False,
     ):
         from pyspark.pandas.frame import DataFrame
         from pyspark.pandas.series import Series
@@ -1865,7 +1865,7 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
             Window.unboundedPreceding, Window.currentRow
         )
 
-        super().__init__(window_spec, com, span, halflife, alpha, ignore_na, min_periods)
+        super().__init__(window_spec, com, span, halflife, alpha, min_periods, ignore_na)
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeExponentialMoving, item):
@@ -1934,14 +1934,14 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
     # TODO: when add 'adjust' parameter, should add to here too.
     def __repr__(self) -> str:
         return (
-            "ExponentialMoving [com={}, span={}, halflife={}, alpha={}, ignore_na={}, "
-            "min_periods={}]".format(
+            "ExponentialMoving [com={}, span={}, halflife={}, alpha={}, "
+            "min_periods={}, ignore_na={}]".format(
                 self._com,
                 self._span,
                 self._halflife,
                 self._alpha,
-                self._ignore_na,
                 self._min_periods,
+                self._ignore_na,
             )
         )
 

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -1761,6 +1761,7 @@ class ExponentialMovingLike(Generic[FrameLike], metaclass=ABCMeta):
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
+        ignore_na: bool = False,
         min_periods: Optional[int] = None,
     ):
         if (min_periods is not None) and (min_periods < 0):
@@ -1768,6 +1769,7 @@ class ExponentialMovingLike(Generic[FrameLike], metaclass=ABCMeta):
         if min_periods is None:
             min_periods = 0
         self._min_periods = min_periods
+        self._ignore_na = ignore_na
 
         self._window = window
         # This unbounded Window is later used to handle 'min_periods' for now.
@@ -1828,10 +1830,11 @@ class ExponentialMovingLike(Generic[FrameLike], metaclass=ABCMeta):
         unified_alpha = self._compute_unified_alpha()
 
         def mean(scol: Column) -> Column:
-            jf = SparkContext._active_spark_context._jvm.PythonSQLUtils.ewm
+            sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
             return F.when(
-                F.row_number().over(self._unbounded_window) >= self._min_periods,
-                Column(jf(scol._jc, unified_alpha)).over(self._window),
+                F.count(F.when(~scol.isNull(), 1).otherwise(None)).over(self._unbounded_window)
+                >= self._min_periods,
+                Column(sql_utils.ewm(scol._jc, unified_alpha, self._ignore_na)).over(self._window),
             ).otherwise(SF.lit(None))
 
         return self._apply_as_series_or_frame(mean)
@@ -1845,6 +1848,7 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
         span: Optional[float] = None,
         halflife: Optional[float] = None,
         alpha: Optional[float] = None,
+        ignore_na: bool = False,
         min_periods: Optional[int] = None,
     ):
         from pyspark.pandas.frame import DataFrame
@@ -1861,7 +1865,7 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
             Window.unboundedPreceding, Window.currentRow
         )
 
-        super().__init__(window_spec, com, span, halflife, alpha, min_periods)
+        super().__init__(window_spec, com, span, halflife, alpha, ignore_na, min_periods)
 
     def __getattr__(self, item: str) -> Any:
         if hasattr(MissingPandasLikeExponentialMoving, item):
@@ -1882,7 +1886,6 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
         -----
         There are behavior differences between pandas-on-Spark and pandas.
 
-        * the data should not contain NaNs. pandas-on-Spark will return an error.
         * the current implementation of this API uses Spark's Window without
           specifying partition specification. This leads to move all data into
           single partition in single machine and could cause serious
@@ -1928,10 +1931,18 @@ class ExponentialMoving(ExponentialMovingLike[FrameLike]):
         """
         return super().mean()
 
-    # TODO: when add 'adjust' and 'ignore_na' parameter, should add to here too.
+    # TODO: when add 'adjust' parameter, should add to here too.
     def __repr__(self) -> str:
-        return "ExponentialMoving [com={}, span={}, halflife={}, alpha={}, min_periods={}]".format(
-            self._com, self._span, self._halflife, self._alpha, self._min_periods
+        return (
+            "ExponentialMoving [com={}, span={}, halflife={}, alpha={}, ignore_na={}, "
+            "min_periods={}]".format(
+                self._com,
+                self._span,
+                self._halflife,
+                self._alpha,
+                self._ignore_na,
+                self._min_periods,
+            )
         )
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -95,7 +95,8 @@ private[sql] object PythonSQLUtils extends Logging {
 
   def castTimestampNTZToLong(c: Column): Column = Column(CastTimestampNTZToLong(c.expr))
 
-  def ewm(e: Column, alpha: Double): Column = Column(EWM(e.expr, alpha))
+  def ewm(e: Column, alpha: Double, ignoreNA: Boolean): Column =
+    Column(EWM(e.expr, alpha, ignoreNA))
 
   def lastNonNull(e: Column): Column = Column(LastNonNull(e.expr))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
EWM support ignore_na

### Why are the changes needed?
`ignore_na` is supported in pandas.
after adding this param, EWM can deal with dataset containing NaN/Null.


### Does this PR introduce _any_ user-facing change?
Yes, a new param added

### How was this patch tested?
added testsuites
