### PR TITLE
[SPARK-39297][CORE][UI] bugfix: spark.ui.proxyBase contains proxy or history

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -97,14 +97,14 @@ function formatLogsCells(execLogs, type) {
 
 function getStandAloneAppId(cb) {
   var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
+  var ind = indexOfExcludeBaseProxy(words, "proxy");
   var appId;
   if (ind > 0) {
     appId = words[ind + 1];
     cb(appId);
     return;
   }
-  ind = words.indexOf("history");
+  ind = indexOfExcludeBaseProxy(words, "history");
   if (ind > 0) {
     appId = words[ind + 1];
     cb(appId);
@@ -149,13 +149,13 @@ function ConvertDurationString(data) {
 
 function createTemplateURI(appId, templateName) {
   var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
+  var ind = indexOfExcludeBaseProxy(words, "proxy");
   var baseURI;
   if (ind > 0) {
     baseURI = words.slice(0, ind + 1).join('/') + '/' + appId + '/static/' + templateName + '-template.html';
     return baseURI;
   }
-  ind = words.indexOf("history");
+  ind = indexOfExcludeBaseProxy(words, "history");
   if(ind > 0) {
     baseURI = words.slice(0, ind).join('/') + '/static/' + templateName + '-template.html';
     return baseURI;
@@ -184,14 +184,14 @@ function formatDate(date) {
 
 function createRESTEndPointForExecutorsPage(appId) {
   var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
+  var ind = indexOfExcludeBaseProxy(words, "proxy");
   var newBaseURI;
   if (ind > 0) {
     appId = words[ind + 1];
     newBaseURI = words.slice(0, ind + 2).join('/');
     return newBaseURI + "/api/v1/applications/" + appId + "/allexecutors";
   }
-  ind = words.indexOf("history");
+  ind = indexOfExcludeBaseProxy(words, "history");
   if (ind > 0) {
     appId = words[ind + 1];
     var attemptId = words[ind + 2];
@@ -207,14 +207,14 @@ function createRESTEndPointForExecutorsPage(appId) {
 
 function createRESTEndPointForMiscellaneousProcess(appId) {
   var words = getBaseURI().split('/');
-  var ind = words.indexOf("proxy");
+  var ind = indexOfExcludeBaseProxy(words, "proxy");
   var newBaseURI;
   if (ind > 0) {
     appId = words[ind + 1];
     newBaseURI = words.slice(0, ind + 2).join('/');
     return newBaseURI + "/api/v1/applications/" + appId + "/allmiscellaneousprocess";
   }
-  ind = words.indexOf("history");
+  ind = indexOfExcludeBaseProxy(words, "history");
   if (ind > 0) {
     appId = words[ind + 1];
     var attemptId = words[ind + 2];
@@ -230,5 +230,15 @@ function createRESTEndPointForMiscellaneousProcess(appId) {
 
 function getBaseURI() {
   return document.baseURI || document.URL;
+}
+
+function indexOfExcludeBaseProxy(words, searchWords) {
+    var wordsOfRoot = uiRoot.split('/');
+    var ind = wordsOfRoot.indexOf(searchWords);
+    if (ind < 0) {
+        return words.indexOf(searchWords);
+    } else {
+        return words.indexOf(searchWords, words.indexOf(searchWords) + 1);
+    }
 }
 /* eslint-enable no-unused-vars */


### PR DESCRIPTION
### What changes were proposed in this pull request?

add a new method to search app id in the utils, it will also consider spark.ui.proxyBase

### Why are the changes needed?

if spark.ui.proxyBase contains proxy or history, js will fail to get appid. It is very common to use a proxy which has ingress path /proxy.

### Does this PR introduce _any_ user-facing change?

Yes, user will use them in the JavaScript for the Web UI.

### How the changes have been tested ?
modify the utils.js,then build a spark distribution package, start engine and submit a job local. then visit the application page after proxy. 

