### PR TITLE
[WIP][SPARK-30983] Support typed select in Datasets up to the max tuple size

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1698,6 +1698,448 @@ class Dataset[T] private[sql](
     selectUntyped(c1, c2, c3, c4, c5).asInstanceOf[Dataset[(U1, U2, U3, U4, U5)]]
 
   /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6]): Dataset[(U1, U2, U3, U4, U5, U6)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6).asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7]): Dataset[(U1, U2, U3, U4, U5, U6, U7)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7).asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10)]]
+
+  // scalastyle:off argcount
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15, c16)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15, U16)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16],
+      c17: TypedColumn[T, U17]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16, U17)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15, c16, c17)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15, U16, U17)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16],
+      c17: TypedColumn[T, U17],
+      c18: TypedColumn[T, U18]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16, U17, U18)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
+      c12, c13, c14, c15, c16, c17, c18)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15, U16, U17, U18)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18, U19](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16],
+      c17: TypedColumn[T, U17],
+      c18: TypedColumn[T, U18],
+      c19: TypedColumn[T, U19]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16, U17, U18, U19)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15, c16, c17, c18, c19)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11,
+      U12, U13, U14, U15, U16, U17, U18, U19)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18, U19,
+    U20](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16],
+      c17: TypedColumn[T, U17],
+      c18: TypedColumn[T, U18],
+      c19: TypedColumn[T, U19],
+      c20: TypedColumn[T, U20]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16, U17, U18, U19, U20)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15, c16, c17, c18, c19, c20)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15, U16, U17, U18, U19, U20)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18, U19,
+    U20, U21](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16],
+      c17: TypedColumn[T, U17],
+      c18: TypedColumn[T, U18],
+      c19: TypedColumn[T, U19],
+      c20: TypedColumn[T, U20],
+      c21: TypedColumn[T, U21]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16, U17, U18, U19, U20, U21)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15, c16, c17, c18, c19, c20, c21)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15, U16, U17, U18, U19, U20, U21)]]
+
+  /**
+   * returns a new Dataset by computing the given [[Column]] expressions for each element.
+   *
+   * @group typedrel
+   * @since 3.3
+   */
+  def select[U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12, U13, U14, U15, U16, U17, U18, U19,
+    U20, U21, U22](
+      c1: TypedColumn[T, U1],
+      c2: TypedColumn[T, U2],
+      c3: TypedColumn[T, U3],
+      c4: TypedColumn[T, U4],
+      c5: TypedColumn[T, U5],
+      c6: TypedColumn[T, U6],
+      c7: TypedColumn[T, U7],
+      c8: TypedColumn[T, U8],
+      c9: TypedColumn[T, U9],
+      c10: TypedColumn[T, U10],
+      c11: TypedColumn[T, U11],
+      c12: TypedColumn[T, U12],
+      c13: TypedColumn[T, U13],
+      c14: TypedColumn[T, U14],
+      c15: TypedColumn[T, U15],
+      c16: TypedColumn[T, U16],
+      c17: TypedColumn[T, U17],
+      c18: TypedColumn[T, U18],
+      c19: TypedColumn[T, U19],
+      c20: TypedColumn[T, U20],
+      c21: TypedColumn[T, U21],
+      c22: TypedColumn[T, U22]): Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+    U13, U14, U15, U16, U17, U18, U19, U20, U21, U22)] =
+    selectUntyped(c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12,
+      c13, c14, c15, c16, c17, c18, c19, c20, c21, c22)
+      .asInstanceOf[Dataset[(U1, U2, U3, U4, U5, U6, U7, U8, U9, U10, U11, U12,
+      U13, U14, U15, U16, U17, U18, U19, U20, U21, U22)]]
+
+  // scalastyle:on argcount
+
+  /**
    * Filters rows using the given condition.
    * {{{
    *   // The following are equivalent:

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetAggregatorSuite.scala
@@ -403,19 +403,4 @@ class DatasetAggregatorSuite extends QueryTest with SharedSparkSession {
     checkAnswer(group, Row("bob", Row(true, 3)) :: Nil)
     checkDataset(group.as[OptionBooleanIntData], OptionBooleanIntData("bob", Some((true, 3))))
   }
-
-  test("SPARK-30590: untyped select should not accept typed column that needs input type") {
-    val df = Seq((1, 2, 3, 4, 5, 6)).toDF("a", "b", "c", "d", "e", "f")
-    val fooAgg = (i: Int) => FooAgg(i).toColumn.name(s"foo_agg_$i")
-
-    val agg1 = df.select(fooAgg(1), fooAgg(2), fooAgg(3), fooAgg(4), fooAgg(5))
-    checkDataset(agg1, (3, 5, 7, 9, 11))
-
-    // Passes typed columns to untyped `Dataset.select` API.
-    val err = intercept[AnalysisException] {
-      df.select(fooAgg(1), fooAgg(2), fooAgg(3), fooAgg(4), fooAgg(5), fooAgg(6))
-    }.getMessage
-    assert(err.contains("cannot be passed in untyped `select` API. " +
-      "Use the typed `Dataset.select` API instead."))
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -318,6 +318,134 @@ class DatasetSuite extends QueryTest
       ("a", ClassData("a", 1)), ("b", ClassData("b", 2)), ("c", ClassData("c", 3)))
   }
 
+  test("select typed n") {
+    val df = Seq((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+      12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22)).toDF()
+
+    // First check that all tuples compile
+    val ds2: Dataset[(Int, Int)] = df.select(col("_1").as[Int], col("_2").as[Int])
+    val ds3: Dataset[(Int, Int, Int)] = df.select(col("_1").as[Int], col("_2").as[Int],
+      col("_3").as[Int])
+    val ds4: Dataset[(Int, Int, Int, Int)] = df.select(col("_1").as[Int], col("_2").as[Int],
+      col("_3").as[Int], col("_4").as[Int])
+    val ds5: Dataset[(Int, Int, Int, Int, Int)] = df.select(col("_1").as[Int], col("_2").as[Int],
+      col("_3").as[Int], col("_4").as[Int], col("_5").as[Int])
+    val ds6: Dataset[(Int, Int, Int, Int, Int, Int)] = df.select(col("_1").as[Int],
+      col("_2").as[Int], col("_3").as[Int], col("_4").as[Int], col("_5").as[Int],
+      col("_6").as[Int])
+    val ds7: Dataset[(Int, Int, Int, Int, Int, Int, Int)] = df.select(col("_1").as[Int],
+      col("_2").as[Int], col("_3").as[Int], col("_4").as[Int], col("_5").as[Int],
+      col("_6").as[Int], col("_7").as[Int])
+    val ds8: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int)] = df.select(col("_1").as[Int],
+      col("_2").as[Int], col("_3").as[Int], col("_4").as[Int], col("_5").as[Int],
+      col("_6").as[Int], col("_7").as[Int], col("_8").as[Int])
+    val ds9: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int)] = df.select(col("_1").as[Int],
+      col("_2").as[Int], col("_3").as[Int], col("_4").as[Int], col("_5").as[Int],
+      col("_6").as[Int], col("_7").as[Int], col("_8").as[Int], col("_9").as[Int])
+    val ds10: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)] = df.select(
+      col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+      col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+      col("_9").as[Int], col("_10").as[Int])
+    val ds11: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)] = df.select(
+      col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+      col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+      col("_9").as[Int], col("_10").as[Int], col("_11").as[Int])
+    val ds12: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)] = df.select(
+      col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+      col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+      col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int])
+    val ds13: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int])
+    val ds14: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int])
+    val ds15: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int])
+    val ds16: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int])
+    val ds17: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int],
+        col("_17").as[Int])
+    val ds18: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int],
+        col("_17").as[Int], col("_18").as[Int])
+    val ds19: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int],
+        col("_17").as[Int], col("_18").as[Int], col("_19").as[Int])
+    val ds20: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int],
+        col("_17").as[Int], col("_18").as[Int], col("_19").as[Int], col("_20").as[Int])
+    val ds21: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int],
+        col("_17").as[Int], col("_18").as[Int], col("_19").as[Int], col("_20").as[Int],
+        col("_21").as[Int])
+    val ds22: Dataset[(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int, Int, Int, Int, Int)] =
+      df.select(col("_1").as[Int], col("_2").as[Int], col("_3").as[Int], col("_4").as[Int],
+        col("_5").as[Int], col("_6").as[Int], col("_7").as[Int], col("_8").as[Int],
+        col("_9").as[Int], col("_10").as[Int], col("_11").as[Int], col("_12").as[Int],
+        col("_13").as[Int], col("_14").as[Int], col("_15").as[Int], col("_16").as[Int],
+        col("_17").as[Int], col("_18").as[Int], col("_19").as[Int], col("_20").as[Int],
+        col("_21").as[Int], col("_22").as[Int])
+
+    // Then check that they all give the right results
+    checkDataset(ds2, (1, 2))
+    checkDataset(ds3, (1, 2, 3))
+    checkDataset(ds4, (1, 2, 3, 4))
+    checkDataset(ds5, (1, 2, 3, 4, 5))
+    checkDataset(ds6, (1, 2, 3, 4, 5, 6))
+    checkDataset(ds7, (1, 2, 3, 4, 5, 6, 7))
+    checkDataset(ds8, (1, 2, 3, 4, 5, 6, 7, 8))
+    checkDataset(ds9, (1, 2, 3, 4, 5, 6, 7, 8, 9))
+    checkDataset(ds10, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    checkDataset(ds11, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+    checkDataset(ds12, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+    checkDataset(ds13, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13))
+    checkDataset(ds14, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14))
+    checkDataset(ds15, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15))
+    checkDataset(ds16, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+    checkDataset(ds17, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17))
+    checkDataset(ds18, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18))
+    checkDataset(ds19, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19))
+    checkDataset(ds20, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20))
+    checkDataset(ds21, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21))
+    checkDataset(ds22, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+      22))
+  }
+
   test("REGEX column specification") {
     val ds = Seq(("a", 1), ("b", 2), ("c", 3)).toDS()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR simply adds typed select methods to Dataset up to the max Tuple size of 22.

This has been bugging me for years, so I finally decided to get off my backside and do something about it :-).

As noted in the JIRA issue, technically, this is a breaking change - indeed, I had to remove an old test that specifically tested that Spark didn't support typed select for tuples larger than 5.  However, it would take someone explicitly relying on select returning a DataFrame instead of a Dataset when using select on large tuples of typed columns (though I guess that test I had to remove exhibits one case where this may happen).

I've set the PR as WIP because I've been unable to run all tests so far - not due to the fix, but rather due to not having things set up correctly on my computer.  Still working on that.

### Why are the changes needed?
Arbitrarily supporting only up to 5-tuples is weird and unpredictable.

### Does this PR introduce _any_ user-facing change?
Yes, select on tuples of all typed columns larger than 5 will now return a Dataset instead of a DataFrame

### How was this patch tested?
I've run all sql tests, and they all pass (though testing itself still fails on my machine, I think with a path-too-long error
I've added a test to make sure the typed select works on all sizes - mostly this is a compile issue, not a run-time issue, but I checked values too, just to double-check that I didn't miss anything (which is a big potential problem with long tuples and copy-paste errors)
