### PR TITLE
[SPARK-39056][CORE][SQL] Use `Collections.singletonList` instead of `Arrays.asList` when only one argument

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaOffsetReaderConsumer.scala
@@ -306,9 +306,9 @@ private[kafka010] class KafkaOffsetReaderConsumer(
 
         partitionOffsets.foreach {
           case (tp, KafkaOffsetRangeLimit.LATEST) =>
-            consumer.seekToEnd(ju.Arrays.asList(tp))
+            consumer.seekToEnd(ju.Collections.singletonList(tp))
           case (tp, KafkaOffsetRangeLimit.EARLIEST) =>
-            consumer.seekToBeginning(ju.Arrays.asList(tp))
+            consumer.seekToBeginning(ju.Collections.singletonList(tp))
           case (tp, off) => consumer.seek(tp, off)
         }
 

--- a/connector/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaDataConsumer.scala
+++ b/connector/kafka-0-10/src/main/scala/org/apache/spark/streaming/kafka010/KafkaDataConsumer.scala
@@ -117,7 +117,7 @@ private[kafka010] class InternalKafkaConsumer[K, V](
       .setAuthenticationConfigIfNeeded()
       .build()
     val c = new KafkaConsumer[K, V](updatedKafkaParams)
-    val topics = ju.Arrays.asList(topicPartition)
+    val topics = ju.Collections.singletonList(topicPartition)
     c.assign(topics)
     c
   }

--- a/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
+++ b/core/src/main/scala/org/apache/spark/SparkStatusTracker.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark
 
-import java.util.Arrays
+import java.util.Collections
 
 import org.apache.spark.status.AppStatusStore
 import org.apache.spark.status.api.v1.StageStatus
@@ -58,7 +58,7 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
    * This method does not guarantee the order of the elements in its result.
    */
   def getActiveStageIds(): Array[Int] = {
-    store.stageList(Arrays.asList(StageStatus.ACTIVE)).map(_.stageId).toArray
+    store.stageList(Collections.singletonList(StageStatus.ACTIVE)).map(_.stageId).toArray
   }
 
   /**
@@ -67,7 +67,7 @@ class SparkStatusTracker private[spark] (sc: SparkContext, store: AppStatusStore
    * This method does not guarantee the order of the elements in its result.
    */
   def getActiveJobIds(): Array[Int] = {
-    store.jobsList(Arrays.asList(JobExecutionStatus.RUNNING)).map(_.jobId).toArray
+    store.jobsList(Collections.singletonList(JobExecutionStatus.RUNNING)).map(_.jobId).toArray
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -24,7 +24,7 @@ import java.nio.file.{Files => JavaFiles, Paths}
 import java.nio.file.attribute.PosixFilePermission.{OWNER_EXECUTE, OWNER_READ, OWNER_WRITE}
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import java.util.{Arrays, EnumSet, Locale}
+import java.util.{Collections, EnumSet, Locale}
 import java.util.concurrent.{TimeoutException, TimeUnit}
 import java.util.jar.{JarEntry, JarOutputStream, Manifest}
 import java.util.regex.Pattern
@@ -170,7 +170,8 @@ private[spark] object TestUtils {
     } else {
       Seq.empty
     }
-    compiler.getTask(null, null, null, options.asJava, null, Arrays.asList(sourceFile)).call()
+    compiler.getTask(null, null, null, options.asJava, null,
+      Collections.singletonList(sourceFile)).call()
 
     val fileName = className + ".class"
     val result = new File(fileName)

--- a/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/NettyRpcEnv.scala
@@ -67,7 +67,7 @@ private[netty] class NettyRpcEnv(
 
   private def createClientBootstraps(): java.util.List[TransportClientBootstrap] = {
     if (securityManager.isAuthenticationEnabled()) {
-      java.util.Arrays.asList(new AuthClientBootstrap(transportConf,
+      java.util.Collections.singletonList(new AuthClientBootstrap(transportConf,
         securityManager.getSaslUser(), securityManager))
     } else {
       java.util.Collections.emptyList[TransportClientBootstrap]
@@ -118,7 +118,7 @@ private[netty] class NettyRpcEnv(
   def startServer(bindAddress: String, port: Int): Unit = {
     val bootstraps: java.util.List[TransportServerBootstrap] =
       if (securityManager.isAuthenticationEnabled()) {
-        java.util.Arrays.asList(new AuthServerBootstrap(transportConf, securityManager))
+        java.util.Collections.singletonList(new AuthServerBootstrap(transportConf, securityManager))
       } else {
         java.util.Collections.emptyList()
       }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractLauncher.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractLauncher.java
@@ -19,6 +19,7 @@ package org.apache.spark.launcher;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.spark.launcher.CommandBuilderUtils.*;
@@ -138,7 +139,7 @@ public abstract class AbstractLauncher<T extends AbstractLauncher<T>> {
    */
   public T addSparkArg(String arg) {
     SparkSubmitOptionParser validator = new ArgumentValidator(false);
-    validator.parse(Arrays.asList(arg));
+    validator.parse(Collections.singletonList(arg));
     builder.userArgs.add(arg);
     return self();
   }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.hive.thriftserver
 
 import java.security.PrivilegedExceptionAction
-import java.util.{Arrays, Map => JMap}
+import java.util.{Collections, Map => JMap}
 import java.util.concurrent.{Executors, RejectedExecutionException, TimeUnit}
 
 import scala.collection.JavaConverters._
@@ -76,7 +76,7 @@ private[hive] class SparkExecuteStatementOperation(
 
   private lazy val resultSchema: TableSchema = {
     if (result == null || result.schema.isEmpty) {
-      new TableSchema(Arrays.asList(new FieldSchema("Result", "string", "")))
+      new TableSchema(Collections.singletonList(new FieldSchema("Result", "string", "")))
     } else {
       logInfo(s"Result Schema: ${result.schema}")
       SparkExecuteStatementOperation.getTableSchema(result.schema)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLDriver.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive.thriftserver
 
-import java.util.{ArrayList => JArrayList, Arrays, List => JList}
+import java.util.{ArrayList => JArrayList, Collections, List => JList}
 
 import scala.collection.JavaConverters._
 
@@ -48,7 +48,7 @@ private[hive] class SparkSQLDriver(val context: SQLContext = SparkSQLEnv.sqlCont
     val analyzed = query.analyzed
     logDebug(s"Result Schema: ${analyzed.output}")
     if (analyzed.output.isEmpty) {
-      new Schema(Arrays.asList(new FieldSchema("Response code", "string", "")), null)
+      new Schema(Collections.singletonList(new FieldSchema("Response code", "string", "")), null)
     } else {
       val fieldSchemas = analyzed.output.map { attr =>
         new FieldSchema(attr.name, attr.dataType.catalogString, "")


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is pr use `Collections.singletonList` instead of `Arrays.asList` when there is only one argument.

**Before**

```
List<String> one = Arrays.asList("one"); 
```

**After**

```
List<String> one = Collections.singletonList("one"); 
```

### Why are the changes needed?
A minor optimization will save a little memory due to `Arrays.asList` will create an `E[]` but `Collections.SingletonList` not.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA