### PR TITLE
SPARK-39103: SparkContext.addFiles trigger backend exception if it tr…

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -767,9 +767,9 @@ private[spark] object Utils extends Logging {
       }
       val subfiles = source.listFiles()
       subfiles.foreach(f => copyRecursive(f, new File(dest, f.getName)))
-    } else {
+    } else if (source.isFile()) {
       Files.copy(source.toPath, dest.toPath)
-    }
+    } // Do nothing if source does not exist
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
In Utils.copyRecursive, make sure invoke Files.copy only if the source file exists

### Why are the changes needed?
Spark would throw a backend exception if the application try to add empty Hadoop files using SparkContext.addFile without the PR

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Adding a new unit test which otherwise fail without the PR