### PR TITLE
[SPARK-39123][BUILD] Upgrade `org.scalatestplus:mockito` to 3.2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>mockito-4-2_${scala.binary.version}</artifactId>
+      <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1143,8 +1143,8 @@
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>mockito-4-2_${scala.binary.version}</artifactId>
-        <version>3.2.11.0</version>
+        <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
+        <version>3.2.12.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1156,13 +1156,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.2.0</version>
+        <version>4.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>4.2.0</version>
+        <version>4.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `org.scalatestplus:mockito-4-2_${scala.binary.version}:3.2.11.0` to `org.scalatestplus:mockito-4-5_${scala.binary.version}:3.2.12.0` and mockito from 4.2.0 to 4.5.1.

### Why are the changes needed?
Upgrade `org.scalatestplus:mockito` to use mockito 4.5.1, the upgrade of the `mockito`only brought some bug fixes of itself:

- https://github.com/mockito/mockito/releases/tag/v4.3.0
- https://github.com/mockito/mockito/releases/tag/v4.3.1
- https://github.com/mockito/mockito/releases/tag/v4.4.0
- https://github.com/mockito/mockito/releases/tag/v4.5.0
- https://github.com/mockito/mockito/releases/tag/v4.5.1

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GA