### PR TITLE
[SPARK-38994][DOCS] Add an Python example of StreamingQueryListener

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -3323,7 +3323,7 @@ Will print something like the following.
 
 You can also asynchronously monitor all queries associated with a
 `SparkSession` by attaching a `StreamingQueryListener`
-([Scala](api/scala/org/apache/spark/sql/streaming/StreamingQueryListener.html)/[Java](api/java/org/apache/spark/sql/streaming/StreamingQueryListener.html) docs).
+([Scala](api/scala/org/apache/spark/sql/streaming/StreamingQueryListener.html)/[Java](api/java/org/apache/spark/sql/streaming/StreamingQueryListener.html)/[Python](api/python/reference/api/pyspark.sql.streaming.StreamingQueryListener.html) docs).
 Once you attach your custom `StreamingQueryListener` object with
 `sparkSession.streams.addListener()`, you will get callbacks when a query is started and
 stopped and when there is progress made in an active query. Here is an example,
@@ -3371,8 +3371,21 @@ spark.streams().addListener(new StreamingQueryListener() {
 
 </div>
 <div data-lang="python"  markdown="1">
-{% highlight bash %}
-Not available in Python.
+{% highlight python %}
+spark = ...
+
+class Listener(StreamingQueryListener):
+    def onQueryStarted(self, event):
+        print("Query started: " + queryStarted.id)
+
+    def onQueryProgress(self, event):
+        println("Query terminated: " + queryTerminated.id)
+
+    def onQueryTerminated(self, event):
+        println("Query made progress: " + queryProgress.progress)
+
+
+spark.streams.addListener(Listener())
 {% endhighlight %}
 
 </div>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add an example of `StreamingQueryListener` in Python addd in SPARK-38759.

### Why are the changes needed?

To guide users about the new feature `StreamingQueryListener`.

### Does this PR introduce _any_ user-facing change?

Yes, new example in the documentation:

<img width="947" alt="Screen Shot 2022-04-22 at 2 01 36 PM" src="https://user-images.githubusercontent.com/6477701/164606564-2aaeb912-7c09-463d-a567-d4d52cab8c97.png">

### How was this patch tested?

Manually built the docs and checked the output.