### PR TITLE
[SPARK-39207][SQL] Record the SQL text when executing a query using SparkSession.sql()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -93,9 +93,10 @@ private[sql] object Dataset {
   }
 
   /** A variant of ofRows that allows passing in a tracker so we can track query parsing time. */
-  def ofRows(sparkSession: SparkSession, logicalPlan: LogicalPlan, tracker: QueryPlanningTracker)
-    : DataFrame = sparkSession.withActive {
-    val qe = new QueryExecution(sparkSession, logicalPlan, tracker)
+  def ofRows(
+      sparkSession: SparkSession, logicalPlan: LogicalPlan,
+      tracker: QueryPlanningTracker, sqlText: String): DataFrame = sparkSession.withActive {
+    val qe = new QueryExecution(sparkSession, logicalPlan, tracker, sqlText = Some(sqlText))
     qe.assertAnalyzed()
     new Dataset[Row](qe, RowEncoder(qe.analyzed.schema))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -619,7 +619,7 @@ class SparkSession private(
     val plan = tracker.measurePhase(QueryPlanningTracker.PARSING) {
       sessionState.sqlParser.parsePlan(sqlText)
     }
-    Dataset.ofRows(self, plan, tracker)
+    Dataset.ofRows(self, plan, tracker, sqlText)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -55,7 +55,8 @@ class QueryExecution(
     val sparkSession: SparkSession,
     val logical: LogicalPlan,
     val tracker: QueryPlanningTracker = new QueryPlanningTracker,
-    val mode: CommandExecutionMode.Value = CommandExecutionMode.ALL) extends Logging {
+    val mode: CommandExecutionMode.Value = CommandExecutionMode.ALL,
+    val sqlText: Option[String] = None) extends Logging {
 
   val id: Long = QueryExecution.nextExecutionId
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -82,7 +82,7 @@ object SQLExecution {
           val redactedStr = Utils
             .redact(sparkSession.sessionState.conf.stringRedactionPattern, sqlStr)
           redactedStr.substring(0, Math.min(truncateLength, redactedStr.length))
-        }.getOrElse(callSite.shortForm)
+        }.orElse(queryExecution.sqlText).getOrElse(callSite.shortForm)
 
       val planDescriptionMode =
         ExplainMode.fromString(sparkSession.sessionState.conf.uiExplainMode)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/QueryExecutionSuite.scala
@@ -279,4 +279,10 @@ class QueryExecutionSuite extends SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-39207: Record the query text when executed with SQL API") {
+    val query = "select 1 -- test query text"
+    val df = spark.sql(query)
+    assert(df.queryExecution.sqlText.contains(query))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Record the query text when executed with SQL API.


### Why are the changes needed?
* When executing a query using `SparkSession.sql`, the descript in UI is the call stack of this query. Using the query text should be more meaningful
* Record the query text will allow the listeners to get more context of the executed query


### Does this PR introduce _any_ user-facing change?
Yes, in the UI, the descript of an executed query will be the raw query text if is available
```scala
spark.sql("SELECT 1 -- this is a test").collect()
```
**Previous UI**
<img width="719" alt="image" src="https://user-images.githubusercontent.com/67896261/168788283-2360a365-eadf-4f89-8fff-1329485ae0d9.png">


Current UI
<img width="751" alt="image" src="https://user-images.githubusercontent.com/67896261/168787699-e841d00b-5522-442b-acbe-872aea7e5bcb.png">

### How was this patch tested?
newly added UT