### PR TITLE
[SPARK-38982][PYTHON][PS][TESTS] Skip categories setter test

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_category.py
+++ b/python/pyspark/pandas/tests/indexes/test_category.py
@@ -82,7 +82,11 @@ class CategoricalIndexTest(PandasOnSparkTestCase, TestUtils):
 
         pidx.categories = ["z", "y", "x"]
         psidx.categories = ["z", "y", "x"]
-        if LooseVersion(pd.__version__) >= LooseVersion("1.1"):
+        # Pandas deprecated all the in-place category-setting behaviors, dtypes also not be
+        # refreshed in categories.setter since Pandas 1.4+, we should also consider to clean up
+        # this test when in-place category-setting removed:
+        # https://github.com/pandas-dev/pandas/issues/46820
+        if LooseVersion("1.4") >= LooseVersion(pd.__version__) >= LooseVersion("1.1"):
             self.assert_eq(pidx, psidx)
             self.assert_eq(pdf, psdf)
         else:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Since https://github.com/pandas-dev/pandas/commit/126a19d038b65493729e21ca969fbb58dab9a408, pandas changes behavior.

Before pandas 1.4, the pandas will refresh dtypes according to categories, since panda 1.4, `categories.setter` dtype refresh will not work. According to https://github.com/pandas-dev/pandas/issues/46820 , the complete support of `categories.setter` will never back.

And also only categories is refreshed (but dtype not) is useless behavior so we'd better to only fix test and keep current PS behavior, then remove this setter support when we remove all deprecated methods.

### Why are the changes needed?
Make CI passed with pandas 1.4.x

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
test_categories_setter passed with 1.3.X and also 1.4.x