### PR TITLE
[SPARK-39027][SQL][3.3] Output SQL statements in error messages in upper case and w/o double quotes

### DIFF
--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -258,7 +258,7 @@ class UDFTests(ReusedSQLTestCase):
         def runWithJoinType(join_type, type_string):
             with self.assertRaisesRegex(
                 AnalysisException,
-                """Using PythonUDF in join condition of join type "%s" is not supported"""
+                """Using PythonUDF in join condition of join type %s is not supported"""
                 % type_string,
             ):
                 left.join(right, [f("a", "b"), left.a1 == right.b1], join_type).collect()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
@@ -52,9 +52,8 @@ trait QueryErrorsBase {
     "\"" + elem + "\""
   }
 
-  // Quote sql statements in error messages.
   def toSQLStmt(text: String): String = {
-    quoteByDefault(text.toUpperCase(Locale.ROOT))
+    text.toUpperCase(Locale.ROOT)
   }
 
   def toSQLId(parts: Seq[String]): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ExtractPythonUDFFromJoinConditionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ExtractPythonUDFFromJoinConditionSuite.scala
@@ -189,7 +189,7 @@ class ExtractPythonUDFFromJoinConditionSuite extends PlanTest {
       }
       assert(e.message ==
         "The feature is not supported: " +
-        s"""Using PythonUDF in join condition of join type "${joinType.sql}" is not supported.""")
+        s"""Using PythonUDF in join condition of join type ${joinType.sql} is not supported.""")
 
       val query2 = testRelationLeft.join(
         testRelationRight,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -2069,11 +2069,11 @@ class DDLParserSuite extends AnalysisTest {
     comparePlans(
       parsePlan("SHOW FUNCTIONS IN db LIKE 'funct*'"),
       ShowFunctions(UnresolvedNamespace(Seq("db")), true, true, Some("funct*")))
-    intercept("SHOW other FUNCTIONS", "\"SHOW\" other \"FUNCTIONS\" not supported")
+    intercept("SHOW other FUNCTIONS", "SHOW other FUNCTIONS not supported")
     intercept("SHOW FUNCTIONS IN db f1",
-      "Invalid pattern in \"SHOW FUNCTIONS\": `f1`")
+      "Invalid pattern in SHOW FUNCTIONS: `f1`")
     intercept("SHOW FUNCTIONS IN db LIKE f1",
-      "Invalid pattern in \"SHOW FUNCTIONS\": `f1`")
+      "Invalid pattern in SHOW FUNCTIONS: `f1`")
 
     // The legacy syntax.
     comparePlans(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1245,7 +1245,7 @@ class PlanParserSuite extends AnalysisTest {
         |    "escapeChar" = "\\")
         |FROM testData
       """.stripMargin,
-      "\"TRANSFORM\" with serde is only supported in hive mode")
+      "TRANSFORM with serde is only supported in hive mode")
   }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
@@ -153,7 +153,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The feature is not supported: "LATERAL" join with "NATURAL" join.(line 1, pos 14)
+The feature is not supported: LATERAL join with NATURAL join.(line 1, pos 14)
 
 == SQL ==
 SELECT * FROM t1 NATURAL JOIN LATERAL (SELECT c1 + c2 AS c2)
@@ -167,7 +167,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The feature is not supported: "LATERAL" join with "USING" join.(line 1, pos 14)
+The feature is not supported: LATERAL join with USING join.(line 1, pos 14)
 
 == SQL ==
 SELECT * FROM t1 JOIN LATERAL (SELECT c1 + c2 AS c2) USING (c2)

--- a/sql/core/src/test/resources/sql-tests/results/transform.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/transform.sql.out
@@ -719,7 +719,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The feature is not supported: "TRANSFORM" does not support "DISTINCT"/"ALL" in inputs(line 1, pos 17)
+The feature is not supported: TRANSFORM does not support DISTINCT/ALL in inputs(line 1, pos 17)
 
 == SQL ==
 SELECT TRANSFORM(DISTINCT b, a, c)
@@ -739,7 +739,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-The feature is not supported: "TRANSFORM" does not support "DISTINCT"/"ALL" in inputs(line 1, pos 17)
+The feature is not supported: TRANSFORM does not support DISTINCT/ALL in inputs(line 1, pos 17)
 
 == SQL ==
 SELECT TRANSFORM(ALL b, a, c)

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsDSv2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsDSv2Suite.scala
@@ -43,7 +43,7 @@ class QueryCompilationErrorsDSv2Suite
 
         checkAnswer(spark.table(tbl), spark.emptyDataFrame)
         assert(e.getMessage === "The feature is not supported: " +
-          s""""IF NOT EXISTS" for the table `testcat`.`ns1`.`ns2`.`tbl` by "INSERT INTO".""")
+          s"""IF NOT EXISTS for the table `testcat`.`ns1`.`ns2`.`tbl` by INSERT INTO.""")
         assert(e.getErrorClass === "UNSUPPORTED_FEATURE")
         assert(e.getSqlState === "0A000")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -149,7 +149,7 @@ class QueryCompilationErrorsSuite extends QueryTest with SharedSparkSession {
     assert(e.getSqlState === "0A000")
     assert(e.message ===
       "The feature is not supported: " +
-      "Using PythonUDF in join condition of join type \"LEFT OUTER\" is not supported.")
+      "Using PythonUDF in join condition of join type LEFT OUTER is not supported.")
   }
 
   test("UNSUPPORTED_FEATURE: Using pandas UDF aggregate expression with pivot") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -156,7 +156,7 @@ class QueryExecutionErrorsSuite extends QueryTest
     }
     assert(e1.getErrorClass === "UNSUPPORTED_FEATURE")
     assert(e1.getSqlState === "0A000")
-    assert(e1.getMessage === """The feature is not supported: Repeated "PIVOT"s.""")
+    assert(e1.getMessage === """The feature is not supported: Repeated PIVOTs.""")
 
     val e2 = intercept[SparkUnsupportedOperationException] {
       trainingSales
@@ -167,7 +167,7 @@ class QueryExecutionErrorsSuite extends QueryTest
     }
     assert(e2.getErrorClass === "UNSUPPORTED_FEATURE")
     assert(e2.getSqlState === "0A000")
-    assert(e2.getMessage === """The feature is not supported: "PIVOT" not after a "GROUP BY".""")
+    assert(e2.getMessage === """The feature is not supported: PIVOT not after a GROUP BY.""")
   }
 
   test("INCONSISTENT_BEHAVIOR_CROSS_VERSION: " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -44,7 +44,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "0A000",
       message =
         """
-          |The feature is not supported: "LATERAL" join with "NATURAL" join.(line 1, pos 14)
+          |The feature is not supported: LATERAL join with NATURAL join.(line 1, pos 14)
           |
           |== SQL ==
           |SELECT * FROM t1 NATURAL JOIN LATERAL (SELECT c1 + c2 AS c2)
@@ -59,7 +59,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "0A000",
       message =
         """
-          |The feature is not supported: "LATERAL" join with "USING" join.(line 1, pos 14)
+          |The feature is not supported: LATERAL join with USING join.(line 1, pos 14)
           |
           |== SQL ==
           |SELECT * FROM t1 JOIN LATERAL (SELECT c1 + c2 AS c2) USING (c2)
@@ -75,7 +75,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
         sqlState = "0A000",
         message =
           s"""
-            |The feature is not supported: "LATERAL" join type "$joinType".(line 1, pos 14)
+            |The feature is not supported: LATERAL join type $joinType.(line 1, pos 14)
             |
             |== SQL ==
             |SELECT * FROM t1 $joinType JOIN LATERAL (SELECT c1 + c2 AS c3) ON c2 = c3
@@ -99,7 +99,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
         sqlState = "42000",
         message =
           s"""
-            |Invalid SQL syntax: "LATERAL" can only be used with subquery.(line 1, pos $pos)
+            |Invalid SQL syntax: LATERAL can only be used with subquery.(line 1, pos $pos)
             |
             |== SQL ==
             |$sqlText
@@ -115,7 +115,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "0A000",
       message =
         """
-          |The feature is not supported: "NATURAL CROSS JOIN".(line 1, pos 14)
+          |The feature is not supported: NATURAL CROSS JOIN.(line 1, pos 14)
           |
           |== SQL ==
           |SELECT * FROM a NATURAL CROSS JOIN b
@@ -175,7 +175,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "0A000",
       message =
         """
-          |The feature is not supported: "TRANSFORM" does not support "DISTINCT"/"ALL" in inputs(line 1, pos 17)
+          |The feature is not supported: TRANSFORM does not support DISTINCT/ALL in inputs(line 1, pos 17)
           |
           |== SQL ==
           |SELECT TRANSFORM(DISTINCT a) USING 'a' FROM t
@@ -191,7 +191,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession {
       sqlState = "0A000",
       message =
         """
-          |The feature is not supported: "TRANSFORM" with serde is only supported in hive mode(line 1, pos 0)
+          |The feature is not supported: TRANSFORM with serde is only supported in hive mode(line 1, pos 0)
           |
           |== SQL ==
           |SELECT TRANSFORM(a) ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde' USING 'a' FROM t

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkScriptTransformationSuite.scala
@@ -56,7 +56,7 @@ class SparkScriptTransformationSuite extends BaseScriptTransformationSuite with 
             |FROM v
           """.stripMargin)
       }.getMessage
-      assert(e.contains("\"TRANSFORM\" with serde is only supported in hive mode"))
+      assert(e.contains("TRANSFORM with serde is only supported in hive mode"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to output any SQL statement in error messages in upper case, and apply new implementation of `QueryErrorsBase.toSQLStmt()` to all exceptions in `Query.*Errors` w/ error classes. Also this PR modifies all affected tests, see the list in the section "How was this patch tested?".

This is a backport of https://github.com/apache/spark/pull/36359.

### Why are the changes needed?
To improve user experience with Spark SQL by highlighting SQL statements in error massage and make them more visible to users. Also this PR makes SQL statements in error messages consistent to the docs where such elements are showed in upper case w/ any quotes.

### Does this PR introduce _any_ user-facing change?
Yes. The changes might influence on error messages:

Before:
```sql
The operation "DESC PARTITION" is not allowed
```

After:
```sql
The operation DESC PARTITION is not allowed
```

### How was this patch tested?
By running affected test suites:
```
$ build/sbt "sql/testOnly *QueryExecutionErrorsSuite"
$ build/sbt "sql/testOnly *QueryParsingErrorsSuite"
$ build/sbt "sql/testOnly *QueryCompilationErrorsSuite"
$ build/sbt "test:testOnly *QueryCompilationErrorsDSv2Suite"
$ build/sbt "test:testOnly *ExtractPythonUDFFromJoinConditionSuite"
$ build/sbt "testOnly *PlanParserSuite"
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z transform.sql"
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z join-lateral.sql"
$ build/sbt "sql/testOnly *SQLQueryTestSuite -- -z describe.sql"
$ build/sbt "testOnly *DDLParserSuite"
```
