### PR TITLE
[SPARK-39219][DOC] Promote Structured Streaming over DStream

### DIFF
--- a/docs/streaming-programming-guide.md
+++ b/docs/streaming-programming-guide.md
@@ -23,6 +23,14 @@ license: |
 * This will become a table of contents (this text will be scraped).
 {:toc}
 
+# Note
+
+Spark Streaming is the previous generation of Spark’s streaming engine. There are no longer
+updates to Spark Streaming and it’s a legacy project. There is a newer and easier to use
+streaming engine in Spark called Structured Streaming. You should use Spark Structured Streaming
+for your streaming applications and pipelines. See
+[Structured Streaming Programming Guide](structured-streaming-programming-guide.html).
+
 # Overview
 Spark Streaming is an extension of the core Spark API that enables scalable, high-throughput,
 fault-tolerant stream processing of live data streams. Data can be ingested from many sources


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add NOTE section for DStream guide doc to promote Structured Streaming. 

Screenshot:

<img width="992" alt="screenshot-spark-streaming-programming-guide-change" src="https://user-images.githubusercontent.com/1317309/168977732-4c32db9a-0fb1-4a82-a542-bf385e5f3683.png">

### Why are the changes needed?

We see efforts of community are more focused on Structured Streaming (based on Spark SQL) than Spark Streaming (DStream). We would like to encourage end users to use Structured Streaming than Spark Streaming whenever possible for their workloads.

### Does this PR introduce _any_ user-facing change?

Yes, doc change.

### How was this patch tested?

N/A