### PR TITLE
[SPARK-39203][SQL] Rewrite table location to absolute URI based on database URI

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1441,17 +1441,13 @@ object HiveExternalCatalog {
    *   parentUri: viewfs://clusterA/user/hive/warehouse/
    *   The result is: viewfs://clusterA/user/hive/warehouse/test_table
    */
-  private[spark] def toAbsoluteURI(uri: URI, parentUri: Option[URI]): URI = {
-    if (uri.isAbsolute) {
-      uri
+  private[spark] def toAbsoluteURI(uri: URI, absoluteUri: Option[URI]): URI = {
+    if (!uri.isAbsolute && absoluteUri.isDefined) {
+      val aUri = absoluteUri.get
+      new URI(aUri.getScheme, aUri.getUserInfo, aUri.getHost, aUri.getPort,
+        uri.getPath, uri.getQuery, uri.getFragment)
     } else {
-      parentUri match {
-        case Some(pUri) if pUri.isAbsolute =>
-          new URI(pUri.getScheme, pUri.getUserInfo, pUri.getHost, pUri.getPort,
-            uri.getPath, uri.getQuery, uri.getFragment)
-        case _ =>
-          uri
-      }
+      uri
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.hive
 
 import java.io.IOException
 import java.lang.reflect.InvocationTargetException
+import java.net.URI
 import java.util
 import java.util.Locale
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -843,9 +843,8 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
     // source tables. Here we set the table location to `locationUri` field and filter out the
     // path option in storage properties, to avoid exposing this concept externally.
     val storageWithLocation = {
-      val tableLocation = getLocationFromStorageProps(table).map { loc =>
-        val uri = CatalogUtils.stringToURI(loc)
-        table.storage.locationUri.map(HiveExternalCatalog.toAbsoluteURI(uri, _)).getOrElse(uri)
+      val tableLocation = getLocationFromStorageProps(table).map { path =>
+        toAbsoluteURI(CatalogUtils.stringToURI(path), table.storage.locationUri)
       }
       // We pass None as `newPath` here, to remove the path option in storage properties.
       updateLocationInStorageProps(table, newPath = None).copy(locationUri = tableLocation)
@@ -1442,12 +1441,17 @@ object HiveExternalCatalog {
    *   parentUri: viewfs://clusterA/user/hive/warehouse/
    *   The result is: viewfs://clusterA/user/hive/warehouse/test_table
    */
-  private[spark] def toAbsoluteURI(uri: URI, parentUri: URI): URI = {
-    if (!uri.isAbsolute && parentUri.isAbsolute) {
-      new URI(parentUri.getScheme, parentUri.getUserInfo, parentUri.getHost, parentUri.getPort,
-        uri.getPath, uri.getQuery, uri.getFragment)
-    } else {
+  private[spark] def toAbsoluteURI(uri: URI, parentUri: Option[URI]): URI = {
+    if (uri.isAbsolute) {
       uri
+    } else {
+      parentUri match {
+        case Some(pUri) if pUri.isAbsolute =>
+          new URI(pUri.getScheme, pUri.getUserInfo, pUri.getHost, pUri.getPort,
+            uri.getPath, uri.getQuery, uri.getFragment)
+        case _ =>
+          uri
+      }
     }
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -1435,12 +1435,10 @@ object HiveExternalCatalog {
     case _ => true
   }
 
-  /**
-   * Rewrite uri to absolute location. For example:
-   *   uri: /user/hive/warehouse/test_table
-   *   parentUri: viewfs://clusterA/user/hive/warehouse/
-   *   The result is: viewfs://clusterA/user/hive/warehouse/test_table
-   */
+  // Rewrite uri to absolute location. For example:
+  //   uri: /user/hive/warehouse/test_table
+  //   absoluteUri: viewfs://clusterA/user/hive/warehouse/
+  //   The result is: viewfs://clusterA/user/hive/warehouse/test_table
   private[spark] def toAbsoluteURI(uri: URI, absoluteUri: Option[URI]): URI = {
     if (!uri.isAbsolute && absoluteUri.isDefined) {
       val aUri = absoluteUri.get

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -520,12 +520,12 @@ private[hive] class HiveClientImpl(
       storage = CatalogStorageFormat(
         locationUri = shim.getDataLocation(h).map { location =>
           val tableUri = CatalogUtils.stringToURI(location)
-          val dbUri = if (!tableUri.isAbsolute) {
-            Some(CatalogUtils.stringToURI(client.getDatabase(h.getDbName).getLocationUri))
+          if (!tableUri.isAbsolute) {
+            val dbUri = CatalogUtils.stringToURI(client.getDatabase(h.getDbName).getLocationUri)
+            HiveExternalCatalog.toAbsoluteURI(tableUri, dbUri)
           } else {
-            None
+            tableUri
           }
-          HiveExternalCatalog.toAbsoluteURI(tableUri, dbUri)
         },
         // To avoid ClassNotFound exception, we try our best to not get the format class, but get
         // the class name directly. However, for non-native tables, there is no interface to get
@@ -1164,7 +1164,7 @@ private[hive] object HiveClientImpl extends Logging {
       spec = Option(hp.getSpec).map(_.asScala.toMap).getOrElse(Map.empty),
       storage = CatalogStorageFormat(
         locationUri = Option(HiveExternalCatalog.toAbsoluteURI(
-          CatalogUtils.stringToURI(apiPartition.getSd.getLocation), Some(table.location))),
+          CatalogUtils.stringToURI(apiPartition.getSd.getLocation), table.location)),
         inputFormat = Option(apiPartition.getSd.getInputFormat),
         outputFormat = Option(apiPartition.getSd.getOutputFormat),
         serde = Option(apiPartition.getSd.getSerdeInfo.getSerializationLib),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -200,4 +200,20 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
       assert(alteredTable.provider === Some("foo"))
     })
   }
+
+  test("SPARK-39203: Rewrite table location to absolute location based on database location") {
+    val tableLocation1 = CatalogUtils.stringToURI("/user/hive/warehouse/t1")
+    val tableLocation2 = CatalogUtils.stringToURI("viewfs://clusterB/user/hive/warehouse/t2")
+
+    val dbLocation = CatalogUtils.stringToURI("viewfs://clusterA/user/hive/warehouse/")
+
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, Some(dbLocation))
+      .equals(CatalogUtils.stringToURI("viewfs://clusterA/user/hive/warehouse/t1")))
+
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, None)
+      .equals(tableLocation1))
+
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation2, Some(dbLocation))
+      .equals(tableLocation2))
+  }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -206,9 +206,13 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
     val tableLocation2 = CatalogUtils.stringToURI("viewfs://clusterB/user/hive/warehouse/t2")
     val dbLocation = CatalogUtils.stringToURI("viewfs://clusterA/user/hive/warehouse/")
 
-    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, dbLocation)
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, Some(dbLocation))
       .equals(CatalogUtils.stringToURI("viewfs://clusterA/user/hive/warehouse/t1")))
-    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation2, dbLocation)
+
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, None)
+      .equals(tableLocation1))
+
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation2, Some(dbLocation))
       .equals(tableLocation2))
   }
 }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogSuite.scala
@@ -204,16 +204,11 @@ class HiveExternalCatalogSuite extends ExternalCatalogSuite {
   test("SPARK-39203: Rewrite table location to absolute location based on database location") {
     val tableLocation1 = CatalogUtils.stringToURI("/user/hive/warehouse/t1")
     val tableLocation2 = CatalogUtils.stringToURI("viewfs://clusterB/user/hive/warehouse/t2")
-
     val dbLocation = CatalogUtils.stringToURI("viewfs://clusterA/user/hive/warehouse/")
 
-    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, Some(dbLocation))
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, dbLocation)
       .equals(CatalogUtils.stringToURI("viewfs://clusterA/user/hive/warehouse/t1")))
-
-    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation1, None)
-      .equals(tableLocation1))
-
-    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation2, Some(dbLocation))
+    assert(HiveExternalCatalog.toAbsoluteURI(tableLocation2, dbLocation)
       .equals(tableLocation2))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rewrite table location to absolute location based on database location. For example:
```
Table location: /user/hive/warehouse/db_spark_39203.db/t1
Database location: viewfs://clusterA/user/hive/warehouse/db_spark_39203.db/
```
The current table location is: `viewfs://clusterA/user/hive/warehouse/db_spark_39203.db/t1`.

### Why are the changes needed?

The old Spark version(before SPARK-19257) will not use absolute path when using the following SQL create table:
```sql
CREATE TABLE DB_SPARK_39203.t6(id int)
USING parquet
OPTIONS (
  path '/user/hive/warehouse/db_spark_39203.db/t1'
);
```
<img width="551" alt="image" src="https://user-images.githubusercontent.com/5399861/170249177-dded6f23-2a59-4d08-a410-df4c975693b7.png">


This issue makes Spark can't read tables across cluster. For example:
Hive, Spark 2.1 and HDFS 1 on cluster A.
Spark 3.0 and HDFS 2 on cluster B.

The other create table command and latest spark do not have this issue:
```sql
CREATE TABLE DB_SPARK_39203.t7(id int) using parquet;

CREATE TABLE DB_SPARK_39203.t8(id int)
stored as parquet
LOCATION '/user/hive/warehouse/db_spark_39203.db/t1';

CREATE EXTERNAL TABLE DB_SPARK_39203.t9(id int)
stored as parquet
LOCATION '/user/hive/warehouse/db_spark_39203.db/t1';
```
<img width="569" alt="image" src="https://user-images.githubusercontent.com/5399861/170249397-8d1677bc-b506-4d66-b703-928367c9d780.png">



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test and production test: we have been using this patch for over two years.