### PR TITLE
[SPARK-39236][SQL] Make CreateTable and ListTables be compatible with 3 layer namespace

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -663,7 +663,7 @@ test_that("test tableNames and tables", {
   expect_equal(count(tables), count + 1)
   expect_equal(count(tables()), count(tables))
   expect_true("tableName" %in% colnames(tables()))
-  expect_true(all(c("tableName", "database", "isTemporary") %in% colnames(tables())))
+  expect_true(all(c("tableName", "namespace", "isTemporary") %in% colnames(tables())))
 
   suppressWarnings(registerTempTable(df, "table2"))
   tables <- listTables()
@@ -4026,7 +4026,7 @@ test_that("catalog APIs, listTables, listColumns, listFunctions", {
   tb <- listTables()
   count <- count(tables())
   expect_equal(nrow(tb), count)
-  expect_equal(colnames(tb), c("name", "database", "description", "tableType", "isTemporary"))
+  expect_equal(colnames(tb), c("name", "catalog", "database", "description", "tableType", "isTemporary"))
 
   createOrReplaceTempView(as.DataFrame(cars), "cars")
 

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -4026,7 +4026,8 @@ test_that("catalog APIs, listTables, listColumns, listFunctions", {
   tb <- listTables()
   count <- count(tables())
   expect_equal(nrow(tb), count)
-  expect_equal(colnames(tb), c("name", "catalog", "database", "description", "tableType", "isTemporary"))
+  expect_equal(colnames(tb),
+               c("name", "catalog", "namespace", "description", "tableType", "isTemporary"))
 
   createOrReplaceTempView(as.DataFrame(cars), "cars")
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -965,7 +965,7 @@ class SessionCatalog(
     isTempView(nameParts.asTableIdentifier)
   }
 
-  def isGlobalTempView(dbName: String): Boolean = {
+  def isGlobalTempViewDB(dbName: String): Boolean = {
     globalTempViewManager.database.equals(dbName)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -965,6 +965,10 @@ class SessionCatalog(
     isTempView(nameParts.asTableIdentifier)
   }
 
+  def isGlobalTempView(dbName: String): Boolean = {
+    globalTempViewManager.database.equals(dbName)
+  }
+
   def lookupTempView(name: TableIdentifier): Option[View] = {
     val tableName = formatTableName(name.table)
     if (name.database.isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2186,7 +2186,7 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def tableOrViewNotFound(ident: Seq[String]): Throwable = {
-    val fullName = ident.mkString(".")
+    val fullName = ident.quoted
     new AnalysisException(s"Table or view '$fullName' not found")
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2186,8 +2186,7 @@ object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def tableOrViewNotFound(ident: Seq[String]): Throwable = {
-    val fullName = ident.quoted
-    new AnalysisException(s"Table or view '$fullName' not found")
+    new AnalysisException(s"Table or view '${ident.quoted}' not found")
   }
 
   def unexpectedTypeOfRelationError(relation: LogicalPlan, tableName: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2185,6 +2185,11 @@ object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException(s"Table or view '$tableName' not found in database '$dbName'")
   }
 
+  def tableOrViewNotFound(ident: Seq[String]): Throwable = {
+    val fullName = ident.mkString(".")
+    new AnalysisException(s"Table or view '$fullName' not found")
+  }
+
   def unexpectedTypeOfRelationError(relation: LogicalPlan, tableName: String): Throwable = {
     new AnalysisException(
       s"Unexpected type ${relation.getClass.getCanonicalName} of the relation $tableName")

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -78,7 +78,6 @@ class Table(
       s"tableType='$tableType', " +
       s"isTemporary='$isTemporary']"
   }
-
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -55,7 +55,8 @@ class Database(
  * A table in Spark, as returned by the `listTables` method in [[Catalog]].
  *
  * @param name name of the table.
- * @param database name of the database the table belongs to.
+ * @param catalog name of the catalog that the table belongs to.
+ * @param qualifier qualifier of the namespace that the table belongs to.
  * @param description description of the table.
  * @param tableType type of the table (e.g. view, table).
  * @param isTemporary whether the table is a temporary table.
@@ -64,7 +65,7 @@ class Database(
 @Stable
 class Table(
     val name: String,
-    @Nullable catalog: String,
+    @Nullable val catalog: String,
     @Nullable val qualifier: Array[String],
     @Nullable val description: String,
     val tableType: String,
@@ -76,9 +77,7 @@ class Table(
     this(name, null, Array(database), description, tableType, isTemporary)
   }
 
-  def database: String = parseQualifier
-
-  def parseQualifier: String = {
+  def database: String = {
     if (qualifier == null) {
       null
     } else if (qualifier.length == 2) {
@@ -93,6 +92,7 @@ class Table(
   override def toString: String = {
     "Table[" +
       s"name='$name', " +
+      Option(catalog).map { d => s"catalog='$d', " }.getOrElse("") +
       Option(database).map { d => s"database='$d', " }.getOrElse("") +
       Option(description).map { d => s"description='$d', " }.getOrElse("") +
       s"tableType='$tableType', " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -78,6 +78,7 @@ class Table(
       s"tableType='$tableType', " +
       s"isTemporary='$isTemporary']"
   }
+  
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -70,7 +70,19 @@ class Table(
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
 
-  def database: String = if (qualifier.length == 2) qualifier(1) else null
+  def database: String = parseQualifier
+
+  def parseQualifier: String = {
+    if (qualifier == null) {
+      null
+    } else if (qualifier.length == 2) {
+      qualifier(1)
+    } else if (qualifier.length == 1) {
+      qualifier(0)
+    } else {
+      null
+    }
+  }
 
   override def toString: String = {
     "Table[" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -78,7 +78,7 @@ class Table(
       s"tableType='$tableType', " +
       s"isTemporary='$isTemporary']"
   }
-  
+
 }
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -56,7 +56,7 @@ class Database(
  *
  * @param name name of the table.
  * @param catalog name of the catalog that the table belongs to.
- * @param qualifier qualifier of the namespace that the table belongs to.
+ * @param namespace qualifier of the namespace that the table belongs to.
  * @param description description of the table.
  * @param tableType type of the table (e.g. view, table).
  * @param isTemporary whether the table is a temporary table.
@@ -66,7 +66,7 @@ class Database(
 class Table(
     val name: String,
     @Nullable val catalog: String,
-    @Nullable val qualifier: Array[String],
+    @Nullable val namespace: Array[String],
     @Nullable val description: String,
     val tableType: String,
     val isTemporary: Boolean)
@@ -78,12 +78,12 @@ class Table(
   }
 
   def database: String = {
-    if (qualifier == null) {
+    if (namespace == null) {
       null
-    } else if (qualifier.length == 2) {
-      qualifier(1)
-    } else if (qualifier.length == 1) {
-      qualifier(0)
+    } else if (namespace.length == 2) {
+      namespace(1)
+    } else if (namespace.length == 1) {
+      namespace(0)
     } else {
       null
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -64,11 +64,17 @@ class Database(
 @Stable
 class Table(
     val name: String,
+    @Nullable catalog: String,
     @Nullable val qualifier: Array[String],
     @Nullable val description: String,
     val tableType: String,
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
+
+  def this(
+    name: String, database: String, description: String, tableType: String, isTemporary: Boolean) {
+    this(name, null, Array(database), description, tableType, isTemporary)
+  }
 
   def database: String = parseQualifier
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -56,7 +56,7 @@ class Database(
  *
  * @param name name of the table.
  * @param catalog name of the catalog that the table belongs to.
- * @param namespace qualifier of the namespace that the table belongs to.
+ * @param namespace the namespace that the table belongs to.
  * @param description description of the table.
  * @param tableType type of the table (e.g. view, table).
  * @param isTemporary whether the table is a temporary table.
@@ -72,16 +72,18 @@ class Table(
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
 
-  def this(name: String, database: String, description: String, tableType: String,
-    isTemporary: Boolean) = {
+  def this(
+      name: String,
+      database: String,
+      description: String,
+      tableType: String,
+      isTemporary: Boolean) = {
     this(name, null, Array(database), description, tableType, isTemporary)
   }
 
   def database: String = {
     if (namespace == null) {
       null
-    } else if (namespace.length == 2) {
-      namespace(1)
     } else if (namespace.length == 1) {
       namespace(0)
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -64,11 +64,13 @@ class Database(
 @Stable
 class Table(
     val name: String,
-    @Nullable val database: String,
+    @Nullable val qualifier: Array[String],
     @Nullable val description: String,
     val tableType: String,
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
+
+  def database: String = if (qualifier.length == 2) qualifier(1) else null
 
   override def toString: String = {
     "Table[" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -72,8 +72,8 @@ class Table(
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
 
-  def this(
-    name: String, database: String, description: String, tableType: String, isTemporary: Boolean) {
+  def this(name: String, database: String, description: String, tableType: String,
+    isTemporary: Boolean) = {
     this(name, null, Array(database), description, tableType, isTemporary)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -128,9 +128,11 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       case NonFatal(_) => None
     }
     val isTemp = sessionCatalog.isTempView(tableIdent)
+    val qualifier =
+      Array(metadata.map(_.identifier.database).getOrElse(tableIdent.database).orNull)
     new Table(
       name = tableIdent.table,
-      database = metadata.map(_.identifier.database).getOrElse(tableIdent.database).orNull,
+      qualifier = qualifier,
       description = metadata.map(_.comment.orNull).orNull,
       tableType = if (isTemp) "TEMPORARY" else metadata.map(_.tableType.name).orNull,
       isTemporary = isTemp)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -147,7 +147,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
           TableCatalog.PROP_EXTERNAL, "false").equals("true")
         new Table(
           name = t.identifier.name(),
-          database = t.identifier.namespace().head,
+          qualifier = t.identifier.namespace(),
           description = t.table.properties().get("comment"),
           tableType =
             if (isExternal) CatalogTableType.EXTERNAL.name
@@ -156,11 +156,11 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       case v: ResolvedView =>
         new Table(
           name = v.identifier.name(),
-          database = v.identifier.namespace().toString,
+          qualifier = v.identifier.namespace(),
           description = "",
           tableType = if (v.isTemp) "TEMPORARY" else "VIEW",
           isTemporary = v.isTemp)
-      case _ => throw new Exception(ident.mkString(".") + " not found")
+      case _ => throw QueryCompilationErrors.tableOrViewNotFound(ident)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -148,7 +148,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         new Table(
           name = t.identifier.name(),
           catalog = t.catalog.name(),
-          qualifier = t.identifier.namespace(),
+          namespace = t.identifier.namespace(),
           description = t.table.properties().get("comment"),
           tableType =
             if (isExternal) CatalogTableType.EXTERNAL.name
@@ -158,7 +158,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         new Table(
           name = v.identifier.name(),
           catalog = null,
-          qualifier = v.identifier.namespace(),
+          namespace = v.identifier.namespace(),
           description = null,
           tableType = if (v.isTemp) "TEMPORARY" else "VIEW",
           isTemporary = v.isTemp)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -132,7 +132,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       Array(metadata.map(_.identifier.database).getOrElse(tableIdent.database).orNull)
     new Table(
       name = tableIdent.table,
-      qualifier = qualifier,
+      database = tableIdent.database.getOrElse(null),
       description = metadata.map(_.comment.orNull).orNull,
       tableType = if (isTemp) "TEMPORARY" else metadata.map(_.tableType.name).orNull,
       isTemporary = isTemp)
@@ -147,6 +147,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
           TableCatalog.PROP_EXTERNAL, "false").equals("true")
         new Table(
           name = t.identifier.name(),
+          catalog = t.catalog.name(),
           qualifier = t.identifier.namespace(),
           description = t.table.properties().get("comment"),
           tableType =
@@ -156,8 +157,9 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       case v: ResolvedView =>
         new Table(
           name = v.identifier.name(),
+          catalog = null,
           qualifier = v.identifier.namespace(),
-          description = "",
+          description = null,
           tableType = if (v.isTemp) "TEMPORARY" else "VIEW",
           isTemporary = v.isTemp)
       case _ => throw QueryCompilationErrors.tableOrViewNotFound(ident)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -165,7 +165,7 @@ class GlobalTempViewSuite extends QueryTest with SharedSparkSession {
       assert(spark.catalog.tableExists(globalTempDB, "src"))
       assert(spark.catalog.getTable(globalTempDB, "src").toString == new Table(
         name = "src",
-        database = globalTempDB,
+        qualifier = Array(globalTempDB),
         description = null,
         tableType = "TEMPORARY",
         isTemporary = true).toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -165,7 +165,8 @@ class GlobalTempViewSuite extends QueryTest with SharedSparkSession {
       assert(spark.catalog.tableExists(globalTempDB, "src"))
       assert(spark.catalog.getTable(globalTempDB, "src").toString == new Table(
         name = "src",
-        database = globalTempDB,
+        catalog = "spark_catalog",
+        namespace = Array(globalTempDB),
         description = null,
         tableType = "TEMPORARY",
         isTemporary = true).toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -165,7 +165,7 @@ class GlobalTempViewSuite extends QueryTest with SharedSparkSession {
       assert(spark.catalog.tableExists(globalTempDB, "src"))
       assert(spark.catalog.getTable(globalTempDB, "src").toString == new Table(
         name = "src",
-        qualifier = Array(globalTempDB),
+        database = globalTempDB,
         description = null,
         tableType = "TEMPORARY",
         isTemporary = true).toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalog.Table
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint}
+import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -165,7 +166,7 @@ class GlobalTempViewSuite extends QueryTest with SharedSparkSession {
       assert(spark.catalog.tableExists(globalTempDB, "src"))
       assert(spark.catalog.getTable(globalTempDB, "src").toString == new Table(
         name = "src",
-        catalog = "spark_catalog",
+        catalog = CatalogManager.SESSION_CATALOG_NAME,
         namespace = Array(globalTempDB),
         description = null,
         tableType = "TEMPORARY",

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -275,7 +275,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   test("Table.toString") {
-    assert(new Table("volley", "databasa", "one", "world", isTemporary = true).toString ==
+    assert(new Table("volley", Array("databasa"), "one", "world", isTemporary = true).toString ==
       "Table[name='volley', database='databasa', description='one', " +
         "tableType='world', isTemporary='true']")
     assert(new Table("volley", null, null, "world", isTemporary = true).toString ==
@@ -304,7 +304,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
 
   test("catalog classes format in Dataset.show") {
     val db = new Database("nama", "descripta", "locata")
-    val table = new Table("nama", "databasa", "descripta", "typa", isTemporary = false)
+    val table = new Table("nama", Array("databasa"), "descripta", "typa", isTemporary = false)
     val function = new Function("nama", "databasa", "descripta", "classa", isTemporary = false)
     val column = new Column(
       "nama", "descripta", "typa", nullable = false, isPartition = true, isBucket = true)

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -317,7 +317,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     assert(Seq(tableFields.apply(0), tableFields.apply(1), tableFields.apply(3),
       tableFields.apply(4), tableFields.apply(5)) ==
       Seq("nama", "cataloa", "descripta", "typa", false))
-    assert(tableFields.apply(2).asInstanceOf[Array[String]].deep == Array("databasa").deep)
+    assert(tableFields.apply(2).asInstanceOf[Array[String]].sameElements(Array("databasa")))
     assert(functionFields == Seq("nama", "databasa", "descripta", "classa", false))
     assert(columnFields == Seq("nama", "descripta", "typa", false, true, true))
     val dbString = CatalogImpl.makeDataset(Seq(db), spark).showString(10)

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -674,7 +674,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   test("list tables when there is `default` catalog") {
     spark.conf.set("spark.sql.catalog.default", classOf[InMemoryCatalog].getName)
 
-    assert(spark.catalog.listTables().collect().isEmpty)
+    assert(spark.catalog.listTables("default").collect().isEmpty)
     createTable("my_table1")
     createTable("my_table2")
     createTempTable("my_temp_table")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -670,4 +670,15 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         expectedTable2.isTemporary == t.isTemporary))
     }
   }
+
+  test("list tables when there is `default` catalog") {
+    spark.conf.set("spark.sql.catalog.default", classOf[InMemoryCatalog].getName)
+
+    assert(spark.catalog.listTables().collect().isEmpty)
+    createTable("my_table1")
+    createTable("my_table2")
+    createTempTable("my_temp_table")
+    assert(spark.catalog.listTables("default").collect().map(_.name).toSet ==
+      Set("my_table1", "my_table2", "my_temp_table"))
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -313,7 +313,9 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val functionFields = ScalaReflection.getConstructorParameterValues(function)
     val columnFields = ScalaReflection.getConstructorParameterValues(column)
     assert(dbFields == Seq("nama", "descripta", "locata"))
-    assert(tableFields == Seq("nama", "databasa", "descripta", "typa", false))
+    assert(Seq(tableFields.apply(0), tableFields.apply(2), tableFields.apply(3),
+      tableFields.apply(4)) == Seq("nama", "descripta", "typa", false))
+    assert(tableFields.apply(1).asInstanceOf[Array[String]].deep == Array("databasa").deep)
     assert(functionFields == Seq("nama", "databasa", "descripta", "classa", false))
     assert(columnFields == Seq("nama", "descripta", "typa", false, true, true))
     val dbString = CatalogImpl.makeDataset(Seq(db), spark).showString(10)
@@ -321,7 +323,8 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val functionString = CatalogImpl.makeDataset(Seq(function), spark).showString(10)
     val columnString = CatalogImpl.makeDataset(Seq(column), spark).showString(10)
     dbFields.foreach { f => assert(dbString.contains(f.toString)) }
-    tableFields.foreach { f => assert(tableString.contains(f.toString)) }
+    tableFields.foreach { f => assert(tableString.contains(f.toString) ||
+      tableString.contains(f.asInstanceOf[Array[String]].mkString(""))) }
     functionFields.foreach { f => assert(functionString.contains(f.toString)) }
     columnFields.foreach { f => assert(columnString.contains(f.toString)) }
   }
@@ -647,7 +650,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       assert(tables.size == 2)
 
       val expectedTable1 =
-        new Table(tableName, dbName, description, CatalogTableType.MANAGED.name, false)
+        new Table(tableName, Array(dbName), description, CatalogTableType.MANAGED.name, false)
       assert(tables.exists(t =>
         expectedTable1.name.equals(t.name) && expectedTable1.database.equals(t.database) &&
         expectedTable1.description.equals(t.description) &&
@@ -655,7 +658,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         expectedTable1.isTemporary == t.isTemporary))
 
       val expectedTable2 =
-        new Table(tableName2, dbName, description2, CatalogTableType.EXTERNAL.name, false)
+        new Table(tableName2, Array(dbName), description2, CatalogTableType.EXTERNAL.name, false)
       assert(tables.exists(t =>
         expectedTable2.name.equals(t.name) && expectedTable2.database.equals(t.database) &&
         expectedTable2.description.equals(t.description) &&

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -314,10 +314,9 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val functionFields = ScalaReflection.getConstructorParameterValues(function)
     val columnFields = ScalaReflection.getConstructorParameterValues(column)
     assert(dbFields == Seq("nama", "descripta", "locata"))
-    assert(Seq(tableFields.apply(0), tableFields.apply(1), tableFields.apply(3),
-      tableFields.apply(4), tableFields.apply(5)) ==
+    assert(Seq(tableFields(0), tableFields(1), tableFields(3), tableFields(4), tableFields(5)) ==
       Seq("nama", "cataloa", "descripta", "typa", false))
-    assert(tableFields.apply(2).asInstanceOf[Array[String]].sameElements(Array("databasa")))
+    assert(tableFields(2).asInstanceOf[Array[String]].sameElements(Array("databasa")))
     assert(functionFields == Seq("nama", "databasa", "descripta", "classa", false))
     assert(columnFields == Seq("nama", "descripta", "typa", false, true, true))
     val dbString = CatalogImpl.makeDataset(Seq(db), spark).showString(10)

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -275,8 +275,8 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   test("Table.toString") {
-    assert(new Table("volley", Array("databasa"), "one", "world", isTemporary = true).toString ==
-      "Table[name='volley', database='databasa', description='one', " +
+    assert(new Table("volley", null, Array("databasa"), "one", "world", isTemporary = true).toString
+      == "Table[name='volley', database='databasa', description='one', " +
         "tableType='world', isTemporary='true']")
     assert(new Table("volley", null, null, "world", isTemporary = true).toString ==
       "Table[name='volley', tableType='world', isTemporary='true']")
@@ -304,7 +304,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
 
   test("catalog classes format in Dataset.show") {
     val db = new Database("nama", "descripta", "locata")
-    val table = new Table("nama", Array("databasa"), "descripta", "typa", isTemporary = false)
+    val table = new Table("nama", "databasa", "descripta", "typa", isTemporary = false)
     val function = new Function("nama", "databasa", "descripta", "classa", isTemporary = false)
     val column = new Column(
       "nama", "descripta", "typa", nullable = false, isPartition = true, isBucket = true)
@@ -572,7 +572,6 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   test("three layer namespace compatibility - create managed table") {
-    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryCatalog].getName)
     val catalogName = "testcat"
     val dbName = "my_db"
     val tableName = "my_table"
@@ -650,7 +649,8 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       assert(tables.size == 2)
 
       val expectedTable1 =
-        new Table(tableName, Array(dbName), description, CatalogTableType.MANAGED.name, false)
+        new Table(tableName, catalogName, Array(dbName), description,
+          CatalogTableType.MANAGED.name, false)
       assert(tables.exists(t =>
         expectedTable1.name.equals(t.name) && expectedTable1.database.equals(t.database) &&
         expectedTable1.description.equals(t.description) &&
@@ -658,7 +658,8 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         expectedTable1.isTemporary == t.isTemporary))
 
       val expectedTable2 =
-        new Table(tableName2, Array(dbName), description2, CatalogTableType.EXTERNAL.name, false)
+        new Table(tableName2, catalogName, Array(dbName), description2,
+          CatalogTableType.EXTERNAL.name, false)
       assert(tables.exists(t =>
         expectedTable2.name.equals(t.name) && expectedTable2.database.equals(t.database) &&
         expectedTable2.description.equals(t.description) &&

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/MetastoreDataSourcesSuite.scala
@@ -524,7 +524,7 @@ class MetastoreDataSourcesSuite extends QueryTest with SQLTestUtils with TestHiv
           assert(
             intercept[AnalysisException] {
               sparkSession.catalog.createTable("createdJsonTable", jsonFilePath.toString)
-            }.getMessage.contains("Table createdJsonTable already exists."),
+            }.getMessage.contains("Table default.createdJsonTable already exists."),
             "We should complain that createdJsonTable already exists")
         }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1650,8 +1650,8 @@ class HiveDDLSuite
         // Even if index tables exist, listTables and getTable APIs should still work
         checkAnswer(
           spark.catalog.listTables().toDF(),
-          Row(indexTabName, null, Array("default"), null, null, false) ::
-            Row(tabName, null, Array("default"), null, "MANAGED", false) :: Nil)
+          Row(indexTabName, "spark_catalog", Array("default"), null, null, false) ::
+            Row(tabName, "spark_catalog", Array("default"), null, "MANAGED", false) :: Nil)
         assert(spark.catalog.getTable("default", indexTabName).name === indexTabName)
 
         intercept[TableAlreadyExistsException] {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -1650,8 +1650,8 @@ class HiveDDLSuite
         // Even if index tables exist, listTables and getTable APIs should still work
         checkAnswer(
           spark.catalog.listTables().toDF(),
-          Row(indexTabName, "default", null, null, false) ::
-            Row(tabName, "default", null, "MANAGED", false) :: Nil)
+          Row(indexTabName, null, Array("default"), null, null, false) ::
+            Row(tabName, null, Array("default"), null, "MANAGED", false) :: Nil)
         assert(spark.catalog.getTable("default", indexTabName).name === indexTabName)
 
         intercept[TableAlreadyExistsException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. Change `CreateTable` API to make it support 3 layer namespace.
2. Change `ListTables` API such that a) it supports `database` parameter and if that `database` does not exist b) further check if the parameter is `catalog.database`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->

CreateTable and ListTables does not support 3 layer namespace.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. The API change here is backward compatible and it extends the API to further support 3 layer namespace (e.g. catalog.database.table).

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

UT