### PR TITLE
[SPARK-38960][CORE]Spark should fail fast if initial memory too large…

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -529,6 +529,17 @@ class SparkConf(loadDefaults: Boolean) extends Cloneable with Logging with Seria
           s"(was '$javaOpts'). Use spark.executor.memory instead."
         throw new Exception(msg)
       }
+      if (javaOpts.contains("-Xms") && contains(EXECUTOR_MEMORY)) {
+        val executorInitialMemory = Utils.executorInitialMemorySizeAsMb(javaOpts)
+        val executorMemory = Utils.memoryStringToMb(get(EXECUTOR_MEMORY.key))
+        if (executorInitialMemory > executorMemory) {
+          val msg = s"The initial memory value ${executorInitialMemory}Mb " +
+            s"(set by $executorOptsKey=$javaOpts) " +
+            s"must not be larger than the value ${executorMemory}Mb " +
+            s"(set by ${EXECUTOR_MEMORY.key}=${get(EXECUTOR_MEMORY.key)})."
+          throw new Exception(msg)
+        }
+      }
     }
 
     // Validate memory fractions

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3195,6 +3195,14 @@ private[spark] object Utils extends Logging {
   }
 
   /**
+   * Convert initial memory size(set by spark.executor.extraJavaOptions=-XmsXXX) to MB Unit
+   */
+  def executorInitialMemorySizeAsMb(javaOpts: String): Int = {
+    val javaXmsOpts = Utils.splitCommandString(javaOpts).filter(_.startsWith("-Xms"))
+    Utils.memoryStringToMb(javaXmsOpts.last.substring("-Xms".length))
+  }
+
+  /**
    * return 0 if MEMORY_OFFHEAP_ENABLED is false.
    */
   def checkOffHeapEnabled(sparkConf: SparkConf, offHeapSize: Long): Long = {

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -520,6 +520,29 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
         }
     }
   }
+
+  test("executor initial memory must not be larger than spark.executor.memory") {
+    val conf = new SparkConf()
+    conf.validateSettings()
+
+    conf.set(EXECUTOR_MEMORY.key, "10G")
+    conf.set(EXECUTOR_JAVA_OPTIONS, "-Xms20G")
+    val e1 = intercept[Exception] {
+      conf.validateSettings()
+    }
+    assert(e1.getMessage ===
+      "The initial memory value 20480Mb (set by spark.executor.extraJavaOptions=-Xms20G) " +
+        "must not be larger than the value 10240Mb (set by spark.executor.memory=10G).")
+
+    conf.set(EXECUTOR_MEMORY.key, "10G")
+    conf.set(EXECUTOR_JAVA_OPTIONS, "-Xms20G -Xms15G")
+    val e2 = intercept[Exception] {
+      conf.validateSettings()
+    }
+    assert(e2.getMessage ===
+      "The initial memory value 15360Mb (set by spark.executor.extraJavaOptions=-Xms20G -Xms15G) " +
+        "must not be larger than the value 10240Mb (set by spark.executor.memory=10G).")
+  }
 }
 
 class Class1 {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added an exception to be thrown in SparkConf.validateSettings if set initial memory(set by "spark.executor.extraJavaOptions=-Xms{XXX}G" ) larger than maximum memory(set by "spark.executor.memory")

### How was this patch tested?
This patch was tested manually by passing in config options to Spark submit. I also added a test in SparkConfSuite

**Test with large initial executor memory:**
./bin/spark-submit --master yarn --deploy-mode client --conf spark.executor.memory=1G --conf spark.executor.extraJavaOptions=-Xms2G --class org.apache.spark.examples.SparkPi ./examples/jars/spark-examples_*.jar 10
Exception in thread "main" java.lang.Exception: The initial memory value 2048Mb (set by spark.executor.extraJavaOptions=-Xms2G) must be smaller than the value 1024Mb  (set by spark.executor.memory=1G).
	at org.apache.spark.SparkConf.$anonfun$validateSettings$4(SparkConf.scala:541)
	at org.apache.spark.SparkConf.$anonfun$validateSettings$4$adapted(SparkConf.scala:522)
	at scala.Option.foreach(Option.scala:407)
	at org.apache.spark.SparkConf.validateSettings(SparkConf.scala:522)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:390)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2706)
	at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:949)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:943)
	at org.apache.spark.examples.SparkPi$.main(SparkPi.scala:30)
	at org.apache.spark.examples.SparkPi.main(SparkPi.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:958)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1046)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1055)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)