### PR TITLE
[SPARK-39095][PYTHON] Adjust `GroupBy.std` to match pandas 1.4

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -640,6 +640,17 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         """
         assert ddof in (0, 1)
 
+        # Raise the TypeError when all aggregation columns are of unaccepted data types
+        all_unaccepted = True
+        for _agg_col in self._agg_columns:
+            if isinstance(_agg_col.spark.data_type, (NumericType, BooleanType)):
+                all_unaccepted = False
+                break
+        if all_unaccepted:
+            raise TypeError(
+                "Unaccepted data types of aggregation columns; numeric or bool expected."
+            )
+
         return self._reduce_for_stat_function(
             F.stddev_pop if ddof == 0 else F.stddev_samp,
             accepted_spark_types=(NumericType,),
@@ -2756,9 +2767,9 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
 
         Parameters
         ----------
-        sfun : The aggregate function to apply per column
+        sfun : The aggregate function to apply per column.
         accepted_spark_types: Accepted spark types of columns to be aggregated;
-                              default None means all spark types are accepted
+                              default None means all spark types are accepted.
         bool_to_numeric: If True, boolean columns are converted to numeric columns, which
                          are accepted for all statistical functions regardless of
                          `accepted_spark_types`.

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1286,13 +1286,24 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             ps.DataFrame({"B": [3.1, 3.1], "D": [0, 0]}, index=pd.Index([1, 2], name="A")),
         )
 
-        # TODO: fix bug of `std` and re-enable the test below
-        # self._test_stat_func(lambda groupby_obj: groupby_obj.std(), check_exact=False)
-        self.assert_eq(psdf.groupby("A").std(), pdf.groupby("A").std(), check_exact=False)
+        with self.assertRaisesRegex(
+            TypeError, "Unaccepted data types of aggregation columns; numeric or bool expected."
+        ):
+            psdf.groupby("A")[["C"]].std()
+
+        self.assert_eq(
+            psdf.groupby("A").std().sort_index(),
+            pdf.groupby("A").std().sort_index(),
+            check_exact=False,
+        )
 
         # TODO: fix bug of `sum` and re-enable the test below
         # self._test_stat_func(lambda groupby_obj: groupby_obj.sum(), check_exact=False)
-        self.assert_eq(psdf.groupby("A").sum(), pdf.groupby("A").sum(), check_exact=False)
+        self.assert_eq(
+            psdf.groupby("A").sum().sort_index(),
+            pdf.groupby("A").sum().sort_index(),
+            check_exact=False,
+        )
 
     def test_min(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.min())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust `GroupBy.std` to match pandas 1.4.

Specifically, raise the TypeError when all aggregation columns are of unaccepted data types.

### Why are the changes needed?
Improve API compatibility with pandas.

### Does this PR introduce _any_ user-facing change?
Yes.
```py
>>> psdf = ps.DataFrame(
...             {
...                 "A": [1, 2, 1, 2],
...                 "B": [3.1, 4.1, 4.1, 3.1],
...                 "C": ["a", "b", "b", "a"],
...                 "D": [True, False, False, True],
...             }
...         )
>>> psdf
   A    B  C      D
0  1  3.1  a   True
1  2  4.1  b  False
2  1  4.1  b  False
3  2  3.1  a   True

### Before
>>> psdf.groupby('A')[['C']].std()
Empty DataFrame
Columns: []
Index: [1, 2]

### After
>>> psdf.groupby('A')[['C']].std()
...
TypeError: Unaccepted data types of aggregation columns; numeric or bool expected.
```

### How was this patch tested?
Unit tests.