### PR TITLE
[SPARK-39278][CORE] Fix backward compatibility of alternative configs of Hadoop Filesystems to access

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkConf.scala
+++ b/core/src/main/scala/org/apache/spark/SparkConf.scala
@@ -714,8 +714,8 @@ private[spark] object SparkConf extends Logging {
     KERBEROS_RELOGIN_PERIOD.key -> Seq(
       AlternateConfig("spark.yarn.kerberos.relogin.period", "3.0")),
     KERBEROS_FILESYSTEMS_TO_ACCESS.key -> Seq(
-      AlternateConfig("spark.yarn.access.namenodes", "2.2"),
-      AlternateConfig("spark.yarn.access.hadoopFileSystems", "3.0")),
+      AlternateConfig("spark.yarn.access.hadoopFileSystems", "3.0"),
+      AlternateConfig("spark.yarn.access.namenodes", "2.2")),
     "spark.kafka.consumer.cache.capacity" -> Seq(
       AlternateConfig("spark.sql.kafkaConsumerCache.capacity", "3.0"))
   )

--- a/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkConfSuite.scala
@@ -277,8 +277,11 @@ class SparkConfSuite extends SparkFunSuite with LocalSparkContext with ResetSyst
     conf.set("spark.yarn.access.namenodes", "testNode")
     assert(conf.get(KERBEROS_FILESYSTEMS_TO_ACCESS) === Array("testNode"))
 
-    conf.set("spark.yarn.access.hadoopFileSystems", "testNode")
-    assert(conf.get(KERBEROS_FILESYSTEMS_TO_ACCESS) === Array("testNode"))
+    conf.set("spark.yarn.access.hadoopFileSystems", "testNode2")
+    assert(conf.get(KERBEROS_FILESYSTEMS_TO_ACCESS) === Array("testNode2"))
+
+    conf.set("spark.yarn.access.namenodes", "testNode3")
+    assert(conf.get(KERBEROS_FILESYSTEMS_TO_ACCESS) === Array("testNode2"))
   }
 
   test("akka deprecated configs") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix precedence of configs of Hadoop Filesystems to access.

Before this PR
```
spark.kerberos.access.hadoopFileSystems -> spark.yarn.access.namenodes -> spark.yarn.access.hadoopFileSystems
```

After this PR
```
spark.kerberos.access.hadoopFileSystems ->  spark.yarn.access.hadoopFileSystems -> spark.yarn.access.namenodes
```

### Why are the changes needed?
Before https://github.com/apache/spark/pull/23698, the precedence of configuring Hadoop Filesystems to access is
```
spark.yarn.access.hadoopFileSystems -> spark.yarn.access.namenodes
```
Afterwards, it's
```
spark.kerberos.access.hadoopFileSystems -> spark.yarn.access.namenodes -> spark.yarn.access.hadoopFileSystems
```
When both `spark.yarn.access.hadoopFileSystems` and `spark.yarn.access.namenodes` are configured with different values, the PR will break backward compatibility and cause application failure.

### Does this PR introduce _any_ user-facing change?
Yes. Fix backward compatibility.


### How was this patch tested?
Updated UT.
