### PR TITLE
[SPARK-37474][R][DOCS][FOLLOW-UP] Make SparkR documentation able to build on Mac OS

### DIFF
--- a/R/create-docs.sh
+++ b/R/create-docs.sh
@@ -55,7 +55,7 @@ pushd pkg/html
 
 
 # Determine Spark(R) version
-SPARK_VERSION=$(grep -oP "(?<=Version:\ ).*" ../DESCRIPTION)
+SPARK_VERSION=$(grep Version "../DESCRIPTION" | awk '{print $NF}')
 
 # Update url
 sed "s/{SPARK_VERSION}/$SPARK_VERSION/" ../pkgdown/_pkgdown_template.yml > ../_pkgdown.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently SparkR documentation fails because of the usage `grep -oP `. Mac OS does not have this.
This PR fixes it via using the existing way used in the current scripts at: https://github.com/apache/spark/blob/0494dc90af48ce7da0625485a4dc6917a244d580/R/check-cran.sh#L52

### Why are the changes needed?

To make the dev easier.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested via:

```bash
cd R
./create-docs.sh
```