### PR TITLE
[SPARK-39244][INFRA] Use `--no-echo` instead of `--slave` in R 4.0+

### DIFF
--- a/dev/ansible-for-test-node/roles/jenkins-worker/tasks/install_spark_build_packages.yml
+++ b/dev/ansible-for-test-node/roles/jenkins-worker/tasks/install_spark_build_packages.yml
@@ -158,7 +158,7 @@
       - r-mathlib
 
 - name: install required R packages via Rscript (default version)
-  command: /usr/bin/Rscript --slave --no-save --no-restore-history -e "if (! ('{{ item }}' %in% installed.packages()[,'Package'])) { install.packages(pkgs='{{ item }}'); print('Added'); } else { print('Already installed'); }"
+  command: /usr/bin/Rscript --no-echo --no-save --no-restore-history -e "if (! ('{{ item }}' %in% installed.packages()[,'Package'])) { install.packages(pkgs='{{ item }}'); print('Added'); } else { print('Already installed'); }"
   register: r_result
   failed_when: "r_result.rc != 0 or 'had non-zero exit status' in r_result.stderr"
   changed_when: "'Added' in r_result.stdout"
@@ -179,5 +179,5 @@
   register: r_check
 
 - name: install lintr v2.0.0
-  command: /usr/bin/Rscript --slave --no-save --no-restore-history -e "devtools::install_github('jimhester/lintr@v2.0.0')"
+  command: /usr/bin/Rscript --no-echo --no-save --no-restore-history -e "devtools::install_github('jimhester/lintr@v2.0.0')"
   when: "'lintr' not in r_check.stdout"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use `--no-echo` instead of `--slave` in R 4.0+

### Why are the changes needed?
- https://github.com/rstudio/rstudio/issues/5923
- https://github.com/wch/r-source/commit/f1ff49e74593341c74c20de9517f31a22c8bcb04
The R community has already moved to `--no-echo`

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
N/A, this is infra code. 