### PR TITLE
[DON'T MERGE] Replace `finalize()` with custom `ReferenceQueue` for `LevelDB/RocksDBIterator` cleanup 

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDB.java
@@ -20,6 +20,7 @@ package org.apache.spark.util.kvstore;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +35,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import org.fusesource.leveldbjni.JniDBFactory;
 import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.WriteBatch;
 
@@ -74,6 +76,9 @@ public class LevelDB implements KVStore {
    * to ensure that the iterator can be GCed, when it is only referenced here.
    */
   private final ConcurrentLinkedQueue<Reference<LevelDBIterator<?>>> iteratorTracker;
+  private final ReferenceQueue<LevelDBIterator<?>> referenceQueue;
+  private volatile boolean stopped = false;
+  private final Thread cleaningThread;
 
   public LevelDB(File path) throws Exception {
     this(path, new KVStoreSerializer());
@@ -107,6 +112,11 @@ public class LevelDB implements KVStore {
     typeAliases = new ConcurrentHashMap<>(aliases);
 
     iteratorTracker = new ConcurrentLinkedQueue<>();
+
+    referenceQueue = new ReferenceQueue<>();
+    cleaningThread = new Thread(this::keepCleaning);
+    cleaningThread.setDaemon(true);
+    cleaningThread.start();
   }
 
   @Override
@@ -251,7 +261,7 @@ public class LevelDB implements KVStore {
       public Iterator<T> iterator() {
         try {
           LevelDBIterator<T> it = new LevelDBIterator<>(type, LevelDB.this, this);
-          iteratorTracker.add(new WeakReference<>(it));
+          iteratorTracker.add(new LevelDBIteratorWeakReference(it, referenceQueue));
           return it;
         } catch (Exception e) {
           throw Throwables.propagate(e);
@@ -305,6 +315,7 @@ public class LevelDB implements KVStore {
       }
 
       try {
+        stopCleanupThread();
         if (iteratorTracker != null) {
           for (Reference<LevelDBIterator<?>> ref: iteratorTracker) {
             LevelDBIterator<?> it = ref.get();
@@ -318,20 +329,6 @@ public class LevelDB implements KVStore {
         throw ioe;
       } catch (Exception e) {
         throw new IOException(e.getMessage(), e);
-      }
-    }
-  }
-
-  /**
-   * Closes the given iterator if the DB is still open. Trying to close a JNI LevelDB handle
-   * with a closed DB can cause JVM crashes, so this ensures that situation does not happen.
-   */
-  void closeIterator(LevelDBIterator<?> it) throws IOException {
-    notifyIteratorClosed(it);
-    synchronized (this._db) {
-      DB _db = this._db.get();
-      if (_db != null) {
-        it.close();
       }
     }
   }
@@ -385,6 +382,31 @@ public class LevelDB implements KVStore {
     return alias;
   }
 
+  private void stopCleanupThread() throws InterruptedException {
+    if (cleaningThread != null) {
+      stopped = true;
+      cleaningThread.interrupt();
+      cleaningThread.join();
+    }
+  }
+
+  private void keepCleaning() {
+    if (!stopped) {
+      try {
+        Optional<? extends Reference<? extends LevelDBIterator<?>>> removed =
+          Optional.ofNullable(referenceQueue.remove(1000L));
+        if (removed.isPresent()) {
+          LevelDBIteratorWeakReference reference =
+                  (LevelDBIteratorWeakReference) removed.get();
+          iteratorTracker.remove(reference);
+          reference.close();
+        }
+      } catch (InterruptedException ignored) {
+        // do nothing
+      }
+    }
+  }
+
   /** Needs to be public for Jackson. */
   public static class TypeAliases {
 
@@ -424,4 +446,23 @@ public class LevelDB implements KVStore {
 
   }
 
+  private static class LevelDBIteratorWeakReference extends WeakReference<LevelDBIterator<?>> {
+
+    private final DBIterator it;
+
+    LevelDBIteratorWeakReference(
+        LevelDBIterator<?> referent,
+        ReferenceQueue<? super LevelDBIterator<?>> q) {
+      super(referent, q);
+      it = referent.internalIterator();
+    }
+
+    public void close() {
+      try {
+        it.close();
+      } catch (IOException ioe) {
+        // ignored
+      }
+    }
+  }
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -192,17 +192,6 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
     }
   }
 
-  /**
-   * Because it's tricky to expose closeable iterators through many internal APIs, especially
-   * when Scala wrappers are used, this makes sure that, hopefully, the JNI resources held by
-   * the iterator will eventually be released.
-   */
-  @SuppressWarnings("deprecation")
-  @Override
-  protected void finalize() throws Throwable {
-    db.closeIterator(this);
-  }
-
   private byte[] loadNext() {
     if (count >= max) {
       return null;
@@ -282,4 +271,7 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
     return a.length - b.length;
   }
 
+  DBIterator internalIterator() {
+    return it;
+  }
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDB.java
@@ -20,6 +20,7 @@ package org.apache.spark.util.kvstore;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -111,6 +112,9 @@ public class RocksDB implements KVStore {
    * to ensure that the iterator can be GCed, when it is only referenced here.
    */
   private final ConcurrentLinkedQueue<Reference<RocksDBIterator<?>>> iteratorTracker;
+  private final ReferenceQueue<RocksDBIterator<?>> referenceQueue;
+  private volatile boolean stopped = false;
+  private final Thread cleaningThread;
 
   public RocksDB(File path) throws Exception {
     this(path, new KVStoreSerializer());
@@ -141,6 +145,11 @@ public class RocksDB implements KVStore {
     typeAliases = new ConcurrentHashMap<>(aliases);
 
     iteratorTracker = new ConcurrentLinkedQueue<>();
+
+    referenceQueue = new ReferenceQueue<>();
+    cleaningThread = new Thread(this::keepCleaning);
+    cleaningThread.setDaemon(true);
+    cleaningThread.start();
   }
 
   @Override
@@ -284,7 +293,7 @@ public class RocksDB implements KVStore {
       public Iterator<T> iterator() {
         try {
           RocksDBIterator<T> it = new RocksDBIterator<>(type, RocksDB.this, this);
-          iteratorTracker.add(new WeakReference<>(it));
+          iteratorTracker.add(new RocksDBIteratorWeakReference(it, referenceQueue));
           return it;
         } catch (Exception e) {
           throw Throwables.propagate(e);
@@ -338,6 +347,7 @@ public class RocksDB implements KVStore {
       }
 
       try {
+        stopCleanupThread();
         if (iteratorTracker != null) {
           for (Reference<RocksDBIterator<?>> ref: iteratorTracker) {
             RocksDBIterator<?> it = ref.get();
@@ -351,20 +361,6 @@ public class RocksDB implements KVStore {
         throw ioe;
       } catch (Exception e) {
         throw new IOException(e.getMessage(), e);
-      }
-    }
-  }
-
-  /**
-   * Closes the given iterator if the DB is still open. Trying to close a JNI RocksDB handle
-   * with a closed DB can cause JVM crashes, so this ensures that situation does not happen.
-   */
-  void closeIterator(RocksDBIterator<?> it) throws IOException {
-    notifyIteratorClosed(it);
-    synchronized (this._db) {
-      org.rocksdb.RocksDB _db = this._db.get();
-      if (_db != null) {
-        it.close();
       }
     }
   }
@@ -418,6 +414,32 @@ public class RocksDB implements KVStore {
     return alias;
   }
 
+  private void stopCleanupThread() throws InterruptedException {
+    if (cleaningThread != null) {
+      stopped = true;
+      cleaningThread.interrupt();
+      cleaningThread.join();
+    }
+  }
+
+  private void keepCleaning() {
+    if (!stopped) {
+      try {
+        Optional<? extends Reference<? extends RocksDBIterator<?>>> removed =
+          Optional.ofNullable(referenceQueue.remove(1000L));
+        if (removed.isPresent()) {
+          RocksDBIteratorWeakReference reference =
+            (RocksDBIteratorWeakReference) removed.get();
+          iteratorTracker.remove(reference);
+          reference.close();
+        }
+      } catch (InterruptedException ignored) {
+        // do nothing
+      }
+    }
+  }
+
+
   /** Needs to be public for Jackson. */
   public static class TypeAliases {
 
@@ -454,7 +476,21 @@ public class RocksDB implements KVStore {
       }
       return prefix;
     }
-
   }
 
+  private static class RocksDBIteratorWeakReference extends WeakReference<RocksDBIterator<?>> {
+
+    private final RocksIterator it;
+
+    RocksDBIteratorWeakReference(
+        RocksDBIterator<?> referent,
+        ReferenceQueue<? super RocksDBIterator<?>> q) {
+      super(referent, q);
+      it = referent.internalIterator();
+    }
+
+    public void close() {
+      it.close();
+    }
+  }
 }

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
@@ -186,16 +186,6 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
     }
   }
 
-  /**
-   * Because it's tricky to expose closeable iterators through many internal APIs, especially
-   * when Scala wrappers are used, this makes sure that, hopefully, the JNI resources held by
-   * the iterator will eventually be released.
-   */
-  @Override
-  protected void finalize() throws Throwable {
-    db.closeIterator(this);
-  }
-
   private byte[] loadNext() {
     if (count >= max) {
       return null;
@@ -274,4 +264,7 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
     return a.length - b.length;
   }
 
+  RocksIterator internalIterator() {
+    return it;
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
