### PR TITLE
[SPARK-39074][CI] Fail on upload, not download of missing test files

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -280,6 +280,7 @@ jobs:
       with:
         name: test-results-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/test-reports/*.xml"
+        if-no-files-found: error
     - name: Upload unit tests log files
       if: failure()
       uses: actions/upload-artifact@v2
@@ -389,6 +390,7 @@ jobs:
       with:
         name: test-results-${{ matrix.modules }}--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
+        if-no-files-found: error
     - name: Upload unit tests log files
       if: failure()
       uses: actions/upload-artifact@v2
@@ -465,6 +467,7 @@ jobs:
       with:
         name: test-results-sparkr--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
+        if-no-files-found: error
 
   # Static analysis, and documentation build
   lint:
@@ -772,6 +775,7 @@ jobs:
       with:
         name: test-results-tpcds--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
+        if-no-files-found: error
     - name: Upload unit tests log files
       if: failure()
       uses: actions/upload-artifact@v2
@@ -837,6 +841,7 @@ jobs:
       with:
         name: test-results-docker-integration--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
+        if-no-files-found: error
     - name: Upload unit tests log files
       if: failure()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
     - name: Download test results to report
       uses: dawidd6/action-download-artifact@09385b76de790122f4da9c82b17bccf858b9557c # pin@v2
+      continue-on-error: true
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -41,5 +42,6 @@ jobs:
       with:
         check_name: Report test results
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        fail_if_no_tests: false
         report_paths: "**/target/test-reports/*.xml"
         commit: ${{ github.event.workflow_run.head_commit.id }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The CI should not fail when there are no test result files to be downloaded.

### Why are the changes needed?
The CI workflow "Report test results" fails when there are no artifacts to be downloaded from the triggering workflow. In some situations, the triggering workflow is not skipped, but all test jobs are skipped in case no code changes are detected.

Examples:
- https://github.com/G-Research/spark/runs/6208072225?check_suite_focus=true#step:4:14
- https://github.com/G-Research/spark/runs/6094719451?check_suite_focus=true#step:4:14

In that situation, no test files are uploaded, which makes the triggered workflow fail.

Downloading no test files can have two reasons:
1. The code has been build but no tests have been executed, or tests have been executed but no test files have been generated.
3. No code has been built and tested deliberately.

You want to be notified in the first situation to fix the CI. Therefore, CI should fail when code is built and tests are run but no test result files are been found.

The `dawidd6/action-download-artifact` action cannot be configured to not fail when there are no files. But Github Actions can be configured (`continue-on-error`) to ignore that and still have the job succeed. However, if that action fails for a different reason, this will not be raised as an error any more.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not tested