### PR TITLE
[SPARK-39224][CORE] Lower general ProcfsMetricsGetter error log levels except `/proc/` lookup error

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -46,8 +46,6 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
   private val testing = Utils.isTesting
   private val pageSize = computePageSize()
   private var isAvailable: Boolean = isProcfsAvailable
-  private var ignoreProcfsMetricsGetterWarning =
-    SparkEnv.get.conf.get(config.IGNORE_PROCFS_TREE_METRICS_GETTER_WARNING)
   private val pid = computePid()
 
   private lazy val isProcfsAvailable: Boolean = {
@@ -79,10 +77,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
     }
     catch {
       case e: SparkException =>
-        if (!ignoreProcfsMetricsGetterWarning) {
-          logWarning("Exception when trying to compute process tree." +
-            " As a result reporting of ProcessTree metrics is stopped", e)
-        }
+        logDebug("Exception when trying to compute process tree." +
+          " As a result reporting of ProcessTree metrics is stopped", e)
         isAvailable = false
         -1
     }
@@ -98,10 +94,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       Integer.parseInt(out.split("\n")(0))
     } catch {
       case e: Exception =>
-        if (!ignoreProcfsMetricsGetterWarning) {
-          logWarning("Exception when trying to compute pagesize, as a" +
-            " result reporting of ProcessTree metrics is stopped")
-        }
+        logDebug("Exception when trying to compute pagesize, as a" +
+          " result reporting of ProcessTree metrics is stopped")
         isAvailable = false
         0
     }
@@ -159,10 +153,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       childPidsInInt
     } catch {
       case e: Exception =>
-        if (!ignoreProcfsMetricsGetterWarning) {
-          logWarning("Exception when trying to compute process tree." +
-            " As a result reporting of ProcessTree metrics is stopped.", e)
-        }
+        logDebug("Exception when trying to compute process tree." +
+          " As a result reporting of ProcessTree metrics is stopped.", e)
         isAvailable = false
         mutable.ArrayBuffer.empty[Int]
     }
@@ -207,10 +199,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       }
     } catch {
       case f: IOException =>
-        if (!ignoreProcfsMetricsGetterWarning) {
-          logWarning("There was a problem with reading" +
-            " the stat file of the process. ", f)
-        }
+        logDebug("There was a problem with reading" +
+          " the stat file of the process. ", f)
         throw f
     }
   }

--- a/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
+++ b/core/src/main/scala/org/apache/spark/executor/ProcfsMetricsGetter.scala
@@ -46,6 +46,8 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
   private val testing = Utils.isTesting
   private val pageSize = computePageSize()
   private var isAvailable: Boolean = isProcfsAvailable
+  private var ignoreProcfsMetricsGetterWarning =
+    SparkEnv.get.conf.get(config.IGNORE_PROCFS_TREE_METRICS_GETTER_WARNING)
   private val pid = computePid()
 
   private lazy val isProcfsAvailable: Boolean = {
@@ -77,8 +79,10 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
     }
     catch {
       case e: SparkException =>
-        logWarning("Exception when trying to compute process tree." +
-          " As a result reporting of ProcessTree metrics is stopped", e)
+        if (!ignoreProcfsMetricsGetterWarning) {
+          logWarning("Exception when trying to compute process tree." +
+            " As a result reporting of ProcessTree metrics is stopped", e)
+        }
         isAvailable = false
         -1
     }
@@ -94,8 +98,10 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       Integer.parseInt(out.split("\n")(0))
     } catch {
       case e: Exception =>
-        logWarning("Exception when trying to compute pagesize, as a" +
-          " result reporting of ProcessTree metrics is stopped")
+        if (!ignoreProcfsMetricsGetterWarning) {
+          logWarning("Exception when trying to compute pagesize, as a" +
+            " result reporting of ProcessTree metrics is stopped")
+        }
         isAvailable = false
         0
     }
@@ -153,8 +159,10 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       childPidsInInt
     } catch {
       case e: Exception =>
-        logWarning("Exception when trying to compute process tree." +
-          " As a result reporting of ProcessTree metrics is stopped.", e)
+        if (!ignoreProcfsMetricsGetterWarning) {
+          logWarning("Exception when trying to compute process tree." +
+            " As a result reporting of ProcessTree metrics is stopped.", e)
+        }
         isAvailable = false
         mutable.ArrayBuffer.empty[Int]
     }
@@ -199,8 +207,10 @@ private[spark] class ProcfsMetricsGetter(procfsDir: String = "/proc/") extends L
       }
     } catch {
       case f: IOException =>
-        logWarning("There was a problem with reading" +
-          " the stat file of the process. ", f)
+        if (!ignoreProcfsMetricsGetterWarning) {
+          logWarning("There was a problem with reading" +
+            " the stat file of the process. ", f)
+        }
         throw f
     }
   }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -278,13 +278,6 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
-  private[spark] val IGNORE_PROCFS_TREE_METRICS_GETTER_WARNING =
-    ConfigBuilder("spark.executor.ignoreProcfsTreeMetricsGetterWarning")
-      .doc("When true, Spark will ignore warning messages in ProcfsTreeMetricsGetter.")
-      .version("3.4.0")
-      .booleanConf
-      .createWithDefault(true)
-
   private[spark] val EXECUTOR_METRICS_POLLING_INTERVAL =
     ConfigBuilder("spark.executor.metrics.pollingInterval")
       .doc("How often to collect executor metrics (in milliseconds). " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -278,6 +278,13 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  private[spark] val IGNORE_PROCFS_TREE_METRICS_GETTER_WARNING =
+    ConfigBuilder("spark.executor.ignoreProcfsTreeMetricsGetterWarning")
+      .doc("When true, Spark will ignore warning messages in ProcfsTreeMetricsGetter.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
   private[spark] val EXECUTOR_METRICS_POLLING_INTERVAL =
     ConfigBuilder("spark.executor.metrics.pollingInterval")
       .doc("How often to collect executor metrics (in milliseconds). " +


### PR DESCRIPTION

### What changes were proposed in this pull request?
There are many noisy warning logs such as 
```
22/05/18 16:48:58 WARN ProcfsMetricsGetter: There was a problem with reading the stat file of the process.
java.io.FileNotFoundException: /proc/50371/stat (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at org.apache.spark.executor.ProcfsMetricsGetter.openReader$1(ProcfsMetricsGetter.scala:174)
	at org.apache.spark.executor.ProcfsMetricsGetter.$anonfun$addProcfsMetricsFromOneProcess$1(ProcfsMetricsGetter.scala:176)
	at org.apache.spark.util.Utils$.tryWithResource(Utils.scala:2647)
	at org.apache.spark.executor.ProcfsMetricsGetter.addProcfsMetricsFromOneProcess(ProcfsMetricsGetter.scala:176)
	at org.apache.spark.executor.ProcfsMetricsGetter.$anonfun$computeAllMetrics$1(ProcfsMetricsGetter.scala:216)
	at scala.runtime.java8.JFunction1$mcVI$sp.apply(JFunction1$mcVI$sp.java:23)
	at scala.collection.immutable.Set$Set2.foreach(Set.scala:132)
	at org.apache.spark.executor.ProcfsMetricsGetter.computeAllMetrics(ProcfsMetricsGetter.scala:214)
	at org.apache.spark.metrics.ProcessTreeMetrics$.getMetricValues(ExecutorMetricType.scala:93)
	at org.apache.spark.executor.ExecutorMetrics$.$anonfun$getCurrentMetrics$1(ExecutorMetrics.scala:103)
	at org.apache.spark.executor.ExecutorMetrics$.$anonfun$getCurrentMetrics$1$adapted(ExecutorMetrics.scala:102)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at org.apache.spark.executor.ExecutorMetrics$.getCurrentMetrics(ExecutorMetrics.scala:102)
	at org.apache.spark.SparkContext.reportHeartBeat(SparkContext.scala:2578)
	at org.apache.spark.SparkContext.$anonfun$new$30(SparkContext.scala:587)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.apache.spark.util.Utils$.logUncaughtExceptions(Utils.scala:2022)
	at org.apache.spark.Heartbeater$$anon$1.run(Heartbeater.scala:46)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
```

Many user complain about this. We can ignore this by default.


### Why are the changes needed?

Ignore noisy logs

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
MT
