### PR TITLE
[SPARK-37523][SQL] Re-optimize partitions in Distribution and Ordering if numPartitions is not specified

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
@@ -48,6 +48,22 @@ public interface RequiresDistributionAndOrdering extends Write {
   Distribution requiredDistribution();
 
   /**
+   * Returns if the distribution required by this write is strictly required or best effort only.
+   * <p>
+   * If true, Spark will strictly distribute incoming records across partitions to satisfy
+   * the required distribution before passing the records to the data source table on write.
+   * Spark will not re-optimize by splitting skewed partitions since this changes the required
+   * distribution, but Spark may re-optimize by coalescing small partitions.
+   * <p>
+   * If false, Spark will try its best efforts to distribute incoming records across partitions
+   * to satisfy the required distribution before passing the records to the data source table on
+   * write. Spark may re-optimize by splitting skewed partitions or coalescing small partitions.
+   *
+   * @return true if the distribution required by this write is strictly required; false otherwise.
+   */
+  default boolean distributionStrictlyRequired() { return true; }
+
+  /**
    * Returns the number of partitions required by this write.
    * <p>
    * Implementations may override this to require a specific number of input partitions.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/RequiresDistributionAndOrdering.java
@@ -52,12 +52,8 @@ public interface RequiresDistributionAndOrdering extends Write {
    * <p>
    * If true, Spark will strictly distribute incoming records across partitions to satisfy
    * the required distribution before passing the records to the data source table on write.
-   * Spark will not re-optimize by splitting skewed partitions since this changes the required
-   * distribution, but Spark may re-optimize by coalescing small partitions.
-   * <p>
-   * If false, Spark will try its best efforts to distribute incoming records across partitions
-   * to satisfy the required distribution before passing the records to the data source table on
-   * write. Spark may re-optimize by splitting skewed partitions or coalescing small partitions.
+   * Otherwise, Spark may apply certain optimizations to speed up the query but break
+   * the distribution requirement.
    *
    * @return true if the distribution required by this write is strictly required; false otherwise.
    */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1493,7 +1493,7 @@ case class Repartition(numPartitions: Int, shuffle: Boolean, child: LogicalPlan)
     copy(child = newChild)
 }
 
-trait hasPartitionExpressions extends SQLConfHelper {
+trait HasPartitionExpressions extends SQLConfHelper {
 
   def partitionExpressions: Seq[Expression]
 
@@ -1530,7 +1530,7 @@ trait hasPartitionExpressions extends SQLConfHelper {
 case class RepartitionByExpression(
     partitionExpressions: Seq[Expression],
     child: LogicalPlan,
-    optNumPartitions: Option[Int]) extends RepartitionOperation with hasPartitionExpressions {
+    optNumPartitions: Option[Int]) extends RepartitionOperation with HasPartitionExpressions {
 
   val numPartitions = optNumPartitions.getOrElse(conf.numShufflePartitions)
   require(numPartitions > 0, s"Number of partitions ($numPartitions) must be positive.")
@@ -1570,7 +1570,7 @@ object RepartitionByExpression {
 case class RebalancePartitions(
     partitionExpressions: Seq[Expression],
     child: LogicalPlan,
-    optNumPartitions: Option[Int] = None) extends UnaryNode with hasPartitionExpressions {
+    optNumPartitions: Option[Int] = None) extends UnaryNode with HasPartitionExpressions {
   override def maxRows: Option[Long] = child.maxRows
   override def output: Seq[Attribute] = child.output
   override val nodePatterns: Seq[TreePattern] = Seq(REBALANCE_PARTITIONS)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -53,7 +53,7 @@ class InMemoryTable(
     val distribution: Distribution = Distributions.unspecified(),
     val ordering: Array[SortOrder] = Array.empty,
     val numPartitions: Option[Int] = None,
-    val distributionStrictlyRequired: Boolean = true)
+    val isDistributionStrictlyRequired: Boolean = true)
   extends Table with SupportsRead with SupportsWrite with SupportsDelete
       with SupportsMetadataColumns {
 
@@ -363,7 +363,7 @@ class InMemoryTable(
       override def build(): Write = new Write with RequiresDistributionAndOrdering {
         override def requiredDistribution: Distribution = distribution
 
-        override def distributionStrictlyRequired = distributionStrictlyRequired
+        override def distributionStrictlyRequired = isDistributionStrictlyRequired
 
         override def requiredOrdering: Array[SortOrder] = ordering
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTable.scala
@@ -360,51 +360,26 @@ class InMemoryTable(
         this
       }
 
-      override def build(): Write = {
-        if (distributionStrictlyRequired) {
-          new Write with RequiresDistributionAndOrdering {
-            override def requiredDistribution: Distribution = distribution
+      override def build(): Write = new Write with RequiresDistributionAndOrdering {
+        override def requiredDistribution: Distribution = distribution
 
-            override def requiredOrdering: Array[SortOrder] = ordering
+        override def distributionStrictlyRequired = distributionStrictlyRequired
 
-            override def requiredNumPartitions(): Int = {
-              numPartitions.getOrElse(0)
-            }
+        override def requiredOrdering: Array[SortOrder] = ordering
 
-            override def toBatch: BatchWrite = writer
+        override def requiredNumPartitions(): Int = {
+          numPartitions.getOrElse(0)
+        }
 
-            override def toStreaming: StreamingWrite = streamingWriter match {
-              case exc: StreamingNotSupportedOperation => exc.throwsException()
-              case s => s
-            }
+        override def toBatch: BatchWrite = writer
 
-            override def supportedCustomMetrics(): Array[CustomMetric] = {
-              Array(new InMemorySimpleCustomMetric)
-            }
-          }
-        } else {
-          new Write with RequiresDistributionAndOrdering {
-            override def requiredDistribution: Distribution = distribution
+        override def toStreaming: StreamingWrite = streamingWriter match {
+          case exc: StreamingNotSupportedOperation => exc.throwsException()
+          case s => s
+        }
 
-            override def requiredOrdering: Array[SortOrder] = ordering
-
-            override def distributionStrictlyRequired = false
-
-            override def requiredNumPartitions(): Int = {
-              numPartitions.getOrElse(0)
-            }
-
-            override def toBatch: BatchWrite = writer
-
-            override def toStreaming: StreamingWrite = streamingWriter match {
-              case exc: StreamingNotSupportedOperation => exc.throwsException()
-              case s => s
-            }
-
-            override def supportedCustomMetrics(): Array[CustomMetric] = {
-              Array(new InMemorySimpleCustomMetric)
-            }
-          }
+        override def supportedCustomMetrics(): Array[CustomMetric] = {
+          Array(new InMemorySimpleCustomMetric)
         }
       }
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala
@@ -100,7 +100,8 @@ class BasicInMemoryTableCatalog extends TableCatalog {
       properties: util.Map[String, String],
       distribution: Distribution,
       ordering: Array[SortOrder],
-      requiredNumPartitions: Option[Int]): Table = {
+      requiredNumPartitions: Option[Int],
+      distributionStrictlyRequired: Boolean = true): Table = {
     if (tables.containsKey(ident)) {
       throw new TableAlreadyExistsException(ident)
     }
@@ -109,7 +110,7 @@ class BasicInMemoryTableCatalog extends TableCatalog {
 
     val tableName = s"$name.${ident.quoted}"
     val table = new InMemoryTable(tableName, schema, partitions, properties, distribution,
-      ordering, requiredNumPartitions)
+      ordering, requiredNumPartitions, distributionStrictlyRequired)
     tables.put(ident, table)
     namespaces.putIfAbsent(ident.namespace.toList, Map())
     table

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -45,10 +45,10 @@ object DistributionAndOrderingUtils {
         // for OrderedDistribution and generic expressions for ClusteredDistribution
         // this allows RebalancePartitions/RepartitionByExpression to pick either
         // range or hash partitioning
-        if (!write.distributionStrictlyRequired()) {
-          RebalancePartitions(distribution, query, optNumPartitions)
-        } else {
+        if (write.distributionStrictlyRequired()) {
           RepartitionByExpression(distribution, query, optNumPartitions)
+        } else {
+          RebalancePartitions(distribution, query, optNumPartitions)
         }
       } else if (numPartitions > 0) {
         throw QueryCompilationErrors.numberOfPartitionsNotAllowedWithUnspecifiedDistributionError()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -19,16 +19,15 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils._
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, RepartitionByExpression, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, RebalancePartitions, RepartitionByExpression, Sort}
 import org.apache.spark.sql.connector.distributions._
 import org.apache.spark.sql.connector.write.{RequiresDistributionAndOrdering, Write}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.collection.Utils.sequenceToOption
 
 object DistributionAndOrderingUtils {
 
-  def prepareQuery(write: Write, query: LogicalPlan, conf: SQLConf): LogicalPlan = write match {
+  def prepareQuery(write: Write, query: LogicalPlan): LogicalPlan = write match {
     case write: RequiresDistributionAndOrdering =>
       val numPartitions = write.requiredNumPartitions()
 
@@ -41,15 +40,16 @@ object DistributionAndOrderingUtils {
       }
 
       val queryWithDistribution = if (distribution.nonEmpty) {
-        val finalNumPartitions = if (numPartitions > 0) {
-          numPartitions
-        } else {
-          conf.numShufflePartitions
-        }
+        val optNumPartitions = if (numPartitions == 0) None else Some(numPartitions)
         // the conversion to catalyst expressions above produces SortOrder expressions
         // for OrderedDistribution and generic expressions for ClusteredDistribution
-        // this allows RepartitionByExpression to pick either range or hash partitioning
-        RepartitionByExpression(distribution, query, finalNumPartitions)
+        // this allows RebalancePartitions/RepartitionByExpression to pick either
+        // range or hash partitioning
+        if (!write.distributionStrictlyRequired()) {
+          RebalancePartitions(distribution, query, optNumPartitions)
+        } else {
+          RepartitionByExpression(distribution, query, optNumPartitions)
+        }
       } else if (numPartitions > 0) {
         throw QueryCompilationErrors.numberOfPartitionsNotAllowedWithUnspecifiedDistributionError()
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DistributionAndOrderingUtils.scala
@@ -40,7 +40,7 @@ object DistributionAndOrderingUtils {
       }
 
       val queryWithDistribution = if (distribution.nonEmpty) {
-        val optNumPartitions = if (numPartitions == 0) None else Some(numPartitions)
+        val optNumPartitions = if (numPartitions > 0) Some(numPartitions) else None
         // the conversion to catalyst expressions above produces SortOrder expressions
         // for OrderedDistribution and generic expressions for ClusteredDistribution
         // this allows RebalancePartitions/RepartitionByExpression to pick either

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2Writes.scala
@@ -44,7 +44,7 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
     case a @ AppendData(r: DataSourceV2Relation, query, options, _, None) =>
       val writeBuilder = newWriteBuilder(r.table, options, query.schema)
       val write = writeBuilder.build()
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, conf)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query)
       a.copy(write = Some(write), query = newQuery)
 
     case o @ OverwriteByExpression(r: DataSourceV2Relation, deleteExpr, query, options, _, None) =>
@@ -68,7 +68,7 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
           throw QueryExecutionErrors.overwriteTableByUnsupportedExpressionError(table)
       }
 
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, conf)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query)
       o.copy(write = Some(write), query = newQuery)
 
     case o @ OverwritePartitionsDynamic(r: DataSourceV2Relation, query, options, _, None) =>
@@ -80,7 +80,7 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
         case _ =>
           throw QueryExecutionErrors.dynamicPartitionOverwriteUnsupportedByTableError(table)
       }
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, conf)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query)
       o.copy(write = Some(write), query = newQuery)
 
     case WriteToMicroBatchDataSource(
@@ -90,14 +90,14 @@ object V2Writes extends Rule[LogicalPlan] with PredicateHelper {
       val write = buildWriteForMicroBatch(table, writeBuilder, outputMode)
       val microBatchWrite = new MicroBatchWrite(batchId, write.toStreaming)
       val customMetrics = write.supportedCustomMetrics.toSeq
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, conf)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query)
       WriteToDataSourceV2(relation, microBatchWrite, newQuery, customMetrics)
 
     case rd @ ReplaceData(r: DataSourceV2Relation, _, query, _, None) =>
       val rowSchema = StructType.fromAttributes(rd.dataInput)
       val writeBuilder = newWriteBuilder(r.table, Map.empty, rowSchema)
       val write = writeBuilder.build()
-      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query, conf)
+      val newQuery = DistributionAndOrderingUtils.prepareQuery(write, query)
       // project away any metadata columns that could be used for distribution and ordering
       rd.copy(write = Some(write), query = Project(rd.dataInput, newQuery))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -56,36 +56,15 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
     .add("data", StringType)
 
   test("ordered distribution and sort with same exprs: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithSameExprs(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithSameExprsInVariousCases("append")
   }
 
   test("ordered distribution and sort with same exprs: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithSameExprs(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithSameExprsInVariousCases("overwrite")
   }
 
   test("ordered distribution and sort with same exprs: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithSameExprs(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithSameExprsInVariousCases("overwriteDynamic")
   }
 
   test("ordered distribution and sort with same exprs: micro-batch append") {
@@ -101,47 +80,46 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: append") {
-    checkOrderedDistributionAndSortWithSameExprs("append", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithSameExprs("append", Some(10))
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: overwrite") {
-    checkOrderedDistributionAndSortWithSameExprs("overwrite", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithSameExprs("overwrite", Some(10))
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: overwriteDynamic") {
-    checkOrderedDistributionAndSortWithSameExprs("overwriteDynamic", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithSameExprs("overwriteDynamic")
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: micro-batch append") {
-    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "append", Some(10),
-      true, false, false)
+    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "append", Some(10))
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: micro-batch update") {
-    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "update", Some(10),
-      true, false, false)
+    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "update", Some(10))
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: micro-batch complete") {
-    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "complete", Some(10),
-      true, false, false)
+    checkOrderedDistributionAndSortWithSameExprs(microBatchPrefix + "complete", Some(10))
+  }
+
+  private def checkOrderedDistributionAndSortWithSameExprsInVariousCases(cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkOrderedDistributionAndSortWithSameExprs(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkOrderedDistributionAndSortWithSameExprs(
       command: String,
+      targetNumPartitions: Option[Int] = None,
       distributionStrictlyRequired: Boolean = true,
       dataSkewed: Boolean = false,
       coalesce: Boolean = false): Unit = {
-    checkOrderedDistributionAndSortWithSameExprs(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkOrderedDistributionAndSortWithSameExprs(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
     )
@@ -174,36 +152,15 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs: append") {
-    Seq(true).foreach { distributionStrictlyRequired =>
-      Seq(true).foreach { dataSkewed =>
-        Seq(false).foreach { coalesce =>
-          checkClusteredDistributionAndSortWithSameExprs(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndSortWithSameExprsInVariousCases("append")
   }
 
   test("clustered distribution and sort with same exprs: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndSortWithSameExprs(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndSortWithSameExprsInVariousCases("overwrite")
   }
 
   test("clustered distribution and sort with same exprs: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndSortWithSameExprs(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndSortWithSameExprsInVariousCases("overwriteDynamic")
   }
 
   test("clustered distribution and sort with same exprs: micro-batch append") {
@@ -219,48 +176,47 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: append") {
-    checkClusteredDistributionAndSortWithSameExprs("append", Some(10), true, false, false)
+    checkClusteredDistributionAndSortWithSameExprs("append", Some(10))
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: overwrite") {
-    checkClusteredDistributionAndSortWithSameExprs("overwrite", Some(10), true, false, false)
+    checkClusteredDistributionAndSortWithSameExprs("overwrite", Some(10))
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: overwriteDynamic") {
-    checkClusteredDistributionAndSortWithSameExprs(
-      "overwriteDynamic", Some(10), true, false, false)
+    checkClusteredDistributionAndSortWithSameExprs("overwriteDynamic", Some(10) )
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: micro-batch append") {
-    checkClusteredDistributionAndSortWithSameExprs(
-      microBatchPrefix + "append", Some(10), true, false, false)
+    checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "append", Some(10))
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: micro-batch update") {
-    checkClusteredDistributionAndSortWithSameExprs(
-      microBatchPrefix + "update", Some(10), true, false, false)
+    checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "update", Some(10))
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: micro-batch complete") {
     checkClusteredDistributionAndSortWithSameExprs(
-      microBatchPrefix + "complete", Some(10), true, false, false)
+      microBatchPrefix + "complete", Some(10))
+  }
+
+  private def checkClusteredDistributionAndSortWithSameExprsInVariousCases(cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkClusteredDistributionAndSortWithSameExprs(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkClusteredDistributionAndSortWithSameExprs(
       command: String,
+      targetNumPartitions: Option[Int] = None,
       distributionStrictlyRequired: Boolean = true,
       dataSkewed: Boolean = false,
       coalesce: Boolean = false): Unit = {
-    checkClusteredDistributionAndSortWithSameExprs(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkClusteredDistributionAndSortWithSameExprs(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
@@ -302,102 +258,74 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with extended exprs: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndSortWithExtendedExprs(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndSortWithExtendedExprsInVariousCases("append")
   }
 
   test("clustered distribution and sort with extended exprs: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndSortWithExtendedExprs(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndSortWithExtendedExprsInVariousCases("overwrite")
   }
 
   test("clustered distribution and sort with extended exprs: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndSortWithExtendedExprs(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndSortWithExtendedExprsInVariousCases("overwriteDynamic")
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch append") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "append",
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "append")
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch update") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "update",
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "update")
   }
 
   test("clustered distribution and sort with extended exprs: micro-batch complete") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "complete",
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "complete")
   }
 
   test("clustered distribution and sort with extended exprs with numPartitions: append") {
-    checkClusteredDistributionAndSortWithExtendedExprs("append", Some(10),
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs("append", Some(10))
   }
 
   test("clustered distribution and sort with extended exprs with numPartitions: overwrite") {
-    checkClusteredDistributionAndSortWithExtendedExprs("overwrite", Some(10),
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs("overwrite", Some(10))
   }
 
   test("clustered distribution and sort with extended exprs with numPartitions: " +
     "overwriteDynamic") {
-    checkClusteredDistributionAndSortWithExtendedExprs("overwriteDynamic", Some(10),
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs("overwriteDynamic", Some(10))
   }
 
   test("clustered distribution and sort with extended exprs with numPartitions: " +
     "micro-batch append") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "append", Some(10),
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "append", Some(10))
   }
 
   test("clustered distribution and sort with extended exprs with numPartitions: " +
     "micro-batch update") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "update", Some(10),
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "update", Some(10))
   }
 
   test("clustered distribution and sort with extended exprs with numPartitions: " +
     "micro-batch complete") {
-    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "complete", Some(10),
-      true, false, false)
+    checkClusteredDistributionAndSortWithExtendedExprs(microBatchPrefix + "complete", Some(10))
+  }
+
+  private def checkClusteredDistributionAndSortWithExtendedExprsInVariousCases(cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkClusteredDistributionAndSortWithExtendedExprs(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkClusteredDistributionAndSortWithExtendedExprs(
       command: String,
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
-    checkClusteredDistributionAndSortWithExtendedExprs(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkClusteredDistributionAndSortWithExtendedExprs(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
+      targetNumPartitions: Option[Int] = None,
+      distributionStrictlyRequired: Boolean = true,
+      dataSkewed: Boolean = false,
+      coalesce: Boolean = false): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
@@ -593,67 +521,47 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with manual global sort: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithManualGlobalSort(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithManualGlobalSortInVariousCases("append")
   }
 
   test("ordered distribution and sort with manual global sort: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithManualGlobalSort(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithManualGlobalSortInVariousCases("overwrite")
   }
 
   test("ordered distribution and sort with manual global sort: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithManualGlobalSort(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithManualGlobalSortInVariousCases("overwriteDynamic")
   }
 
   test("ordered distribution and sort with manual global sort with numPartitions: append") {
-    checkOrderedDistributionAndSortWithManualGlobalSort("append", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithManualGlobalSort("append", Some(10))
   }
 
   test("ordered distribution and sort with manual global sort with numPartitions: overwrite") {
-    checkOrderedDistributionAndSortWithManualGlobalSort("overwrite", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithManualGlobalSort("overwrite", Some(10))
   }
 
   test("ordered distribution and sort with manual global sort with numPartitions: " +
     "overwriteDynamic") {
-    checkOrderedDistributionAndSortWithManualGlobalSort(
-      "overwriteDynamic", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithManualGlobalSort("overwriteDynamic", Some(10))
+  }
+
+  private def checkOrderedDistributionAndSortWithManualGlobalSortInVariousCases(cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkOrderedDistributionAndSortWithManualGlobalSort(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkOrderedDistributionAndSortWithManualGlobalSort(
       command: String,
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
-    checkOrderedDistributionAndSortWithManualGlobalSort(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkOrderedDistributionAndSortWithManualGlobalSort(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
+      targetNumPartitions: Option[Int] = None,
+      distributionStrictlyRequired: Boolean = true,
+      dataSkewed: Boolean = false,
+      coalesce: Boolean = false): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
@@ -694,70 +602,49 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with incompatible global sort: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSortInVariousCases("append")
   }
 
   test("ordered distribution and sort with incompatible global sort: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSortInVariousCases("overwrite")
   }
 
   test("ordered distribution and sort with incompatible global sort: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSortInVariousCases("overwriteDynamic")
   }
 
   test("ordered distribution and sort with incompatible global sort with numPartitions: append") {
-    checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-      "append", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSort("append", Some(10))
   }
 
   test("ordered distribution and sort with incompatible global sort with numPartitions: " +
     "overwrite") {
-    checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-      "overwrite", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSort("overwrite", Some(10))
   }
 
   test("ordered distribution and sort with incompatible global sort with numPartitions: " +
     "overwriteDynamic") {
-    checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-      "overwriteDynamic", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithIncompatibleGlobalSort("overwriteDynamic", Some(10))
+  }
+
+  private def checkOrderedDistributionAndSortWithIncompatibleGlobalSortInVariousCases(
+      cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
       command: String,
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
-    checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkOrderedDistributionAndSortWithIncompatibleGlobalSort(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
+      targetNumPartitions: Option[Int] = None,
+      distributionStrictlyRequired: Boolean = true,
+      dataSkewed: Boolean = false,
+      coalesce: Boolean = false): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
@@ -798,67 +685,47 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with manual local sort: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithManualLocalSort(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithManualLocalSortInVariousCases("append")
   }
 
   test("ordered distribution and sort with manual local sort: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithManualLocalSort(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithManualLocalSortInVariousCases("overwrite")
   }
 
   test("ordered distribution and sort with manual local sort: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkOrderedDistributionAndSortWithManualLocalSort(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkOrderedDistributionAndSortWithManualLocalSortInVariousCases("overwriteDynamic")
   }
 
   test("ordered distribution and sort with manual local sort with numPartitions: append") {
-    checkOrderedDistributionAndSortWithManualLocalSort("append", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithManualLocalSort("append", Some(10))
   }
 
   test("ordered distribution and sort with manual local sort with numPartitions: overwrite") {
-    checkOrderedDistributionAndSortWithManualLocalSort("overwrite", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithManualLocalSort("overwrite", Some(10))
   }
 
   test("ordered distribution and sort with manual local sort with numPartitions: " +
     "overwriteDynamic") {
-    checkOrderedDistributionAndSortWithManualLocalSort(
-      "overwriteDynamic", Some(10), true, false, false)
+    checkOrderedDistributionAndSortWithManualLocalSort("overwriteDynamic", Some(10))
+  }
+
+  private def checkOrderedDistributionAndSortWithManualLocalSortInVariousCases(cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkOrderedDistributionAndSortWithManualLocalSort(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkOrderedDistributionAndSortWithManualLocalSort(
       command: String,
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
-    checkOrderedDistributionAndSortWithManualLocalSort(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkOrderedDistributionAndSortWithManualLocalSort(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
+      targetNumPartitions: Option[Int] = None,
+      distributionStrictlyRequired: Boolean = true,
+      dataSkewed: Boolean = false,
+      coalesce: Boolean = false): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
@@ -899,70 +766,49 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and local sort with manual global sort: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndLocalSortWithManualGlobalSortInVariousCases("append")
   }
 
   test("clustered distribution and local sort with manual global sort: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndLocalSortWithManualGlobalSortInVariousCases("overwrite")
   }
 
   test("clustered distribution and local sort with manual global sort: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndLocalSortWithManualGlobalSortInVariousCases("overwriteDynamic")
   }
 
   test("clustered distribution and local sort with manual global sort with numPartitions: append") {
-    checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-      "append", Some(10), true, false, false)
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("append")
   }
 
   test("clustered distribution and local sort with manual global sort with numPartitions: " +
     "overwrite") {
-    checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-      "overwrite", Some(10), true, false, false)
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("overwrite", Some(10))
   }
 
   test("clustered distribution and local sort with manual global sort with numPartitions: " +
     "overwriteDynamic") {
-    checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-      "overwriteDynamic", Some(10), true, false, false)
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("overwriteDynamic", Some(10))
+  }
+
+  private def checkClusteredDistributionAndLocalSortWithManualGlobalSortInVariousCases(
+      cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkClusteredDistributionAndLocalSortWithManualGlobalSort(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkClusteredDistributionAndLocalSortWithManualGlobalSort(
       command: String,
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
-    checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkClusteredDistributionAndLocalSortWithManualGlobalSort(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
+      targetNumPartitions: Option[Int] = None,
+      distributionStrictlyRequired: Boolean = true,
+      dataSkewed: Boolean = false,
+      coalesce: Boolean = false): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
@@ -1004,70 +850,49 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and local sort with manual local sort: append") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndLocalSortWithManualLocalSort(
-            "append", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndLocalSortWithManualLocalSortInVariousCases("append")
   }
 
   test("clustered distribution and local sort with manual local sort: overwrite") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndLocalSortWithManualLocalSort(
-            "overwrite", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndLocalSortWithManualLocalSortInVariousCases("overwrite")
   }
 
   test("clustered distribution and local sort with manual local sort: overwriteDynamic") {
-    Seq(true, false).foreach { distributionStrictlyRequired =>
-      Seq(true, false).foreach { dataSkewed =>
-        Seq(true, false).foreach { coalesce =>
-          checkClusteredDistributionAndLocalSortWithManualLocalSort(
-            "overwriteDynamic", distributionStrictlyRequired, dataSkewed, coalesce)
-        }
-      }
-    }
+    checkClusteredDistributionAndLocalSortWithManualLocalSortInVariousCases("overwriteDynamic")
   }
 
   test("clustered distribution and local sort with manual local sort with numPartitions: append") {
-    checkClusteredDistributionAndLocalSortWithManualLocalSort(
-      "append", Some(10), true, false, false)
+    checkClusteredDistributionAndLocalSortWithManualLocalSort("append", Some(10))
   }
 
   test("clustered distribution and local sort with manual local sort with numPartitions: " +
     "overwrite") {
-    checkClusteredDistributionAndLocalSortWithManualLocalSort(
-      "overwrite", Some(10), true, false, false)
+    checkClusteredDistributionAndLocalSortWithManualLocalSort("overwrite", Some(10))
   }
 
   test("clustered distribution and local sort with manual local sort with numPartitions: " +
     "overwriteDynamic") {
-    checkClusteredDistributionAndLocalSortWithManualLocalSort(
-      "overwriteDynamic", Some(10), true, false, false)
+    checkClusteredDistributionAndLocalSortWithManualLocalSort("overwriteDynamic", Some(10))
+  }
+
+  private def checkClusteredDistributionAndLocalSortWithManualLocalSortInVariousCases(
+      cmd: String) = {
+    Seq(true, false).foreach { distributionStrictlyRequired =>
+      Seq(true, false).foreach { dataSkewed =>
+        Seq(true, false).foreach { coalesce =>
+          checkClusteredDistributionAndLocalSortWithManualLocalSort(
+            cmd, None, distributionStrictlyRequired, dataSkewed, coalesce)
+        }
+      }
+    }
   }
 
   private def checkClusteredDistributionAndLocalSortWithManualLocalSort(
       command: String,
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
-    checkClusteredDistributionAndLocalSortWithManualLocalSort(
-      command, None, distributionStrictlyRequired, dataSkewed, coalesce)
-  }
-
-  private def checkClusteredDistributionAndLocalSortWithManualLocalSort(
-      command: String,
-      targetNumPartitions: Option[Int],
-      distributionStrictlyRequired: Boolean,
-      dataSkewed: Boolean,
-      coalesce: Boolean): Unit = {
+      targetNumPartitions: Option[Int] = None,
+      distributionStrictlyRequired: Boolean = true,
+      dataSkewed: Boolean = false,
+      coalesce: Boolean = false): Unit = {
     val tableOrdering = Array[SortOrder](
       sort(FieldReference("data"), SortDirection.DESCENDING, NullOrdering.NULLS_FIRST),
       sort(FieldReference("id"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -88,7 +88,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: overwriteDynamic") {
-    checkOrderedDistributionAndSortWithSameExprs("overwriteDynamic")
+    checkOrderedDistributionAndSortWithSameExprs("overwriteDynamic", Some(10))
   }
 
   test("ordered distribution and sort with same exprs with numPartitions: micro-batch append") {
@@ -184,7 +184,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: overwriteDynamic") {
-    checkClusteredDistributionAndSortWithSameExprs("overwriteDynamic", Some(10) )
+    checkClusteredDistributionAndSortWithSameExprs("overwriteDynamic", Some(10))
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: micro-batch append") {
@@ -196,8 +196,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and sort with same exprs with numPartitions: micro-batch complete") {
-    checkClusteredDistributionAndSortWithSameExprs(
-      microBatchPrefix + "complete", Some(10))
+    checkClusteredDistributionAndSortWithSameExprs(microBatchPrefix + "complete", Some(10))
   }
 
   private def checkClusteredDistributionAndSortWithSameExprsInVariousCases(cmd: String) = {
@@ -778,7 +777,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
   }
 
   test("clustered distribution and local sort with manual global sort with numPartitions: append") {
-    checkClusteredDistributionAndLocalSortWithManualGlobalSort("append")
+    checkClusteredDistributionAndLocalSortWithManualGlobalSort("append", Some(10))
   }
 
   test("clustered distribution and local sort with manual global sort with numPartitions: " +
@@ -1075,7 +1074,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
         assert(read.head.partitionSpecs.size == 1)
         checkPartitioningAndOrdering(
           // num of partition in expectedWritePartitioning is 1
-          executedPlan, expectedWritePartitioning, expectedWriteOrdering, 1, false)
+          executedPlan, expectedWritePartitioning, expectedWriteOrdering, 1)
       } else {
         if (dataSkewed && !distributionStrictlyRequired) {
           withSQLConf(
@@ -1103,7 +1102,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
             SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "false") {
             val executedPlan = executeCommand()
             checkPartitioningAndOrdering(
-              executedPlan, expectedWritePartitioning, expectedWriteOrdering, 1, false)
+              executedPlan, expectedWritePartitioning, expectedWriteOrdering, 1)
           }
         }
       }
@@ -1170,7 +1169,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
           expectedWritePartitioning,
           expectedWriteOrdering,
           // there is an extra shuffle for groupBy in complete mode
-          maxNumShuffles = if (outputMode != "complete") 1 else 2, false)
+          maxNumShuffles = if (outputMode != "complete") 1 else 2)
 
         val expectedRows = outputMode match {
           case "append" | "update" => Row(1, "a") :: Row(2, "b") :: Nil
@@ -1186,7 +1185,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
       partitioning: physical.Partitioning,
       ordering: Seq[catalyst.expressions.SortOrder],
       maxNumShuffles: Int = 1,
-      skewSplit: Boolean): Unit = {
+      skewSplit: Boolean = false): Unit = {
 
     val sorts = collect(plan) { case s: SortExec => s }
     assert(sorts.size <= 1, "must be at most one sort")

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -1387,7 +1387,7 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
     } else {
       assert(actualPartitioning == expectedPartitioning, "partitioning must match")
     }
-    
+
     val actualOrdering = plan.outputOrdering
     val expectedOrdering = ordering.map(resolveAttrs(_, plan))
     assert(actualOrdering == expectedOrdering, "ordering must match")


### PR DESCRIPTION

### What changes were proposed in this pull request?
Re-optimize partitions in Distribution and Ordering if numPartitions is not specified.

Support both strictly required distribution and best effort distribution. For best effort distribution, if user doesn't request a specific number of partitions, Spark will split skewed partitions and coalesce small partitions (`RebalancePartitions` will be used and  both `OptimizeSkewInRebalancePartitions` and `CoalesceShufflePartitions` will be applied). For strictly required distribution, if user doesn't request a specific number of partitions, Spark will coalesce small partitions but will NOT split skewed partitions(`RepartitionByExpression(distribution, query, None)` will be used and `CoalesceShufflePartitions` will be applied).



### Why are the changes needed?

optimization


### Does this PR introduce _any_ user-facing change?
In interface `RequiresDistributionAndOrdering`, a new API `distributionStrictlyRequired()` will be added to tell if the distribution required by this write is strictly required or best effort only
```
default boolean distributionStrictlyRequired() { return true; }
```


### How was this patch tested?
Existing and new tests
