### PR TITLE
[SPARK-39249][SQL] Improve subexpression elimination for conditional expressions

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/SubexpressionEliminationSuite.scala
@@ -476,7 +476,7 @@ class SubexpressionEliminationSuite extends SparkFunSuite with ExpressionEvalHel
     assert(equivalence1.getAllExprStates().filter(_.useCount == 2).head.expr eq add)
 
     // `add` is in both branches of `If` and predicate, it should be a common expression.
-    val ifExpr2 = If(IsNull(add), Literal(add), KnownNotNull(add))
+    val ifExpr2 = If(IsNull(add), add, KnownNotNull(add))
     val equivalence2 = new EquivalentExpressions
     equivalence2.addExprTree(ifExpr2)
     assert(equivalence2.getCommonSubexpressions.size == 1)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently we can do subexpression elimination for conditional expressions when the subexpression is common across all `branchGroups`. In fact, we can farther improve this when there are common expressions between `alwaysEvaluatedInputs` and `branchGroups`.

### Why are the changes needed?
Take the following case as an example
```
IF(IsNull(a), b, KnowNotNull(a))
```
`a` **may miss subexpression elimination chances** since it is not the common expression between all `branchGroups`, but it's **safe** to evaluate `a` as common subexpression and eagerly execute it since it's part of the prediction, which will always be executed. If `a` is a time-expensive expression, we may waste time on running it.

This kind of expressions are common when we do `sum` on decimal type because of https://github.com/apache/spark/pull/29026
https://github.com/apache/spark/blob/291d155b3c514f8b590a6b078f7efd42a30e67f0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala#L125

Many queries on TPC-DS has positive improvement. Following is some obvious improvements on TPC-DS 10T
Query| With this PR | Without this PR | Speed up
-- | -- | -- | --
4 | 310.862 | 635.299 | 104.37%
44 | 47.851 | 63.717 | 33.16%
50 | 188.106 | 217.023 | 13.32%
80 | 36.723 | 46.006 | 25.28%
93 | 193.26 | 224.135 | 13.78%
95 | 102.811 | 126.125 | 18.48%

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
add more UT.
