### PR TITLE
[SPARK-38948][TESTS] Fix `DiskRowQueue` leak in `PythonForeachWriterSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
@@ -109,8 +109,8 @@ class PythonForeachWriterSuite extends SparkFunSuite with Eventually with Mockit
             }
             Thread.sleep(sleepPerRowReadMs)
           }
-        } catch {
-          case _: InterruptedException => buffer.close()
+        } finally {
+          buffer.close()
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
@@ -102,11 +102,15 @@ class PythonForeachWriterSuite extends SparkFunSuite with Eventually with Mockit
     private val intProj = UnsafeProjection.create(Array[DataType](IntegerType))
     private val thread = new Thread() {
       override def run(): Unit = {
-        while (iterator.hasNext) {
-          outputBuffer.synchronized {
-            outputBuffer += iterator.next().getInt(0)
+        try {
+          while (iterator.hasNext) {
+            outputBuffer.synchronized {
+              outputBuffer += iterator.next().getInt(0)
+            }
+            Thread.sleep(sleepPerRowReadMs)
           }
-          Thread.sleep(sleepPerRowReadMs)
+        } catch {
+          case _: InterruptedException => buffer.close()
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add `try-finally` for  `run` method  of `BufferTester.thread` and call `buffer.close()` in the `finally` block to  ensure the  resources held by `BufferTester.buffer` are released.  

Before this pr, there will be an `DiskRowQueue` resource hold by `BufferTester.buffer` not closed.

### Why are the changes needed?
Minor fix of UT.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GA.