### PR TITLE
[SPARK-38963][WEBUI]Make stage navigable to stage Page from max metrics displayed in UI

### DIFF
--- a/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
+++ b/sql/core/src/main/resources/org/apache/spark/sql/execution/ui/static/spark-sql-viz.js
@@ -102,9 +102,23 @@ function preprocessGraphLayout(g) {
     node.label.split(splitter).forEach(function(text, i) {
       var newTexts = text.match(stageAndTaskMetricsPattern);
       if (newTexts) {
-        node.label = node.label.replace(
-            newTexts[0],
-            newTexts[1] + firstSeparator + newTexts[2] + secondSeparator + newTexts[3]);
+         if (newTexts[2].search("stage ") > 0) {
+           var stageString=newTexts[2].split(" ")
+
+           var stage=stageString[1].split(".")[0]
+           var attempt=stageString[1].split(".")[1].split(":")[0]
+           var url = stageString[0]
+           +" <a href=\"/stages/stage/?id=" + stage + "&attempt="+ attempt+ "\">"  + stageString[1]  +" </a>"
+           + stageString[2] + " "
+           + stageString[3]
+           node.label = node.label.replace(
+               newTexts[0],
+               newTexts[1] + firstSeparator + url + secondSeparator + newTexts[3]);
+         } else {
+           node.label = node.label.replace(
+               newTexts[0],
+               newTexts[1] + firstSeparator + newTexts[2] + secondSeparator + newTexts[3]);
+         }
       }
     });
   }
@@ -197,7 +211,7 @@ function postprocessForAdditionalMetrics() {
           var newTexts = originalText.split(labelSeparator);
           var thisD3Node = d3.selectAll($(this));
           thisD3Node.text(newTexts[0]);
-          thisD3Node.append("tspan").attr("class", "stageId-and-taskId-metrics").text(newTexts[1]);
+          thisD3Node.append("tspan").attr("class", "stageId-and-taskId-metrics").html(newTexts[1]);
           $(this).append(newTexts[2]);
         } else {
           return originalText;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Making stage ID which is currently displayed as a static text in DAG into a navigable link to the particular stage Page.

### Why are the changes needed?
Makes it easier for user to navigate to the stage where the metrics has taken more time and analyse.Otherwise user will have to manually come to stage Page and search for the stage.


### Does this PR introduce _any_ user-facing change?
yes
 the stageId is changes to a hyperlink which redirects to the particular stage page
![Unsaved Image 2](https://user-images.githubusercontent.com/51401130/164164792-45848cdd-7d5f-4156-8cd3-dec73528ab5e.jpg)


### How was this patch tested?
UT
