### PR TITLE
[SPARK-39153][SQL] Sort the tasks on the UI according to the Error co…

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -99,8 +99,7 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
       eventTimelineParameterTaskPageSize).map(_.toInt).getOrElse(100)
 
     val taskSortColumn = Option(parameterTaskSortColumn).map { sortColumn =>
-      UIUtils.decodeURLParameter(sortColumn)
-    }.getOrElse(HEADER_ERROR)
+      UIUtils.decodeURLParameter(sortColumn) }.getOrElse(HEADER_ERROR)
     val taskSortDesc = Option(parameterTaskSortDesc).exists(!_.toBoolean)
     val taskPageSize = Option(parameterTaskPageSize).map(_.toInt).getOrElse(100)
     val stageId = parameterId.toInt

--- a/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/jobs/StagePage.scala
@@ -100,8 +100,8 @@ private[ui] class StagePage(parent: StagesTab, store: AppStatusStore) extends We
 
     val taskSortColumn = Option(parameterTaskSortColumn).map { sortColumn =>
       UIUtils.decodeURLParameter(sortColumn)
-    }.getOrElse("Index")
-    val taskSortDesc = Option(parameterTaskSortDesc).map(_.toBoolean).getOrElse(false)
+    }.getOrElse(HEADER_ERROR)
+    val taskSortDesc = Option(parameterTaskSortDesc).exists(!_.toBoolean)
     val taskPageSize = Option(parameterTaskPageSize).map(_.toInt).getOrElse(100)
     val stageId = parameterId.toInt
     val stageAttemptId = parameterAttempt.toInt


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When a task fails, users are more concerned about the causes of failed tasks and failed tasks. The Current Spark UI and History are sorted according to "Index" rather than "Errors". When a large number of tasks are sorted, you need to wait a certain period for tasks to be sorted. In order to find the cause of Errors for failed tasks, we can improve the user experience by specifying sorting by the "Errors" column at the beginning.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid sorting time for tasks because the user's primary purpose is to view the logs of failed tasks.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no change by default
