### PR TITLE
[SPARK-38899][SQL]DS V2 supports push down datetime functions

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
  *  <li> <code>MONTH</code> Since 3.4.0 </li>
  *  <li> <code>QUARTER</code> Since 3.4.0 </li>
  *  <li> <code>YEAR</code> Since 3.4.0 </li>
- *  <li> <code>ISO_DAY_OF_WEEK</code> Since 3.4.0 </li>
+ *  <li> <code>DAY_OF_WEEK</code> Since 3.4.0 </li>
  *  <li> <code>DAY</code> Since 3.4.0 </li>
  *  <li> <code>DOY</code> Since 3.4.0 </li>
  *  <li> <code>WEEK</code> Since 3.4.0 </li>

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.expressions;
+
+import org.apache.spark.annotation.Evolving;
+
+import java.io.Serializable;
+
+/**
+ * Represent an extract function, which extracts and returns the value of a
+ * and a source expression where the field should be extracted.
+ * <p>
+ * The currently supported field names:
+ * <ol>
+ *  <li>Field Name: <code>SECOND</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(SECOND FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>MINUTE</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(MINUTE FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>HOUR</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(HOUR FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>MONTH</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(MONTH FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>QUARTER</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(QUARTER FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>YEAR</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(YEAR FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>ISO_DAY_OF_WEEK</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(ISO_DAY_OF_WEEK FROM source)</code></li>
+ *    <li>Database dialects need to follow ISO semantics when handling ISO_DAY_OF_WEEK.</li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>DAY</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(DAY FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>DOY</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(DOY FROM source)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>WEEK</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(WEEK FROM source)</code></li>
+ *    <li>Database dialects need to follow ISO semantics when handling WEEK.</li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Field Name: <code>YEAR_OF_WEEK</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>EXTRACT(YEAR_OF_WEEK FROM source)</code></li>
+ *    <li>Database dialects need to follow ISO semantics when handling YEAR_OF_WEEK.</li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ * </ol>
+ *
+ * @since 3.4.0
+ */
+
+@Evolving
+public class Extract implements Expression, Serializable {
+
+  private String field;
+  private Expression source;
+
+  public Extract(String field, Expression source) {
+    this.field = field;
+    this.source = source;
+  }
+
+  public String field() { return field; }
+  public Expression source() { return source; }
+
+  @Override
+  public Expression[] children() { return new Expression[]{ source() }; }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
@@ -25,77 +25,19 @@ import java.io.Serializable;
  * Represent an extract function, which extracts and returns the value of a
  * and a source expression where the field should be extracted.
  * <p>
- * The currently supported field names:
+ * The currently supported fields names following the ISO standard:
  * <ol>
- *  <li>Field Name: <code>SECOND</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(SECOND FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>MINUTE</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(MINUTE FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>HOUR</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(HOUR FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>MONTH</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(MONTH FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>QUARTER</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(QUARTER FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>YEAR</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(YEAR FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>ISO_DAY_OF_WEEK</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(ISO_DAY_OF_WEEK FROM source)</code></li>
- *    <li>Database dialects need to follow ISO semantics when handling ISO_DAY_OF_WEEK.</li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>DAY</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(DAY FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>DOY</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(DOY FROM source)</code></li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>WEEK</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(WEEK FROM source)</code></li>
- *    <li>Database dialects need to follow ISO semantics when handling WEEK.</li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
- *  <li>Field Name: <code>YEAR_OF_WEEK</code>
- *   <ul>
- *    <li>SQL semantic: <code>EXTRACT(YEAR_OF_WEEK FROM source)</code></li>
- *    <li>Database dialects need to follow ISO semantics when handling YEAR_OF_WEEK.</li>
- *    <li>Since version: 3.4.0</li>
- *   </ul>
- *  </li>
+ *  <li> <code>SECOND</code> Since 3.4.0 </li>
+ *  <li> <code>MINUTE</code> Since 3.4.0 </li>
+ *  <li> <code>HOUR</code> Since 3.4.0 </li>
+ *  <li> <code>MONTH</code> Since 3.4.0 </li>
+ *  <li> <code>QUARTER</code> Since 3.4.0 </li>
+ *  <li> <code>YEAR</code> Since 3.4.0 </li>
+ *  <li> <code>ISO_DAY_OF_WEEK</code> Since 3.4.0 </li>
+ *  <li> <code>DAY</code> Since 3.4.0 </li>
+ *  <li> <code>DOY</code> Since 3.4.0 </li>
+ *  <li> <code>WEEK</code> Since 3.4.0 </li>
+ *  <li> <code>YEAR_OF_WEEK</code> Since 3.4.0 </li>
  * </ol>
  *
  * @since 3.4.0

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 
 /**
  * Represent an extract function, which extracts and returns the value of a
- * and a source expression where the field should be extracted.
+ * specified datetime field from a datetime or interval value expression.
  * <p>
  * The currently supported fields names following the ISO standard:
  * <ol>

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Extract.java
@@ -35,7 +35,7 @@ import java.io.Serializable;
  *  <li> <code>YEAR</code> Since 3.4.0 </li>
  *  <li> <code>DAY_OF_WEEK</code> Since 3.4.0 </li>
  *  <li> <code>DAY</code> Since 3.4.0 </li>
- *  <li> <code>DOY</code> Since 3.4.0 </li>
+ *  <li> <code>DAY_OF_YEAR</code> Since 3.4.0 </li>
  *  <li> <code>WEEK</code> Since 3.4.0 </li>
  *  <li> <code>YEAR_OF_WEEK</code> Since 3.4.0 </li>
  * </ol>

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/GeneralScalarExpression.java
@@ -346,6 +346,24 @@ import org.apache.spark.sql.internal.connector.ToStringSQLBuilder;
  *    <li>Since version: 3.4.0</li>
  *   </ul>
  *  </li>
+ *  <li>Name: <code>DATE_ADD</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>DATE_ADD(start_date, num_days)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Name: <code>DATE_DIFF</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>DATE_DIFF(end_date, start_date)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
+ *  <li>Name: <code>TRUNC</code>
+ *   <ul>
+ *    <li>SQL semantic: <code>TRUNC(date, format)</code></li>
+ *    <li>Since version: 3.4.0</li>
+ *   </ul>
+ *  </li>
  * </ol>
  * Note: SQL semantic conforms ANSI standard, so some expressions are not supported when ANSI off,
  * including: add, subtract, multiply, divide, remainder, pmod.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -336,13 +336,6 @@ public class V2ExpressionSQLBuilder {
   }
 
   protected String visitExtract(String field, String source) {
-    switch (field) {
-      case "DAY_OF_WEEK":
-        return "(EXTRACT(ISO_DAY_OF_WEEK FROM " + source + ") % 7)+ 1";
-      case "WEEK_DAY":
-        return  "EXTRACT(ISO_DAY_OF_WEEK FROM " + source + ") -1";
-      default:
-        return "EXTRACT(" + field + " FROM " + source + ")";
-    }
+    return "EXTRACT(" + field + " FROM " + source + ")";
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -377,13 +377,15 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
       generateExpression(child).map(v => new V2Extract("QUARTER", v))
     case Year(child) =>
       generateExpression(child).map(v => new V2Extract("YEAR", v))
-    // translate the DayOfWeek function in Spark using ISO standards
+    // DayOfWeek uses 1 = Sunday, 2 = Monday, ... and ISO standard is Monday=1, ...,
+    // so we use the formula ((ISO_standard % 7) + 1) to do translation.
     case DayOfWeek(child) =>
       generateExpression(child).map(v => new GeneralScalarExpression("+",
         Array[V2Expression](new GeneralScalarExpression("%",
           Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(7, IntegerType))),
           LiteralValue(1, IntegerType))))
-    // translate the WeekDay function in Spark using ISO standards
+    // WeekDay uses 0 = Monday, 1 = Tuesday, ... and ISO standard is Monday=1, ...,
+    // so we use the formula (ISO_standard - 1) to do translation.
     case WeekDay(child) =>
       generateExpression(child).map(v => new GeneralScalarExpression("-",
         Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(1, IntegerType))))

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -377,18 +377,20 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
       generateExpression(child).map(v => new V2Extract("QUARTER", v))
     case Year(child) =>
       generateExpression(child).map(v => new V2Extract("YEAR", v))
+    // translate the DayOfWeek function in Spark using ISO standards
     case DayOfWeek(child) =>
       generateExpression(child).map(v => new GeneralScalarExpression("+",
         Array[V2Expression](new GeneralScalarExpression("%",
           Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(7, IntegerType))),
           LiteralValue(1, IntegerType))))
+    // translate the WeekDay function in Spark using ISO standards
     case WeekDay(child) =>
       generateExpression(child).map(v => new GeneralScalarExpression("-",
         Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(1, IntegerType))))
     case DayOfMonth(child) =>
       generateExpression(child).map(v => new V2Extract("DAY", v))
     case DayOfYear(child) =>
-      generateExpression(child).map(v => new V2Extract("DOY", v))
+      generateExpression(child).map(v => new V2Extract("DAY_OF_YEAR", v))
     case WeekOfYear(child) =>
       generateExpression(child).map(v => new V2Extract("WEEK", v))
     case YearOfWeek(child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -377,14 +377,14 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
       generateExpression(child).map(v => new V2Extract("QUARTER", v))
     case Year(child) =>
       generateExpression(child).map(v => new V2Extract("YEAR", v))
-    // DayOfWeek uses 1 = Sunday, 2 = Monday, ... and ISO standard is Monday=1, ...,
+    // DayOfWeek uses Sunday = 1, Monday = 2, ... and ISO standard is Monday = 1, ...,
     // so we use the formula ((ISO_standard % 7) + 1) to do translation.
     case DayOfWeek(child) =>
       generateExpression(child).map(v => new GeneralScalarExpression("+",
         Array[V2Expression](new GeneralScalarExpression("%",
           Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(7, IntegerType))),
           LiteralValue(1, IntegerType))))
-    // WeekDay uses 0 = Monday, 1 = Tuesday, ... and ISO standard is Monday=1, ...,
+    // WeekDay uses Monday = 0, Tuesday = 1, ... and ISO standard is Monday = 1, ...,
     // so we use the formula (ISO_standard - 1) to do translation.
     case WeekDay(child) =>
       generateExpression(child).map(v => new GeneralScalarExpression("-",

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.util
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, FieldReference, GeneralScalarExpression, LiteralValue, UserDefinedScalarFunc}
+import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, Extract => V2Extract, FieldReference, GeneralScalarExpression, LiteralValue, UserDefinedScalarFunc}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And => V2And, Not => V2Not, Or => V2Or, Predicate => V2Predicate}
 import org.apache.spark.sql.types.BooleanType
 
@@ -344,6 +344,51 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
       } else {
         None
       }
+    case date: DateAdd =>
+      val childrenExpressions = date.children.flatMap(generateExpression(_))
+      if (childrenExpressions.length == date.children.length) {
+        Some(new GeneralScalarExpression("DATE_ADD", childrenExpressions.toArray[V2Expression]))
+      } else {
+        None
+      }
+    case date: DateDiff =>
+      val childrenExpressions = date.children.flatMap(generateExpression(_))
+      if (childrenExpressions.length == date.children.length) {
+        Some(new GeneralScalarExpression("DATE_DIFF", childrenExpressions.toArray[V2Expression]))
+      } else {
+        None
+      }
+    case date: TruncDate =>
+      val childrenExpressions = date.children.flatMap(generateExpression(_))
+      if (childrenExpressions.length == date.children.length) {
+        Some(new GeneralScalarExpression("TRUNC", childrenExpressions.toArray[V2Expression]))
+      } else {
+        None
+      }
+    case Second(child, _) =>
+      generateExpression(child).map(v => new V2Extract("SECOND", v))
+    case Minute(child, _) =>
+      generateExpression(child).map(v => new V2Extract("MINUTE", v))
+    case Hour(child, _) =>
+      generateExpression(child).map(v => new V2Extract("HOUR", v))
+    case Month(child) =>
+      generateExpression(child).map(v => new V2Extract("MONTH", v))
+    case Quarter(child) =>
+      generateExpression(child).map(v => new V2Extract("QUARTER", v))
+    case Year(child) =>
+      generateExpression(child).map(v => new V2Extract("YEAR", v))
+    case DayOfWeek(child) =>
+      generateExpression(child).map(v => new V2Extract("DAY_OF_WEEK", v))
+    case WeekDay(child) =>
+      generateExpression(child).map(v => new V2Extract("WEEK_DAY", v))
+    case DayOfMonth(child) =>
+      generateExpression(child).map(v => new V2Extract("DAY", v))
+    case DayOfYear(child) =>
+      generateExpression(child).map(v => new V2Extract("DOY", v))
+    case WeekOfYear(child) =>
+      generateExpression(child).map(v => new V2Extract("WEEK", v))
+    case YearOfWeek(child) =>
+      generateExpression(child).map(v => new V2Extract("YEAR_OF_WEEK", v))
     // TODO supports other expressions
     case ApplyFunctionExpression(function, children) =>
       val childrenExpressions = children.flatMap(generateExpression(_))

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.util
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.connector.expressions.{Cast => V2Cast, Expression => V2Expression, Extract => V2Extract, FieldReference, GeneralScalarExpression, LiteralValue, UserDefinedScalarFunc}
 import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And => V2And, Not => V2Not, Or => V2Or, Predicate => V2Predicate}
-import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.{BooleanType, IntegerType}
 
 /**
  * The builder to generate V2 expressions from catalyst expressions.
@@ -378,9 +378,13 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
     case Year(child) =>
       generateExpression(child).map(v => new V2Extract("YEAR", v))
     case DayOfWeek(child) =>
-      generateExpression(child).map(v => new V2Extract("DAY_OF_WEEK", v))
+      generateExpression(child).map(v => new GeneralScalarExpression("+",
+        Array[V2Expression](new GeneralScalarExpression("%",
+          Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(7, IntegerType))),
+          LiteralValue(1, IntegerType))))
     case WeekDay(child) =>
-      generateExpression(child).map(v => new V2Extract("WEEK_DAY", v))
+      generateExpression(child).map(v => new GeneralScalarExpression("-",
+        Array[V2Expression](new V2Extract("DAY_OF_WEEK", v), LiteralValue(1, IntegerType))))
     case DayOfMonth(child) =>
       generateExpression(child).map(v => new V2Extract("DAY", v))
     case DayOfYear(child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -140,12 +140,13 @@ private[sql] object H2Dialect extends JdbcDialect {
   class H2JDBCSQLBuilder extends JDBCSQLBuilder {
 
     override def visitExtract(field: String, source: String): String = {
-      field match {
-        case "DAY_OF_WEEK" => s"EXTRACT(ISO_DAY_OF_WEEK FROM $source)"
-        case "WEEK" => s"EXTRACT(ISO_WEEK FROM $source)"
-        case "YEAR_OF_WEEK" => s"EXTRACT(ISO_WEEK_YEAR FROM $source)"
-        case _ => super.visitExtract(field, source)
+      val newField = field match {
+        case "DAY_OF_WEEK" => "ISO_DAY_OF_WEEK"
+        case "WEEK" => "ISO_WEEK"
+        case "YEAR_OF_WEEK" => "ISO_WEEK_YEAR"
+        case _ => field
       }
+      s"EXTRACT($newField FROM $source)"
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -40,9 +40,7 @@ private[sql] object H2Dialect extends JdbcDialect {
     Set("ABS", "COALESCE", "GREATEST", "LEAST", "RAND", "LOG", "LOG10", "LN", "EXP",
       "POWER", "SQRT", "FLOOR", "CEIL", "ROUND", "SIN", "SINH", "COS", "COSH", "TAN",
       "TANH", "COT", "ASIN", "ACOS", "ATAN", "ATAN2", "DEGREES", "RADIANS", "SIGN",
-      "PI", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE", "TRIM", "SECOND", "MINUTE",
-      "HOUR", "MONTH", "QUARTER", "YEAR", "DAY", "DOY", "DAY_OF_WEEK", "YEAR_OF_WEEK",
-      "WEEK")
+      "PI", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE", "TRIM")
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -41,8 +41,8 @@ private[sql] object H2Dialect extends JdbcDialect {
       "POWER", "SQRT", "FLOOR", "CEIL", "ROUND", "SIN", "SINH", "COS", "COSH", "TAN",
       "TANH", "COT", "ASIN", "ACOS", "ATAN", "ATAN2", "DEGREES", "RADIANS", "SIGN",
       "PI", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE", "TRIM", "SECOND", "MINUTE",
-      "HOUR", "MONTH", "QUARTER", "YEAR", "DAY", "DOY", "DAY_OF_WEEK", "WEEK_DAY",
-      "WEEK", "YEAR_OF_WEEK")
+      "HOUR", "MONTH", "QUARTER", "YEAR", "DAY", "DOY", "DAY_OF_WEEK", "YEAR_OF_WEEK",
+      "WEEK")
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
@@ -143,6 +143,7 @@ private[sql] object H2Dialect extends JdbcDialect {
 
     override def visitExtract(field: String, source: String): String = {
       field match {
+        case "DAY_OF_WEEK" => s"EXTRACT(ISO_DAY_OF_WEEK FROM $source)"
         case "WEEK" => s"EXTRACT(ISO_WEEK FROM $source)"
         case "YEAR_OF_WEEK" => s"EXTRACT(ISO_WEEK_YEAR FROM $source)"
         case _ => super.visitExtract(field, source)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -270,6 +270,17 @@ abstract class JdbcDialect extends Serializable with Logging{
           s"${this.getClass.getSimpleName} does not support function: TRIM")
       }
     }
+
+    override def visitExtract(field: String, source: String): String = {
+      if (isSupportedFunction(field)) {
+        super.visitExtract(field, source)
+      } else {
+        // The framework will catch the error and give up the push-down.
+        // Please see `JdbcDialect.compileExpression(expr: Expression)` for more details.
+        throw new UnsupportedOperationException(
+          s"${this.getClass.getSimpleName} does not support function: EXTRACT")
+      }
+    }
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -270,17 +270,6 @@ abstract class JdbcDialect extends Serializable with Logging{
           s"${this.getClass.getSimpleName} does not support function: TRIM")
       }
     }
-
-    override def visitExtract(field: String, source: String): String = {
-      if (isSupportedFunction(field)) {
-        super.visitExtract(field, source)
-      } else {
-        // The framework will catch the error and give up the push-down.
-        // Please see `JdbcDialect.compileExpression(expr: Expression)` for more details.
-        throw new UnsupportedOperationException(
-          s"${this.getClass.getSimpleName} does not support function: EXTRACT")
-      }
-    }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1093,8 +1093,8 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
           "weekday(date1) = 2 AND dayofweek(date1) = 4")
         checkFiltersRemoved(df12)
         val expectedPlanFragment12 =
-          "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(ISO_DAY_OF_WEEK FROM DATE1) -1 = 2, " +
-            "(EXTRACT(ISO_DAY_OF_WEEK FROM DAT..."
+          "PushedFilters: [DATE1 IS NOT NULL, (EXTRACT(DAY_OF_WEEK FROM DATE1) - 1) = 2, " +
+          "((EXTRACT(DAY_OF_WEEK FROM DATE1) ..."
         checkPushedInfo(df12, expectedPlanFragment12)
         checkAnswer(df12, Seq(Row("alex")))
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1042,77 +1042,85 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         }
         checkPushedInfo(df6, expectedPlanFragment6)
         checkAnswer(df6, Seq(Row(2, "david", 10000, 1300, true)))
+      }
+    }
+  }
 
-        val df7 = sql("SELECT name FROM h2.test.datetime WHERE " +
+  test("scan with filter push-down with date time functions") {
+    Seq(false, true).foreach { ansiMode =>
+      withSQLConf(SQLConf.ANSI_ENABLED.key -> ansiMode.toString,
+        SQLConf.MAX_METADATA_STRING_LENGTH.key -> "200") {
+
+        val df1 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "dayofyear(date1) > 100 AND dayofmonth(date1) > 10 ")
-        checkFiltersRemoved(df7)
-        val expectedPlanFragment7 =
+        checkFiltersRemoved(df1)
+        val expectedPlanFragment1 =
           "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(DAY_OF_YEAR FROM DATE1) > 100, " +
-          "EXTRACT(DAY FROM DATE1) > 10]"
-        checkPushedInfo(df7, expectedPlanFragment7)
-        checkAnswer(df7, Seq(Row("amy"), Row("alex")))
+            "EXTRACT(DAY FROM DATE1) > 10]"
+        checkPushedInfo(df1, expectedPlanFragment1)
+        checkAnswer(df1, Seq(Row("amy"), Row("alex")))
 
-        val df8 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df2 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "year(date1) = 2022 AND quarter(date1) = 2")
-        checkFiltersRemoved(df8)
-        val expectedPlanFragment8 =
+        checkFiltersRemoved(df2)
+        val expectedPlanFragment2 =
           "[DATE1 IS NOT NULL, EXTRACT(YEAR FROM DATE1) = 2022, " +
-          "EXTRACT(QUARTER FROM DATE1) = 2]"
-        checkPushedInfo(df8, expectedPlanFragment8)
-        checkAnswer(df8, Seq(Row("amy"), Row("alex")))
+            "EXTRACT(QUARTER FROM DATE1) = 2]"
+        checkPushedInfo(df2, expectedPlanFragment2)
+        checkAnswer(df2, Seq(Row("amy"), Row("alex")))
 
-        val df9 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df3 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "second(time1) = 0 AND month(date1) = 5")
-        checkFiltersRemoved(df9)
-        val expectedPlanFragment9 =
-          "PushedFilters: [TIME1 IS NOT NULL, DATE1 IS NOT NULL, EXTRACT(SECOND FROM TIME1) = 0, " +
-          "EXTRACT(MONTH FROM DATE1) ..."
-        checkPushedInfo(df9, expectedPlanFragment9)
-        checkAnswer(df9, Seq(Row("amy"), Row("alex")))
+        checkFiltersRemoved(df3)
+        val expectedPlanFragment3 =
+          "PushedFilters: [TIME1 IS NOT NULL, DATE1 IS NOT NULL, " +
+            "EXTRACT(SECOND FROM TIME1) = 0, EXTRACT(MONTH FROM DATE1) = 5]"
+        checkPushedInfo(df3, expectedPlanFragment3)
+        checkAnswer(df3, Seq(Row("amy"), Row("alex")))
 
-        val df10 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df4 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "hour(time1) = 0 AND minute(time1) = 0")
-        checkFiltersRemoved(df10)
-        val expectedPlanFragment10 =
+        checkFiltersRemoved(df4)
+        val expectedPlanFragment4 =
           "PushedFilters: [TIME1 IS NOT NULL, EXTRACT(HOUR FROM TIME1) = 0, " +
             "EXTRACT(MINUTE FROM TIME1) = 0]"
-        checkPushedInfo(df10, expectedPlanFragment10)
-        checkAnswer(df10, Seq(Row("amy"), Row("alex")))
+        checkPushedInfo(df4, expectedPlanFragment4)
+        checkAnswer(df4, Seq(Row("amy"), Row("alex")))
 
-        val df11 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df5 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "extract(WEEk from date1) > 10 AND extract(YEAROFWEEK from date1) = 2022")
-        checkFiltersRemoved(df11)
-        val expectedPlanFragment11 =
+        checkFiltersRemoved(df5)
+        val expectedPlanFragment5 =
           "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(WEEK FROM DATE1) > 10, " +
             "EXTRACT(YEAR_OF_WEEK FROM DATE1) = 2022]"
-        checkPushedInfo(df11, expectedPlanFragment11)
-        checkAnswer(df11, Seq(Row("alex"), Row("amy")))
+        checkPushedInfo(df5, expectedPlanFragment5)
+        checkAnswer(df5, Seq(Row("alex"), Row("amy")))
 
         // H2 does not support
-        val df12 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df6 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "trunc(date1, 'week') = date'2022-05-16' AND date_add(date1, 1) = date'2022-05-20' " +
           "AND datediff(date1, '2022-05-10') > 0")
-        checkFiltersRemoved(df12, false)
-        val expectedPlanFragment12 =
+        checkFiltersRemoved(df6, false)
+        val expectedPlanFragment6 =
           "PushedFilters: [DATE1 IS NOT NULL]"
-        checkPushedInfo(df12, expectedPlanFragment12)
-        checkAnswer(df12, Seq(Row("amy")))
+        checkPushedInfo(df6, expectedPlanFragment6)
+        checkAnswer(df6, Seq(Row("amy")))
 
-        val df13 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df7 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "weekday(date1) = 2")
-        checkFiltersRemoved(df13)
-        val expectedPlanFragment13 =
+        checkFiltersRemoved(df7)
+        val expectedPlanFragment7 =
           "PushedFilters: [DATE1 IS NOT NULL, (EXTRACT(DAY_OF_WEEK FROM DATE1) - 1) = 2]"
-        checkPushedInfo(df13, expectedPlanFragment13)
-        checkAnswer(df13, Seq(Row("alex")))
+        checkPushedInfo(df7, expectedPlanFragment7)
+        checkAnswer(df7, Seq(Row("alex")))
 
-        val df14 = sql("SELECT name FROM h2.test.datetime WHERE " +
+        val df8 = sql("SELECT name FROM h2.test.datetime WHERE " +
           "dayofweek(date1) = 4")
-        checkFiltersRemoved(df14)
-        val expectedPlanFragment14 =
+        checkFiltersRemoved(df8)
+        val expectedPlanFragment8 =
           "PushedFilters: [DATE1 IS NOT NULL, ((EXTRACT(DAY_OF_WEEK FROM DATE1) % 7) + 1) = 4]"
-        checkPushedInfo(df14, expectedPlanFragment14)
-        checkAnswer(df14, Seq(Row("alex")))
+        checkPushedInfo(df8, expectedPlanFragment8)
+        checkAnswer(df8, Seq(Row("alex")))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.jdbc
 
 import java.sql.{Connection, DriverManager}
 import java.util.Properties
+
 import scala.util.control.NonFatal
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, ExplainSuiteHelper, QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -29,10 +31,9 @@ import org.apache.spark.sql.connector.{IntegralAverage, StrLen}
 import org.apache.spark.sql.connector.catalog.functions.{ScalarFunction, UnboundFunction}
 import org.apache.spark.sql.connector.expressions.Expression
 import org.apache.spark.sql.connector.expressions.aggregate.{AggregateFunc, UserDefinedAggregateFunc}
-import org.apache.spark.sql.execution.SimpleMode
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, V1ScanWrapper}
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
-import org.apache.spark.sql.functions.{abs, acos, asin, atan, atan2, avg, ceil, coalesce, cos, cosh, cot, count, count_distinct, degrees, exp, floor, lit, log10, not, pow, radians, round, signum, sin, sinh, sqrt, sum, tan, tanh, udf, when, log => logarithm}
+import org.apache.spark.sql.functions.{abs, acos, asin, atan, atan2, avg, ceil, coalesce, cos, cosh, cot, count, count_distinct, degrees, exp, floor, lit, log => logarithm, log10, not, pow, radians, round, signum, sin, sinh, sqrt, sum, tan, tanh, udf, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, IntegerType, StringType}
@@ -209,7 +210,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   private def checkPushedInfo(df: DataFrame, expectedPlanFragment: String*): Unit = {
     df.queryExecution.optimizedPlan.collect {
       case _: DataSourceV2ScanRelation =>
-        checkKeywordsExistsInExplain(df, SimpleMode, expectedPlanFragment: _*)
+        checkKeywordsExistsInExplain(df, expectedPlanFragment: _*)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -208,9 +208,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   private def checkPushedInfo(df: DataFrame, expectedPlanFragment: String*): Unit = {
-    df.queryExecution.optimizedPlan.collect {
-      case _: DataSourceV2ScanRelation =>
-        checkKeywordsExistsInExplain(df, expectedPlanFragment: _*)
+    withSQLConf(SQLConf.MAX_METADATA_STRING_LENGTH.key -> "1000") {
+      df.queryExecution.optimizedPlan.collect {
+        case _: DataSourceV2ScanRelation =>
+          checkKeywordsExistsInExplain(df, expectedPlanFragment: _*)
+      }
     }
   }
 
@@ -753,8 +755,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkSortRemoved(df9)
     checkLimitRemoved(df9)
     checkPushedInfo(df9, "PushedFilters: [], " +
-      "PushedTopN: ORDER BY [CASE WHEN (SALARY > 8000.00) AND " +
-      "(SALARY < 10000.00) THEN SALARY ELSE 0.00 END ASC NULL..., ")
+      "PushedTopN: " +
+      "ORDER BY [CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
+      "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3,")
     checkAnswer(df9,
       Seq(Row(1, "amy", 10000, 0), Row(2, "david", 10000, 0), Row(2, "alex", 12000, 0)))
 
@@ -771,8 +774,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkSortRemoved(df10, false)
     checkLimitRemoved(df10, false)
     checkPushedInfo(df10, "PushedFilters: [], " +
-      "PushedTopN: ORDER BY [CASE WHEN (SALARY > 8000.00) AND " +
-      "(SALARY < 10000.00) THEN SALARY ELSE 0.00 END ASC NULL..., ")
+      "PushedTopN: " +
+      "ORDER BY [CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
+      "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3,")
     checkAnswer(df10,
       Seq(Row(1, "amy", 10000, 0), Row(2, "david", 10000, 0), Row(2, "alex", 12000, 0)))
   }
@@ -889,8 +893,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .filter(floor($"bonus") === 1200)
       .filter(ceil($"bonus") === 1200)
     checkFiltersRemoved(df13)
-    checkPushedInfo(df13, "PushedFilters: [BONUS IS NOT NULL, LN(BONUS) > 7.0, EXP(BONUS) > 0.0, " +
-      "(POWER(BONUS, 2.0)) = 1440000.0, SQRT(BONU...,")
+    checkPushedInfo(df13, "PushedFilters: " +
+      "[BONUS IS NOT NULL, LN(BONUS) > 7.0, EXP(BONUS) > 0.0, (POWER(BONUS, 2.0)) = 1440000.0, " +
+      "SQRT(BONUS) > 34.0, FLOOR(BONUS) = 1200, CEIL(BONUS) = 1200],")
     checkAnswer(df13, Seq(Row(1, "cathy", 9000, 1200, false),
       Row(2, "alex", 12000, 1200, false), Row(6, "jen", 12000, 1200, true)))
 
@@ -912,8 +917,10 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .filter(radians($"bonus") > 20)
       .filter(signum($"bonus") === 1)
     checkFiltersRemoved(df15)
-    checkPushedInfo(df15, "PushedFilters: [BONUS IS NOT NULL, (LOG(2.0, BONUS)) > 10.0, " +
-      "LOG10(BONUS) > 3.0, (ROUND(BONUS, 0)) = 1200.0, DEG...,")
+    checkPushedInfo(df15, "PushedFilters: " +
+      "[BONUS IS NOT NULL, (LOG(2.0, BONUS)) > 10.0, LOG10(BONUS) > 3.0, " +
+      "(ROUND(BONUS, 0)) = 1200.0, DEGREES(BONUS) > 68754.0, RADIANS(BONUS) > 20.0, " +
+      "SIGN(BONUS) = 1.0],")
     checkAnswer(df15, Seq(Row(1, "cathy", 9000, 1200, false),
       Row(2, "alex", 12000, 1200, false), Row(6, "jen", 12000, 1200, true)))
 
@@ -930,8 +937,10 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .filter(atan($"bonus") > 1.4)
       .filter(atan2($"bonus", $"bonus") > 0.7)
     checkFiltersRemoved(df16)
-    checkPushedInfo(df16, "PushedFilters: [BONUS IS NOT NULL, SIN(BONUS) < -0.08, " +
-      "SINH(BONUS) > 200.0, COS(BONUS) > 0.9, COSH(BONUS) > 200....,")
+    checkPushedInfo(df16, "PushedFilters: [" +
+      "BONUS IS NOT NULL, SIN(BONUS) < -0.08, SINH(BONUS) > 200.0, COS(BONUS) > 0.9, " +
+      "COSH(BONUS) > 200.0, TAN(BONUS) < -0.08, TANH(BONUS) = 1.0, COT(BONUS) < -11.0, " +
+      "ASIN(BONUS) > 0.1, ACOS(BONUS) > 1.4, ATAN(BONUS) > 1.4, (ATAN2(BONUS, BONUS)) > 0.7],")
     checkAnswer(df16, Seq(Row(1, "cathy", 9000, 1200, false),
       Row(2, "alex", 12000, 1200, false), Row(6, "jen", 12000, 1200, true)))
 
@@ -1036,7 +1045,8 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         checkFiltersRemoved(df6, ansiMode)
         val expectedPlanFragment6 = if (ansiMode) {
           "PushedFilters: [BONUS IS NOT NULL, DEPT IS NOT NULL, " +
-            "CAST(BONUS AS string) LIKE '%30%', CAST(DEPT AS byte) > 1, ...,"
+            "CAST(BONUS AS string) LIKE '%30%', CAST(DEPT AS byte) > 1, " +
+            "CAST(DEPT AS short) > 1, CAST(BONUS AS decimal(20,2)) > 1200.00]"
         } else {
           "PushedFilters: [BONUS IS NOT NULL, DEPT IS NOT NULL],"
         }
@@ -1047,78 +1057,76 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("scan with filter push-down with date time functions") {
-    withSQLConf(SQLConf.MAX_METADATA_STRING_LENGTH.key -> "200") {
-      val df1 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "dayofyear(date1) > 100 AND dayofmonth(date1) > 10 ")
-      checkFiltersRemoved(df1)
-      val expectedPlanFragment1 =
-        "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(DAY_OF_YEAR FROM DATE1) > 100, " +
-          "EXTRACT(DAY FROM DATE1) > 10]"
-      checkPushedInfo(df1, expectedPlanFragment1)
-      checkAnswer(df1, Seq(Row("amy"), Row("alex")))
+    val df1 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "dayofyear(date1) > 100 AND dayofmonth(date1) > 10 ")
+    checkFiltersRemoved(df1)
+    val expectedPlanFragment1 =
+      "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(DAY_OF_YEAR FROM DATE1) > 100, " +
+        "EXTRACT(DAY FROM DATE1) > 10]"
+    checkPushedInfo(df1, expectedPlanFragment1)
+    checkAnswer(df1, Seq(Row("amy"), Row("alex")))
 
-      val df2 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "year(date1) = 2022 AND quarter(date1) = 2")
-      checkFiltersRemoved(df2)
-      val expectedPlanFragment2 =
-        "[DATE1 IS NOT NULL, EXTRACT(YEAR FROM DATE1) = 2022, " +
-          "EXTRACT(QUARTER FROM DATE1) = 2]"
-      checkPushedInfo(df2, expectedPlanFragment2)
-      checkAnswer(df2, Seq(Row("amy"), Row("alex")))
+    val df2 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "year(date1) = 2022 AND quarter(date1) = 2")
+    checkFiltersRemoved(df2)
+    val expectedPlanFragment2 =
+      "[DATE1 IS NOT NULL, EXTRACT(YEAR FROM DATE1) = 2022, " +
+        "EXTRACT(QUARTER FROM DATE1) = 2]"
+    checkPushedInfo(df2, expectedPlanFragment2)
+    checkAnswer(df2, Seq(Row("amy"), Row("alex")))
 
-      val df3 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "second(time1) = 0 AND month(date1) = 5")
-      checkFiltersRemoved(df3)
-      val expectedPlanFragment3 =
-        "PushedFilters: [TIME1 IS NOT NULL, DATE1 IS NOT NULL, " +
-          "EXTRACT(SECOND FROM TIME1) = 0, EXTRACT(MONTH FROM DATE1) = 5]"
-      checkPushedInfo(df3, expectedPlanFragment3)
-      checkAnswer(df3, Seq(Row("amy"), Row("alex")))
+    val df3 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "second(time1) = 0 AND month(date1) = 5")
+    checkFiltersRemoved(df3)
+    val expectedPlanFragment3 =
+      "PushedFilters: [TIME1 IS NOT NULL, DATE1 IS NOT NULL, " +
+        "EXTRACT(SECOND FROM TIME1) = 0, EXTRACT(MONTH FROM DATE1) = 5]"
+    checkPushedInfo(df3, expectedPlanFragment3)
+    checkAnswer(df3, Seq(Row("amy"), Row("alex")))
 
-      val df4 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "hour(time1) = 0 AND minute(time1) = 0")
-      checkFiltersRemoved(df4)
-      val expectedPlanFragment4 =
-        "PushedFilters: [TIME1 IS NOT NULL, EXTRACT(HOUR FROM TIME1) = 0, " +
-          "EXTRACT(MINUTE FROM TIME1) = 0]"
-      checkPushedInfo(df4, expectedPlanFragment4)
-      checkAnswer(df4, Seq(Row("amy"), Row("alex")))
+    val df4 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "hour(time1) = 0 AND minute(time1) = 0")
+    checkFiltersRemoved(df4)
+    val expectedPlanFragment4 =
+      "PushedFilters: [TIME1 IS NOT NULL, EXTRACT(HOUR FROM TIME1) = 0, " +
+        "EXTRACT(MINUTE FROM TIME1) = 0]"
+    checkPushedInfo(df4, expectedPlanFragment4)
+    checkAnswer(df4, Seq(Row("amy"), Row("alex")))
 
-      val df5 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "extract(WEEk from date1) > 10 AND extract(YEAROFWEEK from date1) = 2022")
-      checkFiltersRemoved(df5)
-      val expectedPlanFragment5 =
-        "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(WEEK FROM DATE1) > 10, " +
-          "EXTRACT(YEAR_OF_WEEK FROM DATE1) = 2022]"
-      checkPushedInfo(df5, expectedPlanFragment5)
-      checkAnswer(df5, Seq(Row("alex"), Row("amy")))
+    val df5 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "extract(WEEk from date1) > 10 AND extract(YEAROFWEEK from date1) = 2022")
+    checkFiltersRemoved(df5)
+    val expectedPlanFragment5 =
+      "PushedFilters: [DATE1 IS NOT NULL, EXTRACT(WEEK FROM DATE1) > 10, " +
+        "EXTRACT(YEAR_OF_WEEK FROM DATE1) = 2022]"
+    checkPushedInfo(df5, expectedPlanFragment5)
+    checkAnswer(df5, Seq(Row("alex"), Row("amy")))
 
-      // H2 does not support
-      val df6 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "trunc(date1, 'week') = date'2022-05-16' AND date_add(date1, 1) = date'2022-05-20' " +
-        "AND datediff(date1, '2022-05-10') > 0")
-      checkFiltersRemoved(df6, false)
-      val expectedPlanFragment6 =
-        "PushedFilters: [DATE1 IS NOT NULL]"
-      checkPushedInfo(df6, expectedPlanFragment6)
-      checkAnswer(df6, Seq(Row("amy")))
+    // H2 does not support
+    val df6 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "trunc(date1, 'week') = date'2022-05-16' AND date_add(date1, 1) = date'2022-05-20' " +
+      "AND datediff(date1, '2022-05-10') > 0")
+    checkFiltersRemoved(df6, false)
+    val expectedPlanFragment6 =
+      "PushedFilters: [DATE1 IS NOT NULL]"
+    checkPushedInfo(df6, expectedPlanFragment6)
+    checkAnswer(df6, Seq(Row("amy")))
 
-      val df7 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "weekday(date1) = 2")
-      checkFiltersRemoved(df7)
-      val expectedPlanFragment7 =
-        "PushedFilters: [DATE1 IS NOT NULL, (EXTRACT(DAY_OF_WEEK FROM DATE1) - 1) = 2]"
-      checkPushedInfo(df7, expectedPlanFragment7)
-      checkAnswer(df7, Seq(Row("alex")))
+    val df7 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "weekday(date1) = 2")
+    checkFiltersRemoved(df7)
+    val expectedPlanFragment7 =
+      "PushedFilters: [DATE1 IS NOT NULL, (EXTRACT(DAY_OF_WEEK FROM DATE1) - 1) = 2]"
+    checkPushedInfo(df7, expectedPlanFragment7)
+    checkAnswer(df7, Seq(Row("alex")))
 
-      val df8 = sql("SELECT name FROM h2.test.datetime WHERE " +
-        "dayofweek(date1) = 4")
-      checkFiltersRemoved(df8)
-      val expectedPlanFragment8 =
-        "PushedFilters: [DATE1 IS NOT NULL, ((EXTRACT(DAY_OF_WEEK FROM DATE1) % 7) + 1) = 4]"
-      checkPushedInfo(df8, expectedPlanFragment8)
-      checkAnswer(df8, Seq(Row("alex")))
-    }
+    val df8 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "dayofweek(date1) = 4")
+    checkFiltersRemoved(df8)
+    val expectedPlanFragment8 =
+      "PushedFilters: [DATE1 IS NOT NULL, ((EXTRACT(DAY_OF_WEEK FROM DATE1) % 7) + 1) = 4]"
+    checkPushedInfo(df8, expectedPlanFragment8)
+    checkAnswer(df8, Seq(Row("alex")))
   }
 
   test("scan with filter push-down with UDF") {
@@ -1298,7 +1306,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkFiltersRemoved(df2)
     val expectedPlanFragment2 =
       "PushedFilters: [NAME IS NOT NULL, TRIM(BOTH FROM NAME) = 'jen', " +
-      "(TRIM(BOTH 'j' FROM NAME)) = 'en', (TRANSLATE(NA..."
+      "(TRIM(BOTH 'j' FROM NAME)) = 'en', (TRANSLATE(NAME, 'e', '1')) = 'j1n']"
     checkPushedInfo(df2, expectedPlanFragment2)
     checkAnswer(df2, Seq(Row(6, "jen", 12000, 1200, true)))
 
@@ -1814,10 +1822,20 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       """.stripMargin)
     checkAggregateRemoved(df)
     checkPushedInfo(df,
-      "PushedAggregates: [COUNT(CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00)" +
-      " THEN SALARY ELSE 0.00 END), COUNT(CAS..., " +
-      "PushedFilters: [], " +
-      "PushedGroupByExpressions: [DEPT], ")
+      "PushedAggregates: " +
+        "[COUNT(CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END), " +
+        "COUNT(CASE WHEN (SALARY > 8000.00) AND (SALARY <= 13000.00) THEN SALARY ELSE 0.00 END), " +
+        "COUNT(CASE WHEN (SALARY > 11000.00) OR (SALARY < 10000.00) THEN SALARY ELSE 0.00 END), " +
+        "COUNT(CASE WHEN (SALARY >= 12000.00) OR (SALARY < 9000.00) THEN SALARY ELSE 0.00 END), " +
+        "MAX(CASE WHEN (SALARY <= 10000.00) AND (SALARY >= 8000.00) THEN SALARY ELSE 0.00 END), " +
+        "MAX(CASE WHEN (SALARY <= 9000.00) OR (SALARY > 10000.00) THEN SALARY ELSE 0.00 END), " +
+        "MAX(CASE WHEN (SALARY = 0.00) OR (SALARY >= 8000.00) THEN SALARY ELSE 0.00 END), " +
+        "MAX(CASE WHEN (SALARY <= 8000.00) OR (SALARY >= 10000.00) THEN 0.00 ELSE SALARY END), " +
+        "MIN(CASE WHEN (SALARY <= 8000.00) AND (SALARY IS NOT NULL) THEN SALARY ELSE 0.00 END), " +
+        "SUM(CASE WHEN SALARY > 10000.00 THEN 2 WHEN SALARY > 8000.00 THEN 1 END), " +
+        "AVG(CASE WHEN (SALARY <= 8000.00) AND (SALARY IS NULL) THEN SALARY ELSE 0.00 END)], " +
+        "PushedFilters: [], " +
+        "PushedGroupByExpressions: [DEPT],")
     checkAnswer(df, Seq(Row(1, 1, 1, 1, 1, 0d, 12000d, 0d, 12000d, 0d, 0d, 2, 0d),
       Row(2, 2, 2, 2, 2, 10000d, 12000d, 10000d, 12000d, 0d, 0d, 3, 0d),
       Row(2, 2, 2, 2, 2, 10000d, 9000d, 10000d, 10000d, 9000d, 0d, 2, 0d)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, Spark have some datetime functions. Please refer
https://github.com/apache/spark/blob/2f8613f22c0750c00cf1dcfb2f31c431d8dc1be7/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala#L577

These functions show below:
`DATE_ADD,`
`DATEDIFF`,
`TRUNC`,
`EXTRACT`,
`SECOND`,
`MINUTE`,
`HOUR`,
`MONTH`,
`QUARTER`,
`YEAR`,
`DAYOFWEEK`,
`DAYOFMONTH`,
`DAYOFYEAR`

The mainstream databases support these functions show below.
Function|PostgreSQL|ClickHouse|H2|MySQL|Oracle|Presto|Teradata|Snowflake|DB2|Vertica|Exasol|Impala|Mariadb|Druid|Singlestore|ElasticSearch
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
`DateAdd`|No|Yes|Yes|Yes|Yes|Yes|No|Yes|No|No|No|Yes|Yes|No|Yes|Yes
`DateDiff`|No|Yes|Yes|Yes|Yes|Yes|No|Yes|No|Yes|No|Yes|Yes|No|Yes|Yes
`DateTrunc`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes| Yes|Yes|Yes|Yes|No|Yes|Yes|Yes
`Hour`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes
`Minute`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes
`Month`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes
`Quarter`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes
`Second`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes
`Year`|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes|Yes
`DayOfMonth`|Yes|Yes|Yes|Yes|Yes|Yes|No|Yes|Yes|Yes|No|Yes|Yes|Yes|No|Yes
`DayOfWeek`|Yes|Yes|Yes|Yes|Yes|Yes|No|Yes|Yes|Yes|No|Yes|Yes|Yes|Yes|Yes
`DayOfYear`|Yes|Yes|Yes|Yes|Yes|Yes|No|Yes|Yes|Yes|No|Yes|Yes|Yes|Yes|Yes
`WEEK_OF_YEAR`|Yes|No|Yes|Yes|Yes|Yes|No|Yes|Yes|Yes|No|Yes|Yes|Yes|Yes|Yes
`YEAR_OF_WEEK`|No|No|Yes|Yes|Yes|Yes|No|Yes|No|No|No|No|Yes|No|No|No

DS V2 should supports push down these datetime functions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
DS V2 supports push down datetime functions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
'No'.
New feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New tests.