### PR TITLE
[MINOR] Remove redundant collection conversion toMap

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1229,7 +1229,7 @@ class Analyzer(override val catalogManager: CatalogManager)
         val partCols = partitionColumnNames(r.table)
         validatePartitionSpec(partCols, i.partitionSpec)
 
-        val staticPartitions = i.partitionSpec.filter(_._2.isDefined).mapValues(_.get).toMap
+        val staticPartitions = i.partitionSpec.filter(_._2.isDefined).mapValues(_.get)
         val query = addStaticPartitionColumns(r, i.query, staticPartitions)
 
         if (!i.overwrite) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove redundant collection conversion toMap.

### Why are the changes needed?
Cleanup

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A