### PR TITLE
[WIP][SPARK-38904] Select by schema

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -509,6 +509,20 @@ class DataFrameSuite extends QueryTest
       Row("1"))
   }
 
+  test("select via struct type") {
+    //   case class TestData(key: Int, value: String)
+    val builder = new MetadataBuilder
+    val metadata = builder.putLong("foo", 42).build()
+    val schema = StructType(Seq(StructField("value", StringType),
+                                StructField("key", IntegerType, metadata = metadata),
+                                ))
+    checkAnswer(
+      testData.select(schema).where($"key" === lit(1)).select("value"),
+      Row("1")
+    )
+    assert(testData.select(schema).schema.fields(1).metadata.contains("foo"))
+  }
+
   test("select with functions") {
     checkAnswer(
       testData.select(sum("value"), avg("value"), count(lit(1))),


### PR DESCRIPTION
Almost copy pasting from https://issues.apache.org/jira/browse/SPARK-38904:

This PR is related to https://stackoverflow.com/questions/71610435. Let's assume I have a pyspark DataFrame with certain schema, and I would like to select/overwrite that schema with a new schema that I *know* is compatible, I could do:

```python
df: DataFrame
new_schema = ...

df.rdd.toDF(schema=new_schema)
```

Unfortunately this triggers computation as described in https://stackoverflow.com/questions/37088484/whats-the-performance-impact-of-converting-between-dataframe-rdd-and-back/37090151#37090151.

Note:
 * the schema can be arbitrarily complicated (nested etc)
 * new schema includes updates to description, nullability and additional metadata

See POC of workaround/util in https://github.com/ravwojdyla/spark-schema-utils

Also posted in https://lists.apache.org/thread/5ds0f7chzp1s3h10tvjm3r96g769rvpj

### What changes were proposed in this pull request?
 * add `DataFrame.select(schema)`

### Why are the changes needed?
 * add `DataFrame.select(schema)`

### Does this PR introduce _any_ user-facing change?
 * yes `DataFrame.select(schema)`