### PR TITLE
[SPARK-39008][BUILD] Change ASF as a single author in Spark distribution

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -3,13 +3,10 @@ Type: Package
 Version: 3.4.0
 Title: R Front End for 'Apache Spark'
 Description: Provides an R Front end for 'Apache Spark' <https://spark.apache.org>.
-Authors@R: c(person("Shivaram", "Venkataraman", role = "aut",
-                    email = "shivaram@cs.berkeley.edu"),
-             person("Xiangrui", "Meng", role = "aut",
-                    email = "meng@databricks.com"),
-             person("Felix", "Cheung", role = c("aut", "cre"),
-                    email = "felixcheung@apache.org"),
-             person(family = "The Apache Software Foundation", role = c("aut", "cph")))
+Authors@R:
+    person(family = "The Apache Software Foundation",
+           email = "dev@spark.apache.org",
+           role = c("aut", "cre", "cph"))
 License: Apache License (== 2.0)
 URL: https://www.apache.org https://spark.apache.org
 BugReports: https://spark.apache.org/contributing.html

--- a/R/pkg/pkgdown/_pkgdown_template.yml
+++ b/R/pkg/pkgdown/_pkgdown_template.yml
@@ -29,12 +29,6 @@ template:
       </a>
 
 authors:
-  Shivaram Venkataraman :
-    href: https://github.com/shivaram
-  Xiangrui Meng:
-    href: https://github.com/mengxr
-  Felix Cheung:
-    href: https://github.com/felixcheung
   " The Apache Software Foundation":
     href: "https://www.apache.org/"
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,16 +43,10 @@
     <url>scm:git:git@github.com:apache/spark.git</url>
     <tag>HEAD</tag>
   </scm>
-  <developers>
-    <developer>
-      <id>matei</id>
-      <name>Matei Zaharia</name>
-      <email>matei.zaharia@gmail.com</email>
-      <url>https://cs.stanford.edu/people/matei</url>
-      <organization>Apache Software Foundation</organization>
-      <organizationUrl>https://spark.apache.org</organizationUrl>
-    </developer>
-  </developers>
+  <organization>
+    <name>Apache Software Foundation</name>
+    <url>https://www.apache.org</url>
+  </organization>
   <issueManagement>
     <system>JIRA</system>
     <url>https://issues.apache.org/jira/browse/SPARK</url>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to have a single author as ASF for Apache Spark project since the project is being maintained under this organization.

For `pom.xml`, I referred to Hadoop https://github.com/apache/hadoop/blob/56cfd6061770872ce35cf815544b0c0f49613209/pom.xml#L76-L79

### Why are the changes needed?

We mention several original developers in authors in `pom.xml` or `R/pkg/DESRIPTION` while the project is being maintained under ASF organization.

In addition, seems like these people (at least Matei) here get arbitrary spam emails.

### Does this PR introduce _any_ user-facing change?

Yes, the authors in the distributions will remain as ASF alone in Apache Spark distributions.

### How was this patch tested?

No, existing build and CRAN check should validate it.
