### PR TITLE
[SPARK-39093][SQL][FOLLOWUP] Fix Period test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -2990,9 +2990,9 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SPARK-39093: divide period by integral expression") {
-    val df = Seq(((Period.ofDays(10)), 2)).toDF("pd", "num")
+    val df = Seq(((Period.ofMonths(10)), 2)).toDF("pd", "num")
     checkAnswer(df.select($"pd" / ($"num" + 3)),
-      Seq((Period.ofDays(2))).toDF)
+      Seq((Period.ofMonths(2))).toDF)
   }
 
   test("SPARK-39093: divide duration by integral expression") {


### PR DESCRIPTION

### What changes were proposed in this pull request?

Change the Period test to use months rather than days.

### Why are the changes needed?

While the Period test as-is confirms that the compilation error is fixed, it doesn't confirm that the newly generated code is correct. Spark ignores any unit less than months in Periods. As a result, we are always testing `0/(num + 3)`, so the test doesn't verify that the code generated for the right-hand operand is correct.

### Does this PR introduce _any_ user-facing change?

No, only changes a test.

### How was this patch tested?

Unit test.
