### PR TITLE
[SPARK-39215][PYTHON] Reduce Py4J calls in pyspark.sql.utils.is_timestamp_ntz_preferred

### DIFF
--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -292,12 +292,4 @@ def is_timestamp_ntz_preferred() -> bool:
     """
     Return a bool if TimestampNTZType is preferred according to the SQL configuration set.
     """
-    jvm = SparkContext._jvm
-    return (
-        jvm is not None
-        and getattr(getattr(jvm.org.apache.spark.sql.internal, "SQLConf$"), "MODULE$")
-        .get()
-        .timestampType()
-        .typeName()
-        == "timestamp_ntz"
-    )
+    return SparkContext._jvm.PythonSQLUtils.isTimestampNTZPreferred()

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -292,4 +292,5 @@ def is_timestamp_ntz_preferred() -> bool:
     """
     Return a bool if TimestampNTZType is preferred according to the SQL configuration set.
     """
-    return SparkContext._jvm.PythonSQLUtils.isTimestampNTZPreferred()  # type: ignore[union-attr]
+    jvm = SparkContext._jvm
+    return jvm is not None and jvm.PythonSQLUtils.isTimestampNTZPreferred()

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -292,4 +292,4 @@ def is_timestamp_ntz_preferred() -> bool:
     """
     Return a bool if TimestampNTZType is preferred according to the SQL configuration set.
     """
-    return SparkContext._jvm.PythonSQLUtils.isTimestampNTZPreferred()
+    return SparkContext._jvm.PythonSQLUtils.isTimestampNTZPreferred()  # type: ignore[union-attr]

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -66,6 +66,9 @@ private[sql] object PythonSQLUtils extends Logging {
     listAllSQLConfigs().filter(p => SQLConf.isStaticConfigKey(p._1)).toArray
   }
 
+  def isTimestampNTZPreferred: Boolean =
+    SQLConf.get.timestampType == org.apache.spark.sql.types.TimestampNTZType
+
   /**
    * Python callable function to read a file in Arrow stream format and create a [[RDD]]
    * using each serialized ArrowRecordBatch as a partition.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to reduce the number of Py4J calls at `pyspark.sql.utils.is_timestamp_ntz_preferred` by having a single method to check.

### Why are the changes needed?

For better performance, and simplicity in the code.

### Does this PR introduce _any_ user-facing change?

Yes, the number of Py4J calls will be reduced, and the driver side access will become faster.

### How was this patch tested?

Existing tests should cover.