### PR TITLE
[SPARK-37939][SQL] Use error classes in the parsing errors of properties

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -212,14 +212,14 @@
       "AES_MODE" : {
         "message" : [ "AES-<mode> with the padding <padding> by the <functionName> function." ]
       },
-      "DESC_TABLE_COLUMN_PARTITION" : {
-        "message" : [ "DESC TABLE COLUMN for a specific partition." ]
-      },
       "CLEAN_RESERVED_NAMESPACE_PROPERTY" : {
         "message" : [ "<property> is a reserved namespace property, <msg>." ]
       },
       "CLEAN_RESERVED_TABLE_PROPERTY" : {
         "message" : [ "<property> is a reserved table property, <msg>." ]
+      },
+      "DESC_TABLE_COLUMN_PARTITION" : {
+        "message" : [ "DESC TABLE COLUMN for a specific partition." ]
       },
       "DISTRIBUTE_BY" : {
         "message" : [ "DISTRIBUTE BY clause." ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -134,10 +134,10 @@
     "sqlState" : "22023"
   },
   "INVALID_PROPERTY_KEY" : {
-    "message" : [ "'<key>' is an invalid property key, please use quotes, e.g. SET `<key>`=`<value>`" ]
+    "message" : [ "<key> is an invalid property key, please use quotes, e.g. SET <key>=<value>" ]
   },
   "INVALID_PROPERTY_VALUE" : {
-    "message" : [ "'<value>' is an invalid property value, please use quotes, e.g. SET `<key>`=`<value>`" ]
+    "message" : [ "<value> is an invalid property value, please use quotes, e.g. SET <key>=<value>" ]
   },
   "INVALID_SQL_SYNTAX" : {
     "message" : [ "Invalid SQL syntax: <inputString>" ],
@@ -272,7 +272,7 @@
         "message" : [ "<property> is a reserved namespace property, <msg>." ]
       },
       "SET_PROPERTIES_AND_DBPROPERTIES" : {
-        "message" : [ "Either PROPERTIES or DBPROPERTIES is allowed." ]
+        "message" : [ "set PROPERTIES and DBPROPERTIES at the same time." ]
       },
       "SET_TABLE_PROPERTY" : {
         "message" : [ "<property> is a reserved table property, <msg>." ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -212,12 +212,6 @@
       "AES_MODE" : {
         "message" : [ "AES-<mode> with the padding <padding> by the <functionName> function." ]
       },
-      "CLEAN_RESERVED_NAMESPACE_PROPERTY" : {
-        "message" : [ "<property> is a reserved namespace property, <msg>." ]
-      },
-      "CLEAN_RESERVED_TABLE_PROPERTY" : {
-        "message" : [ "<property> is a reserved table property, <msg>." ]
-      },
       "DESC_TABLE_COLUMN_PARTITION" : {
         "message" : [ "DESC TABLE COLUMN for a specific partition." ]
       },
@@ -257,14 +251,20 @@
       "PIVOT_TYPE" : {
         "message" : [ "Pivoting by the value '<value>' of the column data type <type>." ]
       },
-      "PROPERTIES_AND_DBPROPERTIES_BOTH_SPECIFIED_CONFLICT" : {
-        "message" : [ "Either PROPERTIES or DBPROPERTIES is allowed." ]
-      },
       "PYTHON_UDF_IN_ON_CLAUSE" : {
         "message" : [ "Python UDF in the ON clause of a <joinType> JOIN." ]
       },
       "REPEATED_PIVOT" : {
         "message" : [ "Repeated PIVOT operation." ]
+      },
+      "SET_NAMESPACE_PROPERTY" : {
+        "message" : [ "<property> is a reserved namespace property, <msg>." ]
+      },
+      "SET_PROPERTIES_AND_DBPROPERTIES" : {
+        "message" : [ "Either PROPERTIES or DBPROPERTIES is allowed." ]
+      },
+      "SET_TABLE_PROPERTY" : {
+        "message" : [ "<property> is a reserved table property, <msg>." ]
       },
       "TOO_MANY_TYPE_ARGUMENTS_FOR_UDF_CLASS" : {
         "message" : [ "UDF class with <n> type arguments." ]

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -129,6 +129,12 @@
     "message" : [ "The value of parameter(s) '<parameter>' in <functionName> is invalid: <expected>" ],
     "sqlState" : "22023"
   },
+  "INVALID_PROPERTY_KEY" : {
+    "message" : [ "'<key>' is an invalid property key, please use quotes, e.g. SET `<key>`=`<value>`" ]
+  },
+  "INVALID_PROPERTY_VALUE" : {
+    "message" : [ "'<value>' is an invalid property value, please use quotes, e.g. SET `<key>`=`<value>`" ]
+  },
   "INVALID_SQL_SYNTAX" : {
     "message" : [ "Invalid SQL syntax: <inputString>" ],
     "sqlState" : "42000"
@@ -209,6 +215,12 @@
       "DESC_TABLE_COLUMN_PARTITION" : {
         "message" : [ "DESC TABLE COLUMN for a specific partition." ]
       },
+      "CLEAN_RESERVED_NAMESPACE_PROPERTY" : {
+        "message" : [ "<property> is a reserved namespace property, <msg>." ]
+      },
+      "CLEAN_RESERVED_TABLE_PROPERTY" : {
+        "message" : [ "<property> is a reserved table property, <msg>." ]
+      },
       "DISTRIBUTE_BY" : {
         "message" : [ "DISTRIBUTE BY clause." ]
       },
@@ -244,6 +256,9 @@
       },
       "PIVOT_TYPE" : {
         "message" : [ "Pivoting by the value '<value>' of the column data type <type>." ]
+      },
+      "PROPERTIES_AND_DBPROPERTIES_BOTH_SPECIFIED_CONFLICT" : {
+        "message" : [ "Either PROPERTIES or DBPROPERTIES is allowed." ]
       },
       "PYTHON_UDF_IN_ON_CLAUSE" : {
         "message" : [ "Python UDF in the ON clause of a <joinType> JOIN." ]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -391,14 +391,16 @@ object QueryParsingErrors extends QueryErrorsBase {
   def invalidPropertyKeyForSetQuotedConfigurationError(
       keyCandidate: String, valueStr: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(errorClass = "INVALID_PROPERTY_KEY",
-      messageParameters = Array(keyCandidate, keyCandidate, valueStr),
+      messageParameters = Array(toSQLConf(keyCandidate),
+        toSQLConf(keyCandidate), toSQLConf(valueStr)),
       ctx)
   }
 
   def invalidPropertyValueForSetQuotedConfigurationError(
       valueCandidate: String, keyStr: String, ctx: ParserRuleContext): Throwable = {
     new ParseException(errorClass = "INVALID_PROPERTY_VALUE",
-      messageParameters = Array(valueCandidate, keyStr, valueCandidate),
+      messageParameters = Array(toSQLConf(valueCandidate),
+        toSQLConf(keyStr), toSQLConf(valueCandidate)),
       ctx)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -267,16 +267,26 @@ object QueryParsingErrors extends QueryErrorsBase {
 
   def cannotCleanReservedNamespacePropertyError(
       property: String, ctx: ParserRuleContext, msg: String): Throwable = {
-    new ParseException(s"$property is a reserved namespace property, $msg.", ctx)
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array("CLEAN_RESERVED_NAMESPACE_PROPERTY", s"$property", s"$msg"),
+      ctx)
   }
 
   def propertiesAndDbPropertiesBothSpecifiedError(ctx: CreateNamespaceContext): Throwable = {
-    new ParseException("Either PROPERTIES or DBPROPERTIES is allowed.", ctx)
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array("PROPERTIES_AND_DBPROPERTIES_BOTH_SPECIFIED_CONFLICT"),
+      ctx
+    )
   }
 
   def cannotCleanReservedTablePropertyError(
       property: String, ctx: ParserRuleContext, msg: String): Throwable = {
-    new ParseException(s"$property is a reserved table property, $msg.", ctx)
+    new ParseException(
+      errorClass = "UNSUPPORTED_FEATURE",
+      messageParameters = Array("CLEAN_RESERVED_TABLE_PROPERTY", s"$property", s"$msg"),
+      ctx)
   }
 
   def duplicatedTablePathsFoundError(
@@ -380,14 +390,16 @@ object QueryParsingErrors extends QueryErrorsBase {
 
   def invalidPropertyKeyForSetQuotedConfigurationError(
       keyCandidate: String, valueStr: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"'$keyCandidate' is an invalid property key, please " +
-      s"use quotes, e.g. SET `$keyCandidate`=`$valueStr`", ctx)
+    new ParseException(errorClass = "INVALID_PROPERTY_KEY",
+      messageParameters = Array(keyCandidate, keyCandidate, valueStr),
+      ctx)
   }
 
   def invalidPropertyValueForSetQuotedConfigurationError(
       valueCandidate: String, keyStr: String, ctx: ParserRuleContext): Throwable = {
-    new ParseException(s"'$valueCandidate' is an invalid property value, please " +
-      s"use quotes, e.g. SET `$keyStr`=`$valueCandidate`", ctx)
+    new ParseException(errorClass = "INVALID_PROPERTY_VALUE",
+      messageParameters = Array(valueCandidate, keyStr, valueCandidate),
+      ctx)
   }
 
   def unexpectedFormatForResetConfigurationError(ctx: ResetConfigurationContext): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -269,14 +269,14 @@ object QueryParsingErrors extends QueryErrorsBase {
       property: String, ctx: ParserRuleContext, msg: String): Throwable = {
     new ParseException(
       errorClass = "UNSUPPORTED_FEATURE",
-      messageParameters = Array("CLEAN_RESERVED_NAMESPACE_PROPERTY", s"$property", s"$msg"),
+      messageParameters = Array("SET_NAMESPACE_PROPERTY", property, msg),
       ctx)
   }
 
   def propertiesAndDbPropertiesBothSpecifiedError(ctx: CreateNamespaceContext): Throwable = {
     new ParseException(
       errorClass = "UNSUPPORTED_FEATURE",
-      messageParameters = Array("PROPERTIES_AND_DBPROPERTIES_BOTH_SPECIFIED_CONFLICT"),
+      messageParameters = Array("SET_PROPERTIES_AND_DBPROPERTIES"),
       ctx
     )
   }
@@ -285,7 +285,7 @@ object QueryParsingErrors extends QueryErrorsBase {
       property: String, ctx: ParserRuleContext, msg: String): Throwable = {
     new ParseException(
       errorClass = "UNSUPPORTED_FEATURE",
-      messageParameters = Array("CLEAN_RESERVED_TABLE_PROPERTY", s"$property", s"$msg"),
+      messageParameters = Array("SET_TABLE_PROPERTY", property, msg),
       ctx)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -687,7 +687,7 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
       errorClass = "INVALID_PROPERTY_KEY",
       sqlState = null,
       message =
-        s"""'' is an invalid property key, please use quotes, e.g. SET ``=`value`(line 1, pos 0)
+        s""""" is an invalid property key, please use quotes, e.g. SET ""="value"(line 1, pos 0)
           |
           |== SQL ==
           |$sql
@@ -702,8 +702,8 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
       errorClass = "INVALID_PROPERTY_VALUE",
       sqlState = null,
       message =
-        """'1;2;;' is an invalid property value, please use quotes, """ +
-        """e.g. SET `key`=`1;2;;`(line 1, pos 0)""" +
+        """"1;2;;" is an invalid property value, please use quotes, """ +
+        """e.g. SET "key"="1;2;;"(line 1, pos 0)""" +
         s"""
            |
            |== SQL ==
@@ -721,8 +721,8 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
       errorSubClass = Some("SET_PROPERTIES_AND_DBPROPERTIES"),
       sqlState = "0A000",
       message =
-        """The feature is not supported: Either PROPERTIES or DBPROPERTIES """ +
-        """is allowed.(line 1, pos 0)""" +
+        """The feature is not supported: set PROPERTIES and DBPROPERTIES at the same time.""" +
+        """(line 1, pos 0)""" +
         s"""
           |
           |== SQL ==

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -643,12 +643,12 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
           |""".stripMargin)
   }
 
-  test("UNSUPPORTED_FEATURE: cannot clean reserved namespace property") {
+  test("UNSUPPORTED_FEATURE: cannot set reserved namespace property") {
     val sql = "CREATE NAMESPACE IF NOT EXISTS a.b.c WITH PROPERTIES ('location'='/home/user/db')"
     validateParsingError(
       sqlText = sql,
       errorClass = "UNSUPPORTED_FEATURE",
-      errorSubClass = Some("CLEAN_RESERVED_NAMESPACE_PROPERTY"),
+      errorSubClass = Some("SET_NAMESPACE_PROPERTY"),
       sqlState = "0A000",
       message =
         """The feature is not supported: location is a reserved namespace property, """ +
@@ -661,13 +661,13 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
           |""".stripMargin)
   }
 
-  test("UNSUPPORTED_FEATURE: cannot clean reserved table property") {
+  test("UNSUPPORTED_FEATURE: cannot set reserved table property") {
     val sql = "CREATE TABLE student (id INT, name STRING, age INT) " +
       "USING PARQUET TBLPROPERTIES ('provider'='parquet')"
     validateParsingError(
       sqlText = sql,
       errorClass = "UNSUPPORTED_FEATURE",
-      errorSubClass = Some("CLEAN_RESERVED_TABLE_PROPERTY"),
+      errorSubClass = Some("SET_TABLE_PROPERTY"),
       sqlState = "0A000",
       message =
         """The feature is not supported: provider is a reserved table property, """ +
@@ -712,13 +712,13 @@ class QueryParsingErrorsSuite extends QueryTest with QueryErrorsSuiteBase {
            |""".stripMargin)
   }
 
-  test("UNSUPPORTED_FEATURE: Properties and DbProperties both specified") {
+  test("UNSUPPORTED_FEATURE: cannot set Properties and DbProperties at the same time") {
     val sql = "CREATE NAMESPACE IF NOT EXISTS a.b.c WITH PROPERTIES ('a'='a', 'b'='b', 'c'='c') " +
       "WITH DBPROPERTIES('a'='a', 'b'='b', 'c'='c')"
     validateParsingError(
       sqlText = sql,
       errorClass = "UNSUPPORTED_FEATURE",
-      errorSubClass = Some("PROPERTIES_AND_DBPROPERTIES_BOTH_SPECIFIED_CONFLICT"),
+      errorSubClass = Some("SET_PROPERTIES_AND_DBPROPERTIES"),
       sqlState = "0A000",
       message =
         """The feature is not supported: Either PROPERTIES or DBPROPERTIES """ +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -168,11 +168,11 @@ class SparkSqlParserSuite extends AnalysisTest {
     intercept("SET a=1;2;;", expectedErrMsg)
 
     intercept("SET a b=`1;;`",
-      "'a b' is an invalid property key, please use quotes, e.g. SET `a b`=`1;;`")
+      "\"a b\" is an invalid property key, please use quotes, e.g. SET \"a b\"=\"1;;\"")
 
     intercept("SET `a`=1;2;;",
-      "'1;2;;' is an invalid property value, please use quotes, e.g." +
-        " SET `a`=`1;2;;`")
+      "\"1;2;;\" is an invalid property value, please use quotes, e.g." +
+        " SET \"a\"=\"1;2;;\"")
   }
 
   test("refresh resource") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/CreateNamespaceParserSuite.scala
@@ -84,7 +84,8 @@ class CreateNamespaceParserSuite extends AnalysisTest {
          |WITH PROPERTIES ('a'='a', 'b'='b', 'c'='c')
          |WITH DBPROPERTIES ('a'='a', 'b'='b', 'c'='c')
       """.stripMargin
-    intercept(sql, "Either PROPERTIES or DBPROPERTIES is allowed")
+    intercept(sql, "The feature is not supported: " +
+      "set PROPERTIES and DBPROPERTIES at the same time.")
   }
 
   test("create namespace - support for other types in PROPERTIES") {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Migrate the following errors in QueryParsingErrors onto use error classes:

- cannotCleanReservedNamespacePropertyError => 
UNSUPPORTED_FEATURE.SET_NAMESPACE_PROPERTY
- cannotCleanReservedTablePropertyError => UNSUPPORTED_FEATURE.SET_TABLE_PROPERTY
- invalidPropertyKeyForSetQuotedConfigurationError => INVALID_PROPERTY_KEY
- invalidPropertyValueForSetQuotedConfigurationError => INVALID_PROPERTY_VALUE
- propertiesAndDbPropertiesBothSpecifiedError => UNSUPPORTED_FEATURE.SET_PROPERTIES_AND_DBPROPERTIES

### Why are the changes needed?
Porting parsing errors of partitions to new error framework, improve test coverage, and document expected error messages in tests.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/testOnly *QueryParsingErrorsSuite*"
```