### PR TITLE
[SPARK-39293][SQL] Fix the accumulator of ArrayAggregate to handle complex types properly

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -826,7 +826,7 @@ case class ArrayAggregate(
       var i = 0
       while (i < arr.numElements()) {
         elementVar.value.set(arr.get(i, elementVar.dataType))
-        accForMergeVar.value.set(mergeForEval.eval(input))
+        accForMergeVar.value.set(InternalRow.copyValue(mergeForEval.eval(input)))
         i += 1
       }
       accForFinishVar.value.set(accForMergeVar.value.get)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -2957,6 +2957,25 @@ class DataFrameSuite extends QueryTest
     checkAnswer(test10, Row(Array(Row("cbaihg"), Row("fedlkj"))) :: Nil)
   }
 
+  test("SPARK-39293: The accumulator of ArrayAggregate to handle complex types properly") {
+    val reverse = udf((s: String) => s.reverse)
+
+    val df = Seq(Array("abc", "def")).toDF("array")
+    val testArray = df.select(
+      aggregate(
+        col("array"),
+        array().cast("array<string>"),
+        (acc, s) => concat(acc, array(reverse(s)))))
+    checkAnswer(testArray, Row(Array("cba", "fed")) :: Nil)
+
+    val testMap = df.select(
+      aggregate(
+        col("array"),
+        map().cast("map<string, string>"),
+        (acc, s) => map_concat(acc, map(s, reverse(s)))))
+    checkAnswer(testMap, Row(Map("abc" -> "cba", "def" -> "fed")) :: Nil)
+  }
+
   test("SPARK-34882: Aggregate with multiple distinct null sensitive aggregators") {
     withUserDefinedFunction(("countNulls", true)) {
       spark.udf.register("countNulls", udaf(new Aggregator[JLong, JLong, JLong] {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the accumulator of `ArrayAggregate` to handle complex types properly.

The accumulator of `ArrayAggregate` should copy the intermediate result if string, struct, array, or map.

### Why are the changes needed?

If the intermediate data of `ArrayAggregate` holds reusable data, the result will be duplicated.

```scala
import org.apache.spark.sql.functions._

val reverse = udf((s: String) => s.reverse)

val df = Seq(Array("abc", "def")).toDF("array")
val testArray = df.withColumn(
  "agg",
  aggregate(
    col("array"),
    array().cast("array<string>"),
    (acc, s) => concat(acc, array(reverse(s)))))

aggArray.show(truncate=false)
```

should be:

```
+----------+----------+
|array     |agg       |
+----------+----------+
|[abc, def]|[cba, fed]|
+----------+----------+
```

but:

```
+----------+----------+
|array     |agg       |
+----------+----------+
|[abc, def]|[fed, fed]|
+----------+----------+
```

### Does this PR introduce _any_ user-facing change?

Yes, this fixes the correctness issue.

### How was this patch tested?

Added a test.
