### PR TITLE
[SPARK-38850][BUILD] Upgrade Kafka to 3.2.0

### DIFF
--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaRDDSuite.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaRDDSuite.scala
@@ -103,6 +103,7 @@ class KafkaRDDSuite extends SparkFunSuite with BeforeAndAfterAll {
       mockTime.scheduler,
       new BrokerTopicStats(),
       mockTime,
+      maxTransactionTimeoutMs = 5 * 60 * 1000, // KAFKA-13221
       Int.MaxValue,
       Int.MaxValue,
       logDirFailureChannel,

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.1.0</kafka.version>
+    <kafka.version>3.2.0</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.2</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Kafka from 3.1.0 to 3.2.0 for Apache Spark 3.4.

### Why are the changes needed?

Apache Kafka 3.2.0 is released recently.

- https://downloads.apache.org/kafka/3.2.0/RELEASE_NOTES.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.