### PR TITLE
[SPARK-39063][CORE] Remove `finalize()` method and related codes from `LevelDB/RocksDBIterator`

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -19,11 +19,8 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.ref.Reference;
-import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -68,13 +65,6 @@ public class LevelDB implements KVStore {
   private final ConcurrentMap<String, byte[]> typeAliases;
   private final ConcurrentMap<Class<?>, LevelDBTypeInfo> types;
 
-  /**
-   * Trying to close a JNI LevelDB handle with a closed DB causes JVM crashes. This is used to
-   * ensure that all iterators are correctly closed before LevelDB is closed. Use weak references
-   * to ensure that the iterator can be GCed, when it is only referenced here.
-   */
-  private final ConcurrentLinkedQueue<Reference<LevelDBIterator<?>>> iteratorTracker;
-
   public LevelDB(File path) throws Exception {
     this(path, new KVStoreSerializer());
   }
@@ -105,8 +95,6 @@ public class LevelDB implements KVStore {
       aliases = new HashMap<>();
     }
     typeAliases = new ConcurrentHashMap<>(aliases);
-
-    iteratorTracker = new ConcurrentLinkedQueue<>();
   }
 
   @Override
@@ -250,9 +238,7 @@ public class LevelDB implements KVStore {
       @Override
       public Iterator<T> iterator() {
         try {
-          LevelDBIterator<T> it = new LevelDBIterator<>(type, LevelDB.this, this);
-          iteratorTracker.add(new WeakReference<>(it));
-          return it;
+          return new LevelDBIterator<>(type, LevelDB.this, this);
         } catch (Exception e) {
           throw Throwables.propagate(e);
         }
@@ -305,14 +291,6 @@ public class LevelDB implements KVStore {
       }
 
       try {
-        if (iteratorTracker != null) {
-          for (Reference<LevelDBIterator<?>> ref: iteratorTracker) {
-            LevelDBIterator<?> it = ref.get();
-            if (it != null) {
-              it.close();
-            }
-          }
-        }
         _db.close();
       } catch (IOException ioe) {
         throw ioe;
@@ -327,21 +305,12 @@ public class LevelDB implements KVStore {
    * with a closed DB can cause JVM crashes, so this ensures that situation does not happen.
    */
   void closeIterator(LevelDBIterator<?> it) throws IOException {
-    notifyIteratorClosed(it);
     synchronized (this._db) {
       DB _db = this._db.get();
       if (_db != null) {
         it.close();
       }
     }
-  }
-
-  /**
-   * Remove iterator from iterator tracker. `LevelDBIterator` calls it to notify
-   * iterator is closed.
-   */
-  void notifyIteratorClosed(LevelDBIterator<?> it) {
-    iteratorTracker.removeIf(ref -> it.equals(ref.get()));
   }
 
   /** Returns metadata about indices for the given type. */

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -185,22 +185,10 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
 
   @Override
   public synchronized void close() throws IOException {
-    db.notifyIteratorClosed(this);
     if (!closed) {
       it.close();
       closed = true;
     }
-  }
-
-  /**
-   * Because it's tricky to expose closeable iterators through many internal APIs, especially
-   * when Scala wrappers are used, this makes sure that, hopefully, the JNI resources held by
-   * the iterator will eventually be released.
-   */
-  @SuppressWarnings("deprecation")
-  @Override
-  protected void finalize() throws Throwable {
-    db.closeIterator(this);
   }
 
   private byte[] loadNext() {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
@@ -179,21 +179,10 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
 
   @Override
   public synchronized void close() throws IOException {
-    db.notifyIteratorClosed(this);
     if (!closed) {
       it.close();
       closed = true;
     }
-  }
-
-  /**
-   * Because it's tricky to expose closeable iterators through many internal APIs, especially
-   * when Scala wrappers are used, this makes sure that, hopefully, the JNI resources held by
-   * the iterator will eventually be released.
-   */
-  @Override
-  protected void finalize() throws Throwable {
-    db.closeIterator(this);
   }
 
   private byte[] loadNext() {

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -19,7 +19,6 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterators;
@@ -283,18 +282,16 @@ public class LevelDBSuite {
     for (int i = 0; i < 8192; i++) {
       dbForCloseTest.write(createCustomType1(i));
     }
-    String key = dbForCloseTest
-      .view(CustomType1.class).iterator().next().key;
-    assertEquals("key0", key);
-    Iterator<CustomType1> it0 = dbForCloseTest
-      .view(CustomType1.class).max(1).iterator();
-    while (it0.hasNext()) {
-      it0.next();
+    try (KVStoreIterator<CustomType1> it0 =
+      dbForCloseTest.view(CustomType1.class).max(1).closeableIterator()) {
+      while (it0.hasNext()) {
+        it0.next();
+      }
     }
-    System.gc();
-    Iterator<CustomType1> it1 = dbForCloseTest
-      .view(CustomType1.class).iterator();
-    assertEquals("key0", it1.next().key);
+    try (KVStoreIterator<CustomType1> it1 =
+      dbForCloseTest.view(CustomType1.class).closeableIterator()) {
+      assertEquals("key0", it1.next().key);
+    }
     try (KVStoreIterator<CustomType1> it2 = dbForCloseTest
       .view(CustomType1.class).closeableIterator()) {
       assertEquals("key0", it2.next().key);

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -19,7 +19,6 @@ package org.apache.spark.util.kvstore;
 
 import java.io.File;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterators;
@@ -281,18 +280,16 @@ public class RocksDBSuite {
     for (int i = 0; i < 8192; i++) {
       dbForCloseTest.write(createCustomType1(i));
     }
-    String key = dbForCloseTest
-      .view(CustomType1.class).iterator().next().key;
-    assertEquals("key0", key);
-    Iterator<CustomType1> it0 = dbForCloseTest
-      .view(CustomType1.class).max(1).iterator();
-    while (it0.hasNext()) {
-      it0.next();
+    try (KVStoreIterator<CustomType1> it0 =
+      dbForCloseTest.view(CustomType1.class).max(1).closeableIterator()) {
+      while (it0.hasNext()) {
+        it0.next();
+      }
     }
-    System.gc();
-    Iterator<CustomType1> it1 = dbForCloseTest
-      .view(CustomType1.class).iterator();
-    assertEquals("key0", it1.next().key);
+    try (KVStoreIterator<CustomType1> it1 =
+      dbForCloseTest.view(CustomType1.class).closeableIterator()) {
+      assertEquals("key0", it1.next().key);
+    }
     try (KVStoreIterator<CustomType1> it2 = dbForCloseTest
       .view(CustomType1.class).closeableIterator()) {
       assertEquals("key0", it2.next().key);


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-38896, all `LevelDBIterator` handles opened by `LevelDB#view(Class<T> type)` method have been closed by `tryWithResource` mechanism, the way of close `LevelDBIterator` handles through `finalize()` mechanism is redundant, so this pr remove the `finalize()` method and related codes from `LevelDB` and `LevelDBIterator`. At the same time, this pr also cleans up similar code in `RocksDB` and `RocksDBIterator`.


### Why are the changes needed?
Clean up redundant code related to `finalize()` from `LevelDB/RocksDBIterator` 




### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GA