### PR TITLE
[SPARK-38633][SQL] Support push down AnsiCast to JDBC data source V2

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -305,7 +305,7 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
 
   override def nullable: Boolean = child.nullable || Cast.forceNullable(child.dataType, dataType)
 
-  protected def ansiEnabled: Boolean
+  def ansiEnabled: Boolean
 
   // When this cast involves TimeZone, it's only resolved if the timeZoneId is set;
   // Otherwise behave like Expression.resolved.
@@ -2158,7 +2158,7 @@ case class AnsiCast(child: Expression, dataType: DataType, timeZoneId: Option[St
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
     copy(timeZoneId = Option(timeZoneId))
 
-  override protected val ansiEnabled: Boolean = true
+  override val ansiEnabled: Boolean = true
 
   override def canCast(from: DataType, to: DataType): Boolean = AnsiCast.canCast(from, to)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import org.apache.spark.sql.catalyst.expressions.{Abs, Add, And, BinaryComparison, BinaryOperator, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Ceil, Coalesce, Contains, Divide, EndsWith, EqualTo, Exp, Expression, Floor, In, InSet, IsNotNull, IsNull, Literal, Log, Multiply, Not, Or, Pow, Predicate, Remainder, Sqrt, StartsWith, StringPredicate, Subtract, UnaryMinus, WidthBucket}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Add, And, BinaryComparison, BinaryOperator, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, CastBase, Ceil, Coalesce, Contains, Divide, EndsWith, EqualTo, Exp, Expression, Floor, In, InSet, IsNotNull, IsNull, Literal, Log, Multiply, Not, Or, Pow, Predicate, Remainder, Sqrt, StartsWith, StringPredicate, Subtract, UnaryMinus, WidthBucket}
 import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, FieldReference, GeneralScalarExpression, LiteralValue}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And => V2And, Not => V2Not, Or => V2Or, Predicate => V2Predicate}
 import org.apache.spark.sql.execution.datasources.PushableColumn
@@ -93,8 +93,8 @@ class V2ExpressionBuilder(
       } else {
         None
       }
-    case Cast(child, dataType, _, true) =>
-      generateExpression(child).map(v => new V2Cast(v, dataType))
+    case cast: CastBase if cast.ansiEnabled =>
+      generateExpression(cast.child).map(v => new V2Cast(v, cast.dataType))
     case Abs(child, true) => generateExpression(child)
       .map(v => new GeneralScalarExpression("ABS", Array[V2Expression](v)))
     case Coalesce(children) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/35947 support push down `Cast` to JDBC data source V2.
But sometimes, Spark creates `AnsiCast` implicitly.
We should push down `AnsiCast` to JDBC data source V2 too.

### Why are the changes needed?
Support push down `AnsiCast` to JDBC data source V2.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
N/A
