### PR TITLE
[SPARK-39133][PYTHON][DOC] Mention log level setting in PYSPARK_JVM_STACKTRACE_ENABLED

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2577,8 +2577,9 @@ object SQLConf {
   val PYSPARK_JVM_STACKTRACE_ENABLED =
     buildConf("spark.sql.pyspark.jvmStacktrace.enabled")
       .doc("When true, it shows the JVM stacktrace in the user-facing PySpark exception " +
-        "together with Python stacktrace. By default, it is disabled and hides JVM stacktrace " +
-        "and shows a Python-friendly exception only.")
+        "together with Python stacktrace. By default, it is disabled to hide JVM stacktrace " +
+        "and shows a Python-friendly exception only (Note that is independent from log level" +
+        "settings. Set log level to FATAL to see Python exceptions only).")
       .version("3.0.0")
       .booleanConf
       // show full stacktrace in tests but hide in production by default.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2578,7 +2578,7 @@ object SQLConf {
     buildConf("spark.sql.pyspark.jvmStacktrace.enabled")
       .doc("When true, it shows the JVM stacktrace in the user-facing PySpark exception " +
         "together with Python stacktrace. By default, it is disabled to hide JVM stacktrace " +
-        "and shows a Python-friendly exception only. Note that this is independent from log "
+        "and shows a Python-friendly exception only. Note that this is independent from log " +
         "level settings.")
       .version("3.0.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2578,8 +2578,8 @@ object SQLConf {
     buildConf("spark.sql.pyspark.jvmStacktrace.enabled")
       .doc("When true, it shows the JVM stacktrace in the user-facing PySpark exception " +
         "together with Python stacktrace. By default, it is disabled to hide JVM stacktrace " +
-        "and shows a Python-friendly exception only (Note that is independent from log level" +
-        "settings. Set log level to FATAL to see Python exceptions only).")
+        "and shows a Python-friendly exception only. Note that this is independent from log "
+        "level settings.")
       .version("3.0.0")
       .booleanConf
       // show full stacktrace in tests but hide in production by default.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mention log level setting in PYSPARK_JVM_STACKTRACE_ENABLED.

### Why are the changes needed?
Even if `spark.sql.pyspark.jvmStacktrace.enabled`  is set False, we should set log level to FATAL to see Python exceptions only. The PR is proposed to document that.

### Does this PR introduce _any_ user-facing change?
No. Documents change only.

### How was this patch tested?
Manual tests.
