### PR TITLE
[SPARK-28330][SQL][FOLLOWUP] Move the check of Offset from analysis to finsh analysis

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -608,7 +608,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
         }
     }
     checkCollectedMetrics(plan)
-    checkOffsetOperator(plan)
     extendedCheckRules.foreach(_(plan))
     plan.foreachUp {
       case o if !o.resolved =>
@@ -849,30 +848,6 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
       })
     }
     check(plan)
-  }
-
-  /**
-   * Validate whether the [[Offset]] is valid.
-   */
-  private def checkOffsetOperator(plan: LogicalPlan): Unit = {
-    plan.foreachUp {
-      case o if !o.isInstanceOf[GlobalLimit] && !o.isInstanceOf[LocalLimit]
-        && o.children.exists(_.isInstanceOf[Offset]) =>
-        failAnalysis(
-          s"""
-             |The OFFSET clause is only allowed in the LIMIT clause, but the OFFSET
-             |clause found in: ${o.nodeName}.""".stripMargin.replace("\n", " "))
-      case _ =>
-    }
-    plan match {
-      case Offset(offsetExpr, _) =>
-        checkLimitLikeClause("offset", offsetExpr)
-        failAnalysis(
-          s"""
-             |The OFFSET clause is only allowed in the LIMIT clause, but the OFFSET
-             |clause is found to be the outermost node.""".stripMargin.replace("\n", " "))
-      case _ =>
-    }
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -281,6 +281,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
     // However, because we also use the analyzer to canonicalized queries (for view definition),
     // we do not eliminate subqueries or compute current time in the analyzer.
     private val rules = Seq(
+      CheckOffsetOperator,
       EliminateResolvedHint,
       EliminateSubqueryAliases,
       EliminateView,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import scala.collection.mutable
+
 import org.apache.spark.sql.catalyst.CurrentUserContext.CURRENT_USER
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2394,4 +2394,11 @@ object QueryCompilationErrors extends QueryErrorsBase {
   def noSuchFunctionError(database: String, funcInfo: String): Throwable = {
     new AnalysisException(s"$database does not support function: $funcInfo")
   }
+
+  def invalidOffsetError(reason: String): Throwable = {
+    new AnalysisException(
+      s"""
+         |The OFFSET clause is only allowed in the LIMIT clause, but the OFFSET
+         |clause is found $reason.""".stripMargin.replace("\n", " "))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -557,20 +557,6 @@ class AnalysisErrorSuite extends AnalysisTest {
   )
 
   errorTest(
-    "OFFSET clause is outermost node",
-    testRelation.offset(Literal(10, IntegerType)),
-    "The OFFSET clause is only allowed in the LIMIT clause, but the OFFSET" +
-      " clause is found to be the outermost node." :: Nil
-  )
-
-  errorTest(
-    "OFFSET clause in other node",
-    testRelation2.offset(Literal(10, IntegerType)).where('b > 1),
-    "The OFFSET clause is only allowed in the LIMIT clause, but the OFFSET" +
-      " clause found in: Filter." :: Nil
-  )
-
-  errorTest(
     "the sum of num_rows in limit clause and num_rows in offset clause less than Int.MaxValue",
     testRelation.offset(Literal(2000000000, IntegerType)).limit(Literal(1000000000, IntegerType)),
     "The sum of the LIMIT clause and the OFFSET clause must not be greater than" +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerSuite.scala
@@ -78,7 +78,7 @@ class OptimizerSuite extends PlanTest {
 
     val analyzed1 =
       Offset(Literal(2), Project(Alias(Literal(5), "attr")() :: Nil, OneRowRelation())).analyze
-    val message1 = intercept[RuntimeException] {
+    val message1 = intercept[AnalysisException] {
       optimizer.execute(analyzed1)
     }.getMessage
     assert(message1.equals(
@@ -88,12 +88,12 @@ class OptimizerSuite extends PlanTest {
 
     val analyzed2 =
       Filter(EqualTo(UnresolvedAttribute(Seq("attr")), Literal("alex")), analyzed1).analyze
-    val message2 = intercept[RuntimeException] {
+    val message2 = intercept[AnalysisException] {
       optimizer.execute(analyzed2)
     }.getMessage
     assert(message2.equals(
       s"""
          |The OFFSET clause is only allowed in the LIMIT clause, but the OFFSET
-         |clause found in: ${analyzed2.nodeName}.""".stripMargin.replace("\n", " ")))
+         |clause is found in: ${analyzed2.nodeName}.""".stripMargin.replace("\n", " ")))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/35975 supported ANSI SQL: result offset clause.
We make some check for offset in `CheckAnalysis`.
The behavior prevents add offset API into `Dataset`.
So this PR move the check of Offset from analysis to finsh analysis.


### Why are the changes needed?
Let we can add offset API into `Dataset`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New tests
