### PR TITLE
[SPARK-39136][SQL] JDBCTable support table properties

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTable.scala
@@ -40,6 +40,8 @@ case class JDBCTable(ident: Identifier, schema: StructType, jdbcOptions: JDBCOpt
     util.EnumSet.of(BATCH_READ, V1_BATCH_WRITE, TRUNCATE)
   }
 
+  override def properties(): util.Map[String, String] = jdbcOptions.parameters.toMap.asJava
+
   override def newScanBuilder(options: CaseInsensitiveStringMap): JDBCScanBuilder = {
     val mergedOptions = new JDBCOptions(
       jdbcOptions.parameters.originalMap ++ options.asCaseSensitiveMap().asScala)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1296,4 +1296,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       }
     }
   }
+
+  test("SPARK-39136: JDBCTable support table properties") {
+    assert(
+      sql("DESC FORMATTED h2.test.employee")
+        .collect()
+        .filter(_.getString(0) == "Table Properties")
+        .head.getString(1)
+        .contains("dbtable=\"test\".\"employee\""))
+  }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Currently, when call `DESC EXTENDED` at an JDBCTable, there is no table properties, user don't know the related url information.
```
> desc formatted jdbc.test.people;
NAME	string
ID	int

# Partitioning
Not partitioned

# Detailed Table Information
Name	test.people
Table Properties	[]
Time taken: 0.048 seconds, Fetched 9 row(s)
``` 

After this pr:
```
+----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------+
|                    col_name|                                                                                                                                                                                                                                      data_type|comment|
+----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------+
|                        DEPT|                                                                                                                                                                                                                                            int|       |
|                        NAME|                                                                                                                                                                                                                                         string|       |
|                      SALARY|                                                                                                                                                                                                                                  decimal(20,2)|       |
|                       BONUS|                                                                                                                                                                                                                                         double|       |
|                  IS_MANAGER|                                                                                                                                                                                                                                        boolean|       |
|                            |                                                                                                                                                                                                                                               |       |
|              # Partitioning|                                                                                                                                                                                                                                               |       |
|             Not partitioned|                                                                                                                                                                                                                                               |       |
|                            |                                                                                                                                                                                                                                               |       |
|# Detailed Table Information|                                                                                                                                                                                                                                               |       |
|                        Name|                                                                                                                                                                                                                                  test.employee|       |
|            Table Properties|[dbtable="test"."employee",driver=org.h2.Driver,pushDownAggregate=true,pushDownLimit=true,url=jdbc:h2:/Users/yi.zhu/Documents/project/Angerszhuuuu/spark/target/tmp/spark-f6094e60-b18a-4591-afb5-c284f1700304;user=testUser;password=testPass]|       |
+----------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------+
```


### Why are the changes needed?
When desc JDBCTable, make it can show JDBCOptions as table properties. Make user easy to check 


### Does this PR introduce _any_ user-facing change?
User can use DESC EXTENDED to know JDBCTable's JDBCOptions


### How was this patch tested?
Added UT