### PR TITLE
[SPARK-39022][SQL] Fix combination of HAVING and SORT not being resolved correctly

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisSuite.scala
@@ -1176,4 +1176,24 @@ class AnalysisSuite extends AnalysisTest with Matchers {
         false)
     }
   }
+
+  test("SPARK-39022: Combination of HAVING and SORT not resolved correctly") {
+    assertAnalysisSuccess(parsePlan(
+      """
+        | SELECT t.a
+        | FROM TaBlE2 as t
+        | GROUP BY t.a
+        | HAVING sum(t.c) > 150
+        | ORDER BY sum(t.c)
+      """.stripMargin), false)
+
+    assertAnalysisSuccess(parsePlan(
+      """
+        | SELECT t.a, sum(t.c)
+        | FROM TaBlE2 as t
+        | GROUP BY t.a
+        | HAVING sum(t.c) > 150
+        | ORDER BY sum(t.c)
+      """.stripMargin), false)
+  }
 }

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
@@ -243,15 +243,15 @@ Input [2]: [ca_state#22, count#29]
 Keys [1]: [ca_state#22]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#31]
-Results [3]: [ca_state#22 AS state#32, count(1)#31 AS cnt#33, ca_state#22]
+Results [2]: [ca_state#22 AS state#32, count(1)#31 AS cnt#33]
 
 (44) Filter [codegen id : 14]
-Input [3]: [state#32, cnt#33, ca_state#22]
+Input [2]: [state#32, cnt#33]
 Condition : (cnt#33 >= 10)
 
 (45) TakeOrderedAndProject
-Input [3]: [state#32, cnt#33, ca_state#22]
-Arguments: 100, [cnt#33 ASC NULLS FIRST, ca_state#22 ASC NULLS FIRST], [state#32, cnt#33]
+Input [2]: [state#32, cnt#33]
+Arguments: 100, [cnt#33 ASC NULLS FIRST, state#32 ASC NULLS FIRST], [state#32, cnt#33]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [cnt,ca_state,state]
+TakeOrderedAndProject [cnt,state]
   WholeStageCodegen (14)
     Filter [cnt]
       HashAggregate [ca_state,count] [count(1),state,cnt,count]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
@@ -213,15 +213,15 @@ Input [2]: [ca_state#2, count#27]
 Keys [1]: [ca_state#2]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#29]
-Results [3]: [ca_state#2 AS state#30, count(1)#29 AS cnt#31, ca_state#2]
+Results [2]: [ca_state#2 AS state#30, count(1)#29 AS cnt#31]
 
 (38) Filter [codegen id : 8]
-Input [3]: [state#30, cnt#31, ca_state#2]
+Input [2]: [state#30, cnt#31]
 Condition : (cnt#31 >= 10)
 
 (39) TakeOrderedAndProject
-Input [3]: [state#30, cnt#31, ca_state#2]
-Arguments: 100, [cnt#31 ASC NULLS FIRST, ca_state#2 ASC NULLS FIRST], [state#30, cnt#31]
+Input [2]: [state#30, cnt#31]
+Arguments: 100, [cnt#31 ASC NULLS FIRST, state#30 ASC NULLS FIRST], [state#30, cnt#31]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/simplified.txt
@@ -1,4 +1,4 @@
-TakeOrderedAndProject [cnt,ca_state,state]
+TakeOrderedAndProject [cnt,state]
   WholeStageCodegen (8)
     Filter [cnt]
       HashAggregate [ca_state,count] [count(1),state,cnt,count]


### PR DESCRIPTION
### What changes were proposed in this pull request?

Provide a way to resolve aggregates in `Sort` nodes if the query also contains `HAVING` by:

* Preventing premature `Project` nodes before sorting
* Allow resolving aggregates in `Sort` nodes even if there is a `Filter` node (introduced by `HAVING`) between the `Sort` and the `Aggregate`

### Why are the changes needed?

Resolve aggregate correctly in sorting/ordering nodes in plan even if the query contains `HAVING`.

### Does this PR introduce _any_ user-facing change?

Queries that contain aggregates, `HAVING`, and sorting/ordering should now resolve correctly, and work as expected.

Examples (see SPARK-39022):
```
SELECT hotel FROM test GROUP BY hotel HAVING sum(price) > 150 ORDER BY sum(price)
SELECT hotel, sum(price) FROM test GROUP BY hotel HAVING sum(price) > 150 ORDER BY sum(price)
```

### How was this patch tested?

Manual testing of examples provided in SPARK-39022.
Additional similar unit tests added in `AnalysisSuite`.

Run unit test:
```
$ build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.analysis.AnalysisSuite -- -z SPARK-39022"
```

Affected modified tests (see SPARK-39022):
```
$ build/sbt "sql/testOnly *TPCDSV2_7_PlanStabilitySuite*"
$ build/sbt "sql/testOnly *TPCDSV2_7_PlanStabilityWithStatsSuite*"
```