### PR TITLE
[SPARK-39013][SQL] Parser change to enforce `()` when creating a table with empty schema

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -198,7 +198,7 @@ class LibSVMRelationSuite
   test("create libsvmTable table without schema and path") {
     try {
       val e = intercept[IllegalArgumentException] {
-        spark.sql("CREATE TABLE libsvmTable USING libsvm")
+        spark.sql("CREATE TABLE libsvmTable () USING libsvm")
       }
       assert(e.getMessage.contains("No input path specified for libsvm data"))
     } finally {

--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -83,7 +83,7 @@ statement
         (RESTRICT | CASCADE)?                                          #dropNamespace
     | SHOW namespaces ((FROM | IN) multipartIdentifier)?
         (LIKE? pattern=STRING)?                                        #showNamespaces
-    | createTableHeader (LEFT_PAREN createOrReplaceTableColTypeList RIGHT_PAREN)? tableProvider?
+    | createTableHeader (LEFT_PAREN createOrReplaceTableColTypeList? RIGHT_PAREN)? tableProvider?
         createTableClauses
         (AS? query)?                                                   #createTable
     | CREATE TABLE (IF NOT EXISTS)? target=tableIdentifier

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -287,7 +287,7 @@ class DDLParserSuite extends AnalysisTest {
   }
 
   test("create/replace table - empty columns list") {
-    val createSql = "CREATE TABLE my_tab PARTITIONED BY (part string)"
+    val createSql = "CREATE TABLE my_tab () PARTITIONED BY (part string)"
     val replaceSql = "REPLACE TABLE my_tab PARTITIONED BY (part string)"
     val expectedTableSpec = TableSpec(
       Seq("my_tab"),
@@ -600,7 +600,7 @@ class DDLParserSuite extends AnalysisTest {
   test("support for other types in OPTIONS") {
     val createSql =
       """
-        |CREATE TABLE table_name USING json
+        |CREATE TABLE table_name () USING json
         |OPTIONS (a 1, b 0.1, c TRUE)
       """.stripMargin
     val replaceSql =

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1664,7 +1664,7 @@ class DataSourceV2SQLSuite
     spark.conf.unset(V2_SESSION_CATALOG_IMPLEMENTATION.key)
     val v1Table = "tbl"
     withTable(v1Table) {
-      sql(s"CREATE TABLE $v1Table" +
+      sql(s"CREATE TABLE $v1Table ()" +
           s" USING ${classOf[SimpleScanSource].getName} OPTIONS (from=0,to=1)")
       val exc = intercept[AnalysisException] {
         sql(s"DELETE FROM $v1Table WHERE i = 2")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1344,7 +1344,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
       withTable("tab1", "tab2") {
         (("a", "b") :: Nil).toDF().write.json(tempDir.getCanonicalPath)
 
-        val e = intercept[AnalysisException] { sql("CREATE TABLE tab1 USING json") }.getMessage
+        val e = intercept[AnalysisException] { sql("CREATE TABLE tab1 () USING json") }.getMessage
         assert(e.contains("Unable to infer schema for JSON. It must be specified manually"))
 
         sql(s"CREATE TABLE tab2 using json location '${tempDir.toURI}'")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -399,7 +399,7 @@ class PlanResolutionSuite extends AnalysisTest {
   test("support for other types in OPTIONS") {
     val sql =
       """
-        |CREATE TABLE table_name USING json
+        |CREATE TABLE table_name () USING json
         |OPTIONS (a 1, b 0.1, c TRUE)
       """.stripMargin
 
@@ -1758,7 +1758,7 @@ class PlanResolutionSuite extends AnalysisTest {
       "sequencefile", "rcfile", "textfile")
 
     allSources.foreach { s =>
-      val query = s"CREATE TABLE my_tab STORED AS $s"
+      val query = s"CREATE TABLE my_tab () STORED AS $s"
       parseAndResolve(query) match {
         case ct: CreateTableV1 =>
           val hiveSerde = HiveSerDe.sourceToSerDe(s)
@@ -1772,7 +1772,7 @@ class PlanResolutionSuite extends AnalysisTest {
   }
 
   test("create hive table - row format and table file format") {
-    val createTableStart = "CREATE TABLE my_tab ROW FORMAT"
+    val createTableStart = "CREATE TABLE my_tab () ROW FORMAT"
     val fileFormat = s"STORED AS INPUTFORMAT 'inputfmt' OUTPUTFORMAT 'outputfmt'"
     val query1 = s"$createTableStart SERDE 'anything' $fileFormat"
     val query2 = s"$createTableStart DELIMITED FIELDS TERMINATED BY ' ' $fileFormat"
@@ -1799,7 +1799,7 @@ class PlanResolutionSuite extends AnalysisTest {
     val supportedSources = Set("sequencefile", "rcfile", "textfile")
 
     allSources.foreach { s =>
-      val query = s"CREATE TABLE my_tab ROW FORMAT SERDE 'anything' STORED AS $s"
+      val query = s"CREATE TABLE my_tab () ROW FORMAT SERDE 'anything' STORED AS $s"
       if (supportedSources.contains(s)) {
         parseAndResolve(query) match {
           case ct: CreateTableV1 =>
@@ -1820,7 +1820,8 @@ class PlanResolutionSuite extends AnalysisTest {
     val supportedSources = Set("textfile")
 
     allSources.foreach { s =>
-      val query = s"CREATE TABLE my_tab ROW FORMAT DELIMITED FIELDS TERMINATED BY ' ' STORED AS $s"
+      val query = s"CREATE TABLE my_tab () " +
+        s"ROW FORMAT DELIMITED FIELDS TERMINATED BY ' ' STORED AS $s"
       if (supportedSources.contains(s)) {
         parseAndResolve(query) match {
           case ct: CreateTableV1 =>
@@ -1838,7 +1839,7 @@ class PlanResolutionSuite extends AnalysisTest {
   }
 
   test("create hive external table") {
-    val withoutLoc = "CREATE EXTERNAL TABLE my_tab STORED AS parquet"
+    val withoutLoc = "CREATE EXTERNAL TABLE my_tab () STORED AS parquet"
     parseAndResolve(withoutLoc) match {
       case ct: CreateTableV1 =>
         assert(ct.tableDesc.tableType == CatalogTableType.EXTERNAL)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1102,7 +1102,7 @@ class JDBCSuite extends QueryTest
       withTable(tableName) {
         val df = sql(
           s"""
-             |CREATE $tableType $tableName
+             |CREATE $tableType $tableName ()
              |USING org.apache.spark.sql.jdbc
              |OPTIONS (
              | url '$urlWithUserAndPass',
@@ -1131,7 +1131,7 @@ class JDBCSuite extends QueryTest
     withTable(tableName) {
       sql(
         s"""
-           |CREATE TABLE $tableName
+           |CREATE TABLE $tableName ()
            |USING org.apache.spark.sql.jdbc
            |OPTIONS (
            | url '$urlWithUserAndPass',
@@ -1169,7 +1169,7 @@ class JDBCSuite extends QueryTest
     withTable(tableName) {
       sql(
         s"""
-           |CREATE TABLE $tableName
+           |CREATE TABLE $tableName ()
            |USING org.apache.spark.sql.jdbc
            |OPTIONS (
            | url '$urlWithUserAndPass',

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/TableScanSuite.scala
@@ -386,7 +386,7 @@ class TableScanSuite extends DataSourceTest with SharedSparkSession {
       val schemaNeeded = intercept[Exception] {
         sql(
           s"""
-             |CREATE $tableType schemaRelationProviderWithoutSchema
+             |CREATE $tableType schemaRelationProviderWithoutSchema ()
              |USING org.apache.spark.sql.sources.AllDataTypesScanSource
              |OPTIONS (
              |  From '1',
@@ -404,7 +404,7 @@ class TableScanSuite extends DataSourceTest with SharedSparkSession {
       withTable (tableName) {
         sql(
           s"""
-             |CREATE $tableType $tableName
+             |CREATE $tableType $tableName ()
              |USING org.apache.spark.sql.sources.SimpleScanSource
              |OPTIONS (
              |  From '1',

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -922,7 +922,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
 
   test("SPARK-18912: number of columns mismatch for non-file-based data source table") {
     withTable("t") {
-      sql("CREATE TABLE t USING org.apache.spark.sql.test.DefaultSource")
+      sql("CREATE TABLE t () USING org.apache.spark.sql.test.DefaultSource")
 
       val e = intercept[AnalysisException] {
         Seq(1 -> "a").toDF("a", "b").write

--- a/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/convert_enum_to_string.q
+++ b/sql/hive/src/test/resources/ql/src/test/queries/clientpositive/convert_enum_to_string.q
@@ -1,6 +1,6 @@
 -- Ensure Enum fields are converted to strings (instead of struct<value:int>)
 
-create table convert_enum_to_string
+create table convert_enum_to_string ()
   partitioned by (b string)
   row format serde "org.apache.hadoop.hive.serde2.thrift.ThriftDeserializer"
     with serdeproperties (

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -1380,7 +1380,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
         // Creates the (non-)partitioned Avro table
         val plan = sql(
           s"""
-             |CREATE TABLE $tableName
+             |CREATE TABLE $tableName ()
              |$partitionClause
              |ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
              |STORED AS

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -921,7 +921,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
         // Creates the (non-)partitioned Avro table
         versionSpark.sql(
           s"""
-             |CREATE TABLE $tableName
+             |CREATE TABLE $tableName ()
              |$partitionClause
              |ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
              |STORED AS
@@ -1049,7 +1049,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
         versionSpark.sql(
           s"""
-             |CREATE TABLE $destTableName
+             |CREATE TABLE $destTableName ()
              |ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
              |WITH SERDEPROPERTIES ('respectSparkSchema' = 'true')
              |STORED AS

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -443,12 +443,12 @@ class HiveDDLSuite
         (("a", "b") :: Nil).toDF().write.json(tempDir.getCanonicalPath)
 
         assertAnalysisError(
-          "CREATE TABLE tab1 USING hive",
+          "CREATE TABLE tab1 () USING hive",
           "Unable to infer the schema. The schema specification is required to " +
             "create the table `default`.`tab1`")
 
         assertAnalysisError(
-          s"CREATE TABLE tab2 USING hive location '${tempDir.getCanonicalPath}'",
+          s"CREATE TABLE tab2 () USING hive location '${tempDir.getCanonicalPath}'",
           "Unable to infer the schema. The schema specification is required to " +
             "create the table `default`.`tab2`")
       }
@@ -1903,7 +1903,7 @@ class HiveDDLSuite
     withTable("t") {
       sql(
         s"""
-          |CREATE TABLE t PARTITIONED BY (ds string)
+          |CREATE TABLE t () PARTITIONED BY (ds string)
           |ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
           |WITH SERDEPROPERTIES ($originalSerdeProperties)
           |STORED AS
@@ -1969,7 +1969,7 @@ class HiveDDLSuite
     withTable("t") {
       sql(
         s"""
-          |CREATE TABLE t PARTITIONED BY (ds string)
+          |CREATE TABLE t () PARTITIONED BY (ds string)
           |ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
           |WITH SERDEPROPERTIES ($originalSerdeProperties)
           |STORED AS


### PR DESCRIPTION
### What changes were proposed in this pull request?
As a syntax guard for downstream datasource that could handle empty schema, we enforce user to use `()` during table creation queries.

E.g. `CREATE TABLE table () USING parquet`.

Note that the `[CREATE OR] REPLACE` is excluded from this change due to additional complexity.

### Why are the changes needed?
To explicitly make sure user are aware that they are creating a table with no columns.

### Does this PR introduce _any_ user-facing change?
Existing code that calls `CREATE TABLE table USING ...` will fail. 

### How was this patch tested?
New unit test.
