### PR TITLE
[SPARK-39114][ML] ml.optim.aggregator avoid re-allocating buffers

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberBlockAggregator.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/optim/aggregator/HuberBlockAggregator.scala
@@ -70,6 +70,8 @@ private[ml] class HuberBlockAggregator(
     Double.NaN
   }
 
+  @transient private var buffer: Array[Double] = _
+
   /**
    * Add a new training instance block to this HuberBlockAggregator, and update the loss
    * and gradient of the objective function.
@@ -87,10 +89,18 @@ private[ml] class HuberBlockAggregator(
     if (block.weightIter.forall(_ == 0)) return this
     val size = block.size
 
+    if (buffer == null || buffer.length < size) {
+      buffer = Array.ofDim[Double](size)
+    }
+
     // arr here represents margins
-    val arr = Array.ofDim[Double](size)
-    if (fitIntercept) java.util.Arrays.fill(arr, marginOffset)
-    BLAS.gemv(1.0, block.matrix, coefficientsArray, 1.0, arr)
+    val arr = buffer
+    if (fitIntercept) {
+      java.util.Arrays.fill(arr, 0, size, marginOffset)
+      BLAS.gemv(1.0, block.matrix, coefficientsArray, 1.0, arr)
+    } else {
+      BLAS.gemv(1.0, block.matrix, coefficientsArray, 0.0, arr)
+    }
 
     // in-place convert margins to multiplier
     // then, arr represents multiplier


### PR DESCRIPTION
### What changes were proposed in this pull request?

ml.optim.aggregator avoid re-allocating buffers


### Why are the changes needed?

in SPARK-30661 (KMeans blockify input vectors), I found that it is sometimes performance-crucial to avoid re-allocating buffers for each blocks.

It should be nice to also apply this optimization to other algorithms.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing testsuites