### PR TITLE
[SPARK-39251][SQL] Simplify MultiLike if remainPatterns is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -754,12 +754,18 @@ object LikeSimplification extends Rule[LogicalPlan] {
       multi
     } else {
       multi match {
-        case l: LikeAll => And(replacements.reduceLeft(And), l.copy(patterns = remainPatterns))
+        case l: LikeAll =>
+          val and = replacements.reduceLeft(And)
+          if (remainPatterns.nonEmpty) And(and, l.copy(patterns = remainPatterns)) else and
         case l: NotLikeAll =>
-          And(replacements.map(Not(_)).reduceLeft(And), l.copy(patterns = remainPatterns))
-        case l: LikeAny => Or(replacements.reduceLeft(Or), l.copy(patterns = remainPatterns))
+          val and = replacements.map(Not(_)).reduceLeft(And)
+          if (remainPatterns.nonEmpty) And(and, l.copy(patterns = remainPatterns)) else and
+        case l: LikeAny =>
+          val or = replacements.reduceLeft(Or)
+          if (remainPatterns.nonEmpty) Or(or, l.copy(patterns = remainPatterns)) else or
         case l: NotLikeAny =>
-          Or(replacements.map(Not(_)).reduceLeft(Or), l.copy(patterns = remainPatterns))
+          val or = replacements.map(Not(_)).reduceLeft(Or)
+          if (remainPatterns.nonEmpty) Or(or, l.copy(patterns = remainPatterns)) else or
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -232,4 +232,22 @@ class LikeSimplificationSuite extends PlanTest {
 
     comparePlans(optimized, correctAnswer)
   }
+
+  test("SPARK-39251: Simplify MultiLike if remainPatterns is empty") {
+    comparePlans(
+      Optimize.execute(testRelation.where($"a" likeAll("abc%")).analyze),
+      testRelation.where(StartsWith($"a", "abc")).analyze)
+
+    comparePlans(
+      Optimize.execute(testRelation.where($"a" notLikeAll("abc%")).analyze),
+      testRelation.where(Not(StartsWith($"a", "abc"))).analyze)
+
+    comparePlans(
+      Optimize.execute(testRelation.where($"a" likeAny("abc%")).analyze),
+      testRelation.where(StartsWith($"a", "abc")).analyze)
+
+    comparePlans(
+      Optimize.execute(testRelation.where($"a" notLikeAny("abc%")).analyze),
+      testRelation.where(Not(StartsWith($"a", "abc"))).analyze)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Simplify MultiLike if remainPatterns is empty. For example:
```scala
sql("select * from range(10) where id like any('1%')").explain(true)
```
Before:
```
== Optimized Logical Plan ==
Filter (StartsWith(cast(id#59L as string), 1) OR likeany(cast(id#59L as string)))
+- Range (0, 10, step=1, splits=None)
```
After:
```
== Optimized Logical Plan ==
Filter (StartsWith(cast(id#59L as string), 1))
+- Range (0, 10, step=1, splits=None)
```

### Why are the changes needed?

Simplify the MultiLike expressions.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.