### PR TITLE
[SPARK-39263][SQL] Make GetTable, TableExists and DatabaseExists be compatible with 3 layer namespace

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -966,7 +966,7 @@ class SessionCatalog(
   }
 
   def isGlobalTempViewDB(dbName: String): Boolean = {
-    globalTempViewManager.database.equals(dbName)
+    globalTempViewManager.database.equalsIgnoreCase(dbName)
   }
 
   def lookupTempView(name: TableIdentifier): Option[View] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -251,6 +251,10 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    * table/view. This throws an `AnalysisException` when no `Table` can be found.
    */
   override def getTable(tableName: String): Table = {
+    // calling `sqlParser.parseTableIdentifier` to parse tableName. If it contains only table name
+    // and optionally contains a database name(thus a TableIdentifier), then that is used to get
+    // the table. Otherwise we try `sqlParser.parseMultipartIdentifier` to have a sequence of string
+    // as the qualified identifier and resolve the table.
     try {
       val ident = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
       getTable(ident.database.orNull, ident.table)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTable, LocalRelation, RecoverPartitions, ShowTables, SubqueryAlias, TableSpec, View}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.DataSource
@@ -306,8 +306,9 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       val ident = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(dbName)
       val plan = sparkSession.sessionState.executePlan(UnresolvedNamespace(ident)).analyzed
       plan match {
-        case ResolvedNamespace(catalog: InMemoryCatalog, _) => catalog.databaseExists(ident(1))
-        case _ => false
+        case ResolvedNamespace(catalog: SupportsNamespaces, _) =>
+          catalog.namespaceExists(ident.toArray)
+        case _ => true
       }
     } else {
       true

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.connector.FakeV2Provider
-import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Identifier, InMemoryCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier, InMemoryCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -684,7 +684,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
 
   test("three layer namespace compatibility - get table") {
     val catalogName = "testcat"
-    val dbName = "my_db"
+    val dbName = "default"
     val tableName = "my_table"
     val tableSchema = new StructType().add("i", "int")
     val description = "this is a test table"
@@ -706,6 +706,12 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
         CatalogTableType.MANAGED.name,
         false)
     assert(expectedTable.toString == t.toString)
+
+    // test when both sessionCatalog and testcat contains tables with same name, and we expect
+    // the table in sessionCatalog is returned when use 2 part name.
+    createTable("my_table")
+    val t2 = spark.catalog.getTable(Array(dbName, tableName).mkString("."))
+    assert(t2.catalog == CatalogManager.SESSION_CATALOG_NAME)
   }
 
   test("three layer namespace compatibility - table exists") {
@@ -734,10 +740,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     sql(s"CREATE NAMESPACE ${catalogName}.${dbName}")
     assert(spark.catalog.databaseExists(Array(catalogName, dbName).mkString(".")))
 
-    val e = intercept[CatalogNotFoundException] {
-      val catalogName2 = "catalog_not_exists"
-      spark.catalog.databaseExists(Array(catalogName2, dbName).mkString("."))
-    }
-    assert(e.getMessage.contains("catalog_not_exists is not defined"))
+    val catalogName2 = "catalog_not_exists"
+    assert(!spark.catalog.databaseExists(Array(catalogName2, dbName).mkString(".")))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -731,6 +731,9 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val dbName = "my_db"
     assert(!spark.catalog.databaseExists(Array(catalogName, dbName).mkString(".")))
 
+    sql("CREATE NAMESPACE testcat.my_db")
+    assert(spark.catalog.databaseExists(Array(catalogName, dbName).mkString(".")))
+
     val e = intercept[CatalogNotFoundException] {
       val catalogName2 = "catalog_not_exists"
       spark.catalog.databaseExists(Array(catalogName2, dbName).mkString("."))

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -731,7 +731,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val dbName = "my_db"
     assert(!spark.catalog.databaseExists(Array(catalogName, dbName).mkString(".")))
 
-    sql("CREATE NAMESPACE testcat.my_db")
+    sql(s"CREATE NAMESPACE ${catalogName}.${dbName}")
     assert(spark.catalog.databaseExists(Array(catalogName, dbName).mkString(".")))
 
     val e = intercept[CatalogNotFoundException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make GetTable, TableExists and DatabaseExists be compatible with 3 layer namespace

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is a part of effort to make catalog API be compatible with 3 layer namespace

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. The API change here is backward compatible and it extends the API to further support 3 layer namespace (e.g. catalog.database.table).
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

UT
