### PR TITLE
[SPARK-39183][BUILD] Upgrade Apache Xerces Java to 2.12.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -260,7 +260,7 @@ transaction-api/1.1//transaction-api-1.1.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 velocity/1.5//velocity-1.5.jar
 xbean-asm9-shaded/4.20//xbean-asm9-shaded-4.20.jar
-xercesImpl/2.12.0//xercesImpl-2.12.0.jar
+xercesImpl/2.12.2//xercesImpl-2.12.2.jar
 xml-apis/1.4.01//xml-apis-1.4.01.jar
 xmlenc/0.52//xmlenc-0.52.jar
 xz/1.8//xz-1.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1438,7 +1438,7 @@
       <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.12.0</version>
+        <version>2.12.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache Xerces Java to 2.12.2

[Release notes](https://xerces.apache.org/xerces2-j/releases.html)

### Why are the changes needed?
[Infinite Loop in Apache Xerces Java](https://github.com/advisories/GHSA-h65f-jvqw-m9fj)

There's a vulnerability within the Apache Xerces Java (XercesJ) XML parser when handling specially crafted XML document payloads. This causes, the XercesJ XML parser to wait in an infinite loop, which may sometimes consume system resources for prolonged duration. This vulnerability is present within XercesJ version 2.12.1 and the previous versions.

References
https://nvd.nist.gov/vuln/detail/CVE-2022-23437
https://lists.apache.org/thread/6pjwm10bb69kq955fzr1n0nflnjd27dl
http://www.openwall.com/lists/oss-security/2022/01/24/3
https://www.oracle.com/security-alerts/cpuapr2022.html


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.
