### PR TITLE
[SPARK-37938][SQL][TESTS] Use error classes in the parsing errors of partitions

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -189,6 +189,9 @@
       "AES_MODE" : {
         "message" : [ "AES-<mode> with the padding <padding> by the <functionName> function." ]
       },
+      "DESC_TABLE_COLUMN_PARTITION" : {
+        "message" : [ "DESC TABLE COLUMN for a specific partition is not supported." ]
+      },
       "DISTRIBUTE_BY" : {
         "message" : [ "DISTRIBUTE BY clause." ]
       },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -207,7 +207,7 @@
         "message" : [ "AES-<mode> with the padding <padding> by the <functionName> function." ]
       },
       "DESC_TABLE_COLUMN_PARTITION" : {
-        "message" : [ "DESC TABLE COLUMN for a specific partition is not supported." ]
+        "message" : [ "DESC TABLE COLUMN for a specific partition." ]
       },
       "DISTRIBUTE_BY" : {
         "message" : [ "DISTRIBUTE BY clause." ]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -79,7 +79,8 @@ object QueryParsingErrors extends QueryErrorsBase {
   def emptyPartitionKeyError(key: String, ctx: PartitionSpecContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Array(s"Partition key '$key' must set value (can't be empty)."),
+      messageParameters =
+        Array(s"Partition key ${toSQLId(key)} must set value (can't be empty)."),
       ctx)
   }
 
@@ -248,7 +249,8 @@ object QueryParsingErrors extends QueryErrorsBase {
       name: String, describe: String, ctx: ApplyTransformContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Array(s"Expected a column reference for transform $name: $describe"),
+      messageParameters =
+        Array(s"Expected a column reference for transform ${toSQLId(name)}: $describe"),
       ctx)
   }
 
@@ -314,7 +316,7 @@ object QueryParsingErrors extends QueryErrorsBase {
       key: String, ctx: DescribeRelationContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX",
-      messageParameters = Array(s"PARTITION specification is incomplete: `$key`"),
+      messageParameters = Array(s"PARTITION specification is incomplete: ${toSQLId(key)}"),
       ctx)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -77,7 +77,10 @@ object QueryParsingErrors extends QueryErrorsBase {
   }
 
   def emptyPartitionKeyError(key: String, ctx: PartitionSpecContext): Throwable = {
-    new ParseException(s"Found an empty partition key '$key'.", ctx)
+    new ParseException(
+      errorClass = "INVALID_SQL_SYNTAX",
+      messageParameters = Array(s"Partition key '$key' must set value (can't be empty)."),
+      ctx)
   }
 
   def combinationQueryResultClausesUnsupportedError(ctx: QueryOrganizationContext): Throwable = {
@@ -243,7 +246,10 @@ object QueryParsingErrors extends QueryErrorsBase {
 
   def partitionTransformNotExpectedError(
       name: String, describe: String, ctx: ApplyTransformContext): Throwable = {
-    new ParseException(s"Expected a column reference for transform $name: $describe", ctx)
+    new ParseException(
+      errorClass = "INVALID_SQL_SYNTAX",
+      messageParameters = Array(s"Expected a column reference for transform $name: $describe"),
+      ctx)
   }
 
   def tooManyArgumentsForTransformError(name: String, ctx: ApplyTransformContext): Throwable = {
@@ -298,12 +304,18 @@ object QueryParsingErrors extends QueryErrorsBase {
   }
 
   def descColumnForPartitionUnsupportedError(ctx: DescribeRelationContext): Throwable = {
-    new ParseException("DESC TABLE COLUMN for a specific partition is not supported", ctx)
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array("DESC_TABLE_COLUMN_PARTITION"),
+      ctx)
   }
 
   def incompletePartitionSpecificationError(
       key: String, ctx: DescribeRelationContext): Throwable = {
-    new ParseException(s"PARTITION specification is incomplete: `$key`", ctx)
+    new ParseException(
+      errorClass = "INVALID_SQL_SYNTAX",
+      messageParameters = Array(s"PARTITION specification is incomplete: `$key`"),
+      ctx)
   }
 
   def computeStatisticsNotExpectedError(ctx: IdentifierContext): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -1201,7 +1201,7 @@ class DDLParserSuite extends AnalysisTest {
     val caught = intercept[AnalysisException](
       parsePlan("DESCRIBE TABLE t PARTITION (ds='1970-01-01') col"))
     assert(caught.getMessage.contains(
-        "DESC TABLE COLUMN for a specific partition is not supported"))
+        "The feature is not supported: DESC TABLE COLUMN for a specific partition."))
   }
 
   test("SPARK-17328 Fix NPE with EXPLAIN DESCRIBE TABLE") {

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -382,7 +382,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 
-PARTITION specification is incomplete: `d`(line 1, pos 0)
+[INVALID_SQL_SYNTAX] Invalid SQL syntax: PARTITION specification is incomplete: `d`(line 1, pos 0)
 
 == SQL ==
 DESC t PARTITION (c='Us', d)

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
@@ -49,17 +49,25 @@ trait QueryErrorsSuiteBase extends SharedSparkSession {
       errorSubClass: Option[String] = None,
       sqlState: String,
       message: String): Unit = {
-    val e = intercept[ParseException] {
+    val exception = intercept[ParseException] {
       sql(sqlText)
     }
+    checkParsingError(exception, errorClass, errorSubClass, sqlState, message)
+  }
 
+  def checkParsingError(
+      exception: Exception with SparkThrowable,
+      errorClass: String,
+      errorSubClass: Option[String] = None,
+      sqlState: String,
+      message: String): Unit = {
     val fullErrorClass = if (errorSubClass.isDefined) {
       errorClass + "." + errorSubClass.get
     } else {
       errorClass
     }
-    assert(e.getErrorClass === errorClass)
-    assert(e.getSqlState === sqlState)
-    assert(e.getMessage === s"""\n[$fullErrorClass] """ + message)
+    assert(exception.getErrorClass === errorClass)
+    assert(exception.getSqlState === sqlState)
+    assert(exception.getMessage === s"""\n[$fullErrorClass] """ + message)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -582,4 +582,64 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
           |---------------------------^^^
           |""".stripMargin)
   }
+
+  test("INVALID_SQL_SYNTAX: show table partition key must set value") {
+    validateParsingError(
+      sqlText = "SHOW TABLE EXTENDED IN default LIKE 'employee' PARTITION (grade)",
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """Invalid SQL syntax: Partition key 'grade' must set value (can't be empty).(line 1, pos 47)
+          |
+          |== SQL ==
+          |SHOW TABLE EXTENDED IN default LIKE 'employee' PARTITION (grade)
+          |-----------------------------------------------^^^
+          |""".stripMargin)
+  }
+
+  test("INVALID_SQL_SYNTAX: expected a column reference for transform bucket") {
+    validateParsingError(
+      sqlText =
+        "CREATE TABLE my_tab(a INT, b STRING) USING parquet PARTITIONED BY (bucket(32, a, 66))",
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """Invalid SQL syntax: Expected a column reference for transform bucket: 66(line 1, pos 67)
+          |
+          |== SQL ==
+          |CREATE TABLE my_tab(a INT, b STRING) USING parquet PARTITIONED BY (bucket(32, a, 66))
+          |-------------------------------------------------------------------^^^
+          |""".stripMargin)
+  }
+
+  test("UNSUPPORTED_FEATURE: DESC TABLE COLUMN for a specific partition") {
+    validateParsingError(
+      sqlText = "DESCRIBE TABLE EXTENDED customer PARTITION (grade = 'A') customer.age",
+      errorClass = "UNSUPPORTED_FEATURE",
+      errorSubClass = Some("DESC_TABLE_COLUMN_PARTITION"),
+      sqlState = "0A000",
+      message =
+        """The feature is not supported: DESC TABLE COLUMN for a specific partition """ +
+        """is not supported.(line 1, pos 0)""" +
+        """|
+           |
+           |== SQL ==
+           |DESCRIBE TABLE EXTENDED customer PARTITION (grade = 'A') customer.age
+           |^^^
+           |""".stripMargin)
+  }
+
+  test("INVALID_SQL_SYNTAX: PARTITION specification is incomplete") {
+    validateParsingError(
+      sqlText = "DESCRIBE TABLE EXTENDED customer PARTITION (grade)",
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """Invalid SQL syntax: PARTITION specification is incomplete: `grade`(line 1, pos 0)
+          |
+          |== SQL ==
+          |DESCRIBE TABLE EXTENDED customer PARTITION (grade)
+          |^^^
+          |""".stripMargin)
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -589,7 +589,7 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
       errorClass = "INVALID_SQL_SYNTAX",
       sqlState = "42000",
       message =
-        """Invalid SQL syntax: Partition key 'grade' must set value (can't be empty).(line 1, pos 47)
+        """Invalid SQL syntax: Partition key `grade` must set value (can't be empty).(line 1, pos 47)
           |
           |== SQL ==
           |SHOW TABLE EXTENDED IN default LIKE 'employee' PARTITION (grade)
@@ -604,7 +604,7 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
       errorClass = "INVALID_SQL_SYNTAX",
       sqlState = "42000",
       message =
-        """Invalid SQL syntax: Expected a column reference for transform bucket: 66(line 1, pos 67)
+        """Invalid SQL syntax: Expected a column reference for transform `bucket`: 66(line 1, pos 67)
           |
           |== SQL ==
           |CREATE TABLE my_tab(a INT, b STRING) USING parquet PARTITIONED BY (bucket(32, a, 66))
@@ -619,8 +619,8 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
       errorSubClass = Some("DESC_TABLE_COLUMN_PARTITION"),
       sqlState = "0A000",
       message =
-        """The feature is not supported: DESC TABLE COLUMN for a specific partition """ +
-        """is not supported.(line 1, pos 0)""" +
+        """The feature is not supported: DESC TABLE COLUMN for a specific partition""" +
+        """.(line 1, pos 0)""" +
         """|
            |
            |== SQL ==

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
@@ -55,7 +55,7 @@ class ShowPartitionsParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
       errorClass = "INVALID_SQL_SYNTAX",
       sqlState = "42000",
       message =
-        """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 25)
+        """Invalid SQL syntax: Partition key `b` must set value (can't be empty).(line 1, pos 25)
           |
           |== SQL ==
           |SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
@@ -48,19 +48,18 @@ class ShowPartitionsParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
   }
 
   test("empty values in non-optional partition specs") {
-    val e = intercept[ParseException] {
-      new SparkSqlParser().parsePlan(
-        "SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)")
-    }
-    val msg =
-      """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 25)
-        |
-        |== SQL ==
-        |SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)
-        |-------------------------^^^
-        |""".stripMargin
-    assert(e.getMessage.contains(msg))
-    assert(e.getErrorClass === "INVALID_SQL_SYNTAX")
-    assert(e.getSqlState === "42000")
+    checkParsingError(
+      exception = intercept[ParseException] {
+        new SparkSqlParser().parsePlan("SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)")
+      },
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 25)
+          |
+          |== SQL ==
+          |SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)
+          |-------------------------^^^
+          |""".stripMargin)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
@@ -21,10 +21,10 @@ import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedPartition
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.ShowPartitions
+import org.apache.spark.sql.errors.QueryErrorsSuiteBase
 import org.apache.spark.sql.execution.SparkSqlParser
-import org.apache.spark.sql.test.SharedSparkSession
 
-class ShowPartitionsParserSuite extends AnalysisTest with SharedSparkSession {
+class ShowPartitionsParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
   test("SHOW PARTITIONS") {
     val commandName = "SHOW PARTITIONS"
     Seq(
@@ -51,7 +51,16 @@ class ShowPartitionsParserSuite extends AnalysisTest with SharedSparkSession {
     val e = intercept[ParseException] {
       new SparkSqlParser().parsePlan(
         "SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)")
-    }.getMessage
-    assert(e.contains("Found an empty partition key 'b'"))
+    }
+    val msg =
+      """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 25)
+        |
+        |== SQL ==
+        |SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)
+        |-------------------------^^^
+        |""".stripMargin
+    assert(e.getMessage.contains(msg))
+    assert(e.getErrorClass === "INVALID_SQL_SYNTAX")
+    assert(e.getSqlState === "42000")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -47,18 +47,18 @@ class TruncateTableParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
   }
 
   test("empty values in non-optional partition specs") {
-    val e = intercept[ParseException] {
-      parsePlan("TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)")
-    }
-    val msg =
-      """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 24)
-        |
-        |== SQL ==
-        |TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)
-        |------------------------^^^
-        |""".stripMargin
-    assert(e.getMessage.contains(msg))
-    assert(e.getErrorClass === "INVALID_SQL_SYNTAX")
-    assert(e.getSqlState === "42000")
+    checkParsingError(
+      exception = intercept[ParseException] {
+        parsePlan("TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)")
+      },
+      errorClass = "INVALID_SQL_SYNTAX",
+      sqlState = "42000",
+      message =
+        """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 24)
+          |
+          |== SQL ==
+          |TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)
+          |------------------------^^^
+          |""".stripMargin)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -21,9 +21,9 @@ import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, UnresolvedPartition
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{TruncatePartition, TruncateTable}
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.errors.QueryErrorsSuiteBase
 
-class TruncateTableParserSuite extends AnalysisTest with SharedSparkSession {
+class TruncateTableParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
   test("truncate table") {
     comparePlans(
       parsePlan("TRUNCATE TABLE a.b.c"),
@@ -47,9 +47,18 @@ class TruncateTableParserSuite extends AnalysisTest with SharedSparkSession {
   }
 
   test("empty values in non-optional partition specs") {
-    val errMsg = intercept[ParseException] {
+    val e = intercept[ParseException] {
       parsePlan("TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)")
-    }.getMessage
-    assert(errMsg.contains("Found an empty partition key 'b'"))
+    }
+    val msg =
+      """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 24)
+        |
+        |== SQL ==
+        |TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)
+        |------------------------^^^
+        |""".stripMargin
+    assert(e.getMessage.contains(msg))
+    assert(e.getErrorClass === "INVALID_SQL_SYNTAX")
+    assert(e.getSqlState === "42000")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -54,7 +54,7 @@ class TruncateTableParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
       errorClass = "INVALID_SQL_SYNTAX",
       sqlState = "42000",
       message =
-        """Invalid SQL syntax: Partition key 'b' must set value (can't be empty).(line 1, pos 24)
+        """Invalid SQL syntax: Partition key `b` must set value (can't be empty).(line 1, pos 24)
           |
           |== SQL ==
           |TRUNCATE TABLE dbx.tab1 PARTITION (a='1', b)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate the following errors in QueryParsingErrors onto use error classes:

- emptyPartitionKeyError => INVALID_SQL_SYNTAX
- partitionTransformNotExpectedError => INVALID_SQL_SYNTAX
- descColumnForPartitionUnsupportedError => UNSUPPORTED_FEATURE.DESC_TABLE_COLUMN_PARTITION
- incompletePartitionSpecificationError => INVALID_SQL_SYNTAX

### Why are the changes needed?
Porting parsing errors of partitions to new error framework, improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryParsingErrorsSuite*"
```