### PR TITLE
[SPARK-39287][CORE] TaskSchedulerImpl should quickly ignore task finished event if its task was finished state.

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -102,6 +102,10 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
               (deserializedResult, size)
           }
 
+          // quickly return if the task has finished
+          if (scheduler.isFinishedTask(taskSetManager, tid)) {
+            return
+          }
           // Set the task result size in the accumulator updates received from the executors.
           // We need to do this here on the driver because if we did this on the executors then
           // we would have to serialize the result again after updating the size.

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -867,6 +867,12 @@ private[spark] class TaskSchedulerImpl(
     taskSetManager.handleTaskGettingResult(tid)
   }
 
+  def isFinishedTask(
+    taskSetManager: TaskSetManager,
+    tid: Long): Boolean = synchronized {
+    taskSetManager.taskInfos(tid).finished
+  }
+
   def handleSuccessfulTask(
       taskSetManager: TaskSetManager,
       tid: Long,


### PR DESCRIPTION

### What changes were proposed in this pull request?

In the  https://github.com/apache/spark/pull/34578 ,  it can ignore task finished events when some tasks are already finished state. But it may not be completely solved yet,  because there is no need to set the task result size in accumulator updates received from the executor when task completion events should be ignored.

### Why are the changes needed?
Reduce unnecessary calculation when some tasks are already finished state.
### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Add unittests.