### PR TITLE
[SPARK-38734][SQL][TESTS] Test the error classes: INVALID_ARRAY_INDEX & INVALID_ARRAY_INDEX_IN_ELEMENT_AT

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.errors
 
-import org.apache.spark.{SparkArithmeticException, SparkConf, SparkDateTimeException}
+import org.apache.spark.{SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkConf, SparkDateTimeException}
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -76,5 +76,24 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with SharedSparkSession {
           |select CAST('66666666666666.666' AS DECIMAL(8, 1))
           |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           |""".stripMargin)
+  }
+
+  test("INVALID_ARRAY_INDEX") {
+    val e = intercept[SparkArrayIndexOutOfBoundsException] {
+      sql("select array(1, 2, 3, 4, 5)[8]").collect()
+    }
+    assert(e.getErrorClass === "INVALID_ARRAY_INDEX")
+    assert(e.getMessage === "Invalid index: 8, numElements: 5. " +
+      "If necessary set spark.sql.ansi.enabled to false to bypass this error.")
+  }
+
+  test("INVALID_ARRAY_INDEX_IN_ELEMENT_AT") {
+    val e = intercept[SparkArrayIndexOutOfBoundsException] {
+      sql("select element_at(array(1, 2, 3, 4, 5), 8)").collect()
+    }
+    assert(e.getErrorClass === "INVALID_ARRAY_INDEX_IN_ELEMENT_AT")
+    assert(e.getMessage === "Invalid index: 8, numElements: 5. " +
+      "To return NULL instead, use 'try_element_at'. " +
+      "If necessary set spark.sql.ansi.enabled to false to bypass this error.")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr aims to add one test for the error class INVALID_ARRAY_INDEX & INVALID_ARRAY_INDEX_IN_ELEMENT_AT to QueryExecutionAnsiErrorsSuite.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
By running new test:
```
build/sbt "sql/testOnly *QueryExecutionAnsiErrorsSuite*"
```