### PR TITLE
[SPARK-38820][PYHTON] Refresh categories.dtype when astype('category')

### DIFF
--- a/python/pyspark/pandas/data_type_ops/base.py
+++ b/python/pyspark/pandas/data_type_ops/base.py
@@ -116,9 +116,12 @@ def _as_categorical_type(
     assert isinstance(dtype, CategoricalDtype)
     if dtype.categories is None:
         codes, uniques = index_ops.factorize()
+        categories = uniques.astype(index_ops.dtype)
         return codes._with_new_scol(
             codes.spark.column,
-            field=codes._internal.data_fields[0].copy(dtype=CategoricalDtype(categories=uniques)),
+            field=codes._internal.data_fields[0].copy(
+                dtype=CategoricalDtype(categories=categories)
+            ),
         )
     else:
         categories = dtype.categories

--- a/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
+++ b/python/pyspark/pandas/tests/data_type_ops/test_num_ops.py
@@ -620,6 +620,7 @@ class FractionalExtensionOpsTest(OpsTestBase):
                 self.check_extension(pser.astype(dtype), psser.astype(dtype))
         for pser, psser in self.fractional_extension_pser_psser_pairs:
             self.assert_eq(pser.astype(float), psser.astype(float))
+            self.assert_eq(pser.astype("category"), psser.astype("category"))
             self.assert_eq(pser.astype(np.float32), psser.astype(np.float32))
             with ps.option_context("compute.eager_check", True):
                 self.assertRaisesRegex(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch refresh categories.dtype when astype('category')


### Why are the changes needed?
categories.dtype is not refreshed before, follow pandas latest version behavior.

Before:
```python
s=ps.Series([True, False], dtype="boolean")
>>> s.astype("category")
0     True
1    False
dtype: category
Categories (2, object): [False, True]
```

After:
```python
s=ps.Series([True, False], dtype="boolean")
>>> s.astype("category")
0     True
1    False
dtype: category
Categories (2, boolean): [False, True]
```

### Does this PR introduce _any_ user-facing change?
Yep, and follow pandas 1.4 behavior


### How was this patch tested?
- BooleanExtensionOpsTest.test_astype
- StringExtensionOpsTest.test_astype
- FractionalExtensionOpsTest.test_astype (new added)

passed with pandas 1.4