### PR TITLE
[MINOR][SQL] Fix typos and formatting in query parsing error messages

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -282,7 +282,7 @@ class ParseException(
     builder ++= "\n" ++= message
     start match {
       case Origin(Some(l), Some(p), _, _, _, _, _) =>
-        builder ++= s"(line $l, pos $p)\n"
+        builder ++= s" (line $l, pos $p)\n"
         command.foreach { cmd =>
           val (above, below) = cmd.split("\n").splitAt(l)
           builder ++= "\n== SQL ==\n"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParseDriver.scala
@@ -282,7 +282,7 @@ class ParseException(
     builder ++= "\n" ++= message
     start match {
       case Origin(Some(l), Some(p), _, _, _, _, _) =>
-        builder ++= s" (line $l, pos $p)\n"
+        builder ++= s"(line $l, pos $p)\n"
         command.foreach { cmd =>
           val (above, below) = cmd.split("\n").splitAt(l)
           builder ++= "\n== SQL ==\n"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -369,13 +369,11 @@ object QueryParsingErrors extends QueryErrorsBase {
     new ParseException(errorClass = "DUPLICATE_KEY", messageParameters = Array(toSQLId(key)), ctx)
   }
 
-  def unexpectedFomatForSetConfigurationError(ctx: ParserRuleContext): Throwable = {
+  def unexpectedFormatForSetConfigurationError(ctx: ParserRuleContext): Throwable = {
     new ParseException(
-      s"""
-         |Expected format is 'SET', 'SET key', or 'SET key=value'. If you want to include
-         |special characters in key, or include semicolon in value, please use quotes,
-         |e.g., SET `ke y`=`v;alue`.
-       """.stripMargin.replaceAll("\n", " "), ctx)
+      "Expected format is 'SET', 'SET key', or 'SET key=value'. If you want to include " +
+      "special characters in key, or include semicolon in value, please use quotes, " +
+      "e.g., SET `key`=`value`.", ctx)
   }
 
   def invalidPropertyKeyForSetQuotedConfigurationError(
@@ -392,10 +390,8 @@ object QueryParsingErrors extends QueryErrorsBase {
 
   def unexpectedFormatForResetConfigurationError(ctx: ResetConfigurationContext): Throwable = {
     new ParseException(
-      s"""
-         |Expected format is 'RESET' or 'RESET key'. If you want to include special characters
-         |in key, please use quotes, e.g., RESET `ke y`.
-       """.stripMargin.replaceAll("\n", " "), ctx)
+      "Expected format is 'RESET' or 'RESET key'. If you want to include special characters " +
+      "in key, please use quotes, e.g., RESET `key`.", ctx)
   }
 
   def intervalValueOutOfRangeError(ctx: IntervalContext): Throwable = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -94,7 +94,7 @@ class SparkSqlAstBuilder extends AstBuilder {
           SetCommand(Some("-v" -> None))
         case s if s.isEmpty =>
           SetCommand(None)
-        case _ => throw QueryParsingErrors.unexpectedFomatForSetConfigurationError(ctx)
+        case _ => throw QueryParsingErrors.unexpectedFormatForSetConfigurationError(ctx)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkSqlParserSuite.scala
@@ -109,7 +109,7 @@ class SparkSqlParserSuite extends AnalysisTest {
 
     val expectedErrMsg = "Expected format is 'SET', 'SET key', or " +
       "'SET key=value'. If you want to include special characters in key, or include semicolon " +
-      "in value, please use quotes, e.g., SET `ke y`=`v;alue`."
+      "in value, please use quotes, e.g., SET `key`=`value`."
     intercept("SET spark.sql.key value", expectedErrMsg)
     intercept("SET spark.sql.key   'value'", expectedErrMsg)
     intercept("SET    spark.sql.key \"value\" ", expectedErrMsg)
@@ -136,7 +136,7 @@ class SparkSqlParserSuite extends AnalysisTest {
 
     val expectedErrMsg = "Expected format is 'RESET' or 'RESET key'. " +
       "If you want to include special characters in key, " +
-      "please use quotes, e.g., RESET `ke y`."
+      "please use quotes, e.g., RESET `key`."
     intercept("RESET spark.sql.key1 key2", expectedErrMsg)
     intercept("RESET spark.  sql.key1 key2", expectedErrMsg)
     intercept("RESET spark.sql.key1 key2 key3", expectedErrMsg)
@@ -162,7 +162,7 @@ class SparkSqlParserSuite extends AnalysisTest {
 
     val expectedErrMsg = "Expected format is 'SET', 'SET key', or " +
       "'SET key=value'. If you want to include special characters in key, or include semicolon " +
-      "in value, please use quotes, e.g., SET `ke y`=`v;alue`."
+      "in value, please use quotes, e.g., SET `key`=`value`."
 
     intercept("SET a=1; SELECT 1", expectedErrMsg)
     intercept("SET a=1;2;;", expectedErrMsg)


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Fix some typos in query parsing error messages.
2. Remove extraneous whitespace in some messages.
3. Fix a typo in a function name.

### Why are the changes needed?
To improve usability.

### Does this PR introduce _any_ user-facing change?
Yes. E.g., before this change, we may have an error
```
scala> spark.sql("SET non-existent-key")
org.apache.spark.sql.catalyst.parser.ParseException:
 Expected format is 'SET', 'SET key', or 'SET key=value'. If you want to include special characters in key, or include semicolon in value, please use quotes, e.g., SET `ke y`=`v;alue`.        (line 1, pos 0)

== SQL ==
SET non-existent-key
^^^

```
After this change, the error message becomes
```
org.apache.spark.sql.catalyst.parser.ParseException:
Expected format is 'SET', 'SET key', or 'SET key=value'. If you want to include special characters in key, or include semicolon in value, please use quotes, e.g., SET `key`=`value`.(line 1, pos 0)
```

### How was this patch tested?
Existing tests were updated to match the corrected error messages.