### PR TITLE
[SPARK-39067][BUILD] Upgrade scala-maven-plugin to 4.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
       See: SPARK-36547, SPARK-38394.
        -->
 
-    <scala-maven-plugin.version>4.5.6</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade scala-maven-plugin to 4.6.1


### Why are the changes needed?
`scala-maven-plugin` 4.6.1 upgrades `zinc` from 1.5.8 to 1.6.1, it also adds some other new features at the same time, for example, [Add maven.main.skip support](https://github.com/davidB/scala-maven-plugin/commit/67f11faa477bc0e5e8cf673a8753b478fe008a09) and [Patch target to match Scala 2.11/2.12 scalac option syntax](https://github.com/davidB/scala-maven-plugin/commit/36453a1b6b00e90c5e0877568a086c97f799ba12)

Other between 4.5.6 and 4.6.1 as follows:

- https://github.com/davidB/scala-maven-plugin/compare/4.5.6...4.6.1


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA