### PR TITLE
[SPARK-38980][SQL][TEST] Move error class tests requiring ANSI SQL mode to QueryExecutionAnsiErrorsSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.errors
+
+import org.apache.spark.{SparkArithmeticException, SparkConf, SparkDateTimeException}
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+// Test suite for all the execution errors that requires enable ANSI SQL mode.
+class QueryExecutionAnsiErrorsSuite extends QueryTest with SharedSparkSession {
+  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")
+
+  test("CAST_CAUSES_OVERFLOW: from timestamp to int") {
+    val e = intercept[SparkArithmeticException] {
+      sql("select CAST(TIMESTAMP '9999-12-31T12:13:14.56789Z' AS INT)").collect()
+    }
+    assert(e.getErrorClass === "CAST_CAUSES_OVERFLOW")
+    assert(e.getSqlState === "22005")
+    assert(e.getMessage === "Casting 253402258394567890L to INT causes overflow. " +
+      "To return NULL instead, use 'try_cast'. " +
+      "If necessary set spark.sql.ansi.enabled to false to bypass this error.")
+  }
+
+  test("DIVIDE_BY_ZERO: can't divide an integer by zero") {
+    val e = intercept[SparkArithmeticException] {
+      sql("select 6/0").collect()
+    }
+    assert(e.getErrorClass === "DIVIDE_BY_ZERO")
+    assert(e.getSqlState === "22012")
+    assert(e.getMessage ===
+      "divide by zero. To return NULL instead, use 'try_divide'. If necessary set " +
+        "spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error." +
+        """
+          |== SQL(line 1, position 7) ==
+          |select 6/0
+          |       ^^^
+          |""".stripMargin)
+  }
+
+  test("INVALID_FRACTION_OF_SECOND: in the function make_timestamp") {
+    val e = intercept[SparkDateTimeException] {
+      sql("select make_timestamp(2012, 11, 30, 9, 19, 60.66666666)").collect()
+    }
+    assert(e.getErrorClass === "INVALID_FRACTION_OF_SECOND")
+    assert(e.getSqlState === "22023")
+    assert(e.getMessage === "The fraction of sec must be zero. Valid range is [0, 60]. " +
+      "If necessary set spark.sql.ansi.enabled to false to bypass this error. ")
+  }
+
+  test("CANNOT_CHANGE_DECIMAL_PRECISION: cast string to decimal") {
+    val e = intercept[SparkArithmeticException] {
+      sql("select CAST('66666666666666.666' AS DECIMAL(8, 1))").collect()
+    }
+    assert(e.getErrorClass === "CANNOT_CHANGE_DECIMAL_PRECISION")
+    assert(e.getSqlState === "22005")
+    assert(e.getMessage ===
+      "Decimal(expanded,66666666666666.666,17,3}) cannot be represented as Decimal(8, 1). " +
+        "If necessary set spark.sql.ansi.enabled to false to bypass this error." +
+        """
+          |== SQL(line 1, position 7) ==
+          |select CAST('66666666666666.666' AS DECIMAL(8, 1))
+          |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          |""".stripMargin)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import test.org.apache.spark.sql.connector.JavaSimpleWritableDataSource
 
-import org.apache.spark.{SparkArithmeticException, SparkDateTimeException, SparkException, SparkIllegalStateException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
+import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalStateException, SparkRuntimeException, SparkUnsupportedOperationException, SparkUpgradeException}
 import org.apache.spark.sql.{DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.util.BadRecordException
 import org.apache.spark.sql.connector.SimpleWritableDataSource
@@ -355,67 +355,6 @@ class QueryExecutionErrorsSuite extends QueryTest
         // make sure we don't have partial data.
         assert(spark.read.format(cls.getName).option("path", path).load().collect().isEmpty)
       }
-    }
-  }
-
-  test("CAST_CAUSES_OVERFLOW: from timestamp to int") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val e = intercept[SparkArithmeticException] {
-        sql("select CAST(TIMESTAMP '9999-12-31T12:13:14.56789Z' AS INT)").collect()
-      }
-      assert(e.getErrorClass === "CAST_CAUSES_OVERFLOW")
-      assert(e.getSqlState === "22005")
-      assert(e.getMessage === "Casting 253402258394567890L to INT causes overflow. " +
-        "To return NULL instead, use 'try_cast'. " +
-        "If necessary set spark.sql.ansi.enabled to false to bypass this error.")
-    }
-  }
-
-  test("DIVIDE_BY_ZERO: can't divide an integer by zero") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val e = intercept[SparkArithmeticException] {
-        sql("select 6/0").collect()
-      }
-      assert(e.getErrorClass === "DIVIDE_BY_ZERO")
-      assert(e.getSqlState === "22012")
-      assert(e.getMessage ===
-        "divide by zero. To return NULL instead, use 'try_divide'. If necessary set " +
-          "spark.sql.ansi.enabled to false (except for ANSI interval type) to bypass this error." +
-          """
-            |== SQL(line 1, position 7) ==
-            |select 6/0
-            |       ^^^
-            |""".stripMargin)
-    }
-  }
-
-  test("INVALID_FRACTION_OF_SECOND: in the function make_timestamp") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val e = intercept[SparkDateTimeException] {
-        sql("select make_timestamp(2012, 11, 30, 9, 19, 60.66666666)").collect()
-      }
-      assert(e.getErrorClass === "INVALID_FRACTION_OF_SECOND")
-      assert(e.getSqlState === "22023")
-      assert(e.getMessage === "The fraction of sec must be zero. Valid range is [0, 60]. " +
-        "If necessary set spark.sql.ansi.enabled to false to bypass this error. ")
-    }
-  }
-
-  test("CANNOT_CHANGE_DECIMAL_PRECISION: cast string to decimal") {
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val e = intercept[SparkArithmeticException] {
-        sql("select CAST('66666666666666.666' AS DECIMAL(8, 1))").collect()
-      }
-      assert(e.getErrorClass === "CANNOT_CHANGE_DECIMAL_PRECISION")
-      assert(e.getSqlState === "22005")
-      assert(e.getMessage ===
-        "Decimal(expanded,66666666666666.666,17,3}) cannot be represented as Decimal(8, 1). " +
-        "If necessary set spark.sql.ansi.enabled to false to bypass this error." +
-        """
-          |== SQL(line 1, position 7) ==
-          |select CAST('66666666666666.666' AS DECIMAL(8, 1))
-          |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          |""".stripMargin)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Move error class tests requiring ANSI SQL mode to QueryExecutionAnsiErrorsSuite

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are some tests requires enabling ANSI SQL mode in `QueryExecutionErrorsSuite`. Before the test suite become big, I suggest putting all those tests into QueryExecutionAnsiErrorsSuite:
1. it is easier to manage test cases
2. developers don't need to write `withSQLConf(SQLConf.ANSI_ENABLED.key -> "true")`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT