### PR TITLE
[SPARK-39206][INFRA][PS] Add PS label for Pandas API on Spark in PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -130,6 +130,8 @@ STRUCTURED STREAMING:
 PYTHON:
   - "bin/pyspark*"
   - "**/python/**/*"
+PS:
+  - "**/python/pyspark/pandas/**/*"
 R:
   - "**/r/**/*"
   - "**/R/**/*"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add "PS" label automatically to PRs.

### Why are the changes needed?

We added Pandas API on Spark in the JIRA component. We should also add it as a label at https://github.com/apache/spark/blob/master/.github/labeler.yml

### Does this PR introduce _any_ user-facing change?
No, dev-only.

### How was this patch tested?
I manually tested via `ls **/python/pyspark/pandas/**/*`