### PR TITLE
[SPARK-38978][SQL] DS V2 supports push down OFFSET operator

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.Evolving;
  * An interface for building the {@link Scan}. Implementations can mixin SupportsPushDownXYZ
  * interfaces to do operator push down, and keep the operator push down result in the returned
  * {@link Scan}. When pushing down operators, the push down order is:
- * sample -&gt; filter -&gt; aggregate -&gt; limit/top-n(sort + limit) -&gt; offset -&gt;
+ * sample -&gt; filter -&gt; aggregate -&gt; offset -&gt; limit/top-n(sort + limit) -&gt;
  * column pruning.
  *
  * @since 3.0.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.Evolving;
  * An interface for building the {@link Scan}. Implementations can mixin SupportsPushDownXYZ
  * interfaces to do operator push down, and keep the operator push down result in the returned
  * {@link Scan}. When pushing down operators, the push down order is:
- * sample -&gt; filter -&gt; aggregate -&gt; offset -&gt; limit/top-n(sort + limit) -&gt;
+ * sample -&gt; filter -&gt; aggregate -&gt; limit/top-n(sort + limit) -&gt; offset -&gt;
  * column pruning.
  *
  * @since 3.0.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
@@ -23,7 +23,8 @@ import org.apache.spark.annotation.Evolving;
  * An interface for building the {@link Scan}. Implementations can mixin SupportsPushDownXYZ
  * interfaces to do operator push down, and keep the operator push down result in the returned
  * {@link Scan}. When pushing down operators, the push down order is:
- * sample -&gt; filter -&gt; aggregate -&gt; limit/top-n(sort + limit) -&gt; offset -&gt; column pruning.
+ * sample -&gt; filter -&gt; aggregate -&gt; limit/top-n(sort + limit) -&gt; offset -&gt;
+ * column pruning.
  *
  * @since 3.0.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.Evolving;
  * An interface for building the {@link Scan}. Implementations can mixin SupportsPushDownXYZ
  * interfaces to do operator push down, and keep the operator push down result in the returned
  * {@link Scan}. When pushing down operators, the push down order is:
- * sample -&gt; filter -&gt; aggregate -&gt; offset -&gt; limit or top N -&gt; column pruning.
+ * sample -&gt; filter -&gt; aggregate -&gt; limit/top-n(sort + limit) -&gt; offset -&gt; column pruning.
  *
  * @since 3.0.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/ScanBuilder.java
@@ -23,7 +23,7 @@ import org.apache.spark.annotation.Evolving;
  * An interface for building the {@link Scan}. Implementations can mixin SupportsPushDownXYZ
  * interfaces to do operator push down, and keep the operator push down result in the returned
  * {@link Scan}. When pushing down operators, the push down order is:
- * sample -&gt; filter -&gt; aggregate -&gt; limit -&gt; column pruning.
+ * sample -&gt; filter -&gt; aggregate -&gt; offset -&gt; limit or top N -&gt; column pruning.
  *
  * @since 3.0.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownLimit.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownLimit.java
@@ -21,7 +21,7 @@ import org.apache.spark.annotation.Evolving;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down LIMIT. We can push down LIMIT with many other operators if they follow the
+ * push down LIMIT. We can push down LIMIT with many other operations if they follow the
  * operator order we defined in {@link ScanBuilder}'s class doc.
  *
  * @since 3.3.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownLimit.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownLimit.java
@@ -21,8 +21,8 @@ import org.apache.spark.annotation.Evolving;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down LIMIT. Please note that the combination of LIMIT with other operations
- * such as AGGREGATE, GROUP BY, SORT BY, CLUSTER BY, DISTRIBUTE BY, etc. is NOT pushed down.
+ * push down LIMIT. We can push down LIMIT with many other operators if they follow the
+ * operator order we defined in {@link ScanBuilder}'s class doc.
  *
  * @since 3.3.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownLimitAndOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownLimitAndOffset.java
@@ -18,27 +18,26 @@
 package org.apache.spark.sql.connector.read;
 
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.expressions.SortOrder;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down top N(query with ORDER BY ... LIMIT n). Please note that the combination of top N
- * with other operations such as AGGREGATE, GROUP BY, CLUSTER BY, DISTRIBUTE BY, etc.
+ * push down LIMIT and OFFSET. Please note that the combination of LIMIT and OFFSET with other
+ * operations such as AGGREGATE, GROUP BY, SORT BY, CLUSTER BY, DISTRIBUTE BY, etc.
  * is NOT pushed down.
  *
- * @since 3.3.0
+ * @since 3.4.0
  */
 @Evolving
-public interface SupportsPushDownTopN extends ScanBuilder {
-
+public interface SupportsPushDownLimitAndOffset {
   /**
-   * Pushes down top N to the data source.
+   * Pushes down LIMIT and OFFSET to the data source.
    */
-  boolean pushTopN(SortOrder[] orders, int limit);
+  boolean pushLimitAndOffset(int limit, int offset);
 
   /**
-   * Whether the top N is partially pushed or not. If it returns true, then Spark will do top N
-   * again. This method will only be called when {@link #pushTopN} returns true.
+   * Whether the LIMIT and OFFSET is partially pushed or not. If it returns true, then Spark will
+   * do LIMIT and OFFSET again. This method will only be called when {@link #pushLimitAndOffset}
+   * returns true.
    */
   default boolean isPartiallyPushed() { return true; }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownOffset.java
@@ -21,23 +21,16 @@ import org.apache.spark.annotation.Evolving;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down LIMIT and OFFSET. Please note that the combination of LIMIT and OFFSET with other
- * operations such as AGGREGATE, GROUP BY, SORT BY, CLUSTER BY, DISTRIBUTE BY, etc.
- * is NOT pushed down.
+ * push down OFFSET. Please note that the combination of OFFSET with other operations
+ * such as AGGREGATE, GROUP BY, SORT BY, CLUSTER BY, DISTRIBUTE BY, etc. is NOT pushed down.
  *
  * @since 3.4.0
  */
 @Evolving
-public interface SupportsPushDownLimitAndOffset {
-  /**
-   * Pushes down LIMIT and OFFSET to the data source.
-   */
-  boolean pushLimitAndOffset(int limit, int offset);
+public interface SupportsPushDownOffset extends ScanBuilder {
 
   /**
-   * Whether the LIMIT and OFFSET is partially pushed or not. If it returns true, then Spark will
-   * do LIMIT and OFFSET again. This method will only be called when {@link #pushLimitAndOffset}
-   * returns true.
+   * Pushes down OFFSET to the data source.
    */
-  default boolean isPartiallyPushed() { return true; }
+  boolean pushOffset(int offset);
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownOffset.java
@@ -21,7 +21,7 @@ import org.apache.spark.annotation.Evolving;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down OFFSET. We can push down OFFSET with many other operators if they follow the
+ * push down OFFSET. We can push down OFFSET with many other operations if they follow the
  * operator order we defined in {@link ScanBuilder}'s class doc.
  *
  * @since 3.4.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownOffset.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownOffset.java
@@ -21,8 +21,8 @@ import org.apache.spark.annotation.Evolving;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down OFFSET. Please note that the combination of OFFSET with other operations
- * such as AGGREGATE, GROUP BY, SORT BY, CLUSTER BY, DISTRIBUTE BY, etc. is NOT pushed down.
+ * push down OFFSET. We can push down OFFSET with many other operators if they follow the
+ * operator order we defined in {@link ScanBuilder}'s class doc.
  *
  * @since 3.4.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -22,9 +22,8 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
- * push down top N(query with ORDER BY ... LIMIT n). Please note that the combination of top N
- * with other operations such as AGGREGATE, GROUP BY, CLUSTER BY, DISTRIBUTE BY, etc.
- * is NOT pushed down.
+ * push down top N(query with ORDER BY ... LIMIT n). We can push down top N with many other
+ * operators if they follow the operator order we defined in {@link ScanBuilder}'s class doc.
  *
  * @since 3.3.0
  */

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsPushDownTopN.java
@@ -23,7 +23,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 /**
  * A mix-in interface for {@link ScanBuilder}. Data sources can implement this interface to
  * push down top N(query with ORDER BY ... LIMIT n). We can push down top N with many other
- * operators if they follow the operator order we defined in {@link ScanBuilder}'s class doc.
+ * operations if they follow the operator order we defined in {@link ScanBuilder}'s class doc.
  *
  * @since 3.3.0
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2103,7 +2103,7 @@ class Dataset[T] private[sql](
   }
 
   /**
-   * Returns a new Dataset by skipping the first `m` rows.
+   * Returns a new Dataset by skipping the first `n` rows.
    *
    * @group typedrel
    * @since 3.4.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -152,6 +152,8 @@ case class RowDataSourceScanExec(
       pushedDownOperators.limit.map(value => "PushedLimit" -> s"LIMIT $value")
     }
 
+    val pushedOffset = pushedDownOperators.offset.map(value => "PushedOffset" -> s"OFFSET $value")
+
     val pushedFilters = if (pushedDownOperators.pushedPredicates.nonEmpty) {
       seqToString(pushedDownOperators.pushedPredicates.map(_.describe()))
     } else {
@@ -164,6 +166,7 @@ case class RowDataSourceScanExec(
         Map("PushedAggregates" -> seqToString(v.aggregateExpressions.map(_.describe())),
           "PushedGroupByExpressions" -> seqToString(v.groupByExpressions.map(_.describe())))} ++
       topNOrLimitInfo ++
+      pushedOffset ++
       pushedDownOperators.sample.map(v => "PushedSample" ->
         s"SAMPLE (${(v.upperBound - v.lowerBound) * 100}) ${v.withReplacement} SEED(${v.seed})"
       )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -144,16 +144,13 @@ case class RowDataSourceScanExec(
 
     val limitOrOffsetInfo =
       if (pushedDownOperators.limit.isDefined && pushedDownOperators.sortValues.nonEmpty) {
+        val topNStr =
+          s"ORDER BY ${seqToString(pushedDownOperators.sortValues.map(_.describe()))}" +
+          s" LIMIT ${pushedDownOperators.limit.get}"
         if (pushedDownOperators.offset.isDefined) {
-          val pushedPaging =
-            s"ORDER BY ${seqToString(pushedDownOperators.sortValues.map(_.describe()))}" +
-              s" LIMIT ${pushedDownOperators.limit.get} OFFSET ${pushedDownOperators.offset.get}"
-          Map("PushedPaging" -> pushedPaging)
+          Map("PushedPaging" -> s"$topNStr OFFSET ${pushedDownOperators.offset.get}")
         } else {
-          val pushedTopN =
-            s"ORDER BY ${seqToString(pushedDownOperators.sortValues.map(_.describe()))}" +
-              s" LIMIT ${pushedDownOperators.limit.get}"
-          Map("PushedTopN" -> pushedTopN)
+          Map("PushedTopN" -> topNStr)
         }
       } else {
         pushedDownOperators.limit.map(value => "PushedLimit" -> s"LIMIT $value").toMap ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -144,12 +144,12 @@ case class RowDataSourceScanExec(
 
     val topNOrLimitInfo =
       if (pushedDownOperators.limit.isDefined && pushedDownOperators.sortValues.nonEmpty) {
-        val topNStr =
+        val pushedTopN =
           s"ORDER BY ${seqToString(pushedDownOperators.sortValues.map(_.describe()))}" +
           s" LIMIT ${pushedDownOperators.limit.get}"
-        Map("PushedTopN" -> topNStr)
+        Some("PushedTopN" -> pushedTopN)
       } else {
-        pushedDownOperators.limit.map(value => "PushedLimit" -> s"LIMIT $value").toMap
+        pushedDownOperators.limit.map(value => "PushedLimit" -> s"LIMIT $value")
       }
 
     val offsetInfo = pushedDownOperators.offset.map(value => "PushedOffset" -> s"OFFSET $value")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -346,7 +346,7 @@ object DataSourceStrategy
         l.output.toStructType,
         Set.empty,
         Set.empty,
-        PushedDownOperators(None, None, None, Seq.empty, Seq.empty),
+        PushedDownOperators(None, None, None, None, Seq.empty, Seq.empty),
         toCatalystRDD(l, baseRelation.buildScan()),
         baseRelation,
         None) :: Nil
@@ -420,7 +420,7 @@ object DataSourceStrategy
         requestedColumns.toStructType,
         pushedFilters.toSet,
         handledFilters,
-        PushedDownOperators(None, None, None, Seq.empty, Seq.empty),
+        PushedDownOperators(None, None, None, None, Seq.empty, Seq.empty),
         scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
         relation.relation,
         relation.catalogTable.map(_.identifier))
@@ -443,7 +443,7 @@ object DataSourceStrategy
         requestedColumns.toStructType,
         pushedFilters.toSet,
         handledFilters,
-        PushedDownOperators(None, None, None, Seq.empty, Seq.empty),
+        PushedDownOperators(None, None, None, None, Seq.empty, Seq.empty),
         scanBuilder(requestedColumns, candidatePredicates, pushedFilters),
         relation.relation,
         relation.catalogTable.map(_.identifier))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -198,8 +198,7 @@ class JDBCOptions(
 
   // An option to allow/disallow pushing down OFFSET into V2 JDBC data source
   // This only applies to Data Source V2 JDBC
-  val pushDownOffset =
-    pushDownLimit && parameters.getOrElse(JDBC_PUSHDOWN_OFFSET, "false").toBoolean
+  val pushDownOffset = parameters.getOrElse(JDBC_PUSHDOWN_OFFSET, "false").toBoolean
 
   // An option to allow/disallow pushing down TABLESAMPLE into JDBC data source
   // This only applies to Data Source V2 JDBC

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -197,7 +197,7 @@ class JDBCOptions(
   val pushDownLimit = parameters.getOrElse(JDBC_PUSHDOWN_LIMIT, "false").toBoolean
 
   // An option to allow/disallow pushing down OFFSET into V2 JDBC data source
-  // This only applies to Data Source V2 JDBC and allow pushing down LIMIT first
+  // This only applies to Data Source V2 JDBC
   val pushDownOffset =
     pushDownLimit && parameters.getOrElse(JDBC_PUSHDOWN_OFFSET, "false").toBoolean
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -196,6 +196,11 @@ class JDBCOptions(
   // This only applies to Data Source V2 JDBC
   val pushDownLimit = parameters.getOrElse(JDBC_PUSHDOWN_LIMIT, "false").toBoolean
 
+  // An option to allow/disallow pushing down OFFSET into V2 JDBC data source
+  // This only applies to Data Source V2 JDBC and allow pushing down LIMIT first
+  val pushDownOffset =
+    pushDownLimit && parameters.getOrElse(JDBC_PUSHDOWN_OFFSET, "false").toBoolean
+
   // An option to allow/disallow pushing down TABLESAMPLE into JDBC data source
   // This only applies to Data Source V2 JDBC
   val pushDownTableSample = parameters.getOrElse(JDBC_PUSHDOWN_TABLESAMPLE, "false").toBoolean
@@ -283,6 +288,7 @@ object JDBCOptions {
   val JDBC_PUSHDOWN_PREDICATE = newOption("pushDownPredicate")
   val JDBC_PUSHDOWN_AGGREGATE = newOption("pushDownAggregate")
   val JDBC_PUSHDOWN_LIMIT = newOption("pushDownLimit")
+  val JDBC_PUSHDOWN_OFFSET = newOption("pushDownOffset")
   val JDBC_PUSHDOWN_TABLESAMPLE = newOption("pushDownTableSample")
   val JDBC_KEYTAB = newOption("keytab")
   val JDBC_PRINCIPAL = newOption("principal")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRelation.scala
@@ -304,7 +304,8 @@ private[sql] case class JDBCRelation(
       groupByColumns: Option[Array[String]],
       tableSample: Option[TableSampleInfo],
       limit: Int,
-      sortOrders: Array[String]): RDD[Row] = {
+      sortOrders: Array[String],
+      offset: Int): RDD[Row] = {
     // Rely on a type erasure hack to pass RDD[InternalRow] back as RDD[Row]
     JDBCRDD.scanTable(
       sparkSession.sparkContext,
@@ -317,7 +318,8 @@ private[sql] case class JDBCRelation(
       groupByColumns,
       tableSample,
       limit,
-      sortOrders).asInstanceOf[RDD[Row]]
+      sortOrders,
+      offset).asInstanceOf[RDD[Row]]
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, AttributeS
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.expressions.SortOrder
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownLimitAndOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownFilters, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources
@@ -131,19 +131,15 @@ object PushDownUtils extends PredicateHelper {
   }
 
   /**
-   * Pushes down LIMIT and OFFSET to the data source Scan.
+   * Pushes down OFFSET to the data source Scan.
    *
-   * @return the tuple of Boolean. The first Boolean value represents whether to push down, and
-   *         the second Boolean value represents whether to push down partially, which means
-   *         Spark will keep the Limit and Offset and do it again.
+   * @return the Boolean value represents whether to push down.
    */
-  def pushLimitAndOffset(scanBuilder: ScanBuilder, limit: Int, offset: Int): (Boolean, Boolean) = {
+  def pushOffset(scanBuilder: ScanBuilder, offset: Int): Boolean = {
     scanBuilder match {
-      case s: SupportsPushDownLimitAndOffset if !s.isPartiallyPushed =>
-        (s.pushLimitAndOffset(limit, offset), false)
-      case s: SupportsPushDownLimit if s.pushLimit(limit + offset) =>
-        (true, s.isPartiallyPushed)
-      case _ => (false, false)
+      case s: SupportsPushDownOffset =>
+        s.pushOffset(offset)
+      case _ => false
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedDownOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedDownOperators.scala
@@ -28,7 +28,8 @@ case class PushedDownOperators(
     aggregation: Option[Aggregation],
     sample: Option[TableSampleInfo],
     limit: Option[Int],
+    offset: Option[Int],
     sortValues: Seq[SortOrder],
     pushedPredicates: Seq[Predicate]) {
-  assert((limit.isEmpty && sortValues.isEmpty) || limit.isDefined)
+  assert((limit.isEmpty && sortValues.isEmpty && offset.isEmpty) || limit.isDefined)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedDownOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedDownOperators.scala
@@ -31,5 +31,5 @@ case class PushedDownOperators(
     offset: Option[Int],
     sortValues: Seq[SortOrder],
     pushedPredicates: Seq[Predicate]) {
-  assert((limit.isEmpty && sortValues.isEmpty && offset.isEmpty) || limit.isDefined)
+  assert((limit.isEmpty && sortValues.isEmpty) || limit.isDefined)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -43,8 +43,8 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
       pushDownSample,
       pushDownFilters,
       pushDownAggregates,
-      pushDownLimits,
       pushDownOffsets,
+      pushDownLimits,
       pruneColumns)
 
     pushdownRules.foldLeft(plan) { (newPlan, pushDownRule) =>
@@ -434,6 +434,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
   }
 
   def pushDownOffsets(plan: LogicalPlan): LogicalPlan = plan.transform {
+    // TODO supports push down Limit append Offset or Offset append Limit
     case offset @ Offset(IntegerLiteral(n), child) =>
       val (newChild, isPushed) = pushDownOffset(child, n)
       if (isPushed) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -442,8 +442,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
       val (newChild, canRemoveLimit) = pushDownLimit(child, limit + offset)
       if (canRemoveLimit) {
         // Try to push down OFFSET only if the LIMIT operator has been pushed and can be removed.
-        // For `df.offset(n).limit(m)`, try to push down `limit(m + n).offset(n)`.
-        // For example, `df.offset(3).limit(5)`, we can push down `limit(8).offset(3)`.
         val isPushed = pushDownOffset(newChild, offset)
         if (isPushed) {
           newChild

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -430,7 +430,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
         if (isPushed) {
           newChild
         } else {
-          // For `df.limit(m).offset(n)`, only push down `limit(m)`.
           // Keep the OFFSET operator if we failed to push down OFFSET to the data source.
           offset.withNewChildren(Seq(newChild))
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -447,8 +447,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
           newChild
         } else {
           // Still keep the OFFSET operator if we can't push it down.
-          // For example, `df.offset(3).limit(5)`, `limit(8)` has been pushed
-          // and can be removed, Spark still do `offset(3)`.
           Offset(Literal(offset), newChild)
         }
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -426,8 +426,6 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
       val (newChild, canRemoveLimit) = pushDownLimit(child, limit)
       if (canRemoveLimit) {
         // Try to push down OFFSET only if the LIMIT operator has been pushed and can be removed.
-        // For `df.limit(m).offset(n)`, try to push down `limit(m).offset(n)`.
-        // For example, `df.limit(5).offset(3)`, we can push down `limit(5).offset(3)`.
         val isPushed = pushDownOffset(newChild, offsetValue)
         if (isPushed) {
           newChild

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -426,8 +426,12 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
       val (isPushed, isPartiallyPushed) =
         PushDownUtils.pushLimitAndOffset(sHolder.builder, limit, offset)
       if (isPushed) {
-        sHolder.pushedLimit = Some(limit)
-        sHolder.pushedOffset = Some(offset)
+        if (isPartiallyPushed) {
+          sHolder.pushedLimit = Some(limit + offset)
+        } else {
+          sHolder.pushedLimit = Some(limit)
+          sHolder.pushedOffset = Some(offset)
+        }
       }
       (operation, isPushed && !isPartiallyPushed)
     case p: Project =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScan.scala
@@ -33,7 +33,8 @@ case class JDBCScan(
     groupByColumns: Option[Array[String]],
     tableSample: Option[TableSampleInfo],
     pushedLimit: Int,
-    sortOrders: Array[String]) extends V1Scan {
+    sortOrders: Array[String],
+    pushedOffset: Int) extends V1Scan {
 
   override def readSchema(): StructType = prunedSchema
 
@@ -49,7 +50,7 @@ case class JDBCScan(
           pushedAggregateColumn
         }
         relation.buildScan(columnList, prunedSchema, pushedPredicates, groupByColumns, tableSample,
-          pushedLimit, sortOrders)
+          pushedLimit, sortOrders, pushedOffset)
       }
     }.asInstanceOf[T]
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.expressions.{FieldReference, SortOrder}
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
 import org.apache.spark.sql.connector.expressions.filter.Predicate
-import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownLimit, SupportsPushDownLimitAndOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, SupportsPushDownAggregates, SupportsPushDownLimit, SupportsPushDownOffset, SupportsPushDownRequiredColumns, SupportsPushDownTableSample, SupportsPushDownTopN, SupportsPushDownV2Filters}
 import org.apache.spark.sql.execution.datasources.PartitioningUtils
 import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JDBCRDD, JDBCRelation}
 import org.apache.spark.sql.execution.datasources.v2.TableSampleInfo
@@ -39,7 +39,7 @@ case class JDBCScanBuilder(
     with SupportsPushDownRequiredColumns
     with SupportsPushDownAggregates
     with SupportsPushDownLimit
-    with SupportsPushDownLimitAndOffset
+    with SupportsPushDownOffset
     with SupportsPushDownTableSample
     with SupportsPushDownTopN
     with Logging {
@@ -142,9 +142,8 @@ case class JDBCScanBuilder(
     false
   }
 
-  override def pushLimitAndOffset(limit: Int, offset: Int): Boolean = {
-    if (jdbcOptions.pushDownOffset) {
-      pushedLimit = limit
+  override def pushOffset(offset: Int): Boolean = {
+    if (jdbcOptions.pushDownOffset && !isPartiallyPushed) {
       pushedOffset = offset
       return true
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -148,7 +148,9 @@ case class JDBCScanBuilder(
       // There are some push down path.
       // 1. For `dataset.limit(m).offset(n)`, try to push down `LIMIT (m - n) OFFSET n`.
       //    For example, `dataset.limit(5).offset(3)`, we can push down `LIMIT 2 OFFSET 3`.
-      // 2. For `dataset.offset(n)`, try to push down `OFFSET n`.
+      // 2. For `dataset.offset(n).limit(m)`, try to push down `LIMIT m OFFSET n`.
+      //    For example, `dataset.offset(3).limit(5)`, we can push down `LIMIT 5 OFFSET 3`.
+      // 3. For `dataset.offset(n)`, try to push down `OFFSET n`.
       //    For example, `dataset.offset(3)`, we can push down `OFFSET 3`.
       if (pushedLimit > 0) {
         pushedLimit = pushedLimit - offset

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -144,6 +144,15 @@ case class JDBCScanBuilder(
 
   override def pushOffset(offset: Int): Boolean = {
     if (jdbcOptions.pushDownOffset && !isPartiallyPushed) {
+      // We pushing down offset when data source have only one partition.
+      // There are some push down path.
+      // 1. For `dataset.limit(m).offset(n)`, try to push down `LIMIT (m - n) OFFSET n`.
+      //    For example, `dataset.limit(5).offset(3)`, we can push down `LIMIT 2 OFFSET 3`.
+      // 2. For `dataset.offset(n)`, try to push down `OFFSET n`.
+      //    For example, `dataset.offset(3)`, we can push down `OFFSET 3`.
+      if (pushedLimit > 0) {
+        pushedLimit = pushedLimit - offset
+      }
       pushedOffset = offset
       return true
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -144,8 +144,8 @@ case class JDBCScanBuilder(
 
   override def pushOffset(offset: Int): Boolean = {
     if (jdbcOptions.pushDownOffset && !isPartiallyPushed) {
-      // We pushing down offset when data source have only one partition.
-      // There are some push down path.
+      // Spark pushes down LIMIT first, then OFFSET. In SQL statements, OFFSET is applied before
+      // LIMIT. Here we need to adjust the LIMIT value to match SQL statements.
       // 1. For `dataset.limit(m).offset(n)`, try to push down `LIMIT (m - n) OFFSET n`.
       //    For example, `dataset.limit(5).offset(3)`, we can push down `LIMIT 2 OFFSET 3`.
       // 2. For `dataset.offset(n).limit(m)`, try to push down `LIMIT m OFFSET n`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCScanBuilder.scala
@@ -146,12 +146,6 @@ case class JDBCScanBuilder(
     if (jdbcOptions.pushDownOffset && !isPartiallyPushed) {
       // Spark pushes down LIMIT first, then OFFSET. In SQL statements, OFFSET is applied before
       // LIMIT. Here we need to adjust the LIMIT value to match SQL statements.
-      // 1. For `dataset.limit(m).offset(n)`, try to push down `LIMIT (m - n) OFFSET n`.
-      //    For example, `dataset.limit(5).offset(3)`, we can push down `LIMIT 2 OFFSET 3`.
-      // 2. For `dataset.offset(n).limit(m)`, try to push down `LIMIT m OFFSET n`.
-      //    For example, `dataset.offset(3).limit(5)`, we can push down `LIMIT 5 OFFSET 3`.
-      // 3. For `dataset.offset(n)`, try to push down `OFFSET n`.
-      //    For example, `dataset.offset(3)`, we can push down `OFFSET 3`.
       if (pushedLimit > 0) {
         pushedLimit = pushedLimit - offset
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -549,6 +549,13 @@ abstract class JdbcDialect extends Serializable with Logging{
     if (limit > 0 ) s"LIMIT $limit" else ""
   }
 
+  /**
+   * returns the OFFSET clause for the SELECT statement
+   */
+  def getOffsetClause(offset: Integer): String = {
+    if (offset > 0 ) s"OFFSET $offset" else ""
+  }
+
   def supportsTableSample: Boolean = false
 
   def getTableSample(sample: TableSampleInfo): String =

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -422,28 +422,28 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("simple scan with OFFSET and LIMIT") {
-//    val df1 = spark.read
-//      .table("h2.test.employee")
-//      .where($"dept" === 1)
-//      .offset(1)
-//      .limit(1)
-//    checkLimitRemoved(df1)
-//    checkOffsetRemoved(df1)
-//    checkPushedInfo(df1,
-//      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
-//    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-//
-//    val df2 = spark.read
-//      .option("pushDownOffset", "false")
-//      .table("h2.test.employee")
-//      .where($"dept" === 1)
-//      .offset(1)
-//      .limit(1)
-//    checkLimitRemoved(df2)
-//    checkOffsetRemoved(df2, false)
-//    checkPushedInfo(df2,
-//      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
-//    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+    val df1 = spark.read
+      .table("h2.test.employee")
+      .where($"dept" === 1)
+      .offset(1)
+      .limit(1)
+    checkLimitRemoved(df1)
+    checkOffsetRemoved(df1)
+    checkPushedInfo(df1,
+      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
+    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+
+    val df2 = spark.read
+      .option("pushDownOffset", "false")
+      .table("h2.test.employee")
+      .where($"dept" === 1)
+      .offset(1)
+      .limit(1)
+    checkLimitRemoved(df2)
+    checkOffsetRemoved(df2, false)
+    checkPushedInfo(df2,
+      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
+    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df3 = spark.read
       .option("pushDownLimit", "false")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -281,7 +281,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkLimitRemoved(df1)
     checkOffsetRemoved(df1)
     checkPushedInfo(df1,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 1, PushedOffset: OFFSET 1,")
     checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df2 = spark.read
@@ -291,9 +291,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limit(2)
       .offset(1)
     checkLimitRemoved(df2, false)
-    checkOffsetRemoved(df2, false)
+    checkOffsetRemoved(df2)
     checkPushedInfo(df2,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedOffset: OFFSET 1, ReadSchema:")
     checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df3 = spark.read

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -422,28 +422,28 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("simple scan with OFFSET and LIMIT") {
-    val df1 = spark.read
-      .table("h2.test.employee")
-      .where($"dept" === 1)
-      .offset(1)
-      .limit(1)
-    checkLimitRemoved(df1)
-    checkOffsetRemoved(df1)
-    checkPushedInfo(df1,
-      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
-    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-
-    val df2 = spark.read
-      .option("pushDownOffset", "false")
-      .table("h2.test.employee")
-      .where($"dept" === 1)
-      .offset(1)
-      .limit(1)
-    checkLimitRemoved(df2, false)
-    checkOffsetRemoved(df2, false)
-    checkPushedInfo(df2,
-      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
-    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+//    val df1 = spark.read
+//      .table("h2.test.employee")
+//      .where($"dept" === 1)
+//      .offset(1)
+//      .limit(1)
+//    checkLimitRemoved(df1)
+//    checkOffsetRemoved(df1)
+//    checkPushedInfo(df1,
+//      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
+//    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+//
+//    val df2 = spark.read
+//      .option("pushDownOffset", "false")
+//      .table("h2.test.employee")
+//      .where($"dept" === 1)
+//      .offset(1)
+//      .limit(1)
+//    checkLimitRemoved(df2)
+//    checkOffsetRemoved(df2, false)
+//    checkPushedInfo(df2,
+//      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
+//    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df3 = spark.read
       .option("pushDownLimit", "false")
@@ -489,7 +489,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .sort($"salary")
       .offset(1)
       .limit(1)
-    checkLimitRemoved(df6, false)
+    checkLimitRemoved(df6)
     checkOffsetRemoved(df6, false)
     checkPushedInfo(df6, "[DEPT IS NOT NULL, DEPT = 1]," +
       " PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2, ReadSchema:")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -236,7 +236,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limitAndOffset(1, 1)
     checkLimitAndOffsetRemoved(df2, false)
     checkPushedInfo(df2,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT > 1], PushedLimit: LIMIT 1, PushedOffset: OFFSET 1,")
+      "PushedFilters: [DEPT IS NOT NULL, DEPT > 1], PushedLimit: LIMIT 2,")
     checkAnswer(df2, Seq(Row(2, "david", 10000.00, 1300.0, true)))
 
     val df3 = sql("SELECT name FROM h2.test.employee WHERE dept > 1 LIMIT 1 OFFSET 1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -340,7 +340,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkLimitRemoved(df5)
     checkOffsetRemoved(df5)
     checkPushedInfo(df5, "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], " +
-      "PushedPaging: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2 OFFSET 1, ReadSchema:")
+      "PushedOffset: OFFSET 1, PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2, ReadSchema:")
     checkAnswer(df5, Seq(Row(1, "amy", 10000.00, 1000.0, true)))
 
     val df6 = spark.read
@@ -479,7 +479,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkLimitRemoved(df5, false)
     checkOffsetRemoved(df5)
     checkPushedInfo(df5, "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], " +
-      "PushedPaging: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2 OFFSET 1, ReadSchema:")
+      "PushedOffset: OFFSET 1, PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2, ReadSchema:")
     checkAnswer(df5, Seq(Row(1, "amy", 10000.00, 1000.0, true)))
 
     val df6 = spark.read

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -430,7 +430,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkLimitRemoved(df1)
     checkOffsetRemoved(df1)
     checkPushedInfo(df1,
-      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 1, PushedOffset: OFFSET 1,")
+      "[DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
     checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df2 = spark.read
@@ -476,7 +476,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .sort($"salary")
       .offset(1)
       .limit(1)
-    checkLimitRemoved(df5, false)
+    checkLimitRemoved(df5)
     checkOffsetRemoved(df5)
     checkPushedInfo(df5, "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], " +
       "PushedOffset: OFFSET 1, PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2, ReadSchema:")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -283,53 +283,53 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("simple scan with LIMIT and OFFSET") {
-    val df1 = spark.read
-      .table("h2.test.employee")
-      .where($"dept" === 1)
-      .limit(2)
-      .offset(1)
-    checkLimitRemoved(df1)
-    checkOffsetRemoved(df1)
-    checkPushedInfo(df1,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
-    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-
-    val df2 = spark.read
-      .option("pushDownLimit", "false")
-      .table("h2.test.employee")
-      .where($"dept" === 1)
-      .limit(2)
-      .offset(1)
-    checkLimitRemoved(df2, false)
-    checkOffsetRemoved(df2, false)
-    checkPushedInfo(df2,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
-    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-
-    val df3 = spark.read
-      .option("pushDownOffset", "false")
-      .table("h2.test.employee")
-      .where($"dept" === 1)
-      .limit(2)
-      .offset(1)
-    checkLimitRemoved(df3)
-    checkOffsetRemoved(df3, false)
-    checkPushedInfo(df3,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
-    checkAnswer(df3, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-
-    val df4 = spark.read
-      .option("pushDownLimit", "false")
-      .option("pushDownOffset", "false")
-      .table("h2.test.employee")
-      .where($"dept" === 1)
-      .limit(2)
-      .offset(1)
-    checkLimitRemoved(df4, false)
-    checkOffsetRemoved(df4, false)
-    checkPushedInfo(df4,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
-    checkAnswer(df4, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+//    val df1 = spark.read
+//      .table("h2.test.employee")
+//      .where($"dept" === 1)
+//      .limit(2)
+//      .offset(1)
+//    checkLimitRemoved(df1)
+//    checkOffsetRemoved(df1)
+//    checkPushedInfo(df1,
+//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
+//    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+//
+//    val df2 = spark.read
+//      .option("pushDownLimit", "false")
+//      .table("h2.test.employee")
+//      .where($"dept" === 1)
+//      .limit(2)
+//      .offset(1)
+//    checkLimitRemoved(df2, false)
+//    checkOffsetRemoved(df2, false)
+//    checkPushedInfo(df2,
+//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
+//    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+//
+//    val df3 = spark.read
+//      .option("pushDownOffset", "false")
+//      .table("h2.test.employee")
+//      .where($"dept" === 1)
+//      .limit(2)
+//      .offset(1)
+//    checkLimitRemoved(df3)
+//    checkOffsetRemoved(df3, false)
+//    checkPushedInfo(df3,
+//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
+//    checkAnswer(df3, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+//
+//    val df4 = spark.read
+//      .option("pushDownLimit", "false")
+//      .option("pushDownOffset", "false")
+//      .table("h2.test.employee")
+//      .where($"dept" === 1)
+//      .limit(2)
+//      .offset(1)
+//    checkLimitRemoved(df4, false)
+//    checkOffsetRemoved(df4, false)
+//    checkPushedInfo(df4,
+//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
+//    checkAnswer(df4, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df5 = spark.read
       .table("h2.test.employee")
@@ -339,8 +339,8 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .offset(1)
     checkLimitRemoved(df5)
     checkOffsetRemoved(df5)
-    checkPushedInfo(df5, "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedOffset: OFFSET 1," +
-      " PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2,")
+    checkPushedInfo(df5, "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], " +
+      "PushedPaging: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2 OFFSET 1, ReadSchema:")
     checkAnswer(df5, Seq(Row(1, "amy", 10000.00, 1000.0, true)))
 
     val df6 = spark.read
@@ -478,8 +478,8 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limit(1)
     checkLimitRemoved(df5, false)
     checkOffsetRemoved(df5)
-    checkPushedInfo(df5, "[DEPT IS NOT NULL, DEPT = 1], PushedOffset: OFFSET 1," +
-      " PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2,")
+    checkPushedInfo(df5, "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], " +
+      "PushedPaging: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 2 OFFSET 1, ReadSchema:")
     checkAnswer(df5, Seq(Row(1, "amy", 10000.00, 1000.0, true)))
 
     val df6 = spark.read

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -283,53 +283,53 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("simple scan with LIMIT and OFFSET") {
-//    val df1 = spark.read
-//      .table("h2.test.employee")
-//      .where($"dept" === 1)
-//      .limit(2)
-//      .offset(1)
-//    checkLimitRemoved(df1)
-//    checkOffsetRemoved(df1)
-//    checkPushedInfo(df1,
-//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
-//    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-//
-//    val df2 = spark.read
-//      .option("pushDownLimit", "false")
-//      .table("h2.test.employee")
-//      .where($"dept" === 1)
-//      .limit(2)
-//      .offset(1)
-//    checkLimitRemoved(df2, false)
-//    checkOffsetRemoved(df2, false)
-//    checkPushedInfo(df2,
-//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
-//    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-//
-//    val df3 = spark.read
-//      .option("pushDownOffset", "false")
-//      .table("h2.test.employee")
-//      .where($"dept" === 1)
-//      .limit(2)
-//      .offset(1)
-//    checkLimitRemoved(df3)
-//    checkOffsetRemoved(df3, false)
-//    checkPushedInfo(df3,
-//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
-//    checkAnswer(df3, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
-//
-//    val df4 = spark.read
-//      .option("pushDownLimit", "false")
-//      .option("pushDownOffset", "false")
-//      .table("h2.test.employee")
-//      .where($"dept" === 1)
-//      .limit(2)
-//      .offset(1)
-//    checkLimitRemoved(df4, false)
-//    checkOffsetRemoved(df4, false)
-//    checkPushedInfo(df4,
-//      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
-//    checkAnswer(df4, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+    val df1 = spark.read
+      .table("h2.test.employee")
+      .where($"dept" === 1)
+      .limit(2)
+      .offset(1)
+    checkLimitRemoved(df1)
+    checkOffsetRemoved(df1)
+    checkPushedInfo(df1,
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
+    checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+
+    val df2 = spark.read
+      .option("pushDownLimit", "false")
+      .table("h2.test.employee")
+      .where($"dept" === 1)
+      .limit(2)
+      .offset(1)
+    checkLimitRemoved(df2, false)
+    checkOffsetRemoved(df2, false)
+    checkPushedInfo(df2,
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
+    checkAnswer(df2, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+
+    val df3 = spark.read
+      .option("pushDownOffset", "false")
+      .table("h2.test.employee")
+      .where($"dept" === 1)
+      .limit(2)
+      .offset(1)
+    checkLimitRemoved(df3)
+    checkOffsetRemoved(df3, false)
+    checkPushedInfo(df3,
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
+    checkAnswer(df3, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
+
+    val df4 = spark.read
+      .option("pushDownLimit", "false")
+      .option("pushDownOffset", "false")
+      .table("h2.test.employee")
+      .where($"dept" === 1)
+      .limit(2)
+      .offset(1)
+    checkLimitRemoved(df4, false)
+    checkOffsetRemoved(df4, false)
+    checkPushedInfo(df4,
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], ReadSchema:")
+    checkAnswer(df4, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df5 = spark.read
       .table("h2.test.employee")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -274,9 +274,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limit(2)
       .offset(1)
     checkLimitRemoved(df1)
-    checkOffsetRemoved(df1)
+    checkOffsetRemoved(df1, false)
     checkPushedInfo(df1,
-      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, PushedOffset: OFFSET 1, ")
+      "PushedFilters: [DEPT IS NOT NULL, DEPT = 1], PushedLimit: LIMIT 2, ReadSchema:")
     checkAnswer(df1, Seq(Row(1, "cathy", 9000.00, 1200.0, false)))
 
     val df2 = spark.read


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, DS V2 push-down supports `LIMIT` but `OFFSET`.
If we can pushing down `OFFSET` to JDBC data source, it will be better performance.


### Why are the changes needed?
push down `OFFSET` could improves the performance.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New tests.
