### PR TITLE
[SPARK-39112][SQL] UnsupportedOperationException if spark.sql.ui.explainMode is set to cost

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/v2ResolutionPlans.scala
@@ -20,7 +20,8 @@ package org.apache.spark.sql.catalyst.analysis
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, LeafExpression, Unevaluable}
-import org.apache.spark.sql.catalyst.plans.logical.LeafNode
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, Statistics}
+import org.apache.spark.sql.catalyst.trees.LeafLike
 import org.apache.spark.sql.catalyst.trees.TreePattern.{TreePattern, UNRESOLVED_FUNC}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogPlugin, FunctionCatalog, Identifier, Table, TableCatalog}
@@ -141,10 +142,18 @@ case class UnresolvedDBObjectName(nameParts: Seq[String], isNamespace: Boolean) 
 }
 
 /**
+ * A resolved leaf like node that its statistics is no meaning.
+ */
+trait ResolvedLeafObject extends LogicalPlan with LeafLike[LogicalPlan] {
+  // Here we just return a dummy statistics to avoid compute statsCache
+  override def stats: Statistics = Statistics.DUMMY
+}
+
+/**
  * A plan containing resolved namespace.
  */
 case class ResolvedNamespace(catalog: CatalogPlugin, namespace: Seq[String])
-  extends LeafNode {
+  extends ResolvedLeafObject {
   override def output: Seq[Attribute] = Nil
 }
 
@@ -156,7 +165,7 @@ case class ResolvedTable(
     identifier: Identifier,
     table: Table,
     outputAttributes: Seq[Attribute])
-  extends LeafNode {
+  extends ResolvedLeafObject {
   override def output: Seq[Attribute] = {
     val qualifier = catalog.name +: identifier.namespace :+ identifier.name
     outputAttributes.map(_.withQualifier(qualifier))
@@ -191,7 +200,7 @@ case class ResolvedFieldPosition(position: ColumnPosition) extends FieldPosition
  */
 // TODO: create a generic representation for temp view, v1 view and v2 view, after we add view
 //       support to v2 catalog. For now we only need the identifier to fallback to v1 command.
-case class ResolvedView(identifier: Identifier, isTemp: Boolean) extends LeafNode {
+case class ResolvedView(identifier: Identifier, isTemp: Boolean) extends ResolvedLeafObject {
   override def output: Seq[Attribute] = Nil
 }
 
@@ -202,20 +211,26 @@ case class ResolvedPersistentFunc(
     catalog: FunctionCatalog,
     identifier: Identifier,
     func: UnboundFunction)
-  extends LeafNode {
+  extends ResolvedLeafObject {
   override def output: Seq[Attribute] = Nil
 }
 
 /**
  * A plan containing resolved non-persistent (temp or built-in) function.
  */
-case class ResolvedNonPersistentFunc(name: String, func: UnboundFunction) extends LeafNode {
+case class ResolvedNonPersistentFunc(
+    name: String,
+    func: UnboundFunction)
+  extends ResolvedLeafObject {
   override def output: Seq[Attribute] = Nil
 }
 
 /**
  * A plan containing resolved database object name with catalog determined.
  */
-case class ResolvedDBObjectName(catalog: CatalogPlugin, nameParts: Seq[String]) extends LeafNode {
+case class ResolvedDBObjectName(
+    catalog: CatalogPlugin,
+    nameParts: Seq[String])
+  extends ResolvedLeafObject {
   override def output: Seq[Attribute] = Nil
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -528,6 +528,23 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
         "== Analyzed Logical Plan ==\nCreateViewCommand")
     }
   }
+
+  test("SPARK-39112: UnsupportedOperationException if spark.sql.ui.explainMode is set to cost") {
+    withSQLConf(SQLConf.UI_EXPLAIN_MODE.key -> "cost") {
+      withTempDir { dir =>
+        sql("CREATE DATABASE tmp")
+        sql("DESC DATABASE tmp")
+        sql(s"ALTER DATABASE tmp SET LOCATION '${dir.toURI.toString}'")
+        sql("USE tmp")
+        sql("CREATE TABLE t(c1 int) USING PARQUET")
+        sql("SHOW TABLES")
+        sql("SHOW CREATE TABLE t")
+        sql("SHOW TBLPROPERTIES t")
+        sql("DROP TABLE t")
+        sql("DROP DATABASE tmp")
+      }
+    }
+  }
 }
 
 class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -529,20 +529,18 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
     }
   }
 
-  test("SPARK-39112: UnsupportedOperationException if spark.sql.ui.explainMode is set to cost") {
-    withSQLConf(SQLConf.UI_EXPLAIN_MODE.key -> "cost") {
-      withTempDir { dir =>
-        sql("CREATE DATABASE tmp")
-        sql("DESC DATABASE tmp")
-        sql(s"ALTER DATABASE tmp SET LOCATION '${dir.toURI.toString}'")
-        sql("USE tmp")
-        sql("CREATE TABLE t(c1 int) USING PARQUET")
-        sql("SHOW TABLES")
-        sql("SHOW CREATE TABLE t")
-        sql("SHOW TBLPROPERTIES t")
-        sql("DROP TABLE t")
-        sql("DROP DATABASE tmp")
-      }
+  test("SPARK-39112: UnsupportedOperationException if explain cost command using v2 command") {
+    withTempDir { dir =>
+      sql("EXPLAIN COST CREATE DATABASE tmp")
+      sql("EXPLAIN COST DESC DATABASE tmp")
+      sql(s"EXPLAIN COST ALTER DATABASE tmp SET LOCATION '${dir.toURI.toString}'")
+      sql("EXPLAIN COST USE tmp")
+      sql("EXPLAIN COST CREATE TABLE t(c1 int) USING PARQUET")
+      sql("EXPLAIN COST SHOW TABLES")
+      sql("EXPLAIN COST SHOW CREATE TABLE t")
+      sql("EXPLAIN COST SHOW TBLPROPERTIES t")
+      sql("EXPLAIN COST DROP TABLE t")
+      sql("EXPLAIN COST DROP DATABASE tmp")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new leaf like node `LeafNodeWithoutStats` and apply to the list:
- ResolvedDBObjectName
- ResolvedNamespace
- ResolvedTable
- ResolvedView
- ResolvedNonPersistentFunc
- ResolvedPersistentFunc



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We enable v2 command at 3.3.0 branch by default `spark.sql.legacy.useV1Command`. However this is a behavior change between v1 and c2 command.

- v1 command:
  We resolve logical plan to command at analyzer phase by `ResolveSessionCatalog`

- v2 commnd:
  We resolve logical plan to v2 command at physical phase by `DataSourceV2Strategy`

Foe cost explain mode, we will call `LogicalPlanStats.stats` using optimized plan so there is a gap between v1 and v2 command.
Unfortunately, the logical plan of v2 command contains the `LeafNode` which does not override the `computeStats`. As a result, there is a error running such sql:
```sql
set spark.sql.ui.explainMode=cost;
show tables;
```

```
java.lang.UnsupportedOperationException:
	at org.apache.spark.sql.catalyst.plans.logical.LeafNode.computeStats(LogicalPlan.scala:171)
	at org.apache.spark.sql.catalyst.plans.logical.LeafNode.computeStats$(LogicalPlan.scala:171)
	at org.apache.spark.sql.catalyst.analysis.ResolvedNamespace.computeStats(v2ResolutionPlans.scala:155)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.default(SizeInBytesOnlyStatsPlanVisitor.scala:55)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.default(SizeInBytesOnlyStatsPlanVisitor.scala:27)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlanVisitor.visit(LogicalPlanVisitor.scala:49)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlanVisitor.visit$(LogicalPlanVisitor.scala:25)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.visit(SizeInBytesOnlyStatsPlanVisitor.scala:27)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.$anonfun$stats$1(LogicalPlanStats.scala:37)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.stats(LogicalPlanStats.scala:33)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.stats$(LogicalPlanStats.scala:33)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.stats(LogicalPlan.scala:30)
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, bug fix

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test