### PR TITLE
[SPARK-39254][BUILD] Upgrade ZSTD-JNI to 1.5.2-3

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -267,4 +267,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.5.2-2//zstd-jni-1.5.2-2.jar
+zstd-jni/1.5.2-3//zstd-jni-1.5.2-3.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -254,4 +254,4 @@ xz/1.8//xz-1.8.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.6.2//zookeeper-jute-3.6.2.jar
 zookeeper/3.6.2//zookeeper-3.6.2.jar
-zstd-jni/1.5.2-2//zstd-jni-1.5.2-2.jar
+zstd-jni/1.5.2-3//zstd-jni-1.5.2-3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.2-2</version>
+        <version>1.5.2-3</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade zstd-jni to 1.5.2-3.


### Why are the changes needed?
This version bring some fix and improvements, for example, this version added [Add NoFinalizer variants for the direct buffer streams.](https://github.com/luben/zstd-jni/commit/31060934c26e080031465702ec369591e12874f8) and [Add methods for streaming (de)compression of direct ByteBuffers.](https://github.com/luben/zstd-jni/commit/510bbd6be80592227c6e5cf8cd8d71cb76c0c279).

All changes as follows:

- https://github.com/luben/zstd-jni/compare/v1.5.2-2...v1.5.2-3

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions