### PR TITLE
[SPARK-39092][SQL] Propagate Empty Partitions

### DIFF
--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -2532,7 +2532,7 @@ class MinHashLSH(
     >>> model.approxSimilarityJoin(df, df2, 0.6, distCol="JaccardDistance").select(
     ...     col("datasetA.id").alias("idA"),
     ...     col("datasetB.id").alias("idB"),
-    ...     col("JaccardDistance")).show()
+    ...     col("JaccardDistance")).orderBy("idA").show()
     +---+---+---------------+
     |idA|idB|JaccardDistance|
     +---+---+---------------+

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -995,7 +995,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> set_option("compute.ops_on_diff_frames", True)
         >>> s1 = ps.Series([0.90010907, 0.13484424, 0.62036035])
         >>> s2 = ps.Series([0.12528585, 0.26962463, 0.51111198])
-        >>> s1.cov(s2)
+        >>> s1.cov(s2) # doctest: +ELLIPSIS
         -0.016857626527158744
         >>> reset_option("compute.ops_on_diff_frames")
         """

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -995,8 +995,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> set_option("compute.ops_on_diff_frames", True)
         >>> s1 = ps.Series([0.90010907, 0.13484424, 0.62036035])
         >>> s2 = ps.Series([0.12528585, 0.26962463, 0.51111198])
-        >>> s1.cov(s2) # doctest: +ELLIPSIS
-        -0.016857626527158744
+        >>> s1.cov(s2)
+        -0.0168576265271587...
         >>> reset_option("compute.ops_on_diff_frames")
         """
         if not isinstance(other, Series):

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -899,7 +899,7 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         )
 
         with ps.option_context("compute.eager_check", False):
-            self.assert_eq(expected, psser1.compare(psser2))
+            self.assert_eq(expected, psser1.compare(psser2).sort_index())
 
     def test_different_columns(self):
         psdf1 = self.psdf1

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -652,6 +652,14 @@ object SQLConf {
       .checkValue(_ > 0, "The initial number of partitions must be positive.")
       .createOptional
 
+  val PROPAGATE_EMPTY_PARTITIONS_ENABLED =
+    buildConf("spark.sql.adaptive.propagateEmptyPartitions.enabled")
+      .doc(s"When true and '${ADAPTIVE_EXECUTION_ENABLED.key}' is true, Spark will propagate " +
+        "empty partitions to avoid unnecessary shuffle read and task computation.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val FETCH_SHUFFLE_BLOCKS_IN_BATCH =
     buildConf("spark.sql.adaptive.fetchShuffleBlocksInBatch")
       .internal()
@@ -4064,6 +4072,8 @@ class SQLConf extends Serializable with Logging {
     getConf(NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN)
 
   def coalesceShufflePartitionsEnabled: Boolean = getConf(COALESCE_PARTITIONS_ENABLED)
+
+  def propagateEmptyPartitionsEnabled: Boolean = getConf(PROPAGATE_EMPTY_PARTITIONS_ENABLED)
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -134,7 +134,8 @@ case class AdaptiveSparkPlanExec(
     CoalesceShufflePartitions(context.session),
     // `OptimizeShuffleWithLocalRead` needs to make use of 'AQEShuffleReadExec.partitionSpecs'
     // added by `CoalesceShufflePartitions`, and must be executed after it.
-    OptimizeShuffleWithLocalRead
+    OptimizeShuffleWithLocalRead,
+    PropagateEmptyPartitions
   )
 
   // This rule is stateful as it maintains the codegen stage ID. We can't create a fresh one every

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -131,11 +131,11 @@ case class AdaptiveSparkPlanExec(
     PlanAdaptiveDynamicPruningFilters(this),
     ReuseAdaptiveSubquery(context.subqueryCache),
     OptimizeSkewInRebalancePartitions,
+    PropagateEmptyPartitions,
     CoalesceShufflePartitions(context.session),
     // `OptimizeShuffleWithLocalRead` needs to make use of 'AQEShuffleReadExec.partitionSpecs'
     // added by `CoalesceShufflePartitions`, and must be executed after it.
-    OptimizeShuffleWithLocalRead,
-    PropagateEmptyPartitions
+    OptimizeShuffleWithLocalRead
   )
 
   // This rule is stateful as it maintains the codegen stage ID. We can't create a fresh one every

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PropagateEmptyPartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PropagateEmptyPartitions.scala
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.execution.adaptive
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.execution._
+import org.apache.spark.sql.execution.exchange._
+import org.apache.spark.sql.execution.joins._
+
+/**
+ * A rule to propagate empty partitions, so that some unnecessary shuffle read can be skipped.
+ *
+ * The general idea is to utilize the shuffled join to skip some partitions.
+ *
+ * For example, assume the shuffled join has 4 partitions, and L2 and R3 are empty:
+ * left:  [L1, L2, L3, L4]
+ * right: [R1, R2, R3, R4]
+ *
+ * Suppose the join type is Inner. Then this rule will skip reading partitions: L2, R2, L3, R3.
+ *
+ * Suppose the join type is LeftOuter. Then this rule will skip reading partitions: L2, R2, R3.
+ *
+ * Suppose the join type is RightOuter. Then this rule will skip reading partitions: L2, L3, R3.
+ *
+ * Suppose the join type is FullOuter. Then this rule will skip reading partitions: L2, R3.
+ */
+object PropagateEmptyPartitions extends AQEShuffleReadRule {
+
+  override val supportedShuffleOrigins: Seq[ShuffleOrigin] =
+    Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NUM, REPARTITION_BY_COL,
+      REBALANCE_PARTITIONS_BY_NONE, REBALANCE_PARTITIONS_BY_COL)
+
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.propagateEmptyPartitionsEnabled) {
+      return plan
+    }
+
+    // If there is no ShuffledJoin, no need to continue.
+    if (plan.collectFirst { case j: ShuffledJoin => j }.isEmpty) {
+      return plan
+    }
+
+    val stages = plan.collect { case s: ShuffleQueryStageExec => s }
+    // currently, empty information is only extracted from and propagated to shuffle data.
+    // TODO: support DataScan in the future.
+    if (stages.size < 2 || !stages.forall(_.isMaterialized)) {
+      return plan
+    }
+
+    val (_, emptyGroupInfos) = collectEmptyGroups(plan)
+
+    // stageId -> propagated empty indices
+    val emptyIndicesMap = mutable.Map.empty[Int, Set[Int]]
+    emptyGroupInfos.foreach {
+      case EmptyGroupInfo(stageIds, emptyIndices) =>
+        if (stageIds.nonEmpty && emptyIndices.nonEmpty) {
+          stageIds.foreach { stageId =>
+            val emptySet = emptyIndicesMap.getOrElse(stageId, Set.empty)
+            emptyIndicesMap.update(stageId, emptySet ++ emptyIndices)
+          }
+        }
+    }
+
+    if (emptyIndicesMap.nonEmpty) {
+      updateShuffleReads(plan, emptyIndicesMap.toMap)
+    } else {
+      plan
+    }
+  }
+
+  /**
+   *  collect following information from a plan:
+   *  1, group info at current operator
+   *  2, collected group infos at AQEShuffleRead/ShuffleQueryStage/ShuffledJoin operators
+   */
+  private def collectEmptyGroups(plan: SparkPlan): (EmptyGroupInfo, Seq[EmptyGroupInfo]) = {
+    plan match {
+      case AQEShuffleReadExec(stage: ShuffleQueryStageExec, specs: Seq[ShufflePartitionSpec]) =>
+        val emptyIndices = Iterator.range(0, specs.length).filter { i =>
+          specs(i) match {
+            case CoalescedPartitionSpec(_, _, Some(0L)) => true
+            case PartialReducerPartitionSpec(_, _, _, 0L) => true
+            case EmptyPartitionSpec => true
+            case _ => false
+          }
+        }.toSet
+        val currentGroupInfo = EmptyGroupInfo(Seq(stage.id), emptyIndices)
+        (currentGroupInfo, Seq(currentGroupInfo))
+
+      case stage: ShuffleQueryStageExec =>
+        val sizes = stage.mapStats.get.bytesByPartitionId
+        val emptyIndices = Iterator.range(0, sizes.length).filter(sizes(_) == 0).toSet
+        val currentGroupInfo = EmptyGroupInfo(Seq(stage.id), emptyIndices)
+        (currentGroupInfo, Seq(currentGroupInfo))
+
+      case _: LeafExecNode => (EmptyGroupInfo(Nil, Set.empty), Nil)
+
+      case unary: UnaryExecNode => collectEmptyGroups(unary.child)
+
+      case join: ShuffledJoin =>
+        val (EmptyGroupInfo(leftStageIds, leftEmptyIndices), leftGroupInfos) =
+          collectEmptyGroups(join.left)
+        val (EmptyGroupInfo(rightStageIds, rightEmptyIndices), rightGroupInfos) =
+          collectEmptyGroups(join.right)
+        val currentGroupInfo = join.joinType match {
+          case Inner | Cross =>
+            EmptyGroupInfo(leftStageIds ++ rightStageIds, leftEmptyIndices ++ rightEmptyIndices)
+
+          case LeftOuter | LeftAnti | LeftSemi =>
+            EmptyGroupInfo(leftStageIds ++ rightStageIds, leftEmptyIndices)
+
+          case RightOuter =>
+            EmptyGroupInfo(leftStageIds ++ rightStageIds, rightEmptyIndices)
+
+          case FullOuter =>
+            EmptyGroupInfo(leftStageIds ++ rightStageIds, leftEmptyIndices & rightEmptyIndices)
+
+          case _ => EmptyGroupInfo(Nil, Set.empty)
+        }
+        (currentGroupInfo, leftGroupInfos ++ rightGroupInfos :+ currentGroupInfo)
+
+      case _ =>
+        val childGroupInfos = plan.children.flatMap(collectEmptyGroups(_)._2)
+        (EmptyGroupInfo(Nil, Set.empty), childGroupInfos)
+    }
+  }
+
+  private def updateShuffleReads(
+      plan: SparkPlan,
+      emptyIndicesMap: Map[Int, Set[Int]]): SparkPlan = plan match {
+    case AQEShuffleReadExec(stage: ShuffleQueryStageExec, specs: Seq[ShufflePartitionSpec])
+      if emptyIndicesMap.contains(stage.id) =>
+      val indices = emptyIndicesMap(stage.id)
+      val newSpecs = Seq.tabulate(specs.length) { i =>
+        if (indices.contains(i)) {
+          EmptyPartitionSpec
+        } else {
+          specs(i)
+        }
+      }
+      AQEShuffleReadExec(stage, newSpecs)
+
+    case stage: ShuffleQueryStageExec if emptyIndicesMap.contains(stage.id) =>
+      val indices = emptyIndicesMap(stage.id)
+      val sizes = stage.mapStats.get.bytesByPartitionId
+      val newSpecs = Seq.tabulate(sizes.length) { i =>
+        if (indices.contains(i)) {
+          EmptyPartitionSpec
+        } else {
+          CoalescedPartitionSpec(i, i + 1, sizes(i))
+        }
+      }
+      AQEShuffleReadExec(stage, newSpecs)
+
+    case _ => plan.mapChildren(updateShuffleReads(_, emptyIndicesMap))
+  }
+}
+
+/**
+ * group info at one operator
+ * @param stageIds indicate which AQEShuffleReadExec/ShuffleQueryStageExec
+ *                 this emptyIndices can propagate to
+ * @param emptyIndices indices of empty partitions
+ */
+private case class EmptyGroupInfo(
+    stageIds: Seq[Int],
+    emptyIndices: Set[Int])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PropagateEmptyPartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PropagateEmptyPartitions.scala
@@ -63,18 +63,13 @@ object PropagateEmptyPartitions extends AQEShuffleReadRule {
     Seq(ENSURE_REQUIREMENTS, REPARTITION_BY_NUM, REPARTITION_BY_COL,
       REBALANCE_PARTITIONS_BY_NONE, REBALANCE_PARTITIONS_BY_COL)
 
-  private val supportedJoinTypes: Seq[JoinType] =
-    Seq(Inner, LeftOuter, LeftAnti, LeftSemi, RightOuter, Cross)
-
   override def apply(plan: SparkPlan): SparkPlan = {
     if (!conf.propagateEmptyPartitionsEnabled) {
       return plan
     }
 
-    // If there is no ShuffledJoin, or only a full outer ShuffledJoin, no need to continue.
-    if (plan
-      .collectFirst { case j: ShuffledJoin if supportedJoinTypes.contains(j.joinType) => j }
-      .isEmpty) {
+    // If there is no ShuffledJoin, no need to continue.
+    if (!plan.exists(_.isInstanceOf[ShuffledJoin])) {
       return plan
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/ShufflePartitionsUtil.scala
@@ -224,14 +224,6 @@ object ShufflePartitionsUtil extends Logging {
       targetSize: Long,
       minPartitionSize: Long,
       checkFirstIndex: Boolean): Seq[Seq[ShufflePartitionSpec]] = {
-    // Do not coalesce if any of the map output stats are missing or if not all shuffles have
-    // partition specs, which should not happen in practice.
-    if (!mapOutputStatistics.forall(_.isDefined) || !inputPartitionSpecs.forall(_.isDefined)) {
-      logWarning("Could not apply partition coalescing because of missing MapOutputStatistics " +
-        "or shuffle partition specs.")
-      return Seq.empty
-    }
-
     val validMetrics = mapOutputStatistics.map(_.get)
     // Extract the start indices of each partition spec. Give invalid index -1 to unexpected
     // partition specs. When we reach here, it means skew join optimization has been applied.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -444,6 +444,6 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with BeforeAndAfterAl
 
 object CoalescedShuffleRead {
   def unapply(read: AQEShuffleReadExec): Boolean = {
-    !read.isLocalRead && !read.hasSkewedPartition && read.hasCoalescedPartition
+    !read.isLocalRead && !read.hasSkewedPartition && read.isCoalescedRead
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -1677,7 +1677,7 @@ class AdaptiveQueryExecSuite
         assert(aqeReads.length == 2)
         if (coalescedRead) assert(aqeReads.forall(_.hasCoalescedPartition))
       } else {
-        assert(aqeReads.isEmpty || aqeReads.forall(_.hasSkippedPartition))
+        assert(aqeReads.isEmpty)
       }
     }
 
@@ -1720,7 +1720,8 @@ class AdaptiveQueryExecSuite
         SQLConf.SKEW_JOIN_ENABLED.key -> "true",
         SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "1",
         SQLConf.SKEW_JOIN_SKEWED_PARTITION_FACTOR.key -> "0",
-        SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "10") {
+        SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "10",
+        SQLConf.PROPAGATE_EMPTY_PARTITIONS_ENABLED.key -> "false") {
         // Repartition with no partition num specified.
         checkSMJ(df.repartition($"b"),
           // The top shuffle from repartition is optimized out.
@@ -1862,9 +1863,9 @@ class AdaptiveQueryExecSuite
           SQLConf.SHUFFLE_PARTITIONS.key -> "10",
           combineUnionConfig) {
         withTempView("t1", "t2") {
-          spark.sparkContext.parallelize((1 to 10).map(i => TestData(i, i.toString)), 2)
+          spark.sparkContext.parallelize((1 to 100).map(i => TestData(i, i.toString)), 2)
             .toDF().createOrReplaceTempView("t1")
-          spark.sparkContext.parallelize((1 to 10).map(i => TestData(i, i.toString)), 4)
+          spark.sparkContext.parallelize((1 to 100).map(i => TestData(i, i.toString)), 4)
             .toDF().createOrReplaceTempView("t2")
 
           // positive test that could be coalesced


### PR DESCRIPTION
### What changes were proposed in this pull request?
add a new AQE rule to propagate empty partitions

let A inner join B, when the i-th partition in A is empty, then we do not need to fetch the  i-th partition in B


### Why are the changes needed?
to prune shuffle partitions when possible


### Does this PR introduce _any_ user-facing change?
yes, a new sql conf added


### How was this patch tested?
added testsuits
