### PR TITLE
[SPARK-39072][SHUFFLE]Fast fail the remaining push blocks if shuffle …

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -386,4 +386,12 @@ public class TransportConf {
   public int ioExceptionsThresholdDuringMerge() {
     return conf.getInt("spark.shuffle.push.server.ioExceptionsThresholdDuringMerge", 4);
   }
+
+  /**
+   * The threshold for push blocks in flight. So we can fast fail the remaining blocks in
+   * OneForOneBlockPusher if shuffle stage is finalized.
+   */
+  public int maxPushBlocksInFlightPerNode() {
+    return conf.getInt("spark.shuffle.push.server.maxPushBlocksInFlightPerNode", 10);
+  }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -171,7 +171,8 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
                 "Expecting a BlockPushingListener, but got " + inputListener.getClass();
               TransportClient client = clientFactory.createClient(host, port);
               new OneForOneBlockPusher(client, appId, comparableAppAttemptId, inputBlockId,
-                (BlockPushingListener) inputListener, buffersWithId).start();
+                (BlockPushingListener) inputListener, buffersWithId,
+                transportConf.maxPushBlocksInFlightPerNode()).start();
             } else {
               logger.info("This clientFactory was closed. Skipping further block push retries.");
             }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockPusherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockPusherSuite.java
@@ -97,7 +97,7 @@ public class OneForOneBlockPusherSuite {
 
     verify(listener, times(1)).onBlockPushSuccess(eq("shufflePush_0_0_0_0"), any());
     verify(listener, times(1)).onBlockPushFailure(eq("shufflePush_0_0_1_0"), any());
-    verify(listener, times(1)).onBlockPushFailure(eq("shufflePush_0_0_2_0"), any());
+    verify(listener, times(0)).onBlockPushFailure(eq("shufflePush_0_0_2_0"), any());
   }
 
   @Test
@@ -161,6 +161,7 @@ public class OneForOneBlockPusherSuite {
     try {
       pusher.start();
     } catch (InterruptedException e) {
+      e.printStackTrace();
     }
     return listener;
   }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockPusherSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/OneForOneBlockPusherSuite.java
@@ -134,7 +134,7 @@ public class OneForOneBlockPusherSuite {
     TransportClient client = mock(TransportClient.class);
     BlockPushingListener listener = mock(BlockPushingListener.class);
     OneForOneBlockPusher pusher =
-      new OneForOneBlockPusher(client, "app-id", 0, blockIds, listener, blocks);
+      new OneForOneBlockPusher(client, "app-id", 0, blockIds, listener, blocks, 10);
 
     Iterator<Map.Entry<String, ManagedBuffer>> blockIterator = blocks.entrySet().iterator();
     Iterator<BlockTransferMessage> msgIterator = expectMessages.iterator();
@@ -158,7 +158,10 @@ public class OneForOneBlockPusherSuite {
       return null;
     }).when(client).uploadStream(any(ManagedBuffer.class), any(), any(RpcResponseCallback.class));
 
-    pusher.start();
+    try {
+      pusher.start();
+    } catch (InterruptedException e) {
+    }
     return listener;
   }
 }


### PR DESCRIPTION
…stage finalized

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Limit the push blocks in flight and try to stop push the remaining blocks shuffle stage is finalized.

### Why are the changes needed?

Map task will try to push all map outputs to external shuffle service now.
After the shuffle stage is finalized, the reduce fetch blocks RPC will be blocked if there are still many map output blocks in flight.
We could stop pushing the remaining blocks if the shuffle stage is finalized.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Exists UT
