### PR TITLE
[SPARK-39131][SQL] Rewrite exists as LeftSemi earlier to allow filters to be inferred 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -137,6 +137,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     val operatorOptimizationBatch: Seq[Batch] = {
       Batch("Operator Optimization before Inferring Filters", fixedPoint,
         operatorOptimizationRuleSet: _*) ::
+      Batch("RewritePredicateSubquery before Inferring Filters", Once,
+        RewritePredicateSubquery) ::
       Batch("Infer Filters", Once,
         InferFiltersFromGenerate,
         InferFiltersFromConstraints) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1156,14 +1156,14 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // positive not in subquery case
       var joinExec = assertJoin((
-        "select * from testData where key not in (select a from testData2)",
+        "select * from testData where key not in (select a from testData2WithNullKeys)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
-      // negative not in subquery case since multi-column is not supported
-      assertJoin((
-        "select * from testData where (key, key + 1) not in (select * from testData2)",
-        classOf[BroadcastNestedLoopJoinExec]))
+     // negative not in subquery case since multi-column is not supported
+     //assertJoin((
+     //  "select * from testData where (key, key + 1) not in (select * from testData2WithNullKeys)",
+     //  classOf[BroadcastNestedLoopJoinExec]))
 
       // positive hand-written left anti join
       // testData.key nullable false

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1156,14 +1156,14 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // positive not in subquery case
       var joinExec = assertJoin((
-        "select * from testData where key not in (select a from testData2WithNullKeys)",
+        "select * from testData where key not in (select a from testData2WithNulls)",
         classOf[BroadcastHashJoinExec]))
       assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
 
-     // negative not in subquery case since multi-column is not supported
-     //assertJoin((
-     //  "select * from testData where (key, key + 1) not in (select * from testData2WithNullKeys)",
-     //  classOf[BroadcastNestedLoopJoinExec]))
+      // negative not in subquery case since multi-column is not supported
+      assertJoin((
+        "select * from testData where (key, key + 1) not in (select * from testData2WithNulls)",
+        classOf[BroadcastNestedLoopJoinExec]))
 
       // positive hand-written left anti join
       // testData.key nullable false

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1906,7 +1906,12 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
   test("SPARK-39131: Infer filters after RewritePredicateSubquery") {
     withTable("t1", "t2") {
-      sql("CREATE TABLE t1 USING parquet AS SELECT IF(id < 5, null, id) as key, id AS value FROM range(10)")
+      sql(
+        """
+          |CREATE TABLE t1 USING parquet AS
+          |SELECT IF(id < 5, null, id) as key, id AS value
+          |FROM range(10)
+          |""".stripMargin)
       val df = sql(
         """
           |SELECT *

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -69,15 +69,15 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
-  protected lazy val testData2WithNullKeys: DataFrame = {
+  protected lazy val testData2WithNulls: DataFrame = {
     val df = spark.sparkContext.parallelize(
-      TestData2WithNullKeys(1, 1) ::
-      TestData2WithNullKeys(null, 2) ::
-      TestData2WithNullKeys(2, 1) ::
-      TestData2WithNullKeys(2, 2) ::
-      TestData2WithNullKeys(null, 1) ::
-      TestData2WithNullKeys(3, 2) :: Nil, 2).toDF()
-    df.createOrReplaceTempView("testData2WithNullKeys")
+      TestData2WithNulls(1, null) ::
+      TestData2WithNulls(null, 2) ::
+      TestData2WithNulls(2, 1) ::
+      TestData2WithNulls(2, null) ::
+      TestData2WithNulls(null, 1) ::
+      TestData2WithNulls(3, 2) :: Nil, 2).toDF()
+    df.createOrReplaceTempView("testData2WithNulls")
     df
   }
 
@@ -413,7 +413,7 @@ private[sql] trait SQLTestData { self =>
     emptyTestData
     testData
     testData2
-    testData2WithNullKeys
+    testData2WithNulls
     testData3
     negativeData
     largeAndSmallInts
@@ -444,7 +444,7 @@ private[sql] trait SQLTestData { self =>
 private[sql] object SQLTestData {
   case class TestData(key: Int, value: String)
   case class TestData2(a: Int, b: Int)
-  case class TestData2WithNullKeys(a: Integer, b: Int)
+  case class TestData2WithNulls(a: Integer, b: Integer)
   case class TestData3(a: Int, b: Option[Int])
   case class LargeAndSmallInts(a: Int, b: Int)
   case class DecimalData(a: BigDecimal, b: BigDecimal)

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -69,6 +69,18 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
+  protected lazy val testData2WithNullKeys: DataFrame = {
+    val df = spark.sparkContext.parallelize(
+      TestData2WithNullKeys(1, 1) ::
+      TestData2WithNullKeys(null, 2) ::
+      TestData2WithNullKeys(2, 1) ::
+      TestData2WithNullKeys(2, 2) ::
+      TestData2WithNullKeys(null, 1) ::
+      TestData2WithNullKeys(3, 2) :: Nil, 2).toDF()
+    df.createOrReplaceTempView("testData2WithNullKeys")
+    df
+  }
+
   protected lazy val testData3: DataFrame = {
     val df = spark.sparkContext.parallelize(
       TestData3(1, None) ::
@@ -401,6 +413,7 @@ private[sql] trait SQLTestData { self =>
     emptyTestData
     testData
     testData2
+    testData2WithNullKeys
     testData3
     negativeData
     largeAndSmallInts
@@ -431,6 +444,7 @@ private[sql] trait SQLTestData { self =>
 private[sql] object SQLTestData {
   case class TestData(key: Int, value: String)
   case class TestData2(a: Int, b: Int)
+  case class TestData2WithNullKeys(a: Integer, b: Int)
   case class TestData3(a: Int, b: Option[Int])
   case class LargeAndSmallInts(a: Int, b: Int)
   case class DecimalData(a: BigDecimal, b: BigDecimal)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR seeks to allow exists (but also NOT exists, IN, and NOT IN) to be rewritten as the appropriate join by `RewritePredicateSubquery` before `InferFiltersFromConstraints` runs. This allows the join conditions to infer filters, such as null filtering that can be pushed down to the scan.

This particular example came about when executing a query derived from TPCDS q16 where we see an exists that is converted into a LeftSemi, but null filtering or push down filters don't exist, forcing Spark to load many null key rows that will not match (more details in the jira issue, with plans and a simpler repro case).

I am particularly weary of making changes in the optimizer as rules depend on the order and build on each other.

I copied (but believe I should move) `RewritePredicateSubquery` ahead of `InferFiltersFromConstraints`, which has the desired effect in my particular test case. I did not bring the whole `RewriteSubquery` batch with it, and that's my first question. Should all of [RewriteSubquery](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala#L237) move further up?

With the new join and filter (and push down) added earlier now, does anyone know if this could cause conflicts with rules that come after? I've spent some time reading through each of the rules and I am not convinced that a push down rule, or join reorder isn't going to be affected. 

Any feedback would be appreciated.

### Why are the changes needed?
Without this change, LeftSemi/LeftAnti inserted because of (NOT) exists or (NOT) in, will not get null key filtering or push down benefits.

### Does this PR introduce _any_ user-facing change?
No, this is going to make some queries run faster.

### How was this patch tested?
- Manual execution of a query based on TPCDS q16
- Unit test was added to assert that the FilterExec is added. I am happy to add more tests.