### PR TITLE
[SPARK-39038][CI] Skip reporting test results if triggering workflow was skipped

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   test_report:
+    if: github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
     steps:
     - name: Download test results to report


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `"Report test results"` workflow should be skipped when the triggering workflow completed with conclusion `'skipped'`.

### Why are the changes needed?
The `"Report test results"` workflow is triggered when either `"Build and test"` or `"Build and test (ANSI)"` complete. On fork repositories, workflow `"Build and test (ANSI)"` is always skipped.

The triggered `"Report test results"` workflow downloads artifacts from the triggering workflow and errors because there are none artifacts.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
In personal repo:
- https://github.com/EnricoMi/spark/actions/runs/2231657986
- triggered by https://github.com/EnricoMi/spark/actions/runs/2231657828