### PR TITLE
[SPARK-35320][SQL][FOLLOWUP] Remove duplicated test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -489,10 +489,10 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   test("SPARK-24027: from_json of a map with unsupported key type") {
     val schema = MapType(StructType(StructField("f", IntegerType) :: Nil), StringType)
     val startMsg = "cannot resolve 'entries' due to data type mismatch:"
-    val exception1 = intercept[AnalysisException] {
+    val exception = intercept[AnalysisException] {
       Seq("""{{"f": 1}: "a"}""").toDS().select(from_json($"value", schema))
     }.getMessage
-    assert(exception1.contains(startMsg))
+    assert(exception.contains(startMsg))
   }
 
   test("SPARK-24709: infers schemas of json strings and pass them to from_json") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -493,10 +493,6 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq("""{{"f": 1}: "a"}""").toDS().select(from_json($"value", schema))
     }.getMessage
     assert(exception1.contains(startMsg))
-    val exception2 = intercept[AnalysisException] {
-      Seq("""{{"f": 1}: "a"}""").toDS().select(from_json($"value", schema))
-    }.getMessage
-    assert(exception2.contains(startMsg))
   }
 
   test("SPARK-24709: infers schemas of json strings and pass them to from_json") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Follow-up for https://github.com/apache/spark/pull/33525 to remove duplicated test.


### Why are the changes needed?

We don't need to do the same test twice.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

This patch remove the duplicated test, so the existing test should pass.
