### PR TITLE
[SPARK-39054][PYTHON][PS] Ensure infer schema accuracy in GroupBy.apply

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1394,7 +1394,10 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 "it is expensive to infer the data type internally."
             )
             limit = get_option("compute.shortcut_limit")
-            pdf = psdf.head(limit + 1)._to_internal_pandas()
+            # Ensure sampling rows >= 2 to make sure apply's infer schema is accurate
+            # See related: https://github.com/pandas-dev/pandas/issues/46893
+            sample_limit = limit + 1 if limit else 2
+            pdf = psdf.head(sample_limit)._to_internal_pandas()
             groupkeys = [
                 pdf[groupkey_name].rename(psser.name)
                 for groupkey_name, psser in zip(groupkey_names, self._groupkeys)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensure sampling rows >= 2 to make sure apply's infer schema is accurate.

### Why are the changes needed?

GroupBy.apply infers schema when the type hints is not specified for the func of `grouby.apply`. We cannot guarantee that the infer schema of the sampled values ​​is completely accurate, but we should make it as accurate as possible.

Since v1.4, Pandas introduce an interface change [1], especially it has some impact the behavior of Group.apply when df has single row (`head(1)`):

```python
>> psdf
Out[9]: 
  __groupkey_0__  timestamp car_id
0              A        0.0      A
1              A        0.0      A

>> psdf.head(1)._to_internal_pandas().groupby(groupkeys).apply(pandas_apply, *args, **kwargs)

Out[10]: 
   column
0     0.0

>> psdf.head(2)._to_internal_pandas().groupby(groupkeys).apply(pandas_apply, *args, **kwargs)

Out[11]: 
          column
car_id          
A      0     0.0
```

Finally, it causes the mismatch error of sample apply infer schema and final apply results.

[1] https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#groupby-apply-consistent-transform-detection


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- GA CI passed
- `test_apply_infer_schema_without_shortcut` and `test_apply_with_new_dataframe_without_shortcut` passed with v1.4.