### PR TITLE
 [WIP][SPARK-37942][SQL]Use error classes in the compilation errors of properties 

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -19,6 +19,10 @@
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
   },
+  "CANNOT_READ_CORRUPTED_TABLE_PROPERTY" : {
+    "message" : [ "Cannot read table property '%s' as it's corrupted.%s" ],
+    "sqlState" : "42000"
+  },
   "CANNOT_UP_CAST_DATATYPE" : {
     "message" : [ "Cannot up cast <value> from <sourceType> to <targetType>.\n<details>" ]
   },
@@ -182,6 +186,10 @@
     "message" : [ "Unrecognized SQL type <typeName>" ],
     "sqlState" : "42000"
   },
+  "UNSET_NON_EXISTENT_PROPERTY" : {
+    "message" : [ "Attempted to unset non-existent property '%s' in table '%s'" ],
+    "sqlState" : "42000"
+  },
   "UNSUPPORTED_DATATYPE" : {
     "message" : [ "Unsupported data type <typeName>" ],
     "sqlState" : "0A000"
@@ -200,6 +208,9 @@
       },
       "JDBC_TRANSACTION" : {
         "message" : [ "The target JDBC server does not support transactions and can only support ALTER TABLE with a single action." ]
+      },
+      "JDBC_CATALOG" : {
+        "message" : [ "<command> is not supported in JDBC catalog." ]
       },
       "LATERAL_JOIN_OF_TYPE" : {
         "message" : [ "<joinType> JOIN with LATERAL correlation." ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -19,10 +19,6 @@
     "message" : [ "Cannot parse decimal" ],
     "sqlState" : "42000"
   },
-  "CANNOT_READ_CORRUPTED_TABLE_PROPERTY" : {
-    "message" : [ "Cannot read table property '%s' as it's corrupted.%s" ],
-    "sqlState" : "42000"
-  },
   "CANNOT_UP_CAST_DATATYPE" : {
     "message" : [ "Cannot up cast <value> from <sourceType> to <targetType>.\n<details>" ]
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -499,12 +499,12 @@ object CatalogTable {
       } else {
         val numParts = props.get(s"$key.numParts")
         if (numParts.isEmpty) {
-          throw QueryCompilationErrors.cannotReadCorruptedTablePropertyError(key)
+          throw new IllegalStateException(s"Cannot read table property '$key' as it's corrupted.");
         } else {
           val parts = (0 until numParts.get.toInt).map { index =>
             props.getOrElse(s"$key.part.$index", {
-              throw QueryCompilationErrors.cannotReadCorruptedTablePropertyError(
-                key, s"Missing part $index, $numParts parts are expected.")
+              throw new IllegalStateException(s"Cannot read table property '$key' as " +
+                s"it's corrupted. Missing part $index, $numParts parts are expected.")
             })
           }
           Some(parts.mkString)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -700,7 +700,8 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def cannotReadCorruptedTablePropertyError(key: String, details: String = ""): Throwable = {
-    new AnalysisException(s"Cannot read table property '$key' as it's corrupted.$details")
+    new AnalysisException(errorClass = "CANNOT_READ_CORRUPTED_TABLE_PROPERTY",
+      messageParameters = Array(key, details))
   }
 
   def invalidSchemaStringError(exp: Expression): Throwable = {
@@ -884,7 +885,8 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   private def notSupportedInJDBCCatalog(cmd: String): Throwable = {
-    new AnalysisException(s"$cmd is not supported in JDBC catalog.")
+    new AnalysisException(errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array("JDBC_CATALOG", cmd))
   }
 
   def cannotCreateJDBCTableUsingProviderError(): Throwable = {
@@ -953,7 +955,8 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   private def notSupportedForV2TablesError(cmd: String): Throwable = {
-    new AnalysisException(s"$cmd is not supported for v2 tables.")
+    new AnalysisException(errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array(s"$cmd is not supported for v2 tables."))
   }
 
   def analyzeTableNotSupportedForV2TablesError(): Throwable = {
@@ -1792,7 +1795,8 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def unsetNonExistentPropertyError(property: String, table: TableIdentifier): Throwable = {
-    new AnalysisException(s"Attempted to unset non-existent property '$property' in table '$table'")
+    new AnalysisException(errorClass = "UNSET_NON_EXISTENT_PROPERTY",
+      messageParameters = Array(property, table))
   }
 
   def alterTableChangeColumnNotSupportedForColumnTypeError(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
