### PR TITLE
[SPARK-38463][CORE] Use error classes in org.apache.spark.input

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -266,6 +266,9 @@
   "UNSUPPORTED_GROUPING_EXPRESSION" : {
     "message" : [ "grouping()/grouping_id() can only be used with GroupingSets/Cube/Rollup" ]
   },
+  "UNSUPPORTED_READ_COMPRESSED_FILE" : {
+    "message" : [ "<component> does not support reading compressed files." ]
+  },
   "UNSUPPORTED_SAVE_MODE" : {
     "message" : [ "The save mode <saveMode> is not supported for: " ],
     "subClass" : {

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -19,7 +19,9 @@ package org.apache.spark.errors
 
 import java.io.IOException
 import java.util.concurrent.TimeoutException
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.{SparkException, SparkIOException, TaskNotSerializableException}
 import org.apache.spark.scheduler.{BarrierJobRunWithDynamicAllocationException, BarrierJobSlotsNumberCheckFailed, BarrierJobUnsupportedRDDChainException}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -19,10 +19,8 @@ package org.apache.spark.errors
 
 import java.io.IOException
 import java.util.concurrent.TimeoutException
-
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.{SparkException, TaskNotSerializableException}
+import org.apache.spark.{SparkException, SparkIOException, TaskNotSerializableException}
 import org.apache.spark.scheduler.{BarrierJobRunWithDynamicAllocationException, BarrierJobSlotsNumberCheckFailed, BarrierJobUnsupportedRDDChainException}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockNotFoundException, BlockSavedOnDecommissionedBlockManagerException, RDDBlockId, UnrecognizedBlockId}
@@ -324,5 +322,10 @@ object SparkCoreErrors {
   def graphiteSinkPropertyMissingError(missingProperty: String): Throwable = {
     new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
       messageParameters = Array(missingProperty), cause = null)
+  }
+
+  def unsupportedReadCompressedFileError(component: String): Throwable = {
+    new SparkIOException(errorClass = "UNSUPPORTED_READ_COMPRESSED_FILE",
+      messageParameters = Array(component))
   }
 }

--- a/core/src/main/scala/org/apache/spark/input/FixedLengthBinaryRecordReader.scala
+++ b/core/src/main/scala/org/apache/spark/input/FixedLengthBinaryRecordReader.scala
@@ -17,13 +17,13 @@
 
 package org.apache.spark.input
 
-import java.io.IOException
-
 import org.apache.hadoop.fs.FSDataInputStream
 import org.apache.hadoop.io.{BytesWritable, LongWritable}
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.apache.hadoop.mapreduce.{InputSplit, RecordReader, TaskAttemptContext}
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
+
+import org.apache.spark.errors.SparkCoreErrors
 
 /**
  * FixedLengthBinaryRecordReader is returned by FixedLengthBinaryInputFormat.
@@ -86,7 +86,7 @@ private[spark] class FixedLengthBinaryRecordReader
     // check compression
     val codec = new CompressionCodecFactory(conf).getCodec(file)
     if (codec != null) {
-      throw new IOException("FixedLengthRecordReader does not support reading compressed files")
+      throw SparkCoreErrors.unsupportedReadCompressedFileError("FixedLengthRecordReader")
     }
     // get the record length
     recordLength = FixedLengthBinaryInputFormat.getRecordLength(context)

--- a/core/src/test/scala/org/apache/spark/input/FixedLengthBinaryRecordReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/FixedLengthBinaryRecordReaderSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.input
+
+import java.io.File
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.hadoop.mapreduce.lib.input.FileSplit
+import org.mockito.Mockito.{mock, when}
+
+import org.apache.spark.{SparkFunSuite, SparkIOException}
+
+class FixedLengthBinaryRecordReaderSuite extends SparkFunSuite {
+
+  test("UNSUPPORTED_READ_COMPRESSED_FILE: " +
+    "FixedLengthRecordReader does not support reading compressed files") {
+    withTempDir { dir =>
+      val fileName = "file1.gz"
+      val inputSplit = generateFakeFileSplit(dir, fileName)
+
+      val taskAttemptContext = mock(classOf[TaskAttemptContext])
+      val configuration = new Configuration()
+      configuration.set("io.compression.codecs", "org.apache.hadoop.io.compress.GzipCodec")
+      when(taskAttemptContext.getConfiguration).thenReturn(configuration)
+
+      val fixedLengthBinaryRecordReader = new FixedLengthBinaryRecordReader()
+      val e = intercept[SparkIOException](
+        fixedLengthBinaryRecordReader.initialize(inputSplit, taskAttemptContext)
+      )
+      assert(e.getErrorClass === "UNSUPPORTED_READ_COMPRESSED_FILE")
+      assert(e.getMessage === "[UNSUPPORTED_READ_COMPRESSED_FILE] " +
+        "FixedLengthRecordReader does not support reading compressed files.")
+    }
+  }
+
+  private def generateFakeFileSplit(dir: File, fileName: String): FileSplit = {
+    val path = s"${dir.getCanonicalPath}/$fileName"
+    new FileSplit(new Path(path), 0, 1,
+      Array[String]("loc1", "loc2", "loc3", "loc4", "loc5"))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change is to refactor exceptions thrown in FixedLengthBinaryRecordReader to use error class framework.

### Why are the changes needed?
This is to follow the error class framework, improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Added unit tests.