### PR TITLE
[SPARK-39096][SQL][FOLLOW-UP] Fix "MERGE INTO TABLE" test to pass with ANSI mode on

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1661,7 +1661,7 @@ class PlanResolutionSuite extends AnalysisTest {
             val target = m.targetTable
             val d = target.output.find(_.name == "default").get.asInstanceOf[AttributeReference]
             m.mergeCondition match {
-              case EqualTo(Cast(l: AttributeReference, _, _, _), _: AttributeReference) =>
+              case EqualTo(Cast(l: AttributeReference, _, _, _), _) =>
                 assert(l.sameRef(d))
               case Literal(_, BooleanType) => // this is acceptable as a merge condition
               case other =>
@@ -1695,6 +1695,10 @@ class PlanResolutionSuite extends AnalysisTest {
         val cond = m.mergeCondition
         cond match {
           case EqualTo(Cast(l: AttributeReference, IntegerType, _, _), r: AttributeReference) =>
+            assert(l.name == "i")
+            assert(r.name == "i")
+          case EqualTo(l: AttributeReference, r: AttributeReference) =>
+            // ANSI mode on.
             assert(l.name == "i")
             assert(r.name == "i")
           case Literal(_, BooleanType) => // this is acceptable as a merge condition


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a minor followup of https://github.com/apache/spark/pull/36445 that fixes the tests to pass with ANSI mode is on. Currently, it fails when ANSI mode is on, (https://github.com/apache/spark/runs/6451765082).

### Why are the changes needed?

To make the tests pass with ANSI on.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran the tests.