### PR TITLE
[SPARK-39267][SQL] Clean up dsl unnecessary symbol

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -151,6 +151,9 @@ package object dsl {
     def desc: SortOrder = SortOrder(expr, Descending)
     def desc_nullsFirst: SortOrder = SortOrder(expr, Descending, NullsFirst, Seq.empty)
     def as(alias: String): NamedExpression = Alias(expr, alias)()
+    // TODO: Remove at Spark 4.0.0
+    @deprecated("Use as(alias: String)", "3.4.0")
+    def as(alias: Symbol): NamedExpression = Alias(expr, alias.name)()
   }
 
   trait ExpressionConversions {
@@ -460,6 +463,9 @@ package object dsl {
           orderSpec: Seq[SortOrder]): LogicalPlan =
         Window(windowExpressions, partitionSpec, orderSpec, logicalPlan)
 
+      // TODO: Remove at Spark 4.0.0
+      @deprecated("Use subquery(alias: String)", "3.4.0")
+      def subquery(alias: Symbol): LogicalPlan = SubqueryAlias(alias.name, logicalPlan)
       def subquery(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
       def as(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -151,7 +151,6 @@ package object dsl {
     def desc: SortOrder = SortOrder(expr, Descending)
     def desc_nullsFirst: SortOrder = SortOrder(expr, Descending, NullsFirst, Seq.empty)
     def as(alias: String): NamedExpression = Alias(expr, alias)()
-    def as(alias: Symbol): NamedExpression = Alias(expr, alias.name)()
   }
 
   trait ExpressionConversions {
@@ -461,8 +460,8 @@ package object dsl {
           orderSpec: Seq[SortOrder]): LogicalPlan =
         Window(windowExpressions, partitionSpec, orderSpec, logicalPlan)
 
-      def subquery(alias: Symbol): LogicalPlan = SubqueryAlias(alias.name, logicalPlan)
       def subquery(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
+      def as(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
 
       def except(otherPlan: LogicalPlan, isAll: Boolean): LogicalPlan =
         Except(logicalPlan, otherPlan, isAll)
@@ -489,8 +488,6 @@ package object dsl {
           overwrite: Boolean = false,
           ifPartitionNotExists: Boolean = false): LogicalPlan =
         InsertIntoStatement(table, partition, Nil, logicalPlan, overwrite, ifPartitionNotExists)
-
-      def as(alias: String): LogicalPlan = SubqueryAlias(alias, logicalPlan)
 
       def coalesce(num: Integer): LogicalPlan =
         Repartition(num, shuffle = false, logicalPlan)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/PullOutNondeterministicSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/PullOutNondeterministicSuite.scala
@@ -30,7 +30,7 @@ class PullOutNondeterministicSuite extends AnalysisTest {
   private lazy val a = $"a".int
   private lazy val b = $"b".int
   private lazy val r = LocalRelation(a, b)
-  private lazy val rnd = Rand(10).as(Symbol("_nondeterministic"))
+  private lazy val rnd = Rand(10).as("_nondeterministic")
   private lazy val rndref = rnd.toAttribute
 
   test("no-op on filter") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveHintsSuite.scala
@@ -85,7 +85,7 @@ class ResolveHintsSuite extends AnalysisTest {
       caseSensitive = false)
 
     checkAnalysisWithoutViewWrapper(
-      UnresolvedHint("MAPJOIN", Seq("tableAlias"), table("table").subquery(Symbol("tableAlias"))),
+      UnresolvedHint("MAPJOIN", Seq("tableAlias"), table("table").subquery("tableAlias")),
       ResolvedHint(testRelation, HintInfo(strategy = Some(BROADCAST))),
       caseSensitive = false)
 
@@ -99,7 +99,7 @@ class ResolveHintsSuite extends AnalysisTest {
   test("do not traverse past subquery alias") {
     checkAnalysisWithoutViewWrapper(
       UnresolvedHint("MAPJOIN", Seq("table"), table("table").where($"a" > 1)
-        .subquery(Symbol("tableAlias"))),
+        .subquery("tableAlias")),
       testRelation.where($"a" > 1).analyze,
       caseSensitive = false)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolvedUuidExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolvedUuidExpressionsSuite.scala
@@ -30,9 +30,9 @@ class ResolvedUuidExpressionsSuite extends AnalysisTest {
 
   private lazy val a = $"a".int
   private lazy val r = LocalRelation(a)
-  private lazy val uuid1 = Uuid().as(Symbol("_uuid1"))
-  private lazy val uuid2 = Uuid().as(Symbol("_uuid2"))
-  private lazy val uuid3 = Uuid().as(Symbol("_uuid3"))
+  private lazy val uuid1 = Uuid().as("_uuid1")
+  private lazy val uuid2 = Uuid().as("_uuid2")
+  private lazy val uuid3 = Uuid().as("_uuid3")
   private lazy val uuid1Ref = uuid1.toAttribute
 
   private val tracker = new QueryPlanningTracker

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -61,10 +61,10 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("Remove aliased literals") {
-    val query = testRelation.select($"a", $"b", Literal(1).as(Symbol("y")))
+    val query = testRelation.select($"a", $"b", Literal(1).as("y"))
       .groupBy($"a", $"y")(sum($"b"))
     val optimized = Optimize.execute(analyzer.execute(query))
-    val correctAnswer = testRelation.select($"a", $"b", Literal(1).as(Symbol("y")))
+    val correctAnswer = testRelation.select($"a", $"b", Literal(1).as("y"))
       .groupBy($"a")(sum($"b")).analyze
 
     comparePlans(optimized, correctAnswer)
@@ -80,8 +80,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("SPARK-34808: Remove left join if it only has distinct on left side") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     val query = Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr)).select("x.b".attr))
     val correctAnswer = x.select("x.b".attr).groupBy("x.b".attr)("x.b".attr)
 
@@ -89,8 +89,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("SPARK-34808: Remove right join if it only has distinct on right side") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     val query = Distinct(x.join(y, RightOuter, Some("x.a".attr === "y.a".attr)).select("y.b".attr))
     val correctAnswer = y.select("y.b".attr).groupBy("y.b".attr)("y.b".attr)
 
@@ -98,8 +98,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("SPARK-34808: Should not remove left join if select 2 join sides") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     val query = Distinct(x.join(y, RightOuter, Some("x.a".attr === "y.a".attr))
       .select("x.b".attr, "y.c".attr))
     val correctAnswer = Aggregate(query.child.output, query.child.output, query.child)
@@ -108,8 +108,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("SPARK-34808: aggregateExpressions only contains groupingExpressions") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     comparePlans(
       Optimize.execute(
         Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
@@ -130,8 +130,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("SPARK-37292: Removes outer join if it only has DISTINCT on streamed side with alias") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     comparePlans(
       Optimize.execute(
         Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
@@ -153,8 +153,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
   }
 
   test("SPARK-38489: Aggregate.groupOnly support foldable expressions") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     comparePlans(
       Optimize.execute(
         Distinct(x.join(y, LeftOuter, Some("x.a".attr === "y.a".attr))
@@ -167,8 +167,8 @@ class AggregateOptimizeSuite extends AnalysisTest {
 
   test("SPARK-38886: Remove outer join if aggregate functions are duplicate agnostic on " +
     "streamed side") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     Seq((LeftOuter, "x", x), (RightOuter, "y", y)).foreach { case (joinType, t, streamed) =>
       comparePlans(Optimize.execute(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseProjectSuite.scala
@@ -38,25 +38,25 @@ class CollapseProjectSuite extends PlanTest {
 
   test("collapse two deterministic, independent projects into one") {
     val query = testRelation
-      .select(($"a" + 1).as(Symbol("a_plus_1")), $"b")
-      .select($"a_plus_1", ($"b" + 1).as(Symbol("b_plus_1")))
+      .select(($"a" + 1).as("a_plus_1"), $"b")
+      .select($"a_plus_1", ($"b" + 1).as("b_plus_1"))
 
     val optimized = Optimize.execute(query.analyze)
-    val correctAnswer = testRelation.select(($"a" + 1).as(Symbol("a_plus_1")),
-      ($"b" + 1).as(Symbol("b_plus_1"))).analyze
+    val correctAnswer = testRelation.select(($"a" + 1).as("a_plus_1"),
+      ($"b" + 1).as("b_plus_1")).analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("collapse two deterministic, dependent projects into one") {
     val query = testRelation
-      .select(($"a" + 1).as(Symbol("a_plus_1")), $"b")
-      .select(($"a_plus_1" + 1).as(Symbol("a_plus_2")), $"b")
+      .select(($"a" + 1).as("a_plus_1"), $"b")
+      .select(($"a_plus_1" + 1).as("a_plus_2"), $"b")
 
     val optimized = Optimize.execute(query.analyze)
 
     val correctAnswer = testRelation.select(
-      (($"a" + 1).as(Symbol("a_plus_1")) + 1).as(Symbol("a_plus_2")),
+      (($"a" + 1).as("a_plus_1") + 1).as("a_plus_2"),
       $"b").analyze
 
     comparePlans(optimized, correctAnswer)
@@ -64,8 +64,8 @@ class CollapseProjectSuite extends PlanTest {
 
   test("do not collapse nondeterministic projects") {
     val query = testRelation
-      .select(Rand(10).as(Symbol("rand")))
-      .select(($"rand" + 1).as(Symbol("rand1")), ($"rand" + 2).as(Symbol("rand2")))
+      .select(Rand(10).as("rand"))
+      .select(($"rand" + 1).as("rand1"), ($"rand" + 2).as("rand2"))
 
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = query.analyze
@@ -75,39 +75,39 @@ class CollapseProjectSuite extends PlanTest {
 
   test("collapse two nondeterministic, independent projects into one") {
     val query = testRelation
-      .select(Rand(10).as(Symbol("rand")))
-      .select(Rand(20).as(Symbol("rand2")))
+      .select(Rand(10).as("rand"))
+      .select(Rand(20).as("rand2"))
 
     val optimized = Optimize.execute(query.analyze)
 
     val correctAnswer = testRelation
-      .select(Rand(20).as(Symbol("rand2"))).analyze
+      .select(Rand(20).as("rand2")).analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("collapse one nondeterministic, one deterministic, independent projects into one") {
     val query = testRelation
-      .select(Rand(10).as(Symbol("rand")), $"a")
-      .select(($"a" + 1).as(Symbol("a_plus_1")))
+      .select(Rand(10).as("rand"), $"a")
+      .select(($"a" + 1).as("a_plus_1"))
 
     val optimized = Optimize.execute(query.analyze)
 
     val correctAnswer = testRelation
-      .select(($"a" + 1).as(Symbol("a_plus_1"))).analyze
+      .select(($"a" + 1).as("a_plus_1")).analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("collapse project into aggregate") {
     val query = testRelation
-      .groupBy($"a", $"b")(($"a" + 1).as(Symbol("a_plus_1")), $"b")
-      .select($"a_plus_1", ($"b" + 1).as(Symbol("b_plus_1")))
+      .groupBy($"a", $"b")(($"a" + 1).as("a_plus_1"), $"b")
+      .select($"a_plus_1", ($"b" + 1).as("b_plus_1"))
 
     val optimized = Optimize.execute(query.analyze)
 
     val correctAnswer = testRelation
-      .groupBy($"a", $"b")(($"a" + 1).as(Symbol("a_plus_1")), ($"b" + 1).as(Symbol("b_plus_1")))
+      .groupBy($"a", $"b")(($"a" + 1).as("a_plus_1"), ($"b" + 1).as("b_plus_1"))
       .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -115,8 +115,8 @@ class CollapseProjectSuite extends PlanTest {
 
   test("do not collapse common nondeterministic project and aggregate") {
     val query = testRelation
-      .groupBy($"a")($"a", Rand(10).as(Symbol("rand")))
-      .select(($"rand" + 1).as(Symbol("rand1")), ($"rand" + 2).as(Symbol("rand2")))
+      .groupBy($"a")($"a", Rand(10).as("rand"))
+      .select(($"rand" + 1).as("rand1"), ($"rand" + 2).as("rand2"))
 
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = query.analyze
@@ -176,45 +176,45 @@ class CollapseProjectSuite extends PlanTest {
 
   test("collapse redundant alias through limit") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"a" as Symbol("b")).limit(1).select($"b" as Symbol("c")).analyze
+    val query = relation.select($"a" as "b").limit(1).select($"b" as "c").analyze
     val optimized = Optimize.execute(query)
-    val expected = relation.select($"a" as Symbol("c")).limit(1).analyze
+    val expected = relation.select($"a" as "c").limit(1).analyze
     comparePlans(optimized, expected)
   }
 
   test("collapse redundant alias through local limit") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = LocalLimit(1, relation.select($"a" as Symbol("b")))
-      .select($"b" as Symbol("c")).analyze
+    val query = LocalLimit(1, relation.select($"a" as "b"))
+      .select($"b" as "c").analyze
     val optimized = Optimize.execute(query)
-    val expected = LocalLimit(1, relation.select($"a" as Symbol("c"))).analyze
+    val expected = LocalLimit(1, relation.select($"a" as "c")).analyze
     comparePlans(optimized, expected)
   }
 
   test("collapse redundant alias through repartition") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"a" as Symbol("b")).repartition(1)
-      .select($"b" as Symbol("c")).analyze
+    val query = relation.select($"a" as "b").repartition(1)
+      .select($"b" as "c").analyze
     val optimized = Optimize.execute(query)
-    val expected = relation.select($"a" as Symbol("c")).repartition(1).analyze
+    val expected = relation.select($"a" as "c").repartition(1).analyze
     comparePlans(optimized, expected)
   }
 
   test("collapse redundant alias through sample") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = Sample(0.0, 0.6, false, 11L, relation.select($"a" as Symbol("b")))
-      .select($"b" as Symbol("c")).analyze
+    val query = Sample(0.0, 0.6, false, 11L, relation.select($"a" as "b"))
+      .select($"b" as "c").analyze
     val optimized = Optimize.execute(query)
-    val expected = Sample(0.0, 0.6, false, 11L, relation.select($"a" as Symbol("c"))).analyze
+    val expected = Sample(0.0, 0.6, false, 11L, relation.select($"a" as "c")).analyze
     comparePlans(optimized, expected)
   }
 
   test("SPARK-36086: CollapseProject should keep output schema name") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val select = relation.select(($"a" + $"b").as(Symbol("c"))).analyze
+    val select = relation.select(($"a" + $"b").as("c")).analyze
     val query = Project(Seq(select.output.head.withName("C")), select)
     val optimized = Optimize.execute(query)
-    val expected = relation.select(($"a" + $"b").as(Symbol("C"))).analyze
+    val expected = relation.select(($"a" + $"b").as("C")).analyze
     comparePlans(optimized, expected)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseWindowSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CollapseWindowSuite.scala
@@ -42,28 +42,28 @@ class CollapseWindowSuite extends PlanTest {
 
   test("collapse two adjacent windows with the same partition/order") {
     val query = testRelation
-      .window(Seq(min(a).as(Symbol("min_a"))), partitionSpec1, orderSpec1)
-      .window(Seq(max(a).as(Symbol("max_a"))), partitionSpec1, orderSpec1)
-      .window(Seq(sum(b).as(Symbol("sum_b"))), partitionSpec1, orderSpec1)
-      .window(Seq(avg(b).as(Symbol("avg_b"))), partitionSpec1, orderSpec1)
+      .window(Seq(min(a).as("min_a")), partitionSpec1, orderSpec1)
+      .window(Seq(max(a).as("max_a")), partitionSpec1, orderSpec1)
+      .window(Seq(sum(b).as("sum_b")), partitionSpec1, orderSpec1)
+      .window(Seq(avg(b).as("avg_b")), partitionSpec1, orderSpec1)
 
     val analyzed = query.analyze
     val optimized = Optimize.execute(analyzed)
     assert(analyzed.output === optimized.output)
 
     val correctAnswer = testRelation.window(Seq(
-      min(a).as(Symbol("min_a")),
-      max(a).as(Symbol("max_a")),
-      sum(b).as(Symbol("sum_b")),
-      avg(b).as(Symbol("avg_b"))), partitionSpec1, orderSpec1)
+      min(a).as("min_a"),
+      max(a).as("max_a"),
+      sum(b).as("sum_b"),
+      avg(b).as("avg_b")), partitionSpec1, orderSpec1)
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("Don't collapse adjacent windows with different partitions or orders") {
     val query1 = testRelation
-      .window(Seq(min(a).as(Symbol("min_a"))), partitionSpec1, orderSpec1)
-      .window(Seq(max(a).as(Symbol("max_a"))), partitionSpec1, orderSpec2)
+      .window(Seq(min(a).as("min_a")), partitionSpec1, orderSpec1)
+      .window(Seq(max(a).as("max_a")), partitionSpec1, orderSpec2)
 
     val optimized1 = Optimize.execute(query1.analyze)
     val correctAnswer1 = query1.analyze
@@ -71,8 +71,8 @@ class CollapseWindowSuite extends PlanTest {
     comparePlans(optimized1, correctAnswer1)
 
     val query2 = testRelation
-      .window(Seq(min(a).as(Symbol("min_a"))), partitionSpec1, orderSpec1)
-      .window(Seq(max(a).as(Symbol("max_a"))), partitionSpec2, orderSpec1)
+      .window(Seq(min(a).as("min_a")), partitionSpec1, orderSpec1)
+      .window(Seq(max(a).as("max_a")), partitionSpec2, orderSpec1)
 
     val optimized2 = Optimize.execute(query2.analyze)
     val correctAnswer2 = query2.analyze
@@ -82,8 +82,8 @@ class CollapseWindowSuite extends PlanTest {
 
   test("Don't collapse adjacent windows with dependent columns") {
     val query = testRelation
-      .window(Seq(sum(a).as(Symbol("sum_a"))), partitionSpec1, orderSpec1)
-      .window(Seq(max($"sum_a").as(Symbol("max_sum_a"))), partitionSpec1, orderSpec1)
+      .window(Seq(sum(a).as("sum_a")), partitionSpec1, orderSpec1)
+      .window(Seq(max($"sum_a").as("max_sum_a")), partitionSpec1, orderSpec1)
       .analyze
 
     val expected = query.analyze
@@ -94,7 +94,7 @@ class CollapseWindowSuite extends PlanTest {
   test("Skip windows with empty window expressions") {
     val query = testRelation
       .window(Seq(), partitionSpec1, orderSpec1)
-      .window(Seq(sum(a).as(Symbol("sum_a"))), partitionSpec1, orderSpec1)
+      .window(Seq(sum(a).as("sum_a")), partitionSpec1, orderSpec1)
 
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = query.analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -288,14 +288,14 @@ class ColumnPruningSuite extends PlanTest {
 
     val originalQuery =
       testRelation
-        .groupBy($"a")($"a" as Symbol("c"), count($"b"))
+        .groupBy($"a")($"a" as "c", count($"b"))
         .select($"c")
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
         .select($"a")
-        .groupBy($"a")($"a" as Symbol("c")).analyze
+        .groupBy($"a")($"a" as "c").analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -320,7 +320,7 @@ class ColumnPruningSuite extends PlanTest {
 
   test("push down project past sort") {
     val testRelation = LocalRelation($"a".int, $"b".int, $"c".int)
-    val x = testRelation.subquery(Symbol("x"))
+    val x = testRelation.subquery("x")
 
     // push down valid
     val originalQuery = {
@@ -358,7 +358,7 @@ class ColumnPruningSuite extends PlanTest {
     val winExpr = windowExpr(count($"d"), winSpec)
 
     val originalQuery = input.groupBy($"a", $"c", $"d")($"a", $"c", $"d",
-      winExpr.as(Symbol("window"))).select($"a", $"c")
+      winExpr.as("window")).select($"a", $"c")
     val correctAnswer = input.select($"a", $"c", $"d").groupBy($"a", $"c", $"d")($"a", $"c").analyze
     val optimized = Optimize.execute(originalQuery.analyze)
 
@@ -371,11 +371,11 @@ class ColumnPruningSuite extends PlanTest {
     val winExpr = windowExpr(count($"b"), winSpec)
 
     val originalQuery =
-      input.select($"a", $"b", $"c", $"d", winExpr.as(Symbol("window")))
+      input.select($"a", $"b", $"c", $"d", winExpr.as("window"))
         .where($"window" > 1).select($"a", $"c")
     val correctAnswer =
       input.select($"a", $"b", $"c")
-        .window(winExpr.as(Symbol("window")) :: Nil, $"a" :: Nil, $"b".asc :: Nil)
+        .window(winExpr.as("window") :: Nil, $"a" :: Nil, $"b".asc :: Nil)
         .where($"window" > 1).select($"a", $"c").analyze
     val optimized = Optimize.execute(originalQuery.analyze)
 
@@ -388,7 +388,7 @@ class ColumnPruningSuite extends PlanTest {
     val winExpr = windowExpr(count($"b"), winSpec)
 
     val originalQuery = input.select($"a", $"b", $"c", $"d",
-      winExpr.as(Symbol("window"))).select($"a", $"c")
+      winExpr.as("window")).select($"a", $"c")
     val correctAnswer = input.select($"a", $"c").analyze
     val optimized = Optimize.execute(originalQuery.analyze)
 
@@ -437,16 +437,16 @@ class ColumnPruningSuite extends PlanTest {
 
   test("push project down into sample") {
     val testRelation = LocalRelation($"a".int, $"b".int, $"c".int)
-    val x = testRelation.subquery(Symbol("x"))
+    val x = testRelation.subquery("x")
 
     val query1 = Sample(0.0, 0.6, false, 11L, x).select($"a")
     val optimized1 = Optimize.execute(query1.analyze)
     val expected1 = Sample(0.0, 0.6, false, 11L, x.select($"a"))
     comparePlans(optimized1, expected1.analyze)
 
-    val query2 = Sample(0.0, 0.6, false, 11L, x).select($"a" as Symbol("aa"))
+    val query2 = Sample(0.0, 0.6, false, 11L, x).select($"a" as "aa")
     val optimized2 = Optimize.execute(query2.analyze)
-    val expected2 = Sample(0.0, 0.6, false, 11L, x.select($"a" as Symbol("aa")))
+    val expected2 = Sample(0.0, 0.6, false, 11L, x.select($"a" as "aa"))
     comparePlans(optimized2, expected2.analyze)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecimalAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/DecimalAggregatesSuite.scala
@@ -70,12 +70,12 @@ class DecimalAggregatesSuite extends PlanTest {
 
   test("Decimal Sum Aggregation over Window: Optimized") {
     val spec = windowSpec(Seq($"a"), Nil, UnspecifiedFrame)
-    val originalQuery = testRelation.select(windowExpr(sum($"a"), spec).as(Symbol("sum_a")))
+    val originalQuery = testRelation.select(windowExpr(sum($"a"), spec).as("sum_a"))
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .select($"a")
       .window(
-        Seq(MakeDecimal(windowExpr(sum(UnscaledValue($"a")), spec), 12, 1).as(Symbol("sum_a"))),
+        Seq(MakeDecimal(windowExpr(sum(UnscaledValue($"a")), spec), 12, 1).as("sum_a")),
         Seq($"a"),
         Nil)
       .select($"a", $"sum_a", $"sum_a")
@@ -96,13 +96,13 @@ class DecimalAggregatesSuite extends PlanTest {
 
   test("Decimal Average Aggregation over Window: Optimized") {
     val spec = windowSpec(Seq($"a"), Nil, UnspecifiedFrame)
-    val originalQuery = testRelation.select(windowExpr(avg($"a"), spec).as(Symbol("avg_a")))
+    val originalQuery = testRelation.select(windowExpr(avg($"a"), spec).as("avg_a"))
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .select($"a")
       .window(
         Seq((windowExpr(avg(UnscaledValue($"a")), spec) / 10.0).cast(DecimalType(6, 5))
-          .as(Symbol("avg_a"))),
+          .as("avg_a")),
         Seq($"a"),
         Nil)
       .select($"a", $"avg_a", $"avg_a")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateAggregateFilterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateAggregateFilterSuite.scala
@@ -34,10 +34,10 @@ class EliminateAggregateFilterSuite extends PlanTest {
 
   test("Eliminate Filter always is true") {
     val query = testRelation
-      .select(sumDistinct($"a", Some(Literal.TrueLiteral)).as(Symbol("result")))
+      .select(sumDistinct($"a", Some(Literal.TrueLiteral)).as("result"))
       .analyze
     val answer = testRelation
-      .select(sumDistinct($"a").as(Symbol("result")))
+      .select(sumDistinct($"a").as("result"))
       .analyze
     comparePlans(Optimize.execute(query), answer)
   }
@@ -45,20 +45,20 @@ class EliminateAggregateFilterSuite extends PlanTest {
   test("Eliminate Filter is foldable and always is true") {
     val query = testRelation
       .select(countDistinctWithFilter(GreaterThan(Literal(2), Literal(1)), $"a")
-        .as(Symbol("result")))
+        .as("result"))
       .analyze
     val answer = testRelation
-      .select(countDistinct($"a").as(Symbol("result")))
+      .select(countDistinct($"a").as("result"))
       .analyze
     comparePlans(Optimize.execute(query), answer)
   }
 
   test("Eliminate Filter always is false") {
     val query = testRelation
-      .select(sumDistinct($"a", Some(Literal.FalseLiteral)).as(Symbol("result")))
+      .select(sumDistinct($"a", Some(Literal.FalseLiteral)).as("result"))
       .analyze
     val answer = testRelation
-      .groupBy()(Literal.create(null, LongType).as(Symbol("result")))
+      .groupBy()(Literal.create(null, LongType).as("result"))
       .analyze
     comparePlans(Optimize.execute(query), answer)
   }
@@ -66,10 +66,10 @@ class EliminateAggregateFilterSuite extends PlanTest {
   test("Eliminate Filter is foldable and always is false") {
     val query = testRelation
       .select(countDistinctWithFilter(GreaterThan(Literal(1), Literal(2)), $"a")
-        .as(Symbol("result")))
+        .as("result"))
       .analyze
     val answer = testRelation
-      .groupBy()(Literal.create(0L, LongType).as(Symbol("result")))
+      .groupBy()(Literal.create(0L, LongType).as("result"))
       .analyze
     comparePlans(Optimize.execute(query), answer)
   }
@@ -77,11 +77,11 @@ class EliminateAggregateFilterSuite extends PlanTest {
   test("SPARK-38177: Eliminate Filter in non-root node") {
     val query = testRelation
       .select(countDistinctWithFilter(GreaterThan(Literal(1), Literal(2)), $"a")
-        .as(Symbol("result")))
+        .as("result"))
       .limit(1)
       .analyze
     val answer = testRelation
-      .groupBy()(Literal.create(0L, LongType).as(Symbol("result")))
+      .groupBy()(Literal.create(0L, LongType).as("result"))
       .limit(1)
       .analyze
     comparePlans(Optimize.execute(query), answer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateDistinctSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateDistinctSuite.scala
@@ -50,10 +50,10 @@ class EliminateDistinctSuite extends PlanTest {
       val agg = aggBuilder($"a")
       test(s"Eliminate Distinct in $agg") {
         val query = testRelation
-          .select(agg.toAggregateExpression(isDistinct = true).as(Symbol("result")))
+          .select(agg.toAggregateExpression(isDistinct = true).as("result"))
           .analyze
         val answer = testRelation
-          .select(agg.toAggregateExpression(isDistinct = false).as(Symbol("result")))
+          .select(agg.toAggregateExpression(isDistinct = false).as("result"))
           .analyze
         assert(query != answer)
         comparePlans(Optimize.execute(query), answer)
@@ -61,11 +61,11 @@ class EliminateDistinctSuite extends PlanTest {
 
       test(s"SPARK-38177: Eliminate Distinct in non-root $agg") {
         val query = testRelation
-          .select(agg.toAggregateExpression(isDistinct = true).as(Symbol("result")))
+          .select(agg.toAggregateExpression(isDistinct = true).as("result"))
           .limit(1)
           .analyze
         val answer = testRelation
-          .select(agg.toAggregateExpression(isDistinct = false).as(Symbol("result")))
+          .select(agg.toAggregateExpression(isDistinct = false).as("result"))
           .limit(1)
           .analyze
         assert(query != answer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/EliminateSortsSuite.scala
@@ -97,11 +97,11 @@ class EliminateSortsSuite extends AnalysisTest {
   test("Remove no-op alias") {
     val x = testRelation
 
-    val query = x.select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
+    val query = x.select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
       .orderBy($"x".asc, $"y".asc, $"b".desc)
     val optimized = Optimize.execute(analyzer.execute(query))
     val correctAnswer = analyzer.execute(
-      x.select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
+      x.select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
         .orderBy($"x".asc, $"b".desc))
 
     comparePlans(optimized, correctAnswer)
@@ -248,10 +248,10 @@ class EliminateSortsSuite extends AnalysisTest {
       testRelation.select($"b").where($"b" > Literal(0)).orderBy($"b".desc).analyze
     comparePlans(optimizedWithBoth, correctAnswerWithBoth)
 
-    val orderedThrice = orderedTwiceWithBoth.select(($"b" + 1).as(Symbol("c"))).orderBy($"c".asc)
+    val orderedThrice = orderedTwiceWithBoth.select(($"b" + 1).as("c")).orderBy($"c".asc)
     val optimizedThrice = Optimize.execute(orderedThrice.analyze)
     val correctAnswerThrice = testRelation.select($"b").where($"b" > Literal(0))
-      .select(($"b" + 1).as(Symbol("c"))).orderBy($"c".asc).analyze
+      .select(($"b" + 1).as("c")).orderBy($"c".asc).analyze
     comparePlans(optimizedThrice, correctAnswerThrice)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownOnePassSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownOnePassSuite.scala
@@ -46,8 +46,8 @@ class FilterPushdownOnePassSuite extends PlanTest {
   val testRelation2 = LocalRelation($"a".int, $"d".int, $"e".int)
 
   test("really simple predicate push down") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y = testRelation2.subquery(Symbol("y"))
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
 
     val originalQuery = x.join(y).where("x.a".attr === 1)
 
@@ -58,8 +58,8 @@ class FilterPushdownOnePassSuite extends PlanTest {
   }
 
   test("push down conjunctive predicates") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y = testRelation2.subquery(Symbol("y"))
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
 
     val originalQuery = x.join(y).where("x.a".attr === 1 && "y.d".attr < 1)
 
@@ -70,8 +70,8 @@ class FilterPushdownOnePassSuite extends PlanTest {
   }
 
   test("push down predicates for simple joins") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y = testRelation2.subquery(Symbol("y"))
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
 
     val originalQuery =
       x.where("x.c".attr < 0)
@@ -87,8 +87,8 @@ class FilterPushdownOnePassSuite extends PlanTest {
   }
 
   test("push down top-level filters for cascading joins") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y = testRelation2.subquery(Symbol("y"))
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
 
     val originalQuery =
       y.join(x).join(x).join(x).join(x).join(x).where("y.d".attr === 0)
@@ -100,9 +100,9 @@ class FilterPushdownOnePassSuite extends PlanTest {
   }
 
   test("push down predicates for tree-like joins") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y1 = testRelation2.subquery(Symbol("y1"))
-    val y2 = testRelation2.subquery(Symbol("y2"))
+    val x = testRelation1.subquery("x")
+    val y1 = testRelation2.subquery("y1")
+    val y2 = testRelation2.subquery("y2")
 
     val originalQuery =
       y1.join(x).join(x)
@@ -118,8 +118,8 @@ class FilterPushdownOnePassSuite extends PlanTest {
   }
 
   test("push down through join and project") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y = testRelation2.subquery(Symbol("y"))
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
 
     val originalQuery =
       x.where($"a" > 0).select($"a", $"b")
@@ -135,40 +135,40 @@ class FilterPushdownOnePassSuite extends PlanTest {
   }
 
   test("push down through deep projects") {
-    val x = testRelation1.subquery(Symbol("x"))
+    val x = testRelation1.subquery("x")
 
     val originalQuery =
-      x.select(($"a" + 1) as Symbol("a1"), $"b")
-        .select(($"a1" + 1) as Symbol("a2"), $"b")
-        .select(($"a2" + 1) as Symbol("a3"), $"b")
-        .select(($"a3" + 1) as Symbol("a4"), $"b")
+      x.select(($"a" + 1) as "a1", $"b")
+        .select(($"a1" + 1) as "a2", $"b")
+        .select(($"a2" + 1) as "a3", $"b")
+        .select(($"a3" + 1) as "a4", $"b")
         .select($"b")
         .where($"b" > 0)
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       x.where($"b" > 0)
-        .select(($"a" + 1) as Symbol("a1"), $"b")
-        .select(($"a1" + 1) as Symbol("a2"), $"b")
-        .select(($"a2" + 1) as Symbol("a3"), $"b")
-        .select(($"a3" + 1) as Symbol("a4"), $"b")
+        .select(($"a" + 1) as "a1", $"b")
+        .select(($"a1" + 1) as "a2", $"b")
+        .select(($"a2" + 1) as "a3", $"b")
+        .select(($"a3" + 1) as "a4", $"b")
         .select($"b").analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("push down through aggregate and join") {
-    val x = testRelation1.subquery(Symbol("x"))
-    val y = testRelation2.subquery(Symbol("y"))
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
 
     val left = x
       .where($"c" > 0)
       .groupBy($"a")($"a", count($"b"))
-      .subquery(Symbol("left"))
+      .subquery("left")
     val right = y
       .where($"d" < 0)
       .groupBy($"a")($"a", count($"d"))
-      .subquery(Symbol("right"))
+      .subquery("right")
     val originalQuery = left
       .join(right).where("left.a".attr < 100 && "right.a".attr < 100)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -58,8 +58,8 @@ class FilterPushdownSuite extends PlanTest {
   val simpleDisjunctivePredicate =
     ("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11)
   val expectedPredicatePushDownResult = {
-    val left = testRelation.where(($"a" > 3 || $"a" > 1)).subquery(Symbol("x"))
-    val right = testRelation.where($"a" > 13 || $"a" > 11).subquery(Symbol("y"))
+    val left = testRelation.where(($"a" > 3 || $"a" > 1)).subquery("x")
+    val right = testRelation.where($"a" > 13 || $"a" > 11).subquery("y")
     left.join(right, condition = Some("x.b".attr === "y.b".attr
       && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11)))).analyze
   }
@@ -68,7 +68,7 @@ class FilterPushdownSuite extends PlanTest {
   test("eliminate subqueries") {
     val originalQuery =
       testRelation
-        .subquery(Symbol("y"))
+        .subquery("y")
         .select($"a")
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -150,7 +150,7 @@ class FilterPushdownSuite extends PlanTest {
   test("can't push without rewrite") {
     val originalQuery =
       testRelation
-        .select($"a" + $"b" as Symbol("e"))
+        .select($"a" + $"b" as "e")
         .where($"e" === 1)
         .analyze
 
@@ -158,7 +158,7 @@ class FilterPushdownSuite extends PlanTest {
     val correctAnswer =
       testRelation
         .where($"a" + $"b" === 1)
-        .select($"a" + $"b" as Symbol("e"))
+        .select($"a" + $"b" as "e")
         .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -182,7 +182,7 @@ class FilterPushdownSuite extends PlanTest {
 
   test("nondeterministic: can't push down filter through project with nondeterministic field") {
     val originalQuery = testRelation
-      .select(Rand(10).as(Symbol("rand")), $"a")
+      .select(Rand(10).as("rand"), $"a")
       .where($"a" > 5)
       .analyze
 
@@ -193,7 +193,7 @@ class FilterPushdownSuite extends PlanTest {
 
   test("nondeterministic: can't push down filter through aggregate with nondeterministic field") {
     val originalQuery = testRelation
-      .groupBy($"a")($"a", Rand(10).as(Symbol("rand")))
+      .groupBy($"a")($"a", Rand(10).as("rand"))
       .where($"a" > 5)
       .analyze
 
@@ -235,8 +235,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push to either side") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y)
@@ -254,8 +254,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push to one side") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y)
@@ -272,8 +272,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: do not push down non-deterministic filters into join condition") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery = x.join(y).where(Rand(10) > 5.0).analyze
     val optimized = Optimize.execute(originalQuery)
@@ -282,8 +282,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push to one side after transformCondition") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery = {
       x.join(y)
@@ -301,8 +301,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: rewrite filter to push to either side") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y)
@@ -319,8 +319,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down left semi join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery = {
       x.join(y, LeftSemi, Option("x.a".attr === "y.d".attr && "x.b".attr >= 1 && "y.d".attr >= 2))
@@ -336,8 +336,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down left outer join #1") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, LeftOuter)
@@ -353,8 +353,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down right outer join #1") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, RightOuter)
@@ -362,7 +362,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val right = testRelation.where($"b" === 2).subquery(Symbol("d"))
+    val right = testRelation.where($"b" === 2).subquery("d")
     val correctAnswer =
       x.join(right, RightOuter).where("x.b".attr === 1).analyze
 
@@ -370,8 +370,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down left outer join #2") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, LeftOuter, Some("x.b".attr === 1))
@@ -379,7 +379,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"b" === 2).subquery(Symbol("d"))
+    val left = testRelation.where($"b" === 2).subquery("d")
     val correctAnswer =
       left.join(y, LeftOuter, Some("d.b".attr === 1)).where("y.b".attr === 2).analyze
 
@@ -387,8 +387,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down right outer join #2") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, RightOuter, Some("y.b".attr === 1))
@@ -396,7 +396,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val right = testRelation.where($"b" === 2).subquery(Symbol("d"))
+    val right = testRelation.where($"b" === 2).subquery("d")
     val correctAnswer =
       x.join(right, RightOuter, Some("d.b".attr === 1)).where("x.b".attr === 2).analyze
 
@@ -404,8 +404,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down left outer join #3") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, LeftOuter, Some("y.b".attr === 1))
@@ -413,8 +413,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"b" === 2).subquery(Symbol("l"))
-    val right = testRelation.where($"b" === 1).subquery(Symbol("r"))
+    val left = testRelation.where($"b" === 2).subquery("l")
+    val right = testRelation.where($"b" === 1).subquery("r")
     val correctAnswer =
       left.join(right, LeftOuter).where("r.b".attr === 2).analyze
 
@@ -422,8 +422,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down right outer join #3") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, RightOuter, Some("y.b".attr === 1))
@@ -431,7 +431,7 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val right = testRelation.where($"b" === 2).subquery(Symbol("r"))
+    val right = testRelation.where($"b" === 2).subquery("r")
     val correctAnswer =
       x.join(right, RightOuter, Some("r.b".attr === 1)).where("x.b".attr === 2).analyze
 
@@ -439,8 +439,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down left outer join #4") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, LeftOuter, Some("y.b".attr === 1))
@@ -448,8 +448,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"b" === 2).subquery(Symbol("l"))
-    val right = testRelation.where($"b" === 1).subquery(Symbol("r"))
+    val left = testRelation.where($"b" === 2).subquery("l")
+    val right = testRelation.where($"b" === 1).subquery("r")
     val correctAnswer =
       left.join(right, LeftOuter).where("r.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
 
@@ -457,8 +457,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down right outer join #4") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, RightOuter, Some("y.b".attr === 1))
@@ -466,8 +466,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.subquery(Symbol("l"))
-    val right = testRelation.where($"b" === 2).subquery(Symbol("r"))
+    val left = testRelation.subquery("l")
+    val right = testRelation.where($"b" === 2).subquery("r")
     val correctAnswer =
       left.join(right, RightOuter, Some("r.b".attr === 1)).
         where("l.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
@@ -476,8 +476,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down left outer join #5") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, LeftOuter, Some("y.b".attr === 1 && "x.a".attr === 3))
@@ -485,8 +485,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"b" === 2).subquery(Symbol("l"))
-    val right = testRelation.where($"b" === 1).subquery(Symbol("r"))
+    val left = testRelation.where($"b" === 2).subquery("l")
+    val right = testRelation.where($"b" === 1).subquery("r")
     val correctAnswer =
       left.join(right, LeftOuter, Some("l.a".attr===3)).
         where("r.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
@@ -495,8 +495,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down right outer join #5") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, RightOuter, Some("y.b".attr === 1 && "x.a".attr === 3))
@@ -504,8 +504,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"a" === 3).subquery(Symbol("l"))
-    val right = testRelation.where($"b" === 2).subquery(Symbol("r"))
+    val left = testRelation.where($"a" === 3).subquery("l")
+    val right = testRelation.where($"b" === 2).subquery("r")
     val correctAnswer =
       left.join(right, RightOuter, Some("r.b".attr === 1)).
         where("l.b".attr === 2 && "l.c".attr === "r.c".attr).analyze
@@ -514,8 +514,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: can't push down") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y, condition = Some("x.b".attr === "y.b".attr))
@@ -526,8 +526,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: conjunctive predicates") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y)
@@ -535,8 +535,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"a" === 1).subquery(Symbol("x"))
-    val right = testRelation.where($"a" === 1).subquery(Symbol("y"))
+    val left = testRelation.where($"a" === 1).subquery("x")
+    val right = testRelation.where($"a" === 1).subquery("y")
     val correctAnswer =
       left.join(right, condition = Some("x.b".attr === "y.b".attr))
         .analyze
@@ -545,8 +545,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: conjunctive predicates #2") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = {
       x.join(y)
@@ -554,8 +554,8 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"a" === 1).subquery(Symbol("x"))
-    val right = testRelation.subquery(Symbol("y"))
+    val left = testRelation.where($"a" === 1).subquery("x")
+    val right = testRelation.subquery("y")
     val correctAnswer =
       left.join(right, condition = Some("x.b".attr === "y.b".attr))
         .analyze
@@ -564,9 +564,9 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: conjunctive predicates #3") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
-    val z = testRelation.subquery(Symbol("z"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
+    val z = testRelation.subquery("z")
 
     val originalQuery = {
       z.join(x.join(y))
@@ -575,9 +575,9 @@ class FilterPushdownSuite extends PlanTest {
     }
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val lleft = testRelation.where($"a" >= 3).subquery(Symbol("z"))
-    val left = testRelation.where($"a" === 1).subquery(Symbol("x"))
-    val right = testRelation.subquery(Symbol("y"))
+    val lleft = testRelation.where($"a" >= 3).subquery("z")
+    val left = testRelation.where($"a" === 1).subquery("x")
+    val right = testRelation.subquery("y")
     val correctAnswer =
       lleft.join(
         left.join(right, condition = Some("x.b".attr === "y.b".attr)),
@@ -588,8 +588,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: push down where clause into left anti join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     val originalQuery =
       x.join(y, LeftAnti, Some("x.b".attr === "y.b".attr))
         .where("x.a".attr > 10)
@@ -603,8 +603,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: only push down join conditions to the right of a left anti join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     val originalQuery =
       x.join(y,
         LeftAnti,
@@ -620,8 +620,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("joins: only push down join conditions to the right of an existence join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
     val fillerVal = $"val".boolean
     val originalQuery =
       x.join(y,
@@ -715,7 +715,7 @@ class FilterPushdownSuite extends PlanTest {
 
   test("aggregate: push down filter when filter on group by expression") {
     val originalQuery = testRelation
-                        .groupBy($"a")($"a", count($"b") as Symbol("c"))
+                        .groupBy($"a")($"a", count($"b") as "c")
                         .select($"a", $"c")
                         .where($"a" === 2)
 
@@ -723,7 +723,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val correctAnswer = testRelation
                         .where($"a" === 2)
-                        .groupBy($"a")($"a", count($"b") as Symbol("c"))
+                        .groupBy($"a")($"a", count($"b") as "c")
                         .analyze
     comparePlans(optimized, correctAnswer)
   }
@@ -731,7 +731,7 @@ class FilterPushdownSuite extends PlanTest {
   test("aggregate: don't push down filter when filter not on group by expression") {
     val originalQuery = testRelation
                         .select($"a", $"b")
-                        .groupBy($"a")($"a", count($"b") as Symbol("c"))
+                        .groupBy($"a")($"a", count($"b") as "c")
                         .where($"c" === 2L)
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -742,7 +742,7 @@ class FilterPushdownSuite extends PlanTest {
   test("aggregate: push down filters partially which are subset of group by expressions") {
     val originalQuery = testRelation
                         .select($"a", $"b")
-                        .groupBy($"a")($"a", count($"b") as Symbol("c"))
+                        .groupBy($"a")($"a", count($"b") as "c")
                         .where($"c" === 2L && $"a" === 3)
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -750,7 +750,7 @@ class FilterPushdownSuite extends PlanTest {
     val correctAnswer = testRelation
                         .where($"a" === 3)
                         .select($"a", $"b")
-                        .groupBy($"a")($"a", count($"b") as Symbol("c"))
+                        .groupBy($"a")($"a", count($"b") as "c")
                         .where($"c" === 2L)
                         .analyze
 
@@ -760,7 +760,7 @@ class FilterPushdownSuite extends PlanTest {
   test("aggregate: push down filters with alias") {
     val originalQuery = testRelation
       .select($"a", $"b")
-      .groupBy($"a")(($"a" + 1) as Symbol("aa"), count($"b") as Symbol("c"))
+      .groupBy($"a")(($"a" + 1) as "aa", count($"b") as "c")
       .where(($"c" === 2L || $"aa" > 4) && $"aa" < 3)
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -768,7 +768,7 @@ class FilterPushdownSuite extends PlanTest {
     val correctAnswer = testRelation
       .where($"a" + 1 < 3)
       .select($"a", $"b")
-      .groupBy($"a")(($"a" + 1) as Symbol("aa"), count($"b") as Symbol("c"))
+      .groupBy($"a")(($"a" + 1) as "aa", count($"b") as "c")
       .where($"c" === 2L || $"aa" > 4)
       .analyze
 
@@ -778,7 +778,7 @@ class FilterPushdownSuite extends PlanTest {
   test("aggregate: push down filters with literal") {
     val originalQuery = testRelation
       .select($"a", $"b")
-      .groupBy($"a")($"a", count($"b") as Symbol("c"), "s" as Symbol("d"))
+      .groupBy($"a")($"a", count($"b") as "c", "s" as "d")
       .where($"c" === 2L && $"d" === "s")
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -786,7 +786,7 @@ class FilterPushdownSuite extends PlanTest {
     val correctAnswer = testRelation
       .where("s" === "s")
       .select($"a", $"b")
-      .groupBy($"a")($"a", count($"b") as Symbol("c"), "s" as Symbol("d"))
+      .groupBy($"a")($"a", count($"b") as "c", "s" as "d")
       .where($"c" === 2L)
       .analyze
 
@@ -796,7 +796,7 @@ class FilterPushdownSuite extends PlanTest {
   test("aggregate: don't push down filters that are nondeterministic") {
     val originalQuery = testRelation
       .select($"a", $"b")
-      .groupBy($"a")($"a" + Rand(10) as Symbol("aa"), count($"b") as Symbol("c"),
+      .groupBy($"a")($"a" + Rand(10) as "aa", count($"b") as "c",
         Rand(11).as("rnd"))
       .where($"c" === 2L && $"aa" + Rand(10).as("rnd") === 3 && $"rnd" === 5)
 
@@ -804,7 +804,7 @@ class FilterPushdownSuite extends PlanTest {
 
     val correctAnswer = testRelation
       .select($"a", $"b")
-      .groupBy($"a")($"a" + Rand(10) as Symbol("aa"), count($"b") as Symbol("c"),
+      .groupBy($"a")($"a" + Rand(10) as "aa", count($"b") as "c",
         Rand(11).as("rnd"))
       .where($"c" === 2L && $"aa" + Rand(10).as("rnd") === 3 && $"rnd" === 5)
       .analyze
@@ -898,9 +898,9 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("predicate subquery: push down simple") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
-    val z = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("z"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
+    val z = LocalRelation($"a".int, $"b".int, $"c".int).subquery("z")
 
     val query = x
       .join(y, Inner, Option("x.a".attr === "y.a".attr))
@@ -915,10 +915,10 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("predicate subquery: push down complex") {
-    val w = testRelation.subquery(Symbol("w"))
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
-    val z = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("z"))
+    val w = testRelation.subquery("w")
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
+    val z = LocalRelation($"a".int, $"b".int, $"c".int).subquery("z")
 
     val query = w
       .join(x, Inner, Option("w.a".attr === "x.a".attr))
@@ -935,9 +935,9 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("SPARK-20094: don't push predicate with IN subquery into join condition") {
-    val x = testRelation.subquery(Symbol("x"))
-    val z = testRelation.subquery(Symbol("z"))
-    val w = testRelation1.subquery(Symbol("w"))
+    val x = testRelation.subquery("x")
+    val z = testRelation.subquery("z")
+    val w = testRelation1.subquery("w")
 
     val queryPlan = x
       .join(z)
@@ -959,10 +959,10 @@ class FilterPushdownSuite extends PlanTest {
       windowSpec($"a" :: Nil, $"b".asc :: Nil, UnspecifiedFrame))
 
     val originalQuery = testRelation.select($"a", $"b", $"c",
-      winExpr.as(Symbol("window"))).where($"a" > 1)
+      winExpr.as("window")).where($"a" > 1)
     val correctAnswer = testRelation
       .where($"a" > 1).select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a" :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a" :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -974,10 +974,10 @@ class FilterPushdownSuite extends PlanTest {
         windowSpec($"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil, UnspecifiedFrame))
 
     val originalQuery = testRelation.select($"a", $"b", $"c",
-      winExpr.as(Symbol("window"))).where($"a" * 3 > 15)
+      winExpr.as("window")).where($"a" * 3 > 15)
     val correctAnswer = testRelation
       .where($"a" * 3 > 15).select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -988,12 +988,12 @@ class FilterPushdownSuite extends PlanTest {
     val winExpr1 = windowExpr(count($"b"), winSpec)
     val winExpr2 = windowExpr(sum($"b"), winSpec)
     val originalQuery = testRelation
-      .select($"a", $"b", $"c", winExpr1.as(Symbol("window1")), winExpr2.as(Symbol("window2")))
+      .select($"a", $"b", $"c", winExpr1.as("window1"), winExpr2.as("window2"))
       .where($"a" > 1)
 
     val correctAnswer = testRelation
       .where($"a" > 1).select($"a", $"b", $"c")
-      .window(winExpr1.as(Symbol("window1")) :: winExpr2.as(Symbol("window2")) :: Nil,
+      .window(winExpr1.as("window1") :: winExpr2.as("window2") :: Nil,
         $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window1", $"window2").analyze
 
@@ -1007,19 +1007,19 @@ class FilterPushdownSuite extends PlanTest {
     val winSpec2 = windowSpec($"a".attr :: $"b".attr :: Nil, $"a".asc :: Nil, UnspecifiedFrame)
     val winExpr2 = windowExpr(count($"b"), winSpec2)
     val originalQuery = testRelation
-      .select($"a", $"b", $"c", winExpr1.as(Symbol("window1")), winExpr2.as(Symbol("window2")))
+      .select($"a", $"b", $"c", winExpr1.as("window1"), winExpr2.as("window2"))
       .where($"a" > 1)
 
     val correctAnswer1 = testRelation
       .where($"a" > 1).select($"a", $"b", $"c")
-      .window(winExpr1.as(Symbol("window1")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
-      .window(winExpr2.as(Symbol("window2")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"a".asc :: Nil)
+      .window(winExpr1.as("window1") :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr2.as("window2") :: Nil, $"a".attr :: $"b".attr :: Nil, $"a".asc :: Nil)
       .select($"a", $"b", $"c", $"window1", $"window2").analyze
 
     val correctAnswer2 = testRelation
       .where($"a" > 1).select($"a", $"b", $"c")
-      .window(winExpr2.as(Symbol("window2")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"a".asc :: Nil)
-      .window(winExpr1.as(Symbol("window1")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr2.as("window2") :: Nil, $"a".attr :: $"b".attr :: Nil, $"a".asc :: Nil)
+      .window(winExpr1.as("window1") :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window1", $"window2").analyze
 
     // When Analyzer adding Window operators after grouping the extracted Window Expressions
@@ -1040,18 +1040,18 @@ class FilterPushdownSuite extends PlanTest {
     val winSpec2 = windowSpec($"b".attr :: Nil, $"b".asc :: Nil, UnspecifiedFrame)
     val winExpr2 = windowExpr(count($"a"), winSpec2)
     val originalQuery = testRelation
-      .select($"a", winExpr1.as(Symbol("window1")), $"b", $"c", winExpr2.as(Symbol("window2")))
+      .select($"a", winExpr1.as("window1"), $"b", $"c", winExpr2.as("window2"))
       .where($"b" > 1)
 
     val correctAnswer1 = testRelation.select($"a", $"b", $"c")
-      .window(winExpr1.as(Symbol("window1")) :: Nil, $"a".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr1.as("window1") :: Nil, $"a".attr :: Nil, $"b".asc :: Nil)
       .where($"b" > 1)
-      .window(winExpr2.as(Symbol("window2")) :: Nil, $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr2.as("window2") :: Nil, $"b".attr :: Nil, $"b".asc :: Nil)
       .select($"a", $"window1", $"b", $"c", $"window2").analyze
 
     val correctAnswer2 = testRelation.select($"a", $"b", $"c")
-      .window(winExpr2.as(Symbol("window2")) :: Nil, $"b".attr :: Nil, $"b".asc :: Nil)
-      .window(winExpr1.as(Symbol("window1")) :: Nil, $"a".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr2.as("window2") :: Nil, $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr1.as("window1") :: Nil, $"a".attr :: Nil, $"b".asc :: Nil)
       .where($"b" > 1)
       .select($"a", $"window1", $"b", $"c", $"window2").analyze
 
@@ -1071,11 +1071,11 @@ class FilterPushdownSuite extends PlanTest {
       windowExpr(count($"b"),
         windowSpec($"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil, UnspecifiedFrame))
 
-    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as("window"))
       .where($"a" + $"b" > 1)
     val correctAnswer = testRelation
       .where($"a" + $"b" > 1).select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -1097,11 +1097,11 @@ class FilterPushdownSuite extends PlanTest {
       UnspecifiedFrame)
     val winExprAnalyzed = windowExpr(count($"b"), winSpecAnalyzed)
 
-    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as("window"))
       .where($"a" + $"b" > 1)
     val correctAnswer = testRelation
       .where($"a" + $"b" > 1).select($"a", $"b", $"c", ($"a" + $"b").as("_w0"))
-      .window(winExprAnalyzed.as(Symbol("window")) :: Nil, $"_w0" :: Nil, $"b".asc :: Nil)
+      .window(winExprAnalyzed.as("window") :: Nil, $"_w0" :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -1115,10 +1115,10 @@ class FilterPushdownSuite extends PlanTest {
     val winExpr = windowExpr(count($"b"), winSpec)
 
     // No push down: the predicate is c > 1, but the partitioning key is (a, b).
-    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as("window"))
       .where($"c" > 1)
     val correctAnswer = testRelation.select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a".attr :: $"b".attr :: Nil, $"b".asc :: Nil)
       .where($"c" > 1).select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -1132,7 +1132,7 @@ class FilterPushdownSuite extends PlanTest {
     val winExpr = windowExpr(count($"b"), winSpec)
 
     // No push down: the predicate is a > 1, but the partitioning key is (a + b, b)
-    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as("window"))
       .where($"a" > 1)
 
     val winSpecAnalyzed = windowSpec(
@@ -1142,7 +1142,7 @@ class FilterPushdownSuite extends PlanTest {
     val winExprAnalyzed = windowExpr(count($"b"), winSpecAnalyzed)
     val correctAnswer = testRelation.select($"a", $"b", $"c", ($"a" + $"b").as("_w0"))
       .window(
-        winExprAnalyzed.as(Symbol("window")) :: Nil, $"_w0" :: $"b".attr :: Nil, $"b".asc :: Nil)
+        winExprAnalyzed.as("window") :: Nil, $"_w0" :: $"b".attr :: Nil, $"b".asc :: Nil)
       .where($"a" > 1).select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -1154,11 +1154,11 @@ class FilterPushdownSuite extends PlanTest {
     val winExpr = windowExpr(count($"b"), winSpec)
 
     // No push down: the predicate is a + b > 1, but the partitioning key is b.
-    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as("window"))
       .where($"a" + $"b" > 1)
     val correctAnswer = testRelation
       .select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"b".attr :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"b".attr :: Nil, $"b".asc :: Nil)
       .where($"a" + $"b" > 1).select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -1179,10 +1179,10 @@ class FilterPushdownSuite extends PlanTest {
     val winExprAnalyzed = windowExpr(count($"b"), winSpecAnalyzed)
 
     // No push down: the predicate is a + b > 1, but the partitioning key is a + b.
-    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+    val originalQuery = testRelation.select($"a", $"b", $"c", winExpr.as("window"))
       .where($"a" - $"b" > 1)
     val correctAnswer = testRelation.select($"a", $"b", $"c", ($"a" + $"b").as("_w0"))
-      .window(winExprAnalyzed.as(Symbol("window")) :: Nil, $"_w0" :: Nil, $"b".asc :: Nil)
+      .window(winExprAnalyzed.as("window") :: Nil, $"_w0" :: Nil, $"b".asc :: Nil)
       .where($"a" - $"b" > 1).select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
@@ -1292,8 +1292,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("push down filter predicates through inner join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery = x.join(y).where(("x.b".attr === "y.b".attr) && (simpleDisjunctivePredicate))
 
@@ -1302,8 +1302,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("push down join predicates through inner join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery =
       x.join(y, condition = Some(("x.b".attr === "y.b".attr) && (simpleDisjunctivePredicate)))
@@ -1313,8 +1313,8 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("push down complex predicates through inner join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val joinCondition = (("x.b".attr === "y.b".attr)
       && ((("x.a".attr === 5) && ("y.a".attr >= 2) && ("y.a".attr <= 3))
@@ -1324,18 +1324,18 @@ class FilterPushdownSuite extends PlanTest {
     val originalQuery = x.join(y, condition = Some(joinCondition))
     val optimized = Optimize.execute(originalQuery.analyze)
     val left = testRelation.where(
-      ($"a" === 5 || $"a" === 2 || $"a" === 1)).subquery(Symbol("x"))
+      ($"a" === 5 || $"a" === 2 || $"a" === 1)).subquery("x")
     val right = testRelation.where(
       ($"a" >= 2 && $"a" <= 3) || ($"a" >= 1 && $"a" <= 14) || ($"a" >= 9 && $"a" <= 27))
-      .subquery(Symbol("y"))
+      .subquery("y")
     val correctAnswer = left.join(right, condition = Some(joinCondition)).analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("push down predicates(with NOT predicate) through inner join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery =
       x.join(y, condition = Some(("x.b".attr === "y.b".attr)
@@ -1343,8 +1343,8 @@ class FilterPushdownSuite extends PlanTest {
         && ("x.a".attr < 2 || ("y.a".attr > 13)) || ("x.a".attr > 1) && ("y.a".attr > 11))))
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"a" <= 3 || $"a" >= 2).subquery(Symbol("x"))
-    val right = testRelation.subquery(Symbol("y"))
+    val left = testRelation.where($"a" <= 3 || $"a" >= 2).subquery("x")
+    val right = testRelation.subquery("y")
     val correctAnswer =
       left.join(right, condition = Some("x.b".attr === "y.b".attr
         && (("x.a".attr <= 3) || (("x.a".attr >= 2) && ("y.a".attr <= 13)))
@@ -1354,16 +1354,16 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("push down predicates through left join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery =
       x.join(y, joinType = LeftOuter, condition = Some(("x.b".attr === "y.b".attr)
         && simpleDisjunctivePredicate))
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.subquery(Symbol("x"))
-    val right = testRelation.where($"a" > 13 || $"a" > 11).subquery(Symbol("y"))
+    val left = testRelation.subquery("x")
+    val right = testRelation.where($"a" > 13 || $"a" > 11).subquery("y")
     val correctAnswer =
       left.join(right, joinType = LeftOuter, condition = Some("x.b".attr === "y.b".attr
         && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
@@ -1373,16 +1373,16 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("push down predicates through right join") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery =
       x.join(y, joinType = RightOuter, condition = Some(("x.b".attr === "y.b".attr)
         && simpleDisjunctivePredicate))
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.where($"a" > 3 || $"a" > 1).subquery(Symbol("x"))
-    val right = testRelation.subquery(Symbol("y"))
+    val left = testRelation.where($"a" > 3 || $"a" > 1).subquery("x")
+    val right = testRelation.subquery("y")
     val correctAnswer =
       left.join(right, joinType = RightOuter, condition = Some("x.b".attr === "y.b".attr
         && (("x.a".attr > 3) && ("y.a".attr > 13) || ("x.a".attr > 1) && ("y.a".attr > 11))))
@@ -1392,16 +1392,16 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("SPARK-32302: avoid generating too many predicates") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val originalQuery =
       x.join(y, condition = Some(("x.b".attr === "y.b".attr) && ((("x.a".attr > 3) &&
         ("x.a".attr < 13) && ("y.c".attr <= 5)) || (("y.a".attr > 2) && ("y.c".attr < 1)))))
 
     val optimized = Optimize.execute(originalQuery.analyze)
-    val left = testRelation.subquery(Symbol("x"))
-    val right = testRelation.where($"c" <= 5 || ($"a" > 2 && $"c" < 1)).subquery(Symbol("y"))
+    val left = testRelation.subquery("x")
+    val right = testRelation.where($"c" <= 5 || ($"a" > 2 && $"c" < 1)).subquery("y")
     val correctAnswer = left.join(right, condition = Some("x.b".attr === "y.b".attr &&
       ((("x.a".attr > 3) && ("x.a".attr < 13) && ("y.c".attr <= 5)) ||
         (("y.a".attr > 2) && ("y.c".attr < 1))))).analyze
@@ -1410,9 +1410,9 @@ class FilterPushdownSuite extends PlanTest {
   }
 
   test("push down predicate through multiple joins") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
-    val z = testRelation.subquery(Symbol("z"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
+    val z = testRelation.subquery("z")
     val xJoinY = x.join(y, condition = Some("x.b".attr === "y.b".attr))
     val originalQuery = z.join(xJoinY,
       condition = Some("x.a".attr === "z.a".attr && simpleDisjunctivePredicate))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FoldablePropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FoldablePropagationSuite.scala
@@ -35,49 +35,49 @@ class FoldablePropagationSuite extends PlanTest {
 
   test("Propagate from subquery") {
     val query = OneRowRelation()
-      .select(Literal(1).as(Symbol("a")), Literal(2).as(Symbol("b")))
-      .subquery(Symbol("T"))
+      .select(Literal(1).as("a"), Literal(2).as("b"))
+      .subquery("T")
       .select($"a", $"b")
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = OneRowRelation()
-      .select(Literal(1).as(Symbol("a")), Literal(2).as(Symbol("b")))
-      .subquery(Symbol("T"))
-      .select(Literal(1).as(Symbol("a")), Literal(2).as(Symbol("b"))).analyze
+      .select(Literal(1).as("a"), Literal(2).as("b"))
+      .subquery("T")
+      .select(Literal(1).as("a"), Literal(2).as("b")).analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("Propagate to select clause") {
     val query = testRelation
-      .select($"a".as(Symbol("x")), "str".as(Symbol("y")), $"b".as(Symbol("z")))
+      .select($"a".as("x"), "str".as("y"), $"b".as("z"))
       .select($"x", $"y", $"z")
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = testRelation
-      .select($"a".as(Symbol("x")), "str".as(Symbol("y")), $"b".as(Symbol("z")))
-      .select($"x", "str".as(Symbol("y")), $"z").analyze
+      .select($"a".as("x"), "str".as("y"), $"b".as("z"))
+      .select($"x", "str".as("y"), $"z").analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("Propagate to where clause") {
     val query = testRelation
-      .select("str".as(Symbol("y")))
+      .select("str".as("y"))
       .where($"y" === "str" && "str" === $"y")
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = testRelation
-      .select("str".as(Symbol("y")))
-      .where("str".as(Symbol("y")) === "str" && "str" === "str".as(Symbol("y"))).analyze
+      .select("str".as("y"))
+      .where("str".as("y") === "str" && "str" === "str".as("y")).analyze
 
     comparePlans(optimized, correctAnswer)
   }
 
   test("Propagate to orderBy clause") {
     val query = testRelation
-      .select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
+      .select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
       .orderBy($"x".asc, $"y".asc, $"b".desc)
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = testRelation
-      .select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
+      .select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
       .orderBy($"x".asc, SortOrder(Year(CurrentDate()), Ascending), $"b".desc).analyze
 
     comparePlans(optimized, correctAnswer)
@@ -85,13 +85,13 @@ class FoldablePropagationSuite extends PlanTest {
 
   test("Propagate to groupBy clause") {
     val query = testRelation
-      .select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
-      .groupBy($"x", $"y", $"b")(sum($"x"), avg($"y").as(Symbol("AVG")), count($"b"))
+      .select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
+      .groupBy($"x", $"y", $"b")(sum($"x"), avg($"y").as("AVG"), count($"b"))
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = testRelation
-      .select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
-      .groupBy($"x", Year(CurrentDate()).as(Symbol("y")), $"b")(sum($"x"),
-        avg(Year(CurrentDate())).as(Symbol("AVG")),
+      .select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
+      .groupBy($"x", Year(CurrentDate()).as("y"), $"b")(sum($"x"),
+        avg(Year(CurrentDate())).as("AVG"),
         count($"b")).analyze
 
     comparePlans(optimized, correctAnswer)
@@ -99,16 +99,16 @@ class FoldablePropagationSuite extends PlanTest {
 
   test("Propagate in a complex query") {
     val query = testRelation
-      .select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
+      .select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
       .where($"x" > 1 && $"y" === 2016 && $"b" > 1)
-      .groupBy($"x", $"y", $"b")(sum($"x"), avg($"y").as(Symbol("AVG")), count($"b"))
+      .groupBy($"x", $"y", $"b")(sum($"x"), avg($"y").as("AVG"), count($"b"))
       .orderBy($"x".asc, $"AVG".asc)
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = testRelation
-      .select($"a".as(Symbol("x")), Year(CurrentDate()).as(Symbol("y")), $"b")
-      .where($"x" > 1 && Year(CurrentDate()).as(Symbol("y")) === 2016 && $"b" > 1)
+      .select($"a".as("x"), Year(CurrentDate()).as("y"), $"b")
+      .where($"x" > 1 && Year(CurrentDate()).as("y") === 2016 && $"b" > 1)
       .groupBy($"x", Year(CurrentDate()).as("y"), $"b")(sum($"x"),
-        avg(Year(CurrentDate())).as(Symbol("AVG")),
+        avg(Year(CurrentDate())).as("AVG"),
         count($"b"))
       .orderBy($"x".asc, $"AVG".asc).analyze
 
@@ -118,27 +118,27 @@ class FoldablePropagationSuite extends PlanTest {
   test("Propagate in subqueries of Union queries") {
     val query = Union(
       Seq(
-        testRelation.select(Literal(1).as(Symbol("x")), $"a").select($"x", $"x" + $"a"),
-        testRelation.select(Literal(2).as(Symbol("x")), $"a").select($"x", $"x" + $"a")))
+        testRelation.select(Literal(1).as("x"), $"a").select($"x", $"x" + $"a"),
+        testRelation.select(Literal(2).as("x"), $"a").select($"x", $"x" + $"a")))
       .select($"x")
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = Union(
       Seq(
-        testRelation.select(Literal(1).as(Symbol("x")), $"a")
-          .select(Literal(1).as(Symbol("x")), (Literal(1).as(Symbol("x")) + $"a").as("(x + a)")),
-        testRelation.select(Literal(2).as(Symbol("x")), $"a")
-          .select(Literal(2).as(Symbol("x")), (Literal(2).as(Symbol("x")) + $"a").as("(x + a)"))))
+        testRelation.select(Literal(1).as("x"), $"a")
+          .select(Literal(1).as("x"), (Literal(1).as("x") + $"a").as("(x + a)")),
+        testRelation.select(Literal(2).as("x"), $"a")
+          .select(Literal(2).as("x"), (Literal(2).as("x") + $"a").as("(x + a)"))))
       .select($"x").analyze
     comparePlans(optimized, correctAnswer)
   }
 
   test("Propagate in inner join") {
-    val ta = testRelation.select($"a", Literal(1).as(Symbol("tag")))
-      .union(testRelation.select($"a".as(Symbol("a")), Literal(2).as(Symbol("tag"))))
-      .subquery(Symbol("ta"))
-    val tb = testRelation.select($"a", Literal(1).as(Symbol("tag")))
-      .union(testRelation.select($"a".as(Symbol("a")), Literal(2).as(Symbol("tag"))))
-      .subquery(Symbol("tb"))
+    val ta = testRelation.select($"a", Literal(1).as("tag"))
+      .union(testRelation.select($"a".as("a"), Literal(2).as("tag")))
+      .subquery("ta")
+    val tb = testRelation.select($"a", Literal(1).as("tag"))
+      .union(testRelation.select($"a".as("a"), Literal(2).as("tag")))
+      .subquery("tb")
     val query = ta.join(tb, Inner,
       Some("ta.a".attr === "tb.a".attr && "ta.tag".attr === "tb.tag".attr))
     val optimized = Optimize.execute(query.analyze)
@@ -147,8 +147,8 @@ class FoldablePropagationSuite extends PlanTest {
   }
 
   test("Propagate in expand") {
-    val c1 = Literal(1).as(Symbol("a"))
-    val c2 = Literal(2).as(Symbol("b"))
+    val c1 = Literal(1).as("a")
+    val c2 = Literal(2).as("b")
     val a1 = c1.toAttribute.newInstance().withNullability(true)
     val a2 = c2.toAttribute.newInstance().withNullability(true)
     val expand = Expand(
@@ -165,21 +165,21 @@ class FoldablePropagationSuite extends PlanTest {
   }
 
   test("Propagate above outer join") {
-    val left = LocalRelation($"a".int).select($"a", Literal(1).as(Symbol("b")))
-    val right = LocalRelation($"c".int).select($"c", Literal(1).as(Symbol("d")))
+    val left = LocalRelation($"a".int).select($"a", Literal(1).as("b"))
+    val right = LocalRelation($"c".int).select($"c", Literal(1).as("d"))
 
     val join = left.join(
       right,
       joinType = LeftOuter,
       condition = Some($"a" === $"c" && $"b" === $"d"))
-    val query = join.select(($"b" + 3).as(Symbol("res"))).analyze
+    val query = join.select(($"b" + 3).as("res")).analyze
     val optimized = Optimize.execute(query)
 
     val correctAnswer = left.join(
       right,
       joinType = LeftOuter,
       condition = Some($"a" === $"c" && Literal(1) === Literal(1)))
-      .select((Literal(1) + 3).as(Symbol("res"))).analyze
+      .select((Literal(1) + 3).as("res")).analyze
     comparePlans(optimized, correctAnswer)
   }
 
@@ -197,13 +197,13 @@ class FoldablePropagationSuite extends PlanTest {
 
   test("SPARK-32951: Foldable propagation from Aggregate") {
     val query = testRelation
-      .groupBy($"a")($"a", sum($"b").as(Symbol("b")), Literal(1).as(Symbol("c")))
+      .groupBy($"a")($"a", sum($"b").as("b"), Literal(1).as("c"))
       .select($"a", $"b", $"c")
 
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = testRelation
-      .groupBy($"a")($"a", sum($"b").as(Symbol("b")), Literal(1).as(Symbol("c")))
-      .select($"a", $"b", Literal(1).as(Symbol("c"))).analyze
+      .groupBy($"a")($"a", sum($"b").as("b"), Literal(1).as("c"))
+      .select($"a", $"b", Literal(1).as("c")).analyze
     comparePlans(optimized, correctAnswer)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOptimizationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinOptimizationSuite.scala
@@ -48,9 +48,9 @@ class JoinOptimizationSuite extends PlanTest {
   val testRelation1 = LocalRelation($"d".int)
 
   test("extract filters and joins") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
-    val z = testRelation.subquery(Symbol("z"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
+    val z = testRelation.subquery("z")
 
     def testExtract(plan: LogicalPlan,
         expected: Option[(Seq[LogicalPlan], Seq[Expression])]): Unit = {
@@ -96,9 +96,9 @@ class JoinOptimizationSuite extends PlanTest {
   }
 
   test("reorder inner joins") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
-    val z = testRelation.subquery(Symbol("z"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
+    val z = testRelation.subquery("z")
 
     val queryAnswers = Seq(
       (

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -111,7 +111,7 @@ class LeftSemiPushdownSuite extends PlanTest {
 
   test("Aggregate: LeftSemiAnti join no pushdown due to non-deterministic aggr expressions") {
     val originalQuery = testRelation
-      .groupBy($"b")($"b", Rand(10).as(Symbol("c")))
+      .groupBy($"b")($"b", Rand(10).as("c"))
       .join(testRelation1, joinType = LeftSemi, condition = Some($"b" === $"d"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -120,13 +120,13 @@ class LeftSemiPushdownSuite extends PlanTest {
 
   test("Aggregate: LeftSemi join partial pushdown") {
     val originalQuery = testRelation
-      .groupBy($"b")($"b", sum($"c").as(Symbol("sum")))
+      .groupBy($"b")($"b", sum($"c").as("sum"))
       .join(testRelation1, joinType = LeftSemi, condition = Some($"b" === $"d" && $"sum" === 10))
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
       .join(testRelation1, joinType = LeftSemi, condition = Some($"b" === $"d"))
-      .groupBy($"b")($"b", sum($"c").as(Symbol("sum")))
+      .groupBy($"b")($"b", sum($"c").as("sum"))
       .where($"sum" === 10)
       .analyze
 
@@ -135,7 +135,7 @@ class LeftSemiPushdownSuite extends PlanTest {
 
   test("Aggregate: LeftAnti join no pushdown") {
     val originalQuery = testRelation
-      .groupBy($"b")($"b", sum($"c").as(Symbol("sum")))
+      .groupBy($"b")($"b", sum($"c").as("sum"))
       .join(testRelation1, joinType = LeftAnti, condition = Some($"b" === $"d" && $"sum" === 10))
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -144,7 +144,7 @@ class LeftSemiPushdownSuite extends PlanTest {
 
   test("LeftSemiAnti join over aggregate - no pushdown") {
     val originalQuery = testRelation
-      .groupBy($"b")($"b", sum($"c").as(Symbol("sum")))
+      .groupBy($"b")($"b", sum($"c").as("sum"))
       .join(testRelation1, joinType = LeftSemi, condition = Some($"b" === $"d" && $"sum" === $"d"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -171,7 +171,7 @@ class LeftSemiPushdownSuite extends PlanTest {
       windowSpec($"a" :: Nil, $"b".asc :: Nil, UnspecifiedFrame))
 
     val originalQuery = testRelation
-      .select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+      .select($"a", $"b", $"c", winExpr.as("window"))
       .join(testRelation1, joinType = LeftSemi, condition = Some($"a" === $"d"))
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -179,7 +179,7 @@ class LeftSemiPushdownSuite extends PlanTest {
     val correctAnswer = testRelation
       .join(testRelation1, joinType = LeftSemi, condition = Some($"a" === $"d"))
       .select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a" :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a" :: Nil, $"b".asc :: Nil)
       .select($"a", $"b", $"c", $"window").analyze
 
     comparePlans(optimized, correctAnswer)
@@ -192,7 +192,7 @@ class LeftSemiPushdownSuite extends PlanTest {
       windowSpec($"a" :: Nil, $"b".asc :: Nil, UnspecifiedFrame))
 
     val originalQuery = testRelation
-      .select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+      .select($"a", $"b", $"c", winExpr.as("window"))
       .join(testRelation1, joinType = LeftSemi, condition = Some($"a" === $"d" && $"b" > 5))
 
     val optimized = Optimize.execute(originalQuery.analyze)
@@ -200,7 +200,7 @@ class LeftSemiPushdownSuite extends PlanTest {
     val correctAnswer = testRelation
       .join(testRelation1, joinType = LeftSemi, condition = Some($"a" === $"d"))
       .select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a" :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a" :: Nil, $"b".asc :: Nil)
       .where($"b" > 5)
       .select($"a", $"b", $"c", $"window").analyze
 
@@ -214,14 +214,14 @@ class LeftSemiPushdownSuite extends PlanTest {
       windowSpec($"a" :: Nil, $"b".asc :: Nil, UnspecifiedFrame))
 
     val originalQuery = testRelation
-      .select($"a", $"b", $"c", winExpr.as(Symbol("window")))
+      .select($"a", $"b", $"c", winExpr.as("window"))
       .join(testRelation1, joinType = LeftAnti, condition = Some($"a" === $"d" && $"b" > 5))
 
     val optimized = Optimize.execute(originalQuery.analyze)
 
     val correctAnswer = testRelation
       .select($"a", $"b", $"c")
-      .window(winExpr.as(Symbol("window")) :: Nil, $"a" :: Nil, $"b".asc :: Nil)
+      .window(winExpr.as("window") :: Nil, $"a" :: Nil, $"b".asc :: Nil)
       .join(testRelation1, joinType = LeftAnti, condition = Some($"a" === $"d" && $"b" > 5))
       .select($"a", $"b", $"c", $"window").analyze
     comparePlans(optimized, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -45,8 +45,8 @@ class LimitPushdownSuite extends PlanTest {
   private val testRelation2 = LocalRelation.fromExternalRows(
     Seq("d".attr.int, "e".attr.int, "f".attr.int),
     1.to(6).map(_ => Row(1, 2, 3)))
-  private val x = testRelation.subquery(Symbol("x"))
-  private val y = testRelation.subquery(Symbol("y"))
+  private val x = testRelation.subquery("x")
+  private val y = testRelation.subquery("y")
 
   // Union ---------------------------------------------------------------------------------------
 
@@ -153,7 +153,7 @@ class LimitPushdownSuite extends PlanTest {
   }
 
   test("full outer join where neither side is limited and left side has larger statistics") {
-    val xBig = testRelation.copy(data = Seq.fill(10)(null)).subquery(Symbol("x"))
+    val xBig = testRelation.copy(data = Seq.fill(10)(null)).subquery("x")
     assert(xBig.stats.sizeInBytes > y.stats.sizeInBytes)
     val originalQuery = xBig.join(y, FullOuter).limit(1).analyze
     val optimized = Optimize.execute(originalQuery)
@@ -162,7 +162,7 @@ class LimitPushdownSuite extends PlanTest {
   }
 
   test("full outer join where neither side is limited and right side has larger statistics") {
-    val yBig = testRelation.copy(data = Seq.fill(10)(null)).subquery(Symbol("y"))
+    val yBig = testRelation.copy(data = Seq.fill(10)(null)).subquery("y")
     assert(x.stats.sizeInBytes < yBig.stats.sizeInBytes)
     val originalQuery = x.join(yBig, FullOuter).limit(1).analyze
     val optimized = Optimize.execute(originalQuery)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NestedColumnAliasingSuite.scala
@@ -498,7 +498,7 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
     val spec = windowSpec($"address" :: Nil, $"id".asc :: Nil, UnspecifiedFrame)
     val winExpr = windowExpr(RowNumber(), spec)
     val query = contact
-      .select($"name.first", winExpr.as(Symbol("window")))
+      .select($"name.first", winExpr.as("window"))
       .orderBy($"name.last".asc)
       .analyze
     val optimized = Optimize.execute(query)
@@ -516,7 +516,7 @@ class NestedColumnAliasingSuite extends SchemaPruningTest {
   test("Nested field pruning for Filter with other supported operators") {
     val spec = windowSpec($"address" :: Nil, $"id".asc :: Nil, UnspecifiedFrame)
     val winExpr = windowExpr(RowNumber(), spec)
-    val query1 = contact.select($"name.first", winExpr.as(Symbol("window")))
+    val query1 = contact.select($"name.first", winExpr.as("window"))
       .where($"window" === 1 && $"name.first" === "a")
       .analyze
     val optimized1 = Optimize.execute(query1)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeLimitZeroSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeLimitZeroSuite.scala
@@ -68,10 +68,10 @@ class OptimizeLimitZeroSuite extends PlanTest {
 
   Seq(
     (Inner, LocalRelation($"a".int, $"b".int)),
-    (LeftOuter, Project(Seq($"a", Literal(null).cast(IntegerType).as(Symbol("b"))), testRelation1)
+    (LeftOuter, Project(Seq($"a", Literal(null).cast(IntegerType).as("b")), testRelation1)
       .analyze),
     (RightOuter, LocalRelation($"a".int, $"b".int)),
-    (FullOuter, Project(Seq($"a", Literal(null).cast(IntegerType).as(Symbol("b"))), testRelation1)
+    (FullOuter, Project(Seq($"a", Literal(null).cast(IntegerType).as("b")), testRelation1)
       .analyze)
   ).foreach { case (jt, correctAnswer) =>
       test(s"Limit 0: for join type $jt") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerStructuralIntegrityCheckerSuite.scala
@@ -62,7 +62,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
 
   test("check for invalid plan after execution of rule - special expression in wrong operator") {
     val analyzed =
-      Aggregate(Nil, Seq[NamedExpression](max($"id") as Symbol("m")),
+      Aggregate(Nil, Seq[NamedExpression](max($"id") as "m"),
         LocalRelation($"id".long)).analyze
     assert(analyzed.resolved)
 
@@ -80,7 +80,7 @@ class OptimizerStructuralIntegrityCheckerSuite extends PlanTest {
 
   test("check for invalid plan before execution of any rule") {
     val analyzed =
-      Aggregate(Nil, Seq[NamedExpression](max($"id") as Symbol("m")),
+      Aggregate(Nil, Seq[NamedExpression](max($"id") as "m"),
         LocalRelation($"id".long)).analyze
     val invalidPlan = OptimizeRuleBreakSI.apply(analyzed)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OuterJoinEliminationSuite.scala
@@ -42,8 +42,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   val testRelation1 = LocalRelation($"d".int, $"e".int, $"f".int)
 
   test("joins: full outer to inner") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, FullOuter, Option("x.a".attr === "y.d".attr))
@@ -59,8 +59,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("joins: full outer to right") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, FullOuter, Option("x.a".attr === "y.d".attr)).where("y.d".attr > 2)
@@ -75,8 +75,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("joins: full outer to left") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, FullOuter, Option("x.a".attr === "y.d".attr)).where("x.a".attr <=> 2)
@@ -91,8 +91,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("joins: right to inner") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, RightOuter, Option("x.a".attr === "y.d".attr)).where("x.b".attr > 2)
@@ -107,8 +107,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("joins: left to inner") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
@@ -125,8 +125,8 @@ class OuterJoinEliminationSuite extends PlanTest {
 
   // evaluating if mixed OR and NOT expressions can eliminate all null-supplying rows
   test("joins: left to inner with complicated filter predicates #1") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
@@ -143,8 +143,8 @@ class OuterJoinEliminationSuite extends PlanTest {
 
   // eval(emptyRow) of 'e.in(1, 2) will return null instead of false
   test("joins: left to inner with complicated filter predicates #2") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
@@ -161,8 +161,8 @@ class OuterJoinEliminationSuite extends PlanTest {
 
   // evaluating if mixed OR and AND expressions can eliminate all null-supplying rows
   test("joins: left to inner with complicated filter predicates #3") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, LeftOuter, Option("x.a".attr === "y.d".attr))
@@ -182,8 +182,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   // can eliminate all null-supplying rows
   // FULL OUTER => INNER
   test("joins: left to inner with complicated filter predicates #4") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, FullOuter, Option("x.a".attr === "y.d".attr))
@@ -199,8 +199,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("joins: no outer join elimination if the filter is not NULL eliminated") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, FullOuter, Option("x.a".attr === "y.d".attr))
@@ -218,8 +218,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("joins: no outer join elimination if the filter's constraints are not NULL eliminated") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val originalQuery =
       x.join(y, FullOuter, Option("x.a".attr === "y.d".attr))
@@ -238,8 +238,8 @@ class OuterJoinEliminationSuite extends PlanTest {
 
   test("no outer join elimination if constraint propagation is disabled") {
     withSQLConf(SQLConf.CONSTRAINT_PROPAGATION_ENABLED.key -> "false") {
-      val x = testRelation.subquery(Symbol("x"))
-      val y = testRelation1.subquery(Symbol("y"))
+      val x = testRelation.subquery("x")
+      val y = testRelation1.subquery("y")
 
       // The predicate "x.b + y.d >= 3" will be inferred constraints like:
       // "x.b != null" and "y.d != null", if constraint propagation is enabled.
@@ -256,8 +256,8 @@ class OuterJoinEliminationSuite extends PlanTest {
   }
 
   test("SPARK-38868: exception thrown from filter predicate does not propagate") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation1.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
 
     val message = Literal(UTF8String.fromString("Bad value"), StringType)
     val originalQuery =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelationSuite.scala
@@ -79,7 +79,7 @@ class PropagateEmptyRelationSuite extends PlanTest {
 
     val query2 = testRelation1.where(false).union(testRelation2)
     val optimized2 = Optimize.execute(query2.analyze)
-    val correctAnswer2 = testRelation2.select($"b".as(Symbol("a"))).analyze
+    val correctAnswer2 = testRelation2.select($"b".as("a")).analyze
     comparePlans(optimized2, correctAnswer2)
 
     val query3 = testRelation1.union(testRelation2.where(false)).union(testRelation3)
@@ -89,7 +89,7 @@ class PropagateEmptyRelationSuite extends PlanTest {
 
     val query4 = testRelation1.where(false).union(testRelation2).union(testRelation3)
     val optimized4 = Optimize.execute(query4.analyze)
-    val correctAnswer4 = testRelation2.union(testRelation3).select($"b".as(Symbol("a"))).analyze
+    val correctAnswer4 = testRelation2.union(testRelation3).select($"b".as("a")).analyze
     comparePlans(optimized4, correctAnswer4)
 
     // Nullability can change from nullable to non-nullable
@@ -119,11 +119,11 @@ class PropagateEmptyRelationSuite extends PlanTest {
       (true, false, Inner, Some(LocalRelation($"a".int, $"b".int))),
       (true, false, Cross, Some(LocalRelation($"a".int, $"b".int))),
       (true, false, LeftOuter,
-        Some(Project(Seq($"a", Literal(null).cast(IntegerType).as(Symbol("b"))), testRelation1)
+        Some(Project(Seq($"a", Literal(null).cast(IntegerType).as("b")), testRelation1)
           .analyze)),
       (true, false, RightOuter, Some(LocalRelation($"a".int, $"b".int))),
       (true, false, FullOuter,
-        Some(Project(Seq($"a", Literal(null).cast(IntegerType).as(Symbol("b"))), testRelation1)
+        Some(Project(Seq($"a", Literal(null).cast(IntegerType).as("b")), testRelation1)
           .analyze)),
       (true, false, LeftAnti, Some(testRelation1)),
       (true, false, LeftSemi, Some(LocalRelation($"a".int))),
@@ -132,10 +132,10 @@ class PropagateEmptyRelationSuite extends PlanTest {
       (false, true, Cross, Some(LocalRelation($"a".int, $"b".int))),
       (false, true, LeftOuter, Some(LocalRelation($"a".int, $"b".int))),
       (false, true, RightOuter,
-        Some(Project(Seq(Literal(null).cast(IntegerType).as(Symbol("a")), $"b"), testRelation2)
+        Some(Project(Seq(Literal(null).cast(IntegerType).as("a"), $"b"), testRelation2)
           .analyze)),
       (false, true, FullOuter,
-        Some(Project(Seq(Literal(null).cast(IntegerType).as(Symbol("a")), $"b"), testRelation2)
+        Some(Project(Seq(Literal(null).cast(IntegerType).as("a"), $"b"), testRelation2)
           .analyze)),
       (false, true, LeftAnti, Some(LocalRelation($"a".int))),
       (false, true, LeftSemi, Some(LocalRelation($"a".int))),
@@ -165,10 +165,10 @@ class PropagateEmptyRelationSuite extends PlanTest {
       (Inner, Some(LocalRelation($"a".int, $"b".int))),
       (Cross, Some(LocalRelation($"a".int, $"b".int))),
       (LeftOuter,
-        Some(Project(Seq($"a", Literal(null).cast(IntegerType).as(Symbol("b"))), testRelation1)
+        Some(Project(Seq($"a", Literal(null).cast(IntegerType).as("b")), testRelation1)
           .analyze)),
       (RightOuter,
-        Some(Project(Seq(Literal(null).cast(IntegerType).as(Symbol("a")), $"b"), testRelation2)
+        Some(Project(Seq(Literal(null).cast(IntegerType).as("a"), $"b"), testRelation2)
           .analyze)),
       (FullOuter, None),
       (LeftAnti, Some(testRelation1)),
@@ -261,7 +261,7 @@ class PropagateEmptyRelationSuite extends PlanTest {
   test("propagate empty relation through Aggregate with grouping expressions") {
     val query = testRelation1
       .where(false)
-      .groupBy($"a")($"a", ($"a" + 1).as(Symbol("x")))
+      .groupBy($"a")($"a", ($"a" + 1).as("x"))
 
     val optimized = Optimize.execute(query.analyze)
     val correctAnswer = LocalRelation($"a".int, $"x".int).analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PruneFiltersSuite.scala
@@ -42,8 +42,8 @@ class PruneFiltersSuite extends PlanTest {
   val testRelation = LocalRelation($"a".int, $"b".int, $"c".int)
 
   test("Constraints of isNull + LeftOuter") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val query = x.where("x.b".attr.isNull).join(y, LeftOuter)
     val queryWithUselessFilter = query.where("x.b".attr.isNull)
@@ -72,8 +72,8 @@ class PruneFiltersSuite extends PlanTest {
   }
 
   test("Pruning multiple constraints in the same run") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
 
     val query = tr1
       .where("tr1.a".attr > 10 || "tr1.c".attr < 10)
@@ -92,8 +92,8 @@ class PruneFiltersSuite extends PlanTest {
   }
 
   test("Partial pruning") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
 
     // One of the filter condition does not exist in the constraints of its child
     // Thus, the filter is not removed
@@ -114,8 +114,8 @@ class PruneFiltersSuite extends PlanTest {
   }
 
   test("No predicate is pruned") {
-    val x = testRelation.subquery(Symbol("x"))
-    val y = testRelation.subquery(Symbol("y"))
+    val x = testRelation.subquery("x")
+    val y = testRelation.subquery("y")
 
     val query = x.where("x.b".attr.isNull).join(y, LeftOuter)
     val queryWithExtraFilters = query.where("x.b".attr.isNotNull)
@@ -136,8 +136,8 @@ class PruneFiltersSuite extends PlanTest {
   }
 
   test("No pruning when constraint propagation is disabled") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
 
     val query = tr1
       .where("tr1.a".attr > 10 || "tr1.c".attr < 10)
@@ -162,7 +162,7 @@ class PruneFiltersSuite extends PlanTest {
   }
 
   test("SPARK-35273: CombineFilters support non-deterministic expressions") {
-    val x = testRelation.where(!$"a".attr.in(1, 3, 5)).subquery(Symbol("x"))
+    val x = testRelation.where(!$"a".attr.in(1, 3, 5)).subquery("x")
 
     comparePlans(
       Optimize.execute(x.where($"a".attr === 7 && Rand(10) > 0.1).analyze),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregatesSuite.scala
@@ -35,8 +35,8 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
   }
 
   private val relation = LocalRelation($"a".int, $"b".int)
-  private val x = relation.subquery(Symbol("x"))
-  private val y = relation.subquery(Symbol("y"))
+  private val x = relation.subquery("x")
+  private val y = relation.subquery("y")
 
   private def aggregates(e: Expression): Seq[Expression] = {
     Seq(
@@ -90,11 +90,11 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
   test("Remove redundant aggregate with aliases") {
     for (agg <- aggregates($"b")) {
       val query = relation
-        .groupBy($"a" + $"b")(($"a" + $"b") as Symbol("c"), agg)
+        .groupBy($"a" + $"b")(($"a" + $"b") as "c", agg)
         .groupBy($"c")($"c")
         .analyze
       val expected = relation
-        .groupBy($"a" + $"b")(($"a" + $"b") as Symbol("c"))
+        .groupBy($"a" + $"b")(($"a" + $"b") as "c")
         .analyze
       val optimized = Optimize.execute(query)
       comparePlans(optimized, expected)
@@ -104,10 +104,10 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
   test("Remove redundant aggregate with non-deterministic upper") {
     val query = relation
       .groupBy($"a")($"a")
-      .groupBy($"a")($"a", rand(0) as Symbol("c"))
+      .groupBy($"a")($"a", rand(0) as "c")
       .analyze
     val expected = relation
-      .groupBy($"a")($"a", rand(0) as Symbol("c"))
+      .groupBy($"a")($"a", rand(0) as "c")
       .analyze
     val optimized = Optimize.execute(query)
     comparePlans(optimized, expected)
@@ -115,11 +115,11 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
 
   test("Remove redundant aggregate with non-deterministic lower") {
     val query = relation
-      .groupBy($"a", $"c")($"a", rand(0) as Symbol("c"))
+      .groupBy($"a", $"c")($"a", rand(0) as "c")
       .groupBy($"a", $"c")($"a", $"c")
       .analyze
     val expected = relation
-      .groupBy($"a", $"c")($"a", rand(0) as Symbol("c"))
+      .groupBy($"a", $"c")($"a", rand(0) as "c")
       .analyze
     val optimized = Optimize.execute(query)
     comparePlans(optimized, expected)
@@ -160,7 +160,7 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
   test("Keep non-redundant aggregate - upper references agg expression") {
     for (agg <- aggregates($"b")) {
       val query = relation
-        .groupBy($"a")($"a", agg as Symbol("c"))
+        .groupBy($"a")($"a", agg as "c")
         .groupBy($"c")($"c")
         .analyze
       val optimized = Optimize.execute(query)
@@ -170,11 +170,11 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
 
   test("Remove non-redundant aggregate - upper references non-deterministic non-grouping") {
     val query = relation
-      .groupBy($"a")($"a", ($"a" + rand(0)) as Symbol("c"))
+      .groupBy($"a")($"a", ($"a" + rand(0)) as "c")
       .groupBy($"a", $"c")($"a", $"c")
       .analyze
     val expected = relation
-      .groupBy($"a")($"a", ($"a" + rand(0)) as Symbol("c"))
+      .groupBy($"a")($"a", ($"a" + rand(0)) as "c")
       .select($"a", $"c")
       .analyze
     val optimized = Optimize.execute(query)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
@@ -38,14 +38,14 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
 
   test("all expressions in project list are aliased child output") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"a" as Symbol("a"), $"b" as Symbol("b")).analyze
+    val query = relation.select($"a" as "a", $"b" as "b").analyze
     val optimized = Optimize.execute(query)
     comparePlans(optimized, relation)
   }
 
   test("all expressions in project list are aliased child output but with different order") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"b" as Symbol("b"), $"a" as Symbol("a")).analyze
+    val query = relation.select($"b" as "b", $"a" as "a").analyze
     val optimized = Optimize.execute(query)
     val expected = relation.select($"b", $"a").analyze
     comparePlans(optimized, expected)
@@ -53,14 +53,14 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
 
   test("some expressions in project list are aliased child output") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"a" as Symbol("a"), $"b").analyze
+    val query = relation.select($"a" as "a", $"b").analyze
     val optimized = Optimize.execute(query)
     comparePlans(optimized, relation)
   }
 
   test("some expressions in project list are aliased child output but with different order") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"b" as Symbol("b"), $"a").analyze
+    val query = relation.select($"b" as "b", $"a").analyze
     val optimized = Optimize.execute(query)
     val expected = relation.select($"b", $"a").analyze
     comparePlans(optimized, expected)
@@ -68,7 +68,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
 
   test("some expressions in project list are not Alias or Attribute") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.select($"a" as Symbol("a"), $"b" + 1).analyze
+    val query = relation.select($"a" as "a", $"b" + 1).analyze
     val optimized = Optimize.execute(query)
     val expected = relation.select($"a", $"b" + 1).analyze
     comparePlans(optimized, expected)
@@ -85,9 +85,9 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
 
   test("remove redundant project with self-join") {
     val relation = LocalRelation($"a".int)
-    val fragment = relation.select($"a" as Symbol("a"))
-    val query = fragment.select($"a" as Symbol("a"))
-      .join(fragment.select($"a" as Symbol("a"))).analyze
+    val fragment = relation.select($"a" as "a")
+    val query = fragment.select($"a" as "a")
+      .join(fragment.select($"a" as "a")).analyze
     val optimized = Optimize.execute(query)
     val expected = relation.join(relation).analyze
     comparePlans(optimized, expected)
@@ -96,8 +96,8 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
   test("alias removal should not break after push project through union") {
     val r1 = LocalRelation($"a".int)
     val r2 = LocalRelation($"b".int)
-    val query = r1.select($"a" as Symbol("a"))
-      .union(r2.select($"b" as Symbol("b"))).select($"a").analyze
+    val query = r1.select($"a" as "a")
+      .union(r2.select($"b" as "b")).select($"a").analyze
     val optimized = Optimize.execute(query)
     val expected = r1.union(r2)
     comparePlans(optimized, expected)
@@ -105,7 +105,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
 
   test("remove redundant alias from aggregate") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.groupBy($"a" as Symbol("a"))($"a" as Symbol("a"), sum($"b")).analyze
+    val query = relation.groupBy($"a" as "a")($"a" as "a", sum($"b")).analyze
     val optimized = Optimize.execute(query)
     val expected = relation.groupBy($"a")($"a", sum($"b")).analyze
     comparePlans(optimized, expected)
@@ -113,7 +113,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
 
   test("remove redundant alias from window") {
     val relation = LocalRelation($"a".int, $"b".int)
-    val query = relation.window(Seq($"b" as Symbol("b")), Seq($"a" as Symbol("a")), Seq()).analyze
+    val query = relation.window(Seq($"b" as "b"), Seq($"a" as "a"), Seq()).analyze
     val optimized = Optimize.execute(query)
     val expected = relation.window(Seq($"b"), Seq($"a"), Seq()).analyze
     comparePlans(optimized, expected)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -522,8 +522,8 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
       function = !(cond <=> TrueLiteral),
       arguments = lambdaArgs)
     testProjection(
-      originalExpr = createExpr(argument, lambda1) as Symbol("x"),
-      expectedExpr = createExpr(argument, lambda2) as Symbol("x"))
+      originalExpr = createExpr(argument, lambda1) as "x",
+      expectedExpr = createExpr(argument, lambda2) as "x")
   }
 
   private def test(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
@@ -45,8 +45,8 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
   test("single distinct group with partial aggregates") {
     val input = testRelation
       .groupBy($"a", $"d")(
-        countDistinct($"e", $"c").as(Symbol("agg1")),
-        max($"b").as(Symbol("agg2")))
+        countDistinct($"e", $"c").as("agg1"),
+        max($"b").as("agg2"))
       .analyze
     val rewrite = RewriteDistinctAggregates(input)
     comparePlans(input, rewrite)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SetOperationSuite.scala
@@ -81,11 +81,11 @@ class SetOperationSuite extends PlanTest {
 
   test("Remove unnecessary distincts in multiple unions") {
     val query1 = OneRowRelation()
-      .select(Literal(1).as(Symbol("a")))
+      .select(Literal(1).as("a"))
     val query2 = OneRowRelation()
-      .select(Literal(2).as(Symbol("b")))
+      .select(Literal(2).as("b"))
     val query3 = OneRowRelation()
-      .select(Literal(3).as(Symbol("c")))
+      .select(Literal(3).as("c"))
 
     // D - U - D - U - query1
     //     |       |
@@ -113,13 +113,13 @@ class SetOperationSuite extends PlanTest {
 
   test("Keep necessary distincts in multiple unions") {
     val query1 = OneRowRelation()
-      .select(Literal(1).as(Symbol("a")))
+      .select(Literal(1).as("a"))
     val query2 = OneRowRelation()
-      .select(Literal(2).as(Symbol("b")))
+      .select(Literal(2).as("b"))
     val query3 = OneRowRelation()
-      .select(Literal(3).as(Symbol("c")))
+      .select(Literal(3).as("c"))
     val query4 = OneRowRelation()
-      .select(Literal(4).as(Symbol("d")))
+      .select(Literal(4).as("d"))
 
     // U - D - U - query1
     // |       |
@@ -148,11 +148,11 @@ class SetOperationSuite extends PlanTest {
 
   test("SPARK-34283: Remove unnecessary deduplicate in multiple unions") {
     val query1 = OneRowRelation()
-      .select(Literal(1).as(Symbol("a")))
+      .select(Literal(1).as("a"))
     val query2 = OneRowRelation()
-      .select(Literal(2).as(Symbol("b")))
+      .select(Literal(2).as("b"))
     val query3 = OneRowRelation()
-      .select(Literal(3).as(Symbol("c")))
+      .select(Literal(3).as("c"))
 
     // D - U - D - U - query1
     //     |       |
@@ -195,13 +195,13 @@ class SetOperationSuite extends PlanTest {
 
   test("SPARK-34283: Keep necessary deduplicate in multiple unions") {
     val query1 = OneRowRelation()
-      .select(Literal(1).as(Symbol("a")))
+      .select(Literal(1).as("a"))
     val query2 = OneRowRelation()
-      .select(Literal(2).as(Symbol("b")))
+      .select(Literal(2).as("b"))
     val query3 = OneRowRelation()
-      .select(Literal(3).as(Symbol("c")))
+      .select(Literal(3).as("c"))
     val query4 = OneRowRelation()
-      .select(Literal(4).as(Symbol("d")))
+      .select(Literal(4).as("d"))
 
     // U - D - U - query1
     // |       |

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyStringCaseConversionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyStringCaseConversionSuite.scala
@@ -37,12 +37,12 @@ class SimplifyStringCaseConversionSuite extends PlanTest {
   test("simplify UPPER(UPPER(str))") {
     val originalQuery =
       testRelation
-        .select(Upper(Upper($"a")) as Symbol("u"))
+        .select(Upper(Upper($"a")) as "u")
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .select(Upper($"a") as Symbol("u"))
+        .select(Upper($"a") as "u")
         .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -51,12 +51,12 @@ class SimplifyStringCaseConversionSuite extends PlanTest {
   test("simplify UPPER(LOWER(str))") {
     val originalQuery =
       testRelation
-        .select(Upper(Lower($"a")) as Symbol("u"))
+        .select(Upper(Lower($"a")) as "u")
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .select(Upper($"a") as Symbol("u"))
+        .select(Upper($"a") as "u")
         .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -65,11 +65,11 @@ class SimplifyStringCaseConversionSuite extends PlanTest {
   test("simplify LOWER(UPPER(str))") {
     val originalQuery =
       testRelation
-        .select(Lower(Upper($"a")) as Symbol("l"))
+        .select(Lower(Upper($"a")) as "l")
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
-      .select(Lower($"a") as Symbol("l"))
+      .select(Lower($"a") as "l")
       .analyze
 
     comparePlans(optimized, correctAnswer)
@@ -78,11 +78,11 @@ class SimplifyStringCaseConversionSuite extends PlanTest {
   test("simplify LOWER(LOWER(str))") {
     val originalQuery =
       testRelation
-        .select(Lower(Lower($"a")) as Symbol("l"))
+        .select(Lower(Lower($"a")) as "l")
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer = testRelation
-      .select(Lower($"a") as Symbol("l"))
+      .select(Lower($"a") as "l")
       .analyze
 
     comparePlans(optimized, correctAnswer)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -415,12 +415,12 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
       testRelation
         .select(
           namedStruct("col1", $"b", "col2", $"c").as("s1"), $"a", $"b")
-        .select($"s1" getField "col2" as Symbol("s1Col2"),
+        .select($"s1" getField "col2" as "s1Col2",
           namedStruct("col1", $"a", "col2", $"b").as("s2"))
-        .select($"s1Col2", $"s2" getField "col2" as Symbol("s2Col2"))
+        .select($"s1Col2", $"s2" getField "col2" as "s2Col2")
     val correctAnswer =
       testRelation
-        .select($"c" as Symbol("s1Col2"), $"b" as Symbol("s2Col2"))
+        .select($"c" as "s1Col2", $"b" as "s2Col2")
     checkRule(originalQuery, correctAnswer)
   }
 
@@ -428,11 +428,11 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
     val originalQuery =
       testRelation
         .select(
-          namedStruct("col1", $"b", "col2", $"c") getField "col2" as Symbol("sCol2"),
-          namedStruct("col1", $"a", "col2", $"c") getField "col1" as Symbol("sCol1"))
+          namedStruct("col1", $"b", "col2", $"c") getField "col2" as "sCol2",
+          namedStruct("col1", $"a", "col2", $"c") getField "col1" as "sCol1")
     val correctAnswer =
       testRelation
-        .select($"c" as Symbol("sCol2"), $"a" as Symbol("sCol1"))
+        .select($"c" as "sCol2", $"a" as "sCol1")
     checkRule(originalQuery, correctAnswer)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/StarJoinReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/StarJoinReorderSuite.scala
@@ -150,7 +150,7 @@ class StarJoinReorderSuite extends JoinReorderPlanTestBase with StatsEstimationT
     attributeStats = AttributeMap(Seq("f11_fk1", "f11_fk2", "f11_fk3", "f11_c4")
       .map(nameToColInfo)))
 
-  private val subq = d3.select(sum($"d3_fk1").as(Symbol("col")))
+  private val subq = d3.select(sum($"d3_fk1").as("col"))
 
   test("Test 1: Selective star-join on all dimensions") {
     // Star join:
@@ -362,7 +362,7 @@ class StarJoinReorderSuite extends JoinReorderPlanTestBase with StatsEstimationT
           (nameToAttr("f1_fk3") === "col".attr))
 
     val expected =
-      d3.select($"d3_fk1").select(sum($"d3_fk1").as(Symbol("col")))
+      d3.select($"d3_fk1").select(sum($"d3_fk1").as("col"))
         .join(f1, Inner, Some(nameToAttr("f1_fk3") === "col".attr))
         .join(d1, Inner, Some(nameToAttr("f1_fk1") === nameToAttr("d1_pk1")))
         .join(d2.where(nameToAttr("d2_c2") === 2), Inner,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ExpressionParserSuite.scala
@@ -99,7 +99,7 @@ class ExpressionParserSuite extends AnalysisTest {
     assertEqual("1SL", $"1SL")
 
     // Aliased star is allowed.
-    assertEqual("a.* b", UnresolvedStar(Option(Seq("a"))) as Symbol("b"))
+    assertEqual("a.* b", UnresolvedStar(Option(Seq("a"))) as "b")
   }
 
   test("binary logical expressions") {
@@ -406,7 +406,7 @@ class ExpressionParserSuite extends AnalysisTest {
     // Note that '(a)' will be interpreted as a nested expression.
     assertEqual("(a, b)", CreateStruct(Seq($"a", $"b")))
     assertEqual("(a, b, c)", CreateStruct(Seq($"a", $"b", $"c")))
-    assertEqual("(a as b, b as c)", CreateStruct(Seq($"a" as Symbol("b"), $"b" as Symbol("c"))))
+    assertEqual("(a as b, b as c)", CreateStruct(Seq($"a" as "b", $"b" as "c")))
   }
 
   test("scalar sub-query") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/ConstraintPropagationSuite.scala
@@ -128,11 +128,11 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
   test("propagating constraints in aliases") {
     val tr = LocalRelation($"a".int, $"b".string, $"c".int)
 
-    assert(tr.where($"c".attr > 10).select($"a".as(Symbol("x")), $"b".as(Symbol("y")))
+    assert(tr.where($"c".attr > 10).select($"a".as("x"), $"b".as("y"))
       .analyze.constraints.isEmpty)
 
-    val aliasedRelation = tr.where($"a".attr > 10).select($"a".as(Symbol("x")), $"b",
-      $"b".as(Symbol("y")), $"a".as(Symbol("z")))
+    val aliasedRelation = tr.where($"a".attr > 10).select($"a".as("x"), $"b",
+      $"b".as("y"), $"a".as("z"))
 
     verifyConstraints(aliasedRelation.analyze.constraints,
       ExpressionSet(Seq(resolveColumn(aliasedRelation.analyze, "x") > 10,
@@ -142,7 +142,7 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
         resolveColumn(aliasedRelation.analyze, "z") > 10,
         IsNotNull(resolveColumn(aliasedRelation.analyze, "z")))))
 
-    val multiAlias = tr.where($"a" === $"c" + 10).select($"a".as(Symbol("x")), $"c".as(Symbol("y")))
+    val multiAlias = tr.where($"a" === $"c" + 10).select($"a".as("x"), $"c".as("y"))
     verifyConstraints(multiAlias.analyze.constraints,
       ExpressionSet(Seq(IsNotNull(resolveColumn(multiAlias.analyze, "x")),
         IsNotNull(resolveColumn(multiAlias.analyze, "y")),
@@ -210,8 +210,8 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
   }
 
   test("propagating constraints in inner join") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
     verifyConstraints(tr1
       .where($"a".attr > 10)
       .join(tr2.where($"d".attr < 100), Inner, Some("tr1.a".attr === "tr2.a".attr))
@@ -227,8 +227,8 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
   }
 
   test("propagating constraints in left-semi join") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
     verifyConstraints(tr1
       .where($"a".attr > 10)
       .join(tr2.where($"d".attr < 100), LeftSemi, Some("tr1.a".attr === "tr2.a".attr))
@@ -238,8 +238,8 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
   }
 
   test("propagating constraints in left-outer join") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
     verifyConstraints(tr1
       .where($"a".attr > 10)
       .join(tr2.where($"d".attr < 100), LeftOuter, Some("tr1.a".attr === "tr2.a".attr))
@@ -249,8 +249,8 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
   }
 
   test("propagating constraints in right-outer join") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
     verifyConstraints(tr1
       .where($"a".attr > 10)
       .join(tr2.where($"d".attr < 100), RightOuter, Some("tr1.a".attr === "tr2.a".attr))
@@ -260,8 +260,8 @@ class ConstraintPropagationSuite extends SparkFunSuite with PlanTest {
   }
 
   test("propagating constraints in full-outer join") {
-    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery(Symbol("tr1"))
-    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery(Symbol("tr2"))
+    val tr1 = LocalRelation($"a".int, $"b".int, $"c".int).subquery("tr1")
+    val tr2 = LocalRelation($"a".int, $"d".int, $"e".int).subquery("tr2")
     assert(tr1.where($"a".attr > 10)
       .join(tr2.where($"d".attr < 100), FullOuter, Some("tr1.a".attr === "tr2.a".attr))
       .analyze.constraints.isEmpty)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/DistinctKeyVisitorSuite.scala
@@ -179,9 +179,9 @@ class DistinctKeyVisitorSuite extends PlanTest {
 
     checkDistinctAttributes(
       Distinct(t1)
-        .select($"a", $"b", $"c", winExpr.as(Symbol("window"))), Set(ExpressionSet(Seq(a, b, c))))
+        .select($"a", $"b", $"c", winExpr.as("window")), Set(ExpressionSet(Seq(a, b, c))))
     checkDistinctAttributes(
-      Distinct(t1).select($"a", $"b", winExpr.as(Symbol("window"))), Set())
+      Distinct(t1).select($"a", $"b", winExpr.as("window")), Set())
   }
 
   test("Tail's distinct attributes") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -177,7 +177,7 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
   }
 
   test("windows") {
-    val windows = plan.window(Seq(min(attribute).as(Symbol("sum_attr"))), Seq(attribute), Nil)
+    val windows = plan.window(Seq(min(attribute).as("sum_attr")), Seq(attribute), Nil)
     val windowsStats = Statistics(sizeInBytes = plan.size.get * (4 + 4 + 8) / (4 + 8))
     checkStats(
       windows,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/PhysicalAggregationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/PhysicalAggregationSuite.scala
@@ -30,9 +30,9 @@ class PhysicalAggregationSuite extends PlanTest {
 
   test("SPARK-35014: a foldable expression should not be replaced by an AttributeReference") {
     val query = testRelation
-      .groupBy($"a", Literal.create(1) as Symbol("k"))(
-        $"a", Round(Literal.create(1.2), Literal.create(1)) as Symbol("r"),
-        count($"b") as Symbol("c"))
+      .groupBy($"a", Literal.create(1) as "k")(
+        $"a", Round(Literal.create(1.2), Literal.create(1)) as "r",
+        count($"b") as "c")
     val analyzedQuery = SimpleAnalyzer.execute(query)
 
     val PhysicalAggregation(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
add deprecated tag for two methods in dsl:
- subquery(alias: Symbol)
- as(alias: Symbol)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
dsl is a test helper file which provide easy used functions. But some of these are unnecessary, for example:
`def subquery(alias: Symbol): LogicalPlan`
For a subquery, we only need the name, so a string type parameter is enough. 

Besides, the symbol is not a very stable interface in scala. It should be better to clean up it if unnecessary.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
pass exists test