### PR TITLE
[SPARK-39080][SHUFFLE]Optimize shuffle error handler

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -20,12 +20,8 @@ package org.apache.spark.network.shuffle;
 import java.io.FileNotFoundException;
 import java.net.ConnectException;
 
-import com.google.common.base.Throwables;
-
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.network.server.BlockPushNonFatalFailure;
-
-import static org.apache.spark.network.server.BlockPushNonFatalFailure.ReturnCode.*;
 
 /**
  * Plugs into {@link RetryingBlockTransferor} to further control when an exception should be retried
@@ -37,82 +33,88 @@ import static org.apache.spark.network.server.BlockPushNonFatalFailure.ReturnCod
  * @since 3.1.0
  */
 @Evolving
-public interface ErrorHandler {
+public abstract class ErrorHandler {
 
-  boolean shouldRetryError(Throwable t);
+  public abstract boolean shouldRetryError(Throwable t);
 
-  default boolean shouldLogError(Throwable t) {
-    return true;
-  }
+  public abstract boolean shouldLogError(Throwable t);
+
+  /**
+   * String constant used for generating exception messages indicating the server encountered
+   * IOExceptions multiple times, greater than the configured threshold, while trying to merged
+   * shuffle blocks of the same shuffle partition. When the client receives this this response,
+   * it will stop pushing any more blocks for the same shuffle partition.
+   */
+  public static final String IOEXCEPTIONS_EXCEEDED_THRESHOLD_PREFIX =
+      "IOExceptions exceeded the threshold";
+
+  /**
+   * String constant used for generating exception messages indicating the server rejecting a
+   * shuffle finalize request since shuffle blocks of a higher shuffleMergeId for a shuffle is
+   * already being pushed. This typically happens in the case of indeterminate stage retries
+   * where if a stage attempt fails then the entirety of the shuffle output needs to be rolled
+   * back. For more details refer SPARK-23243, SPARK-25341 and SPARK-32923.
+   */
+  public static final String STALE_SHUFFLE_FINALIZE_SUFFIX =
+    "stale shuffle finalize request as shuffle blocks of a higher shuffleMergeId for the"
+        + " shuffle is already being pushed";
+
+  public static final String STALE_SHUFFLE_BLOCK_FETCH =
+    "stale shuffle block fetch request as shuffle blocks of a higher shuffleMergeId for the"
+        + " shuffle is available";
 
   /**
    * A no-op error handler instance.
    */
-  ErrorHandler NOOP_ERROR_HANDLER = t -> true;
+  public static final ErrorHandler NOOP_ERROR_HANDLER = new ErrorHandler() {
+    @Override
+    public boolean shouldRetryError(Throwable t) {
+      return true;
+    }
+
+    @Override
+    public boolean shouldLogError(Throwable t) {
+      return true;
+    }
+  };
+
+  private static volatile ErrorHandler instance = null;
 
   /**
    * The error handler for pushing shuffle blocks to remote shuffle services.
    *
    * @since 3.1.0
    */
-  class BlockPushErrorHandler implements ErrorHandler {
-    /**
-     * String constant used for generating exception messages indicating the server encountered
-     * IOExceptions multiple times, greater than the configured threshold, while trying to merged
-     * shuffle blocks of the same shuffle partition. When the client receives this this response,
-     * it will stop pushing any more blocks for the same shuffle partition.
-     */
-    public static final String IOEXCEPTIONS_EXCEEDED_THRESHOLD_PREFIX =
-      "IOExceptions exceeded the threshold";
+  public static ErrorHandler blockPushErrorHandler() {
+    if(instance != null) {
+      synchronized (ErrorHandler.class) {
+        if(instance == null) {
+          instance = new ErrorHandler() {
 
-    /**
-     * String constant used for generating exception messages indicating the server rejecting a
-     * shuffle finalize request since shuffle blocks of a higher shuffleMergeId for a shuffle is
-     * already being pushed. This typically happens in the case of indeterminate stage retries
-     * where if a stage attempt fails then the entirety of the shuffle output needs to be rolled
-     * back. For more details refer SPARK-23243, SPARK-25341 and SPARK-32923.
-     */
-    public static final String STALE_SHUFFLE_FINALIZE_SUFFIX =
-      "stale shuffle finalize request as shuffle blocks of a higher shuffleMergeId for the"
-        + " shuffle is already being pushed";
+            @Override
+            public boolean shouldRetryError(Throwable t) {
+              if(t instanceof BlockPushNonFatalFailure) {
+                return false;
+              }
+              // If it is a connection time-out or a connection closed exception, no need to retry.
+              // If it is a FileNotFoundException originating from the client while pushing the
+              // shuffle blocks to the server, even then there is no need to retry. We will still
+              // log this exception once which helps with debugging.
+              if (t.getCause() != null && (t.getCause() instanceof ConnectException ||
+                  t.getCause() instanceof FileNotFoundException)) {
+                return false;
+              }
+              return true;
+            }
 
-    @Override
-    public boolean shouldRetryError(Throwable t) {
-      // If it is a connection time-out or a connection closed exception, no need to retry.
-      // If it is a FileNotFoundException originating from the client while pushing the shuffle
-      // blocks to the server, even then there is no need to retry. We will still log this
-      // exception once which helps with debugging.
-      if (t.getCause() instanceof ConnectException ||
-          t.getCause() instanceof FileNotFoundException) {
-        return false;
+            @Override
+            public boolean shouldLogError(Throwable t) {
+              return !(t instanceof BlockPushNonFatalFailure);
+            }
+          };
+        }
       }
-
-      // If the block is too late or the invalid block push or the attempt is not the latest one,
-      // there is no need to retry it
-      return !(t instanceof BlockPushNonFatalFailure &&
-        BlockPushNonFatalFailure
-          .shouldNotRetryErrorCode(((BlockPushNonFatalFailure) t).getReturnCode()));
     }
-
-    @Override
-    public boolean shouldLogError(Throwable t) {
-      return !(t instanceof BlockPushNonFatalFailure);
-    }
-  }
-
-  class BlockFetchErrorHandler implements ErrorHandler {
-    public static final String STALE_SHUFFLE_BLOCK_FETCH =
-      "stale shuffle block fetch request as shuffle blocks of a higher shuffleMergeId for the"
-        + " shuffle is available";
-
-    @Override
-    public boolean shouldRetryError(Throwable t) {
-      return !Throwables.getStackTraceAsString(t).contains(STALE_SHUFFLE_BLOCK_FETCH);
-    }
-
-    @Override
-    public boolean shouldLogError(Throwable t) {
-      return !Throwables.getStackTraceAsString(t).contains(STALE_SHUFFLE_BLOCK_FETCH);
-    }
+    return instance;
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -88,7 +88,7 @@ public abstract class ErrorHandler {
   public static ErrorHandler blockPushErrorHandler() {
     if(instance != null) {
       synchronized (ErrorHandler.class) {
-        if(instance == null) {
+        if(instance != null) {
           instance = new ErrorHandler() {
 
             @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ErrorHandler.java
@@ -86,9 +86,9 @@ public abstract class ErrorHandler {
    * @since 3.1.0
    */
   public static ErrorHandler blockPushErrorHandler() {
-    if(instance != null) {
+    if(instance == null) {
       synchronized (ErrorHandler.class) {
-        if(instance != null) {
+        if(instance == null) {
           instance = new ErrorHandler() {
 
             @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -47,8 +47,6 @@ import org.apache.spark.network.util.TransportConf;
  * (via BlockTransferService), which has the downside of losing the data if we lose the executors.
  */
 public class ExternalBlockStoreClient extends BlockStoreClient {
-  private static final ErrorHandler PUSH_ERROR_HANDLER = new ErrorHandler.BlockPushErrorHandler();
-
   private final boolean authEnabled;
   private final SecretKeyHolder secretKeyHolder;
   private final long registrationTimeoutMs;
@@ -178,8 +176,8 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
           };
       int maxRetries = transportConf.maxIORetries();
       if (maxRetries > 0) {
-        new RetryingBlockTransferor(
-          transportConf, blockPushStarter, blockIds, listener, PUSH_ERROR_HANDLER).start();
+        new RetryingBlockTransferor(transportConf, blockPushStarter, blockIds, listener,
+          ErrorHandler.blockPushErrorHandler()).start();
       } else {
         blockPushStarter.createAndStart(blockIds, listener);
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockPusher.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/OneForOneBlockPusher.java
@@ -45,7 +45,6 @@ import org.apache.spark.network.shuffle.protocol.PushBlockStream;
  */
 public class OneForOneBlockPusher {
   private static final Logger logger = LoggerFactory.getLogger(OneForOneBlockPusher.class);
-  private static final ErrorHandler PUSH_ERROR_HANDLER = new ErrorHandler.BlockPushErrorHandler();
   public static final String SHUFFLE_PUSH_BLOCK_PREFIX = "shufflePush";
 
   private final TransportClient client;
@@ -128,7 +127,7 @@ public class OneForOneBlockPusher {
     // would immediately invoke parent listener's onBlockTransferFailure. However, the remaining
     // blocks in the same batch would remain current and active and they won't be impacted by
     // this exception.
-    if (PUSH_ERROR_HANDLER.shouldRetryError(e)) {
+    if (ErrorHandler.blockPushErrorHandler().shouldRetryError(e)) {
       String[] targetBlockId = Arrays.copyOfRange(blockIds, index, index + 1);
       failRemainingBlocks(targetBlockId, e);
     } else {

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ErrorHandlerSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/ErrorHandlerSuite.java
@@ -33,7 +33,7 @@ public class ErrorHandlerSuite {
 
   @Test
   public void testErrorRetry() {
-    ErrorHandler.BlockPushErrorHandler pushHandler = new ErrorHandler.BlockPushErrorHandler();
+    ErrorHandler pushHandler = ErrorHandler.blockPushErrorHandler();
     assertFalse(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
       ReturnCode.TOO_LATE_BLOCK_PUSH, "")));
     assertFalse(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
@@ -44,15 +44,11 @@ public class ErrorHandlerSuite {
     assertTrue(pushHandler.shouldRetryError(new BlockPushNonFatalFailure(
       ReturnCode.BLOCK_APPEND_COLLISION_DETECTED, "")));
     assertTrue(pushHandler.shouldRetryError(new Throwable()));
-
-    ErrorHandler.BlockFetchErrorHandler fetchHandler = new ErrorHandler.BlockFetchErrorHandler();
-    assertFalse(fetchHandler.shouldRetryError(new RuntimeException(
-      ErrorHandler.BlockFetchErrorHandler.STALE_SHUFFLE_BLOCK_FETCH)));
   }
 
   @Test
   public void testErrorLogging() {
-    ErrorHandler.BlockPushErrorHandler pushHandler = new ErrorHandler.BlockPushErrorHandler();
+    ErrorHandler pushHandler = ErrorHandler.blockPushErrorHandler();
     assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(
       ReturnCode.TOO_LATE_BLOCK_PUSH, "")));
     assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(
@@ -62,9 +58,5 @@ public class ErrorHandlerSuite {
     assertFalse(pushHandler.shouldLogError(new BlockPushNonFatalFailure(
       ReturnCode.BLOCK_APPEND_COLLISION_DETECTED, "")));
     assertTrue(pushHandler.shouldLogError(new Throwable()));
-
-    ErrorHandler.BlockFetchErrorHandler fetchHandler = new ErrorHandler.BlockFetchErrorHandler();
-    assertFalse(fetchHandler.shouldLogError(new RuntimeException(
-      ErrorHandler.BlockFetchErrorHandler.STALE_SHUFFLE_BLOCK_FETCH)));
   }
 }

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -106,20 +106,6 @@ public class RemoteBlockPushResolverSuite {
   }
 
   @Test
-  public void testErrorLogging() {
-    ErrorHandler.BlockPushErrorHandler errorHandler = RemoteBlockPushResolver.createErrorHandler();
-    assertFalse(errorHandler.shouldLogError(new BlockPushNonFatalFailure(
-      BlockPushNonFatalFailure.ReturnCode.TOO_LATE_BLOCK_PUSH, "")));
-    assertFalse(errorHandler.shouldLogError(new BlockPushNonFatalFailure(
-      BlockPushNonFatalFailure.ReturnCode.TOO_OLD_ATTEMPT_PUSH, "")));
-    assertFalse(errorHandler.shouldLogError(new BlockPushNonFatalFailure(
-      BlockPushNonFatalFailure.ReturnCode.STALE_BLOCK_PUSH, "")));
-    assertFalse(errorHandler.shouldLogError(new BlockPushNonFatalFailure(
-      BlockPushNonFatalFailure.ReturnCode.BLOCK_APPEND_COLLISION_DETECTED, "")));
-    assertTrue(errorHandler.shouldLogError(new Throwable()));
-  }
-
-  @Test
   public void testNoIndexFile() {
     RuntimeException re = assertThrows(RuntimeException.class,
       () -> pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0));

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockPusher.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.shuffle
 
-import java.io.{File, FileNotFoundException}
+import java.io.File
 import java.net.ConnectException
 import java.nio.ByteBuffer
 import java.util.concurrent.ExecutorService

--- a/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/ShuffleBlockPusherSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.internal.config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.server.BlockPushNonFatalFailure
 import org.apache.spark.network.server.BlockPushNonFatalFailure.ReturnCode
-import org.apache.spark.network.shuffle.{BlockPushingListener, BlockStoreClient}
+import org.apache.spark.network.shuffle.{BlockPushingListener, BlockStoreClient, ErrorHandler}
 import org.apache.spark.network.util.TransportConf
 import org.apache.spark.serializer.JavaSerializer
 import org.apache.spark.shuffle.ShuffleBlockPusher.PushRequest
@@ -295,8 +295,7 @@ class ShuffleBlockPusherSuite extends SparkFunSuite with BeforeAndAfterEach {
   }
 
   test("Error retries") {
-    val pusher = new ShuffleBlockPusher(conf)
-    val errorHandler = pusher.createErrorHandler()
+    val errorHandler = ErrorHandler.blockPushErrorHandler
     assert(
       !errorHandler.shouldRetryError(new BlockPushNonFatalFailure(
         ReturnCode.TOO_LATE_BLOCK_PUSH, "")))
@@ -314,8 +313,7 @@ class ShuffleBlockPusherSuite extends SparkFunSuite with BeforeAndAfterEach {
   }
 
   test("Error logging") {
-    val pusher = new ShuffleBlockPusher(conf)
-    val errorHandler = pusher.createErrorHandler()
+    val errorHandler = ErrorHandler.blockPushErrorHandler
     assert(
       !errorHandler.shouldLogError(new BlockPushNonFatalFailure(
         ReturnCode.TOO_LATE_BLOCK_PUSH, "")))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Optimize ErrorHandler code. 


### Why are the changes needed?

Shuffle ErrorHandler only has two stateless method, so we do not need create a ErrorHandler instance for each shuffle fetcher or shuffle pusher.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Exists UT
