### PR TITLE
[SPARK-38466][CORE] Use error classes in org.apache.spark.mapred

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -26,6 +26,9 @@
     "message" : [ "Casting <value> to <type> causes overflow. To return NULL instead, use 'try_cast'. If necessary set <config> to false to bypass this error." ],
     "sqlState" : "22005"
   },
+  "COMMIT_DENIED" : {
+    "message" : [ "Commit denied for partition <partId> (task <taskId>, attempt <attemptId>, stage <stageId>.<stageAttempt>)" ]
+  },
   "CONCURRENT_QUERY" : {
     "message" : [ "Another instance of this query was just started by a concurrent session." ]
   },

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeoutException
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkException, TaskNotSerializableException}
+import org.apache.spark.executor.CommitDeniedException
 import org.apache.spark.scheduler.{BarrierJobRunWithDynamicAllocationException, BarrierJobSlotsNumberCheckFailed, BarrierJobUnsupportedRDDChainException}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockNotFoundException, BlockSavedOnDecommissionedBlockManagerException, RDDBlockId, UnrecognizedBlockId}
@@ -324,5 +325,14 @@ object SparkCoreErrors {
   def graphiteSinkPropertyMissingError(missingProperty: String): Throwable = {
     new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
       messageParameters = Array(missingProperty), cause = null)
+  }
+
+  def commitDeniedError(
+      partId: Int,
+      taskId: Long,
+      attemptId: Int,
+      stageId: Int,
+      stageAttempt: Int): Throwable = {
+    new CommitDeniedException(partId, taskId, attemptId, stageId, stageAttempt)
   }
 }

--- a/core/src/main/scala/org/apache/spark/executor/CommitDeniedException.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CommitDeniedException.scala
@@ -17,17 +17,20 @@
 
 package org.apache.spark.executor
 
-import org.apache.spark.TaskCommitDenied
+import org.apache.spark.{SparkException, TaskCommitDenied}
 
 /**
  * Exception thrown when a task attempts to commit output to HDFS but is denied by the driver.
  */
 private[spark] class CommitDeniedException(
-    msg: String,
-    jobID: Int,
-    splitID: Int,
-    attemptNumber: Int)
-  extends Exception(msg) {
+    partitionId: Int,
+    taskId: Long,
+    attemptId: Int,
+    stageId: Int,
+    stageAttempt: Int)
+  extends SparkException(errorClass = "COMMIT_DENIED",
+    messageParameters = Array(partitionId.toString, taskId.toString,
+      attemptId.toString, stageId.toString, stageAttempt.toString), cause = null) {
 
-  def toTaskCommitDeniedReason: TaskCommitDenied = TaskCommitDenied(jobID, splitID, attemptNumber)
+  def toTaskCommitDeniedReason: TaskCommitDenied = TaskCommitDenied(stageId, partitionId, attemptId)
 }

--- a/core/src/main/scala/org/apache/spark/mapred/SparkHadoopMapRedUtil.scala
+++ b/core/src/main/scala/org/apache/spark/mapred/SparkHadoopMapRedUtil.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.mapreduce.{TaskAttemptContext => MapReduceTaskAttemptCo
 import org.apache.hadoop.mapreduce.{OutputCommitter => MapReduceOutputCommitter}
 
 import org.apache.spark.{SparkEnv, TaskContext}
-import org.apache.spark.executor.CommitDeniedException
+import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.util.Utils
 
@@ -82,7 +82,8 @@ object SparkHadoopMapRedUtil extends Logging {
           logInfo(message)
           // We need to abort the task so that the driver can reschedule new attempts, if necessary
           committer.abortTask(mrTaskContext)
-          throw new CommitDeniedException(message, ctx.stageId(), splitId, ctx.attemptNumber())
+          throw SparkCoreErrors.commitDeniedError(splitId, ctx.taskAttemptId(), ctx.attemptNumber(),
+            ctx.stageId(), ctx.stageAttemptNumber())
         }
       } else {
         // Speculation is disabled or a user has chosen to manually bypass the commit coordination

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -291,4 +291,16 @@ abstract class SparkFunSuite
       _loggingEvents.filterNot(_ == null)
     }
   }
+
+  /**
+   * Runs `f` with TaskContext.
+   */
+  final protected def withTaskContext[T](taskContext: TaskContext)(f: => T): T = {
+    try {
+      TaskContext.setTaskContext(taskContext)
+      f
+    } finally {
+      TaskContext.unset()
+    }
+  }
 }

--- a/core/src/test/scala/org/apache/spark/mapred/SparkHadoopMapRedUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/mapred/SparkHadoopMapRedUtilSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mapred
+
+import org.apache.hadoop.mapreduce.{JobID, OutputCommitter, TaskAttemptContext, TaskAttemptID, TaskID}
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkEnv, SparkFunSuite, TaskContextImpl}
+import org.apache.spark.executor.CommitDeniedException
+import org.apache.spark.scheduler.{LiveListenerBus, OutputCommitCoordinator}
+
+class SparkHadoopMapRedUtilSuite extends SparkFunSuite with LocalSparkContext with BeforeAndAfter {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    val conf = new SparkConf()
+    sc = new SparkContext("local[2, 4]", "test", conf) {
+      override private[spark] def createSparkEnv(
+          conf: SparkConf,
+          isLocal: Boolean,
+          listenerBus: LiveListenerBus): SparkEnv = {
+        val outputCommitCoordinator = new OutputCommitCoordinator(conf, isDriver = true) {
+          override def canCommit(stage: Int, stageAttempt: Int,
+              partition: Int, attemptNumber: Int): Boolean = {
+            false
+          }
+        }
+
+        SparkEnv.createDriverEnv(conf, isLocal, listenerBus,
+          SparkContext.numDriverCores(master), Some(outputCommitCoordinator))
+      }
+    }
+  }
+
+  test("Commit task be denied, because the driver did not authorize commit ") {
+    val taskContext = mock(classOf[TaskContextImpl])
+    withTaskContext(taskContext) {
+      val taskAttemptContext = mock(classOf[TaskAttemptContext])
+
+      val attemptId = mock(classOf[TaskAttemptID])
+      when(taskAttemptContext.getTaskAttemptID).thenReturn(attemptId)
+
+      val jobId = mock(classOf[JobID])
+      when(attemptId.getJobID).thenReturn(jobId)
+
+      val taskId = mock(classOf[TaskID])
+      when(attemptId.getTaskID).thenReturn(taskId)
+
+      val committer = mock(classOf[OutputCommitter])
+      when(committer.needsTaskCommit(taskAttemptContext)).thenReturn(true)
+
+      val e = intercept[CommitDeniedException](
+        SparkHadoopMapRedUtil.commitTask(committer, taskAttemptContext,
+          taskAttemptContext.getTaskAttemptID.getJobID.getId,
+          taskAttemptContext.getTaskAttemptID.getTaskID.getId)
+      )
+
+      assert(e.getErrorClass === "COMMIT_DENIED")
+      assert(e.getMessage ===
+        "[COMMIT_DENIED] Commit denied for partition 0 (task 0, attempt 0, stage 0.0)")
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -678,9 +678,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
 
   def commitDeniedError(
       partId: Int, taskId: Long, attemptId: Int, stageId: Int, stageAttempt: Int): Throwable = {
-    val message = s"Commit denied for partition $partId (task $taskId, attempt $attemptId, " +
-      s"stage $stageId.$stageAttempt)"
-    new CommitDeniedException(message, stageId, partId, attemptId)
+    new CommitDeniedException(partId, taskId, attemptId, stageId, stageAttempt)
   }
 
   def unsupportedTableWritesError(ident: Identifier): Throwable = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to refactor exceptions thrown in SparkHadoopMapRedUtil to use error class framework.

### Why are the changes needed?
This is to follow the error class framework, improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added unit tests.