### PR TITLE
[SPARK-38970][CI] Skip build-and-test workflow on forks when scheduled

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,10 +145,11 @@ jobs:
   build:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
     needs: [configure-jobs, precondition]
-    # Run for all scheduled jobs
-    # Run for all other jobs only when changes exist
+    # Run scheduled jobs for Apache Spark only
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
     if: >-
-      needs.configure-jobs.outputs.type == 'scheduled' || fromJson(needs.precondition.outputs.required).build == 'true'
+      needs.configure-jobs.outputs.type == 'scheduled'
+      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
     runs-on: ubuntu-20.04
     strategy:
@@ -288,9 +289,9 @@ jobs:
 
   pyspark:
     needs: [configure-jobs, precondition]
-    # Run PySpark coverage scheduled jobs
-    # Run scheduled jobs only with JDK 17
-    # Run regular jobs only if pyspark changes exist
+    # Run PySpark coverage scheduled jobs for Apache Spark only
+    # Run scheduled jobs with JDK 17 in Apache Spark
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if pyspark changes exist
     if: >-
       needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled'
       || (needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
@@ -397,8 +398,8 @@ jobs:
 
   sparkr:
     needs: [configure-jobs, precondition]
-    # Run scheduled jobs only with JDK 17
-    # Run regular jobs only if sparkr changes exist
+    # Run scheduled jobs with JDK 17 in Apache Spark
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if sparkr changes exist
     if: >-
       (needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
       || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).sparkr == 'true')
@@ -582,7 +583,7 @@ jobs:
 
   java-11-17:
     needs: [configure-jobs, precondition]
-    # Run regular jobs only if changes exist
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
     name: Java ${{ matrix.java }} build with Maven
     strategy:
@@ -638,7 +639,7 @@ jobs:
 
   scala-213:
     needs: [configure-jobs, precondition]
-    # Run regular jobs only if changes exist
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
@@ -684,7 +685,7 @@ jobs:
 
   tpcds-1g:
     needs: [configure-jobs, precondition]
-    # Run regular jobs only if tpcds changes exist
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if tpcds changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).tpcds == 'true'
     name: Run TPC-DS queries with SF=1
     runs-on: ubuntu-20.04
@@ -780,7 +781,7 @@ jobs:
 
   docker-integration-tests:
     needs: [configure-jobs, precondition]
-    # Run regular jobs only if docker changes exist
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if docker changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).docker == 'true'
     name: Run Docker integration tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,6 +48,11 @@ jobs:
   configure-jobs:
     name: Configure jobs
     runs-on: ubuntu-20.04
+    # All other jobs in this workflow depend on this job,
+    # so the entire workflow is skipped when these conditions evaluate to false:
+    # Run all jobs for Apache Spark repository
+    # Run only non-scheduled jobs for forked repositories
+    if: github.repository == 'apache/spark' || github.event_name != 'schedule'
     outputs:
       java: ${{ steps.set-outputs.outputs.java }}
       branch: ${{ steps.set-outputs.outputs.branch }}
@@ -106,10 +111,6 @@ jobs:
     name: Check changes
     runs-on: ubuntu-20.04
     needs: configure-jobs
-    # Run scheduled jobs for Apache Spark only
-    # Run regular jobs for commit in both Apache Spark and forked repository
-    if: >-
-      (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled') || (needs.configure-jobs.outputs.type == 'regular')
     env:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     outputs:
@@ -144,11 +145,10 @@ jobs:
   build:
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
     needs: [configure-jobs, precondition]
-    # Run scheduled jobs for Apache Spark only
-    # Run regular jobs for commit in both Apache Spark and forked repository
+    # Run for all scheduled jobs
+    # Run for all other jobs only when changes exist
     if: >-
-      (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled')
-      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
+      needs.configure-jobs.outputs.type == 'scheduled' || fromJson(needs.precondition.outputs.required).build == 'true'
     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
     runs-on: ubuntu-20.04
     strategy:
@@ -288,12 +288,12 @@ jobs:
 
   pyspark:
     needs: [configure-jobs, precondition]
-    # Run PySpark coverage scheduled jobs for Apache Spark only
-    # Run scheduled jobs with JDK 17 in Apache Spark
-    # Run regular jobs for commit in both Apache Spark and forked repository
+    # Run PySpark coverage scheduled jobs
+    # Run scheduled jobs only with JDK 17
+    # Run regular jobs only if pyspark changes exist
     if: >-
-      (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled')
-      || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
+      needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled'
+      || (needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
       || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).pyspark == 'true')
     name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
@@ -397,9 +397,11 @@ jobs:
 
   sparkr:
     needs: [configure-jobs, precondition]
+    # Run scheduled jobs only with JDK 17
+    # Run regular jobs only if sparkr changes exist
     if: >-
-      (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).sparkr == 'true')
-      || (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
+      (needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
+      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).sparkr == 'true')
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
@@ -580,6 +582,7 @@ jobs:
 
   java-11-17:
     needs: [configure-jobs, precondition]
+    # Run regular jobs only if changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
     name: Java ${{ matrix.java }} build with Maven
     strategy:
@@ -635,6 +638,7 @@ jobs:
 
   scala-213:
     needs: [configure-jobs, precondition]
+    # Run regular jobs only if changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
@@ -680,6 +684,7 @@ jobs:
 
   tpcds-1g:
     needs: [configure-jobs, precondition]
+    # Run regular jobs only if tpcds changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).tpcds == 'true'
     name: Run TPC-DS queries with SF=1
     runs-on: ubuntu-20.04
@@ -775,6 +780,7 @@ jobs:
 
   docker-integration-tests:
     needs: [configure-jobs, precondition]
+    # Run regular jobs only if docker changes exist
     if: needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).docker == 'true'
     name: Run Docker integration tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -106,6 +106,10 @@ jobs:
     name: Check changes
     runs-on: ubuntu-20.04
     needs: configure-jobs
+    # Run scheduled jobs for Apache Spark only
+    # Run regular jobs for commit in both Apache Spark and forked repository
+    if: >-
+      (github.repository == 'apache/spark' && needs.configure-jobs.outputs.type == 'scheduled') || (needs.configure-jobs.outputs.type == 'regular')
     env:
       GITHUB_PREV_SHA: ${{ github.event.before }}
     outputs:


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `configure-jobs` and `precondition` jobs in the `build-and-test` workflow should be skipped on fork repositories as all subsequent / dependent jobs are already skipped.

### Why are the changes needed?
The `build and test` workflow is scheduled to run six times a day. The jobs then only run for `type == 'scheduled'` inside apache/spark repository, not for forks. However, the `configure-jobs` and `precondition` jobs always run, even though all subsequent jobs are skipped on forks.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No