### PR TITLE
[SPARK-39001][SQL][DOCS][FOLLOW-UP] Revert the doc changes for dropFieldIfAllNull, prefersDecimal and primitivesAsString (schema_of_json)

### DIFF
--- a/docs/sql-data-sources-json.md
+++ b/docs/sql-data-sources-json.md
@@ -127,13 +127,13 @@ Data source options of JSON can be set via:
   <tr>
     <td><code>primitivesAsString</code></td>
     <td><code>false</code></td>
-    <td>Infers all primitive values as a string type. JSON built-in functions ignore this option.</td>
+    <td>Infers all primitive values as a string type.</td>
     <td>read</td>
   </tr>
   <tr>
     <td><code>prefersDecimal</code></td>
     <td><code>false</code></td>
-    <td>Infers all floating-point values as a decimal type. If the values do not fit in decimal, then it infers them as doubles. JSON built-in functions ignore this option.</td>
+    <td>Infers all floating-point values as a decimal type. If the values do not fit in decimal, then it infers them as doubles.</td>
     <td>read</td>
   </tr>
   <tr>
@@ -235,7 +235,7 @@ Data source options of JSON can be set via:
   <tr>
     <td><code>dropFieldIfAllNull</code></td>
     <td><code>false</code></td>
-    <td>Whether to ignore column of all null values or empty array during schema inference. JSON built-in functions ignore this option.</td>
+    <td>Whether to ignore column of all null values or empty array during schema inference.</td>
     <td>read</td>
   </tr>
   <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/36339. Actually `schema_of_json` expression supports `dropFieldIfAllNull`, `prefersDecimal` an `primitivesAsString`:

```scala
scala> spark.range(1).selectExpr("""schema_of_json("{'a': null}", map('dropFieldIfAllNull', 'true'))""").show()
+---------------------------+
|schema_of_json({'a': null})|
+---------------------------+
|                   STRUCT<>|
+---------------------------+


scala> spark.range(1).selectExpr("""schema_of_json("{'b': 1.0}", map('prefersDecimal', 'true'))""").show()
+--------------------------+
|schema_of_json({'b': 1.0})|
+--------------------------+
|      STRUCT<b: DECIMAL...|
+--------------------------+


scala> spark.range(1).selectExpr("""schema_of_json("{'b': 1.0}", map('primitivesAsString', 'true'))""").show()
+--------------------------+
|schema_of_json({'b': 1.0})|
+--------------------------+
|         STRUCT<b: STRING>|
+--------------------------+
```

### Why are the changes needed?
For correct documentation.

### Does this PR introduce _any_ user-facing change?

To end users, no because it's a partial revert of the docs unreleased yet.

### How was this patch tested?

Partial logical revert so I did not add a test also since this is just a doc change.