### PR TITLE
[SPARK-39154][PYTHON][DOCS] Remove outdated statements on distributed-sequence default index 

### DIFF
--- a/python/docs/source/user_guide/pandas_on_spark/options.rst
+++ b/python/docs/source/user_guide/pandas_on_spark/options.rst
@@ -186,9 +186,7 @@ This is conceptually equivalent to the PySpark example as below:
 **distributed-sequence** (default): It implements a sequence that increases one by one, by group-by and
 group-map approach in a distributed manner. It still generates the sequential index globally.
 If the default index must be the sequence in a large dataset, this
-index has to be used.
-Note that if more data are added to the data source after creating this index,
-then it does not guarantee the sequential index. See the example below:
+index has to be used. See the example below:
 
 .. code-block:: python
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove outdated statements on distributed-sequence default index.


### Why are the changes needed?
Since distributed-sequence default index is updated to be enforced only while execution, there are stale statements in documents to be removed.


### Does this PR introduce _any_ user-facing change?
No. Doc change only.

### How was this patch tested?
Manual tests.
