### PR TITLE
[SPARK-39262][PYTHON] Correct the behavior of creating DataFrame from an RDD

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -612,7 +612,7 @@ class SparkSession(SparkConversionMixin):
         """
         first = rdd.first()
         if first is None:
-            raise ValueError("The first row in RDD is empty, " "can not infer schema")
+            raise ValueError("The first row in RDD is empty, can not infer schema")
 
         infer_dict_as_struct = self._jconf.inferDictAsStruct()
         infer_array_from_first_element = self._jconf.legacyInferArrayTypeFromFirstElement()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -611,7 +611,7 @@ class SparkSession(SparkConversionMixin):
         :class:`pyspark.sql.types.StructType`
         """
         first = rdd.first()
-        if first != 0 and not first:
+        if first is None:
             raise ValueError("The first row in RDD is empty, " "can not infer schema")
 
         infer_dict_as_struct = self._jconf.inferDictAsStruct()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -611,7 +611,7 @@ class SparkSession(SparkConversionMixin):
         :class:`pyspark.sql.types.StructType`
         """
         first = rdd.first()
-        if not first:
+        if first is None:
             raise ValueError("The first row in RDD is empty, " "can not infer schema")
 
         infer_dict_as_struct = self._jconf.inferDictAsStruct()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -611,7 +611,7 @@ class SparkSession(SparkConversionMixin):
         :class:`pyspark.sql.types.StructType`
         """
         first = rdd.first()
-        if first is None:
+        if first != 0 and not first:
             raise ValueError("The first row in RDD is empty, " "can not infer schema")
 
         infer_dict_as_struct = self._jconf.inferDictAsStruct()

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -17,6 +17,7 @@
 
 import sys
 import warnings
+from collections.abc import Sized
 from functools import reduce
 from threading import RLock
 from types import TracebackType
@@ -611,7 +612,7 @@ class SparkSession(SparkConversionMixin):
         :class:`pyspark.sql.types.StructType`
         """
         first = rdd.first()
-        if first is None:
+        if isinstance(first, Sized) and len(first) == 0:
             raise ValueError("The first row in RDD is empty, can not infer schema")
 
         infer_dict_as_struct = self._jconf.inferDictAsStruct()

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -81,6 +81,8 @@ class SparkSessionTests3(unittest.TestCase):
             activeSession = SparkSession.getActiveSession()
             df = activeSession.createDataFrame([(1, "Alice")], ["age", "name"])
             self.assertEqual(df.collect(), [Row(age=1, name="Alice")])
+            df = activeSession.createDataFrame(activeSession._sc.parallelize([[], []]))
+            self.assertEqual(df.collect(), [Row(), Row()])
         finally:
             spark.stop()
 

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -81,8 +81,8 @@ class SparkSessionTests3(unittest.TestCase):
             activeSession = SparkSession.getActiveSession()
             df = activeSession.createDataFrame([(1, "Alice")], ["age", "name"])
             self.assertEqual(df.collect(), [Row(age=1, name="Alice")])
-            df = activeSession.createDataFrame(activeSession._sc.parallelize([[], []]))
-            self.assertEqual(df.collect(), [Row(), Row()])
+            with self.assertRaises(ValueError):
+                activeSession.createDataFrame(activeSession._sc.parallelize([[], []]))
         finally:
             spark.stop()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the behavior of creating DataFrame from an RDD **with `0` as the first element**.

See **Does this PR introduce _any_ user-facing change?** for the corrected behaviors.

### Why are the changes needed?
Improve error messages and debugability.

### Does this PR introduce _any_ user-facing change?

Before:
```py
>>> spark.createDataFrame(spark._sc.parallelize([0, 1]))
Traceback (most recent call last):
...
ValueError: The first row in RDD is empty, can not infer schema
```

After:
```py
>>> spark.createDataFrame(spark._sc.parallelize([0, 1]))
Traceback (most recent call last):                                              
...
TypeError: Can not infer schema for type: <class 'int'>
```

### How was this patch tested?
Existing tests.