### PR TITLE
[SPARK-39079][SQL] Forbid dot in V2 catalog name

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -130,8 +130,11 @@ package object util extends Logging {
     "`" + name.replace("`", "``") + "`"
   }
 
+  def isValidPartName(part: String): Boolean =
+    part.matches("[a-zA-Z0-9_]+") && !part.matches("\\d+")
+
   def quoteIfNeeded(part: String): String = {
-    if (part.matches("[a-zA-Z0-9_]+") && !part.matches("\\d+")) {
+    if (isValidPartName(part)) {
       part
     } else {
       s"`${part.replace("`", "``")}`"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -130,11 +130,8 @@ package object util extends Logging {
     "`" + name.replace("`", "``") + "`"
   }
 
-  def isValidPartName(part: String): Boolean =
-    part.matches("[a-zA-Z0-9_]+") && !part.matches("\\d+")
-
   def quoteIfNeeded(part: String): String = {
-    if (isValidPartName(part)) {
+    if (part.matches("[a-zA-Z0-9_]+") && !part.matches("\\d+")) {
       part
     } else {
       s"`${part.replace("`", "``")}`"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.connector.catalog
 
 import java.lang.reflect.InvocationTargetException
 import java.util
+import java.util.NoSuchElementException
 import java.util.regex.Pattern
 
 import org.apache.spark.SparkException
@@ -43,11 +44,12 @@ private[sql] object Catalogs {
   @throws[CatalogNotFoundException]
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
-    if (name.contains(".")) {
-      throw QueryExecutionErrors.invalidCatalogNameError(name)
-    }
     val pluginClassName = try {
-      conf.getConfString(s"spark.sql.catalog.$name")
+      val _pluginClassName = conf.getConfString(s"spark.sql.catalog.$name")
+      if (name.contains(".")) {
+        throw QueryExecutionErrors.invalidCatalogNameError(name)
+      }
+      _pluginClassName
     } catch {
       case _: NoSuchElementException =>
         throw QueryExecutionErrors.catalogPluginClassNotFoundError(name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.connector.catalog
 
 import java.lang.reflect.InvocationTargetException
 import java.util
-import java.util.NoSuchElementException
 import java.util.regex.Pattern
 
 import org.apache.spark.SparkException
@@ -44,12 +43,11 @@ private[sql] object Catalogs {
   @throws[CatalogNotFoundException]
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
+    if (name.contains(".")) {
+      throw QueryExecutionErrors.invalidCatalogNameError(name)
+    }
     val pluginClassName = try {
-      val _pluginClassName = conf.getConfString(s"spark.sql.catalog.$name")
-      if (name.contains(".")) {
-        throw QueryExecutionErrors.invalidCatalogNameError(name)
-      }
-      _pluginClassName
+      conf.getConfString(s"spark.sql.catalog.$name")
     } catch {
       case _: NoSuchElementException =>
         throw QueryExecutionErrors.catalogPluginClassNotFoundError(name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.connector.catalog
 
 import java.lang.reflect.InvocationTargetException
 import java.util
-import java.util.NoSuchElementException
 import java.util.regex.Pattern
 
 import org.apache.spark.SparkException
@@ -39,13 +38,15 @@ private[sql] object Catalogs {
    * @param conf a SQLConf
    * @return an initialized CatalogPlugin
    * @throws CatalogNotFoundException if the plugin class cannot be found
-   * @throws org.apache.spark.SparkException           if the plugin class cannot be instantiated
+   * @throws org.apache.spark.SparkException if the plugin class cannot be instantiated
    */
   @throws[CatalogNotFoundException]
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
       val _pluginClassName = conf.getConfString(s"spark.sql.catalog.$name")
+      // SPARK-39079 do configuration check first, otherwise some path-based table like
+      // `org.apache.spark.sql.json`.`/path/json_file` may fail on analyze phase
       if (name.contains(".")) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -39,7 +39,7 @@ private[sql] object Catalogs {
    * @param conf a SQLConf
    * @return an initialized CatalogPlugin
    * @throws CatalogNotFoundException if the plugin class cannot be found
-   * @throws org.apache.spark.SparkException if the plugin class cannot be instantiated
+   * @throws org.apache.spark.SparkException           if the plugin class cannot be instantiated
    */
   @throws[CatalogNotFoundException]
   @throws[SparkException]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -44,11 +44,12 @@ private[sql] object Catalogs {
   @throws[CatalogNotFoundException]
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
-    if (name.contains(".")) {
-      throw QueryExecutionErrors.invalidCatalogNameError(name)
-    }
     val pluginClassName = try {
-      conf.getConfString("spark.sql.catalog." + name)
+      val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
+      if (name.contains(".")) {
+        throw QueryExecutionErrors.invalidCatalogNameError(name)
+      }
+      _pluginClassName
     } catch {
       case _: NoSuchElementException =>
         throw QueryExecutionErrors.catalogPluginClassNotFoundError(name)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.connector.catalog
 
 import java.lang.reflect.InvocationTargetException
 import java.util
+import java.util.NoSuchElementException
 import java.util.regex.Pattern
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.catalyst.util.isValidPartName
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -46,7 +46,7 @@ private[sql] object Catalogs {
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
       val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
-      if (isValidPartName(name)) {
+      if (name.contains(".")) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }
       _pluginClassName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -46,7 +46,7 @@ private[sql] object Catalogs {
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
       val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
-      if (isValidPartName(name)) {
+      if (!isValidPartName(name)) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }
       _pluginClassName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -46,7 +46,7 @@ private[sql] object Catalogs {
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
       val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
-      if (!isValidPartName(name)) {
+      if (isValidPartName(name)) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }
       _pluginClassName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -45,7 +45,7 @@ private[sql] object Catalogs {
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
-      val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
+      val _pluginClassName = conf.getConfString(s"spark.sql.catalog.$name")
       if (!isValidPartName(name)) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -45,7 +45,7 @@ private[sql] object Catalogs {
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
-      val _pluginClassName = conf.getConfString(s"spark.sql.catalog.$name")
+      val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
       if (!isValidPartName(name)) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -39,7 +39,7 @@ private[sql] object Catalogs {
    * @param conf a SQLConf
    * @return an initialized CatalogPlugin
    * @throws CatalogNotFoundException if the plugin class cannot be found
-   * @throws org.apache.spark.SparkException           if the plugin class cannot be instantiated
+   * @throws org.apache.spark.SparkException if the plugin class cannot be instantiated
    */
   @throws[CatalogNotFoundException]
   @throws[SparkException]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -45,7 +45,7 @@ private[sql] object Catalogs {
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
-      val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
+      val _pluginClassName = conf.getConfString(s"spark.sql.catalog.$name")
       if (name.contains(".")) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -44,6 +44,9 @@ private[sql] object Catalogs {
   @throws[CatalogNotFoundException]
   @throws[SparkException]
   def load(name: String, conf: SQLConf): CatalogPlugin = {
+    if (name.contains(".")) {
+      throw QueryExecutionErrors.invalidCatalogNameError(name)
+    }
     val pluginClassName = try {
       conf.getConfString("spark.sql.catalog." + name)
     } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.connector.catalog
 
 import java.lang.reflect.InvocationTargetException
 import java.util
-import java.util.NoSuchElementException
 import java.util.regex.Pattern
 
 import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.util.isValidPartName
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -46,7 +46,7 @@ private[sql] object Catalogs {
   def load(name: String, conf: SQLConf): CatalogPlugin = {
     val pluginClassName = try {
       val _pluginClassName = conf.getConfString("spark.sql.catalog." + name)
-      if (name.contains(".")) {
+      if (isValidPartName(name)) {
         throw QueryExecutionErrors.invalidCatalogNameError(name)
       }
       _pluginClassName

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1535,7 +1535,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
   }
 
   def invalidCatalogNameError(name: String): Throwable = {
-    new SparkException(s"'$name' is an illegal catalog name, should not contain '.'")
+    new SparkException(s"Invalid catalog name: $name")
   }
 
   def catalogPluginClassNotFoundError(name: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1534,6 +1534,10 @@ object QueryExecutionErrors extends QueryErrorsBase {
     new UnsupportedOperationException(s"Invalid output mode: $outputMode")
   }
 
+  def invalidCatalogNameError(name: String): Throwable = {
+    new SparkException(s"'$name' is an illegal catalog name, should not contain '.'")
+  }
+
   def catalogPluginClassNotFoundError(name: String): Throwable = {
     new CatalogNotFoundException(
       s"Catalog '$name' plugin class not found: spark.sql.catalog.$name is not defined")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1535,7 +1535,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
   }
 
   def invalidCatalogNameError(name: String): Throwable = {
-    new SparkException(s"Invalid catalog name: $name")
+    new SparkException(s"'$name' is an illegal catalog name, should not contain '.'")
   }
 
   def catalogPluginClassNotFoundError(name: String): Throwable = {

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -47,7 +47,7 @@ public class CatalogLoadingSuite {
     SparkException exc = Assert.assertThrows(SparkException.class,
             () -> Catalogs.load("test.name", conf));
     Assert.assertTrue("Catalog name should not contain '.'", exc.getMessage().contains(
-            "Invalid catalog name: test.name"));
+            "'test.name' is an illegal catalog name, should not contain '.'"));
   }
 
   @Test

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -27,16 +27,16 @@ public class CatalogLoadingSuite {
   @Test
   public void testLoad() throws SparkException {
     SQLConf conf = new SQLConf();
-    conf.setConfString("spark.sql.catalog.test_name", TestCatalogPlugin.class.getCanonicalName());
+    conf.setConfString("spark.sql.catalog.test-name", TestCatalogPlugin.class.getCanonicalName());
 
-    CatalogPlugin plugin = Catalogs.load("test_name", conf);
+    CatalogPlugin plugin = Catalogs.load("test-name", conf);
     Assert.assertNotNull("Should instantiate a non-null plugin", plugin);
     Assert.assertEquals("Plugin should have correct implementation",
         TestCatalogPlugin.class, plugin.getClass());
 
     TestCatalogPlugin testPlugin = (TestCatalogPlugin) plugin;
     Assert.assertEquals("Options should contain no keys", 0, testPlugin.options.size());
-    Assert.assertEquals("Catalog should have correct name", "test_name", testPlugin.name());
+    Assert.assertEquals("Catalog should have correct name", "test-name", testPlugin.name());
   }
 
   @Test
@@ -53,11 +53,11 @@ public class CatalogLoadingSuite {
   @Test
   public void testInitializationOptions() throws SparkException {
     SQLConf conf = new SQLConf();
-    conf.setConfString("spark.sql.catalog.test_name", TestCatalogPlugin.class.getCanonicalName());
-    conf.setConfString("spark.sql.catalog.test_name.name", "not_catalog_name");
-    conf.setConfString("spark.sql.catalog.test_name.kEy", "valUE");
+    conf.setConfString("spark.sql.catalog.test-name", TestCatalogPlugin.class.getCanonicalName());
+    conf.setConfString("spark.sql.catalog.test-name.name", "not-catalog-name");
+    conf.setConfString("spark.sql.catalog.test-name.kEy", "valUE");
 
-    CatalogPlugin plugin = Catalogs.load("test_name", conf);
+    CatalogPlugin plugin = Catalogs.load("test-name", conf);
     Assert.assertNotNull("Should instantiate a non-null plugin", plugin);
     Assert.assertEquals("Plugin should have correct implementation",
         TestCatalogPlugin.class, plugin.getClass());
@@ -66,7 +66,7 @@ public class CatalogLoadingSuite {
 
     Assert.assertEquals("Options should contain only two keys", 2, testPlugin.options.size());
     Assert.assertEquals("Options should contain correct value for name (not overwritten)",
-        "not_catalog_name", testPlugin.options.get("name"));
+        "not-catalog-name", testPlugin.options.get("name"));
     Assert.assertEquals("Options should contain correct value for key",
         "valUE", testPlugin.options.get("key"));
   }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -47,7 +47,7 @@ public class CatalogLoadingSuite {
     SparkException exc = Assert.assertThrows(SparkException.class,
             () -> Catalogs.load("test.name", conf));
     Assert.assertTrue("Catalog name should not contain '.'", exc.getMessage().contains(
-            "'test.name' is an illegal catalog name, should not contain '.'"));
+            "Invalid catalog name: test.name"));
   }
 
   @Test

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -27,16 +27,16 @@ public class CatalogLoadingSuite {
   @Test
   public void testLoad() throws SparkException {
     SQLConf conf = new SQLConf();
-    conf.setConfString("spark.sql.catalog.test-name", TestCatalogPlugin.class.getCanonicalName());
+    conf.setConfString("spark.sql.catalog.test_name", TestCatalogPlugin.class.getCanonicalName());
 
-    CatalogPlugin plugin = Catalogs.load("test-name", conf);
+    CatalogPlugin plugin = Catalogs.load("test_name", conf);
     Assert.assertNotNull("Should instantiate a non-null plugin", plugin);
     Assert.assertEquals("Plugin should have correct implementation",
         TestCatalogPlugin.class, plugin.getClass());
 
     TestCatalogPlugin testPlugin = (TestCatalogPlugin) plugin;
     Assert.assertEquals("Options should contain no keys", 0, testPlugin.options.size());
-    Assert.assertEquals("Catalog should have correct name", "test-name", testPlugin.name());
+    Assert.assertEquals("Catalog should have correct name", "test_name", testPlugin.name());
   }
 
   @Test
@@ -53,11 +53,11 @@ public class CatalogLoadingSuite {
   @Test
   public void testInitializationOptions() throws SparkException {
     SQLConf conf = new SQLConf();
-    conf.setConfString("spark.sql.catalog.test-name", TestCatalogPlugin.class.getCanonicalName());
-    conf.setConfString("spark.sql.catalog.test-name.name", "not-catalog-name");
-    conf.setConfString("spark.sql.catalog.test-name.kEy", "valUE");
+    conf.setConfString("spark.sql.catalog.test_name", TestCatalogPlugin.class.getCanonicalName());
+    conf.setConfString("spark.sql.catalog.test_name.name", "not_catalog_name");
+    conf.setConfString("spark.sql.catalog.test_name.kEy", "valUE");
 
-    CatalogPlugin plugin = Catalogs.load("test-name", conf);
+    CatalogPlugin plugin = Catalogs.load("test_name", conf);
     Assert.assertNotNull("Should instantiate a non-null plugin", plugin);
     Assert.assertEquals("Plugin should have correct implementation",
         TestCatalogPlugin.class, plugin.getClass());
@@ -66,7 +66,7 @@ public class CatalogLoadingSuite {
 
     Assert.assertEquals("Options should contain only two keys", 2, testPlugin.options.size());
     Assert.assertEquals("Options should contain correct value for name (not overwritten)",
-        "not-catalog-name", testPlugin.options.get("name"));
+        "not_catalog_name", testPlugin.options.get("name"));
     Assert.assertEquals("Options should contain correct value for key",
         "valUE", testPlugin.options.get("key"));
   }

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -40,6 +40,17 @@ public class CatalogLoadingSuite {
   }
 
   @Test
+  public void testIllegalCatalogName() {
+    SQLConf conf = new SQLConf();
+    conf.setConfString("spark.sql.catalog.test.name", TestCatalogPlugin.class.getCanonicalName());
+
+    SparkException exc =
+            Assert.assertThrows(SparkException.class, () -> Catalogs.load("test.name", conf));
+    Assert.assertTrue("Catalog name should not contain '.'",
+            exc.getMessage().contains("'test.name' is an illegal catalog name, should not contain '.'"));
+  }
+
+  @Test
   public void testInitializationOptions() throws SparkException {
     SQLConf conf = new SQLConf();
     conf.setConfString("spark.sql.catalog.test-name", TestCatalogPlugin.class.getCanonicalName());

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -44,10 +44,10 @@ public class CatalogLoadingSuite {
     SQLConf conf = new SQLConf();
     conf.setConfString("spark.sql.catalog.test.name", TestCatalogPlugin.class.getCanonicalName());
 
-    SparkException exc =
-            Assert.assertThrows(SparkException.class, () -> Catalogs.load("test.name", conf));
-    Assert.assertTrue("Catalog name should not contain '.'",
-            exc.getMessage().contains("'test.name' is an illegal catalog name, should not contain '.'"));
+    SparkException exc = Assert.assertThrows(SparkException.class,
+            () -> Catalogs.load("test.name", conf));
+    Assert.assertTrue("Catalog name should not contain '.'", exc.getMessage().contains(
+            "'test.name' is an illegal catalog name, should not contain '.'"));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Forbid dot in V2 catalog name.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In the following configuration, we define 2 catalogs `test`, `test.cat`.
```
spark.sql.catalog.test=CatalogTestImpl
spark.sql.catalog.test.k1=v1
spark.sql.catalog.test.cat=CatalogTestImpl
spark.sql.catalog.test.cat.k1=v1
```

In the current implementation, three keys will be treated to `test`'s configuration, it's a little bit weird.
```
k1=v1
cat=CatalogTestImpl
cat.k1=v1
```

Besides, the current implementation of `SHOW CATALOGS` use lazy load strategy, it's not friendly for GUI client like DBeaver to display available catalog list, w/o this restriction, it is hard to find the catalog key in configuration to load catalogs eagerly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, previously Spark allows the catalog name contain `.` but not after this change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT.