### PR TITLE
[SPARK-38744][SQL][TESTS] Test the error class: NON_LITERAL_PIVOT_VALUES

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -544,7 +544,8 @@ class QueryCompilationErrorsSuite
           agg(sum($"earnings")).collect()
       },
       errorClass = "NON_LITERAL_PIVOT_VALUES",
-      msg = "Literal expressions required for pivot values, found 'earnings#12'")
+      msg = "Literal expressions required for pivot values, found 'earnings#\\w+'",
+      matchMsg = true)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -527,6 +527,25 @@ class QueryCompilationErrorsSuite
         msg = "Field name m.n is invalid: m is not a struct.; line 1 pos 27")
     }
   }
+
+  test("NON_LITERAL_PIVOT_VALUES: literal expressions required for pivot values") {
+    val df = Seq(
+      ("dotNET", 2012, 10000),
+      ("Java", 2012, 20000),
+      ("dotNET", 2012, 5000),
+      ("dotNET", 2013, 48000),
+      ("Java", 2013, 30000)
+    ).toDF("course", "year", "earnings")
+
+    checkErrorClass(
+      exception = intercept[AnalysisException] {
+        df.groupBy(df("course")).
+          pivot(df("year"), Seq($"earnings")).
+          agg(sum($"earnings")).collect()
+      },
+      errorClass = "NON_LITERAL_PIVOT_VALUES",
+      msg = "Literal expressions required for pivot values, found 'earnings#12'")
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR aims to add a test for the error class NON_LITERAL_PIVOT_VALUES to `QueryCompilationErrorsSuite`.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryCompilationErrorsSuite*"
```