### PR TITLE
[SPARK-38737][SQL][TESTS] Test the error classes: INVALID_FIELD_NAME

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -513,6 +513,20 @@ class QueryCompilationErrorsSuite
       msg = "Invalid pivot value 'struct(col1, dotnet, col2, Experts)': value data type " +
         "struct<col1:string,col2:string> does not match pivot column data type int")
   }
+
+  test("INVALID_FIELD_NAME: add a nested field for not struct parent") {
+    withTable("t") {
+      sql("CREATE TABLE t(c struct<x:string>, m string) USING parquet")
+
+      val e = intercept[AnalysisException] {
+        sql("ALTER TABLE t ADD COLUMNS (m.n int)")
+      }
+      checkErrorClass(
+        exception = e,
+        errorClass = "INVALID_FIELD_NAME",
+        msg = "Field name m.n is invalid: m is not a struct.; line 1 pos 27")
+    }
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR aims to add a test for the error class INVALID_FIELD_NAME to `QueryCompilationErrorsSuite`.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryCompilationErrorsSuite*"
```