### PR TITLE
[SPARK-39042][CORE][SQL][SS] Use `Map.values()` instead of `Map.entrySet()` in scene that don't use keys

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -113,9 +113,9 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
         logger.warn("ChunkReceivedCallback.onFailure throws exception", e);
       }
     }
-    for (Map.Entry<Long, BaseResponseCallback> entry : outstandingRpcs.entrySet()) {
+    for (BaseResponseCallback callback : outstandingRpcs.values()) {
       try {
-        entry.getValue().onFailure(cause);
+        callback.onFailure(cause);
       } catch (Exception e) {
         logger.warn("RpcResponseCallback.onFailure throws exception", e);
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -450,7 +450,7 @@ class RocksDB(
   }
 
   private def closePrefixScanIterators(): Unit = {
-    prefixScanReuseIter.entrySet().asScala.foreach(_.getValue.close())
+    prefixScanReuseIter.values().asScala.foreach(_.close())
     prefixScanReuseIter.clear()
   }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/operation/LogDivertAppender.java
@@ -264,8 +264,7 @@ public class LogDivertAppender extends AbstractWriterAppender<WriterManager> {
     StringLayout layout = null;
 
     Map<String, Appender> appenders = root.getAppenders();
-    for (Map.Entry<String, Appender> entry : appenders.entrySet()) {
-      Appender ap = entry.getValue();
+    for (Appender ap : appenders.values()) {
       if (ap.getClass().equals(ConsoleAppender.class)) {
         Layout l = ap.getLayout();
         if (l instanceof StringLayout) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Some code in Spark use `Map.entrySet()`, but doesn't need a keys, this pr use `Map.values()` to simplified them.


### Why are the changes needed?
Code simplification


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA