### PR TITLE
[SPARK-30661][ML][PYTHON] KMeans blockify input vectors

### DIFF
--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Matrices.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Matrices.scala
@@ -478,6 +478,22 @@ object DenseMatrix {
   private[ml] def unapply(dm: DenseMatrix): Option[(Int, Int, Array[Double], Boolean)] =
     Some((dm.numRows, dm.numCols, dm.values, dm.isTransposed))
 
+  private[ml] def fromVectors(vectors: Seq[Vector]): DenseMatrix = {
+    val numRows = vectors.length
+    val numCols = vectors.head.size
+    val values = Array.ofDim[Double](numRows * numCols)
+    var offset = 0
+    var j = 0
+    while (j < numRows) {
+      vectors(j).foreachNonZero { (i, v) =>
+        values(offset + i) = v
+      }
+      offset += numCols
+      j += 1
+    }
+    new DenseMatrix(numRows, numCols, values, true)
+  }
+
   /**
    * Generate a `DenseMatrix` consisting of zeros.
    * @param numRows number of rows of the matrix
@@ -833,6 +849,30 @@ object SparseMatrix {
        sm: SparseMatrix): Option[(Int, Int, Array[Int], Array[Int], Array[Double], Boolean)] =
     Some((sm.numRows, sm.numCols, sm.colPtrs, sm.rowIndices, sm.values, sm.isTransposed))
 
+  private[ml] def fromVectors(vectors: Seq[Vector]): SparseMatrix = {
+    val numRows = vectors.length
+    val numCols = vectors.head.size
+    val colIndices = MArrayBuilder.make[Int]
+    val values = MArrayBuilder.make[Double]
+    val rowPtrs = MArrayBuilder.make[Int]
+    var rowPtr = 0
+    rowPtrs += 0
+    var j = 0
+    while (j < numRows) {
+      var nnz = 0
+      vectors(j).foreachNonZero { (i, v) =>
+        colIndices += i
+        values += v
+        nnz += 1
+      }
+      rowPtr += nnz
+      rowPtrs += rowPtr
+      j += 1
+    }
+    new SparseMatrix(numRows, numCols, rowPtrs.result(),
+      colIndices.result(), values.result(), true)
+  }
+
   /**
    * Generate a `SparseMatrix` from Coordinate List (COO) format. Input must be an array of
    * (i, j, value) tuples. Entries that have duplicate values of i and j are
@@ -1014,37 +1054,9 @@ object Matrices {
     val nnz = vectors.iterator.map(_.numNonzeros).sum
     val sparseSize = Matrices.getSparseSize(nnz, numRows + 1)
     if (denseSize < sparseSize) {
-      val values = Array.ofDim[Double](numRows * numCols)
-      var offset = 0
-      var j = 0
-      while (j < numRows) {
-        vectors(j).foreachNonZero { (i, v) =>
-          values(offset + i) = v
-        }
-        offset += numCols
-        j += 1
-      }
-      new DenseMatrix(numRows, numCols, values, true)
+      DenseMatrix.fromVectors(vectors)
     } else {
-      val colIndices = MArrayBuilder.make[Int]
-      val values = MArrayBuilder.make[Double]
-      val rowPtrs = MArrayBuilder.make[Int]
-      var rowPtr = 0
-      rowPtrs += 0
-      var j = 0
-      while (j < numRows) {
-        var nnz = 0
-        vectors(j).foreachNonZero { (i, v) =>
-          colIndices += i
-          values += v
-          nnz += 1
-        }
-        rowPtr += nnz
-        rowPtrs += rowPtr
-        j += 1
-      }
-      new SparseMatrix(numRows, numCols, rowPtrs.result(),
-        colIndices.result(), values.result(), true)
+      SparseMatrix.fromVectors(vectors)
     }
   }
 

--- a/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
+++ b/mllib-local/src/main/scala/org/apache/spark/ml/linalg/Vectors.scala
@@ -372,6 +372,13 @@ object Vectors {
     }
   }
 
+  private[ml] def normalize(vector: Vector, p: Double): Vector = {
+    val n = norm(vector, p)
+    require(n > 0, "Can not normalize zero-length vectors.")
+    BLAS.scal(1.0 / n, vector)
+    vector
+  }
+
   /**
    * Returns the squared distance between two Vectors.
    * @param v1 first Vector.

--- a/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/clustering/KMeans.scala
@@ -26,12 +26,12 @@ import org.apache.spark.ml.{Estimator, Model, PipelineStage}
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
+import org.apache.spark.ml.stat.Summarizer
 import org.apache.spark.ml.util._
 import org.apache.spark.ml.util.DatasetUtils._
 import org.apache.spark.ml.util.Instrumentation.instrumented
-import org.apache.spark.mllib.clustering.{DistanceMeasure, KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
+import org.apache.spark.mllib.clustering.{KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors}
-import org.apache.spark.mllib.linalg.VectorImplicits._
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{IntegerType, StructType}
@@ -42,7 +42,9 @@ import org.apache.spark.util.VersionUtils.majorVersion
  * Common params for KMeans and KMeansModel
  */
 private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFeaturesCol
-  with HasSeed with HasPredictionCol with HasTol with HasDistanceMeasure with HasWeightCol {
+  with HasSeed with HasPredictionCol with HasTol with HasDistanceMeasure with HasWeightCol
+  with HasSolver with HasMaxBlockSizeInMB {
+  import KMeans._
 
   /**
    * The number of clusters to create (k). Must be &gt; 1. Note that it is possible for fewer than
@@ -67,7 +69,7 @@ private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFe
   @Since("1.5.0")
   final val initMode = new Param[String](this, "initMode", "The initialization algorithm. " +
     "Supported options: 'random' and 'k-means||'.",
-    (value: String) => MLlibKMeans.validateInitMode(value))
+    ParamValidators.inArray[String](supportedInitModes))
 
   /** @group expertGetParam */
   @Since("1.5.0")
@@ -86,8 +88,28 @@ private[clustering] trait KMeansParams extends Params with HasMaxIter with HasFe
   @Since("1.5.0")
   def getInitSteps: Int = $(initSteps)
 
-  setDefault(k -> 2, maxIter -> 20, initMode -> MLlibKMeans.K_MEANS_PARALLEL, initSteps -> 2,
-    tol -> 1e-4, distanceMeasure -> DistanceMeasure.EUCLIDEAN)
+  /**
+   * Param for the name of optimization method used in KMeans.
+   * Supported options:
+   *  - "auto": Automatically select the solver based on the input schema and sparsity:
+   *            If input instances are arrays or input vectors are dense, set to "block".
+   *            Else, set to "row".
+   *  - "row": input instances are processed row by row, and triangle-inequality is applied to
+   *           accelerate the training.
+   *  - "block": input instances are stacked to blocks, and GEMM is applied to compute the
+   *             distances.
+   * Default is "auto".
+   *
+   * @group expertParam
+   */
+  @Since("3.4.0")
+  final override val solver: Param[String] = new Param[String](this, "solver",
+    "The solver algorithm for optimization. Supported options: " +
+      s"${supportedSolvers.mkString(", ")}. (Default auto)",
+    ParamValidators.inArray[String](supportedSolvers))
+
+  setDefault(k -> 2, maxIter -> 20, initMode -> K_MEANS_PARALLEL, initSteps -> 2,
+    tol -> 1e-4, distanceMeasure -> EUCLIDEAN, solver -> AUTO, maxBlockSizeInMB -> 0.0)
 
   /**
    * Validates and transforms the input schema.
@@ -151,7 +173,7 @@ class KMeansModel private[ml] (
   }
 
   @Since("3.0.0")
-  def predict(features: Vector): Int = parentModel.predict(features)
+  def predict(features: Vector): Int = parentModel.predict(OldVectors.fromML(features))
 
   @Since("2.0.0")
   def clusterCenters: Array[Vector] = parentModel.clusterCenters.map(_.asML)
@@ -272,6 +294,7 @@ object KMeansModel extends MLReadable[KMeansModel] {
 class KMeans @Since("1.5.0") (
     @Since("1.5.0") override val uid: String)
   extends Estimator[KMeansModel] with KMeansParams with DefaultParamsWritable {
+  import KMeans._
 
   @Since("1.5.0")
   override def copy(extra: ParamMap): KMeans = defaultCopy(extra)
@@ -325,6 +348,24 @@ class KMeans @Since("1.5.0") (
   @Since("3.0.0")
   def setWeightCol(value: String): this.type = set(weightCol, value)
 
+  /**
+   * Sets the value of param [[solver]].
+   * Default is "auto".
+   *
+   * @group expertSetParam
+   */
+  @Since("3.4.0")
+  def setSolver(value: String): this.type = set(solver, value)
+
+  /**
+   * Sets the value of param [[maxBlockSizeInMB]].
+   * Default is 0.0, then 1.0 MB will be chosen.
+   *
+   * @group expertSetParam
+   */
+  @Since("3.4.0")
+  def setMaxBlockSizeInMB(value: Double): this.type = set(maxBlockSizeInMB, value)
+
   @Since("2.0.0")
   override def fit(dataset: Dataset[_]): KMeansModel = instrumented { instr =>
     transformSchema(dataset.schema, logging = true)
@@ -332,7 +373,58 @@ class KMeans @Since("1.5.0") (
     instr.logPipelineStage(this)
     instr.logDataset(dataset)
     instr.logParams(this, featuresCol, predictionCol, k, initMode, initSteps, distanceMeasure,
-      maxIter, seed, tol, weightCol)
+      maxIter, seed, tol, weightCol, solver, maxBlockSizeInMB)
+
+    val oldModel = if (preferBlockSolver(dataset)) {
+      trainWithBlock(dataset, instr)
+    } else {
+      trainWithRow(dataset, instr)
+    }
+
+    val model = copyValues(new KMeansModel(uid, oldModel).setParent(this))
+    val summary = new KMeansSummary(
+      model.transform(dataset),
+      $(predictionCol),
+      $(featuresCol),
+      $(k),
+      oldModel.numIter,
+      oldModel.trainingCost)
+
+    model.setSummary(Some(summary))
+    instr.logNamedValue("clusterSizes", summary.clusterSizes)
+    model
+  }
+
+  private def preferBlockSolver(dataset: Dataset[_]): Boolean = {
+    $(solver) match {
+      case ROW => false
+      case BLOCK => true
+      case AUTO =>
+        dataset.schema($(featuresCol)).dataType match {
+          case _: VectorUDT =>
+            val Row(count: Long, numNonzeros: Vector) = dataset
+              .select(Summarizer.metrics("count", "numNonZeros")
+                .summary(col($(featuresCol))).as("summary"))
+              .select("summary.count", "summary.numNonZeros")
+              .first()
+            val numFeatures = numNonzeros.size
+            val nnz = numNonzeros.activeIterator.map(_._1).foldLeft(BigDecimal(0))(_ + _)
+            nnz >= BigDecimal(count) * numFeatures * 0.5
+
+          case fdt: ArrayType =>
+            // when input schema is array, it should be dense
+            fdt.elementType match {
+              case _: FloatType => true
+              case _: DoubleType => true
+              case _ => false
+            }
+
+          case _ => false
+        }
+    }
+  }
+
+  private def trainWithRow(dataset: Dataset[_], instr: Instrumentation) = {
     val algo = new MLlibKMeans()
       .setK($(k))
       .setInitializationMode($(initMode))
@@ -349,20 +441,157 @@ class KMeans @Since("1.5.0") (
     }.setName("training instances")
 
     val handlePersistence = dataset.storageLevel == StorageLevel.NONE
-    val parentModel = algo.runWithWeight(instances, handlePersistence, Some(instr))
-    val model = copyValues(new KMeansModel(uid, parentModel).setParent(this))
+    algo.runWithWeight(instances, handlePersistence, Some(instr))
+  }
 
-    val summary = new KMeansSummary(
-      model.transform(dataset),
-      $(predictionCol),
-      $(featuresCol),
-      $(k),
-      parentModel.numIter,
-      parentModel.trainingCost)
+  private def trainWithBlock(dataset: Dataset[_], instr: Instrumentation) = {
+    if (dataset.storageLevel != StorageLevel.NONE) {
+      instr.logWarning(s"Input vectors will be blockified to blocks, and " +
+        s"then cached during training. Be careful of double caching!")
+    }
 
-    model.setSummary(Some(summary))
-    instr.logNamedValue("clusterSizes", summary.clusterSizes)
-    model
+    val initStartTime = System.nanoTime
+    val centers = initialize(dataset)
+    val initTimeInSeconds = (System.nanoTime - initStartTime) / 1e9
+    instr.logInfo(f"Initialization with ${$(initMode)} took $initTimeInSeconds%.3f seconds.")
+
+    val numFeatures = centers.head.size
+    instr.logNumFeatures(numFeatures)
+
+    val w = if (isDefined(weightCol) && $(weightCol).nonEmpty) {
+      checkNonNegativeWeight(col($(weightCol)).cast(DoubleType))
+    } else {
+      lit(1.0)
+    }
+
+    val instances = $(distanceMeasure) match {
+      case EUCLIDEAN =>
+        dataset.select(DatasetUtils.columnToVector(dataset, getFeaturesCol), w).rdd
+          .map { case Row(features: Vector, weight: Double) =>
+            Instance(BLAS.dot(features, features), weight, features)
+          }
+
+      case COSINE =>
+        dataset.select(DatasetUtils.columnToVector(dataset, getFeaturesCol), w).rdd
+          .map { case Row(features: Vector, weight: Double) =>
+            Instance(1.0, weight, Vectors.normalize(features, 2))
+          }
+    }
+
+    var actualBlockSizeInMB = $(maxBlockSizeInMB)
+    if (actualBlockSizeInMB == 0) {
+      actualBlockSizeInMB = InstanceBlock.DefaultBlockSizeInMB
+      require(actualBlockSizeInMB > 0, "inferred actual BlockSizeInMB must > 0")
+      instr.logNamedValue("actualBlockSizeInMB", actualBlockSizeInMB.toString)
+    }
+    val maxMemUsage = (actualBlockSizeInMB * 1024L * 1024L).ceil.toLong
+    val blocks = InstanceBlock.blokifyWithMaxMemUsage(instances, maxMemUsage)
+      .persist(StorageLevel.MEMORY_AND_DISK)
+      .setName(s"$uid: training blocks (blockSizeInMB=$actualBlockSizeInMB)")
+
+    val distanceFunction = getDistanceFunction
+    val sc = dataset.sparkSession.sparkContext
+    val iterationStartTime = System.nanoTime
+    var converged = false
+    var cost = 0.0
+    var iteration = 0
+
+    // Execute iterations of Lloyd's algorithm until converged
+    while (iteration < $(maxIter) && !converged) {
+      // Find the new centers
+      val bcCenters = sc.broadcast(DenseMatrix.fromVectors(centers))
+      val countSumAccum = if (iteration == 0) sc.longAccumulator else null
+      val weightSumAccum = if (iteration == 0) sc.doubleAccumulator else null
+      val costSumAccum = sc.doubleAccumulator
+
+      val newCenters = blocks.mapPartitions { iter =>
+        if (iter.nonEmpty) {
+          val agg = new KMeansAggregator(bcCenters.value, $(k), numFeatures, $(distanceMeasure))
+          iter.foreach(agg.add)
+          if (iteration == 0) {
+            countSumAccum.add(agg.count)
+            weightSumAccum.add(agg.weightSum)
+          }
+          costSumAccum.add(agg.costSum)
+          agg.weightSumVec.iterator.zip(agg.sumMat.rowIter)
+            .flatMap { case ((i, weightSum), vectorSum) =>
+              if (weightSum > 0) Some((i, (weightSum, vectorSum.toDense))) else None
+            }
+        } else Iterator.empty
+      }.reduceByKey { (sum1, sum2) =>
+        BLAS.axpy(1.0, sum2._2, sum1._2)
+        (sum1._1 + sum2._1, sum1._2)
+      }.mapValues { case (weightSum, vectorSum) =>
+        BLAS.scal(1.0 / weightSum, vectorSum)
+        $(distanceMeasure) match {
+          case COSINE => Vectors.normalize(vectorSum, 2)
+          case _ => vectorSum
+        }
+      }.collectAsMap()
+      bcCenters.destroy()
+
+      if (iteration == 0) {
+        instr.logNumExamples(countSumAccum.value)
+        instr.logSumOfWeights(weightSumAccum.value)
+      }
+
+      // Update the cluster centers and costs
+      converged = true
+      newCenters.foreach { case (i, newCenter) =>
+        if (converged && distanceFunction(centers(i), newCenter) > $(tol)) {
+          converged = false
+        }
+        centers(i) = newCenter
+      }
+      cost = costSumAccum.value
+      iteration += 1
+    }
+    blocks.unpersist()
+
+    val iterationTimeInSeconds = (System.nanoTime() - iterationStartTime) / 1e9
+    instr.logInfo(f"Iterations took $iterationTimeInSeconds%.3f seconds.")
+
+    if (iteration == $(maxIter)) {
+      instr.logInfo(s"KMeans reached the max number of iterations: ${$(maxIter)}.")
+    } else {
+      instr.logInfo(s"KMeans converged in $iteration iterations.")
+    }
+    instr.logInfo(s"The cost is $cost.")
+    new MLlibKMeansModel(centers.map(OldVectors.fromML), $(distanceMeasure), cost, iteration)
+  }
+
+  private def getDistanceFunction = $(distanceMeasure) match {
+    case EUCLIDEAN =>
+      (v1: Vector, v2: Vector) =>
+        math.sqrt(Vectors.sqdist(v1, v2))
+    case COSINE =>
+      (v1: Vector, v2: Vector) =>
+        val norm1 = Vectors.norm(v1, 2)
+        val norm2 = Vectors.norm(v2, 2)
+        require(norm1 > 0 && norm2 > 0,
+          "Cosine distance is not defined for zero-length vectors.")
+        1 - BLAS.dot(v1, v2) / norm1 / norm2
+  }
+
+  private def initialize(dataset: Dataset[_]): Array[Vector] = {
+    val algo = new MLlibKMeans()
+      .setK($(k))
+      .setInitializationMode($(initMode))
+      .setInitializationSteps($(initSteps))
+      .setMaxIterations($(maxIter))
+      .setSeed($(seed))
+      .setEpsilon($(tol))
+      .setDistanceMeasure($(distanceMeasure))
+
+    val vectors = dataset.select(DatasetUtils.columnToVector(dataset, getFeaturesCol))
+      .rdd
+      .map { case Row(features: Vector) => OldVectors.fromML(features) }
+
+    val centers = algo.initialize(vectors).map(_.asML)
+    $(distanceMeasure) match {
+      case EUCLIDEAN => centers
+      case COSINE => centers.map(Vectors.normalize(_, 2))
+    }
   }
 
   @Since("1.5.0")
@@ -376,6 +605,31 @@ object KMeans extends DefaultParamsReadable[KMeans] {
 
   @Since("1.6.0")
   override def load(path: String): KMeans = super.load(path)
+
+  /** String name for random mode type. */
+  private[clustering] val RANDOM = "random"
+
+  /** String name for k-means|| mode type. */
+  private[clustering] val K_MEANS_PARALLEL = "k-means||"
+
+  private[clustering] val supportedInitModes = Array(RANDOM, K_MEANS_PARALLEL)
+
+  /** String name for euclidean distance. */
+  private[clustering] val EUCLIDEAN = "euclidean"
+
+  /** String name for cosine distance. */
+  private[clustering] val COSINE = "cosine"
+
+  /** String name for optimizer based on triangle-inequality. */
+  private[clustering] val ROW = "row"
+
+  /** String name for optimizer based on blockifying and gemm. */
+  private[clustering] val BLOCK = "block"
+
+  /** String name for optimizer automatically chosen based on data schema and sparsity. */
+  private[clustering] val AUTO = "auto"
+
+  private[clustering] val supportedSolvers = Array(ROW, BLOCK, AUTO)
 }
 
 /**
@@ -398,3 +652,134 @@ class KMeansSummary private[clustering] (
     numIter: Int,
     @Since("2.4.0") val trainingCost: Double)
   extends ClusteringSummary(predictions, predictionCol, featuresCol, k, numIter)
+
+/**
+ * KMeansAggregator computes the distances and updates the centers for blocks
+ * in sparse or dense matrix in an online fashion.
+ * @param centerMatrix The matrix containing center vectors.
+ * @param k The number of clusters.
+ * @param numFeatures The number of features.
+ * @param distanceMeasure The distance measure.
+ *                        When 'euclidean' is chosen, the instance blocks should contains
+ *                        the squared norms in the labels field;
+ *                        When 'cosine' is chosen, the vectors should be already normalized.
+ */
+private class KMeansAggregator (
+    val centerMatrix: DenseMatrix,
+    val k: Int,
+    val numFeatures: Int,
+    val distanceMeasure: String) extends Serializable {
+  import KMeans.{EUCLIDEAN, COSINE}
+
+  def weightSum: Double = weightSumVec.values.sum
+
+  var costSum = 0.0
+  var count = 0L
+  val weightSumVec = new DenseVector(Array.ofDim[Double](k))
+  val sumMat = new DenseMatrix(k, numFeatures, Array.ofDim[Double](k * numFeatures))
+
+  @transient private lazy val centerSquaredNorms = {
+    distanceMeasure match {
+      case EUCLIDEAN =>
+        centerMatrix.rowIter.map(center => center.dot(center)).toArray
+      case COSINE => null
+    }
+  }
+
+  // It is performance-critical to avoid reallocating a dense matrix (size x k)
+  // for each instance block!
+  @transient private var buffer: Array[Double] = _
+
+  def add(block: InstanceBlock): this.type = {
+    val size = block.size
+    require(block.matrix.isTransposed)
+    require(numFeatures == block.numFeatures, s"Dimensions mismatch when adding new " +
+      s"instance. Expecting $numFeatures but got ${block.numFeatures}.")
+    require(block.weightIter.forall(_ >= 0),
+      s"instance weights ${block.weightIter.mkString("[", ",", "]")} has to be >= 0.0")
+    if (block.weightIter.forall(_ == 0)) return this
+
+    if (buffer == null || buffer.length < size * k) {
+      buffer = Array.ofDim[Double](size * k)
+    }
+
+    distanceMeasure match {
+      case EUCLIDEAN => euclideanUpdateInPlace(block)
+      case COSINE => cosineUpdateInPlace(block)
+    }
+    count += size
+
+    this
+  }
+
+  private def euclideanUpdateInPlace(block: InstanceBlock): Unit = {
+    val localBuffer = buffer
+    BLAS.gemm(-2.0, block.matrix, centerMatrix.transpose, 0.0, localBuffer)
+
+    val size = block.size
+    val localCenterSquaredNorms = centerSquaredNorms
+    val localWeightSumArr = weightSumVec.values
+    val localSumArr = sumMat.values
+    var i = 0
+    var j = 0
+    while (i < size) {
+      val weight = block.getWeight(i)
+      if (weight > 0) {
+        val instanceSquaredNorm = block.getLabel(i)
+        var bestIndex = 0
+        var bestSquaredDistance = Double.PositiveInfinity
+        j = 0
+        while (j < k) {
+          val squaredDistance = localBuffer(i + j * size) +
+            instanceSquaredNorm + localCenterSquaredNorms(j)
+          if (squaredDistance < bestSquaredDistance) {
+            bestIndex = j
+            bestSquaredDistance = squaredDistance
+          }
+          j += 1
+        }
+
+        costSum += weight * bestSquaredDistance
+        localWeightSumArr(bestIndex) += weight
+        block.getNonZeroIter(i)
+          .foreach { case (j, v) => localSumArr(bestIndex + j * k) += v * weight }
+      }
+
+      i += 1
+    }
+  }
+
+  private def cosineUpdateInPlace(block: InstanceBlock): Unit = {
+    val localBuffer = buffer
+    BLAS.gemm(-1.0, block.matrix, centerMatrix.transpose, 0.0, localBuffer)
+
+    val size = block.size
+    val localWeightSumArr = weightSumVec.values
+    val localSumArr = sumMat.values
+    var i = 0
+    var j = 0
+    while (i < size) {
+      val weight = block.getWeight(i)
+      if (weight > 0) {
+        var bestIndex = 0
+        var bestDistance = Double.PositiveInfinity
+        j = 0
+        while (j < k) {
+          val cosineDistance = 1 + localBuffer(i + j * size)
+          if (cosineDistance < bestDistance) {
+            bestIndex = j
+            bestDistance = cosineDistance
+          }
+          j += 1
+        }
+
+        costSum += weight * bestDistance
+        localWeightSumArr(bestIndex) += weight
+        block.getNonZeroIter(i)
+          .foreach { case (j, v) => localSumArr(bestIndex + j * k) += v * weight }
+      }
+
+      i += 1
+    }
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/clustering/KMeansSuite.scala
@@ -27,8 +27,7 @@ import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils, PMMLReadWriteTest}
 import org.apache.spark.ml.util.TestingUtils._
-import org.apache.spark.mllib.clustering.{DistanceMeasure, KMeans => MLlibKMeans,
-  KMeansModel => MLlibKMeansModel}
+import org.apache.spark.mllib.clustering.{DistanceMeasure, KMeans => MLlibKMeans, KMeansModel => MLlibKMeansModel}
 import org.apache.spark.mllib.linalg.{Vectors => MLlibVectors}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
@@ -54,10 +53,11 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
     assert(kmeans.getFeaturesCol === "features")
     assert(kmeans.getPredictionCol === "prediction")
     assert(kmeans.getMaxIter === 20)
-    assert(kmeans.getInitMode === MLlibKMeans.K_MEANS_PARALLEL)
+    assert(kmeans.getInitMode === KMeans.K_MEANS_PARALLEL)
     assert(kmeans.getInitSteps === 2)
     assert(kmeans.getTol === 1e-4)
-    assert(kmeans.getDistanceMeasure === DistanceMeasure.EUCLIDEAN)
+    assert(kmeans.getSolver === KMeans.AUTO)
+    assert(kmeans.getDistanceMeasure === KMeans.EUCLIDEAN)
     val model = kmeans.setMaxIter(1).fit(dataset)
 
     val transformed = model.transform(dataset)
@@ -80,21 +80,21 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       .setFeaturesCol("test_feature")
       .setPredictionCol("test_prediction")
       .setMaxIter(33)
-      .setInitMode(MLlibKMeans.RANDOM)
+      .setInitMode(KMeans.RANDOM)
       .setInitSteps(3)
       .setSeed(123)
       .setTol(1e-3)
-      .setDistanceMeasure(DistanceMeasure.COSINE)
+      .setDistanceMeasure(KMeans.COSINE)
 
     assert(kmeans.getK === 9)
     assert(kmeans.getFeaturesCol === "test_feature")
     assert(kmeans.getPredictionCol === "test_prediction")
     assert(kmeans.getMaxIter === 33)
-    assert(kmeans.getInitMode === MLlibKMeans.RANDOM)
+    assert(kmeans.getInitMode === KMeans.RANDOM)
     assert(kmeans.getInitSteps === 3)
     assert(kmeans.getSeed === 123)
     assert(kmeans.getTol === 1e-3)
-    assert(kmeans.getDistanceMeasure === DistanceMeasure.COSINE)
+    assert(kmeans.getDistanceMeasure === KMeans.COSINE)
   }
 
   test("parameters validation") {
@@ -172,26 +172,29 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       Vectors.dense(-100.0, 90.0)
     )).map(v => TestRow(v)))
 
-    val model = new KMeans()
-      .setK(3)
-      .setSeed(42)
-      .setInitMode(MLlibKMeans.RANDOM)
-      .setTol(1e-6)
-      .setDistanceMeasure(DistanceMeasure.COSINE)
-      .fit(df)
+    Seq(KMeans.AUTO, KMeans.ROW, KMeans.BLOCK).foreach { solver =>
+      val model = new KMeans()
+        .setK(3)
+        .setSeed(42)
+        .setInitMode(MLlibKMeans.RANDOM)
+        .setTol(1e-6)
+        .setDistanceMeasure(DistanceMeasure.COSINE)
+        .setSolver(solver)
+        .fit(df)
 
-    val predictionDf = model.transform(df)
-    assert(predictionDf.select("prediction").distinct().count() == 3)
-    val predictionsMap = predictionDf.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap(Vectors.dense(1.0, 1.0)) ==
-      predictionsMap(Vectors.dense(10.0, 10.0)))
-    assert(predictionsMap(Vectors.dense(1.0, 0.5)) ==
-      predictionsMap(Vectors.dense(10.0, 4.4)))
-    assert(predictionsMap(Vectors.dense(-1.0, 1.0)) ==
-      predictionsMap(Vectors.dense(-100.0, 90.0)))
+      val predictionDf = model.transform(df)
+      assert(predictionDf.select("prediction").distinct().count() == 3)
+      val predictionsMap = predictionDf.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap(Vectors.dense(1.0, 1.0)) ==
+        predictionsMap(Vectors.dense(10.0, 10.0)))
+      assert(predictionsMap(Vectors.dense(1.0, 0.5)) ==
+        predictionsMap(Vectors.dense(10.0, 4.4)))
+      assert(predictionsMap(Vectors.dense(-1.0, 1.0)) ==
+        predictionsMap(Vectors.dense(-100.0, 90.0)))
 
-    assert(model.clusterCenters.forall(Vectors.norm(_, 2) ~== 1.0 absTol 1e-6))
+      assert(model.clusterCenters.forall(Vectors.norm(_, 2) ~== 1.0 absTol 1e-6))
+    }
   }
 
   test("KMeans with cosine distance is not supported for 0-length vectors") {
@@ -269,27 +272,6 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       Vectors.dense(-100.0, 90.0), Vectors.dense(-100.0, 90.0)
     )).map(v => TestRow(v)))
 
-    val model1 = new KMeans()
-      .setK(3)
-      .setSeed(42)
-      .setInitMode(MLlibKMeans.RANDOM)
-      .setTol(1e-6)
-      .setDistanceMeasure(DistanceMeasure.COSINE)
-      .fit(df1)
-
-    val predictionDf1 = model1.transform(df1)
-    assert(predictionDf1.select("prediction").distinct().count() == 3)
-    val predictionsMap1 = predictionDf1.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap1(Vectors.dense(1.0, 1.0)) ==
-      predictionsMap1(Vectors.dense(10.0, 10.0)))
-    assert(predictionsMap1(Vectors.dense(1.0, 0.5)) ==
-      predictionsMap1(Vectors.dense(10.0, 4.4)))
-    assert(predictionsMap1(Vectors.dense(-1.0, 1.0)) ==
-      predictionsMap1(Vectors.dense(-100.0, 90.0)))
-
-    assert(model1.clusterCenters.forall(Vectors.norm(_, 2) ~== 1.0 absTol 1e-6))
-
     val df2 = spark.createDataFrame(spark.sparkContext.parallelize(Seq(
       (Vectors.dense(1.0, 1.0), 1.0),
       (Vectors.dense(10.0, 10.0), 2.0),
@@ -298,31 +280,56 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       (Vectors.dense(-1.0, 1.0), 1.0),
       (Vectors.dense(-100.0, 90.0), 2.0)))).toDF("features", "weightCol")
 
-    val model2 = new KMeans()
-      .setK(3)
-      .setSeed(42)
-      .setInitMode(MLlibKMeans.RANDOM)
-      .setTol(1e-6)
-      .setDistanceMeasure(DistanceMeasure.COSINE)
-      .setWeightCol("weightCol")
-      .fit(df2)
+    Seq(KMeans.AUTO, KMeans.ROW, KMeans.BLOCK).foreach { solver =>
+      val model1 = new KMeans()
+        .setK(3)
+        .setSeed(42)
+        .setInitMode(MLlibKMeans.RANDOM)
+        .setTol(1e-6)
+        .setSolver(solver)
+        .setDistanceMeasure(DistanceMeasure.COSINE)
+        .fit(df1)
 
-    val predictionDf2 = model2.transform(df2)
-    assert(predictionDf2.select("prediction").distinct().count() == 3)
-    val predictionsMap2 = predictionDf2.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap2(Vectors.dense(1.0, 1.0)) ==
-      predictionsMap2(Vectors.dense(10.0, 10.0)))
-    assert(predictionsMap2(Vectors.dense(1.0, 0.5)) ==
-      predictionsMap2(Vectors.dense(10.0, 4.4)))
-    assert(predictionsMap2(Vectors.dense(-1.0, 1.0)) ==
-      predictionsMap2(Vectors.dense(-100.0, 90.0)))
+      val predictionDf1 = model1.transform(df1)
+      assert(predictionDf1.select("prediction").distinct().count() == 3)
+      val predictionsMap1 = predictionDf1.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap1(Vectors.dense(1.0, 1.0)) ==
+        predictionsMap1(Vectors.dense(10.0, 10.0)))
+      assert(predictionsMap1(Vectors.dense(1.0, 0.5)) ==
+        predictionsMap1(Vectors.dense(10.0, 4.4)))
+      assert(predictionsMap1(Vectors.dense(-1.0, 1.0)) ==
+        predictionsMap1(Vectors.dense(-100.0, 90.0)))
 
-    assert(model2.clusterCenters.forall(Vectors.norm(_, 2) ~== 1.0 absTol 1e-6))
+      assert(model1.clusterCenters.forall(Vectors.norm(_, 2) ~== 1.0 absTol 1e-6))
 
-    // compare if model1 and model2 have the same cluster centers
-    assert(model1.clusterCenters.length === model2.clusterCenters.length)
-    assert(model1.clusterCenters.toSet.subsetOf((model2.clusterCenters.toSet)))
+      val model2 = new KMeans()
+        .setK(3)
+        .setSeed(42)
+        .setInitMode(MLlibKMeans.RANDOM)
+        .setTol(1e-6)
+        .setSolver(solver)
+        .setDistanceMeasure(DistanceMeasure.COSINE)
+        .setWeightCol("weightCol")
+        .fit(df2)
+
+      val predictionDf2 = model2.transform(df2)
+      assert(predictionDf2.select("prediction").distinct().count() == 3)
+      val predictionsMap2 = predictionDf2.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap2(Vectors.dense(1.0, 1.0)) ==
+        predictionsMap2(Vectors.dense(10.0, 10.0)))
+      assert(predictionsMap2(Vectors.dense(1.0, 0.5)) ==
+        predictionsMap2(Vectors.dense(10.0, 4.4)))
+      assert(predictionsMap2(Vectors.dense(-1.0, 1.0)) ==
+        predictionsMap2(Vectors.dense(-100.0, 90.0)))
+
+      assert(model2.clusterCenters.forall(Vectors.norm(_, 2) ~== 1.0 absTol 1e-6))
+
+      // compare if model1 and model2 have the same cluster centers
+      assert(model1.clusterCenters.length === model2.clusterCenters.length)
+      assert(model1.clusterCenters.toSet.subsetOf((model2.clusterCenters.toSet)))
+    }
   }
 
   test("Two centers with weightCol") {
@@ -335,38 +342,6 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       (Vectors.dense(9.0, 0.2), 2.0),
       (Vectors.dense(9.2, 0.0), 2.0)))).toDF("features", "weightCol")
 
-    val model1 = new KMeans()
-      .setK(2)
-      .setInitMode(MLlibKMeans.RANDOM)
-      .setWeightCol("weightCol")
-      .setMaxIter(10)
-      .fit(df1)
-
-    val predictionDf1 = model1.transform(df1)
-    assert(predictionDf1.select("prediction").distinct().count() == 2)
-    val predictionsMap1 = predictionDf1.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap1(Vectors.dense(0.0, 0.0)) ==
-      predictionsMap1(Vectors.dense(0.0, 0.1)))
-    assert(predictionsMap1(Vectors.dense(0.0, 0.0)) ==
-      predictionsMap1(Vectors.dense(0.1, 0.0)))
-    assert(predictionsMap1(Vectors.dense(9.0, 0.0)) ==
-      predictionsMap1(Vectors.dense(9.0, 0.2)))
-    assert(predictionsMap1(Vectors.dense(9.0, 0.2)) ==
-      predictionsMap1(Vectors.dense(9.2, 0.0)))
-
-    // center 1:
-    // total weights in cluster 1: 2.0 + 2.0 + 2.0 = 6.0
-    // x: 9.0 * (2.0/6.0) + 9.0 * (2.0/6.0) + 9.2 * (2.0/6.0) = 9.066666666666666
-    // y: 0.0 * (2.0/6.0) + 0.2 * (2.0/6.0) + 0.0 * (2.0/6.0) = 0.06666666666666667
-    // center 2:
-    // total weights in cluster 2: 2.0 + 2.0 + 2.0 = 6.0
-    // x: 0.0 * (2.0/6.0) + 0.0 * (2.0/6.0) + 0.1 * (2.0/6.0) = 0.03333333333333333
-    // y: 0.0 * (2.0/6.0) + 0.1 * (2.0/6.0) + 0.0 * (2.0/6.0) = 0.03333333333333333
-    val model1_center1 = Vectors.dense(9.066666666666666, 0.06666666666666667)
-    val model1_center2 = Vectors.dense(0.03333333333333333, 0.03333333333333333)
-    assert(model1.clusterCenters(0) === model1_center1)
-    assert(model1.clusterCenters(1) === model1_center2)
 
     // use different weight
     val df2 = spark.createDataFrame(spark.sparkContext.parallelize(Seq(
@@ -377,38 +352,75 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       (Vectors.dense(9.0, 0.2), 1.0),
       (Vectors.dense(9.2, 0.0), 2.0)))).toDF("features", "weightCol")
 
-    val model2 = new KMeans()
-      .setK(2)
-      .setInitMode(MLlibKMeans.RANDOM)
-      .setWeightCol("weightCol")
-      .setMaxIter(10)
-      .fit(df2)
+    Seq(KMeans.AUTO, KMeans.ROW, KMeans.BLOCK).foreach { solver =>
+      val model1 = new KMeans()
+        .setK(2)
+        .setInitMode(MLlibKMeans.RANDOM)
+        .setWeightCol("weightCol")
+        .setMaxIter(10)
+        .setSolver(solver)
+        .fit(df1)
 
-    val predictionDf2 = model2.transform(df2)
-    assert(predictionDf2.select("prediction").distinct().count() == 2)
-    val predictionsMap2 = predictionDf2.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap2(Vectors.dense(0.0, 0.0)) ==
-      predictionsMap2(Vectors.dense(0.0, 0.1)))
-    assert(predictionsMap2(Vectors.dense(0.0, 0.0)) ==
-      predictionsMap2(Vectors.dense(0.1, 0.0)))
-    assert(predictionsMap2(Vectors.dense(9.0, 0.0)) ==
-      predictionsMap2(Vectors.dense(9.0, 0.2)))
-    assert(predictionsMap2(Vectors.dense(9.0, 0.2)) ==
-      predictionsMap2(Vectors.dense(9.2, 0.0)))
+      val predictionDf1 = model1.transform(df1)
+      assert(predictionDf1.select("prediction").distinct().count() == 2)
+      val predictionsMap1 = predictionDf1.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap1(Vectors.dense(0.0, 0.0)) ==
+        predictionsMap1(Vectors.dense(0.0, 0.1)))
+      assert(predictionsMap1(Vectors.dense(0.0, 0.0)) ==
+        predictionsMap1(Vectors.dense(0.1, 0.0)))
+      assert(predictionsMap1(Vectors.dense(9.0, 0.0)) ==
+        predictionsMap1(Vectors.dense(9.0, 0.2)))
+      assert(predictionsMap1(Vectors.dense(9.0, 0.2)) ==
+        predictionsMap1(Vectors.dense(9.2, 0.0)))
 
-    // center 1:
-    // total weights in cluster 1: 2.5 + 1.0 + 2.0 = 5.5
-    // x: 9.0 * (2.5/5.5) + 9.0 * (1.0/5.5) + 9.2 * (2.0/5.5) = 9.072727272727272
-    // y: 0.0 * (2.5/5.5) + 0.2 * (1.0/5.5) + 0.0 * (2.0/5.5) = 0.03636363636363637
-    // center 2:
-    // total weights in cluster 2: 1.0 + 2.0 + 3.0 = 6.0
-    // x: 0.0 * (1.0/6.0) + 0.0 * (2.0/6.0) + 0.1 * (3.0/6.0) = 0.05
-    // y: 0.0 * (1.0/6.0) + 0.1 * (2.0/6.0) + 0.0 * (3.0/6.0) = 0.03333333333333333
-    val model2_center1 = Vectors.dense(9.072727272727272, 0.03636363636363637)
-    val model2_center2 = Vectors.dense(0.05, 0.03333333333333333)
-    assert(model2.clusterCenters(0) === model2_center1)
-    assert(model2.clusterCenters(1) === model2_center2)
+      // center 1:
+      // total weights in cluster 1: 2.0 + 2.0 + 2.0 = 6.0
+      // x: 9.0 * (2.0/6.0) + 9.0 * (2.0/6.0) + 9.2 * (2.0/6.0) = 9.066666666666666
+      // y: 0.0 * (2.0/6.0) + 0.2 * (2.0/6.0) + 0.0 * (2.0/6.0) = 0.06666666666666667
+      // center 2:
+      // total weights in cluster 2: 2.0 + 2.0 + 2.0 = 6.0
+      // x: 0.0 * (2.0/6.0) + 0.0 * (2.0/6.0) + 0.1 * (2.0/6.0) = 0.03333333333333333
+      // y: 0.0 * (2.0/6.0) + 0.1 * (2.0/6.0) + 0.0 * (2.0/6.0) = 0.03333333333333333
+      val model1_center1 = Vectors.dense(9.066666666666666, 0.06666666666666667)
+      val model1_center2 = Vectors.dense(0.03333333333333333, 0.03333333333333333)
+      assert(model1.clusterCenters(0) === model1_center1)
+      assert(model1.clusterCenters(1) === model1_center2)
+
+      val model2 = new KMeans()
+        .setK(2)
+        .setInitMode(MLlibKMeans.RANDOM)
+        .setWeightCol("weightCol")
+        .setMaxIter(10)
+        .setSolver(solver)
+        .fit(df2)
+
+      val predictionDf2 = model2.transform(df2)
+      assert(predictionDf2.select("prediction").distinct().count() == 2)
+      val predictionsMap2 = predictionDf2.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap2(Vectors.dense(0.0, 0.0)) ==
+        predictionsMap2(Vectors.dense(0.0, 0.1)))
+      assert(predictionsMap2(Vectors.dense(0.0, 0.0)) ==
+        predictionsMap2(Vectors.dense(0.1, 0.0)))
+      assert(predictionsMap2(Vectors.dense(9.0, 0.0)) ==
+        predictionsMap2(Vectors.dense(9.0, 0.2)))
+      assert(predictionsMap2(Vectors.dense(9.0, 0.2)) ==
+        predictionsMap2(Vectors.dense(9.2, 0.0)))
+
+      // center 1:
+      // total weights in cluster 1: 2.5 + 1.0 + 2.0 = 5.5
+      // x: 9.0 * (2.5/5.5) + 9.0 * (1.0/5.5) + 9.2 * (2.0/5.5) = 9.072727272727272
+      // y: 0.0 * (2.5/5.5) + 0.2 * (1.0/5.5) + 0.0 * (2.0/5.5) = 0.03636363636363637
+      // center 2:
+      // total weights in cluster 2: 1.0 + 2.0 + 3.0 = 6.0
+      // x: 0.0 * (1.0/6.0) + 0.0 * (2.0/6.0) + 0.1 * (3.0/6.0) = 0.05
+      // y: 0.0 * (1.0/6.0) + 0.1 * (2.0/6.0) + 0.0 * (3.0/6.0) = 0.03333333333333333
+      val model2_center1 = Vectors.dense(9.072727272727272, 0.03636363636363637)
+      val model2_center2 = Vectors.dense(0.05, 0.03333333333333333)
+      assert(model2.clusterCenters(0) === model2_center1)
+      assert(model2.clusterCenters(1) === model2_center2)
+    }
   }
 
   test("Four centers with weightCol") {
@@ -423,25 +435,6 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       Vectors.dense(-6.0, -6.0),
       Vectors.dense(-10.0, -10.0))).map(v => TestRow(v)))
 
-    val model1 = new KMeans()
-      .setK(4)
-      .setInitMode(MLlibKMeans.K_MEANS_PARALLEL)
-      .setMaxIter(10)
-      .fit(df1)
-
-    val predictionDf1 = model1.transform(df1)
-    assert(predictionDf1.select("prediction").distinct().count() == 4)
-    val predictionsMap1 = predictionDf1.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap1(Vectors.dense(0.1, 0.1)) ==
-      predictionsMap1(Vectors.dense(5.0, 0.2)) )
-    assert(predictionsMap1(Vectors.dense(10.0, 0.0)) ==
-      predictionsMap1(Vectors.dense(15.0, 0.5)) )
-    assert(predictionsMap1(Vectors.dense(32.0, 18.0)) ==
-      predictionsMap1(Vectors.dense(30.1, 20.0)))
-    assert(predictionsMap1(Vectors.dense(-6.0, -6.0)) ==
-      predictionsMap1(Vectors.dense(-10.0, -10.0)))
-
     // use same weight, should have the same result as no weight
     val df2 = spark.createDataFrame(spark.sparkContext.parallelize(Seq(
       (Vectors.dense(0.1, 0.1), 2.0),
@@ -453,27 +446,51 @@ class KMeansSuite extends MLTest with DefaultReadWriteTest with PMMLReadWriteTes
       (Vectors.dense(-6.0, -6.0), 2.0),
       (Vectors.dense(-10.0, -10.0), 2.0)))).toDF("features", "weightCol")
 
-    val model2 = new KMeans()
-      .setK(4)
-      .setInitMode(MLlibKMeans.K_MEANS_PARALLEL)
-      .setWeightCol("weightCol")
-      .setMaxIter(10)
-      .fit(df2)
+    Seq(KMeans.AUTO, KMeans.ROW, KMeans.BLOCK).foreach { solver =>
 
-    val predictionDf2 = model2.transform(df2)
-    assert(predictionDf2.select("prediction").distinct().count() == 4)
-    val predictionsMap2 = predictionDf2.collect().map(row =>
-      row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
-    assert(predictionsMap2(Vectors.dense(0.1, 0.1)) ==
-      predictionsMap2(Vectors.dense(5.0, 0.2)))
-    assert(predictionsMap2(Vectors.dense(10.0, 0.0)) ==
-      predictionsMap2(Vectors.dense(15.0, 0.5)))
-    assert(predictionsMap2(Vectors.dense(32.0, 18.0)) ==
-      predictionsMap2(Vectors.dense(30.1, 20.0)))
-    assert(predictionsMap2(Vectors.dense(-6.0, -6.0)) ==
-      predictionsMap2(Vectors.dense(-10.0, -10.0)))
+      val model1 = new KMeans()
+        .setK(4)
+        .setInitMode(MLlibKMeans.K_MEANS_PARALLEL)
+        .setMaxIter(10)
+        .setSolver(solver)
+        .fit(df1)
 
-    assert(model1.clusterCenters === model2.clusterCenters)
+      val predictionDf1 = model1.transform(df1)
+      assert(predictionDf1.select("prediction").distinct().count() == 4)
+      val predictionsMap1 = predictionDf1.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap1(Vectors.dense(0.1, 0.1)) ==
+        predictionsMap1(Vectors.dense(5.0, 0.2)) )
+      assert(predictionsMap1(Vectors.dense(10.0, 0.0)) ==
+        predictionsMap1(Vectors.dense(15.0, 0.5)) )
+      assert(predictionsMap1(Vectors.dense(32.0, 18.0)) ==
+        predictionsMap1(Vectors.dense(30.1, 20.0)))
+      assert(predictionsMap1(Vectors.dense(-6.0, -6.0)) ==
+        predictionsMap1(Vectors.dense(-10.0, -10.0)))
+
+      val model2 = new KMeans()
+        .setK(4)
+        .setInitMode(MLlibKMeans.K_MEANS_PARALLEL)
+        .setWeightCol("weightCol")
+        .setMaxIter(10)
+        .setSolver(solver)
+        .fit(df2)
+
+      val predictionDf2 = model2.transform(df2)
+      assert(predictionDf2.select("prediction").distinct().count() == 4)
+      val predictionsMap2 = predictionDf2.collect().map(row =>
+        row.getAs[Vector]("features") -> row.getAs[Int]("prediction")).toMap
+      assert(predictionsMap2(Vectors.dense(0.1, 0.1)) ==
+        predictionsMap2(Vectors.dense(5.0, 0.2)))
+      assert(predictionsMap2(Vectors.dense(10.0, 0.0)) ==
+        predictionsMap2(Vectors.dense(15.0, 0.5)))
+      assert(predictionsMap2(Vectors.dense(32.0, 18.0)) ==
+        predictionsMap2(Vectors.dense(30.1, 20.0)))
+      assert(predictionsMap2(Vectors.dense(-6.0, -6.0)) ==
+        predictionsMap2(Vectors.dense(-10.0, -10.0)))
+
+      assert(model1.clusterCenters === model2.clusterCenters)
+    }
   }
 }
 

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -581,6 +581,7 @@ class _KMeansParams(
     HasDistanceMeasure,
     HasWeightCol,
     HasSolver,
+    HasMaxBlockSizeInMB,
 ):
     """
     Params for :py:class:`KMeans` and :py:class:`KMeansModel`.

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -34,6 +34,8 @@ from pyspark.ml.param.shared import (
     HasProbabilityCol,
     HasDistanceMeasure,
     HasCheckpointInterval,
+    HasSolver,
+    HasMaxBlockSizeInMB,
     Param,
     Params,
     TypeConverters,
@@ -571,7 +573,14 @@ class KMeansSummary(ClusteringSummary):
 
 @inherit_doc
 class _KMeansParams(
-    HasMaxIter, HasFeaturesCol, HasSeed, HasPredictionCol, HasTol, HasDistanceMeasure, HasWeightCol
+    HasMaxIter,
+    HasFeaturesCol,
+    HasSeed,
+    HasPredictionCol,
+    HasTol,
+    HasDistanceMeasure,
+    HasWeightCol,
+    HasSolver,
 ):
     """
     Params for :py:class:`KMeans` and :py:class:`KMeansModel`.
@@ -599,6 +608,12 @@ class _KMeansParams(
         "The number of steps for k-means|| " + "initialization mode. Must be > 0.",
         typeConverter=TypeConverters.toInt,
     )
+    solver: Param[str] = Param(
+        Params._dummy(),
+        "solver",
+        "The solver algorithm for optimization. Supported " + "options: auto, row, block.",
+        typeConverter=TypeConverters.toString,
+    )
 
     def __init__(self, *args: Any):
         super(_KMeansParams, self).__init__(*args)
@@ -609,6 +624,8 @@ class _KMeansParams(
             tol=1e-4,
             maxIter=20,
             distanceMeasure="euclidean",
+            solver="auto",
+            maxBlockSizeInMB=0.0,
         )
 
     @since("1.5.0")
@@ -711,7 +728,11 @@ class KMeans(JavaEstimator[KMeansModel], _KMeansParams, JavaMLWritable, JavaMLRe
     >>> kmeans.getMaxIter()
     10
     >>> kmeans.clear(kmeans.maxIter)
+    >>> kmeans.getSolver()
+    'auto'
     >>> model = kmeans.fit(df)
+    >>> model.getMaxBlockSizeInMB()
+    0.0
     >>> model.getDistanceMeasure()
     'euclidean'
     >>> model.setPredictionCol("newPrediction")
@@ -770,11 +791,14 @@ class KMeans(JavaEstimator[KMeansModel], _KMeansParams, JavaMLWritable, JavaMLRe
         seed: Optional[int] = None,
         distanceMeasure: str = "euclidean",
         weightCol: Optional[str] = None,
+        solver: str = "auto",
+        maxBlockSizeInMB: float = 0.0,
     ):
         """
         __init__(self, \\*, featuresCol="features", predictionCol="prediction", k=2, \
                  initMode="k-means||", initSteps=2, tol=1e-4, maxIter=20, seed=None, \
-                 distanceMeasure="euclidean", weightCol=None)
+                 distanceMeasure="euclidean", weightCol=None, solver="auto", \
+                 maxBlockSizeInMB=0.0)
         """
         super(KMeans, self).__init__()
         self._java_obj = self._new_java_obj("org.apache.spark.ml.clustering.KMeans", self.uid)
@@ -799,11 +823,14 @@ class KMeans(JavaEstimator[KMeansModel], _KMeansParams, JavaMLWritable, JavaMLRe
         seed: Optional[int] = None,
         distanceMeasure: str = "euclidean",
         weightCol: Optional[str] = None,
+        solver: str = "auto",
+        maxBlockSizeInMB: float = 0.0,
     ) -> "KMeans":
         """
         setParams(self, \\*, featuresCol="features", predictionCol="prediction", k=2, \
                   initMode="k-means||", initSteps=2, tol=1e-4, maxIter=20, seed=None, \
-                  distanceMeasure="euclidean", weightCol=None)
+                  distanceMeasure="euclidean", weightCol=None, solver="auto", \
+                  maxBlockSizeInMB=0.0)
 
         Sets params for KMeans.
         """
@@ -879,6 +906,20 @@ class KMeans(JavaEstimator[KMeansModel], _KMeansParams, JavaMLWritable, JavaMLRe
         Sets the value of :py:attr:`weightCol`.
         """
         return self._set(weightCol=value)
+
+    @since("3.4.0")
+    def setSolver(self, value: str) -> "KMeans":
+        """
+        Sets the value of :py:attr:`solver`.
+        """
+        return self._set(solver=value)
+
+    @since("3.4.0")
+    def setMaxBlockSizeInMB(self, value: float) -> "KMeans":
+        """
+        Sets the value of :py:attr:`maxBlockSizeInMB`.
+        """
+        return self._set(maxBlockSizeInMB=value)
 
 
 @inherit_doc


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, add a new impl of kmeans which can use GEMM to accelerate the training;
2, add a new param `solver` to control the code path, by default it is `auto`, which will choose the underlying impls based on the dataset sparsity.


### Why are the changes needed?
on dense dataset, it could be 30% ~ 3x faster than existing impl


### Does this PR introduce _any_ user-facing change?
yes, new params added


### How was this patch tested?
updated testsuites