### PR TITLE
[SPARK-39030][PYTHON] Rename sum to avoid shading the builtin Python function

### DIFF
--- a/python/pyspark/pandas/base.py
+++ b/python/pyspark/pandas/base.py
@@ -1364,8 +1364,8 @@ class IndexOpsMixin(object, metaclass=ABCMeta):
                 sdf = sdf.orderBy(F.col("count").desc())
 
         if normalize:
-            sum = sdf_dropna.count()
-            sdf = sdf.withColumn("count", F.col("count") / SF.lit(sum))
+            drop_sum = sdf_dropna.count()
+            sdf = sdf.withColumn("count", F.col("count") / SF.lit(drop_sum))
 
         internal = InternalFrame(
             spark_frame=sdf,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename sum to something else. 


### Why are the changes needed?
Sum is a build in function in python. [SUM() at python docs](https://docs.python.org/3/library/functions.html#sum)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Use existing tests.  
