### PR TITLE
[SPARK-38979][SQL] Improve error log readability in OrcUtils.requestedColumnIds

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -225,7 +225,7 @@ object OrcUtils extends Logging {
         // In these cases we map the physical schema to the data schema by index.
         assert(orcFieldNames.length <= dataSchema.length, "The given data schema " +
           s"${dataSchema.catalogString} (length:${dataSchema.length}) " +
-          s"has less ${orcFieldNames.length - dataSchema.length} fields than " +
+          s"has fewer ${orcFieldNames.length - dataSchema.length} fields than " +
           s"the actual ORC physical schema $orcSchema (length:${orcFieldNames.length}), " +
           "no idea which columns were dropped, fail to read.")
         // for ORC file written by Hive, no field names

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -224,8 +224,10 @@ object OrcUtils extends Logging {
         // the physical schema doesn't match the data schema).
         // In these cases we map the physical schema to the data schema by index.
         assert(orcFieldNames.length <= dataSchema.length, "The given data schema " +
-          s"${dataSchema.catalogString} has less fields than the actual ORC physical schema, " +
-          "no idea which columns were dropped, fail to read.")
+          s"${dataSchema.catalogString} (length:${dataSchema.length}) " +
+          s"has less ${orcFieldNames.length - dataSchema.length} fields than " +
+          s"the actual ORC physical schema $orcSchema (length:${orcFieldNames.length}), " +
+          s"no idea which columns were dropped, fail to read.")
         // for ORC file written by Hive, no field names
         // in the physical schema, there is a need to send the
         // entire dataSchema instead of required schema.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -227,7 +227,7 @@ object OrcUtils extends Logging {
           s"${dataSchema.catalogString} (length:${dataSchema.length}) " +
           s"has less ${orcFieldNames.length - dataSchema.length} fields than " +
           s"the actual ORC physical schema $orcSchema (length:${orcFieldNames.length}), " +
-          s"no idea which columns were dropped, fail to read.")
+          "no idea which columns were dropped, fail to read.")
         // for ORC file written by Hive, no field names
         // in the physical schema, there is a need to send the
         // entire dataSchema instead of required schema.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add detailed log in `OrcUtils#requestedColumnIds`.

### Why are the changes needed?
In `OrcUtils#requestedColumnIds` sometimes it fails because `orcFieldNames.length > dataSchema.length`, the log is not very clear. 

```
java.lang.AssertionError: assertion failed: The given data schema struct<field1:int> has less fields than the actual ORC physical schema, no idea which columns were dropped, fail to read.
```

after the change
```
java.lang.AssertionError: assertion failed: The given data schema struct<field1:int> (length:1) has fewer 1 fields than the actual ORC physical schema struct<field1:int,field2:int> (length:2), no idea which columns were dropped, fail to read.
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exist UT / local test
