### PR TITLE
[SPARK-38956][TESTS] Fix FAILED_EXECUTE_UDF test case on Java 17

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -432,6 +432,6 @@ class QueryExecutionErrorsSuite extends QueryTest
     val e2 = e1.getCause.asInstanceOf[SparkException]
     assert(e2.getErrorClass === "FAILED_EXECUTE_UDF")
     assert(e2.getMessage.matches("Failed to execute user defined function " +
-      "\\(QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\d+: \\(string, int\\) => string\\)"))
+      "\\(QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+: \\(string, int\\) => string\\)"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR aims to fix FAILED_EXECUTE_UDF test case on Java 17.

### Why are the changes needed?
**BEFORE (Java17)**
```
[info] QueryExecutionErrorsSuite:
16:04:22.234 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
16:04:24.377 ERROR org.apache.spark.executor.Executor: Exception in task 0.0 in stage 0.0 (TID 0)
org.apache.spark.SparkException: Failed to execute user defined function (QueryExecutionErrorsSuite$$Lambda$1582/0x0000000801653be8: (string, int) => string)
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test on Java 17. 