### PR TITLE
[SPARK-39234][SQL][3.3] Code clean up in SparkThrowableHelper.getMessage

### DIFF
--- a/core/src/main/scala/org/apache/spark/ErrorInfo.scala
+++ b/core/src/main/scala/org/apache/spark/ErrorInfo.scala
@@ -62,7 +62,7 @@ private[spark] object SparkThrowableHelper {
     val errorInfo = errorClassToInfoMap.getOrElse(errorClass,
       throw new IllegalArgumentException(s"Cannot find error class '$errorClass'"))
     String.format(errorInfo.messageFormat.replaceAll("<[a-zA-Z0-9_-]+>", "%s"),
-      messageParameters: _*) + queryContext
+      messageParameters: _*) + s"\n$queryContext"
   }
 
   def getSqlState(errorClass: String): String = {

--- a/core/src/main/scala/org/apache/spark/ErrorInfo.scala
+++ b/core/src/main/scala/org/apache/spark/ErrorInfo.scala
@@ -61,8 +61,13 @@ private[spark] object SparkThrowableHelper {
       queryContext: String = ""): String = {
     val errorInfo = errorClassToInfoMap.getOrElse(errorClass,
       throw new IllegalArgumentException(s"Cannot find error class '$errorClass'"))
+    val displayQueryContext = if (queryContext.isEmpty) {
+      ""
+    } else {
+      s"\n$queryContext"
+    }
     String.format(errorInfo.messageFormat.replaceAll("<[a-zA-Z0-9_-]+>", "%s"),
-      messageParameters: _*) + s"\n$queryContext"
+      messageParameters: _*) + displayQueryContext
   }
 
   def getSqlState(errorClass: String): String = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -89,7 +89,7 @@ case class Origin(
         ""
       }
       val builder = new StringBuilder
-      builder ++= s"\n== SQL$objectContext$positionContext ==\n"
+      builder ++= s"== SQL$objectContext$positionContext ==\n"
 
       val text = sqlText.get
       val start = math.max(startIndex.get, 0)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -876,8 +876,7 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
       objectType = Some("VIEW"),
       objectName = Some("some_view"))
     val expected =
-      """
-        |== SQL of VIEW some_view(line 3, position 38) ==
+      """== SQL of VIEW some_view(line 3, position 38) ==
         |...7890 + 1234567890 + 1234567890, cast('a'
         |                                   ^^^^^^^^
         |as /* comment */


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Remove the starting "\n" in `Origin.context`. The "\n" will be append in the method `SparkThrowableHelper.getMessage` instead.
2. Code clean up the method SparkThrowableHelper.getMessage to eliminate redundant code.

### Why are the changes needed?

Code clean up to eliminate redundant code.
### Does this PR introduce _any_ user-facing change?

No
### How was this patch tested?

Existing UT