### PR TITLE
[SPARK-39100][CORE] RDD `DeterministicLevel` needs backward compatibility

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
+++ b/core/src/main/scala/org/apache/spark/ui/scope/RDDOperationGraph.scala
@@ -50,7 +50,7 @@ private[spark] case class RDDOperationNode(
     cached: Boolean,
     barrier: Boolean,
     callsite: String,
-    outputDeterministicLevel: DeterministicLevel.Value)
+    outputDeterministicLevel: DeterministicLevel.Value = DeterministicLevel.DETERMINATE)
 
 /**
  * A directed edge connecting two nodes in an RDDOperationGraph.
@@ -254,11 +254,7 @@ private[spark] object RDDOperationGraph extends Logging {
     } else {
       ""
     }
-    val outputDeterministicLevel = node.outputDeterministicLevel match {
-      case DeterministicLevel.DETERMINATE => ""
-      case DeterministicLevel.INDETERMINATE => " [Indeterminate]"
-      case DeterministicLevel.UNORDERED => " [Unordered]"
-    }
+    val outputDeterministicLevel = formatDeterministicLevel(node)
     val escapedCallsite = Utility.escape(node.callsite)
     val label = s"${node.name} [${node.id}]$isCached$isBarrier$outputDeterministicLevel" +
       s"<br>${escapedCallsite}"
@@ -279,5 +275,13 @@ private[spark] object RDDOperationGraph extends Logging {
       makeDotSubgraph(subgraph, cscope, indent + "  ")
     }
     subgraph.append(indent).append("}\n")
+  }
+
+  def formatDeterministicLevel(node: RDDOperationNode): String = {
+    node.outputDeterministicLevel match {
+      case DeterministicLevel.INDETERMINATE => " [Indeterminate]"
+      case DeterministicLevel.UNORDERED => " [Unordered]"
+      case _ => ""
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/scope/RDDOperationGraphSuite.scala
@@ -36,4 +36,19 @@ class RDDOperationGraphSuite extends SparkFunSuite {
 
     assert(c1 == c1copy)
   }
+
+  test("Test formatting DeterministicLevel") {
+    val n1 = new RDDOperationNode(3, "Marvin", false, false, "collect!",
+      DeterministicLevel.INDETERMINATE)
+    val n2 = new RDDOperationNode(3, "Marvin", false, false, "collect!",
+      DeterministicLevel.UNORDERED)
+    val n3 = new RDDOperationNode(3, "Marvin", false, false, "collect!",
+      DeterministicLevel.DETERMINATE)
+    val n4 = new RDDOperationNode(3, "Marvin", false, false, "collect!")
+
+    assert( " [Indeterminate]" === RDDOperationGraph.formatDeterministicLevel(n1))
+    assert( " [Unordered]" === RDDOperationGraph.formatDeterministicLevel(n2))
+    assert( "" === RDDOperationGraph.formatDeterministicLevel(n3))
+    assert( "" === RDDOperationGraph.formatDeterministicLevel(n4))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is to enhance backward compatibility for history server. Namely, RDD data w/o DeterministicLevel would be considered as DETERMINATE by default.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[SPARK-34592](https://issues.apache.org/jira/browse/SPARK-34592) introduces RDD DeterministicLevel - which would be used in Spark UI stage DAG visualization.

This is not a fully-backward compatible for History Server. In production, history server (despite its own version), could be responsible to deserialize job / RDD data even for multiple Spark versions. Historical RDD data from previous Spark version do have the new field, and UI rendering for stages / executors tab could crash with -

```
    throwable: { [-] 
      class:  scala.MatchError 
      msg:  null 
      stack: [ [-] 
        org.apache.spark.ui.scope.RDDOperationGraph$.org$apache$spark$ui$scope$RDDOperationGraph$$makeDotNode(RDDOperationGraph.scala:242) 
        org.apache.spark.ui.scope.RDDOperationGraph$$anonfun$org$apache$spark$ui$scope$RDDOperationGraph$$makeDotSubgraph$1.apply(RDDOperationGraph.scala:260) 
        org.apache.spark.ui.scope.RDDOperationGraph$$anonfun$org$apache$spark$ui$scope$RDDOperationGraph$$makeDotSubgraph$1.apply(RDDOperationGraph.scala:259) 
        scala.collection.immutable.Stream.foreach(Stream.scala:594) 
        org.apache.spark.ui.scope.RDDOperationGraph$.org$apache$spark$ui$scope$RDDOperationGraph$$makeDotSubgraph(RDDOperationGraph.scala:259) 
        org.apache.spark.ui.scope.RDDOperationGraph$$anonfun$org$apache$spark$ui$scope$RDDOperationGraph$$makeDotSubgraph$2.apply(RDDOperationGraph.scala:263) 
        org.apache.spark.ui.scope.RDDOperationGraph$$anonfun$org$apache$spark$ui$scope$RDDOperationGraph$$makeDotSubgraph$2.apply(RDDOperationGraph.scala:262) 
        scala.collection.immutable.Stream.foreach(Stream.scala:594) 
        org.apache.spark.ui.scope.RDDOperationGraph$.org$apache$spark$ui$scope$RDDOperationGraph$$makeDotSubgraph(RDDOperationGraph.scala:262) 
        org.apache.spark.ui.scope.RDDOperationGraph$.makeDotFile(RDDOperationGraph.scala:227) 
        org.apache.spark.ui.UIUtils$$anonfun$showDagViz$1.apply(UIUtils.scala:433) 
        org.apache.spark.ui.UIUtils$$anonfun$showDagViz$1.apply(UIUtils.scala:429) 
        scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234) 
        scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234) 
        scala.collection.immutable.List.foreach(List.scala:392) 
        scala.collection.TraversableLike$class.map(TraversableLike.scala:234) 
        scala.collection.immutable.List.map(List.scala:296) 
        org.apache.spark.ui.UIUtils$.showDagViz(UIUtils.scala:429) 
        org.apache.spark.ui.UIUtils$.showDagVizForStage(UIUtils.scala:401) 
        org.apache.spark.ui.jobs.StagePage.render(StagePage.scala:257) 
        org.apache.spark.ui.WebUI$$anonfun$2.apply(WebUI.scala:90) 
        org.apache.spark.ui.WebUI$$anonfun$2.apply(WebUI.scala:90) 
        org.apache.spark.ui.JettyUtils$$anon$3.doGet(JettyUtils.scala:90) 
        javax.servlet.http.HttpServlet.service(HttpServlet.java:687) 
        javax.servlet.http.HttpServlet.service(HttpServlet.java:790) 
        org.spark_project.jetty.servlet.ServletHolder.handle(ServletHolder.java:791) 
        org.spark_project.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1626) 
        org.spark_project.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) 
        org.spark_project.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601) 
        org.apache.spark.deploy.history.ApplicationCacheCheckFilter.doFilter(ApplicationCache.scala:405) 
        org.spark_project.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) 
        org.spark_project.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1601) 
        org.spark_project.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:548) 
        org.spark_project.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) 
        org.spark_project.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1435) 
        org.spark_project.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) 
        org.spark_project.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501) 
        org.spark_project.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) 
        org.spark_project.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1350) 
        org.spark_project.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) 
        org.spark_project.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:234) 
        org.spark_project.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) 
        org.spark_project.jetty.server.Server.handle(Server.java:516) 
        org.spark_project.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388) 
        org.spark_project.jetty.server.HttpChannel.dispatch(HttpChannel.java:633) 
        org.spark_project.jetty.server.HttpChannel.handle(HttpChannel.java:380) 
        org.spark_project.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) 
        org.spark_project.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) 
        org.spark_project.jetty.io.FillInterest.fillable(FillInterest.java:105) 
        org.spark_project.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) 
        org.spark_project.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336) 
        org.spark_project.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313) 
        org.spark_project.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171) 
        org.spark_project.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129) 
        org.spark_project.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:383) 
        org.spark_project.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:882) 
        org.spark_project.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1036) 
        java.lang.Thread.run(Thread.java:748) 
     ] 
   } 

```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test.