### PR TITLE
[SPARK-39121][K8S][DOCS] Fix format error on running-on-kubernetes doc

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1699,7 +1699,7 @@ Kubernetes supports [Pod priority](https://kubernetes.io/docs/concepts/schedulin
 
 Spark on Kubernetes allows defining the priority of jobs by [Pod template](#pod-template). The user can specify the <code>priorityClassName</code> in driver or executor Pod template <code>spec</code> section. Below is an example to show how to specify it:
 
-```
+```yaml
 apiVersion: v1
 Kind: Pod
 metadata:
@@ -1729,8 +1729,8 @@ Spark allows users to specify a custom Kubernetes schedulers.
 3. Specify scheduler feature step.
 
    Users may also consider to use <code>spark.kubernetes.{driver/executor}.pod.featureSteps</code> to support more complex requirements, including but not limited to:
-  - Create additional Kubernetes custom resources for driver/executor scheduling.
-  - Set scheduler hints according to configuration or existing Pod info dynamically.
+   - Create additional Kubernetes custom resources for driver/executor scheduling.
+   - Set scheduler hints according to configuration or existing Pod info dynamically.
 
 #### Using Volcano as Customized Scheduler for Spark on Kubernetes
 
@@ -1766,7 +1766,7 @@ To use Volcano as a custom scheduler the user needs to specify the following con
 --conf spark.kubernetes.scheduler.volcano.podGroupTemplateFile=/path/to/podgroup-template.yaml
 # Specify driver/executor VolcanoFeatureStep
 --conf spark.kubernetes.driver.pod.featureSteps=org.apache.spark.deploy.k8s.features.VolcanoFeatureStep
---conf spark.kubernetes.executor.pod.featureSteps=org.apache.spark.deploy.k8s.features.VolcanoFeatureStep```
+--conf spark.kubernetes.executor.pod.featureSteps=org.apache.spark.deploy.k8s.features.VolcanoFeatureStep
 ```
 
 ##### Volcano Feature Step


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix format error on running-on-kubernetes doc

### Why are the changes needed?
Fix format syntax error 


### Does this PR introduce _any_ user-facing change?
No, unreleased doc only


### How was this patch tested?
- `SKIP_API=1 bundle exec jekyll serve --watch`
- CI passed