### PR TITLE
[SPARK-39243][SQL][DOCS] Rules of quoting elements in error messages

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
@@ -23,6 +23,21 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.util.quoteIdentifier
 import org.apache.spark.sql.types.{DataType, DoubleType, FloatType}
 
+/**
+ * The trait exposes util methods for preparing error messages such as quoting of error elements.
+ * All classes that extent `QueryErrorsBase` shall follow the rules:
+ * 1. Any values shall be outputted in the SQL standard style by using `toSQLValue()`.
+ *   For example: 'a string value', 1, NULL.
+ * 2. SQL types shall be double quoted and outputted in the upper case using `toSQLType()`.
+ *   For example: "INT", "DECIMAL(10,0)".
+ * 3. Elements of identifiers shall be wrapped by backticks by using `toSQLId()`.
+ *   For example: `namespaceA`.`funcB`, `tableC`.
+ * 4. SQL statements shall be in the upper case prepared by using `toSQLStmt`.
+ *   For example: DESC PARTITION, DROP TEMPORARY FUNCTION.
+ * 5. SQL configs and datasource options shall be wrapped by double quotes by using
+ *   `toSQLConf()`/`toDSOption()`.
+ *   For example: "spark.sql.ansi.enabled".
+ */
 trait QueryErrorsBase {
   // Converts an error class parameter to its SQL representation
   def toSQLValue(v: Any, t: DataType): String = Literal.create(v, t) match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryErrorsBase.scala
@@ -37,6 +37,8 @@ import org.apache.spark.sql.types.{DataType, DoubleType, FloatType}
  * 5. SQL configs and datasource options shall be wrapped by double quotes by using
  *   `toSQLConf()`/`toDSOption()`.
  *   For example: "spark.sql.ansi.enabled".
+ * 6. Any values of datasource options or SQL configs shall be double quoted.
+ *   For example: "true", "CORRECTED".
  */
 trait QueryErrorsBase {
   // Converts an error class parameter to its SQL representation


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to describe the rules of quoting elements in error messages introduced by the PRs:
- https://github.com/apache/spark/pull/36210
- https://github.com/apache/spark/pull/36233
- https://github.com/apache/spark/pull/36259
- https://github.com/apache/spark/pull/36324
- https://github.com/apache/spark/pull/36335
- https://github.com/apache/spark/pull/36359
- https://github.com/apache/spark/pull/36579

### Why are the changes needed?
To improve code maintenance, and the process of code review. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By existing GAs.