### PR TITLE
[SPARK-38955][SQL] Disable lineSep option in 'from_csv' and 'schema_of_csv'

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CsvFunctionsSuite.scala
@@ -379,4 +379,11 @@ class CsvFunctionsSuite extends QueryTest with SharedSparkSession {
       .selectExpr("value.a")
     checkAnswer(fromCsvDF, Row(null))
   }
+
+  test("SPARK-38955: disable lineSep option in from_csv and schema_of_csv") {
+    val df = Seq[String]("1,2\n2").toDF("csv")
+    val actual = df.select(from_csv(
+      $"csv", schema_of_csv("1,2\n2"), Map.empty[String, String].asJava))
+    checkAnswer(actual, Row(Row(1, "2\n2")))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disable `lineSep` option in `from_csv` and `schema_of_csv` expression by setting Noncharacters according to [unicode specification](https://www.unicode.org/charts/PDF/UFFF0.pdf), `\UFFFF`. This can be used for the internal purpose in a program according to the specification.

The Univocity parser does not allow to omit the line separator (from my code reading) so this approach was proposed.

This specific code path is not affected by our `encoding` or `charset` option because Unicovity parser parses them as unicodes as are internally.

### Why are the changes needed?

Currently, this option is weirdly effective. See the example of `from_csv` as below:

```scala
import org.apache.spark.sql.types._
import org.apache.spark.sql.functions._

Seq[String]("1,\n2,3,4,5").toDF.select(
  col("value"),
  from_csv(
    col("value"),
    StructType(Seq(StructField("a", LongType), StructField("b", StringType)
  )), Map[String,String]())).show()
```

```
+-----------+---------------+
|      value|from_csv(value)|
+-----------+---------------+
|1,\n2,3,4,5|      {1, null}|
+-----------+---------------+
```

`{1, null}` has to be `{1, \n2}`.

The CSV expressions cannot easily make it supported because this option is plan-wise option that can change the number of returned rows; however, the expressions are designed to emit one row only whereas this option is easily effective in the scan plan with CSV data source. Therefore, we should disable this option.

### Does this PR introduce _any_ user-facing change?

Yes, now the `lineSep` can be located in the output from `from_csv` and `schema_of_csv`.

### How was this patch tested?

Manually tested, and unit test was added.