### PR TITLE
[SPARK-32268][SQL][TESTS][FOLLOW-UP] Use function registry in the SparkSession

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -147,6 +147,9 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   test("SPARK-14415: All functions should have own descriptions") {
     for (f <- spark.sessionState.functionRegistry.listFunction()) {
       if (!Seq("cube", "grouping", "grouping_id", "rollup").contains(f.unquotedString)) {
+        if (f.unquotedString == "bloom_filter_agg") {
+          null
+        }
         checkKeywordsNotExist(sql(s"describe function $f"), "N/A.")
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -147,9 +147,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   test("SPARK-14415: All functions should have own descriptions") {
     for (f <- spark.sessionState.functionRegistry.listFunction()) {
       if (!Seq("cube", "grouping", "grouping_id", "rollup").contains(f.unquotedString)) {
-        if (f.unquotedString == "bloom_filter_agg") {
-          null
-        }
         checkKeywordsNotExist(sql(s"describe function $f"), "N/A.")
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes:
1. Use the function registry in the Spark Session being used
2. Move function registration into `beforeAll`

### Why are the changes needed?

Registration of the function without `beforeAll` at `builtin` can affect other tests. See also https://lists.apache.org/thread/jp0ccqv10ht716g9xldm2ohdv3mpmmz1.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Unittests fixed.