### PR TITLE
[SPARK-39093][SQL] Avoid codegen compilation error when dividing year-month intervals or day-time intervals by an integral

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -670,21 +670,20 @@ case class DivideYMInterval(
           case _ => classOf[IntMath].getName
         }
         val javaType = CodeGenerator.javaType(dataType)
-        val months = left.genCode(ctx)
-        val num = right.genCode(ctx)
-        val checkIntegralDivideOverflow =
-          s"""
-             |if (${months.value} == ${Int.MinValue} && ${num.value} == -1)
-             |  throw QueryExecutionErrors.overflowInIntegralDivideError($errorContext);
-             |""".stripMargin
-        nullSafeCodeGen(ctx, ev, (m, n) =>
+        nullSafeCodeGen(ctx, ev, (m, n) => {
+          val checkIntegralDivideOverflow =
+            s"""
+               |if ($m == ${Int.MinValue} && $n == -1)
+               |  throw QueryExecutionErrors.overflowInIntegralDivideError($errorContext);
+               |""".stripMargin
           // Similarly to non-codegen code. The result of `divide(Int, Long, ...)` must fit
           // to `Int`. Casting to `Int` is safe here.
           s"""
              |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
              |$checkIntegralDivideOverflow
              |${ev.value} = ($javaType)$math.divide($m, $n, java.math.RoundingMode.HALF_UP);
-          """.stripMargin)
+          """.stripMargin
+        })
       case _: DecimalType =>
         nullSafeCodeGen(ctx, ev, (m, n) =>
           s"""
@@ -744,19 +743,18 @@ case class DivideDTInterval(
     right.dataType match {
       case _: IntegralType =>
         val math = classOf[LongMath].getName
-        val micros = left.genCode(ctx)
-        val num = right.genCode(ctx)
-        val checkIntegralDivideOverflow =
-          s"""
-             |if (${micros.value} == ${Long.MinValue}L && ${num.value} == -1L)
-             |  throw QueryExecutionErrors.overflowInIntegralDivideError($errorContext);
-             |""".stripMargin
-        nullSafeCodeGen(ctx, ev, (m, n) =>
+        nullSafeCodeGen(ctx, ev, (m, n) => {
+          val checkIntegralDivideOverflow =
+            s"""
+               |if ($m == ${Long.MinValue}L && $n == -1L)
+               |  throw QueryExecutionErrors.overflowInIntegralDivideError($errorContext);
+               |""".stripMargin
           s"""
              |${divideByZeroCheckCodegen(right.dataType, n, errorContext)}
              |$checkIntegralDivideOverflow
              |${ev.value} = $math.divide($m, $n, java.math.RoundingMode.HALF_UP);
-          """.stripMargin)
+          """.stripMargin
+        })
       case _: DecimalType =>
         nullSafeCodeGen(ctx, ev, (m, n) =>
           s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2989,19 +2989,15 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     // scalastyle:on
   }
 
-  test("divide period by integral (wholestage codegen off") {
-    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
-      val df = Seq(((Period.ofDays(4)), 2)).toDF("pd", "num")
-      checkAnswer(df.select($"pd" / $"num"),
-        Seq((Period.ofDays(2))).toDF)
-    }
+  test("divide period by integral expression") {
+    val df = Seq(((Period.ofDays(10)), 2)).toDF("pd", "num")
+    checkAnswer(df.select($"pd" / ($"num" + 3)),
+      Seq((Period.ofDays(2))).toDF)
   }
 
-  test("divide duration by integral (wholestage codegen off") {
-    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
-      val df = Seq(((Duration.ofDays(4)), 2)).toDF("dd", "num")
-      checkAnswer(df.select($"dd" / $"num"),
-        Seq((Duration.ofDays(2))).toDF)
-    }
+  test("divide duration by integral expression") {
+    val df = Seq(((Duration.ofDays(10)), 2)).toDF("dd", "num")
+    checkAnswer(df.select($"dd" / ($"num" + 3)),
+      Seq((Duration.ofDays(2))).toDF)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2988,4 +2988,20 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     checkAnswer(uncDf.filter($"src".ilike("ѐёђѻώề")), Seq("ЀЁЂѺΏỀ").toDF())
     // scalastyle:on
   }
+
+  test("divide period by integral (wholestage codegen off") {
+    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+      val df = Seq(((Period.ofDays(4)), 2)).toDF("pd", "num")
+      checkAnswer(df.select($"pd" / $"num"),
+        Seq((Period.ofDays(2))).toDF)
+    }
+  }
+
+  test("divide duration by integral (wholestage codegen off") {
+    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+      val df = Seq(((Duration.ofDays(4)), 2)).toDF("dd", "num")
+      checkAnswer(df.select($"dd" / $"num"),
+        Seq((Duration.ofDays(2))).toDF)
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2989,13 +2989,13 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
     // scalastyle:on
   }
 
-  test("divide period by integral expression") {
+  test("SPARK-39093: divide period by integral expression") {
     val df = Seq(((Period.ofDays(10)), 2)).toDF("pd", "num")
     checkAnswer(df.select($"pd" / ($"num" + 3)),
       Seq((Period.ofDays(2))).toDF)
   }
 
-  test("divide duration by integral expression") {
+  test("SPARK-39093: divide duration by integral expression") {
     val df = Seq(((Duration.ofDays(10)), 2)).toDF("dd", "num")
     checkAnswer(df.select($"dd" / ($"num" + 3)),
       Seq((Duration.ofDays(2))).toDF)


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `DivideYMInterval#doGenCode` and `DivideDTInterval#doGenCode`, rely on the operand variable names provided by `nullSafeCodeGen` rather than calling `genCode` on the operands twice.


### Why are the changes needed?

`DivideYMInterval#doGenCode` and `DivideDTInterval#doGenCode` call `genCode` on the operands twice (once directly, and once indirectly via `nullSafeCodeGen`). However, if you call `genCode` on an operand twice, you might not get back the same variable name for both calls (e.g., when the operand is not a `BoundReference` or if whole-stage codegen is turned off). When that happens, `nullSafeCodeGen` generates initialization code for one set of variables, but the divide expression generates usage code for another set of variables, resulting in compilation errors like this:
```
spark-sql> create or replace temp view v1 as
         > select * FROM VALUES
         > (interval '10' months, interval '10' day, 2)
         > as v1(period, duration, num);
Time taken: 2.81 seconds
spark-sql> cache table v1;
Time taken: 2.184 seconds
spark-sql> select period/(num + 3) from v1;
22/05/03 08:56:37 ERROR CodeGenerator: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 40, Column 44: Expression "project_value_2" is not an rvalue
...
22/05/03 08:56:37 WARN UnsafeProjection: Expr codegen error and falling back to interpreter mode
...
0-2
Time taken: 0.149 seconds, Fetched 1 row(s)
spark-sql> select duration/(num + 3) from v1;
22/05/03 08:57:29 ERROR CodeGenerator: failed to compile: org.codehaus.commons.compiler.CompileException: File 'generated.java', Line 40, Column 54: Expression "project_value_2" is not an rvalue
...
22/05/03 08:57:29 WARN UnsafeProjection: Expr codegen error and falling back to interpreter mode
...
2 00:00:00.000000000
Time taken: 0.089 seconds, Fetched 1 row(s)
```
The error is not fatal (unless you have `spark.sql.codegen.fallback` set to `false`), but it muddies the log and can slow the query (since the expression is interpreted).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit tests (unit tests run with `spark.sql.codegen.fallback` set to `false`, so the new tests fail without the fix).
