### PR TITLE
[SPARK-39049][PYTHON][CORE][ML] Remove unneeded `pass`

### DIFF
--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -110,7 +110,6 @@ class Estimator(Params, Generic[M], metaclass=ABCMeta):
     .. versionadded:: 1.3.0
     """
 
-
     @abstractmethod
     def _fit(self, dataset: DataFrame) -> M:
         """
@@ -218,7 +217,6 @@ class Transformer(Params, metaclass=ABCMeta):
 
     .. versionadded:: 1.3.0
     """
-
 
     @abstractmethod
     def _transform(self, dataset: DataFrame) -> DataFrame:

--- a/python/pyspark/ml/base.py
+++ b/python/pyspark/ml/base.py
@@ -110,7 +110,6 @@ class Estimator(Params, Generic[M], metaclass=ABCMeta):
     .. versionadded:: 1.3.0
     """
 
-    pass
 
     @abstractmethod
     def _fit(self, dataset: DataFrame) -> M:
@@ -220,7 +219,6 @@ class Transformer(Params, metaclass=ABCMeta):
     .. versionadded:: 1.3.0
     """
 
-    pass
 
     @abstractmethod
     def _transform(self, dataset: DataFrame) -> DataFrame:

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -67,7 +67,6 @@ class Evaluator(Params, metaclass=ABCMeta):
     .. versionadded:: 1.4.0
     """
 
-    pass
 
     @abstractmethod
     def _evaluate(self, dataset: DataFrame) -> float:

--- a/python/pyspark/ml/evaluation.py
+++ b/python/pyspark/ml/evaluation.py
@@ -67,7 +67,6 @@ class Evaluator(Params, metaclass=ABCMeta):
     .. versionadded:: 1.4.0
     """
 
-
     @abstractmethod
     def _evaluate(self, dataset: DataFrame) -> float:
         """

--- a/python/pyspark/tests/test_worker.py
+++ b/python/pyspark/tests/test_worker.py
@@ -70,7 +70,6 @@ class WorkerTests(ReusedPySparkTestCase):
                 try:
                     daemon_pid, worker_pid = map(int, data)
                 except ValueError:
-                    pass
                     # In case the value is not written yet.
                     cnt += 1
                     if cnt == 10:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unneeded `pass` 

### Why are the changes needed?
Class`s Estimator, Transformer and Evaluator are abstract classes. Which has functions.  

ValueError in def run() has code. 

By removing `pass` it will be easier to read, understand and reuse code. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests passed.