### PR TITLE
[SPARK-39204][CORE][SQL] Replace `Utils.createTempDir` with `JavaUtils.createTempDir`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -373,6 +373,22 @@ public class JavaUtils {
   }
 
   /**
+   * Create a temporary directory inside the given parent directory with default namePrefix "spark".
+   * The directory will be automatically deleted when the VM shuts down.
+   */
+  public static File createTempDirWithRoot(String root) throws IOException {
+    return createTempDir(root, null);
+  }
+
+  /**
+   * Create a temporary directory inside `java.io.tmpdir` with specified namePrefix.
+   * The directory will be automatically deleted when the VM shuts down.
+   */
+  public static File createTempDirWithPrefix(String namePrefix) throws IOException {
+    return createTempDir(null, namePrefix);
+  }
+
+  /**
    * Create a temporary directory inside the given parent directory. The directory will be
    * automatically deleted when the VM shuts down.
    */

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerKrbJDBCIntegrationSuite.scala
@@ -26,6 +26,7 @@ import scala.io.Source
 
 import org.apache.hadoop.minikdc.MiniKdc
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.{SecurityUtils, Utils}
@@ -44,7 +45,7 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
   override def beforeAll(): Unit = runIfTestsEnabled(s"Prepare for ${this.getClass.getName}") {
     SecurityUtils.setGlobalKrbDebug(true)
 
-    val kdcDir = Utils.createTempDir()
+    val kdcDir = JavaUtils.createTempDir()
     val kdcConf = MiniKdc.createConf()
     kdcConf.setProperty(MiniKdc.DEBUG, "true")
     kdc = new MiniKdc(kdcConf, kdcDir)
@@ -52,8 +53,8 @@ abstract class DockerKrbJDBCIntegrationSuite extends DockerJDBCIntegrationSuite 
 
     principal = s"$userName@${kdc.getRealm}"
 
-    entryPointDir = Utils.createTempDir()
-    initDbDir = Utils.createTempDir()
+    entryPointDir = JavaUtils.createTempDir()
+    initDbDir = JavaUtils.createTempDir()
     val keytabFile = new File(initDbDir, keytabFileName)
     keytabFullPath = keytabFile.getAbsolutePath
     kdc.createPrincipal(keytabFile, userName)

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaMicroBatchSourceSuite.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.TopicPartition
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.time.SpanSugar._
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{Dataset, ForeachWriter, Row, SparkSession}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
@@ -48,7 +49,6 @@ import org.apache.spark.sql.streaming.{StreamingQuery, StreamTest, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.Utils
 
 abstract class KafkaSourceTest extends StreamTest with SharedSparkSession with KafkaTest {
 
@@ -1502,7 +1502,7 @@ class KafkaMicroBatchV2SourceSuite extends KafkaMicroBatchSourceSuiteBase {
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.4.3-kafka-include-headers-default/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaTestUtils.scala
@@ -54,6 +54,7 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.kafka010.KafkaTokenUtil
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{SecurityUtils, ShutdownHookManager, Utils}
 
 /**
@@ -131,7 +132,7 @@ class KafkaTestUtils(
   }
 
   private def setUpMiniKdc(): Unit = {
-    val kdcDir = Utils.createTempDir()
+    val kdcDir = JavaUtils.createTempDir()
     val kdcConf = MiniKdc.createConf()
     kdcConf.setProperty(MiniKdc.DEBUG, "true")
     // The port for MiniKdc service gets selected in the constructor, but will be bound
@@ -200,7 +201,7 @@ class KafkaTestUtils(
 
   private def createKeytabsAndJaasConfigFile(): String = {
     assert(kdcReady, "KDC should be set up beforehand")
-    val baseDir = Utils.createTempDir()
+    val baseDir = JavaUtils.createTempDir()
 
     val zkServerUser = s"zookeeper/$localCanonicalHostName"
     val zkServerKeytabFile = new File(baseDir, "zookeeper.keytab")
@@ -490,7 +491,7 @@ class KafkaTestUtils(
     val props = new Properties()
     props.put("broker.id", "0")
     props.put("listeners", s"PLAINTEXT://127.0.0.1:$brokerPort")
-    props.put("log.dir", Utils.createTempDir().getAbsolutePath)
+    props.put("log.dir", JavaUtils.createTempDir().getAbsolutePath)
     props.put("zookeeper.connect", zkAddress)
     props.put("zookeeper.connection.timeout.ms", "60000")
     props.put("log.flush.interval.messages", "1")
@@ -637,8 +638,8 @@ class KafkaTestUtils(
   private class EmbeddedZookeeper(val zkConnect: String) {
     private val ZOOKEEPER_AUTH_PROVIDER = "zookeeper.authProvider.1"
 
-    val snapshotDir = Utils.createTempDir()
-    val logDir = Utils.createTempDir()
+    val snapshotDir = JavaUtils.createTempDir()
+    val logDir = JavaUtils.createTempDir()
 
     if (secure) {
       System.setProperty(ZOOKEEPER_AUTH_PROVIDER, classOf[SASLAuthenticationProvider].getName)

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/DirectKafkaStreamSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{LocalStreamingContext, Milliseconds, StreamingContext, Time}
 import org.apache.spark.streaming.dstream.DStream
@@ -335,7 +336,7 @@ class DirectKafkaStreamSuite
   test("offset recovery") {
     val topic = "recovery"
     kafkaTestUtils.createTopic(topic)
-    testDir = Utils.createTempDir()
+    testDir = JavaUtils.createTempDir()
 
     val kafkaParams = getKafkaParams("auto.offset.reset" -> "earliest")
 

--- a/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
+++ b/connector/kafka-0-10/src/test/scala/org/apache/spark/streaming/kafka010/KafkaTestUtils.scala
@@ -40,6 +40,7 @@ import org.apache.zookeeper.server.{NIOServerCnxnFactory, ZooKeeperServer}
 
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.streaming.Time
 import org.apache.spark.util.{ShutdownHookManager, Utils}
 
@@ -234,7 +235,7 @@ private[kafka010] class KafkaTestUtils extends Logging {
     producer = null
   }
 
-  val brokerLogDir = Utils.createTempDir().getAbsolutePath
+  val brokerLogDir = JavaUtils.createTempDir().getAbsolutePath
 
   private def brokerConfiguration: Properties = {
     val props = new Properties()
@@ -313,8 +314,8 @@ private[kafka010] class KafkaTestUtils extends Logging {
   }
 
   private class EmbeddedZookeeper(val zkConnect: String) {
-    val snapshotDir = Utils.createTempDir()
-    val logDir = Utils.createTempDir()
+    val snapshotDir = JavaUtils.createTempDir()
+    val logDir = JavaUtils.createTempDir()
 
     val zookeeper = new ZooKeeperServer(snapshotDir, logDir, 500)
     val (ip, port) = {

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisStreamSuite.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisStreamSuite.scala
@@ -37,7 +37,6 @@ import org.apache.spark.streaming.kinesis.KinesisReadConfigurations._
 import org.apache.spark.streaming.kinesis.KinesisTestUtils._
 import org.apache.spark.streaming.receiver.BlockManagerBasedStoreResult
 import org.apache.spark.streaming.scheduler.ReceivedBlockInfo
-import org.apache.spark.util.Utils
 
 abstract class KinesisStreamTests(aggregateTestData: Boolean) extends KinesisFunSuite
   with LocalStreamingContext with Eventually with BeforeAndAfter with BeforeAndAfterAll {
@@ -356,7 +355,7 @@ abstract class KinesisStreamTests(aggregateTestData: Boolean) extends KinesisFun
 
   testIfEnabled("failure recovery") {
     val sparkConf = new SparkConf().setMaster("local[4]").setAppName(this.getClass.getSimpleName)
-    val checkpointDir = Utils.createTempDir().getAbsolutePath
+    val checkpointDir = JavaUtils.createTempDir().getAbsolutePath
 
     ssc = new StreamingContext(sc, Milliseconds(1000))
     ssc.checkpoint(checkpointDir)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -54,6 +54,7 @@ import org.apache.spark.internal.plugin.PluginContainer
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.launcher.JavaModuleOptions
 import org.apache.spark.metrics.source.JVMCPUSource
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.partial.{ApproximateEvaluator, PartialResult}
 import org.apache.spark.rdd._
 import org.apache.spark.resource._
@@ -1655,7 +1656,7 @@ class SparkContext(config: SparkConf) extends Logging {
       // If the scheme is file, use URI to simply copy instead of downloading.
       val uriToUse = if (!isLocal && scheme == "file") uri else new URI(key)
       val uriToDownload = UriBuilder.fromUri(uriToUse).fragment(null).build()
-      val source = Utils.fetchFile(uriToDownload.toString, Utils.createTempDir(), conf,
+      val source = Utils.fetchFile(uriToDownload.toString, JavaUtils.createTempDir(), conf,
         hadoopConfiguration, timestamp, useCache = false, shouldUntar = false)
       val dest = new File(
         SparkFiles.getRootDirectory(),

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -39,6 +39,7 @@ import org.apache.spark.memory.{MemoryManager, UnifiedMemoryManager}
 import org.apache.spark.metrics.{MetricsSystem, MetricsSystemInstances}
 import org.apache.spark.network.netty.{NettyBlockTransferService, SparkTransportConf}
 import org.apache.spark.network.shuffle.ExternalBlockStoreClient
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.{RpcEndpoint, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler.{LiveListenerBus, OutputCommitCoordinator}
 import org.apache.spark.scheduler.OutputCommitCoordinator.OutputCommitCoordinatorEndpoint
@@ -417,7 +418,8 @@ object SparkEnv extends Logging {
     // called, and we only need to do it for driver. Because driver may run as a service, and if we
     // don't delete this tmp dir when sc is stopped, then will create too many tmp dirs.
     if (isDriver) {
-      val sparkFilesDir = Utils.createTempDir(Utils.getLocalDir(conf), "userFiles").getAbsolutePath
+      val sparkFilesDir =
+        JavaUtils.createTempDir(Utils.getLocalDir(conf), "userFiles").getAbsolutePath
       envInstance.driverTmpDir = Some(sparkFilesDir)
     }
 

--- a/core/src/main/scala/org/apache/spark/TestUtils.scala
+++ b/core/src/main/scala/org/apache/spark/TestUtils.scala
@@ -54,6 +54,7 @@ import org.json4s.JsonAST.JValue
 import org.json4s.jackson.JsonMethods.{compact, render}
 
 import org.apache.spark.executor.TaskMetrics
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler._
 import org.apache.spark.util.Utils
 
@@ -77,7 +78,7 @@ private[spark] object TestUtils {
       toStringValue: String = "",
       classNamesWithBase: Seq[(String, String)] = Seq.empty,
       classpathUrls: Seq[URL] = Seq.empty): URL = {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val files1 = for (name <- classNames) yield {
       createCompiledClass(name, tempDir, toStringValue, classpathUrls = classpathUrls)
     }
@@ -93,7 +94,7 @@ private[spark] object TestUtils {
    * file names in the jar file to their contents.
    */
   def createJarWithFiles(files: Map[String, String], dir: File = null): URL = {
-    val tempDir = Option(dir).getOrElse(Utils.createTempDir())
+    val tempDir = Option(dir).getOrElse(JavaUtils.createTempDir())
     val jarFile = File.createTempFile("testJar", ".jar", tempDir)
     val jarStream = new JarOutputStream(new FileOutputStream(jarFile))
     files.foreach { case (k, v) =>

--- a/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala
@@ -32,6 +32,7 @@ import org.apache.spark._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{BUFFER_SIZE, EXECUTOR_CORES}
 import org.apache.spark.internal.config.Python._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceProfile.{EXECUTOR_CORES_LOCAL_PROPERTY, PYSPARK_MEMORY_LOCAL_PROPERTY}
 import org.apache.spark.security.SocketAuthHelper
 import org.apache.spark.util._
@@ -70,7 +71,7 @@ private[spark] object PythonEvalType {
 
 private object BasePythonRunner {
 
-  private lazy val faultHandlerLogDir = Utils.createTempDir(namePrefix = "faulthandler")
+  private lazy val faultHandlerLogDir = JavaUtils.createTempDirWithPrefix("faulthandler")
 
   private def faultHandlerLogPath(pid: Int): Path = {
     new File(faultHandlerLogDir, pid.toString).toPath

--- a/core/src/main/scala/org/apache/spark/deploy/FaultToleranceTest.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/FaultToleranceTest.scala
@@ -35,7 +35,8 @@ import org.json4s.jackson.JsonMethods
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.deploy.master.RecoveryState
 import org.apache.spark.internal.{config, Logging}
-import org.apache.spark.util.{ThreadUtils, Utils}
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.util.ThreadUtils
 
 /**
  * This suite tests the fault tolerance of the Spark standalone scheduler, mainly the Master.
@@ -408,7 +409,7 @@ private object SparkDocker {
 
   private def startNode(dockerCmd: ProcessBuilder) : (String, DockerId, File) = {
     val ipPromise = Promise[String]()
-    val outFile = File.createTempFile("fault-tolerance-test", "", Utils.createTempDir())
+    val outFile = File.createTempFile("fault-tolerance-test", "", JavaUtils.createTempDir())
     val outStream: FileWriter = new FileWriter(outFile)
     def findIpAndLog(line: String): Unit = {
       if (line.startsWith("CONTAINER_IP=")) {

--- a/core/src/main/scala/org/apache/spark/deploy/LocalSparkCluster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/LocalSparkCluster.scala
@@ -25,6 +25,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.deploy.master.Master
 import org.apache.spark.deploy.worker.Worker
 import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.util.Utils
 
@@ -68,7 +69,7 @@ class LocalSparkCluster private (
     /* Start the Workers */
     for (workerNum <- 1 to numWorkers) {
       val workDir = if (Utils.isTesting) {
-        Utils.createTempDir(namePrefix = "worker").getAbsolutePath
+        JavaUtils.createTempDirWithPrefix("worker").getAbsolutePath
       } else null
       if (Utils.isTesting) {
         workerDirs += workDir

--- a/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/PythonRunner.scala
@@ -28,6 +28,7 @@ import scala.util.Try
 import org.apache.spark.{SparkConf, SparkUserAppException}
 import org.apache.spark.api.python.{Py4JServer, PythonUtils}
 import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{RedirectThread, Utils}
 
 /**
@@ -157,7 +158,7 @@ object PythonRunner {
    * if exist in the given paths.
    */
   private def resolvePyFiles(pyFiles: Array[String]): Array[String] = {
-    lazy val dest = Utils.createTempDir(namePrefix = "localPyFiles")
+    lazy val dest = JavaUtils.createTempDirWithPrefix("localPyFiles")
     pyFiles.flatMap { pyFile =>
       // In case of client with submit, the python paths should be set before context
       // initialization because the context initialization can be done later.

--- a/core/src/main/scala/org/apache/spark/deploy/RPackageUtils.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/RPackageUtils.scala
@@ -28,6 +28,7 @@ import com.google.common.io.{ByteStreams, Files}
 
 import org.apache.spark.api.r.RUtils
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{RedirectThread, Utils}
 
 private[deploy] object RPackageUtils extends Logging {
@@ -140,7 +141,7 @@ private[deploy] object RPackageUtils extends Logging {
    * Extracts the files under /R in the jar to a temporary directory for building.
    */
   private def extractRFolder(jar: JarFile, printStream: PrintStream, verbose: Boolean): File = {
-    val tempDir = Utils.createTempDir(null)
+    val tempDir = JavaUtils.createTempDir()
     val jarEntries = jar.entries()
     while (jarEntries.hasMoreElements) {
       val entry = jarEntries.nextElement()
@@ -184,7 +185,7 @@ private[deploy] object RPackageUtils extends Logging {
             print(s"$file contains R source code. Now installing package.", printStream, Level.INFO)
             val rSource = extractRFolder(jar, printStream, verbose)
             if (RUtils.rPackages.isEmpty) {
-              RUtils.rPackages = Some(Utils.createTempDir().getAbsolutePath)
+              RUtils.rPackages = Some(JavaUtils.createTempDir().getAbsolutePath)
             }
             try {
               if (!rPackageBuilder(rSource, printStream, verbose, RUtils.rPackages.get)) {

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -55,6 +55,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util._
 
 /**
@@ -341,7 +342,7 @@ private[spark] class SparkSubmit extends Logging {
     // update spark config from args
     args.toSparkConf(Option(sparkConf))
     val hadoopConf = conf.getOrElse(SparkHadoopUtil.newConfiguration(sparkConf))
-    val targetDir = Utils.createTempDir()
+    val targetDir = JavaUtils.createTempDir()
 
     // Kerberos is not supported in standalone mode, and keytab support is not yet available
     // in Mesos cluster mode.

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.History.HybridStoreDiskBackend.LEVELDB
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.status.KVUtils
 import org.apache.spark.status.KVUtils._
 import org.apache.spark.util.{Clock, Utils}
@@ -120,7 +121,7 @@ private class HistoryServerDiskManager(
     val needed = approximateSize(eventLogSize, isCompressed)
     makeRoom(needed)
 
-    val tmp = Utils.createTempDir(tmpStoreDir.getPath(), "appstore")
+    val tmp = JavaUtils.createTempDir(tmpStoreDir.getPath(), "appstore")
     Utils.chmod700(tmp)
 
     updateUsage(needed)

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -44,6 +44,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.internal.plugin.PluginContainer
 import org.apache.spark.memory.{SparkOutOfMemoryError, TaskMemoryManager}
 import org.apache.spark.metrics.source.JVMCPUSource
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.rpc.RpcTimeout
 import org.apache.spark.scheduler._
@@ -988,7 +989,7 @@ private[spark] class Executor(
         logInfo(s"Fetching $name with timestamp $timestamp")
         val sourceURI = new URI(name)
         val uriToDownload = UriBuilder.fromUri(sourceURI).fragment(null).build()
-        val source = Utils.fetchFile(uriToDownload.toString, Utils.createTempDir(), conf,
+        val source = Utils.fetchFile(uriToDownload.toString, JavaUtils.createTempDir(), conf,
           hadoopConf, timestamp, useCache = !isLocal, shouldUntar = false)
         val dest = new File(
           SparkFiles.getRootDirectory(),

--- a/core/src/main/scala/org/apache/spark/util/DependencyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/DependencyUtils.scala
@@ -28,6 +28,7 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.SparkSubmitUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
 
 private[spark] case class IvyProperties(
     packagesExclusions: String,
@@ -191,7 +192,7 @@ private[spark] object DependencyUtils extends Logging {
       userJar: String,
       sparkConf: SparkConf,
       hadoopConf: Configuration): String = {
-    val targetDir = Utils.createTempDir()
+    val targetDir = JavaUtils.createTempDir()
     val userJarName = userJar.split(File.separatorChar).last
     Option(jars)
       .map {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -980,7 +980,7 @@ private[spark] object Utils extends Logging {
       try {
         val rootDir = new File(root)
         if (rootDir.exists || rootDir.mkdirs()) {
-          val dir = createTempDir(root)
+          val dir = JavaUtils.createTempDirWithRoot(root)
           chmod700(dir)
           Some(dir.getAbsolutePath)
         } else {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -333,18 +333,6 @@ private[spark] object Utils extends Logging {
   }
 
   /**
-   * Create a temporary directory inside the given parent directory. The directory will be
-   * automatically deleted when the VM shuts down.
-   */
-  def createTempDir(
-      root: String = System.getProperty("java.io.tmpdir"),
-      namePrefix: String = "spark"): File = {
-    val dir = createDirectory(root, namePrefix)
-    ShutdownHookManager.registerShutdownDeleteDir(dir)
-    dir
-  }
-
-  /**
    * Copy all data from an InputStream to an OutputStream. NIO way of file stream to file stream
    * copying is disabled by default unless explicitly set transferToEnabled as true,
    * the parameter transferToEnabled should be configured by spark.file.transferTo = [true|false].

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -45,6 +45,7 @@ import org.apache.spark.io.LZFCompressionCodec;
 import org.apache.spark.io.SnappyCompressionCodec;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.memory.TestMemoryManager;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.network.util.LimitedInputStream;
 import org.apache.spark.scheduler.MapStatus;
 import org.apache.spark.security.CryptoStreamUtils;
@@ -91,7 +92,7 @@ public class UnsafeShuffleWriterSuite implements ShuffleChecksumTestHelper {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    tempDir = Utils.createTempDir(null, "test");
+    tempDir = JavaUtils.createTempDir(null, "test");
     mergedOutputFile = File.createTempFile("mergedoutput", "", tempDir);
     partitionSizesInMergedFile = null;
     spillFilesCreated.clear();

--- a/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
+++ b/core/src/test/java/org/apache/spark/unsafe/map/AbstractBytesToBytesMapSuite.java
@@ -83,7 +83,7 @@ public abstract class AbstractBytesToBytesMapSuite {
           .set(package$.MODULE$.SHUFFLE_COMPRESS(), false));
     taskMemoryManager = new TaskMemoryManager(memoryManager, 0);
 
-    tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "unsafe-test");
+    tempDir = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "unsafe-test");
     spillFilesCreated.clear();
     MockitoAnnotations.openMocks(this).close();
     when(blockManager.diskBlockManager()).thenReturn(diskBlockManager);

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSuite.java
@@ -38,6 +38,7 @@ import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.internal.config.package$;
 import org.apache.spark.memory.TestMemoryManager;
 import org.apache.spark.memory.TaskMemoryManager;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.serializer.JavaSerializer;
 import org.apache.spark.serializer.SerializerInstance;
 import org.apache.spark.serializer.SerializerManager;
@@ -93,7 +94,7 @@ public class UnsafeExternalSorterSuite {
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "unsafe-test");
+    tempDir = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "unsafe-test");
     spillFilesCreated.clear();
     taskContext = mock(TaskContext.class);
     when(taskContext.taskMetrics()).thenReturn(new TaskMetrics());

--- a/core/src/test/java/test/org/apache/spark/JavaSparkContextSuite.java
+++ b/core/src/test/java/test/org/apache/spark/JavaSparkContextSuite.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import org.apache.spark.api.java.*;
 import org.apache.spark.*;
-import org.apache.spark.util.Utils;
+import org.apache.spark.network.util.JavaUtils;
 
 /**
  * Java apps can use both Java-friendly JavaSparkContext and Scala SparkContext.
@@ -37,7 +37,7 @@ public class JavaSparkContextSuite implements Serializable {
 
   @Test
   public void javaSparkContext() throws IOException {
-    File tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
+    File tempDir = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     String dummyJarFile = File.createTempFile(tempDir.toString(), "jarFile").toString();
     String[] jars = new String[] {};
     java.util.Map<String, String> environment = new java.util.HashMap<>();

--- a/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
+++ b/core/src/test/scala/org/apache/spark/CheckpointSuite.scala
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.internal.config.CACHE_CHECKPOINT_PREFERRED_LOCS_EXPIRE_TIME
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.io.CompressionCodec
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd._
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.storage.{BlockId, StorageLevel, TestBlockId}
@@ -254,7 +255,7 @@ class CheckpointSuite extends SparkFunSuite with RDDCheckpointTester with LocalS
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    checkpointDir = File.createTempFile("temp", "", Utils.createTempDir())
+    checkpointDir = File.createTempFile("temp", "", JavaUtils.createTempDir())
     checkpointDir.delete()
     sc = new SparkContext("local", "test")
     sc.setCheckpointDir(checkpointDir.toString)

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.mapreduce.lib.input.{FileSplit => NewFileSplit, TextInp
 import org.apache.hadoop.mapreduce.lib.output.{TextOutputFormat => NewTextOutputFormat}
 
 import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.{HadoopRDD, NewHadoopRDD}
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.storage.StorageLevel
@@ -45,7 +46,7 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/org/apache/spark/LocalRootDirsTest.scala
+++ b/core/src/test/scala/org/apache/spark/LocalRootDirsTest.scala
@@ -20,6 +20,7 @@ package org.apache.spark
 import java.io.File
 import java.util.UUID
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -39,7 +40,7 @@ trait LocalRootDirsTest extends SparkFunSuite with LocalSparkContext {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    tempDir = Utils.createTempDir(namePrefix = "local")
+    tempDir = JavaUtils.createTempDirWithPrefix("local")
     conf.set("spark.local.dir",
       tempDir.getAbsolutePath + File.separator + UUID.randomUUID().toString)
   }

--- a/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SecurityManagerSuite.scala
@@ -28,8 +28,9 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.security.GroupMappingServiceProvider
-import org.apache.spark.util.{ResetSystemProperties, SparkConfWithEnv, Utils}
+import org.apache.spark.util.{ResetSystemProperties, SparkConfWithEnv}
 
 class DummyGroupMappingServiceProvider extends GroupMappingServiceProvider {
 
@@ -512,7 +513,7 @@ class SecurityManagerSuite extends SparkFunSuite with ResetSystemProperties {
   }
 
   private def createTempSecretFile(contents: String = "test-secret"): File = {
-    val secretDir = Utils.createTempDir("temp-secrets")
+    val secretDir = JavaUtils.createTempDirWithRoot("temp-secrets")
     val secretFile = new File(secretDir, "temp-secret.txt")
     Files.write(secretFile.toPath, contents.getBytes(UTF_8))
     secretFile

--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -40,6 +40,7 @@ import org.apache.spark.TestUtils._
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests._
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceAllocation
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
@@ -285,8 +286,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
 
   test("addFile recursive works") {
     withTempDir { pluto =>
-      val neptune = Utils.createTempDir(pluto.getAbsolutePath)
-      val saturn = Utils.createTempDir(neptune.getAbsolutePath)
+      val neptune = JavaUtils.createTempDirWithRoot(pluto.getAbsolutePath)
+      val saturn = JavaUtils.createTempDirWithRoot(neptune.getAbsolutePath)
       val alien1 = File.createTempFile("alien", "1", neptune)
       val alien2 = File.createTempFile("alien", "2", saturn)
 
@@ -318,7 +319,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     withTempDir { dir =>
       try {
         val sep = File.separator
-        val tmpDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
+        val tmpDir = JavaUtils.createTempDirWithRoot(dir.getAbsolutePath + sep + "test space")
         val tmpConfFile1 = File.createTempFile("test file", ".conf", tmpDir)
 
         sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
@@ -336,7 +337,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     withTempDir { dir =>
       try {
           val sep = File.separator
-          val tmpDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
+          val tmpDir = JavaUtils.createTempDirWithRoot(dir.getAbsolutePath + sep + "test space")
           val tmpConfFile2 = File.createTempFile("test file", ".conf", tmpDir)
 
           sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
@@ -415,7 +416,7 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     withTempDir { dir =>
        try {
           val sep = File.separator
-          val tmpDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
+          val tmpDir = JavaUtils.createTempDirWithRoot(dir.getAbsolutePath + sep + "test space")
           val tmpJar = File.createTempFile("test", ".jar", tmpDir)
 
           sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
@@ -1307,7 +1308,8 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
           new SparkConf().setAppName("test").setMaster("local-cluster[3, 1, 1024]"))
 
         val sep = File.separator
-        val tmpCanonicalDir = Utils.createTempDir(dir.getAbsolutePath + sep + "test space")
+        val tmpCanonicalDir =
+          JavaUtils.createTempDirWithRoot(dir.getAbsolutePath + sep + "test space")
         val tmpAbsoluteDir = new File(tmpCanonicalDir.getAbsolutePath + sep + '.' + sep)
         val tmpJar = File.createTempFile("test", ".jar", tmpAbsoluteDir)
         val tmpFile = File.createTempFile("test", ".txt", tmpAbsoluteDir)

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.spark.deploy.LocalSparkCluster
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.Tests.IS_TESTING
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{AccumulatorContext, Utils}
 
 /**
@@ -217,7 +218,7 @@ abstract class SparkFunSuite
    * returns.
    */
   protected def withTempDir(f: File => Unit): Unit = {
-    val dir = Utils.createTempDir()
+    val dir = JavaUtils.createTempDir()
     try f(dir) finally {
       Utils.deleteRecursively(dir)
     }

--- a/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonRDDSuite.scala
@@ -33,6 +33,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 
 import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.{HadoopRDD, RDD}
 import org.apache.spark.security.{SocketAuthHelper, SocketAuthServer}
 import org.apache.spark.util.Utils
@@ -43,7 +44,7 @@ class PythonRDDSuite extends SparkFunSuite with LocalSparkContext {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/spark/deploy/DecommissionWorkerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/DecommissionWorkerSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.network.TransportContext
 import org.apache.spark.network.netty.SparkTransportConf
 import org.apache.spark.network.shuffle.ExternalBlockHandler
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.{RpcAddress, RpcEnv}
 import org.apache.spark.scheduler._
 import org.apache.spark.shuffle.FetchFailedException
@@ -379,7 +380,7 @@ class DecommissionWorkerSuite
     workers.clear()
     val rpcAddressToRpcEnv: mutable.HashMap[RpcAddress, RpcEnv] = mutable.HashMap.empty
     workerRpcEnvs.foreach { rpcEnv =>
-      val workDir = Utils.createTempDir(namePrefix = this.getClass.getSimpleName()).toString
+      val workDir = JavaUtils.createTempDirWithPrefix(this.getClass.getSimpleName()).toString
       val worker = new Worker(rpcEnv, 0, cores, memory, Array(masterRpcEnv.address),
         Worker.ENDPOINT_NAME, workDir, masterAndWorkerConf, masterAndWorkerSecurityManager)
       rpcEnv.setupEndpoint(Worker.ENDPOINT_NAME, worker)

--- a/core/src/test/scala/org/apache/spark/deploy/IvyTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/IvyTestUtils.scala
@@ -30,7 +30,7 @@ import org.apache.ivy.core.settings.IvySettings
 
 import org.apache.spark.TestUtils.{createCompiledClass, JavaSourceFromString}
 import org.apache.spark.deploy.SparkSubmitUtils.MavenCoordinate
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 private[deploy] object IvyTestUtils {
 
@@ -295,7 +295,7 @@ private[deploy] object IvyTestUtils {
       withPython: Boolean = false,
       withR: Boolean = false): File = {
     // Where the root of the repository exists, and what Ivy will search in
-    val tempPath = tempDir.getOrElse(Utils.createTempDir())
+    val tempPath = tempDir.getOrElse(JavaUtils.createTempDir())
     // Create directory if it doesn't exist
     Files.createParentDirs(tempPath)
     // Where to create temporary class files and such

--- a/core/src/test/scala/org/apache/spark/deploy/RPackageUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/RPackageUtilsSuite.scala
@@ -32,6 +32,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.api.r.RUtils
 import org.apache.spark.deploy.SparkSubmitUtils.MavenCoordinate
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{ResetSystemProperties, Utils}
 
 class RPackageUtilsSuite
@@ -143,7 +144,7 @@ class RPackageUtilsSuite
   }
 
   test("SparkR zipping works properly") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     Utils.tryWithSafeFinally {
       IvyTestUtils.writeFile(tempDir, "test.R", "abc")
       val fakeSparkRDir = new File(tempDir, "SparkR")

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -44,6 +44,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{CommandLineUtils, DependencyUtils, ResetSystemProperties, Utils}
 
 trait TestPrematureExit {
@@ -1008,36 +1009,36 @@ class SparkSubmitSuite
   }
 
   test("SPARK-27575: yarn confs should merge new value with existing value") {
-    val tmpJarDir = Utils.createTempDir()
+    val tmpJarDir = JavaUtils.createTempDir()
     val jar1 = TestUtils.createJarWithFiles(Map("test.resource" -> "1"), tmpJarDir)
     val jar2 = TestUtils.createJarWithFiles(Map("test.resource" -> "USER"), tmpJarDir)
 
-    val tmpJarDirYarnOpt = Utils.createTempDir()
+    val tmpJarDirYarnOpt = JavaUtils.createTempDir()
     val jar1YarnOpt = TestUtils.createJarWithFiles(Map("test.resource" -> "2"), tmpJarDirYarnOpt)
     val jar2YarnOpt = TestUtils.createJarWithFiles(Map("test.resource" -> "USER2"),
       tmpJarDirYarnOpt)
 
-    val tmpFileDir = Utils.createTempDir()
+    val tmpFileDir = JavaUtils.createTempDir()
     val file1 = File.createTempFile("tmpFile1", "", tmpFileDir)
     val file2 = File.createTempFile("tmpFile2", "", tmpFileDir)
 
-    val tmpFileDirYarnOpt = Utils.createTempDir()
+    val tmpFileDirYarnOpt = JavaUtils.createTempDir()
     val file1YarnOpt = File.createTempFile("tmpPy1YarnOpt", ".py", tmpFileDirYarnOpt)
     val file2YarnOpt = File.createTempFile("tmpPy2YarnOpt", ".egg", tmpFileDirYarnOpt)
 
-    val tmpPyFileDir = Utils.createTempDir()
+    val tmpPyFileDir = JavaUtils.createTempDir()
     val pyFile1 = File.createTempFile("tmpPy1", ".py", tmpPyFileDir)
     val pyFile2 = File.createTempFile("tmpPy2", ".egg", tmpPyFileDir)
 
-    val tmpPyFileDirYarnOpt = Utils.createTempDir()
+    val tmpPyFileDirYarnOpt = JavaUtils.createTempDir()
     val pyFile1YarnOpt = File.createTempFile("tmpPy1YarnOpt", ".py", tmpPyFileDirYarnOpt)
     val pyFile2YarnOpt = File.createTempFile("tmpPy2YarnOpt", ".egg", tmpPyFileDirYarnOpt)
 
-    val tmpArchiveDir = Utils.createTempDir()
+    val tmpArchiveDir = JavaUtils.createTempDir()
     val archive1 = File.createTempFile("archive1", ".zip", tmpArchiveDir)
     val archive2 = File.createTempFile("archive2", ".zip", tmpArchiveDir)
 
-    val tmpArchiveDirYarnOpt = Utils.createTempDir()
+    val tmpArchiveDirYarnOpt = JavaUtils.createTempDir()
     val archive1YarnOpt = File.createTempFile("archive1YarnOpt", ".zip", tmpArchiveDirYarnOpt)
     val archive2YarnOpt = File.createTempFile("archive2YarnOpt", ".zip", tmpArchiveDirYarnOpt)
 
@@ -1112,14 +1113,14 @@ class SparkSubmitSuite
     val sparkConf = new SparkConf(false)
     intercept[IOException] {
       DependencyUtils.downloadFile(
-        "abc:/my/file", Utils.createTempDir(), sparkConf, new Configuration())
+        "abc:/my/file", JavaUtils.createTempDir(), sparkConf, new Configuration())
     }
   }
 
   test("downloadFile - file doesn't exist") {
     val sparkConf = new SparkConf(false)
     val hadoopConf = new Configuration()
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     updateConfWithFakeS3Fs(hadoopConf)
     intercept[FileNotFoundException] {
       DependencyUtils.downloadFile("s3a:/no/such/file", tmpDir, sparkConf, hadoopConf)
@@ -1243,7 +1244,7 @@ class SparkSubmitSuite
   }
 
   test("SPARK-32119: Jars and files should be loaded when Executors launch for plugins") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val tempFileName = "test.txt"
     val tempFile = new File(tempDir, tempFileName)
 
@@ -1334,7 +1335,7 @@ class SparkSubmitSuite
     }
     hadoopConf.set("fs.http.impl.disable.cache", "true")
 
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     val mainResource = File.createTempFile("tmpPy", ".py", tmpDir)
     val tmpS3Jar = TestUtils.createJarWithFiles(Map("test.resource" -> "USER"), tmpDir)
     val tmpS3JarPath = s"s3a://${new File(tmpS3Jar.toURI).getAbsolutePath}"
@@ -1469,7 +1470,7 @@ class SparkSubmitSuite
 
     val props = new java.util.Properties()
     val propsFile = File.createTempFile("test-spark-conf", ".properties",
-      Utils.createTempDir())
+      JavaUtils.createTempDir())
     val propsOutputStream = new FileOutputStream(propsFile)
     try {
       testProps.foreach { case (k, v) => props.put(k, v) }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitUtilsSuite.scala
@@ -32,7 +32,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.deploy.SparkSubmitUtils.MavenCoordinate
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class SparkSubmitUtilsSuite extends SparkFunSuite with BeforeAndAfterAll {
 
@@ -56,7 +56,7 @@ class SparkSubmitUtilsSuite extends SparkFunSuite with BeforeAndAfterAll {
     super.beforeAll()
     // We don't want to write logs during testing
     SparkSubmitUtils.printStream = new BufferPrintStream
-    tempIvyPath = Utils.createTempDir(namePrefix = "ivy").getAbsolutePath()
+    tempIvyPath = JavaUtils.createTempDirWithPrefix("ivy").getAbsolutePath()
   }
 
   test("incorrect maven coordinate throws error") {

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileReadersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileReadersSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.deploy.history.RollingEventLogFilesWriter._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.io.CompressionCodec
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -45,7 +46,7 @@ abstract class EventLogFileReadersSuite extends SparkFunSuite with LocalSparkCon
   protected var testDirPath: Path = _
 
   before {
-    testDir = Utils.createTempDir(namePrefix = s"event log")
+    testDir = JavaUtils.createTempDirWithPrefix("event log")
     testDirPath = new Path(testDir.getAbsolutePath())
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/EventLogFileWritersSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.history.EventLogTestHelper._
 import org.apache.spark.internal.config._
 import org.apache.spark.io.CompressionCodec
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -44,7 +45,7 @@ abstract class EventLogFileWritersSuite extends SparkFunSuite with LocalSparkCon
   protected var testDirPath: Path = _
 
   before {
-    testDir = Utils.createTempDir(namePrefix = s"event log")
+    testDir = JavaUtils.createTempDirWithPrefix("event log")
     testDirPath = new Path(testDir.getAbsolutePath())
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/FsHistoryProviderSuite.scala
@@ -45,6 +45,7 @@ import org.apache.spark.internal.config.DRIVER_LOG_DFS_DIR
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.UI.{ADMIN_ACLS, ADMIN_ACLS_GROUPS, UI_VIEW_ACLS, UI_VIEW_ACLS_GROUPS, USER_GROUPS_MAPPING}
 import org.apache.spark.io._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.security.GroupMappingServiceProvider
@@ -62,7 +63,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with L
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    testDir = Utils.createTempDir(namePrefix = s"a b%20c+d")
+    testDir = JavaUtils.createTempDirWithPrefix("a b%20c+d")
   }
 
   override def afterEach(): Unit = {
@@ -665,7 +666,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with L
     val maxAge = TimeUnit.SECONDS.toSeconds(40)
     val clock = new ManualClock(0)
     val testConf = new SparkConf()
-    testConf.set(HISTORY_LOG_DIR, Utils.createTempDir(namePrefix = "eventLog").getAbsolutePath())
+    testConf.set(HISTORY_LOG_DIR, JavaUtils.createTempDirWithPrefix("eventLog").getAbsolutePath())
     testConf.set(DRIVER_LOG_DFS_DIR, testDir.getAbsolutePath())
     testConf.set(DRIVER_LOG_CLEANER_ENABLED, true)
     testConf.set(DRIVER_LOG_CLEANER_INTERVAL, maxAge / 4)
@@ -1657,7 +1658,7 @@ abstract class FsHistoryProviderSuite extends SparkFunSuite with Matchers with L
       .set(FAST_IN_PROGRESS_PARSING, true)
 
     if (!inMemory) {
-      conf.set(LOCAL_STORE_DIR, Utils.createTempDir().getAbsolutePath())
+      conf.set(LOCAL_STORE_DIR, JavaUtils.createTempDir().getAbsolutePath())
     }
     conf.set(HYBRID_STORE_ENABLED, useHybridStore)
     conf.set(HYBRID_STORE_DISK_BACKEND.key, diskBackend.toString)

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -27,6 +27,7 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.History.HybridStoreDiskBackend
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.status.KVUtils
 import org.apache.spark.tags.ExtendedLevelDBTest
 import org.apache.spark.util.{ManualClock, Utils}
@@ -49,7 +50,7 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
   private var store: KVStore = _
 
   before {
-    testDir = Utils.createTempDir()
+    testDir = JavaUtils.createTempDir()
     store = KVUtils.open(new File(testDir, "listing"), "test", conf)
   }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerSuite.scala
@@ -47,6 +47,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.History._
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.status.api.v1.ApplicationInfo
 import org.apache.spark.status.api.v1.JobData
 import org.apache.spark.tags.ExtendedLevelDBTest
@@ -70,7 +71,7 @@ abstract class HistoryServerSuite extends SparkFunSuite with BeforeAndAfter with
 
   private val logDir = getTestResourcePath("spark-events")
   private val expRoot = getTestResourceFile("HistoryServerExpectations")
-  private val storeDir = Utils.createTempDir(namePrefix = "history")
+  private val storeDir = JavaUtils.createTempDirWithPrefix("history")
 
   private var provider: FsHistoryProvider = null
   private var server: HistoryServer = null

--- a/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/RealBrowserUIHistoryServerSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark._
 import org.apache.spark.internal.config.{EVENT_LOG_STAGE_EXECUTOR_METRICS, EXECUTOR_PROCESS_TREE_METRICS_ENABLED}
 import org.apache.spark.internal.config.History.{HISTORY_LOG_DIR, LOCAL_STORE_DIR, UPDATE_INTERVAL_S}
 import org.apache.spark.internal.config.Tests.IS_TESTING
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{ResetSystemProperties, Utils}
 
 /**
@@ -44,7 +45,7 @@ abstract class RealBrowserUIHistoryServerSuite(val driverProp: String)
 
   private val driverPropPrefix = "spark.test."
   private val logDir = getTestResourcePath("spark-events")
-  private val storeDir = Utils.createTempDir(namePrefix = "history")
+  private val storeDir = JavaUtils.createTempDirWithPrefix("history")
 
   private var provider: FsHistoryProvider = null
   private var server: HistoryServer = null

--- a/core/src/test/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/security/HadoopDelegationTokenManagerSuite.scala
@@ -30,8 +30,8 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.security.HadoopDelegationTokenProvider
-import org.apache.spark.util.Utils
 
 private class ExceptionThrowingDelegationTokenProvider extends HadoopDelegationTokenProvider {
   ExceptionThrowingDelegationTokenProvider.constructed = true
@@ -90,7 +90,7 @@ class HadoopDelegationTokenManagerSuite extends SparkFunSuite {
     try {
       // UserGroupInformation.setConfiguration needs default kerberos realm which can be set in
       // krb5.conf. MiniKdc sets "java.security.krb5.conf" in start and removes it when stop called.
-      val kdcDir = Utils.createTempDir()
+      val kdcDir = JavaUtils.createTempDir()
       val kdcConf = MiniKdc.createConf()
       // The port for MiniKdc service gets selected in the constructor, but will be bound
       // to it later in MiniKdc.start() -> MiniKdc.initKDCServer() -> KdcServer.start().

--- a/core/src/test/scala/org/apache/spark/deploy/worker/WorkerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/worker/WorkerSuite.scala
@@ -41,11 +41,11 @@ import org.apache.spark.deploy.DeployMessages.{DriverStateChanged, ExecutorState
 import org.apache.spark.deploy.master.DriverState
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config.Worker._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.{ResourceAllocation, ResourceInformation}
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs.{WORKER_FPGA_ID, WORKER_GPU_ID}
 import org.apache.spark.rpc.{RpcAddress, RpcEnv}
-import org.apache.spark.util.Utils
 
 class WorkerSuite extends SparkFunSuite with Matchers with BeforeAndAfter {
 
@@ -70,7 +70,7 @@ class WorkerSuite extends SparkFunSuite with Matchers with BeforeAndAfter {
     val securityMgr = new SecurityManager(conf)
     val rpcEnv = RpcEnv.create("test", "localhost", 12345, conf, securityMgr)
     val resourcesFile = conf.get(SPARK_WORKER_RESOURCE_FILE)
-    val workDir = Utils.createTempDir(namePrefix = this.getClass.getSimpleName).toString
+    val workDir = JavaUtils.createTempDirWithPrefix(this.getClass.getSimpleName).toString
     val localWorker = new Worker(rpcEnv, 50000, 20, 1234 * 5,
       Array.fill(1)(RpcAddress("1.2.3.4", 1234)), "Worker", workDir,
       conf, securityMgr, resourcesFile, shuffleServiceSupplier)
@@ -362,7 +362,7 @@ class WorkerSuite extends SparkFunSuite with Matchers with BeforeAndAfter {
       override def get: ExternalShuffleService = shuffleService
     }
     val worker = makeWorker(conf, externalShuffleServiceSupplier)
-    val workDir = Utils.createTempDir(namePrefix = "work")
+    val workDir = JavaUtils.createTempDirWithPrefix("work")
     // initialize workers
     worker.workDir = workDir
     // Create the executor's working directory

--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -37,10 +37,10 @@ import org.apache.spark.TestUtils._
 import org.apache.spark.api.plugin._
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.resource.ResourceUtils.GPU
 import org.apache.spark.resource.TestResourceIDs.{DRIVER_GPU_ID, EXECUTOR_GPU_ID, WORKER_GPU_ID}
-import org.apache.spark.util.Utils
 
 class PluginContainerSuite extends SparkFunSuite with BeforeAndAfterEach with LocalSparkContext {
 
@@ -165,7 +165,7 @@ class PluginContainerSuite extends SparkFunSuite with BeforeAndAfterEach with Lo
   }
 
   test("plugin initialization in non-local mode") {
-    val path = Utils.createTempDir()
+    val path = JavaUtils.createTempDir()
 
     val conf = new SparkConf()
       .setAppName(getClass().getName())

--- a/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/metrics/InputOutputMetricsSuite.scala
@@ -33,6 +33,7 @@ import org.apache.hadoop.mapreduce.lib.output.{TextOutputFormat => NewTextOutput
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SharedSparkContext, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.util.{ThreadUtils, Utils}
 
@@ -46,7 +47,7 @@ class InputOutputMetricsSuite extends SparkFunSuite with SharedSparkContext
   @transient val numBuckets: Int = 10
 
   before {
-    tmpDir = Utils.createTempDir()
+    tmpDir = JavaUtils.createTempDir()
     val testTempDir = new File(tmpDir, "test")
     testTempDir.mkdir()
 

--- a/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDCleanerSuite.scala
@@ -25,6 +25,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
 
 import org.apache.spark._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -32,8 +33,8 @@ class RDDCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
 
   test("RDD shuffle cleanup standalone") {
     val conf = new SparkConf()
-    val localDir = Utils.createTempDir()
-    val checkpointDir = Utils.createTempDir()
+    val localDir = JavaUtils.createTempDir()
+    val checkpointDir = JavaUtils.createTempDir()
     def getAllFiles: Set[File] =
       FileUtils.listFiles(localDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE).asScala.toSet
     try {

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -33,6 +33,7 @@ import org.scalatest.concurrent.Eventually
 import org.apache.spark._
 import org.apache.spark.api.java.{JavaRDD, JavaSparkContext}
 import org.apache.spark.internal.config.RDD_PARALLEL_LISTING_THRESHOLD
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDDSuiteUtils._
 import org.apache.spark.util.{ThreadUtils, Utils}
 
@@ -41,7 +42,7 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/EventLoggingListenerSuite.scala
@@ -39,6 +39,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{EVENT_LOG_DIR, EVENT_LOG_ENABLED}
 import org.apache.spark.io._
 import org.apache.spark.metrics.{ExecutorMetricType, MetricsSystem}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.util.{JsonProtocol, Utils}
@@ -59,7 +60,7 @@ class EventLoggingListenerSuite extends SparkFunSuite with LocalSparkContext wit
   private var testDirPath: Path = _
 
   before {
-    testDir = Utils.createTempDir(namePrefix = s"history log")
+    testDir = JavaUtils.createTempDirWithPrefix("history log")
     testDir.deleteOnExit()
     testDirPath = new Path(testDir.getAbsolutePath())
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorSuite.scala
@@ -32,6 +32,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark._
 import org.apache.spark.internal.io.{FileCommitProtocol, HadoopMapRedCommitProtocol, SparkHadoopWriterUtils}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.{FakeOutputCommitter, RDD}
 import org.apache.spark.shuffle.FetchFailedException
 import org.apache.spark.util.{ThreadUtils, Utils}
@@ -76,7 +77,7 @@ class OutputCommitCoordinatorSuite extends SparkFunSuite with BeforeAndAfter {
   var sc: SparkContext = null
 
   before {
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
     val conf = new SparkConf()
       .setMaster("local[4]")
       .setAppName(classOf[OutputCommitCoordinatorSuite].getSimpleName)

--- a/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/ReplayListenerSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.history.EventLogFileReader
 import org.apache.spark.deploy.history.EventLogTestHelper._
 import org.apache.spark.io.{CompressionCodec, LZ4CompressionCodec}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.{JsonProtocol, JsonProtocolSuite, Utils}
 
 /**
@@ -44,7 +45,7 @@ class ReplayListenerSuite extends SparkFunSuite with BeforeAndAfter with LocalSp
   private var testDir: File = _
 
   before {
-    testDir = Utils.createTempDir()
+    testDir = JavaUtils.createTempDir()
   }
 
   after {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -36,6 +36,7 @@ import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.TestUtils.JavaSourceFromString
 import org.apache.spark.internal.config.Network.RPC_MESSAGE_MAX_SIZE
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.storage.TaskResultBlockId
 import org.apache.spark.util.{MutableURLClassLoader, RpcUtils, ThreadUtils, Utils}
 
@@ -204,7 +205,7 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
    */
   test("failed task deserialized with the correct classloader (SPARK-11195)") {
     // compile a small jar containing an exception that will be thrown on an executor.
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val srcDir = new File(tempDir, "repro/")
     srcDir.mkdirs()
     val excSource = new JavaSourceFromString(new File(srcDir, "MyException").toURI.getPath,

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
 import org.apache.spark.internal.config
 import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
 import org.apache.spark.network.shuffle.checksum.ShuffleChecksumHelper
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.{JavaSerializer, SerializerInstance, SerializerManager}
 import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleChecksumTestHelper}
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
@@ -65,7 +66,7 @@ class BypassMergeSortShuffleWriterSuite
   override def beforeEach(): Unit = {
     super.beforeEach()
     MockitoAnnotations.openMocks(this).close()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
     outputFile = File.createTempFile("shuffle", null, tempDir)
     taskMetrics = new TaskMetrics
     shuffleHandle = new BypassMergeSortShuffleHandle[Int, Int](

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/IndexShuffleBlockResolverSuite.scala
@@ -29,6 +29,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.shuffle.{IndexShuffleBlockResolver, ShuffleBlockInfo}
 import org.apache.spark.storage._
 import org.apache.spark.util.Utils
@@ -44,7 +45,7 @@ class IndexShuffleBlockResolverSuite extends SparkFunSuite with BeforeAndAfterEa
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
     MockitoAnnotations.openMocks(this).close()
 
     when(blockManager.diskBlockManager).thenReturn(diskBlockManager)

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -30,6 +30,7 @@ import org.mockito.MockitoAnnotations
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.shuffle.IndexShuffleBlockResolver
 import org.apache.spark.util.Utils
 
@@ -66,7 +67,7 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
 
   override def beforeEach(): Unit = {
     MockitoAnnotations.openMocks(this).close()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
     mergedOutputFile = File.createTempFile("mergedoutput", "", tempDir)
     tempFile = File.createTempFile("tempfile", "", tempDir)
     partitionSizesInMergedFile = null

--- a/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusListenerSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
 import org.apache.spark.internal.config.History.{HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend}
 import org.apache.spark.internal.config.Status._
 import org.apache.spark.metrics.ExecutorMetricType
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster._
@@ -57,7 +58,7 @@ abstract class AppStatusListenerSuite extends SparkFunSuite with BeforeAndAfter 
 
   before {
     time = 0L
-    testDir = Utils.createTempDir()
+    testDir = JavaUtils.createTempDir()
     store = new ElementTrackingStore(createKVStore, conf)
     taskIdTracker = -1L
   }

--- a/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/status/AppStatusStoreSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.internal.config.History.{HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend}
 import org.apache.spark.internal.config.Status.LIVE_ENTITY_UPDATE_PERIOD
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.{SparkListenerStageSubmitted, SparkListenerTaskStart, StageInfo, TaskInfo, TaskLocality}
 import org.apache.spark.status.api.v1.SpeculationStageSummary
@@ -93,7 +94,7 @@ class AppStatusStoreSuite extends SparkFunSuite {
 
     val store: KVStore = if (disk) {
       conf.set(HYBRID_STORE_DISK_BACKEND, diskStoreType.toString)
-      val testDir = Utils.createTempDir()
+      val testDir = JavaUtils.createTempDir()
       val diskStore = KVUtils.open(testDir, getClass.getName, conf)
       new ElementTrackingStore(diskStore, conf)
     } else {

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockManagerSuite.scala
@@ -30,6 +30,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -43,8 +44,8 @@ class DiskBlockManagerSuite extends SparkFunSuite with BeforeAndAfterEach with B
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    rootDir0 = Utils.createTempDir()
-    rootDir1 = Utils.createTempDir()
+    rootDir0 = JavaUtils.createTempDir()
+    rootDir1 = JavaUtils.createTempDir()
     rootDirs = rootDir0.getAbsolutePath + "," + rootDir1.getAbsolutePath
   }
 

--- a/core/src/test/scala/org/apache/spark/storage/DiskBlockObjectWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/DiskBlockObjectWriterSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.executor.ShuffleWriteMetrics
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.{JavaSerializer, SerializerManager}
 import org.apache.spark.util.Utils
 
@@ -31,7 +32,7 @@ class DiskBlockObjectWriterSuite extends SparkFunSuite with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -44,6 +44,7 @@ import org.apache.spark.MapOutputTracker.SHUFFLE_PUSH_MAP_ID
 import org.apache.spark.network._
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.shuffle.{BlockFetchingListener, DownloadFileManager, ExternalBlockStoreClient, MergedBlockMeta, MergedBlocksMetaListener}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.network.util.LimitedInputStream
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
 import org.apache.spark.storage.BlockManagerId.SHUFFLE_MERGER_IDENTIFIER
@@ -840,7 +841,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
   }
 
   test("ensure big blocks available as a concatenated stream can be read") {
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     val tmpFile = new File(tmpDir, "someFile.txt")
     val os = new FileOutputStream(tmpFile)
     val buf = ByteBuffer.allocate(10000)
@@ -923,7 +924,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
     " threshold(maxReqSizeShuffleToMem).") {
     val blockManager = createMockBlockManager()
     val diskBlockManager = mock(classOf[DiskBlockManager])
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     doReturn{
       val blockId = TempLocalBlockId(UUID.randomUUID())
       (blockId, new File(tmpDir, blockId.name))

--- a/core/src/test/scala/org/apache/spark/storage/TopologyMapperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/TopologyMapperSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.matchers.must.Matchers
 
 import org.apache.spark._
 import org.apache.spark.internal.config.STORAGE_REPLICATION_TOPOLOGY_FILE
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class TopologyMapperSuite  extends SparkFunSuite
   with Matchers
@@ -54,7 +54,7 @@ class TopologyMapperSuite  extends SparkFunSuite
   }
 
   def createPropertiesFile(props: Map[String, String]): File = {
-    val testFile = new File(Utils.createTempDir(), "TopologyMapperSuite-test").getAbsoluteFile
+    val testFile = new File(JavaUtils.createTempDir(), "TopologyMapperSuite-test").getAbsoluteFile
     val fileOS = new FileOutputStream(testFile)
     props.foreach{case (k, v) => fileOS.write(s"$k=$v\n".getBytes)}
     fileOS.close

--- a/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/FileAppenderSuite.scala
@@ -35,11 +35,12 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.logging.{FileAppender, RollingFileAppender, SizeBasedRollingPolicy, TimeBasedRollingPolicy}
 
 class FileAppenderSuite extends SparkFunSuite with BeforeAndAfter with Logging {
 
-  val testFile = new File(Utils.createTempDir(), "FileAppenderSuite-test").getAbsoluteFile
+  val testFile = new File(JavaUtils.createTempDir(), "FileAppenderSuite-test").getAbsoluteFile
 
   before {
     cleanup()

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -44,6 +44,7 @@ import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Tests.IS_TESTING
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.SparkListener
 import org.apache.spark.util.io.ChunkedByteBufferInputStream
 
@@ -545,9 +546,9 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     // create some temporary directories and files
     withTempDir { parent =>
       // The parent directory has two child directories
-      val child1: File = Utils.createTempDir(parent.getCanonicalPath)
-      val child2: File = Utils.createTempDir(parent.getCanonicalPath)
-      val child3: File = Utils.createTempDir(child1.getCanonicalPath)
+      val child1: File = JavaUtils.createTempDirWithRoot(parent.getCanonicalPath)
+      val child2: File = JavaUtils.createTempDirWithRoot(parent.getCanonicalPath)
+      val child3: File = JavaUtils.createTempDirWithRoot(child1.getCanonicalPath)
       // set the last modified time of child1 to 30 secs old
       child1.setLastModified(System.currentTimeMillis() - (1000 * 30))
 
@@ -704,12 +705,12 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
   }
 
   test("deleteRecursively") {
-    val tempDir1 = Utils.createTempDir()
+    val tempDir1 = JavaUtils.createTempDir()
     assert(tempDir1.exists())
     Utils.deleteRecursively(tempDir1)
     assert(!tempDir1.exists())
 
-    val tempDir2 = Utils.createTempDir()
+    val tempDir2 = JavaUtils.createTempDir()
     val sourceFile1 = new File(tempDir2, "foo.txt")
     Files.touch(sourceFile1)
     assert(sourceFile1.exists())
@@ -758,7 +759,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
     withTempDir { tempDir =>
       val sourceDir = new File(tempDir, "source-dir")
       sourceDir.mkdir()
-      val innerSourceDir = Utils.createTempDir(root = sourceDir.getPath)
+      val innerSourceDir = JavaUtils.createTempDirWithRoot(sourceDir.getPath)
       val sourceFile = File.createTempFile("someprefix", "somesuffix", innerSourceDir)
       val targetDir = new File(tempDir, "target-dir")
       Files.write("some text", sourceFile, UTF_8)

--- a/core/src/test/scala/org/apache/spark/util/collection/ExternalSorterSpillSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/collection/ExternalSorterSpillSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.{SparkConf, SparkEnv, SparkFunSuite, TaskContext}
 import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.internal.config
 import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.{KryoSerializer, SerializerInstance, SerializerManager}
 import org.apache.spark.storage.{BlockId, BlockManager, DiskBlockManager, DiskBlockObjectWriter, TempShuffleBlockId}
 import org.apache.spark.util.{Utils => UUtils}
@@ -48,7 +49,7 @@ class ExternalSorterSpillSuite extends SparkFunSuite with BeforeAndAfterEach {
   private var taskContext: TaskContext = _
 
   override protected def beforeEach(): Unit = {
-    tempDir = UUtils.createTempDir(null, "test")
+    tempDir = JavaUtils.createTempDir(null, "test")
     spillFilesCreated.clear()
 
     val env: SparkEnv = mock(classOf[SparkEnv])

--- a/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/logging/DriverLoggerSuite.scala
@@ -34,7 +34,7 @@ class DriverLoggerSuite extends SparkFunSuite with LocalSparkContext {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    rootDfsDir = Utils.createTempDir(namePrefix = "dfs_logs")
+    rootDfsDir = JavaUtils.createTempDirWithPrefix("dfs_logs")
   }
 
   override def afterAll(): Unit = {

--- a/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/mllib/JavaStreamingTestExample.java
@@ -23,11 +23,11 @@ import org.apache.spark.mllib.stat.test.StreamingTest;
 import org.apache.spark.mllib.stat.test.StreamingTestResult;
 // $example off$
 import org.apache.spark.SparkConf;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.streaming.Duration;
 import org.apache.spark.streaming.Seconds;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
-import org.apache.spark.util.Utils;
 
 
 /**
@@ -68,7 +68,8 @@ public class JavaStreamingTestExample {
     SparkConf conf = new SparkConf().setMaster("local").setAppName("StreamingTestExample");
     JavaStreamingContext ssc = new JavaStreamingContext(conf, batchDuration);
 
-    ssc.checkpoint(Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark").toString());
+    ssc.checkpoint(
+      JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "spark").toString());
 
     // $example on$
     JavaDStream<BinarySample> data = ssc.textFileStream(dataDir).map(line -> {

--- a/examples/src/main/scala/org/apache/spark/examples/ml/DataFrameExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/DataFrameExample.scala
@@ -26,8 +26,8 @@ import org.apache.spark.examples.mllib.AbstractParams
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.stat.MultivariateOnlineSummarizer
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.util.Utils
 
 /**
  * An example of how to use [[DataFrame]] for ML. Run with
@@ -85,7 +85,7 @@ object DataFrameExample {
     println(s"Selected features column with average values:\n ${featureSummary.mean.toString}")
 
     // Save the records in a parquet file.
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     val outputDir = new File(tmpDir, "dataframe").toString
     println(s"Saving to $outputDir as Parquet file.")
     df.write.parquet(outputDir)

--- a/examples/src/main/scala/org/apache/spark/examples/ml/UnaryTransformerExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/UnaryTransformerExample.scala
@@ -22,6 +22,7 @@ package org.apache.spark.examples.ml
 import org.apache.spark.ml.UnaryTransformer
 import org.apache.spark.ml.param.DoubleParam
 import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{DataType, DataTypes}
@@ -102,7 +103,7 @@ object UnaryTransformerExample {
     result.show()
 
     // Save and load the Transformer.
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     val dirName = tmpDir.getCanonicalPath
     myTransformer.write.overwrite().save(dirName)
     val sameTransformer = MyTransformer.load(dirName)

--- a/examples/src/main/scala/org/apache/spark/examples/mllib/StreamingTestExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/mllib/StreamingTestExample.scala
@@ -19,8 +19,8 @@ package org.apache.spark.examples.mllib
 
 import org.apache.spark.SparkConf
 import org.apache.spark.mllib.stat.test.{BinarySample, StreamingTest}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.streaming.{Seconds, StreamingContext}
-import org.apache.spark.util.Utils
 
 /**
  * Perform streaming testing using Welch's 2-sample t-test on a stream of data, where the data
@@ -60,7 +60,7 @@ object StreamingTestExample {
     val conf = new SparkConf().setMaster("local").setAppName("StreamingTestExample")
     val ssc = new StreamingContext(conf, batchDuration)
     ssc.checkpoint {
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.toString
     }
 

--- a/graphx/src/test/scala/org/apache/spark/graphx/EdgeRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/EdgeRDDSuite.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.graphx
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.Utils
 
 class EdgeRDDSuite extends SparkFunSuite with LocalSparkContext {
 
@@ -38,7 +38,7 @@ class EdgeRDDSuite extends SparkFunSuite with LocalSparkContext {
     withSpark { sc =>
       val verts = sc.parallelize(List((0L, 0), (1L, 1), (1L, 2), (2L, 3), (2L, 3), (2L, 3)))
       val edges = EdgeRDD.fromEdges(sc.parallelize(List.empty[Edge[Int]]))
-      sc.setCheckpointDir(Utils.createTempDir().getCanonicalPath)
+      sc.setCheckpointDir(JavaUtils.createTempDir().getCanonicalPath)
       edges.checkpoint()
 
       // EdgeRDD not yet checkpointed

--- a/graphx/src/test/scala/org/apache/spark/graphx/GraphLoaderSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/GraphLoaderSuite.scala
@@ -23,13 +23,14 @@ import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class GraphLoaderSuite extends SparkFunSuite with LocalSparkContext {
 
   test("GraphLoader.edgeListFile") {
     withSpark { sc =>
-      val tmpDir = Utils.createTempDir()
+      val tmpDir = JavaUtils.createTempDir()
       val graphFile = new File(tmpDir.getAbsolutePath, "graph.txt")
       val writer = new OutputStreamWriter(new FileOutputStream(graphFile), StandardCharsets.UTF_8)
       for (i <- (1 until 101)) writer.write(s"$i 0\n")

--- a/graphx/src/test/scala/org/apache/spark/graphx/GraphSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/GraphSuite.scala
@@ -20,9 +20,9 @@ package org.apache.spark.graphx
 import org.apache.spark.{SparkContext, SparkFunSuite}
 import org.apache.spark.graphx.Graph._
 import org.apache.spark.graphx.PartitionStrategy._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd._
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.Utils
 
 class GraphSuite extends SparkFunSuite with LocalSparkContext {
 
@@ -332,7 +332,7 @@ class GraphSuite extends SparkFunSuite with LocalSparkContext {
   }
 
   test("checkpoint") {
-    val checkpointDir = Utils.createTempDir()
+    val checkpointDir = JavaUtils.createTempDir()
     withSpark { sc =>
       sc.setCheckpointDir(checkpointDir.getAbsolutePath)
       val ring = (0L to 100L).zip((1L to 99L) :+ 0L).map { case (a, b) => Edge(a, b, 1)}

--- a/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/VertexRDDSuite.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.graphx
 
 import org.apache.spark.{HashPartitioner, SparkContext, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.Utils
 
 class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
 
@@ -202,7 +202,7 @@ class VertexRDDSuite extends SparkFunSuite with LocalSparkContext {
     withSpark { sc =>
       val n = 100
       val verts = vertices(sc, n)
-      sc.setCheckpointDir(Utils.createTempDir().getCanonicalPath)
+      sc.setCheckpointDir(JavaUtils.createTempDir().getCanonicalPath)
       verts.checkpoint()
 
       // VertexRDD not yet checkpointed

--- a/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
+++ b/graphx/src/test/scala/org/apache/spark/graphx/util/PeriodicGraphCheckpointerSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.Assertions
 
 import org.apache.spark.{SparkContext, SparkFunSuite}
 import org.apache.spark.graphx.{Edge, Graph, LocalSparkContext}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.Utils
 
@@ -54,7 +55,7 @@ class PeriodicGraphCheckpointerSuite extends SparkFunSuite with LocalSparkContex
 
   test("Checkpointing") {
     withSpark { sc =>
-      val tempDir = Utils.createTempDir()
+      val tempDir = JavaUtils.createTempDir()
       val path = tempDir.toURI.toString
       val checkpointInterval = 2
       var graphsToCheck = Seq.empty[GraphToCheck]

--- a/mllib/src/test/java/org/apache/spark/ml/source/libsvm/JavaLibSVMRelationSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/source/libsvm/JavaLibSVMRelationSuite.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.ml.linalg.DenseVector;
 import org.apache.spark.ml.linalg.Vectors;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.util.Utils;
@@ -45,7 +46,7 @@ public class JavaLibSVMRelationSuite extends SharedSparkSession {
   @Override
   public void setUp() throws IOException {
     super.setUp();
-    tempDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource");
+    tempDir = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource");
     File file = new File(tempDir, "part-00000");
     String s = "1 1:1.0 3:2.0 5:3.0\n0\n0 2:4.0 4:5.0 6:6.0";
     Files.write(s, file, StandardCharsets.UTF_8);

--- a/mllib/src/test/java/org/apache/spark/ml/util/JavaDefaultReadWriteSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/util/JavaDefaultReadWriteSuite.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.spark.SharedSparkSession;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
 
 public class JavaDefaultReadWriteSuite extends SharedSparkSession {
@@ -32,7 +33,7 @@ public class JavaDefaultReadWriteSuite extends SharedSparkSession {
   @Override
   public void setUp() throws IOException {
     super.setUp();
-    tempDir = Utils.createTempDir(
+    tempDir = JavaUtils.createTempDir(
       System.getProperty("java.io.tmpdir"), "JavaDefaultReadWriteSuite");
   }
 

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaFPGrowthSuite.java
@@ -18,6 +18,7 @@
 package org.apache.spark.mllib.fpm;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -27,6 +28,7 @@ import org.junit.Test;
 
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
 
 public class JavaFPGrowthSuite extends SharedSparkSession {
@@ -58,7 +60,7 @@ public class JavaFPGrowthSuite extends SharedSparkSession {
   }
 
   @Test
-  public void runFPGrowthSaveLoad() {
+  public void runFPGrowthSaveLoad() throws IOException {
 
     JavaRDD<List<String>> rdd = jsc.parallelize(Arrays.asList(
       Arrays.asList("r z h k p".split(" ")),
@@ -73,7 +75,7 @@ public class JavaFPGrowthSuite extends SharedSparkSession {
       .setNumPartitions(2)
       .run(rdd);
 
-    File tempDir = Utils.createTempDir(
+    File tempDir = JavaUtils.createTempDir(
       System.getProperty("java.io.tmpdir"), "JavaFPGrowthSuite");
     String outputPath = tempDir.getPath();
 

--- a/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaPrefixSpanSuite.java
+++ b/mllib/src/test/java/org/apache/spark/mllib/fpm/JavaPrefixSpanSuite.java
@@ -18,6 +18,7 @@
 package org.apache.spark.mllib.fpm;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -27,6 +28,7 @@ import org.junit.Test;
 import org.apache.spark.SharedSparkSession;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.mllib.fpm.PrefixSpan.FreqSequence;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.Utils;
 
 public class JavaPrefixSpanSuite extends SharedSparkSession {
@@ -54,7 +56,7 @@ public class JavaPrefixSpanSuite extends SharedSparkSession {
   }
 
   @Test
-  public void runPrefixSpanSaveLoad() {
+  public void runPrefixSpanSaveLoad() throws IOException {
     JavaRDD<List<List<Integer>>> sequences = jsc.parallelize(Arrays.asList(
       Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3)),
       Arrays.asList(Arrays.asList(1), Arrays.asList(3, 2), Arrays.asList(1, 2)),
@@ -66,7 +68,7 @@ public class JavaPrefixSpanSuite extends SharedSparkSession {
       .setMaxPatternLength(5);
     PrefixSpanModel<Integer> model = prefixSpan.run(sequences);
 
-    File tempDir = Utils.createTempDir(
+    File tempDir = JavaUtils.createTempDir(
       System.getProperty("java.io.tmpdir"), "JavaPrefixSpanSuite");
     String outputPath = tempDir.getPath();
 

--- a/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/classification/GBTClassifierSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, GradientBoostedTrees => OldGBT}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.tree.loss.LogLoss
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.lit
@@ -237,7 +238,7 @@ class GBTClassifierSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("Checkpointing") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     sc.setCheckpointDir(path)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.ml.recommendation.ALS._
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest, MLTestingUtils}
 import org.apache.spark.ml.util.TestingUtils._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{SparkListener, SparkListenerStageCompleted}
 import org.apache.spark.sql.{DataFrame, Encoder, Row, SparkSession}
@@ -1023,8 +1024,8 @@ class ALSCleanerSuite extends SparkFunSuite with LocalRootDirsTest {
 
   test("ALS shuffle cleanup in algorithm") {
     val conf = new SparkConf()
-    val localDir = Utils.createTempDir()
-    val checkpointDir = Utils.createTempDir()
+    val localDir = JavaUtils.createTempDir()
+    val checkpointDir = JavaUtils.createTempDir()
     def getAllFiles: Set[File] = {
       val files = FileUtils.listFiles(
         localDir,

--- a/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/regression/GBTRegressorSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.mllib.regression.{LabeledPoint => OldLabeledPoint}
 import org.apache.spark.mllib.tree.{EnsembleTestHelper, GradientBoostedTrees => OldGBT}
 import org.apache.spark.mllib.tree.configuration.{Algo => OldAlgo}
 import org.apache.spark.mllib.util.LinearDataGenerator
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.lit
@@ -116,7 +117,7 @@ class GBTRegressorSuite extends MLTest with DefaultReadWriteTest {
   }
 
   test("Checkpointing") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     sc.setCheckpointDir(path)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/libsvm/LibSVMRelationSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.ml.attribute.AttributeGroup
 import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.execution.datasources.CommonFileDataSourceSuite
 import org.apache.spark.sql.types.{DoubleType, StructField, StructType}
@@ -61,7 +62,7 @@ class LibSVMRelationSuite
       """
         |0 2:4.0 4:5.0 6:6.0
       """.stripMargin
-    val dir = Utils.createTempDir()
+    val dir = JavaUtils.createTempDir()
     val succ = new File(dir, "_SUCCESS")
     val file0 = new File(dir, "part-00000")
     val file1 = new File(dir, "part-00001")
@@ -129,7 +130,7 @@ class LibSVMRelationSuite
 
   test("write libsvm data and read it again") {
     val df = spark.read.format("libsvm").load(path)
-    val writePath = Utils.createTempDir().getPath
+    val writePath = JavaUtils.createTempDir().getPath
 
     // TODO: Remove requirement to coalesce by supporting multiple reads.
     df.coalesce(1).write.format("libsvm").mode(SaveMode.Overwrite).save(writePath)
@@ -160,7 +161,7 @@ class LibSVMRelationSuite
     )
     val df = spark.sqlContext.createDataFrame(rawData, struct)
 
-    val writePath = Utils.createTempDir().getPath
+    val writePath = JavaUtils.createTempDir().getPath
 
     df.coalesce(1).write.format("libsvm").mode(SaveMode.Overwrite).save(writePath)
 

--- a/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/util/TempDirectory.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 /**
@@ -37,7 +38,7 @@ trait TempDirectory extends BeforeAndAfterAll { self: Suite =>
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    _tempDir = Utils.createTempDir(namePrefix = this.getClass.getName)
+    _tempDir = JavaUtils.createTempDirWithPrefix(this.getClass.getName)
   }
 
   override def afterAll(): Unit = {

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/LogisticRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/LogisticRegressionSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.mllib.optimization._
 import org.apache.spark.mllib.regression._
 import org.apache.spark.mllib.util.{LocalClusterSparkContext, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.util.Utils
 
@@ -536,7 +537,7 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
     model.clearThreshold()
     assert(model.getThreshold.isEmpty)
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.
@@ -563,7 +564,7 @@ class LogisticRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
     // NOTE: This will need to be generalized once there are multiple model format versions.
     val model = LogisticRegressionSuite.multiclassModel
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/NaiveBayesSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.mllib.linalg.{Vector, Vectors}
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.{LocalClusterSparkContext, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 object NaiveBayesSuite {
@@ -304,7 +305,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("model save/load: 2.0 to 2.0") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     Seq(NaiveBayesSuite.binaryBernoulliModel, NaiveBayesSuite.binaryMultinomialModel).foreach {
@@ -326,7 +327,7 @@ class NaiveBayesSuite extends SparkFunSuite with MLlibTestSparkContext {
   test("model save/load: 1.0 to 2.0") {
     val model = NaiveBayesSuite.binaryMultinomialModel
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model as version 1.0, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/classification/SVMSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/classification/SVMSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression._
 import org.apache.spark.mllib.util.{LocalClusterSparkContext, MLlibTestSparkContext}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 object SVMSuite {
@@ -201,7 +202,7 @@ class SVMSuite extends SparkFunSuite with MLlibTestSparkContext {
     model.clearThreshold()
     assert(model.getThreshold.isEmpty)
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/BisectingKMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/BisectingKMeansSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class BisectingKMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -182,7 +183,7 @@ class BisectingKMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("BisectingKMeans model save/load") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     val points = (1 until 8).map(i => Vectors.dense(i))

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/GaussianMixtureSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/GaussianMixtureSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.mllib.linalg.{Matrices, Vector, Vectors}
 import org.apache.spark.mllib.stat.distribution.MultivariateGaussian
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -158,7 +159,7 @@ class GaussianMixtureSuite extends SparkFunSuite with MLlibTestSparkContext {
     val data = sc.parallelize(GaussianTestData.data)
 
     val gmm = new GaussianMixture().setK(2).setSeed(0).run(data)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     try {

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/KMeansSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.internal.config.Kryo._
 import org.apache.spark.mllib.linalg.{DenseVector, SparseVector, Vector, Vectors}
 import org.apache.spark.mllib.util.{LocalClusterSparkContext, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.util.Utils
 
@@ -278,7 +279,7 @@ class KMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("model save/load") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     Array(true, false).foreach { case selector =>

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/LDASuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.graphx.Edge
 import org.apache.spark.mllib.linalg.{DenseMatrix, Matrix, Vector, Vectors}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -467,7 +468,7 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
     // Test for LocalLDAModel.
     val localModel = new LocalLDAModel(tinyTopics,
       Vectors.dense(Array.fill(tinyTopics.numRows)(0.01)), 0.5D, 10D)
-    val tempDir1 = Utils.createTempDir()
+    val tempDir1 = JavaUtils.createTempDir()
     val path1 = tempDir1.toURI.toString
 
     // Test for DistributedLDAModel.
@@ -482,7 +483,7 @@ class LDASuite extends SparkFunSuite with MLlibTestSparkContext {
       .setSeed(12345)
     val corpus = sc.parallelize(tinyCorpus, 2)
     val distributedModel: DistributedLDAModel = lda.run(corpus).asInstanceOf[DistributedLDAModel]
-    val tempDir2 = Utils.createTempDir()
+    val tempDir2 = JavaUtils.createTempDir()
     val path2 = tempDir2.toURI.toString
 
     try {

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/PowerIterationClusteringSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/PowerIterationClusteringSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.{SparkContext, SparkFunSuite}
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class PowerIterationClusteringSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -164,7 +165,7 @@ class PowerIterationClusteringSuite extends SparkFunSuite with MLlibTestSparkCon
   }
 
   test("model save/load") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     val model = PowerIterationClusteringSuite.createModel(sc, 3, 10)
     try {

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/ChiSqSelectorSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/ChiSqSelectorSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class ChiSqSelectorSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -169,7 +170,7 @@ class ChiSqSelectorSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("model load / save") {
     val model = ChiSqSelectorSuite.createModel()
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     try {
       model.save(sc, path)

--- a/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/feature/Word2VecSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.config.Kryo._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.util.Utils
 
@@ -97,7 +98,7 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext {
     )
     val model = new Word2VecModel(word2VecMap)
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     try {
@@ -132,7 +133,7 @@ class Word2VecSuite extends SparkFunSuite with MLlibTestSparkContext {
     // (floatSize * vectorSize + 15) * numWords
     // (4 * 10 + 15) * 10 = 550
     // therefore it should generate multiple partitions
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     try {

--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/FPGrowthSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.mllib.fpm
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -296,7 +297,7 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext {
       (itemset.items.toSet, itemset.freq)
     }
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     try {
       model3.save(sc, path)
@@ -330,7 +331,7 @@ class FPGrowthSuite extends SparkFunSuite with MLlibTestSparkContext {
       (itemset.items.toSet, itemset.freq)
     }
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     try {
       model3.save(sc, path)

--- a/mllib/src/test/scala/org/apache/spark/mllib/fpm/PrefixSpanSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/fpm/PrefixSpanSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.mllib.fpm
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class PrefixSpanSuite extends SparkFunSuite with MLlibTestSparkContext {
@@ -414,7 +415,7 @@ class PrefixSpanSuite extends SparkFunSuite with MLlibTestSparkContext {
       .setMaxPatternLength(5)
     val model = prefixSpan.run(rdd)
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     try {
       model.save(sc, path)

--- a/mllib/src/test/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModelSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/recommendation/MatrixFactorizationModelSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.mllib.recommendation
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.util.Utils
 
@@ -56,7 +57,7 @@ class MatrixFactorizationModelSuite extends SparkFunSuite with MLlibTestSparkCon
 
   test("save/load") {
     val model = new MatrixFactorizationModel(rank, userFeatures, prodFeatures)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     def collect(features: RDD[(Int, Array[Double])]): Set[(Int, Seq[Double])] = {
       features.mapValues(_.toSeq).collect().toSet

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/IsotonicRegressionSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.matchers.must.Matchers
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext with Matchers {
@@ -80,7 +81,7 @@ class IsotonicRegressionSuite extends SparkFunSuite with MLlibTestSparkContext w
     val predictions = Array(1, 2, 2, 6, 16.5, 16.5, 17.0, 18.0)
     val model = new IsotonicRegressionModel(boundaries, predictions, true)
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/LassoSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/LassoSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.{LinearDataGenerator, LocalClusterSparkContext,
   MLlibTestSparkContext}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 private object LassoSuite {
@@ -126,7 +127,7 @@ class LassoSuite extends SparkFunSuite with MLlibTestSparkContext {
   test("model save/load") {
     val model = LassoSuite.model
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/LinearRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/LinearRegressionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.{LinearDataGenerator, LocalClusterSparkContext,
   MLlibTestSparkContext}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 private object LinearRegressionSuite {
@@ -134,7 +135,7 @@ class LinearRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
   test("model save/load") {
     val model = LinearRegressionSuite.model
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/regression/RidgeRegressionSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/regression/RidgeRegressionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.{LinearDataGenerator, LocalClusterSparkContext,
   MLlibTestSparkContext}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 private object RidgeRegressionSuite {
@@ -79,7 +80,7 @@ class RidgeRegressionSuite extends SparkFunSuite with MLlibTestSparkContext {
   test("model save/load") {
     val model = RidgeRegressionSuite.model
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     // Save model, load it back, and compare.

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.mllib.tree.configuration.Strategy
 import org.apache.spark.mllib.tree.impurity.{Entropy, Gini, Variance}
 import org.apache.spark.mllib.tree.model._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -415,7 +416,7 @@ class DecisionTreeSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("model save/load") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     Array(Classification, Regression).foreach { algo =>

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/GradientBoostedTreesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/GradientBoostedTreesSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.mllib.tree.impurity.Variance
 import org.apache.spark.mllib.tree.loss.{AbsoluteError, LogLoss, SquaredError}
 import org.apache.spark.mllib.tree.model.GradientBoostedTreesModel
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 /**
@@ -134,7 +135,7 @@ class GradientBoostedTreesSuite extends SparkFunSuite with MLlibTestSparkContext
   }
 
   test("model save/load") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     val trees = Range(0, 3).map(_ => DecisionTreeSuite.createModel(Regression)).toArray
@@ -159,7 +160,7 @@ class GradientBoostedTreesSuite extends SparkFunSuite with MLlibTestSparkContext
   }
 
   test("Checkpointing") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
     sc.setCheckpointDir(path)
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/RandomForestSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/RandomForestSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.mllib.tree.configuration.Strategy
 import org.apache.spark.mllib.tree.impurity.{Gini, Variance}
 import org.apache.spark.mllib.tree.model.RandomForestModel
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 
@@ -136,7 +137,7 @@ class RandomForestSuite extends SparkFunSuite with MLlibTestSparkContext {
   }
 
   test("model save/load") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val path = tempDir.toURI.toString
 
     Array(Classification, Regression).foreach { algo =>

--- a/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/util/MLUtilsSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.mllib.linalg.{DenseVector, Matrices, SparseVector, Vecto
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.util.MLUtils._
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.MetadataBuilder
@@ -91,7 +92,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
         |0
         |0 2:4.0 4:5.0 6:6.0
       """.stripMargin
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val file = new File(tempDir.getPath, "part-00000")
     Files.write(lines, file, StandardCharsets.UTF_8)
     val path = tempDir.toURI.toString
@@ -124,7 +125,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
         |0
         |0 0:4.0 4:5.0 6:6.0
       """.stripMargin
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val file = new File(tempDir.getPath, "part-00000")
     Files.write(lines, file, StandardCharsets.UTF_8)
     val path = tempDir.toURI.toString
@@ -141,7 +142,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
         |0
         |0 3:4.0 2:5.0 6:6.0
       """.stripMargin
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val file = new File(tempDir.getPath, "part-00000")
     Files.write(lines, file, StandardCharsets.UTF_8)
     val path = tempDir.toURI.toString
@@ -157,7 +158,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       LabeledPoint(1.1, Vectors.sparse(3, Seq((0, 1.23), (2, 4.56)))),
       LabeledPoint(0.0, Vectors.dense(1.01, 2.02, 3.03))
     ), 2)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val outputDir = new File(tempDir, "output")
     MLUtils.saveAsLibSVMFile(examples, outputDir.toURI.toString)
     val sources = outputDir.listFiles()
@@ -227,7 +228,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       Vectors.sparse(2, Array(1), Array(-1.0)),
       Vectors.dense(0.0, 1.0)
     ), 2)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val outputDir = new File(tempDir, "vectors")
     val path = outputDir.toURI.toString
     vectors.saveAsTextFile(path)
@@ -242,7 +243,7 @@ class MLUtilsSuite extends SparkFunSuite with MLlibTestSparkContext {
       LabeledPoint(0.0, Vectors.sparse(2, Array(1), Array(-1.0))),
       LabeledPoint(1.0, Vectors.dense(0.0, 1.0))
     ), 2)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val outputDir = new File(tempDir, "points")
     val path = outputDir.toURI.toString
     points.saveAsTextFile(path)

--- a/repl/src/main/scala-2.12/org/apache/spark/repl/Main.scala
+++ b/repl/src/main/scala-2.12/org/apache/spark/repl/Main.scala
@@ -25,6 +25,7 @@ import scala.tools.nsc.GenericRunnerSettings
 
 import org.apache.spark._
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.util.Utils
@@ -36,7 +37,7 @@ object Main extends Logging {
 
   val conf = new SparkConf()
   val rootDir = conf.getOption("spark.repl.classdir").getOrElse(Utils.getLocalDir(conf))
-  val outputDir = Utils.createTempDir(root = rootDir, namePrefix = "repl")
+  val outputDir = JavaUtils.createTempDir(rootDir, "repl")
 
   var sparkContext: SparkContext = _
   var sparkSession: SparkSession = _

--- a/repl/src/main/scala-2.13/org/apache/spark/repl/Main.scala
+++ b/repl/src/main/scala-2.13/org/apache/spark/repl/Main.scala
@@ -25,6 +25,7 @@ import scala.tools.nsc.GenericRunnerSettings
 
 import org.apache.spark._
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.util.Utils
@@ -37,7 +38,7 @@ object Main extends Logging {
   val conf = new SparkConf()
   val rootDir =
     conf.getOption("spark.repl.classdir").getOrElse(Utils.getLocalDir(conf))
-  val outputDir = Utils.createTempDir(root = rootDir, namePrefix = "repl")
+  val outputDir = JavaUtils.createTempDir(rootDir, "repl")
 
   var sparkContext: SparkContext = _
   var sparkSession: SparkSession = _

--- a/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/ExecutorClassLoaderSuite.scala
@@ -40,6 +40,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.apache.spark._
 import org.apache.spark.TestUtils.JavaSourceFromString
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.util.Utils
 
@@ -59,8 +60,8 @@ class ExecutorClassLoaderSuite
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    tempDir1 = Utils.createTempDir()
-    tempDir2 = Utils.createTempDir()
+    tempDir1 = JavaUtils.createTempDir()
+    tempDir2 = JavaUtils.createTempDir()
     url1 = tempDir1.toURI.toURL.toString
     urls2 = List(tempDir2.toURI.toURL).toArray
     childClassNames.foreach(TestUtils.createCompiledClass(_, tempDir1, "1"))
@@ -284,7 +285,7 @@ class ExecutorClassLoaderSuite
 
   test("SPARK-20547 ExecutorClassLoader should not throw ClassNotFoundException without " +
     "acknowledgment from driver") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     try {
       // Create two classes, "TestClassB" calls "TestClassA", so when calling "TestClassB.foo", JVM
       // will try to load "TestClassA".

--- a/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
+++ b/repl/src/test/scala/org/apache/spark/repl/SingletonReplSuite.scala
@@ -22,6 +22,7 @@ import java.io._
 import org.apache.commons.text.StringEscapeUtils
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 /**
@@ -190,7 +191,7 @@ class SingletonReplSuite extends SparkFunSuite {
   }
 
   test("interacting with files") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val out = new FileWriter(tempDir + "/input")
     out.write("Hello world!\n")
     out.write("What's up?\n")

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/KubernetesUtils.scala
@@ -34,6 +34,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.k8s.Config.KUBERNETES_FILE_UPLOAD_PATH
 import org.apache.spark.internal.Logging
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceUtils
 import org.apache.spark.util.{Clock, SystemClock, Utils}
 import org.apache.spark.util.DependencyUtils.downloadFile
@@ -100,7 +101,7 @@ object KubernetesUtils extends Logging {
       conf: SparkConf): SparkPod = {
     try {
       val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf)
-      val localFile = downloadFile(templateFileName, Utils.createTempDir(), conf, hadoopConf)
+      val localFile = downloadFile(templateFileName, JavaUtils.createTempDir(), conf, hadoopConf)
       val templateFile = new File(new java.net.URI(localFile).getPath)
       val pod = kubernetesClient.pods().load(templateFile).get()
       selectSparkContainer(pod, containerName)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/PodTemplateConfigMapStep.scala
@@ -26,8 +26,8 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.deploy.k8s.{KubernetesConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.DependencyUtils.downloadFile
-import org.apache.spark.util.Utils
 
 private[spark] class PodTemplateConfigMapStep(conf: KubernetesConf)
   extends KubernetesFeatureConfigStep {
@@ -79,7 +79,7 @@ private[spark] class PodTemplateConfigMapStep(conf: KubernetesConf)
     if (hasTemplate) {
       val podTemplateFile = conf.get(KUBERNETES_EXECUTOR_PODTEMPLATE_FILE).get
       val hadoopConf = SparkHadoopUtil.get.newConfiguration(conf.sparkConf)
-      val uri = downloadFile(podTemplateFile, Utils.createTempDir(), conf.sparkConf, hadoopConf)
+      val uri = downloadFile(podTemplateFile, JavaUtils.createTempDir(), conf.sparkConf, hadoopConf)
       val file = new java.net.URI(uri).getPath
       val podTemplateString = Files.toString(new File(file), StandardCharsets.UTF_8)
       Seq(new ConfigMapBuilder()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.deploy.k8s.features.KubernetesFeaturesTestUtils.TestReso
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Python._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource._
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
@@ -283,7 +284,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("Auth secret shouldn't propagate if files are loaded.") {
-    val secretDir = Utils.createTempDir("temp-secret")
+    val secretDir = JavaUtils.createTempDirWithRoot("temp-secret")
     val secretFile = new File(secretDir, "secret-file.txt")
     Files.write(secretFile.toPath, "some-secret".getBytes(StandardCharsets.UTF_8))
     val conf = baseConf.clone()

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverKubernetesCredentialsFeatureStepSuite.scala
@@ -28,11 +28,11 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{KubernetesTestConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class DriverKubernetesCredentialsFeatureStepSuite extends SparkFunSuite {
 
-  private val credentialsTempDirectory = Utils.createTempDir()
+  private val credentialsTempDirectory = JavaUtils.createTempDir()
   private val BASE_DRIVER_POD = SparkPod.initialPod()
 
   test("Don't set any credentials") {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/HadoopConfDriverFeatureStepSuite.scala
@@ -27,7 +27,8 @@ import io.fabric8.kubernetes.api.model.ConfigMap
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Constants._
-import org.apache.spark.util.{SparkConfWithEnv, Utils}
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.util.SparkConfWithEnv
 
 class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
 
@@ -44,7 +45,7 @@ class HadoopConfDriverFeatureStepSuite extends SparkFunSuite {
   }
 
   test("create hadoop config map if config dir is defined") {
-    val confDir = Utils.createTempDir()
+    val confDir = JavaUtils.createTempDir()
     val confFiles = Set("core-site.xml", "hdfs-site.xml")
 
     confFiles.foreach { f =>

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/KerberosConfDriverFeatureStepSuite.scala
@@ -34,14 +34,14 @@ import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.config._
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class KerberosConfDriverFeatureStepSuite extends SparkFunSuite {
 
   import KubernetesFeaturesTestUtils._
   import SecretVolumeUtils._
 
-  private val tmpDir = Utils.createTempDir()
+  private val tmpDir = JavaUtils.createTempDir()
 
   test("mount krb5 config map if defined") {
     val configMap = "testConfigMap"

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/ClientSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{Config, _}
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.deploy.k8s.Fabric8Aliases._
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class ClientSuite extends SparkFunSuite with BeforeAndAfter {
 
@@ -266,7 +266,7 @@ class ClientSuite extends SparkFunSuite with BeforeAndAfter {
     "except templates, spark config, binary files and are within size limit, " +
     "should be populated to pod's configMap.") {
     def testSetup: (SparkConf, Seq[String]) = {
-      val tempDir = Utils.createTempDir()
+      val tempDir = JavaUtils.createTempDir()
       val sparkConf = new SparkConf(loadDefaults = false)
         .setSparkHome(tempDir.getAbsolutePath)
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -29,12 +29,12 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
 
   def testSetup(inputFiles: Map[String, Array[Byte]]): SparkConf = {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val sparkConf = new SparkConf(loadDefaults = false)
       .setSparkHome(tempDir.getAbsolutePath)
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 abstract class BaseYarnClusterSuite
@@ -83,7 +84,7 @@ abstract class BaseYarnClusterSuite
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    tempDir = Utils.createTempDir()
+    tempDir = JavaUtils.createTempDir()
     logConfDir = new File(tempDir, "log4j")
     logConfDir.mkdir()
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -51,6 +51,7 @@ import org.apache.spark.{SparkConf, SparkException, SparkFunSuite, TestUtils}
 import org.apache.spark.deploy.yarn.ResourceRequestHelper._
 import org.apache.spark.deploy.yarn.config._
 import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.resource.ResourceID
 import org.apache.spark.resource.ResourceUtils.AMOUNT
 import org.apache.spark.util.{SparkConfWithEnv, Utils}
@@ -135,7 +136,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
     doReturn(new Path("/")).when(client).copyFileToRemote(any(classOf[Path]),
       any(classOf[Path]), meq(None), any(classOf[MutableHashMap[URI, Path]]), anyBoolean(), any())
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     try {
       // Because we mocked "copyFileToRemote" above to avoid having to create fake local files,
       // we need to create a fake config archive in the temp dir to avoid having
@@ -287,8 +288,8 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   test("spark.yarn.jars with multiple paths and globs") {
-    val libs = Utils.createTempDir()
-    val single = Utils.createTempDir()
+    val libs = JavaUtils.createTempDir()
+    val single = JavaUtils.createTempDir()
     val jar1 = TestUtils.createJarWithFiles(Map(), libs)
     val jar2 = TestUtils.createJarWithFiles(Map(), libs)
     val jar3 = TestUtils.createJarWithFiles(Map(), single)
@@ -303,7 +304,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
     val sparkConf = new SparkConf().set(SPARK_JARS, jarsConf)
     val client = createClient(sparkConf)
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     client.prepareLocalResources(new Path(tempDir.getAbsolutePath()), Nil)
 
     assert(sparkConf.get(SPARK_JARS) ===
@@ -324,7 +325,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   test("distribute jars archive") {
-    val temp = Utils.createTempDir()
+    val temp = JavaUtils.createTempDir()
     val archive = TestUtils.createJarWithFiles(Map(), temp)
 
     val sparkConf = new SparkConf().set(SPARK_ARCHIVE, archive.getPath())
@@ -342,7 +343,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   test("SPARK-37239: distribute jars archive with set STAGING_FILE_REPLICATION") {
-    val temp = Utils.createTempDir()
+    val temp = JavaUtils.createTempDir()
     val archive = TestUtils.createJarWithFiles(Map(), temp)
     val replication = 5
 
@@ -361,13 +362,13 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   test("distribute archive multiple times") {
-    val libs = Utils.createTempDir()
+    val libs = JavaUtils.createTempDir()
     // Create jars dir and RELEASE file to avoid IllegalStateException.
     val jarsDir = new File(libs, "jars")
     assert(jarsDir.mkdir())
     new FileOutputStream(new File(libs, "RELEASE")).close()
 
-    val userLib1 = Utils.createTempDir()
+    val userLib1 = JavaUtils.createTempDir()
     val testJar = TestUtils.createJarWithFiles(Map(), userLib1)
 
     // Case 1:  FILES_TO_DISTRIBUTE and ARCHIVES_TO_DISTRIBUTE can't have duplicate files
@@ -376,7 +377,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set(ARCHIVES_TO_DISTRIBUTE, Seq(testJar.getPath))
 
     val client = createClient(sparkConf)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     intercept[IllegalArgumentException] {
       client.prepareLocalResources(new Path(tempDir.getAbsolutePath()), Nil)
     }
@@ -386,7 +387,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set(FILES_TO_DISTRIBUTE, Seq(testJar.getPath, testJar.getPath))
 
     val clientFiles = createClient(sparkConfFiles)
-    val tempDirForFiles = Utils.createTempDir()
+    val tempDirForFiles = JavaUtils.createTempDir()
     intercept[IllegalArgumentException] {
       clientFiles.prepareLocalResources(new Path(tempDirForFiles.getAbsolutePath()), Nil)
     }
@@ -396,7 +397,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set(ARCHIVES_TO_DISTRIBUTE, Seq(testJar.getPath, testJar.getPath))
 
     val clientArchives = createClient(sparkConfArchives)
-    val tempDirForArchives = Utils.createTempDir()
+    val tempDirForArchives = JavaUtils.createTempDir()
     intercept[IllegalArgumentException] {
       clientArchives.prepareLocalResources(new Path(tempDirForArchives.getAbsolutePath()), Nil)
     }
@@ -406,7 +407,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set(FILES_TO_DISTRIBUTE, Seq(testJar.getPath))
 
     val clientFilesUniq = createClient(sparkConfFilesUniq)
-    val tempDirForFilesUniq = Utils.createTempDir()
+    val tempDirForFilesUniq = JavaUtils.createTempDir()
     clientFilesUniq.prepareLocalResources(new Path(tempDirForFilesUniq.getAbsolutePath()), Nil)
 
     // Case 5: ARCHIVES_TO_DISTRIBUTE can have unique file.
@@ -414,13 +415,13 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set(ARCHIVES_TO_DISTRIBUTE, Seq(testJar.getPath))
 
     val clientArchivesUniq = createClient(sparkConfArchivesUniq)
-    val tempDirArchivesUniq = Utils.createTempDir()
+    val tempDirArchivesUniq = JavaUtils.createTempDir()
     clientArchivesUniq.prepareLocalResources(new Path(tempDirArchivesUniq.getAbsolutePath()), Nil)
 
   }
 
   test("distribute local spark jars") {
-    val temp = Utils.createTempDir()
+    val temp = JavaUtils.createTempDir()
     val jarsDir = new File(temp, "jars")
     assert(jarsDir.mkdir())
     val jar = TestUtils.createJarWithFiles(Map(), jarsDir)
@@ -433,12 +434,12 @@ class ClientSuite extends SparkFunSuite with Matchers {
   }
 
   test("ignore same name jars") {
-    val libs = Utils.createTempDir()
+    val libs = JavaUtils.createTempDir()
     val jarsDir = new File(libs, "jars")
     assert(jarsDir.mkdir())
     new FileOutputStream(new File(libs, "RELEASE")).close()
-    val userLib1 = Utils.createTempDir()
-    val userLib2 = Utils.createTempDir()
+    val userLib1 = JavaUtils.createTempDir()
+    val userLib2 = JavaUtils.createTempDir()
 
     val jar1 = TestUtils.createJarWithFiles(Map(), jarsDir)
     val jar2 = TestUtils.createJarWithFiles(Map(), userLib1)
@@ -455,7 +456,7 @@ class ClientSuite extends SparkFunSuite with Matchers {
       .set(JARS_TO_DISTRIBUTE, Seq(jar2.getPath, jar3.getPath))
 
     val client = createClient(sparkConf)
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     client.prepareLocalResources(new Path(tempDir.getAbsolutePath()), Nil)
 
     // Only jar2 will be added to SECONDARY_JARS, jar3 which has the same name with jar2 will be

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnClusterSuite.scala
@@ -43,6 +43,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.launcher._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationStart, SparkListenerExecutorAdded}
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.tags.ExtendedYarnTest
@@ -132,7 +133,7 @@ class YarnClusterSuite extends BaseYarnClusterSuite {
 
   test("yarn-cluster should respect conf overrides in SparkHadoopUtil (SPARK-16414, SPARK-23630)") {
     // Create a custom hadoop config file, to make sure it's contents are propagated to the driver.
-    val customConf = Utils.createTempDir()
+    val customConf = JavaUtils.createTempDir()
     val coreSite = """<?xml version="1.0" encoding="UTF-8"?>
       |<configuration>
       |  <property>

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/YarnSparkHadoopUtilSuite.scala
@@ -30,7 +30,8 @@ import org.apache.spark.{SecurityManager, SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.UI._
-import org.apache.spark.util.{ResetSystemProperties, Utils}
+import org.apache.spark.network.util.JavaUtils
+import org.apache.spark.util.ResetSystemProperties
 
 class YarnSparkHadoopUtilSuite extends SparkFunSuite with Matchers with Logging
   with ResetSystemProperties {
@@ -52,7 +53,7 @@ class YarnSparkHadoopUtilSuite extends SparkFunSuite with Matchers with Logging
     if (hasBash) test(name)(fn) else ignore(name)(fn)
 
   bashTest("shell script escaping") {
-    val scriptFile = File.createTempFile("script.", ".sh", Utils.createTempDir())
+    val scriptFile = File.createTempFile("script.", ".sh", JavaUtils.createTempDir())
     val args = Array("arg1", "${arg.2}", "\"arg3\"", "'arg4'", "$arg5", "\\arg6")
     try {
       val argLine = args.map(a => YarnSparkHadoopUtil.escapeForShell(a)).mkString(" ")

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -45,9 +45,8 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.internal.config._
 import org.apache.spark.network.shuffle.{NoOpMergedShuffleFileManager, RemoteBlockPushResolver, ShuffleTestAccessor}
 import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo
-import org.apache.spark.network.util.TransportConf
+import org.apache.spark.network.util.{JavaUtils, TransportConf}
 import org.apache.spark.tags.ExtendedLevelDBTest
-import org.apache.spark.util.Utils
 
 @ExtendedLevelDBTest
 class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAndAfterEach {
@@ -67,10 +66,10 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
       classOf[YarnShuffleService].getCanonicalName)
     yarnConfig.setInt(SHUFFLE_SERVICE_PORT.key, 0)
     yarnConfig.setBoolean(YarnShuffleService.STOP_ON_FAILURE_KEY, true)
-    val localDir = Utils.createTempDir()
+    val localDir = JavaUtils.createTempDir()
     yarnConfig.set(YarnConfiguration.NM_LOCAL_DIRS, localDir.getAbsolutePath)
 
-    recoveryLocalDir = Utils.createTempDir()
+    recoveryLocalDir = JavaUtils.createTempDir()
   }
 
   var s1: YarnShuffleService = null
@@ -272,7 +271,7 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
     // Test recovery path is set outside the shuffle service, this is to simulate NM recovery
     // enabled scenario, where recovery path will be set by yarn.
     s1 = new YarnShuffleService
-    val recoveryPath = new Path(Utils.createTempDir().toURI)
+    val recoveryPath = new Path(JavaUtils.createTempDir().toURI)
     s1.setRecoveryPath(recoveryPath)
 
     s1.init(yarnConfig)
@@ -362,7 +361,7 @@ class YarnShuffleServiceSuite extends SparkFunSuite with Matchers with BeforeAnd
 
   test("service throws error if cannot start") {
     // Set up a read-only local dir.
-    val roDir = Utils.createTempDir()
+    val roDir = JavaUtils.createTempDir()
     Files.setPosixFilePermissions(roDir.toPath(), EnumSet.of(OWNER_READ, OWNER_EXECUTE))
 
     // Try to start the shuffle service, it should fail.

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -434,7 +434,7 @@ This file is divided into 3 sections:
   <check customId="GuavaFilesCreateTempDir" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">Files\.createTempDir\(</parameter></parameters>
     <customMessage>Avoid using com.google.common.io.Files.createTempDir due to CVE-2020-8908.
-      Use org.apache.spark.util.Utils.createTempDir instead.
+      Use org.apache.spark.network.util.JavaUtils.createTempDir instead.
     </customMessage>
   </check>
 </scalastyle>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/package.scala
@@ -19,8 +19,8 @@ package org.apache.spark.sql.catalyst.expressions
 
 import scala.reflect.internal.util.AbstractFileClassLoader
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.rules
-import org.apache.spark.util.Utils
 
 /**
  * A collection of generators that build custom bytecode at runtime for performing the evaluation
@@ -45,7 +45,7 @@ package object codegen {
    */
   object DumpByteCode {
     import scala.sys.process._
-    val dumpDirectory = Utils.createTempDir()
+    val dumpDirectory = JavaUtils.createTempDir()
     dumpDirectory.mkdir()
 
     def apply(obj: Any): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{FunctionAlreadyExistsException, NoSuchDatabaseException, NoSuchFunctionException, TableAlreadyExistsException}
@@ -33,7 +34,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces.PROP_OWNER
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 
 /**
@@ -486,7 +486,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     val table = CatalogTable(
       identifier = TableIdentifier("tbl", Some("db1")),
       tableType = CatalogTableType.EXTERNAL,
-      storage = storageFormat.copy(locationUri = Some(Utils.createTempDir().toURI)),
+      storage = storageFormat.copy(locationUri = Some(JavaUtils.createTempDir().toURI)),
       schema = new StructType()
         .add("col1", "int")
         .add("col2", "string")
@@ -871,7 +871,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
       identifier = TableIdentifier("external_table", Some("db1")),
       tableType = CatalogTableType.EXTERNAL,
       storage = CatalogStorageFormat(
-        Some(Utils.createTempDir().toURI),
+        Some(JavaUtils.createTempDir().toURI),
         None, None, None, false, Map.empty),
       schema = new StructType().add("a", "int").add("b", "string"),
       provider = Some(defaultProvider)
@@ -914,7 +914,7 @@ abstract class ExternalCatalogSuite extends SparkFunSuite with BeforeAndAfterEac
     assert(!exists(tableLocation, "partCol1=3", "partCol2=4"))
     assert(!exists(tableLocation, "partCol1=5", "partCol2=6"))
 
-    val tempPath = Utils.createTempDir()
+    val tempPath = JavaUtils.createTempDir()
     // create partition with existing directory is OK.
     val partWithExistingDir = CatalogTablePartition(
       Map("partCol1" -> "7", "partCol2" -> "8"),
@@ -1012,10 +1012,10 @@ abstract class CatalogTestUtils {
 
   def newFunc(): CatalogFunction = newFunc("funcName")
 
-  def newUriForDatabase(): URI = new URI(Utils.createTempDir().toURI.toString.stripSuffix("/"))
+  def newUriForDatabase(): URI = new URI(JavaUtils.createTempDir().toURI.toString.stripSuffix("/"))
 
   def newUriForPartition(parts: Seq[String]): URI = {
-    val path = parts.foldLeft(Utils.createTempDir())(new java.io.File(_, _))
+    val path = parts.foldLeft(JavaUtils.createTempDir())(new java.io.File(_, _))
     new URI(path.toURI.toString.stripSuffix("/"))
   }
 
@@ -1032,7 +1032,7 @@ abstract class CatalogTestUtils {
     CatalogTable(
       identifier = TableIdentifier(name, database),
       tableType = CatalogTableType.EXTERNAL,
-      storage = storageFormat.copy(locationUri = Some(Utils.createTempDir().toURI)),
+      storage = storageFormat.copy(locationUri = Some(JavaUtils.createTempDir().toURI)),
       schema = if (defaultColumns) {
         new StructType()
           .add("col1", "int")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/SQLHelper.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/SQLHelper.scala
@@ -23,6 +23,7 @@ import scala.util.control.NonFatal
 
 import org.scalatest.Assertions.fail
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.getZoneId
@@ -64,7 +65,7 @@ trait SQLHelper {
    * a file/directory is created there by `f`, it will be delete after `f` returns.
    */
   protected def withTempPath(f: File => Unit): Unit = {
-    val path = Utils.createTempDir()
+    val path = JavaUtils.createTempDir()
     path.delete()
     try f(path) finally Utils.deleteRecursively(path)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ResolveWriteToStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ResolveWriteToStream.scala
@@ -23,6 +23,7 @@ import scala.util.control.NonFatal
 
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -31,7 +32,6 @@ import org.apache.spark.sql.catalyst.streaming.{WriteToStream, WriteToStreamStat
 import org.apache.spark.sql.connector.catalog.SupportsWrite
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.Utils
 
 /**
  * Replaces logical [[WriteToStreamStatement]] operator with an [[WriteToStream]] operator.
@@ -75,7 +75,7 @@ object ResolveWriteToStream extends Rule[LogicalPlan] with SQLConfHelper {
     }.getOrElse {
       if (s.useTempCheckpointLocation) {
         deleteCheckpointOnStop = true
-        val tempDir = Utils.createTempDir(namePrefix = s"temporary").getCanonicalPath
+        val tempDir = JavaUtils.createTempDirWithPrefix("temporary").getCanonicalPath
         logWarning("Temporary checkpoint location created which is deleted normally when" +
           s" the query didn't fail: $tempDir. If it's required to delete it under any" +
           s" circumstances, please set ${SQLConf.FORCE_DELETE_TEMP_CHECKPOINT_LOCATION.key} to" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -34,6 +34,7 @@ import org.rocksdb.TickerType._
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.util.{NextIterator, Utils}
 
@@ -53,7 +54,7 @@ import org.apache.spark.util.{NextIterator, Utils}
 class RocksDB(
     dfsRootDir: String,
     val conf: RocksDBConf,
-    localRootDir: File = Utils.createTempDir(),
+    localRootDir: File = JavaUtils.createTempDir(),
     hadoopConf: Configuration = new Configuration,
     loggingId: String = "") extends Logging {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -218,7 +219,7 @@ private[sql] class RocksDBStateStoreProvider
     val storeIdStr = s"StateStoreId(opId=${stateStoreId.operatorId}," +
       s"partId=${stateStoreId.partitionId},name=${stateStoreId.storeName})"
     val sparkConf = Option(SparkEnv.get).map(_.conf).getOrElse(new SparkConf)
-    val localRootDir = Utils.createTempDir(Utils.getLocalDir(sparkConf), storeIdStr)
+    val localRootDir = JavaUtils.createTempDir(Utils.getLocalDir(sparkConf), storeIdStr)
     new RocksDB(dfsRootDir, RocksDBConf(storeConf), localRootDir, hadoopConf, storeIdStr)
   }
 

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
@@ -18,13 +18,14 @@
 package test.org.apache.spark.sql;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,9 +37,9 @@ public class JavaDataFrameReaderWriterSuite {
   private transient String output;
 
   @Before
-  public void setUp() {
-    input = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "input").toString();
-    File f = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "output");
+  public void setUp() throws IOException {
+    input = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "input").toString();
+    File f = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "output");
     f.delete();
     output = f.toString();
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaSaveLoadSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaSaveLoadSuite.java
@@ -28,11 +28,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.Utils;
 
 public class JavaSaveLoadSuite {
 
@@ -53,7 +53,8 @@ public class JavaSaveLoadSuite {
       .getOrCreate();
 
     path =
-      Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource").getCanonicalFile();
+      JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource")
+        .getCanonicalFile();
     if (path.exists()) {
       path.delete();
     }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/streaming/JavaDataStreamReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/streaming/JavaDataStreamReaderWriterSuite.java
@@ -18,6 +18,7 @@
 package test.org.apache.spark.sql.streaming;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
@@ -25,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.spark.api.java.function.VoidFunction2;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.ForeachWriter;
 import org.apache.spark.sql.SparkSession;
@@ -37,9 +39,9 @@ public class JavaDataStreamReaderWriterSuite {
   private String input;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     spark = new TestSparkSession();
-    input = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "input").toString();
+    input = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "input").toString();
   }
 
   @After

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -30,6 +30,7 @@ import scala.util.Random
 import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
@@ -2153,7 +2154,7 @@ class DataFrameSuite extends QueryTest
 
   test("SPARK-13774: Check error message for non existent path without globbed paths") {
     val uuid = UUID.randomUUID().toString
-    val baseDir = Utils.createTempDir()
+    val baseDir = JavaUtils.createTempDir()
     try {
       val e = intercept[AnalysisException] {
         spark.read.format("csv").load(
@@ -2179,8 +2180,8 @@ class DataFrameSuite extends QueryTest
     assert(e.getMessage.startsWith("Path does not exist"))
 
     // Existent initial path component, but no matching files:
-    val baseDir = Utils.createTempDir()
-    val childDir = Utils.createTempDir(baseDir.getAbsolutePath)
+    val baseDir = JavaUtils.createTempDir()
+    val childDir = JavaUtils.createTempDirWithRoot(baseDir.getAbsolutePath)
     assert(childDir.exists())
     try {
       val e1 = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RemoveRedundantProjectsSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.connector.SimpleWritableDataSource
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
@@ -53,7 +54,7 @@ abstract class RemoveRedundantProjectsSuiteBase
     }
   }
 
-  private val tmpPath = Utils.createTempDir()
+  private val tmpPath = JavaUtils.createTempDir()
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/arrow/ArrowConvertersSuite.scala
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.ipc.JsonFileReader
 import org.apache.arrow.vector.util.{ByteArrayReadableSeekableByteChannel, Validator}
 
 import org.apache.spark.{SparkException, TaskContext}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -46,7 +47,7 @@ class ArrowConvertersSuite extends SharedSparkSession {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    tempDataPath = Utils.createTempDir(namePrefix = "arrow").getAbsolutePath
+    tempDataPath = JavaUtils.createTempDirWithPrefix("arrow").getAbsolutePath
   }
 
   test("collect to arrow record batch") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/StateStoreBasicOperationsBenchmark.scala
@@ -22,11 +22,11 @@ import scala.util.Random
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, RocksDBStateStoreProvider, StateStore, StateStoreConf, StateStoreId, StateStoreProvider}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType, TimestampType}
-import org.apache.spark.util.Utils
 
 /**
  * Synthetic benchmark for State Store basic operations.
@@ -366,5 +366,5 @@ object StateStoreBasicOperationsBenchmark extends SqlBasedBenchmark {
     provider
   }
 
-  private def newDir(): String = Utils.createTempDir().toString
+  private def newDir(): String = JavaUtils.createTempDir().toString
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.permission.{AclEntry, AclStatus}
 
 import org.apache.spark.{SparkException, SparkFiles}
 import org.apache.spark.internal.config
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, QualifiedTableName, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TableFunctionRegistry, TempTableAlreadyExistsException}
@@ -2216,7 +2217,7 @@ abstract class DDLSuite extends QueryTest with SQLTestUtils {
   }
 
   test(s"Add a directory when ${SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key} set to false") {
-    val directoryToAdd = Utils.createTempDir("/tmp/spark/addDirectory/")
+    val directoryToAdd = JavaUtils.createTempDirWithRoot("/tmp/spark/addDirectory/")
     val testFile = File.createTempFile("testFile", "1", directoryToAdd)
     spark.sql(s"ADD FILE $directoryToAdd")
     assert(new File(SparkFiles.get(s"${directoryToAdd.getName}/${testFile.getName}")).exists())

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowNamespacesSuite.scala
@@ -17,10 +17,10 @@
 
 package org.apache.spark.sql.execution.command.v1
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.catalog.CatalogDatabase
 import org.apache.spark.sql.execution.command
-import org.apache.spark.util.Utils
 
 /**
  * This base suite contains unified tests for the `SHOW NAMESPACES` and `SHOW DATABASES` commands
@@ -39,7 +39,7 @@ trait ShowNamespacesSuiteBase extends command.ShowNamespacesSuiteBase {
       CatalogDatabase(
         name = ns,
         description = "",
-        locationUri = Utils.createTempDir().toURI,
+        locationUri = JavaUtils.createTempDir().toURI,
         properties = Map.empty),
       ignoreIfExists = false)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteTaskStatsTrackerSuite.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FilterFileSystem, Path}
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker.FILE_LENGTH_XATTR
 import org.apache.spark.util.Utils
 
@@ -37,7 +38,7 @@ import org.apache.spark.util.Utils
  */
 class BasicWriteTaskStatsTrackerSuite extends SparkFunSuite {
 
-  private val tempDir = Utils.createTempDir()
+  private val tempDir = JavaUtils.createTempDir()
   private val tempDirPath = new Path(tempDir.toURI)
   private val conf = new Configuration()
   private val localfs = tempDirPath.getFileSystem(conf)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategySuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.{BlockLocation, FileStatus, Path, RawLocalFileSystem
 import org.apache.hadoop.mapreduce.Job
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -38,7 +39,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
-import org.apache.spark.util.Utils
 
 class FileSourceStrategySuite extends QueryTest with SharedSparkSession with PredicateHelper {
   import testImplicits._
@@ -652,7 +652,7 @@ class FileSourceStrategySuite extends QueryTest with SharedSparkSession with Pre
   def createTable(
       files: Seq[(String, Int)],
       buckets: Int = 0): DataFrame = {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     files.foreach {
       case (name, size) =>
         val file = new File(tempDir, name)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/binaryfile/BinaryFileFormatSuite.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, GlobFilter, Path}
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.execution.datasources.PartitionedFile
@@ -36,7 +37,6 @@ import org.apache.spark.sql.internal.SQLConf.SOURCES_BINARY_FILE_MAX_LENGTH
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
   import BinaryFileFormat._
@@ -52,7 +52,7 @@ class BinaryFileFormatSuite extends QueryTest with SharedSparkSession {
   override def beforeAll(): Unit = {
     super.beforeAll()
 
-    testDir = Utils.createTempDir().getAbsolutePath
+    testDir = JavaUtils.createTempDir().getAbsolutePath
     fsTestDir = new Path(testDir)
     fs = fsTestDir.getFileSystem(sparkContext.hadoopConfiguration)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.io.SequenceFile.CompressionType
 import org.apache.hadoop.io.compress.GzipCodec
 
 import org.apache.spark.{SparkConf, SparkException, TestUtils}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{functions => F, _}
 import org.apache.spark.sql.catalyst.json._
@@ -585,7 +586,7 @@ abstract class JsonSuite
 
   test("Loading a JSON dataset from a text file") {
     withTempView("jsonTable") {
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.delete()
       val path = dir.getCanonicalPath
       primitiveFieldAndType.map(record => record.replaceAll("\n", " ")).write.text(path)
@@ -619,7 +620,7 @@ abstract class JsonSuite
 
   test("Loading a JSON dataset primitivesAsString returns schema with primitive types as strings") {
     withTempView("jsonTable") {
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.delete()
       val path = dir.getCanonicalPath
       primitiveFieldAndType.map(record => record.replaceAll("\n", " ")).write.text(path)
@@ -850,7 +851,7 @@ abstract class JsonSuite
   }
 
   test("Loading a JSON dataset from a text file with SQL") {
-    val dir = Utils.createTempDir()
+    val dir = JavaUtils.createTempDir()
     dir.delete()
     val path = dir.toURI.toString
     primitiveFieldAndType.map(record => record.replaceAll("\n", " ")).write.text(path)
@@ -878,7 +879,7 @@ abstract class JsonSuite
 
   test("Applying schemas") {
     withTempView("jsonTable1", "jsonTable2") {
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.delete()
       val path = dir.getCanonicalPath
       primitiveFieldAndType.map(record => record.replaceAll("\n", " ")).write.text(path)
@@ -1620,7 +1621,7 @@ abstract class JsonSuite
 
   test("Parse JSON rows having an array type and a struct type in the same field.") {
     withTempDir { dir =>
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.delete()
       val path = dir.getCanonicalPath
       arrayAndStructRecords.map(record => record.replaceAll("\n", " ")).write.text(path)
@@ -1637,7 +1638,7 @@ abstract class JsonSuite
 
   test("SPARK-12872 Support to specify the option for compression codec") {
     withTempDir { dir =>
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.delete()
       val path = dir.getCanonicalPath
       primitiveFieldAndType.map(record => record.replaceAll("\n", " ")).write.text(path)
@@ -1672,7 +1673,7 @@ abstract class JsonSuite
       "mapreduce.map.output.compress.codec" -> classOf[GzipCodec].getName
     )
     withTempDir { dir =>
-      val dir = Utils.createTempDir()
+      val dir = JavaUtils.createTempDir()
       dir.delete()
 
       val path = dir.getCanonicalPath

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -33,6 +33,7 @@ import org.apache.orc.mapred.OrcStruct
 import org.apache.orc.mapreduce.OrcInputFormat
 
 import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
@@ -526,8 +527,8 @@ abstract class OrcQueryTest extends OrcTest {
   }
 
   test("read from multiple orc input paths") {
-    val path1 = Utils.createTempDir()
-    val path2 = Utils.createTempDir()
+    val path1 = JavaUtils.createTempDir()
+    val path2 = JavaUtils.createTempDir()
     makeOrcFile((1 to 10).map(Tuple1.apply), path1)
     makeOrcFile((1 to 10).map(Tuple1.apply), path2)
     val df = spark.read.orc(path1.getCanonicalPath, path2.getCanonicalPath)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -34,6 +34,7 @@ import org.apache.orc.impl.RecordReaderImpl
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{Row, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, SchemaMergeUtils}
 import org.apache.spark.sql.internal.SQLConf
@@ -55,8 +56,8 @@ abstract class OrcSuite
   protected override def beforeAll(): Unit = {
     super.beforeAll()
 
-    orcTableAsDir = Utils.createTempDir(namePrefix = "orctests")
-    orcTableDir = Utils.createTempDir(namePrefix = "orctests")
+    orcTableAsDir = JavaUtils.createTempDirWithPrefix("orctests")
+    orcTableDir = JavaUtils.createTempDirWithPrefix("orctests")
 
     sparkContext
       .makeRDD(1 to 10)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/text/TextSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.io.SequenceFile.CompressionType
 import org.apache.hadoop.io.compress.GzipCodec
 
 import org.apache.spark.{SparkConf, TestUtils}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.execution.datasources.CommonFileDataSourceSuite
 import org.apache.spark.sql.internal.SQLConf
@@ -48,7 +49,7 @@ abstract class TextSuite extends QueryTest with SharedSparkSession with CommonFi
   test("SPARK-12562 verify write.text() can handle column name beyond `value`") {
     val df = spark.read.text(testFile).withColumnRenamed("value", "adwrasdf")
 
-    val tempFile = Utils.createTempDir()
+    val tempFile = JavaUtils.createTempDir()
     tempFile.delete()
     df.write.text(tempFile.getCanonicalPath)
     verifyFrame(spark.read.text(tempFile.getCanonicalPath))
@@ -57,7 +58,7 @@ abstract class TextSuite extends QueryTest with SharedSparkSession with CommonFi
   }
 
   test("error handling for invalid schema") {
-    val tempFile = Utils.createTempDir()
+    val tempFile = JavaUtils.createTempDir()
     tempFile.delete()
 
     val df = spark.range(2)
@@ -95,7 +96,7 @@ abstract class TextSuite extends QueryTest with SharedSparkSession with CommonFi
     val extensionNameMap = Map("bzip2" -> ".bz2", "deflate" -> ".deflate", "gzip" -> ".gz")
     extensionNameMap.foreach {
       case (codecName, extension) =>
-        val tempDir = Utils.createTempDir()
+        val tempDir = JavaUtils.createTempDir()
         val tempDirPath = tempDir.getAbsolutePath
         testDf.write.option("compression", codecName).mode(SaveMode.Overwrite).text(tempDirPath)
         val compressedFiles = new File(tempDirPath).listFiles()
@@ -104,7 +105,7 @@ abstract class TextSuite extends QueryTest with SharedSparkSession with CommonFi
     }
 
     val errMsg = intercept[IllegalArgumentException] {
-      val tempDirPath = Utils.createTempDir().getAbsolutePath
+      val tempDirPath = JavaUtils.createTempDir().getAbsolutePath
       testDf.write.option("compression", "illegal").mode(SaveMode.Overwrite).text(tempDirPath)
     }
     assert(errMsg.getMessage.contains("Codec [illegal] is not available. " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/v2/jdbc/JDBCTableCatalogSuite.scala
@@ -22,6 +22,7 @@ import java.util.Properties
 import org.apache.logging.log4j.Level
 
 import org.apache.spark.SparkConf
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchNamespaceException, TableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.parser.ParseException
@@ -32,7 +33,7 @@ import org.apache.spark.util.Utils
 
 class JDBCTableCatalogSuite extends QueryTest with SharedSparkSession {
 
-  val tempDir = Utils.createTempDir()
+  val tempDir = JavaUtils.createTempDir()
   val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"
   val defaultMetadata = new MetadataBuilder().putLong("scale", 0).build()
   var conn: java.sql.Connection = null

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
@@ -26,11 +26,11 @@ import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark._
 import org.apache.spark.memory.{TaskMemoryManager, TestMemoryManager}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.{JavaSerializer, SerializerManager}
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection}
 import org.apache.spark.sql.execution.python.PythonForeachWriter.UnsafeRowBuffer
 import org.apache.spark.sql.types.{DataType, IntegerType}
-import org.apache.spark.util.Utils
 
 class PythonForeachWriterSuite extends SparkFunSuite with Eventually with MockitoSugar {
 
@@ -94,7 +94,7 @@ class PythonForeachWriterSuite extends SparkFunSuite with Eventually with Mockit
       val mem = new TestMemoryManager(conf)
       mem.limit(memBytes)
       val taskM = new TaskMemoryManager(mem, 0)
-      new UnsafeRowBuffer(taskM, Utils.createTempDir(), 1)
+      new UnsafeRowBuffer(taskM, JavaUtils.createTempDir(), 1)
     }
     private val iterator = buffer.iterator
     private val outputBuffer = new ArrayBuffer[Int]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/RowQueueSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/RowQueueSuite.scala
@@ -22,11 +22,11 @@ import java.io.File
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.config._
 import org.apache.spark.memory.{MemoryMode, TaskMemoryManager, TestMemoryManager}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.security.{CryptoStreamUtils, EncryptionFunSuite}
 import org.apache.spark.serializer.{JavaSerializer, SerializerManager}
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.unsafe.memory.MemoryBlock
-import org.apache.spark.util.Utils
 
 class RowQueueSuite extends SparkFunSuite with EncryptionFunSuite {
 
@@ -67,7 +67,7 @@ class RowQueueSuite extends SparkFunSuite with EncryptionFunSuite {
 
   encryptionTest("disk queue") { conf =>
     val serManager = createSerializerManager(conf)
-    val dir = Utils.createTempDir().getCanonicalFile
+    val dir = JavaUtils.createTempDir().getCanonicalFile
     dir.mkdirs()
     val queue = DiskRowQueue(new File(dir, "buffer"), 1, serManager)
     val row = new UnsafeRow(1)
@@ -102,7 +102,7 @@ class RowQueueSuite extends SparkFunSuite with EncryptionFunSuite {
       val mem = new TestMemoryManager(conf)
       mem.limit(4<<10)
       val taskM = new TaskMemoryManager(mem, 0)
-      val queue = HybridRowQueue(taskM, Utils.createTempDir().getCanonicalFile, 1, serManager)
+      val queue = HybridRowQueue(taskM, JavaUtils.createTempDir().getCanonicalFile, 1, serManager)
       val mode = if (isOffHeap) MemoryMode.OFF_HEAP else MemoryMode.ON_HEAP
       assert(queue.getMode === mode)
       val row = new UnsafeRow(1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MemorySinkSuite.scala
@@ -21,12 +21,12 @@ import scala.language.implicitConversions
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.streaming.sources._
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.util.Utils
 
 class MemorySinkSuite extends StreamTest with BeforeAndAfter {
 
@@ -270,7 +270,7 @@ class MemorySinkSuite extends StreamTest with BeforeAndAfter {
   }
 
   test("error if attempting to resume specific checkpoint") {
-    val location = Utils.createTempDir(namePrefix = "steaming.checkpoint").getCanonicalPath
+    val location = JavaUtils.createTempDirWithPrefix("steaming.checkpoint").getCanonicalPath
 
     val input = MemoryStream[Int]
     val query = input.toDF().writeStream

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecutionSuite.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.connector.read.streaming
@@ -29,7 +30,6 @@ import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.functions.{count, timestamp_seconds, window}
 import org.apache.spark.sql.streaming.{StreamTest, Trigger}
 import org.apache.spark.sql.types.{LongType, StructType}
-import org.apache.spark.util.Utils
 
 class MicroBatchExecutionSuite extends StreamTest with BeforeAndAfter {
 
@@ -85,7 +85,7 @@ class MicroBatchExecutionSuite extends StreamTest with BeforeAndAfter {
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-test-offsetId-commitId-inconsistent/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -25,13 +25,13 @@ import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.SparkConf
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.StatefulOperatorStateInfo
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.Platform
-import org.apache.spark.util.Utils
 
 class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvider]
   with BeforeAndAfter {
@@ -83,7 +83,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       val testRDD = spark.sparkContext.makeRDD[String](Seq("a"), 1)
       val testSchema = StructType(Seq(StructField("key", StringType, true)))
       val testStateInfo = StatefulOperatorStateInfo(
-        checkpointLocation = Utils.createTempDir().getAbsolutePath,
+        checkpointLocation = JavaUtils.createTempDir().getAbsolutePath,
         queryRunId = UUID.randomUUID, operatorId = 0, storeVersion = 0, numPartitions = 5)
 
       // Create state store in a task and get the RocksDBConf from the instantiated RocksDB instance

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCompatibilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCompatibilitySuite.scala
@@ -23,20 +23,20 @@ import org.apache.commons.io.FileUtils
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.io.CompressionCodec
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Update
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
-import org.apache.spark.util.Utils
 
 class StateStoreCompatibilitySuite extends StreamTest with StateStoreCodecsTest {
    testWithAllCodec(
       "SPARK-33263: Recovery from checkpoint before codec config introduced") {
      val resourceUri = this.getClass.getResource(
        "/structured-streaming/checkpoint-version-3.0.0-streaming-statestore-codec/").toURI
-     val checkpointDir = Utils.createTempDir().getCanonicalFile
+     val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
      FileUtils.copyDirectory(new File(resourceUri), checkpointDir)
 
      import testImplicits._

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCoordinatorSuite.scala
@@ -23,12 +23,12 @@ import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SharedSparkContext, SparkContext, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingQueryWrapper}
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf.SHUFFLE_PARTITIONS
-import org.apache.spark.util.Utils
 
 class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
 
@@ -130,7 +130,7 @@ class StateStoreCoordinatorSuite extends SparkFunSuite with SharedSparkContext {
       // Start a query and run a batch to load state stores
       val inputData = MemoryStream[Int]
       val aggregated = inputData.toDF().groupBy("value").agg(count("*")) // stateful query
-      val checkpointLocation = Utils.createTempDir().getAbsoluteFile
+      val checkpointLocation = JavaUtils.createTempDir().getAbsoluteFile
       val query = aggregated.writeStream
         .format("memory")
         .outputMode("update")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -36,6 +36,7 @@ import org.scalatest.time.SpanSugar._
 import org.apache.spark._
 import org.apache.spark.LocalSparkContext._
 import org.apache.spark.internal.config.Network.RPC_NUM_RETRIES
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.quietly
@@ -44,7 +45,6 @@ import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.Utils
 
 class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
   with BeforeAndAfter {
@@ -495,7 +495,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
 
   test("SPARK-21145: Restarted queries create new provider instances") {
     try {
-      val checkpointLocation = Utils.createTempDir().getAbsoluteFile
+      val checkpointLocation = JavaUtils.createTempDir().getAbsoluteFile
       val spark = SparkSession.builder().master("local[2]").getOrCreate()
       SparkSession.setActiveSession(spark)
       implicit val sqlContext = spark.sqlContext
@@ -548,7 +548,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     hadoopConf.set(
       SQLConf.STREAMING_CHECKPOINT_FILE_MANAGER_CLASS.parent.key,
       classOf[CreateAtomicTestManager].getName)
-    val remoteDir = Utils.createTempDir().getAbsolutePath
+    val remoteDir = JavaUtils.createTempDir().getAbsolutePath
 
     tryWithProviderResource(newStoreProvider(opId = Random.nextInt, partition = 0,
       dir = remoteDir, hadoopConf = hadoopConf)) { provider =>
@@ -1324,7 +1324,7 @@ object StateStoreTestsHelper {
     Option(store.get(dataToKeyRow(key1, key2))).map(valueRowToData)
   }
 
-  def newDir(): String = Utils.createTempDir().toString
+  def newDir(): String = JavaUtils.createTempDir().toString
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCNestedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCNestedDataSourceSuite.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.jdbc
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.NestedDataSourceSuiteBase
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
 class JDBCNestedDataSourceSuite extends NestedDataSourceSuiteBase {
   override val nestedDataSources: Seq[String] = Seq("jdbc")
-  private val tempDir = Utils.createTempDir()
+  private val tempDir = JavaUtils.createTempDir()
   private val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"
   override val colType: String = "in the customSchema option value"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -21,6 +21,7 @@ import java.sql.{Connection, DriverManager}
 import java.util.Properties
 
 import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, ExplainSuiteHelper, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.CannotReplaceMissingTableException
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, GlobalLimit, LocalLimit, Sort}
@@ -34,7 +35,7 @@ import org.apache.spark.util.Utils
 class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHelper {
   import testImplicits._
 
-  val tempDir = Utils.createTempDir()
+  val tempDir = JavaUtils.createTempDir()
   val url = s"jdbc:h2:${tempDir.getCanonicalPath};user=testUser;password=testPass"
   var conn: java.sql.Connection = null
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/CreateTableAsSelectSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.sources
 import java.io.File
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTableType}
@@ -51,7 +52,7 @@ class CreateTableAsSelectSuite extends DataSourceTest with SharedSparkSession {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    path = Utils.createTempDir()
+    path = JavaUtils.createTempDir()
     path.delete()
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -24,6 +24,7 @@ import java.time.{Duration, Period}
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FSDataOutputStream, Path, RawLocalFileSystem}
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
@@ -65,7 +66,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    path = Utils.createTempDir()
+    path = JavaUtils.createTempDir()
     val ds = (1 to 10).map(i => s"""{"a":$i, "b":"str$i"}""").toDS()
     spark.read.json(ds).createOrReplaceTempView("jt")
     sql(
@@ -601,7 +602,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
             |partitioned by (part1, part2)
           """.stripMargin)
 
-        val path1 = Utils.createTempDir()
+        val path1 = JavaUtils.createTempDir()
         sql(s"alter table t add partition(part1=1, part2=1) location '$path1'")
         sql(s"insert into t partition(part1=1, part2=1) select 1")
         checkAnswer(spark.table("t"), Row(1, 1, 1))
@@ -612,7 +613,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         sql("insert overwrite table t partition(part1=2, part2) select 2, 2")
         checkAnswer(spark.table("t"), Row(2, 1, 1) :: Row(2, 2, 2) :: Nil)
 
-        val path2 = Utils.createTempDir()
+        val path2 = JavaUtils.createTempDir()
         sql(s"alter table t add partition(part1=1, part2=2) location '$path2'")
         sql("insert overwrite table t partition(part1=1, part2=2) select 3")
         checkAnswer(spark.table("t"), Row(2, 1, 1) :: Row(2, 2, 2) :: Row(3, 1, 2) :: Nil)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/PartitionedWriteSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
 
 import org.apache.spark.TestUtils
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -51,7 +52,7 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 
   test("write many partitions") {
-    val path = Utils.createTempDir()
+    val path = JavaUtils.createTempDir()
     path.delete()
 
     val df = spark.range(100).select($"id", lit(1).as("data"))
@@ -65,7 +66,7 @@ class PartitionedWriteSuite extends QueryTest with SharedSparkSession {
   }
 
   test("write many partitions with repeats") {
-    val path = Utils.createTempDir()
+    val path = JavaUtils.createTempDir()
     path.delete()
 
     val base = spark.range(100)

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/SaveLoadSuite.scala
@@ -23,6 +23,7 @@ import java.nio.file.{Files, Paths}
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -41,7 +42,7 @@ class SaveLoadSuite extends DataSourceTest with SharedSparkSession with BeforeAn
     super.beforeAll()
     originalDefaultSource = spark.sessionState.conf.defaultDataSourceName
 
-    path = Utils.createTempDir()
+    path = JavaUtils.createTempDir()
     path.delete()
 
     val ds = (1 to 10).map(i => s"""{"a":$i, "b":"str${i}"}""").toDS()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -29,6 +29,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, Dataset}
 import org.apache.spark.sql.catalyst.plans.logical.EventTimeWatermark
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -38,7 +39,6 @@ import org.apache.spark.sql.execution.streaming.sources.MemorySink
 import org.apache.spark.sql.functions.{count, timestamp_seconds, window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode._
-import org.apache.spark.util.Utils
 
 class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matchers with Logging {
 
@@ -237,7 +237,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.3.1-without-commit-log-metadata/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)
@@ -702,7 +702,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
     val input1 = MemoryStream[Int]
     val input2 = MemoryStream[Int]
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     withSQLConf(SQLConf.STREAMING_MULTIPLE_WATERMARK_POLICY.key -> "max") {
       testStream(dfWithMultipleWatermarks(input1, input2))(
         StartStream(checkpointLocation = checkpointDir.getAbsolutePath),
@@ -733,7 +733,7 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.3.1-for-multi-watermark-policy/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.mapreduce.JobContext
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.util.stringToFile
@@ -40,7 +41,6 @@ import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.util.Utils
 
 abstract class FileStreamSinkSuite extends StreamTest {
   import testImplicits._
@@ -64,8 +64,8 @@ abstract class FileStreamSinkSuite extends StreamTest {
     val inputData = MemoryStream[Int]
     val df = inputData.toDF()
 
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-    val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+    val checkpointDir = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
     var query: StreamingQuery = null
 
@@ -96,8 +96,8 @@ abstract class FileStreamSinkSuite extends StreamTest {
     val inputData = MemoryStream[String]
     val ds = inputData.toDS()
 
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-    val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+    val checkpointDir = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
     val query = ds.map(s => (s, s.length))
       .toDF("value", "len")
@@ -125,8 +125,8 @@ abstract class FileStreamSinkSuite extends StreamTest {
     val inputData = MemoryStream[Int]
     val ds = inputData.toDS()
 
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-    val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+    val checkpointDir = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
     var query: StreamingQuery = null
 
@@ -218,8 +218,8 @@ abstract class FileStreamSinkSuite extends StreamTest {
       .count()
       .select("window.start", "window.end", "count")
 
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-    val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+    val checkpointDir = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
     var query: StreamingQuery = null
 
@@ -268,7 +268,7 @@ abstract class FileStreamSinkSuite extends StreamTest {
 
   test("Update and Complete output mode not supported") {
     val df = MemoryStream[Int].toDF().groupBy().count()
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
 
     withTempDir { dir =>
 
@@ -307,8 +307,8 @@ abstract class FileStreamSinkSuite extends StreamTest {
     val inputData = MemoryStream[Int]
     val ds = inputData.toDS()
 
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-    val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+    val checkpointDir = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
     var query: StreamingQuery = null
 
@@ -349,8 +349,8 @@ abstract class FileStreamSinkSuite extends StreamTest {
         val inputData = MemoryStream[(Int, Int)]
         val df = inputData.toDF()
 
-        val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-        val checkpointDir = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+        val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+        val checkpointDir = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
         var query: StreamingQuery = null
         try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSourceSuite.scala
@@ -33,6 +33,7 @@ import org.scalatest.PrivateMethodTester
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.connector.read.streaming.ReadLimit
@@ -182,7 +183,8 @@ abstract class FileStreamSourceTest
   }
 
   protected def getSourceFromFileStream(df: DataFrame): FileStreamSource = {
-    val checkpointLocation = Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
+    val checkpointLocation =
+      JavaUtils.createTempDirWithPrefix("streaming.metadata").getCanonicalPath
     df.queryExecution.analyzed
       .collect { case StreamingRelation(dataSource, _, _) =>
         // There is only one source in our tests so just set sourceId to 0
@@ -198,8 +200,8 @@ abstract class FileStreamSourceTest
   }
 
   protected def withTempDirs(body: (File, File) => Unit): Unit = {
-    val src = Utils.createTempDir(namePrefix = "streaming.src")
-    val tmp = Utils.createTempDir(namePrefix = "streaming.tmp")
+    val src = JavaUtils.createTempDirWithPrefix("streaming.src")
+    val tmp = JavaUtils.createTempDirWithPrefix("streaming.tmp")
     try {
       body(src, tmp)
     } finally {
@@ -209,9 +211,9 @@ abstract class FileStreamSourceTest
   }
 
   protected def withThreeTempDirs(body: (File, File, File) => Unit): Unit = {
-    val src = Utils.createTempDir(namePrefix = "streaming.src")
-    val tmp = Utils.createTempDir(namePrefix = "streaming.tmp")
-    val archive = Utils.createTempDir(namePrefix = "streaming.archive")
+    val src = JavaUtils.createTempDirWithPrefix("streaming.src")
+    val tmp = JavaUtils.createTempDirWithPrefix("streaming.tmp")
+    val archive = JavaUtils.createTempDirWithPrefix("streaming.archive")
     try {
       body(src, tmp, archive)
     } finally {
@@ -2348,8 +2350,8 @@ class FileStreamSourceStressTestSuite extends FileStreamSourceTest {
   import testImplicits._
 
   testQuietly("file source stress test") {
-    val src = Utils.createTempDir(namePrefix = "streaming.src")
-    val tmp = Utils.createTempDir(namePrefix = "streaming.tmp")
+    val src = JavaUtils.createTempDirWithPrefix("streaming.src")
+    val tmp = JavaUtils.createTempDirWithPrefix("streaming.tmp")
 
     val fileStream = createFileStream("text", src.getCanonicalPath)
     val ds = fileStream.as[String].map(_.toInt + 1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamStressSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamStressSuite.scala
@@ -23,8 +23,8 @@ import java.util.UUID
 import scala.util.Random
 import scala.util.control.NonFatal
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.util.Utils
 
 /**
  * A stress test for streaming queries that read and write files.  This test consists of
@@ -52,10 +52,10 @@ class FileStreamStressSuite extends StreamTest {
 
   def stressTest(partitionWrites: Boolean): Unit = {
     val numRecords = 10000
-    val inputDir = Utils.createTempDir(namePrefix = "stream.input").getCanonicalPath
-    val stagingDir = Utils.createTempDir(namePrefix = "stream.staging").getCanonicalPath
-    val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
-    val checkpoint = Utils.createTempDir(namePrefix = "stream.checkpoint").getCanonicalPath
+    val inputDir = JavaUtils.createTempDirWithPrefix("stream.input").getCanonicalPath
+    val stagingDir = JavaUtils.createTempDirWithPrefix("stream.staging").getCanonicalPath
+    val outputDir = JavaUtils.createTempDirWithPrefix("stream.output").getCanonicalPath
+    val checkpoint = JavaUtils.createTempDirWithPrefix("stream.checkpoint").getCanonicalPath
 
     @volatile
     var continue = true

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateDistributionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateDistributionSuite.scala
@@ -21,12 +21,12 @@ import java.io.File
 
 import org.apache.commons.io.FileUtils
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Update
 import org.apache.spark.sql.execution.streaming.{FlatMapGroupsWithStateExec, MemoryStream}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.GroupStateTimeout.ProcessingTimeTimeout
 import org.apache.spark.sql.streaming.util.{StatefulOpClusteredDistributionTestHelper, StreamManualClock}
-import org.apache.spark.util.Utils
 
 class FlatMapGroupsWithStateDistributionSuite extends StreamTest
   with StatefulOpClusteredDistributionTestHelper {
@@ -176,7 +176,7 @@ class FlatMapGroupsWithStateDistributionSuite extends StreamTest
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-3.2.0-flatmapgroupswithstate1-repartition/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)
@@ -273,7 +273,7 @@ class FlatMapGroupsWithStateDistributionSuite extends StreamTest
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-3.2.0-flatmapgroupswithstate2-repartition/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)
@@ -365,7 +365,7 @@ class FlatMapGroupsWithStateDistributionSuite extends StreamTest
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-3.1.0-flatmapgroupswithstate-repartition/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateSuite.scala
@@ -26,6 +26,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.apache.spark.SparkException
 import org.apache.spark.api.java.Optional
 import org.apache.spark.api.java.function.FlatMapGroupsWithStateFunction
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoder, KeyValueGroupedDataset}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
@@ -39,7 +40,6 @@ import org.apache.spark.sql.functions.timestamp_seconds
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.types.{DataType, IntegerType}
-import org.apache.spark.util.Utils
 
 /** Class to check custom state types */
 case class RunningCount(count: Long)
@@ -1002,7 +1002,7 @@ class FlatMapGroupsWithStateSuite extends StateStoreMetricsTest {
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.3.1-flatMapGroupsWithState-state-format-1/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -32,6 +32,7 @@ import org.apache.hadoop.conf.Configuration
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkConf, SparkContext, TaskContext, TestUtils}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.logical.{Range, RepartitionByExpression}
@@ -47,7 +48,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.StreamSourceProvider
 import org.apache.spark.sql.streaming.util.{BlockOnStopSourceProvider, StreamManualClock}
 import org.apache.spark.sql.types.{IntegerType, LongType, StructField, StructType}
-import org.apache.spark.util.Utils
 
 class StreamSuite extends StreamTest {
 
@@ -746,7 +746,8 @@ class StreamSuite extends StreamTest {
 
     // 1 - Test if recovery from the checkpoint is successful.
     prepareMemoryStream()
-    val dir1 = Utils.createTempDir().getCanonicalFile // not using withTempDir {}, makes test flaky
+    val dir1 =
+      JavaUtils.createTempDir().getCanonicalFile // not using withTempDir {}, makes test flaky
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(checkpointDir, dir1)
@@ -774,7 +775,7 @@ class StreamSuite extends StreamTest {
 
     // 2 - Check recovery with wrong num shuffle partitions
     prepareMemoryStream()
-    val dir2 = Utils.createTempDir().getCanonicalFile
+    val dir2 = JavaUtils.createTempDir().getCanonicalFile
     FileUtils.copyDirectory(checkpointDir, dir2)
     // Since the number of partitions is greater than 10, should throw exception.
     withSQLConf(SQLConf.SHUFFLE_PARTITIONS.key -> "15") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamTest.scala
@@ -31,6 +31,7 @@ import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{Dataset, Encoder, QueryTest, Row}
 import org.apache.spark.sql.catalyst.encoders.{encoderFor, ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -45,7 +46,7 @@ import org.apache.spark.sql.execution.streaming.sources.MemorySink
 import org.apache.spark.sql.execution.streaming.state.StateStore
 import org.apache.spark.sql.streaming.StreamingQueryListener._
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.util.{Clock, SystemClock, Utils}
+import org.apache.spark.util.{Clock, SystemClock}
 
 /**
  * A framework for implementing tests for streaming queries and sources.
@@ -357,7 +358,7 @@ trait StreamTest extends QueryTest with SharedSparkSession with TimeLimits with 
     val sink = new MemorySink
     val resetConfValues = mutable.Map[String, Option[String]]()
     val defaultCheckpointLocation =
-      Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
+      JavaUtils.createTempDirWithPrefix("streaming.metadata").getCanonicalPath
     var manualClockExpectedTime = -1L
 
     @volatile

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationDistributionSuite.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.commons.io.FileUtils
 import org.scalatest.Assertions
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.plans.physical.UnspecifiedDistribution
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.streaming.{MemoryStream, StateStoreRestoreExec, StateStoreSaveExec}
@@ -29,7 +30,6 @@ import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode.Update
 import org.apache.spark.sql.streaming.util.StatefulOpClusteredDistributionTestHelper
-import org.apache.spark.util.Utils
 
 class StreamingAggregationDistributionSuite extends StreamTest
   with StatefulOpClusteredDistributionTestHelper with Assertions {
@@ -98,7 +98,7 @@ class StreamingAggregationDistributionSuite extends StreamTest
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-3.2.0-streaming-aggregate-with-repartition/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingAggregationSuite.scala
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils
 import org.scalatest.Assertions
 
 import org.apache.spark.{SparkEnv, SparkException}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.BlockRDD
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -43,7 +44,6 @@ import org.apache.spark.sql.streaming.OutputMode._
 import org.apache.spark.sql.streaming.util.{MockSourceProvider, StreamManualClock}
 import org.apache.spark.sql.types.{StructType, TimestampType}
 import org.apache.spark.storage.{BlockId, StorageLevel, TestBlockId}
-import org.apache.spark.util.Utils
 
 object FailureSingleton {
   var firstTime = true
@@ -726,7 +726,7 @@ class StreamingAggregationSuite extends StateStoreMetricsTest with Assertions {
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.3.1-streaming-aggregate-state-format-1/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationDistributionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationDistributionSuite.scala
@@ -21,11 +21,11 @@ import java.io.File
 
 import org.apache.commons.io.FileUtils
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Update
 import org.apache.spark.sql.execution.streaming.{MemoryStream, StreamingDeduplicateExec}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.util.StatefulOpClusteredDistributionTestHelper
-import org.apache.spark.util.Utils
 
 class StreamingDeduplicationDistributionSuite extends StreamTest
   with StatefulOpClusteredDistributionTestHelper {
@@ -72,7 +72,7 @@ class StreamingDeduplicationDistributionSuite extends StreamTest
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-3.2.0-deduplication-with-repartition/").toURI
 
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingJoinSuite.scala
@@ -27,6 +27,7 @@ import scala.util.Random
 import org.apache.commons.io.FileUtils
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.ExecutorCacheTaskLocation
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
@@ -652,7 +653,7 @@ class StreamingInnerJoinSuite extends StreamingJoinSuite {
 
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.4.0-streaming-join/").toURI
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)
@@ -1113,7 +1114,7 @@ class StreamingOuterJoinSuite extends StreamingJoinSuite {
 
     val resourceUri = this.getClass.getResource(
       "/structured-streaming/checkpoint-version-2.4.0-streaming-join/").toURI
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     // Copy the checkpoint to a temp dir to prevent changes to the original.
     // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryManagerSuite.scala
@@ -29,12 +29,12 @@ import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{Dataset, Encoders}
 import org.apache.spark.sql.execution.datasources.v2.StreamingDataSourceV2Relation
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.util.BlockingSource
-import org.apache.spark.util.Utils
 
 class StreamingQueryManagerSuite extends StreamTest {
 
@@ -409,7 +409,7 @@ class StreamingQueryManagerSuite extends StreamTest {
           try {
             val df = ds.toDF
             val metadataRoot =
-              Utils.createTempDir(namePrefix = "streaming.checkpoint").getCanonicalPath
+              JavaUtils.createTempDirWithPrefix("streaming.checkpoint").getCanonicalPath
             query =
               df.writeStream
                 .format("memory")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowDistributionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowDistributionSuite.scala
@@ -22,13 +22,13 @@ import java.io.File
 import org.apache.commons.io.FileUtils
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.plans.physical.UnspecifiedDistribution
 import org.apache.spark.sql.execution.aggregate.BaseAggregateExec
 import org.apache.spark.sql.execution.streaming.{MemoryStream, SessionWindowStateStoreRestoreExec, SessionWindowStateStoreSaveExec}
 import org.apache.spark.sql.functions.{count, session_window}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.util.StatefulOpClusteredDistributionTestHelper
-import org.apache.spark.util.Utils
 
 class StreamingSessionWindowDistributionSuite extends StreamTest
   with StatefulOpClusteredDistributionTestHelper with Logging {
@@ -139,7 +139,7 @@ class StreamingSessionWindowDistributionSuite extends StreamTest
       val resourceUri = this.getClass.getResource(
         "/structured-streaming/checkpoint-version-3.2.0-session-window-with-repartition/").toURI
 
-      val checkpointDir = Utils.createTempDir().getCanonicalFile
+      val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
       // Copy the checkpoint to a temp dir to prevent changes to the original.
       // Not doing this will lead to the test passing on the first run, but fail subsequent runs.
       FileUtils.copyDirectory(new File(resourceUri), checkpointDir)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingStateStoreFormatCompatibilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingStateStoreFormatCompatibilitySuite.scala
@@ -24,12 +24,12 @@ import scala.annotation.tailrec
 import org.apache.commons.io.FileUtils
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Complete
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.execution.streaming.state.{InvalidUnsafeRowException, StateSchemaNotCompatible}
 import org.apache.spark.sql.functions._
-import org.apache.spark.util.Utils
 
 /**
  * An integrated test for streaming state store format compatibility.
@@ -45,7 +45,7 @@ class StreamingStateStoreFormatCompatibilitySuite extends StreamTest {
   private def prepareCheckpointDir(testName: String): File = {
     val resourceUri = this.getClass.getResource("/structured-streaming/" +
       s"checkpoint-version-2.4.5-for-compatibility-test-${testName}").toURI
-    val checkpointDir = Utils.createTempDir().getCanonicalFile
+    val checkpointDir = JavaUtils.createTempDir().getCanonicalFile
     FileUtils.copyDirectory(new File(resourceUri), checkpointDir)
     checkpointDir
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/sources/StreamingDataSourceV2Suite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.streaming.sources
 
 import java.util
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.connector.catalog.{SessionConfigSupport, SupportsRead, SupportsWrite, Table, TableCapability, TableProvider}
 import org.apache.spark.sql.connector.catalog.TableCapability._
@@ -35,7 +36,6 @@ import org.apache.spark.sql.sources.{DataSourceRegister, StreamSinkProvider}
 import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, StreamTest, Trigger}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.Utils
 
 class FakeDataStream extends MicroBatchStream with ContinuousStream {
   override def deserializeOffset(json: String): Offset = RateStreamOffset(Map())
@@ -273,7 +273,7 @@ class StreamingDataSourceV2Suite extends StreamTest {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    val fakeCheckpoint = Utils.createTempDir()
+    val fakeCheckpoint = JavaUtils.createTempDir()
     spark.conf.set(SQLConf.CHECKPOINT_LOCATION.key, fakeCheckpoint.getCanonicalPath)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamReaderWriterSuite.scala
@@ -29,6 +29,7 @@ import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.internal.SQLConf
@@ -36,7 +37,6 @@ import org.apache.spark.sql.sources.{StreamSinkProvider, StreamSourceProvider}
 import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, StreamingQueryException, StreamTest}
 import org.apache.spark.sql.streaming.Trigger._
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 object LastOptions {
 
@@ -112,7 +112,7 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
   import testImplicits._
 
   private def newMetadataDir =
-    Utils.createTempDir(namePrefix = "streaming.metadata").getCanonicalPath
+    JavaUtils.createTempDirWithPrefix("streaming.metadata").getCanonicalPath
 
   after {
     spark.streams.active.foreach(_.stop())
@@ -423,7 +423,7 @@ class DataStreamReaderWriterSuite extends StreamTest with BeforeAndAfter {
       meq(Map.empty))
   }
 
-  private def newTextInput = Utils.createTempDir(namePrefix = "text").getCanonicalPath
+  private def newTextInput = JavaUtils.createTempDirWithPrefix("text").getCanonicalPath
 
   test("check foreach() catches null writers") {
     val df = spark.readStream

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/test/DataStreamTableAPISuite.scala
@@ -22,6 +22,7 @@ import java.util
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
@@ -37,7 +38,6 @@ import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.streaming.sources.FakeScanBuilder
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.Utils
 
 class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
   import testImplicits._
@@ -330,7 +330,7 @@ class DataStreamTableAPISuite extends StreamTest with BeforeAndAfter {
       dsw.option("path", output.getCanonicalPath)
     }
     val sq = dsw
-      .option("checkpointLocation", Utils.createTempDir().getCanonicalPath)
+      .option("checkpointLocation", JavaUtils.createTempDir().getCanonicalPath)
       .toTable(tableName)
     memory.addData(1, 2, 3)
     sq.processAllAvailable()

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatusListenerSuite.scala
@@ -25,6 +25,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.History.{HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.getTimeZone
 import org.apache.spark.sql.execution.ui.StreamingQueryStatusStore
 import org.apache.spark.sql.internal.StaticSQLConf
@@ -225,7 +226,7 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
     assume(!Utils.isMacOnAppleSilicon)
     val conf = new SparkConf()
       .set(HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend.LEVELDB.toString)
-    val testDir = Utils.createTempDir()
+    val testDir = JavaUtils.createTempDir()
     val kvStore = KVUtils.open(testDir, getClass.getName, conf)
     try {
       testStreamingQueryData(kvStore)
@@ -238,7 +239,7 @@ class StreamingQueryStatusListenerSuite extends StreamTest {
   test("SPARK-38056: test writing StreamingQueryData to a RocksDB store") {
     val conf = new SparkConf()
       .set(HYBRID_STORE_DISK_BACKEND, HybridStoreDiskBackend.ROCKSDB.toString)
-    val testDir = Utils.createTempDir()
+    val testDir = JavaUtils.createTempDir()
     val kvStore = KVUtils.open(testDir, getClass.getName, conf)
     try {
       testStreamingQueryData(kvStore)

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/DataFrameReaderWriterSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.{SparkContext, TestUtils}
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.internal.io.HadoopMapReduceCommitProtocol
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -148,7 +149,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
   private val userSchemaString = "s STRING"
   private val textSchema = new StructType().add("value", StringType)
   private val data = Seq("1", "2", "3")
-  private val dir = Utils.createTempDir(namePrefix = "input").getCanonicalPath
+  private val dir = JavaUtils.createTempDirWithPrefix("input").getCanonicalPath
 
   before {
     Utils.deleteRecursively(new File(dir))
@@ -469,7 +470,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
   }
 
   test("check jdbc() does not support partitioning, bucketBy or sortBy") {
-    val df = spark.read.text(Utils.createTempDir(namePrefix = "text").getCanonicalPath)
+    val df = spark.read.text(JavaUtils.createTempDirWithPrefix("text").getCanonicalPath)
 
     var w = df.write.partitionBy("value")
     var e = intercept[AnalysisException](w.jdbc(null, null, null))
@@ -987,7 +988,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
 
     def checkReadUserSpecifiedDataColumnDuplication(
         df: DataFrame, format: String, colName0: String, colName1: String, tempDir: File): Unit = {
-      val testDir = Utils.createTempDir(tempDir.getAbsolutePath)
+      val testDir = JavaUtils.createTempDirWithRoot(tempDir.getAbsolutePath)
       df.write.format(format).mode("overwrite").save(testDir.getAbsolutePath)
       val errorMsg = intercept[AnalysisException] {
         spark.read.format(format).schema(s"$colName0 INT, $colName1 INT")
@@ -998,7 +999,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
 
     def checkReadPartitionColumnDuplication(
         format: String, colName0: String, colName1: String, tempDir: File): Unit = {
-      val testDir = Utils.createTempDir(tempDir.getAbsolutePath)
+      val testDir = JavaUtils.createTempDirWithRoot(tempDir.getAbsolutePath)
       Seq(1).toDF("col").write.format(format).mode("overwrite")
         .save(s"${testDir.getAbsolutePath}/$colName0=1/$colName1=1")
       val errorMsg = intercept[AnalysisException] {
@@ -1015,7 +1016,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
           checkReadUserSpecifiedDataColumnDuplication(
             Seq((1, 1)).toDF("c0", "c1"), "csv", c0, c1, src)
           // If `inferSchema` is true, a CSV format is duplicate-safe (See SPARK-16896)
-          var testDir = Utils.createTempDir(src.getAbsolutePath)
+          var testDir = JavaUtils.createTempDirWithRoot(src.getAbsolutePath)
           Seq("a,a", "1,1").toDF().coalesce(1).write.mode("overwrite").text(testDir.getAbsolutePath)
           val df = spark.read.format("csv").option("inferSchema", true).option("header", true)
             .load(testDir.getAbsolutePath)
@@ -1027,7 +1028,7 @@ class DataFrameReaderWriterSuite extends QueryTest with SharedSparkSession with 
           checkReadUserSpecifiedDataColumnDuplication(
             Seq((1, 1)).toDF("c0", "c1"), "json", c0, c1, src)
           // Inferred schema cases
-          testDir = Utils.createTempDir(src.getAbsolutePath)
+          testDir = JavaUtils.createTempDirWithRoot(src.getAbsolutePath)
           Seq(s"""{"$c0":3, "$c1":5}""").toDF().write.mode("overwrite")
             .text(testDir.getAbsolutePath)
           val errorMsg = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestUtils.scala
@@ -33,6 +33,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite, Tag}
 import org.scalatest.concurrent.Eventually
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
@@ -202,7 +203,7 @@ private[sql] trait SQLTestUtils extends SparkFunSuite with SQLTestUtilsBase with
    * deleted after `f` returns.
    */
   protected def withTempPaths(numPaths: Int)(f: Seq[File] => Unit): Unit = {
-    val files = Array.fill[File](numPaths)(Utils.createTempDir().getCanonicalFile)
+    val files = Array.fill[File](numPaths)(JavaUtils.createTempDir().getCanonicalFile)
     try f(files) finally {
       // wait for all tasks to finish before deleting files
       waitForTasksToFinish()

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreLazyInitializationSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/HiveMetastoreLazyInitializationSuite.scala
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.Logger
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.util.Utils
 
@@ -47,7 +48,7 @@ class HiveMetastoreLazyInitializationSuite extends SparkFunSuite {
       assert(spark.range(0, 1).count() === 1)
 
       // We should be able to use fs
-      val path = Utils.createTempDir()
+      val path = JavaUtils.createTempDir()
       path.delete()
       try {
         spark.range(0, 1).write.parquet(path.getAbsolutePath)

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -37,6 +37,7 @@ import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.ProcessTestUtils.ProcessOutputCapturer
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.HiveUtils._
 import org.apache.spark.sql.hive.client.HiveClientImpl
@@ -48,10 +49,10 @@ import org.apache.spark.util.{ThreadUtils, Utils}
  * A test suite for the `spark-sql` CLI tool.
  */
 class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
-  val warehousePath = Utils.createTempDir()
-  val metastorePath = Utils.createTempDir()
-  val scratchDirPath = Utils.createTempDir()
-  val sparkWareHouseDir = Utils.createTempDir()
+  val warehousePath = JavaUtils.createTempDir()
+  val metastorePath = JavaUtils.createTempDir()
+  val scratchDirPath = JavaUtils.createTempDir()
+  val sparkWareHouseDir = JavaUtils.createTempDir()
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -225,7 +226,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
   }
 
   test("load warehouse dir from hive-site.xml") {
-    val metastore = Utils.createTempDir()
+    val metastore = JavaUtils.createTempDir()
     metastore.delete()
     try {
       runCliWithin(1.minute,
@@ -250,7 +251,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("load warehouse dir from --conf spark(.hadoop).hive.*") {
     // override conf from hive-site.xml
-    val metastore = Utils.createTempDir()
+    val metastore = JavaUtils.createTempDir()
     metastore.delete()
     try {
       runCliWithin(2.minute,
@@ -279,7 +280,7 @@ class CliSuite extends SparkFunSuite with BeforeAndAfterAll with Logging {
 
   test("load warehouse dir from spark.sql.warehouse.dir") {
     // spark.sql.warehouse.dir overrides all hive ones
-    val metastore = Utils.createTempDir()
+    val metastore = JavaUtils.createTempDir()
     metastore.delete()
     try {
       runCliWithin(2.minute,

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -47,6 +47,7 @@ import org.scalatest.concurrent.Eventually._
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.ProcessTestUtils.ProcessOutputCapturer
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.hive.test.HiveTestJars
 import org.apache.spark.sql.internal.SQLConf
@@ -1108,7 +1109,7 @@ class HiveThriftCleanUpScratchDirSuite extends HiveThriftServer2TestBase {
   var tempScratchDir: File = _
 
   override protected def beforeAll(): Unit = {
-    tempScratchDir = Utils.createTempDir()
+    tempScratchDir = JavaUtils.createTempDir()
     tempScratchDir.setWritable(true, false)
     assert(tempScratchDir.list().isEmpty)
     new File(tempScratchDir.getAbsolutePath + File.separator + "SPARK-31626").createNewFile()
@@ -1200,7 +1201,7 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
   protected var metastorePath: File = _
   protected def metastoreJdbcUri = s"jdbc:derby:;databaseName=$metastorePath;create=true"
 
-  private val pidDir: File = Utils.createTempDir(namePrefix = "thriftserver-pid")
+  private val pidDir: File = JavaUtils.createTempDirWithPrefix("thriftserver-pid")
   protected var logPath: File = _
   protected var operationLogPath: File = _
   protected var lScratchDir: File = _
@@ -1219,7 +1220,7 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
     val driverClassPath = {
       // Writes a temporary log4j2.properties and prepend it to driver classpath, so that it
       // overrides all other potential log4j configurations contained in other dependency jar files.
-      val tempLog4jConf = Utils.createTempDir().getCanonicalPath
+      val tempLog4jConf = JavaUtils.createTempDir().getCanonicalPath
 
       Files.write(
         """rootLogger.level = info
@@ -1267,13 +1268,13 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
   val SERVER_STARTUP_TIMEOUT = 3.minutes
 
   private def startThriftServer(attempt: Int) = {
-    warehousePath = Utils.createTempDir()
+    warehousePath = JavaUtils.createTempDir()
     warehousePath.delete()
-    metastorePath = Utils.createTempDir()
+    metastorePath = JavaUtils.createTempDir()
     metastorePath.delete()
-    operationLogPath = Utils.createTempDir()
+    operationLogPath = JavaUtils.createTempDir()
     operationLogPath.delete()
-    lScratchDir = Utils.createTempDir()
+    lScratchDir = JavaUtils.createTempDir()
     lScratchDir.delete()
     logPath = null
     logTailingProcess = null

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SharedThriftServer.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SharedThriftServer.scala
@@ -36,8 +36,8 @@ import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.thrift.protocol.TBinaryProtocol
 import org.apache.thrift.transport.{THttpClient, TSocket}
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.util.Utils
 
 trait SharedThriftServer extends SharedSparkSession {
 
@@ -45,9 +45,9 @@ trait SharedThriftServer extends SharedSparkSession {
   private var serverPort: Int = 0
 
   protected val tempScratchDir: File = {
-    val dir = Utils.createTempDir()
+    val dir = JavaUtils.createTempDir()
     dir.setWritable(true, false)
-    Utils.createTempDir(dir.getAbsolutePath)
+    JavaUtils.createTempDirWithRoot(dir.getAbsolutePath)
     dir
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
@@ -22,15 +22,15 @@ import test.custom.listener.{DummyQueryExecutionListener, DummyStreamingQueryLis
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.HiveUtils.{HIVE_METASTORE_JARS, HIVE_METASTORE_VERSION}
 import org.apache.spark.sql.hive.test.TestHiveContext
 import org.apache.spark.sql.internal.StaticSQLConf.{QUERY_EXECUTION_LISTENERS, STREAMING_QUERY_LISTENERS, WAREHOUSE_PATH}
-import org.apache.spark.util.Utils
 
 class SparkSQLEnvSuite extends SparkFunSuite {
   test("SPARK-29604 external listeners should be initialized with Spark classloader") {
-    val metastorePath = Utils.createTempDir("spark_derby")
+    val metastorePath = JavaUtils.createTempDirWithRoot("spark_derby")
     FileUtils.forceDelete(metastorePath)
 
     val jdbcUrl = s"jdbc:derby:;databaseName=$metastorePath;create=true"

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/UISeleniumSuite.scala
@@ -71,7 +71,7 @@ class UISeleniumSuite
     val driverClassPath = {
       // Writes a temporary log4j2.properties and prepend it to driver classpath, so that it
       // overrides all other potential log4j configurations contained in other dependency jar files.
-      val tempLog4jConf = org.apache.spark.util.Utils.createTempDir().getCanonicalPath
+      val tempLog4jConf = org.apache.spark.network.util.JavaUtils.createTempDir().getCanonicalPath
 
       Files.write(
         """rootLogger.level = info

--- a/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveWindowFunctionQuerySuite.scala
+++ b/sql/hive/compatibility/src/test/scala/org/apache/spark/sql/hive/execution/HiveWindowFunctionQuerySuite.scala
@@ -21,9 +21,9 @@ import java.io.File
 
 import org.scalatest.BeforeAndAfter
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.hive.test.TestHive
 import org.apache.spark.sql.hive.test.TestHive._
-import org.apache.spark.util.Utils
 
 /**
  * The test suite for window functions. To actually compare results with Hive,
@@ -32,7 +32,7 @@ import org.apache.spark.util.Utils
  * files, every `createQueryTest` calls should explicitly set `reset` to `false`.
  */
 class HiveWindowFunctionQuerySuite extends HiveComparisonTest with BeforeAndAfter {
-  private val testTempDir = Utils.createTempDir()
+  private val testTempDir = JavaUtils.createTempDir()
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -738,7 +738,7 @@ class HiveWindowFunctionQuerySuite extends HiveComparisonTest with BeforeAndAfte
 
 class HiveWindowFunctionQueryFileSuite
   extends HiveCompatibilitySuite with BeforeAndAfter {
-  private val testTempDir = Utils.createTempDir()
+  private val testTempDir = JavaUtils.createTempDir()
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -37,6 +37,7 @@ import org.apache.hive.common.util.HiveVersionInfo
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.execution.command.DDLUtils
@@ -509,7 +510,7 @@ private[spark] object HiveUtils extends Logging {
   def newTemporaryConfiguration(useInMemoryDerby: Boolean): Map[String, String] = {
     val withInMemoryMode = if (useInMemoryDerby) "memory:" else ""
 
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     val localMetastore = new File(tempDir, "metastore")
     val propMap: HashMap[String, String] = HashMap()
     // We have to mask all properties in hive-site.xml that relates to metastore data source

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -33,12 +33,13 @@ import org.apache.hadoop.hive.shims.ShimLoader
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkSubmitUtils
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.hive.HiveUtils
 import org.apache.spark.sql.internal.NonClosableMutableURLClassLoader
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.util.{MutableURLClassLoader, Utils, VersionUtils}
+import org.apache.spark.util.{MutableURLClassLoader, VersionUtils}
 
 /** Factory for `IsolatedClientLoader` with specific versions of hive. */
 private[hive] object IsolatedClientLoader extends Logging {
@@ -151,7 +152,7 @@ private[hive] object IsolatedClientLoader extends Logging {
     val allFiles = classpaths.map(new File(_)).toSet
 
     // TODO: Remove copy logic.
-    val tempDir = Utils.createTempDir(namePrefix = s"hive-${version}")
+    val tempDir = JavaUtils.createTempDirWithPrefix(s"hive-${version}")
     allFiles.foreach(f => FileUtils.copyFileToDirectory(f, tempDir))
     logInfo(s"Downloaded metastore jars to ${tempDir.getCanonicalPath}")
     tempDir.listFiles().map(_.toURI.toURL)

--- a/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
+++ b/sql/hive/src/test/java/org/apache/spark/sql/hive/JavaMetastoreDataSourcesSuite.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.QueryTest$;
@@ -39,7 +40,6 @@ import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.hive.test.TestHive$;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.TableIdentifier;
-import org.apache.spark.util.Utils;
 
 public class JavaMetastoreDataSourcesSuite {
   private transient JavaSparkContext sc;
@@ -55,8 +55,8 @@ public class JavaMetastoreDataSourcesSuite {
     sqlContext = TestHive$.MODULE$;
     sc = new JavaSparkContext(sqlContext.sparkContext());
 
-    path =
-      Utils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource").getCanonicalFile();
+    path = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "datasource")
+      .getCanonicalFile();
     if (path.exists()) {
       path.delete();
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/CachedTableSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive
 
 import java.io.File
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, Dataset, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
@@ -195,7 +196,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
   }
 
   test("REFRESH TABLE also needs to recache the data (data source tables)") {
-    val tempPath: File = Utils.createTempDir()
+    val tempPath: File = JavaUtils.createTempDir()
     tempPath.delete()
     table("src").write.mode(SaveMode.Overwrite).parquet(tempPath.toString)
     sql("DROP TABLE IF EXISTS refreshTable")
@@ -233,7 +234,7 @@ class CachedTableSuite extends QueryTest with SQLTestUtils with TestHiveSingleto
   }
 
   test("SPARK-15678: REFRESH PATH") {
-    val tempPath: File = Utils.createTempDir()
+    val tempPath: File = JavaUtils.createTempDir()
     tempPath.delete()
     table("src").write.mode(SaveMode.Overwrite).parquet(tempPath.toString)
     sql("DROP TABLE IF EXISTS refreshTable")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark.deploy.SparkSubmitTestUtils
 import org.apache.spark.internal.config.MASTER_REST_SERVER_ENABLED
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.launcher.JavaModuleOptions
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
@@ -57,12 +58,12 @@ import org.apache.spark.util.{Utils, VersionUtils}
 class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
   import HiveExternalCatalogVersionsSuite._
   override protected val defaultSparkSubmitTimeout: Span = 5.minutes
-  private val wareHousePath = Utils.createTempDir(namePrefix = "warehouse")
-  private val tmpDataDir = Utils.createTempDir(namePrefix = "test-data")
+  private val wareHousePath = JavaUtils.createTempDirWithPrefix("warehouse")
+  private val tmpDataDir = JavaUtils.createTempDirWithPrefix("test-data")
   // For local test, you can set `spark.test.cache-dir` to a static value like `/tmp/test-spark`, to
   // avoid downloading Spark of different versions in each run.
   private val sparkTestingDir = Option(System.getProperty(SPARK_TEST_CACHE_DIR_SYSTEM_PROPERTY))
-      .map(new File(_)).getOrElse(Utils.createTempDir(namePrefix = "test-spark"))
+      .map(new File(_)).getOrElse(JavaUtils.createTempDirWithPrefix("test-spark"))
   private val unusedJar = TestUtils.createJarWithClasses(Seq.empty)
   val hiveVersion = if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
     HiveUtils.builtinHiveVersion

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSharedStateSuite.scala
@@ -23,10 +23,10 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.internal.config.UI
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.internal.StaticSQLConf._
-import org.apache.spark.util.Utils
 
 class HiveSharedStateSuite extends SparkFunSuite {
 
@@ -39,9 +39,9 @@ class HiveSharedStateSuite extends SparkFunSuite {
   test("initial configs should be passed to SharedState but not SparkContext") {
     val conf = new SparkConf().setMaster("local").setAppName("SharedState Test")
     val sc = SparkContext.getOrCreate(conf)
-    val warehousePath = Utils.createTempDir().toString
+    val warehousePath = JavaUtils.createTempDir().toString
     val invalidPath = "invalid/path"
-    val metastorePath = Utils.createTempDir()
+    val metastorePath = JavaUtils.createTempDir()
     val tmpDb = "tmp_db"
 
     // The initial configs used to generate SharedState, none of these should affect the global

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveSparkSubmitSuite.scala
@@ -34,6 +34,7 @@ import org.apache.spark._
 import org.apache.spark.deploy.SparkSubmitTestUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.UI.UI_ENABLED
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog._
@@ -232,7 +233,7 @@ class HiveSparkSubmitSuite
     // the value of hive.metastore.warehouse.dir. Also, the value of
     // spark.sql.warehouse.dir should be set to the value of hive.metastore.warehouse.dir.
 
-    val hiveWarehouseLocation = Utils.createTempDir()
+    val hiveWarehouseLocation = JavaUtils.createTempDir()
     hiveWarehouseLocation.delete()
     val hiveSiteXmlContent =
       s"""
@@ -245,7 +246,7 @@ class HiveSparkSubmitSuite
      """.stripMargin
 
     // Write a hive-site.xml containing a setting of hive.metastore.warehouse.dir.
-    val hiveSiteDir = Utils.createTempDir()
+    val hiveSiteDir = JavaUtils.createTempDir()
     val file = new File(hiveSiteDir.getCanonicalPath, "hive-site.xml")
     val bw = new BufferedWriter(new FileWriter(file))
     bw.write(hiveSiteXmlContent)
@@ -272,7 +273,7 @@ class HiveSparkSubmitSuite
     // overridden by hive's default settings when we create a HiveConf object inside
     // HiveClientImpl. Please see SPARK-16901 for more details.
 
-    val metastoreLocation = Utils.createTempDir()
+    val metastoreLocation = JavaUtils.createTempDir()
     metastoreLocation.delete()
     val metastoreURL =
       s"jdbc:derby:memory:;databaseName=${metastoreLocation.getAbsolutePath};create=true"
@@ -287,7 +288,7 @@ class HiveSparkSubmitSuite
      """.stripMargin
 
     // Write a hive-site.xml containing a setting of hive.metastore.warehouse.dir.
-    val hiveSiteDir = Utils.createTempDir()
+    val hiveSiteDir = JavaUtils.createTempDir()
     val file = new File(hiveSiteDir.getCanonicalPath, "hive-site.xml")
     val bw = new BufferedWriter(new FileWriter(file))
     bw.write(hiveSiteXmlContent)
@@ -422,9 +423,9 @@ object SetWarehouseLocationTest extends Logging {
         // hive.metastore.warehouse.dir is set at here.
         (new TestHiveContext(new SparkContext(sparkConf)).sparkSession, warehouseDir)
       case None =>
-        val warehouseLocation = Utils.createTempDir()
+        val warehouseLocation = JavaUtils.createTempDir()
         warehouseLocation.delete()
-        val hiveWarehouseLocation = Utils.createTempDir()
+        val hiveWarehouseLocation = JavaUtils.createTempDir()
         hiveWarehouseLocation.delete()
         // If spark.sql.test.expectedWarehouseDir is not set, we will set
         // spark.sql.warehouse.dir and hive.metastore.warehouse.dir.
@@ -602,7 +603,7 @@ object SparkSubmitClassLoaderTest extends Logging {
   def main(args: Array[String]): Unit = {
     TestUtils.configTestLog4j2("INFO")
     val conf = new SparkConf()
-    val hiveWarehouseLocation = Utils.createTempDir()
+    val hiveWarehouseLocation = JavaUtils.createTempDir()
     conf.set(UI_ENABLED, false)
     conf.set(WAREHOUSE_PATH.key, hiveWarehouseLocation.toString)
     val sc = new SparkContext(conf)
@@ -713,7 +714,7 @@ object SPARK_9757 extends QueryTest {
   def main(args: Array[String]): Unit = {
     TestUtils.configTestLog4j2("INFO")
 
-    val hiveWarehouseLocation = Utils.createTempDir()
+    val hiveWarehouseLocation = JavaUtils.createTempDir()
     val sparkContext = new SparkContext(
       new SparkConf()
         .set(HiveUtils.HIVE_METASTORE_VERSION.key, "0.13.1")
@@ -725,7 +726,7 @@ object SPARK_9757 extends QueryTest {
     spark = hiveContext.sparkSession
     import hiveContext.implicits._
 
-    val dir = Utils.createTempDir()
+    val dir = JavaUtils.createTempDir()
     dir.delete()
 
     try {
@@ -831,7 +832,7 @@ object SPARK_18360 {
         schema = new StructType().add("i", "int"),
         provider = Some(DDLUtils.HIVE_PROVIDER))
 
-      val newWarehousePath = Utils.createTempDir().getAbsolutePath
+      val newWarehousePath = JavaUtils.createTempDir().getAbsolutePath
       hiveClient.runSqlHive(s"SET hive.metastore.warehouse.dir=$newWarehousePath")
       hiveClient.createTable(tableMeta, ignoreIfExists = false)
       val rawTable = hiveClient.getTable("default", "test_tbl")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/InsertSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
 
 import org.apache.spark.SparkException
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{QueryTest, _}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
@@ -32,7 +33,6 @@ import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 case class TestData(key: Int, value: String)
 
@@ -122,7 +122,7 @@ class InsertSuite extends QueryTest with TestHiveSingleton with BeforeAndAfter
 
   test("SPARK-4203:random partition directory order") {
     sql("CREATE TABLE tmp_table (key int, value string)")
-    val tmpDir = Utils.createTempDir()
+    val tmpDir = JavaUtils.createTempDir()
     // The default value of hive.exec.stagingdir.
     val stagingDir = ".hive-staging"
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetPartitioningTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/ParquetPartitioningTest.scala
@@ -19,10 +19,10 @@ package org.apache.spark.sql.hive
 
 import java.io.File
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.test.SQLTestUtils
-import org.apache.spark.util.Utils
 
 // The data where the partitioning key exists only in the directory structure.
 case class ParquetData(intField: Int, stringField: String)
@@ -58,8 +58,8 @@ abstract class ParquetPartitioningTest extends QueryTest with SQLTestUtils with 
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    partitionedTableDir = Utils.createTempDir()
-    normalTableDir = Utils.createTempDir()
+    partitionedTableDir = JavaUtils.createTempDir()
+    normalTableDir = JavaUtils.createTempDir()
 
     (1 to 10).foreach { p =>
       val partDir = new File(partitionedTableDir, s"p=$p")
@@ -75,7 +75,7 @@ abstract class ParquetPartitioningTest extends QueryTest with SQLTestUtils with 
       .toDF()
       .write.parquet(new File(normalTableDir, "normal").getCanonicalPath)
 
-    partitionedTableDirWithKey = Utils.createTempDir()
+    partitionedTableDirWithKey = JavaUtils.createTempDir()
 
     (1 to 10).foreach { p =>
       val partDir = new File(partitionedTableDirWithKey, s"p=$p")
@@ -85,7 +85,7 @@ abstract class ParquetPartitioningTest extends QueryTest with SQLTestUtils with 
         .write.parquet(partDir.getCanonicalPath)
     }
 
-    partitionedTableDirWithKeyAndComplexTypes = Utils.createTempDir()
+    partitionedTableDirWithKeyAndComplexTypes = JavaUtils.createTempDir()
 
     (1 to 10).foreach { p =>
       val partDir = new File(partitionedTableDirWithKeyAndComplexTypes, s"p=$p")
@@ -95,7 +95,7 @@ abstract class ParquetPartitioningTest extends QueryTest with SQLTestUtils with 
       }.toDF().write.parquet(partDir.getCanonicalPath)
     }
 
-    partitionedTableDirWithComplexTypes = Utils.createTempDir()
+    partitionedTableDirWithComplexTypes = JavaUtils.createTempDir()
 
     (1 to 10).foreach { p =>
       val partDir = new File(partitionedTableDirWithComplexTypes, s"p=$p")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/PartitionProviderCompatibilitySuite.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.metrics.source.HiveCatalogMetrics
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.hive.test.TestHiveSingleton
@@ -357,10 +358,10 @@ class PartitionProviderCompatibilitySuite
    *   /P1=1/P2=1  -- default location
    */
   private def testCustomLocations(testFn: => Unit): Unit = {
-    val base = Utils.createTempDir(namePrefix = "base")
-    val a = Utils.createTempDir(namePrefix = "a")
-    val b = Utils.createTempDir(namePrefix = "b")
-    val c = Utils.createTempDir(namePrefix = "c")
+    val base = JavaUtils.createTempDirWithPrefix("base")
+    val a = JavaUtils.createTempDirWithPrefix("a")
+    val b = JavaUtils.createTempDirWithPrefix("b")
+    val c = JavaUtils.createTempDirWithPrefix("c")
     try {
       spark.sql(s"""
         |create table test (id long, P1 int, P2 int)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.util.VersionInfo
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
 import org.apache.spark.util.Utils
 
@@ -36,7 +37,7 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
 
   test("SPARK-32256: Hadoop VersionInfo should be preloaded") {
     val ivyPath =
-      Utils.createTempDir(namePrefix = s"${classOf[HadoopVersionInfoSuite].getSimpleName}-ivy")
+      JavaUtils.createTempDirWithPrefix(s"${classOf[HadoopVersionInfoSuite].getSimpleName}-ivy")
     try {
       val hadoopConf = new Configuration()
       hadoopConf.set("test", "success")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientBuilder.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.util.VersionInfo
 
 import org.apache.spark.SparkConf
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 private[client] object HiveClientBuilder {
   // In order to speed up test execution during development or in Jenkins, you can specify the path
@@ -34,8 +34,8 @@ private[client] object HiveClientBuilder {
   }
 
   private[client] def buildConf(extraConf: Map[String, String]): Map[String, String] = {
-    lazy val warehousePath = Utils.createTempDir()
-    lazy val metastorePath = Utils.createTempDir()
+    lazy val warehousePath = JavaUtils.createTempDir()
+    lazy val metastorePath = JavaUtils.createTempDir()
     metastorePath.delete()
     extraConf ++ Map(
       "javax.jdo.option.ConnectionURL" -> s"jdbc:derby:;databaseName=$metastorePath;create=true",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuite.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.apache.hadoop.mapred.TextInputFormat
 import org.apache.hadoop.security.UserGroupInformation
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{DatabaseAlreadyExistsException, NoSuchDatabaseException, NoSuchPermanentFunctionException, PartitionsAlreadyExistException}
@@ -44,7 +45,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
 
   private var versionSpark: TestHiveVersion = null
 
-  private val emptyDir = Utils.createTempDir().getCanonicalPath
+  private val emptyDir = JavaUtils.createTempDir().getCanonicalPath
 
   /**
    * Drops table `tableName` after calling `f`.
@@ -90,7 +91,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
   // Database related API
   ///////////////////////////////////////////////////////////////////////////
 
-  private val tempDatabasePath = Utils.createTempDir().toURI
+  private val tempDatabasePath = JavaUtils.createTempDir().toURI
 
   test("createDatabase") {
     val defaultDB = CatalogDatabase("default", "desc", new URI("loc"), Map())
@@ -113,7 +114,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
       val ownerProps = Map("owner" -> ownerName)
 
       // create database with owner
-      val dbWithOwner = CatalogDatabase(db1, "desc", Utils.createTempDir().toURI, ownerProps)
+      val dbWithOwner = CatalogDatabase(db1, "desc", JavaUtils.createTempDir().toURI, ownerProps)
       client.createDatabase(dbWithOwner, ignoreIfExists = true)
       val getDbWithOwner = client.getDatabase(db1)
       assert(getDbWithOwner.properties("owner") === ownerName)
@@ -122,7 +123,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
       assert(client.getDatabase(db1).properties("owner") === "")
 
       // create database without owner
-      val dbWithoutOwner = CatalogDatabase(db2, "desc", Utils.createTempDir().toURI, Map())
+      val dbWithoutOwner = CatalogDatabase(db2, "desc", JavaUtils.createTempDir().toURI, Map())
       client.createDatabase(dbWithoutOwner, ignoreIfExists = true)
       val getDbWithoutOwner = client.getDatabase(db2)
       assert(getDbWithoutOwner.properties("owner") === currentUser)
@@ -166,7 +167,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
     assert(client.getDatabase("temporary").properties.contains("flag"))
 
     // test alter database location
-    val tempDatabasePath2 = Utils.createTempDir().toURI
+    val tempDatabasePath2 = JavaUtils.createTempDir().toURI
     // Hive support altering database location since HIVE-8472.
     if (version == "3.0" || version == "3.1") {
       client.alterDatabase(database.copy(locationUri = tempDatabasePath2))
@@ -487,7 +488,7 @@ class HiveClientSuite(version: String, allVersions: Seq[String])
   test("alterPartitions") {
     val spec = Map("key1" -> "1", "key2" -> "2")
     val parameters = Map(StatsSetupConst.TOTAL_SIZE -> "0", StatsSetupConst.NUM_FILES -> "1")
-    val newLocation = new URI(Utils.createTempDir().toURI.toString.stripSuffix("/"))
+    val newLocation = new URI(JavaUtils.createTempDir().toURI.toString.stripSuffix("/"))
     val storage = storageFormat.copy(
       locationUri = Some(newLocation),
       // needed for 0.12 alter partitions

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuite.scala
@@ -22,7 +22,7 @@ import java.security.PrivilegedExceptionAction
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.security.UserGroupInformation
 
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class HiveClientUserNameSuite(version: String) extends HiveVersionSuite(version) {
 
@@ -55,7 +55,7 @@ class HiveClientUserNameSuite(version: String) extends HiveVersionSuite(version)
 
   private def getUserNameFromHiveClient: String = {
     val hadoopConf = new Configuration()
-    hadoopConf.set("hive.metastore.warehouse.dir", Utils.createTempDir().toURI().toString())
+    hadoopConf.set("hive.metastore.warehouse.dir", JavaUtils.createTempDir().toURI().toString())
     val client = buildClient(hadoopConf)
     client.userName
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.serde2.`lazy`.LazySimpleSerDe
 import org.apache.hadoop.mapred.TextInputFormat
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.DEFAULT_PARTITION_NAME
@@ -34,7 +35,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DateType, IntegerType, LongType, StringType, StructType}
-import org.apache.spark.util.Utils
 
 class HivePartitionFilteringSuite(version: String)
     extends HiveVersionSuite(version) with BeforeAndAfterAll with SQLHelper {
@@ -69,7 +69,7 @@ class HivePartitionFilteringSuite(version: String)
   private def init(tryDirectSql: Boolean): HiveClient = {
     val hadoopConf = new Configuration()
     hadoopConf.setBoolean(tryDirectSqlKey, tryDirectSql)
-    hadoopConf.set("hive.metastore.warehouse.dir", Utils.createTempDir().toURI().toString())
+    hadoopConf.set("hive.metastore.warehouse.dir", JavaUtils.createTempDir().toURI().toString())
     val client = buildClient(hadoopConf)
     val tableSchema =
       new StructType().add("value", "int").add("ds", "int").add("h", "int").add("chunk", "string")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/Hive_2_1_DDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/Hive_2_1_DDLSuite.scala
@@ -22,13 +22,13 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.hive.{HiveExternalCatalog, HiveUtils}
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 import org.apache.spark.sql.internal.StaticSQLConf._
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.{ExtendedHiveTest, SlowHiveTest}
-import org.apache.spark.util.Utils
 
 /**
  * A separate set of DDL tests that uses Hive 2.1 libraries, which behave a little differently
@@ -42,8 +42,8 @@ class Hive_2_1_DDLSuite extends SparkFunSuite with TestHiveSingleton with Before
   // Create a custom HiveExternalCatalog instance with the desired configuration. We cannot
   // use SparkSession here since there's already an active on managed by the TestHive object.
   private var catalog = {
-    val warehouse = Utils.createTempDir()
-    val metastore = Utils.createTempDir()
+    val warehouse = JavaUtils.createTempDir()
+    val metastore = JavaUtils.createTempDir()
     metastore.delete()
     val sparkConf = new SparkConf()
       .set(SparkLauncher.SPARK_MASTER, "local")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive.orc
 
 import java.io.File
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.TestingUDT.{IntervalData, IntervalUDT}
 import org.apache.spark.sql.execution.datasources.orc.OrcSuite
@@ -66,7 +67,7 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
   }
 
   test("SPARK-19459/SPARK-18220: read char/varchar column written by Hive") {
-    val location = Utils.createTempDir()
+    val location = JavaUtils.createTempDir()
     val uri = location.toURI
     try {
       hiveClient.runSqlHive("USE default")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -34,6 +34,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener
@@ -267,7 +268,7 @@ private[hive] class TestHiveSparkSession(
   // For some hive test case which contain ${system:test.tmp.dir}
   // Make sure it is not called again when cloning sessions.
   if (parentSessionState.isEmpty) {
-    System.setProperty("test.tmp.dir", Utils.createTempDir().toURI.getPath)
+    System.setProperty("test.tmp.dir", JavaUtils.createTempDir().toURI.getPath)
   }
 
   /** The location of the compiled hive distribution */
@@ -638,13 +639,13 @@ private[hive] object TestHiveContext {
     )
 
   def makeWarehouseDir(): File = {
-    val warehouseDir = Utils.createTempDir(namePrefix = "warehouse")
+    val warehouseDir = JavaUtils.createTempDirWithPrefix("warehouse")
     warehouseDir.delete()
     warehouseDir
   }
 
   def makeScratchDir(): File = {
-    val scratchDir = Utils.createTempDir(namePrefix = "scratch")
+    val scratchDir = JavaUtils.createTempDirWithPrefix("scratch")
     scratchDir.delete()
     scratchDir
   }
@@ -673,7 +674,7 @@ private[sql] class TestHiveSessionStateBuilder(
 
 private[hive] object HiveTestJars {
   private val repository = SQLConf.ADDITIONAL_REMOTE_REPOSITORIES.defaultValueString.split(",")(0)
-  private val hiveTestJarsDir = Utils.createTempDir()
+  private val hiveTestJarsDir = JavaUtils.createTempDir()
 
   def getHiveContribJar(version: String = HiveUtils.builtinHiveVersion): File =
     getJarFromUrl(s"${repository}org/apache/hive/hive-contrib/" +

--- a/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
+++ b/streaming/src/test/java/test/org/apache/spark/streaming/JavaAPISuite.java
@@ -1604,7 +1604,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
   @Test
   public void testTextFileStream() throws IOException {
-    File testDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
+    File testDir = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     List<List<String>> expected = fileTestPrepare(testDir);
 
     JavaDStream<String> input = ssc.textFileStream(testDir.toString());
@@ -1616,7 +1616,7 @@ public class JavaAPISuite extends LocalJavaStreamingContext implements Serializa
 
   @Test
   public void testFileStream() throws IOException {
-    File testDir = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
+    File testDir = JavaUtils.createTempDir(System.getProperty("java.io.tmpdir"), "spark");
     List<List<String>> expected = fileTestPrepare(testDir);
 
     JavaPairInputDStream<LongWritable, Text> inputStream = ssc.fileStream(

--- a/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/CheckpointSuite.scala
@@ -36,6 +36,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite, TestUtils}
 import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.dstream._
 import org.apache.spark.streaming.scheduler._
@@ -96,7 +97,7 @@ trait DStreamCheckpointTester { self: SparkFunSuite =>
     val batchDurationMillis = batchDuration.milliseconds
 
     // Setup the stream computation
-    val checkpointDir = Utils.createTempDir(namePrefix = this.getClass.getSimpleName()).toString
+    val checkpointDir = JavaUtils.createTempDirWithPrefix(this.getClass.getSimpleName()).toString
     logDebug(s"Using checkpoint directory $checkpointDir")
     val ssc = createContextForCheckpointOperation(batchDuration)
     require(ssc.conf.get("spark.streaming.clock") === classOf[ManualClock].getName,
@@ -485,7 +486,7 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
   }
 
   test("recovery with saveAsHadoopFiles operation") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     try {
       testCheckpointedOperation(
         Seq(Seq("a", "a", "b"), Seq("", ""), Seq(), Seq("a", "a", "b"), Seq("", ""), Seq()),
@@ -514,7 +515,7 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
   }
 
   test("recovery with saveAsNewAPIHadoopFiles operation") {
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     try {
       testCheckpointedOperation(
         Seq(Seq("a", "a", "b"), Seq("", ""), Seq(), Seq("a", "a", "b"), Seq("", ""), Seq()),
@@ -558,7 +559,7 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
     //
     // After SPARK-5079 is addressed, should be able to remove this test since a strengthened
     // version of the other saveAsHadoopFile* tests would prevent regressions for this issue.
-    val tempDir = Utils.createTempDir()
+    val tempDir = JavaUtils.createTempDir()
     try {
       testCheckpointedOperation(
         Seq(Seq("a", "a", "b"), Seq("", ""), Seq(), Seq("a", "a", "b"), Seq("", ""), Seq()),
@@ -640,7 +641,7 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
   test("recovery with file input stream") {
     // Set up the streaming context and input streams
     val batchDuration = Seconds(2)  // Due to 1-second resolution of setLastModified() on some OS's.
-    val testDir = Utils.createTempDir()
+    val testDir = JavaUtils.createTempDir()
     val outputBuffer = new ConcurrentLinkedQueue[Seq[Int]]
 
     /**
@@ -864,7 +865,7 @@ class CheckpointSuite extends TestSuiteBase with LocalStreamingContext with DStr
 
   test("SPARK-11267: the race condition of two checkpoints in a batch") {
     val jobGenerator = mock(classOf[JobGenerator])
-    val checkpointDir = Utils.createTempDir().toString
+    val checkpointDir = JavaUtils.createTempDir().toString
     val checkpointWriter =
       new CheckpointWriter(jobGenerator, conf, checkpointDir, new Configuration())
     val bytes1 = Array.fill[Byte](10)(1)

--- a/streaming/src/test/scala/org/apache/spark/streaming/FailureSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/FailureSuite.scala
@@ -23,6 +23,7 @@ import org.scalatest.BeforeAndAfter
 
 import org.apache.spark._
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
 /**
@@ -36,7 +37,7 @@ class FailureSuite extends SparkFunSuite with BeforeAndAfter with Logging {
   private var directory: File = null
 
   before {
-    directory = Utils.createTempDir()
+    directory = JavaUtils.createTempDir()
   }
 
   after {

--- a/streaming/src/test/scala/org/apache/spark/streaming/MapWithStateSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/MapWithStateSuite.scala
@@ -26,6 +26,7 @@ import scala.reflect.ClassTag
 import org.scalatest.PrivateMethodTester._
 
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.streaming.dstream.{DStream, InternalMapWithStateDStream, MapWithStateDStream, MapWithStateDStreamImpl}
 import org.apache.spark.util.{ManualClock, Utils}
 
@@ -43,7 +44,7 @@ class MapWithStateSuite extends SparkFunSuite with LocalStreamingContext
     conf.set("spark.streaming.clock", classOf[ManualClock].getName())
     sc = new SparkContext(conf)
 
-    checkpointDir = Utils.createTempDir(namePrefix = "checkpoint")
+    checkpointDir = JavaUtils.createTempDirWithPrefix("checkpoint")
   }
 
   override def afterEach(): Unit = {

--- a/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/MasterFailureTest.scala
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.Assertions._
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.util.Utils
 
@@ -364,7 +365,7 @@ class FileGeneratingThread(input: Seq[String], testDir: Path, interval: Long)
   extends Thread with Logging {
 
   override def run(): Unit = {
-    val localTestDir = Utils.createTempDir()
+    val localTestDir = JavaUtils.createTempDir()
     var fs = testDir.getFileSystem(new Configuration())
     val maxTries = 3
     try {

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockHandlerSuite.scala
@@ -37,6 +37,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.memory.UnifiedMemoryManager
 import org.apache.spark.network.netty.NettyBlockTransferService
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.RpcEnv
 import org.apache.spark.scheduler.LiveListenerBus
 import org.apache.spark.security.CryptoStreamUtils
@@ -101,7 +102,7 @@ abstract class BaseReceivedBlockHandlerSuite(enableEncryption: Boolean)
     storageLevel = StorageLevel.MEMORY_ONLY_SER
     blockManager = createBlockManager(blockManagerSize, conf)
 
-    tempDirectory = Utils.createTempDir()
+    tempDirectory = JavaUtils.createTempDir()
     manualClock.setTime(0)
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceivedBlockTrackerSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.storage.StreamBlockId
 import org.apache.spark.streaming.receiver.BlockManagerBasedStoreResult
 import org.apache.spark.streaming.scheduler.{AllocatedBlocks, _}
@@ -54,7 +55,7 @@ class ReceivedBlockTrackerSuite
 
   before {
     conf = new SparkConf().setMaster("local[2]").setAppName("ReceivedBlockTrackerSuite")
-    checkpointDirectory = Utils.createTempDir()
+    checkpointDirectory = JavaUtils.createTempDir()
   }
 
   after {

--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
@@ -30,11 +30,11 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StreamBlockId
 import org.apache.spark.streaming.receiver._
 import org.apache.spark.streaming.receiver.WriteAheadLogBasedBlockHandler._
-import org.apache.spark.util.Utils
 
 /** Testsuite for testing the network receiver behavior */
 class ReceiverSuite extends TestSuiteBase with TimeLimits with Serializable {
@@ -208,7 +208,7 @@ class ReceiverSuite extends TestSuiteBase with TimeLimits with Serializable {
       .set("spark.streaming.receiver.writeAheadLog.enable", "true")
       .set("spark.streaming.receiver.writeAheadLog.rollingIntervalSecs", "1")
     val batchDuration = Milliseconds(500)
-    val tempDirectory = Utils.createTempDir()
+    val tempDirectory = JavaUtils.createTempDir()
     val logDirectory1 = new File(checkpointDirToLogDir(tempDirectory.getAbsolutePath, 0))
     val logDirectory2 = new File(checkpointDirToLogDir(tempDirectory.getAbsolutePath, 1))
     val allLogFiles1 = new mutable.HashSet[String]()

--- a/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/StreamingContextSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.metrics.MetricsSystem
 import org.apache.spark.metrics.source.Source
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.dstream.{DStream, InputDStream}
@@ -116,7 +117,7 @@ class StreamingContextSuite
   }
 
   test("checkPoint from conf") {
-    val checkpointDirectory = Utils.createTempDir().getAbsolutePath()
+    val checkpointDirectory = JavaUtils.createTempDir().getAbsolutePath()
 
     val myConf = SparkContext.updatedConf(new SparkConf(false), master, appName)
     myConf.set("spark.streaming.checkpoint.directory", checkpointDirectory)
@@ -147,7 +148,7 @@ class StreamingContextSuite
   }
 
   test("start with non-serializable DStream checkpoints") {
-    val checkpointDir = Utils.createTempDir()
+    val checkpointDir = JavaUtils.createTempDir()
     ssc = new StreamingContext(conf, batchDuration)
     ssc.checkpoint(checkpointDir.getAbsolutePath)
     addInputStream(ssc).foreachRDD { rdd =>
@@ -542,7 +543,7 @@ class StreamingContextSuite
       }
     }
 
-    val emptyPath = Utils.createTempDir().getAbsolutePath()
+    val emptyPath = JavaUtils.createTempDir().getAbsolutePath()
 
     // getOrCreate should create new context with empty path
     testGetOrCreate {
@@ -677,7 +678,7 @@ class StreamingContextSuite
       }
     }
 
-    val emptyPath = Utils.createTempDir().getAbsolutePath()
+    val emptyPath = JavaUtils.createTempDir().getAbsolutePath()
     val corruptedCheckpointPath = createCorruptedCheckpoint()
     val checkpointPath = createValidCheckpoint()
 
@@ -791,7 +792,7 @@ class StreamingContextSuite
   }
 
   test("queueStream doesn't support checkpointing") {
-    val checkpointDirectory = Utils.createTempDir().getAbsolutePath()
+    val checkpointDirectory = JavaUtils.createTempDir().getAbsolutePath()
     def creatingFunction(): StreamingContext = {
       val _ssc = new StreamingContext(conf, batchDuration)
       val rdd = _ssc.sparkContext.parallelize(1 to 10)
@@ -891,8 +892,8 @@ class StreamingContextSuite
   }
 
   def createValidCheckpoint(): String = {
-    val testDirectory = Utils.createTempDir().getAbsolutePath()
-    val checkpointDirectory = Utils.createTempDir().getAbsolutePath()
+    val testDirectory = JavaUtils.createTempDir().getAbsolutePath()
+    val checkpointDirectory = JavaUtils.createTempDir().getAbsolutePath()
     ssc = new StreamingContext(conf.clone.set("someKey", "someValue"), batchDuration)
     ssc.checkpoint(checkpointDirectory)
     ssc.textFileStream(testDirectory).foreachRDD { rdd => rdd.count() }
@@ -908,7 +909,7 @@ class StreamingContextSuite
   }
 
   def createCorruptedCheckpoint(): String = {
-    val checkpointDirectory = Utils.createTempDir().getAbsolutePath()
+    val checkpointDirectory = JavaUtils.createTempDir().getAbsolutePath()
     val fakeCheckpointFile = Checkpoint.checkpointFile(checkpointDirectory, Time(1000))
     FileUtils.write(new File(fakeCheckpointFile.toString()), "blablabla", StandardCharsets.UTF_8)
     assert(Checkpoint.getCheckpointFiles(checkpointDirectory).nonEmpty)

--- a/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/TestSuiteBase.scala
@@ -30,6 +30,7 @@ import org.scalatest.time.{Seconds => ScalaTestSeconds, Span}
 
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.internal.Logging
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.dstream.{DStream, ForEachDStream, InputDStream}
 import org.apache.spark.streaming.scheduler._
@@ -223,7 +224,7 @@ trait TestSuiteBase extends SparkFunSuite with BeforeAndAfterEach with Logging {
 
   // Directory where the checkpoint data will be saved
   lazy val checkpointDir: String = {
-    val dir = Utils.createTempDir()
+    val dir = JavaUtils.createTempDir()
     logDebug(s"checkpointDir: $dir")
     dir.toString
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/MapWithStateRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/MapWithStateRDDSuite.scala
@@ -25,6 +25,7 @@ import scala.reflect.ClassTag
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.spark._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{State, Time}
 import org.apache.spark.streaming.util.OpenHashMapBasedStateMap
@@ -39,7 +40,7 @@ class MapWithStateRDDSuite extends SparkFunSuite with RDDCheckpointTester with B
     super.beforeAll()
     sc = new SparkContext(
       new SparkConf().setMaster("local").setAppName("MapWithStateRDDSuite"))
-    checkpointDir = Utils.createTempDir()
+    checkpointDir = JavaUtils.createTempDir()
     sc.setCheckpointDir(checkpointDir.toString)
   }
 

--- a/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/rdd/WriteAheadLogBackedBlockRDDSuite.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import org.apache.spark.{SparkConf, SparkContext, SparkException, SparkFunSuite}
 import org.apache.spark.internal.config._
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.serializer.SerializerManager
 import org.apache.spark.storage.{BlockId, BlockManager, StorageLevel, StreamBlockId}
 import org.apache.spark.streaming.util.{FileBasedWriteAheadLogSegment, FileBasedWriteAheadLogWriter}
@@ -47,7 +48,7 @@ class WriteAheadLogBackedBlockRDDSuite
   override def beforeEach(): Unit = {
     super.beforeEach()
     initSparkContext()
-    dir = Utils.createTempDir()
+    dir = JavaUtils.createTempDir()
   }
 
   override def afterEach(): Unit = {

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/JobGeneratorSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/JobGeneratorSuite.scala
@@ -23,9 +23,10 @@ import scala.concurrent.duration._
 
 import org.scalatest.concurrent.Eventually._
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming._
-import org.apache.spark.util.{ManualClock, Utils}
+import org.apache.spark.util.ManualClock
 
 class JobGeneratorSuite extends TestSuiteBase {
 
@@ -57,7 +58,7 @@ class JobGeneratorSuite extends TestSuiteBase {
   //
   test("SPARK-6222: Do not clear received block data too soon") {
     import JobGeneratorSuite._
-    val checkpointDir = Utils.createTempDir()
+    val checkpointDir = JavaUtils.createTempDir()
     val testConf = conf
     testConf.set("spark.streaming.clock", "org.apache.spark.streaming.util.ManualClock")
     testConf.set("spark.streaming.receiver.writeAheadLog.rollingInterval", "1")

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogSuite.scala
@@ -40,6 +40,7 @@ import org.scalatest.concurrent.Eventually._
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.streaming.scheduler._
 import org.apache.spark.util.{CompletionIterator, ManualClock, ThreadUtils, Utils}
 
@@ -59,8 +60,8 @@ abstract class CommonWriteAheadLogTests(
   protected var writeAheadLog: WriteAheadLog = null
   protected def testPrefix = if (testTag != "") testTag + " - " else testTag
 
+  tempDir = JavaUtils.createTempDir()
   before {
-    tempDir = Utils.createTempDir()
     testDir = tempDir.toString
     testFile = new File(tempDir, "testFile").toString
     if (writeAheadLog != null) {

--- a/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogUtilsSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/util/WriteAheadLogUtilsSuite.scala
@@ -25,12 +25,12 @@ import scala.reflect.ClassTag
 import org.apache.hadoop.conf.Configuration
 
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
-import org.apache.spark.util.Utils
+import org.apache.spark.network.util.JavaUtils
 
 class WriteAheadLogUtilsSuite extends SparkFunSuite {
   import WriteAheadLogUtilsSuite._
 
-  private val logDir = Utils.createTempDir().getAbsolutePath()
+  private val logDir = JavaUtils.createTempDir().getAbsolutePath()
   private val hadoopConf = new Configuration()
 
   def assertDriverLogClass[T <: WriteAheadLog: ClassTag](


### PR DESCRIPTION
### What changes were proposed in this pull request?
This main change of this pr is replace all use of `Utils.createTempDir` with `JavaUtils.createTempDir`, the replacement rules are as follows:

- `Utils.createTempDir()` -> `JavaUtils.createTempDir()`
- `Utils.createTempDir(rootDir)` and `Utils.createTempDir(root = rootDir)` -> `JavaUtils.createTempDirWithRoot(rootDir)`
- `Utils.createTempDir(namePrefix = prefix)` -> `JavaUtils.createTempDirWithPrefix(prefix)`
- `Utils.createTempDir(rootDir, prefix)` -> `JavaUtils.createTempDir(rootDir, prefix)`

Another change is to delete `Utils.createTempDir()` method to keep only one `createTempDir()` method.

### Why are the changes needed?
Keep only one `createTempDir()` method in Spark.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Action.