### PR TITLE
[SPARK-38733][SQL][TESTS] Test the error class: INCOMPATIBLE_DATASOURCE_REGISTER

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -484,8 +484,7 @@ class QueryExecutionErrorsSuite
     }
   }
 
-  test("INCOMPATIBLE_DATASOURCE_REGISTER: " +
-    "create table using an incompatible dataSource") {
+  test("INCOMPATIBLE_DATASOURCE_REGISTER: create table using an incompatible data source") {
     val newClassLoader = new ClassLoader() {
 
       override def getResources(name: String): java.util.Enumeration[URL] = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR aims to add a test for the error class INCOMPATIBLE_DATASOURCE_REGISTER to `QueryExecutionErrorsSuite`.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryExecutionErrorsSuite*"
```