### PR TITLE
[SPARK-38973][SHUFFLE] Mark stage as merge finalized irrespective of its state 

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2357,10 +2357,9 @@ private[spark] class DAGScheduler(
           // results here just to free up some memory. If the indeterminate stage is resubmitted,
           // merge results are cleared again when the newer attempt is submitted.
           mapOutputTracker.unregisterAllMergeResult(stage.shuffleDep.shuffleId)
-          // For deterministic stages that are cancelled we would like to unregister all the merge
-          // results but we are unable to distinguish between a cancelled stage or whether it
-          // will be resubmitted here. In case the stage is not cancelled, the mergeResults of that
-          // stage will still be usable and valid.
+          // For determinate stages, which have completed merge finalization, we don't need to
+          // unregister merge results - since the stage retry, or any other stage computing the
+          // same shuffle id, can use it.
         }
     }
   }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2338,7 +2338,7 @@ private[spark] class DAGScheduler(
     // re-executing now.
     if (stage.shuffleDep.shuffleMergeId == shuffleMergeId) {
       // When it reaches here, there is a possibility that the stage will be resubmitted again
-      // because of various reasons. Some of the could be:
+      // because of various reasons. Some of these could be:
       // a) Stage results are not available. All the tasks completed once so the
       // pendingPartitions is empty but due to an executor failure some of the map outputs are not
       // available any more, so the stage will be re-submitted.
@@ -2346,7 +2346,7 @@ private[spark] class DAGScheduler(
       // We should mark the stage as merged finalized irrespective of what state it is in.
       // This will prevent the push being enabled for the re-attempt.
       // Note: for indeterminate stages, this doesn't matter at all, since the merge finalization
-      // related state is resetted during the stage submission.
+      // related state is reset during the stage submission.
       stage.shuffleDep.markShuffleMergeFinalized()
       if (stage.pendingPartitions.isEmpty)
         if (runningStages.contains(stage)) {
@@ -2358,9 +2358,9 @@ private[spark] class DAGScheduler(
           // merge results are cleared again when the newer attempt is submitted.
           mapOutputTracker.unregisterAllMergeResult(stage.shuffleDep.shuffleId)
           // For deterministic stages that are cancelled we would like to unregister all the merge
-          // results but we are unable to distinguish between a cancelled stage here or whether it
-          // will be resubmitted. In case the stage is not cancelled, the mergeResults of that stage
-          // will still be usable and valid.
+          // results but we are unable to distinguish between a cancelled stage or whether it
+          // will be resubmitted here. In case the stage is not cancelled, the mergeResults of that
+          // stage will still be usable and valid.
         }
     }
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3709,8 +3709,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
-  test("SPARK-32920: Merge results should not be unregistered if the running stage is cancelled" +
-    " before shuffle merge is finalized") {
+  test("SPARK-32920: Merge results should not be unregistered if a determinate running stage is " +
+    "cancelled before shuffle merge is finalized") {
     initPushBasedShuffleConfs(conf)
     DAGSchedulerSuite.clearMergerLocs()
     DAGSchedulerSuite.addMergerLocs(Seq("host1", "host2", "host3", "host4", "host5"))
@@ -4003,8 +4003,9 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
 
   // Test the behavior of stage cancellation during the spark.shuffle.push.finalize.timeout
   // wait for shuffle merge finalization
-  test("SPARK-33701: check adaptive shuffle merge finalization behavior with stage" +
-    " cancellation during spark.shuffle.push.finalize.timeout wait") {
+  test("SPARK-33701: check adaptive shuffle merge finalization behavior with stage " +
+    "cancellation for determinate and indeterminate stages during " +
+    "spark.shuffle.push.finalize.timeout wait") {
     initPushBasedShuffleConfs(conf)
     conf.set(config.PUSH_BASED_SHUFFLE_SIZE_MIN_SHUFFLE_SIZE_TO_WAIT, 10L)
     conf.set(config.SHUFFLE_MERGER_LOCATIONS_MIN_STATIC_THRESHOLD, 5)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3709,8 +3709,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
-  test("SPARK-32920: Merge results should not be unregistered if a determinate running stage is " +
-    "cancelled before shuffle merge is finalized") {
+  test("SPARK-32920: Cancelled stage should be marked finalized after the shuffle merge " +
+    "is finalized") {
     initPushBasedShuffleConfs(conf)
     DAGSchedulerSuite.clearMergerLocs()
     DAGSchedulerSuite.addMergerLocs(Seq("host1", "host2", "host3", "host4", "host5"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change fixes the scenarios where a stage re-attempt doesn't complete successfully, even though all the tasks complete when push-based shuffle is enabled.  With Adaptive Merge Finalization, a stage may be triggered for finalization when it is the below state:
- The stage is not running (not in the running set of the DAGScheduler) - had failed or canceled or waiting, and
- The stage has no pending partitions (all the tasks completed at-least once)

For such a stage when the finalization completes, the stage will still not be marked as mergeFinalized. 
The stage of the stage will be: 
- `stage.shuffleDependency.mergeFinalized = false`
- `stage.shuffleDependency.getFinalizeTask != Nil`
- Merged statuses of the state are unregistered
 
When the stage is resubmitted, the newer attempt of the stage will never complete even though its tasks may be completed. This is because the newer attempt of the stage will have `shuffleMergeEnabled = true`, since with the previous attempt the stage was never marked as mergedFinalized, and the finalizeTask is present (from finalization attempt for previous stage attempt).

 So, when all the tasks of the newer attempt complete, then these conditions will be true:
- stage will be running
- There will be no pending partitions since all the tasks completed
- `stage.shuffleDependency.shuffleMergeEnabled = true`
- `stage.shuffleDependency.shuffleMergeFinalized = false`
- `stage.shuffleDependency.getFinalizeTask` is `not empty`
This leads the DAGScheduler to try scheduling finalization and not trigger the completion of the Stage. However because of the last condition it never even schedules the finalization and the stage never completes.

In addition, for determinate stages, which have completed merge finalization, we don't need to unregister merge results - since the stage retry, or any other stage computing the same shuffle id, can use it.

### Why are the changes needed?
The change fixes the above issue where the application gets stalled as some stages don't complete successfully.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
I have just modified the existing UT. A stage will be marked finalized irrespective of its state and for deterministic stage we don't want to unregister merge results.