### PR TITLE
[SPARK-39016][TESTS] Fix compilation warnings related to "`enum` will become a keyword in Scala 3"

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -550,8 +550,8 @@ abstract class AvroSuite
     val fixed = spark.read.format("avro").load(testAvro).select("fixed3").collect()
     assert(fixed.map(_(0).asInstanceOf[Array[Byte]]).exists(p => p(1) == 3))
 
-    val enum = spark.read.format("avro").load(testAvro).select("enum").collect()
-    assert(enum.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
+    val enums = spark.read.format("avro").load(testAvro).select("enum").collect()
+    assert(enums.map(_(0)).toSet == Set("SPADES", "CLUBS", "DIAMONDS"))
 
     val record = spark.read.format("avro").load(testAvro).select("record").collect()
     assert(record(0)(0).getClass.toString.contains("Row"))

--- a/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala
@@ -169,20 +169,21 @@ class ConfigEntrySuite extends SparkFunSuite {
 
   test("conf entry: valid values check") {
     val conf = new SparkConf()
-    val enum = ConfigBuilder(testKey("enum"))
+    val enumConf = ConfigBuilder(testKey("enum"))
       .stringConf
       .checkValues(Set("a", "b", "c"))
       .createWithDefault("a")
-    assert(conf.get(enum) === "a")
+    assert(conf.get(enumConf) === "a")
 
-    conf.set(enum, "b")
-    assert(conf.get(enum) === "b")
+    conf.set(enumConf, "b")
+    assert(conf.get(enumConf) === "b")
 
-    conf.set(enum, "d")
+    conf.set(enumConf, "d")
     val enumError = intercept[IllegalArgumentException] {
-      conf.get(enum)
+      conf.get(enumConf)
     }
-    assert(enumError.getMessage === s"The value of ${enum.key} should be one of a, b, c, but was d")
+    assert(enumError.getMessage ===
+      s"The value of ${enumConf.key} should be one of a, b, c, but was d")
   }
 
   test("conf entry: conversion error") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are some compilation warnings:

```
[WARNING] spark-source/core/src/test/scala/org/apache/spark/internal/config/ConfigEntrySuite.scala:172: [deprecation @  | origin= | version=2.13.7] Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
[WARNING] spark-source/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala:553: [deprecation @  | origin= | version=2.13.7] Wrap `enum` in backticks to use it as an identifier, it will become a keyword in Scala 3.
```

this pr just rename the variable name to fix compilation warnings.


### Why are the changes needed?
Fix compilation warnings.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA