### PR TITLE
[SPARK-37544][SQL] Correct date arithmetic in sequences

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -3073,15 +3073,15 @@ object Sequence {
     protected def stepSplitCode(
          stepMonths: String, stepDays: String, stepMicros: String, step: String): String
 
+    private val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
+
     private val addIntervalCode = outerDataType match {
-      case TimestampType | DateType =>
-        "org.apache.spark.sql.catalyst.util.DateTimeUtils.timestampAddInterval"
-      case TimestampNTZType =>
-        "org.apache.spark.sql.catalyst.util.DateTimeUtils.timestampNTZAddInterval"
+      case TimestampType | DateType => s"$dtu.timestampAddInterval"
+      case TimestampNTZType => s"$dtu.timestampNTZAddInterval"
     }
 
-    private val daysToMicrosCode = "org.apache.spark.sql.catalyst.util.DateTimeUtils.daysToMicros"
-    private val microsToDaysCode = "org.apache.spark.sql.catalyst.util.DateTimeUtils.microsToDays"
+    private val daysToMicrosCode = s"$dtu.daysToMicros"
+    private val microsToDaysCode = s"$dtu.microsToDays"
 
     override def genCode(
         ctx: CodegenContext,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -984,7 +984,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     // if the sequence's start-stop includes a "spring forward".
     // take, for example, the following Spark date arithmetic:
     //   select cast(date'2022-03-09' + interval '4' days '23' hour as date) as x;
-    // in the America/Log_Angeles time zone, it returns 2022-03-14.
+    // in the America/Los_Angeles time zone, it returns 2022-03-14.
     // in the UTC time zone, it instead returns 2022-03-13.
     // the sequence function should be consistent with the date arithmetic
     DateTimeTestUtils.withDefaultTimeZone(LA) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils}
-import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{outstandingZoneIds, UTC}
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.{outstandingZoneIds, LA, UTC}
 import org.apache.spark.sql.catalyst.util.IntervalUtils._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -964,7 +964,7 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
     }
   }
 
-  test("SPARK-37544: Time zone should not affect date sequence") {
+  test("SPARK-37544: Time zone should not affect date sequence with month interval") {
     outstandingZoneIds.foreach { zid =>
       DateTimeTestUtils.withDefaultTimeZone(zid) {
         checkEvaluation(new Sequence(
@@ -978,6 +978,33 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
             Date.valueOf("2021-10-01"),
             Date.valueOf("2022-01-01")))
       }
+    }
+
+    // however, time zone should still affect sequences generated using hours interval, especially
+    // if the sequence's start-stop includes a "spring forward".
+    // take, for example, the following Spark date arithmetic:
+    //   select cast(date'2022-03-09' + interval '4' days '23' hour as date) as x;
+    // in the America/Log_Angeles time zone, it returns 2022-03-14.
+    // in the UTC time zone, it instead returns 2022-03-13.
+    // the sequence function should be consistent with the date arithmetic
+    DateTimeTestUtils.withDefaultTimeZone(LA) {
+      checkEvaluation(new Sequence(
+        Literal(Date.valueOf("2022-03-09")),
+        Literal(Date.valueOf("2022-03-15")),
+        Literal(stringToInterval("interval 4 days 23 hours"))),
+        Seq(
+          Date.valueOf("2022-03-09"),
+          Date.valueOf("2022-03-14")))
+    }
+
+    DateTimeTestUtils.withDefaultTimeZone(UTC) {
+      checkEvaluation(new Sequence(
+        Literal(Date.valueOf("2022-03-09")),
+        Literal(Date.valueOf("2022-03-15")),
+        Literal(stringToInterval("interval 4 days 23 hours"))),
+        Seq(
+          Date.valueOf("2022-03-09"),
+          Date.valueOf("2022-03-13"))) // this is different from LA time zone above
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -980,13 +980,13 @@ class CollectionExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper
       }
     }
 
-    // however, time zone should still affect sequences generated using hours interval, especially
-    // if the sequence's start-stop includes a "spring forward".
-    // take, for example, the following Spark date arithmetic:
+    // However, time zone should still affect sequences generated using hours interval,
+    // especially if the sequence's start-stop includes a "spring forward".
+    // Take, for example, the following Spark date arithmetic:
     //   select cast(date'2022-03-09' + interval '4' days '23' hour as date) as x;
-    // in the America/Los_Angeles time zone, it returns 2022-03-14.
-    // in the UTC time zone, it instead returns 2022-03-13.
-    // the sequence function should be consistent with the date arithmetic
+    // In the America/Los_Angeles time zone, it returns 2022-03-14.
+    // In the UTC time zone, it instead returns 2022-03-13.
+    // The sequence function should be consistent with the date arithmetic.
     DateTimeTestUtils.withDefaultTimeZone(LA) {
       checkEvaluation(new Sequence(
         Literal(Date.valueOf("2022-03-09")),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `InternalSequenceBase` to pass a time-zone aware value to `DateTimeUtils#timestampAddInterval`, rather than a time-zone agnostic value, when performing `Date` arithmetic.

### Why are the changes needed?

The following query gets the wrong answer if run in the America/Los_Angeles time zone:
```
spark-sql> select sequence(date '2021-01-01', date '2022-01-01', interval '3' month) x;
[2021-01-01,2021-03-31,2021-06-30,2021-09-30,2022-01-01]
Time taken: 0.664 seconds, Fetched 1 row(s)
spark-sql> 
```
The answer should be
```
[2021-01-01,2021-04-01,2021-07-01,2021-10-01,2022-01-01]
```
`InternalSequenceBase` converts the date to micros by multiplying days by micros per day. This converts the date into a time-zone agnostic timestamp. However, `InternalSequenceBase` uses `DateTimeUtils#timestampAddInterval` to perform the arithmetic, and that function assumes a _time-zone aware_ timestamp.

One simple fix would be to call `DateTimeUtils#timestampNTZAddInterval` instead for date arithmetic. However, Spark date arithmetic is typically time-zone aware (see the comment in the test added by this PR), so this PR converts the date to a time-zone aware value before calling `DateTimeUtils#timestampAddInterval`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit test.
