### PR TITLE
[SPARK-38470][CORE] Use error classes in org.apache.spark.partial

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -266,6 +266,9 @@
   "UNSUPPORTED_GROUPING_EXPRESSION" : {
     "message" : [ "grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup" ]
   },
+  "UNSUPPORTED_OPERATION" : {
+    "message" : [ "The operation is not supported: <message>" ]
+  },
   "UNSUPPORTED_SAVE_MODE" : {
     "message" : [ "The save mode <saveMode> is not supported for: " ],
     "subClass" : {

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeoutException
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkException, TaskNotSerializableException}
+import org.apache.spark.{SparkException, SparkUnsupportedOperationException, TaskNotSerializableException}
 import org.apache.spark.scheduler.{BarrierJobRunWithDynamicAllocationException, BarrierJobSlotsNumberCheckFailed, BarrierJobUnsupportedRDDChainException}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockNotFoundException, BlockSavedOnDecommissionedBlockManagerException, RDDBlockId, UnrecognizedBlockId}
@@ -324,5 +324,10 @@ object SparkCoreErrors {
   def graphiteSinkPropertyMissingError(missingProperty: String): Throwable = {
     new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
       messageParameters = Array(missingProperty), cause = null)
+  }
+
+  def unsupportedOperationError(message: String): Throwable = {
+    new SparkUnsupportedOperationException(errorClass = "UNSUPPORTED_OPERATION",
+      messageParameters = Array(message))
   }
 }

--- a/core/src/main/scala/org/apache/spark/partial/PartialResult.scala
+++ b/core/src/main/scala/org/apache/spark/partial/PartialResult.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.partial
 
+import org.apache.spark.errors.SparkCoreErrors
+
 class PartialResult[R](initialVal: R, isFinal: Boolean) {
   private var finalValue: Option[R] = if (isFinal) Some(initialVal) else None
   private var failure: Option[Exception] = None
@@ -47,7 +49,7 @@ class PartialResult[R](initialVal: R, isFinal: Boolean) {
    */
   def onComplete(handler: R => Unit): PartialResult[R] = synchronized {
     if (completionHandler.isDefined) {
-      throw new UnsupportedOperationException("onComplete cannot be called twice")
+      throw SparkCoreErrors.unsupportedOperationError("onComplete cannot be called twice")
     }
     completionHandler = Some(handler)
     if (finalValue.isDefined) {
@@ -64,7 +66,7 @@ class PartialResult[R](initialVal: R, isFinal: Boolean) {
   def onFail(handler: Exception => Unit): Unit = {
     synchronized {
       if (failureHandler.isDefined) {
-        throw new UnsupportedOperationException("onFail cannot be called twice")
+        throw SparkCoreErrors.unsupportedOperationError("onFail cannot be called twice")
       }
       failureHandler = Some(handler)
       if (failure.isDefined) {
@@ -103,7 +105,8 @@ class PartialResult[R](initialVal: R, isFinal: Boolean) {
   private[spark] def setFinalValue(value: R): Unit = {
     synchronized {
       if (finalValue.isDefined) {
-        throw new UnsupportedOperationException("setFinalValue called twice on a PartialResult")
+        throw SparkCoreErrors.unsupportedOperationError(
+          "setFinalValue called twice on a PartialResult")
       }
       finalValue = Some(value)
       // Call the completion handler if it was set
@@ -118,7 +121,8 @@ class PartialResult[R](initialVal: R, isFinal: Boolean) {
   private[spark] def setFailure(exception: Exception): Unit = {
     synchronized {
       if (failure.isDefined) {
-        throw new UnsupportedOperationException("setFailure called twice on a PartialResult")
+        throw SparkCoreErrors.unsupportedOperationError(
+          "setFailure called twice on a PartialResult")
       }
       failure = Some(exception)
       // Call the failure handler if it was set

--- a/core/src/test/scala/org/apache/spark/partial/PartialResultSuite.scala
+++ b/core/src/test/scala/org/apache/spark/partial/PartialResultSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.partial
+
+import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
+
+class PartialResultSuite extends SparkFunSuite {
+
+  test("UNSUPPORTED_OPERATION: call onComplete twice") {
+    val evaluator = new SumEvaluator(10, 0.95)
+    val partialResult = new PartialResult[BoundedDouble](evaluator.currentResult(), true)
+    partialResult.onComplete(_ => {})
+
+    val e = intercept[SparkUnsupportedOperationException](
+      partialResult.onComplete(_ => {})
+    )
+    assert(e.getErrorClass === "UNSUPPORTED_OPERATION")
+    assert(e.getMessage === "[UNSUPPORTED_OPERATION] " +
+      "The operation is not supported: onComplete cannot be called twice")
+  }
+
+  test("UNSUPPORTED_OPERATION: call onFail twice") {
+    val evaluator = new SumEvaluator(10, 0.95)
+    val partialResult = new PartialResult[BoundedDouble](evaluator.currentResult(), false)
+    partialResult.onFail(_ => {})
+    val e = intercept[SparkUnsupportedOperationException](
+      partialResult.onFail(_ => {})
+    )
+    assert(e.getErrorClass === "UNSUPPORTED_OPERATION")
+    assert(e.getMessage === "[UNSUPPORTED_OPERATION] " +
+      "The operation is not supported: onFail cannot be called twice")
+  }
+
+  test("UNSUPPORTED_OPERATION: call setFinalValue twice") {
+    val evaluator = new SumEvaluator(10, 0.95)
+    val partialResult = new PartialResult[BoundedDouble](evaluator.currentResult(), false)
+    partialResult.setFinalValue(new BoundedDouble(20.0, 0.95,
+      Double.NegativeInfinity, Double.PositiveInfinity))
+    val e = intercept[SparkUnsupportedOperationException](
+      partialResult.setFinalValue(new BoundedDouble(20.0, 0.95,
+        Double.NegativeInfinity, Double.PositiveInfinity))
+    )
+    assert(e.getErrorClass === "UNSUPPORTED_OPERATION")
+    assert(e.getMessage === "[UNSUPPORTED_OPERATION] " +
+      "The operation is not supported: setFinalValue called twice on a PartialResult")
+  }
+
+  test("UNSUPPORTED_OPERATION: call setFailure twice") {
+    val evaluator = new SumEvaluator(10, 0.95)
+    val partialResult = new PartialResult[BoundedDouble](evaluator.currentResult(), false)
+    partialResult.setFailure(new Exception("setFailure failed"))
+    val e = intercept[SparkUnsupportedOperationException](
+      partialResult.setFailure(new Exception("setFailure failed"))
+    )
+    assert(e.getErrorClass === "UNSUPPORTED_OPERATION")
+    assert(e.getMessage === "[UNSUPPORTED_OPERATION] " +
+      "The operation is not supported: setFailure called twice on a PartialResult")
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to refactor exceptions thrown in PartialResult to use error class framework.

### Why are the changes needed?
This is to follow the error class framework, improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added unit tests.