### PR TITLE
[SPARK-39208][SQL] Fix query context bugs in decimal overflow under codegen mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.CurrentOrigin.withOrigin
 import org.apache.spark.sql.catalyst.trees.TreePattern.{SUM, TreePattern}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.TypeUtils
@@ -144,11 +143,10 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
    * So now, if ansi is enabled, then throw exception, if not then return null.
    * If sum is not null, then return the sum.
    */
-  protected def getEvaluateExpression: Expression = resultType match {
+  protected def getEvaluateExpression(queryContext: String): Expression = resultType match {
     case d: DecimalType =>
-      val checkOverflowInSum = withOrigin(origin) {
-        CheckOverflowInSum(sum, d, !useAnsiAdd)
-      }
+      val checkOverflowInSum =
+        CheckOverflowInSum(sum, d, !useAnsiAdd, queryContext)
       If(isEmpty, Literal.create(null, resultType), checkOverflowInSum)
     case _ if shouldTrackIsEmpty =>
       If(isEmpty, Literal.create(null, resultType), sum)
@@ -175,7 +173,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
 case class Sum(
     child: Expression,
     useAnsiAdd: Boolean = SQLConf.get.ansiEnabled)
-  extends SumBase(child) {
+  extends SumBase(child) with SupportQueryContext {
   def this(child: Expression) = this(child, useAnsiAdd = SQLConf.get.ansiEnabled)
 
   override def shouldTrackIsEmpty: Boolean = resultType match {
@@ -189,7 +187,13 @@ case class Sum(
 
   override lazy val mergeExpressions: Seq[Expression] = getMergeExpressions
 
-  override lazy val evaluateExpression: Expression = getEvaluateExpression
+  override lazy val evaluateExpression: Expression = getEvaluateExpression(queryContext)
+
+  override def initQueryContext(): String = if (useAnsiAdd) {
+    origin.context
+  } else {
+    ""
+  }
 }
 
 // scalastyle:off line.size.limit
@@ -246,9 +250,9 @@ case class TrySum(child: Expression) extends SumBase(child) {
 
   override lazy val evaluateExpression: Expression =
     if (useAnsiAdd) {
-      TryEval(getEvaluateExpression)
+      TryEval(getEvaluateExpression(""))
     } else {
-      getEvaluateExpression
+      getEvaluateExpression("")
     }
 
   override protected def withNewChildInternal(newChild: Expression): Expression =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -145,7 +145,6 @@ case class CheckOverflow(
       "\"\""
     } else {
       ctx.addReferenceObj("errCtx", queryContext)
-
     }
     nullSafeCodeGen(ctx, ev, eval => {
       // scalastyle:off line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -175,7 +175,8 @@ case class CheckOverflow(
 case class CheckOverflowInSum(
     child: Expression,
     dataType: DecimalType,
-    nullOnOverflow: Boolean) extends UnaryExpression with SupportQueryContext {
+    nullOnOverflow: Boolean,
+    queryContext: String = "") extends UnaryExpression {
 
   override def nullable: Boolean = true
 
@@ -230,10 +231,4 @@ case class CheckOverflowInSum(
 
   override protected def withNewChildInternal(newChild: Expression): CheckOverflowInSum =
     copy(child = newChild)
-
-  override def initQueryContext(): String = if (nullOnOverflow) {
-    ""
-  } else {
-    origin.context
-  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.trees.CurrentOrigin.withOrigin
+import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{Decimal, DecimalType, LongType}
 
@@ -82,5 +84,24 @@ class DecimalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       Literal.create(null, DecimalType(2, 1)), DecimalType(3, 2), true), null)
     checkEvaluation(CheckOverflow(
       Literal.create(null, DecimalType(2, 1)), DecimalType(3, 2), false), null)
+  }
+
+  test("SPARK-39208: CheckOverflow & CheckOverflowInSum support query context in runtime errors") {
+    val d = Decimal(101, 3, 1)
+    val query = "select cast(d as decimal(4, 3)) from t"
+    val origin = Origin(
+      startIndex = Some(7),
+      stopIndex = Some(30),
+      sqlText = Some(query))
+
+    val expr1 = withOrigin(origin) {
+      CheckOverflow(Literal(d), DecimalType(4, 3), false)
+    }
+    checkExceptionInExpression[ArithmeticException](expr1, query)
+
+    val expr2 = withOrigin(origin) {
+      CheckOverflowInSum(Literal(d), DecimalType(4, 3), false)
+    }
+    checkExceptionInExpression[ArithmeticException](expr2, query)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
@@ -99,9 +99,7 @@ class DecimalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
     checkExceptionInExpression[ArithmeticException](expr1, query)
 
-    val expr2 = withOrigin(origin) {
-      CheckOverflowInSum(Literal(d), DecimalType(4, 3), false)
-    }
+    val expr2 = CheckOverflowInSum(Literal(d), DecimalType(4, 3), false, queryContext = query)
     checkExceptionInExpression[ArithmeticException](expr2, query)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4378,7 +4378,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
   test("SPARK-39190, SPARK-39208: Query context of decimal overflow error should be serialized " +
     "to executors when WSCG is off") {
-    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
+    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
       SQLConf.ANSI_ENABLED.key -> "true") {
       withTable("t") {
         sql("create table t(d decimal(38, 0)) using parquet")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4376,8 +4376,8 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-39190: Query context of decimal overflow error should be serialized to executors" +
-    " when WSCG is off") {
+  test("SPARK-39190, SPARK-39208: Query context of decimal overflow error should be serialized " +
+    "to executors when WSCG is off") {
     withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
       SQLConf.ANSI_ENABLED.key -> "true") {
       withTable("t") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4378,16 +4378,19 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
 
   test("SPARK-39190: Query context of decimal overflow error should be serialized to executors" +
     " when WSCG is off") {
-    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+    withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true",
       SQLConf.ANSI_ENABLED.key -> "true") {
       withTable("t") {
         sql("create table t(d decimal(38, 0)) using parquet")
-        sql("insert into t values (2e37BD)")
-        val query = "select d / 0.1 from t"
-        val msg = intercept[SparkException] {
-          sql(query).collect()
-        }.getMessage
-        assert(msg.contains(query))
+        sql("insert into t values (6e37BD),(6e37BD)")
+        Seq(
+          "select d / 0.1 from t",
+          "select sum(d) from t").foreach { query =>
+          val msg = intercept[SparkException] {
+            sql(query).collect()
+          }.getMessage
+          assert(msg.contains(query))
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. Fix logical bugs in adding query contexts as references under codegen mode. https://github.com/apache/spark/pull/36040/files#diff-4a70d2f3a4b99f58796b87192143f9838f4c4cf469f3313eb30af79c4e07153aR145
The code 
```
    val errorContextCode = if (nullOnOverflow) {
      ctx.addReferenceObj("errCtx", queryContext)
    } else {
      "\"\""
    }
```
should be 
```
    val errorContextCode = if (nullOnOverflow) {
      "\"\""
    } else {
      ctx.addReferenceObj("errCtx", queryContext)
    }
```

2. Similar to https://github.com/apache/spark/pull/36557, make `CheckOverflowInSum` support query context when WSCG is not available.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->

Bugfix and enhancement in the query context of decimal expressions.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, the query context is not released yet.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT