### PR TITLE
[SPARK-39113][CORE][MLLIB][PYTHON] Rename `self` to `cls`

### DIFF
--- a/python/pyspark/mllib/clustering.py
+++ b/python/pyspark/mllib/clustering.py
@@ -176,7 +176,7 @@ class BisectingKMeans:
 
     @classmethod
     def train(
-        self,
+        cls,
         rdd: RDD["VectorLike"],
         k: int = 4,
         maxIterations: int = 20,

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -79,7 +79,7 @@ class ExamplePointUDT(UserDefinedType):
     """
 
     @classmethod
-    def sqlType(self):
+    def sqlType(cls):
         return ArrayType(DoubleType(), False)
 
     @classmethod
@@ -124,7 +124,7 @@ class PythonOnlyUDT(UserDefinedType):
     """
 
     @classmethod
-    def sqlType(self):
+    def sqlType(cls):
         return ArrayType(DoubleType(), False)
 
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename `self` to `cls`


### Why are the changes needed?
Function def train(self....) is decorated as a @classmethod



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass existed tests.
