### PR TITLE
[SPARK-39286][DOC] Update documentation for the decode function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2504,9 +2504,10 @@ object Decode {
   usage = """
     _FUNC_(bin, charset) - Decodes the first argument using the second argument character set.
 
-    _FUNC_(expr, search, result [, search, result ] ... [, default]) - Decode compares expr
-      to each search value one by one. If expr is equal to a search, returns the corresponding result.
-      If no match is found, then Oracle returns default. If default is omitted, returns null.
+    _FUNC_(expr, search, result [, search, result ] ... [, default]) - Compares expr
+      to each search value in order. If expr is equal to a search value, _FUNC_ returns
+      the corresponding result. If no match is found, then it returns default. If default
+      is omitted, it returns null.
   """,
   examples = """
     Examples:


### PR DESCRIPTION
### What changes were proposed in this pull request?
The documentation for the decode function introduced in [SPARK-33527](https://issues.apache.org/jira/browse/SPARK-33527) refers erroneously to Oracle. It appears that the documentation string has been in large parts copied from https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/DECODE.html#GUID-39341D91-3442-4730-BD34-D3CF5D4701CE

This proposes to update the documentation of the decode function to fix the issue.

### Why are the changes needed?
Documentation fix.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
NA