### PR TITLE
[SPARK-38739][SQL][TESTS] Test the error class: INVALID_SYNTAX_FOR_CAST

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -116,16 +116,9 @@ object QueryExecutionErrors extends QueryErrorsBase {
   }
 
   def invalidInputSyntaxForNumericError(
-      e: NumberFormatException,
-      errorContext: String): NumberFormatException = {
-    new NumberFormatException(s"${e.getMessage}. To return NULL instead, use 'try_cast'. " +
-      s"If necessary set ${SQLConf.ANSI_ENABLED.key} to false to bypass this error." + errorContext)
-  }
-
-  def invalidInputSyntaxForNumericError(
       to: DataType,
       s: UTF8String,
-      errorContext: String): NumberFormatException = {
+      errorContext: String): SparkNumberFormatException = {
     new SparkNumberFormatException(errorClass = "INVALID_SYNTAX_FOR_CAST",
       messageParameters = Array(toSQLType(to), toSQLValue(s, StringType),
         SQLConf.ANSI_ENABLED.key, errorContext))

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.errors
 
-import org.apache.spark.{SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkConf, SparkDateTimeException, SparkNoSuchElementException}
+import org.apache.spark.{SparkArithmeticException, SparkArrayIndexOutOfBoundsException, SparkConf, SparkDateTimeException, SparkNoSuchElementException, SparkNumberFormatException}
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.internal.SQLConf
 
@@ -123,5 +123,20 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
           |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           |""".stripMargin
     )
+  }
+
+  test("INVALID_SYNTAX_FOR_CAST: cast string to double") {
+    checkErrorClass(
+      exception = intercept[SparkNumberFormatException] {
+        sql("select CAST('111111111111xe23' AS DOUBLE)").collect()
+      },
+      errorClass = "INVALID_SYNTAX_FOR_CAST",
+      msg = """Invalid input syntax for type "DOUBLE": '111111111111xe23'. """ +
+        """To return NULL instead, use 'try_cast'. If necessary set """ +
+        """spark.sql.ansi.enabled to false to bypass this error.
+          |== SQL(line 1, position 7) ==
+          |select CAST('111111111111xe23' AS DOUBLE)
+          |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          |""".stripMargin)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR aims to add a test for the error class INVALID_SYNTAX_FOR_CAST to `QueryExecutionErrors`. Also the method `invalidInputSyntaxForNumericError` is removed as no longer used.

### Why are the changes needed?
The changes improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *QueryExecutionAnsiErrorsSuite"
```