### PR TITLE
[SPARK-39126][SQL] After eliminating join to one side, that side should take advantage of LocalShuffleRead optimization

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionExtensionSuite.scala
@@ -858,6 +858,9 @@ case class MyShuffleExchangeExec(delegate: ShuffleExchangeExec) extends ShuffleE
   override def shuffleOrigin: ShuffleOrigin = {
     delegate.shuffleOrigin
   }
+  override def changeShuffleOrigin(origin: ShuffleOrigin): Unit = {
+    delegate.shuffleOrigin = origin
+  }
   override def mapOutputStatisticsFuture: Future[MapOutputStatistics] =
     delegate.submitShuffleJob
   override def getShuffleRDD(partitionSpecs: Array[ShufflePartitionSpec]): RDD[_] =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2575,6 +2575,21 @@ class AdaptiveQueryExecSuite
       assert(findTopLevelAggregate(adaptive5).size == 4)
     }
   }
+
+  test("After eliminating join to one side, that side should " +
+    "take advantage of LocalShuffleRead optimization") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "1000") {
+      val (_, adaptivePlan) = runAdaptiveAndVerifyResult(
+        "SELECT * FROM testData LEFT JOIN testData2 ON key = a and a > 10")
+      val localReads = collect(adaptivePlan) {
+        case read: AQEShuffleReadExec if read.isLocalRead => read
+      }
+      assert(localReads.length > 0)
+    }
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2576,7 +2576,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("After eliminating join to one side, that side should " +
+  test("SPARK-39126: After eliminating join to one side, that side should " +
     "take advantage of LocalShuffleRead optimization") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",


### PR DESCRIPTION
### What changes were proposed in this pull request?
PropagateEmptyRelation can simplify Join. For example, if the right side of LEFT JOIN is empty, then it can eliminate join to its left side.

If there is a shuffle on the left side, it can be considered that the shuffle is meaningless, and the shuffle can be optimized by using LocalRead.

For example:
```sql
SELECT * FROM testData LEFT JOIN testData2 ON key = a and a > 10
```
Before this pr:
```tex
AdaptiveSparkPlan isFinalPlan=true
+- == Final Plan ==
   *(3) Project [key#13, value#14, cast(null as int) AS a#23, cast(null as int) AS b#24]
   +- AQEShuffleRead coalesced
      +- ShuffleQueryStage 0
         +- Exchange hashpartitioning(key#13, 5), ENSURE_REQUIREMENTS_MEANINGLESS, [id=#107]
            +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).value, true, false, true) AS value#14]
               +- Scan[obj#12]
```
After this pr:
```tex
AdaptiveSparkPlan isFinalPlan=true
+- == Final Plan ==
   *(3) Project [key#13, value#14, cast(null as int) AS a#23, cast(null as int) AS b#24]
   +- AQEShuffleRead local
      +- ShuffleQueryStage 0
         +- Exchange hashpartitioning(key#13, 5), ENSURE_REQUIREMENTS_MEANINGLESS, [id=#107]
            +- *(1) SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#13, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).value, true, false, true) AS value#14]
               +- Scan[obj#12]
```


### Why are the changes needed?
Avoid remote shuffle read and improve efficiency.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.
