### PR TITLE
[SPARK-39216][SQL] Do not collapse projects in CombineUnions if it hasCorrelatedSubquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1374,16 +1374,15 @@ object CombineUnions extends Rule[LogicalPlan] {
         // Push down projection through Union and then push pushed plan to Stack if
         // there is a Project.
         case Project(projectList, Distinct(u @ Union(children, byName, allowMissingCol)))
-            if projectList.forall(e => e.deterministic && !hasSubquery(e)) && children.nonEmpty &&
+            if projectList.forall(_.deterministic) && children.nonEmpty &&
               flattenDistinct && byName == topByName && allowMissingCol == topAllowMissingCol =>
           stack.pushAll(pushProjectionThroughUnion(projectList, u).reverse)
         case Project(projectList, Deduplicate(keys: Seq[Attribute], u: Union))
-            if projectList.forall(e => e.deterministic && !hasSubquery(e)) && flattenDistinct &&
-              u.byName == topByName && u.allowMissingCol == topAllowMissingCol &&
-              AttributeSet(keys) == u.outputSet =>
+            if projectList.forall(_.deterministic) && flattenDistinct && u.byName == topByName &&
+              u.allowMissingCol == topAllowMissingCol && AttributeSet(keys) == u.outputSet =>
           stack.pushAll(pushProjectionThroughUnion(projectList, u).reverse)
         case Project(projectList, u @ Union(children, byName, allowMissingCol))
-            if projectList.forall(e => e.deterministic && !hasSubquery(e)) && children.nonEmpty &&
+            if projectList.forall(_.deterministic) && children.nonEmpty &&
               byName == topByName && allowMissingCol == topAllowMissingCol =>
           stack.pushAll(pushProjectionThroughUnion(projectList, u).reverse)
         case child =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4427,6 +4427,18 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         ))
     }
   }
+
+  test("SPARK-39216: Do not combine unions if project contains subqueries") {
+    val df = spark.sql(
+      """
+        |SELECT (SELECT IF(x, 1, 0)) AS a
+        |FROM (SELECT true) t(x)
+        |UNION
+        |SELECT 1 AS a
+      """.stripMargin)
+
+    checkAnswer(df, Seq(Row(1)))
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4428,16 +4428,29 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-39216: Do not combine unions if project contains subqueries") {
-    val df = spark.sql(
-      """
-        |SELECT (SELECT IF(x, 1, 0)) AS a
-        |FROM (SELECT true) t(x)
-        |UNION
-        |SELECT 1 AS a
-      """.stripMargin)
+  test("SPARK-39216: Don't collapse projects in CombineUnions if it hasCorrelatedSubquery") {
+    checkAnswer(
+      sql(
+        """
+          |SELECT (SELECT IF(x, 1, 0)) AS a
+          |FROM (SELECT true) t(x)
+          |UNION
+          |SELECT 1 AS a
+        """.stripMargin),
+      Seq(Row(1)))
 
-    checkAnswer(df, Seq(Row(1)))
+    checkAnswer(
+      sql(
+        """
+          |SELECT x + 1
+          |FROM   (SELECT id
+          |               + (SELECT Max(id)
+          |                  FROM   range(2)) AS x
+          |        FROM   range(1)) t
+          |UNION
+          |SELECT 1 AS a
+        """.stripMargin),
+      Seq(Row(2), Row(1)))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Makes `CombineUnions` do not collapse projects if it hasCorrelatedSubquery. For example:
```sql
SELECT (SELECT IF(x, 1, 0)) AS a
FROM (SELECT true) t(x)
UNION
SELECT 1 AS a
```

It will throw exception:
```
java.lang.IllegalStateException: Couldn't find x#4 in [] 
```

### Why are the changes needed?

Fix bug.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.