### PR TITLE
[SPARK-39068][SQL] Make thriftserver and sparksql-cli support in-memory catalog

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -51,14 +51,14 @@ private[hive] object SparkSQLEnv extends Logging {
         .set(SQLConf.DATETIME_JAVA8API_ENABLED, true)
 
       // if user specified in-memory explicitly, we bypass enable hive support.
-      val shouldUseInmemoryCatalog =
+      val shouldUseInMemoryCatalog =
         sparkConf.getOption(CATALOG_IMPLEMENTATION.key).contains("in-memory")
 
       val builder = SparkSession.builder()
         .config(sparkConf)
         .config(BUILTIN_HIVE_VERSION.key, builtinHiveVersion)
 
-      if (!shouldUseInmemoryCatalog) {
+      if (!shouldUseInMemoryCatalog) {
         builder.enableHiveSupport()
       }
       val sparkSession = builder.getOrCreate()
@@ -70,7 +70,7 @@ private[hive] object SparkSQLEnv extends Logging {
       // different class loader).
       sparkSession.sessionState
 
-      if (!shouldUseInmemoryCatalog) {
+      if (!shouldUseInMemoryCatalog) {
         val metadataHive = sparkSession
           .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
         metadataHive.setOut(new PrintStream(System.out, true, UTF_8.name()))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnv.scala
@@ -23,8 +23,10 @@ import java.nio.charset.StandardCharsets.UTF_8
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{SparkSession, SQLContext}
-import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
+import org.apache.spark.sql.hive.HiveExternalCatalog
+import org.apache.spark.sql.hive.HiveUtils._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.util.Utils
 
 /** A singleton object for the master program. The executors should not access this. */
@@ -48,11 +50,18 @@ private[hive] object SparkSQLEnv extends Logging {
         .setAppName(maybeAppName.getOrElse(s"SparkSQL::${Utils.localHostName()}"))
         .set(SQLConf.DATETIME_JAVA8API_ENABLED, true)
 
+      // if user specified in-memory explicitly, we bypass enable hive support.
+      val shouldUseInmemoryCatalog =
+        sparkConf.getOption(CATALOG_IMPLEMENTATION.key).contains("in-memory")
 
-      val sparkSession = SparkSession.builder()
+      val builder = SparkSession.builder()
         .config(sparkConf)
-        .config(HiveUtils.BUILTIN_HIVE_VERSION.key, HiveUtils.builtinHiveVersion)
-        .enableHiveSupport().getOrCreate()
+        .config(BUILTIN_HIVE_VERSION.key, builtinHiveVersion)
+
+      if (!shouldUseInmemoryCatalog) {
+        builder.enableHiveSupport()
+      }
+      val sparkSession = builder.getOrCreate()
       sparkContext = sparkSession.sparkContext
       sqlContext = sparkSession.sqlContext
 
@@ -61,11 +70,13 @@ private[hive] object SparkSQLEnv extends Logging {
       // different class loader).
       sparkSession.sessionState
 
-      val metadataHive = sparkSession
-        .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
-      metadataHive.setOut(new PrintStream(System.out, true, UTF_8.name()))
-      metadataHive.setInfo(new PrintStream(System.err, true, UTF_8.name()))
-      metadataHive.setError(new PrintStream(System.err, true, UTF_8.name()))
+      if (!shouldUseInmemoryCatalog) {
+        val metadataHive = sparkSession
+          .sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+        metadataHive.setOut(new PrintStream(System.out, true, UTF_8.name()))
+        metadataHive.setInfo(new PrintStream(System.err, true, UTF_8.name()))
+        metadataHive.setError(new PrintStream(System.err, true, UTF_8.name()))
+      }
     }
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -21,6 +21,7 @@ import java.io._
 import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
 import java.util.Date
+import java.util.concurrent.CountDownLatch
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -679,5 +680,23 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
     }
     sessionState.close()
     SparkSQLEnv.stop()
+  }
+
+  test("SPARK-39068: support in-memory catalog and running concurrently") {
+    val extraConf = Seq("-c", "spark.sql.catalogImplementation=in-memory")
+    val cd = new CountDownLatch(2)
+    def t: Thread = new Thread {
+      override def run(): Unit = {
+        // catalog is in memory, so that isolated
+        runCliWithin(1.minute, extraArgs = extraConf)(
+          "create table src(key int) using hive;" ->
+            "Hive support is required to CREATE Hive TABLE",
+          "create table src(key int) using parquet;" -> "")
+        cd.countDown()
+      }
+    }
+    t.start()
+    t.start()
+    cd.await()
   }
 }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -683,11 +683,12 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   }
 
   test("SPARK-39068: support in-memory catalog and running concurrently") {
-    val extraConf = Seq("-c", "spark.sql.catalogImplementation=in-memory")
+    val extraConf = Seq("-c", s"${StaticSQLConf.CATALOG_IMPLEMENTATION.key}=in-memory")
     val cd = new CountDownLatch(2)
     def t: Thread = new Thread {
       override def run(): Unit = {
-        // catalog is in memory, so that isolated
+        // catalog is in-memory and isolated, so that we can create table with duplicated
+        // names.
         runCliWithin(1.minute, extraArgs = extraConf)(
           "create table src(key int) using hive;" ->
             "Hive support is required to CREATE Hive TABLE",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

if users specify in-memory explicitly, we bypass enable hive support.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- with in-memory catalog, we can start multiple instances in the same folder without the limitation[1] of derby.
- spark now is multi catalog architecture, the built-in catalog is not always necessary, in-memory is much lightweight if it is unused. if we use hive, in order to pass [1], we need a extra metastore service

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, `spark.sql.catalogImplementation=in-memory` can be used for ./bin/spark-sql; and thriftserver to enable a lightweight in-memory catalog

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

add a new test