### PR TITLE
[SPARK-39176][PYSPARK] Fixed a problem with pyspark serializing pre-1970 datetime in windows

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -27,6 +27,7 @@ import base64
 from array import array
 import ctypes
 import warnings
+import platform
 
 if sys.version >= "3":
     long = int
@@ -192,24 +193,24 @@ class TimestampType(AtomicType):
     def toInternal(self, dt):
         if dt is not None:
             seconds = 0.0
-            try:
-                seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
-                           else time.mktime(dt.timetuple()))
-            except:
+            if platform.system().lower() == 'windows':
                 # On Windows, the current value is converted to a timestamp when the current value is less than 1970
                 seconds = (dt - datetime.datetime.fromtimestamp(int(time.localtime(0).tm_sec) / 1000)).total_seconds()
+            else:
+                seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
+                           else time.mktime(dt.timetuple()))
 
             return int(seconds) * 1000000 + dt.microsecond
 
     def fromInternal(self, ts):
         if ts is not None:
-            try:
-                # using int to avoid precision loss in float
-                return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
-            except:
+            if platform.system().lower() == 'windows':
                 # On Windows, resolve when the timestamp is negative
                 return datetime.datetime.fromtimestamp(int(time.localtime(0).tm_sec) / 1000) + \
                        datetime.timedelta(microseconds=ts)
+            else:
+                # using int to avoid precision loss in float
+                return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
 
 
 class DecimalType(FractionalType):
@@ -1647,12 +1648,13 @@ class DatetimeConverter(object):
     def convert(self, obj, gateway_client):
         Timestamp = JavaClass("java.sql.Timestamp", gateway_client)
         seconds = 0.0
-        try:
-            seconds = (calendar.timegm(obj.utctimetuple()) if obj.tzinfo
-                       else time.mktime(obj.timetuple()))
-        except:
+
+        if platform.system().lower() == 'windows':
             # On Windows, the current value is converted to a timestamp when the current value is less than 1970
             seconds = (obj - datetime.datetime.fromtimestamp(int(time.localtime(0).tm_sec) / 1000)).total_seconds()
+        else:
+            seconds = (calendar.timegm(obj.utctimetuple()) if obj.tzinfo
+                       else time.mktime(obj.timetuple()))
 
         t = Timestamp(int(seconds) * 1000)
         t.setNanos(obj.microsecond * 1000)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -191,14 +191,25 @@ class TimestampType(AtomicType):
 
     def toInternal(self, dt):
         if dt is not None:
-            seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
-                       else time.mktime(dt.timetuple()))
+            seconds = 0.0
+            try:
+                seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
+                           else time.mktime(dt.timetuple()))
+            except:
+                # On Windows, the current value is converted to a timestamp when the current value is less than 1970
+                seconds = (dt - datetime.datetime.fromtimestamp(int(time.localtime(0).tm_sec) / 1000)).total_seconds()
+
             return int(seconds) * 1000000 + dt.microsecond
 
     def fromInternal(self, ts):
         if ts is not None:
-            # using int to avoid precision loss in float
-            return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
+            try:
+                # using int to avoid precision loss in float
+                return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)
+            except:
+                # On Windows, resolve when the timestamp is negative
+                return datetime.datetime.fromtimestamp(int(time.localtime(0).tm_sec) / 1000) + \
+                       datetime.timedelta(microseconds=ts)
 
 
 class DecimalType(FractionalType):
@@ -1635,8 +1646,14 @@ class DatetimeConverter(object):
 
     def convert(self, obj, gateway_client):
         Timestamp = JavaClass("java.sql.Timestamp", gateway_client)
-        seconds = (calendar.timegm(obj.utctimetuple()) if obj.tzinfo
-                   else time.mktime(obj.timetuple()))
+        seconds = 0.0
+        try:
+            seconds = (calendar.timegm(obj.utctimetuple()) if obj.tzinfo
+                       else time.mktime(obj.timetuple()))
+        except:
+            # On Windows, the current value is converted to a timestamp when the current value is less than 1970
+            seconds = (obj - datetime.datetime.fromtimestamp(int(time.localtime(0).tm_sec) / 1000)).total_seconds()
+
         t = Timestamp(int(seconds) * 1000)
         t.setNanos(obj.microsecond * 1000)
         return t

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -26,6 +26,7 @@ from glob import glob
 from py4j.protocol import Py4JJavaError
 
 from pyspark import shuffle, RDD
+from pyspark.sql import SparkSession
 from pyspark.serializers import CloudPickleSerializer, BatchedSerializer, PickleSerializer,\
     MarshalSerializer, UTF8Deserializer, NoOpSerializer
 from pyspark.testing.utils import ReusedPySparkTestCase, SPARK_HOME, QuietTest
@@ -668,6 +669,12 @@ class RDDTests(ReusedPySparkTestCase):
         wr_s11 = rdd.sample(True, 0.4, 11).collect()
         wr_s21 = rdd.sample(True, 0.4, 21).collect()
         self.assertNotEqual(set(wr_s11), set(wr_s21))
+
+    def test_datetime(self):
+        rdd = self.sc.parallelize([('a', datetime(1957, 1, 9, 0, 0)),
+                                   ('b', datetime(2014, 1, 27, 0, 0))])
+        df = SparkSession(self.sc).createDataFrame(rdd, ["id", "date"])
+        self.assertEqual(2, len(df.collect()))
 
     def test_null_in_rdd(self):
         jrdd = self.sc._jvm.PythonUtils.generateRDDWithNull(self.sc._jsc)

--- a/python/pyspark/tests/test_rdd.py
+++ b/python/pyspark/tests/test_rdd.py
@@ -671,6 +671,7 @@ class RDDTests(ReusedPySparkTestCase):
         self.assertNotEqual(set(wr_s11), set(wr_s21))
 
     def test_datetime(self):
+        # SPARK-39176: Pre - 1970 time serialization test
         rdd = self.sc.parallelize([('a', datetime(1957, 1, 9, 0, 0)),
                                    ('b', datetime(2014, 1, 27, 0, 0))])
         df = SparkSession(self.sc).createDataFrame(rdd, ["id", "date"])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix problems with pyspark in Windows:
1. Fixed datetime conversion to timestamp before 1970;
2. Fixed datetime conversion when timestamp is negative;
3. Adding a test script.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Pyspark has problems serializing pre-1970 times in Windows.

An exception occurs when executing the following code under Windows:
```python
rdd = sc.parallelize([('a', datetime(1957, 1, 9, 0, 0)),
                      ('b', datetime(2014, 1, 27, 0, 0))])
df = spark.createDataFrame(rdd, ["id", "date"])

df.show()
df.printSchema()

print(df.collect())
```

```bash
  File "...\spark\python\lib\pyspark.zip\pyspark\sql\types.py", line 195, in toInternal
    else time.mktime(dt.timetuple()))
OverflowError: mktime argument out of range

at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:503)
	at org.apache.spark.api.python.PythonRunner$$anon$3.read(PythonRunner.scala:638)
	at org.apache.spark.api.python.PythonRunner$$anon$3.read(PythonRunner.scala:621)
	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.hasNext(PythonRunner.scala:456)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:489)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:458)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.hasNext(WholeStageCodegenExec.scala:729)
	at org.apache.spark.sql.execution.SparkPlan.$anonfun$getByteArrayRdd$1(SparkPlan.scala:340)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2(RDD.scala:872)
	at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsInternal$2$adapted(RDD.scala:872)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:349)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:313)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:127)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:446)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1377)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:449)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	... 1 more
```
and
```bash
File ...\spark\python\lib\pyspark.zip\pyspark\sql\types.py, in fromInternal:
Line 207:   return datetime.datetime.fromtimestamp(ts // 1000000).replace(microsecond=ts % 1000000)

OSError: [Errno 22] Invalid argument
```
 After updating the code, the above code was run successfully！
```bash
+---+-------------------+
| id|               date|
+---+-------------------+
|  a|1957-01-08 16:00:00|
|  b|2014-01-26 16:00:00|
+---+-------------------+

root
 |-- id: string (nullable = true)
 |-- date: timestamp (nullable = true)

[Row(id='a', date=datetime.datetime(1957, 1, 9, 0, 0)), Row(id='b', date=datetime.datetime(2014, 1, 27, 0, 0))] 
```
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New and existing test suites