### PR TITLE
[SPARK-39174][SQL] Catalogs loading swallows missing classname for ClassNotFoundException

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/Catalogs.scala
@@ -60,8 +60,9 @@ private[sql] object Catalogs {
       plugin.initialize(name, catalogOptions(name, conf))
       plugin
     } catch {
-      case _: ClassNotFoundException =>
-        throw QueryExecutionErrors.catalogPluginClassNotFoundForCatalogError(name, pluginClassName)
+      case e: ClassNotFoundException =>
+        throw QueryExecutionErrors.catalogPluginClassNotFoundForCatalogError(
+          name, pluginClassName, e)
       case e: NoSuchMethodException =>
         throw QueryExecutionErrors.catalogFailToFindPublicNoArgConstructorError(
           name, pluginClassName, e)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1544,8 +1544,14 @@ object QueryExecutionErrors extends QueryErrorsBase {
 
   def catalogPluginClassNotFoundForCatalogError(
       name: String,
-      pluginClassName: String): Throwable = {
-    new SparkException(s"Cannot find catalog plugin class for catalog '$name': $pluginClassName")
+      pluginClassName: String,
+      e: Exception): Throwable = {
+    if (e.getMessage == pluginClassName) {
+      new SparkException(s"Cannot find catalog plugin class for catalog '$name': $pluginClassName")
+    } else {
+      new SparkException("Cannot find catalog plugin dependencies for catalog " +
+        s"'$name': $pluginClassName, due to ${e.getMessage} not found")
+    }
   }
 
   def catalogFailToFindPublicNoArgConstructorError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1546,12 +1546,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
       name: String,
       pluginClassName: String,
       e: Exception): Throwable = {
-    if (e.getMessage == pluginClassName) {
-      new SparkException(s"Cannot find catalog plugin class for catalog '$name': $pluginClassName")
-    } else {
-      new SparkException("Cannot find catalog plugin dependencies for catalog " +
-        s"'$name': $pluginClassName, due to ${e.getMessage} not found")
-    }
+    new SparkException(s"Cannot find catalog plugin class for catalog '$name': $pluginClassName", e)
   }
 
   def catalogFailToFindPublicNoArgConstructorError(

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/connector/catalog/CatalogLoadingSuite.java
@@ -101,14 +101,8 @@ public class CatalogLoadingSuite {
     SparkException exc =
         Assert.assertThrows(SparkException.class, () -> Catalogs.load("missing", conf));
 
-    Assert.assertTrue("Should complain that the dependent class is not found",
-        exc.getMessage().contains("Cannot find catalog plugin dependencies"));
-    Assert.assertTrue("Should identify the catalog by name",
-        exc.getMessage().contains("missing"));
-    Assert.assertTrue("Should identify the catalog class",
-        exc.getMessage().contains(catalogClass));
-    Assert.assertTrue("Should identify the catalog dependent class",
-        exc.getMessage().contains(catalogClass + "Dep"));
+    Assert.assertTrue(exc.getCause() instanceof ClassNotFoundException);
+    Assert.assertTrue(exc.getCause().getMessage().contains(catalogClass + "Dep"));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

this PR captures the actual missing classname when catalog loading meets ClassNotFoundException

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

ClassNotFoundException can occur when missing dependencies, we shall not always report the catalog class is missing

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, when loading catalogs and ClassNotFoundException occurs, it shows the correct missing class.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new test added