### PR TITLE
[SPARK-39043][SQL] Spark SQL Hive client should not gather statistic by default.

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,7 +24,7 @@ license: |
 
 ## Upgrading from Spark SQL 3.3 to 3.4
   
-  - Since Spark 3.4, Spark disable `hive.stats.autogather` when create `HiveClientImpl`. To restore the behavior before Spark 3.4, you can set `spark.hadoop.hive.stats.autogather` to `true`.
+  - Since Spark 3.4, Spark disables `hive.stats.autogather` by default, which means Hive tables won't automatically update statistics that can be consumed by Hive (not Spark). To restore the behavior before Spark 3.4, you can set `spark.hadoop.hive.stats.autogather` to `true`.
 
 ## Upgrading from Spark SQL 3.2 to 3.3
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -22,6 +22,10 @@ license: |
 * Table of contents
 {:toc}
 
+## Upgrading from Spark SQL 3.3 to 3.4
+  
+  - Since Spark 3.4, Spark disable `hive.stats.autogather` when create `HiveClientImpl`. To restore the behavior before Spark 3.4, you can set `spark.hadoop.hive.stats.autogather` to `true`.
+
 ## Upgrading from Spark SQL 3.2 to 3.3
 
   - Since Spark 3.3, the `histogram_numeric` function in Spark SQL returns an output type of an array of structs (x, y), where the type of the 'x' field in the return value is propagated from the input values consumed in the aggregate function. In Spark 3.2 or earlier, 'x' always had double type. Optionally, use the configuration `spark.sql.legacy.histogramNumericPropagateInputType` since Spark 3.3 to revert back to the previous behavior. 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -198,6 +198,12 @@ private[spark] object HiveUtils extends Logging {
     .booleanConf
     .createWithDefault(true)
 
+  val HIVE_STATS_AUTOGATHER = buildConf("spark.sql.hive.stats.autogather")
+    .doc("When set to false, Hive client won't write default statitic metadata.")
+    .version("3.3.0")
+    .booleanConf
+    .createWithDefault(false)
+
   /**
    * The version of the hive client that will be used to communicate with the metastore.  Note that
    * this does not necessarily need to be the same version of Hive that is used internally by

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -198,12 +198,6 @@ private[spark] object HiveUtils extends Logging {
     .booleanConf
     .createWithDefault(true)
 
-  val HIVE_STATS_AUTOGATHER = buildConf("spark.sql.hive.stats.autogather")
-    .doc("When set to false, Hive client won't write default statitic metadata.")
-    .version("3.3.0")
-    .booleanConf
-    .createWithDefault(false)
-
   /**
    * The version of the hive client that will be used to communicate with the metastore.  Note that
    * this does not necessarily need to be the same version of Hive that is used internally by

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -60,7 +60,6 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_SCHEMA
-import org.apache.spark.sql.hive.HiveUtils.HIVE_STATS_AUTOGATHER
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
@@ -1272,9 +1271,8 @@ private[hive] object HiveClientImpl extends Logging {
     // Disable CBO because we removed the Calcite dependency.
     hiveConf.setBoolean("hive.cbo.enable", false)
     // Disable auto gather statistic by default.
-    hiveConf.setBoolean("hive.stats.autogather", sparkConf.get(HIVE_STATS_AUTOGATHER) ||
-      (confMap.contains("hive.stats.autogather") &&
-          confMap("hive.stats.autogather").equalsIgnoreCase("true")))
+    hiveConf.setBoolean("hive.stats.autogather", confMap.contains("hive.stats.autogather") &&
+          confMap("hive.stats.autogather").equalsIgnoreCase("true"))
     // If this is true, SessionState.start will create a file to log hive job which will not be
     // deleted on exit and is useless for spark
     if (hiveConf.getBoolean("hive.session.history.enabled", false)) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -60,6 +60,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.QueryExecutionException
 import org.apache.spark.sql.hive.HiveExternalCatalog
 import org.apache.spark.sql.hive.HiveExternalCatalog.DATASOURCE_SCHEMA
+import org.apache.spark.sql.hive.HiveUtils.HIVE_STATS_AUTOGATHER
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{CircularBuffer, Utils}
@@ -1270,6 +1271,10 @@ private[hive] object HiveClientImpl extends Logging {
     }
     // Disable CBO because we removed the Calcite dependency.
     hiveConf.setBoolean("hive.cbo.enable", false)
+    // Disable auto gather statistic by default.
+    hiveConf.setBoolean("hive.stats.autogather", sparkConf.get(HIVE_STATS_AUTOGATHER) ||
+      (confMap.contains("hive.stats.autogather") &&
+          confMap("hive.stats.autogather").equalsIgnoreCase("true")))
     // If this is true, SessionState.start will create a file to log hive job which will not be
     // deleted on exit and is useless for spark
     if (hiveConf.getBoolean("hive.session.history.enabled", false)) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -101,7 +101,6 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
             .asInstanceOf[HiveTableRelation]
 
           val properties = relation.tableMeta.ignoredProperties
-          // Since HIVE-6727, Hive fixes table-level stats for external tables are incorrect.
           assert(properties.get("totalSize").isEmpty)
           assert(properties.get("rawDataSize").isEmpty)
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -73,8 +73,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
   }
 
   test("Hive serde tables should fallback to HDFS for size estimation") {
-    withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true",
-      HiveUtils.HIVE_STATS_AUTOGATHER.key -> "true") {
+    withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true") {
       withTable("csv_table") {
         withTempDir { tempDir =>
           // EXTERNAL OpenCSVSerde table pointing to LOCATION

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -102,7 +102,7 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
 
           val properties = relation.tableMeta.ignoredProperties
           // Since HIVE-6727, Hive fixes table-level stats for external tables are incorrect.
-          assert(properties("totalSize").toLong == 6)
+          assert(properties.get("totalSize").isEmpty)
           assert(properties.get("rawDataSize").isEmpty)
 
           val sizeInBytes = relation.stats.sizeInBytes

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/StatisticsSuite.scala
@@ -73,7 +73,8 @@ class StatisticsSuite extends StatisticsCollectionTestBase with TestHiveSingleto
   }
 
   test("Hive serde tables should fallback to HDFS for size estimation") {
-    withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true") {
+    withSQLConf(SQLConf.ENABLE_FALL_BACK_TO_HDFS_FOR_STATS.key -> "true",
+      HiveUtils.HIVE_STATS_AUTOGATHER.key -> "true") {
       withTable("csv_table") {
         withTempDir { tempDir =>
           // EXTERNAL OpenCSVSerde table pointing to LOCATION

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -62,6 +62,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
     System.gc() // Hack to avoid SEGV on some JVM versions.
     val hadoopConf = new Configuration()
     hadoopConf.set("test", "success")
+    hadoopConf.set("hive.stats.autogather", "true")
     client = buildClient(hadoopConf)
     if (versionSpark != null) versionSpark.reset()
     versionSpark = TestHiveVersion(client)


### PR DESCRIPTION
### What changes were proposed in this pull request?
When use `InsertIntoHiveTable`, when insert overwrite partition, it will call
`Hive.loadPartition()`, in this method, when `hive.stats.autogather` is true(default is true)

```
      if (oldPart == null) {
        newTPart.getTPartition().setParameters(new HashMap<String,String>());
        if (this.getConf().getBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER)) {
          StatsSetupConst.setBasicStatsStateForCreateTable(newTPart.getParameters(),
              StatsSetupConst.TRUE);
        }

public static void setBasicStatsStateForCreateTable(Map<String, String> params, String setting) {
  if (TRUE.equals(setting)) {
    for (String stat : StatsSetupConst.supportedStats) {
      params.put(stat, "0");
    }
  }
  setBasicStatsState(params, setting);
} 

public static final String[] supportedStats = {NUM_FILES,ROW_COUNT,TOTAL_SIZE,RAW_DATA_SIZE};
```

it set default `numRow` and `numFiles` as 0, since spark will update numFiles and rawSize, so `numRow` remain 0.

This impact other system like presto's CBO. Since spark have it's own statistic related code, here should set this as false by default.


### Why are the changes needed?
Keep consist with spark's own statistic data


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

