### PR TITLE
[SPARK-38988][PYTHON] Suppress PerformanceWarnings of `DataFrame.info`

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -251,9 +251,10 @@ class PandasConversionMixin:
 
             with catch_warnings():
                 simplefilter(action="ignore", category=PerformanceWarning)
-                # `insert` API makes copy of data, we only do it for Series of duplicate column names.
-                # `pdf.iloc[:, index] = pdf.iloc[:, index]...` doesn't always work because `iloc` could
-                # return a view or a copy depending by context.
+                # `insert` API makes copy of data,
+                # we only do it for Series of duplicate column names.
+                # `pdf.iloc[:, index] = pdf.iloc[:, index]...` doesn't always work
+                # because `iloc` could return a view or a copy depending by context.
                 if column_counter[column_name] > 1:
                     df.insert(index, column_name, series, allow_duplicates=True)
                 else:

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 #
 import sys
-import warnings
 from collections import Counter
 from typing import List, Optional, Type, Union, no_type_check, overload, TYPE_CHECKING
+from warnings import catch_warnings, simplefilter, warn
+
+from pandas.errors import PerformanceWarning
 
 from pyspark.rdd import _load_from_socket
 from pyspark.sql.pandas.serializers import ArrowCollectSerializer
@@ -111,7 +113,7 @@ class PandasConversionMixin:
                         "'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to "
                         "true." % str(e)
                     )
-                    warnings.warn(msg)
+                    warn(msg)
                     use_arrow = False
                 else:
                     msg = (
@@ -121,7 +123,7 @@ class PandasConversionMixin:
                         "with 'spark.sql.execution.arrow.pyspark.fallback.enabled' has been set to "
                         "false.\n  %s" % str(e)
                     )
-                    warnings.warn(msg)
+                    warn(msg)
                     raise
 
             # Try to use Arrow optimization when the schema is supported and the required version
@@ -199,7 +201,7 @@ class PandasConversionMixin:
                         "effect on failures in the middle of "
                         "computation.\n  %s" % str(e)
                     )
-                    warnings.warn(msg)
+                    warn(msg)
                     raise
 
         # Below is toPandas without Arrow optimization.
@@ -247,13 +249,15 @@ class PandasConversionMixin:
             if (t is not None and not is_timedelta64_dtype(t)) or should_check_timedelta:
                 series = series.astype(t, copy=False)
 
-            # `insert` API makes copy of data, we only do it for Series of duplicate column names.
-            # `pdf.iloc[:, index] = pdf.iloc[:, index]...` doesn't always work because `iloc` could
-            # return a view or a copy depending by context.
-            if column_counter[column_name] > 1:
-                df.insert(index, column_name, series, allow_duplicates=True)
-            else:
-                df[column_name] = series
+            with catch_warnings():
+                simplefilter(action="ignore", category=PerformanceWarning)
+                # `insert` API makes copy of data, we only do it for Series of duplicate column names.
+                # `pdf.iloc[:, index] = pdf.iloc[:, index]...` doesn't always work because `iloc` could
+                # return a view or a copy depending by context.
+                if column_counter[column_name] > 1:
+                    df.insert(index, column_name, series, allow_duplicates=True)
+                else:
+                    df[column_name] = series
 
         pdf = df
 
@@ -419,7 +423,7 @@ class SparkConversionMixin:
                         "'spark.sql.execution.arrow.pyspark.fallback.enabled' is set to "
                         "true." % str(e)
                     )
-                    warnings.warn(msg)
+                    warn(msg)
                 else:
                     msg = (
                         "createDataFrame attempted Arrow optimization because "
@@ -428,7 +432,7 @@ class SparkConversionMixin:
                         "fallback with 'spark.sql.execution.arrow.pyspark.fallback.enabled' "
                         "has been set to false.\n  %s" % str(e)
                     )
-                    warnings.warn(msg)
+                    warn(msg)
                     raise
         converted_data = self._convert_from_pandas(data, schema, timezone)
         return self._create_dataframe(converted_data, schema, samplingRatio, verifySchema)

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -19,8 +19,6 @@ from collections import Counter
 from typing import List, Optional, Type, Union, no_type_check, overload, TYPE_CHECKING
 from warnings import catch_warnings, simplefilter, warn
 
-from pandas.errors import PerformanceWarning
-
 from pyspark.rdd import _load_from_socket
 from pyspark.sql.pandas.serializers import ArrowCollectSerializer
 from pyspark.sql.types import (
@@ -250,6 +248,8 @@ class PandasConversionMixin:
                 series = series.astype(t, copy=False)
 
             with catch_warnings():
+                from pandas.errors import PerformanceWarning
+
                 simplefilter(action="ignore", category=PerformanceWarning)
                 # `insert` API makes copy of data,
                 # we only do it for Series of duplicate column names.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Suppress PerformanceWarnings of DataFrame.info


### Why are the changes needed?
To improve usability.

### Does this PR introduce _any_ user-facing change?
No. Only PerformanceWarnings of DataFrame.info are suppressed.

### How was this patch tested?
Manual tests.