### PR TITLE
[SPARK-39300][PS] Move pandasSkewness and pandasKurtosis into pandas.spark.functions

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -1518,8 +1518,7 @@ class Frame(object, metaclass=ABCMeta):
                     )
                 )
 
-            sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
-            return Column(sql_utils.pandasSkewness(spark_column._jc))
+            return SF.skew(spark_column)
 
         return self._reduce_for_stat_function(
             skew,
@@ -1588,8 +1587,7 @@ class Frame(object, metaclass=ABCMeta):
                     )
                 )
 
-            sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
-            return Column(sql_utils.pandasKurtosis(spark_column._jc))
+            return SF.kurt(spark_column)
 
         return self._reduce_for_stat_function(
             kurtosis,

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -41,7 +41,6 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like  # type: ignore[attr-defined]
 
-from pyspark import SparkContext
 from pyspark.sql import Column, functions as F
 from pyspark.sql.types import (
     BooleanType,

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -748,13 +748,8 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         pyspark.pandas.Series.groupby
         pyspark.pandas.DataFrame.groupby
         """
-
-        def skew(scol: Column) -> Column:
-            sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
-            return Column(sql_utils.pandasSkewness(scol._jc))
-
         return self._reduce_for_stat_function(
-            skew,
+            SF.skew,
             accepted_spark_types=(NumericType,),
             bool_to_numeric=True,
         )

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -54,7 +54,6 @@ else:
 
     _builtin_table = SelectionMixin._builtin_table  # type: ignore[attr-defined]
 
-from pyspark import SparkContext
 from pyspark.sql import Column, DataFrame as SparkDataFrame, Window, functions as F
 from pyspark.sql.types import (
     BooleanType,

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -36,6 +36,16 @@ from pyspark.sql.types import (
 )
 
 
+def skew(col: Column) -> Column:
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.PythonSQLUtils.pandasSkewness(col._jc))
+
+
+def kurt(col: Column) -> Column:
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.PythonSQLUtils.pandasKurtosis(col._jc))
+
+
 def repeat(col: Column, n: Union[int, Column]) -> Column:
     """
     Repeats a string column n times, and returns it as a new string column.

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -121,20 +121,18 @@ class RollingAndExpanding(Generic[FrameLike], metaclass=ABCMeta):
 
     def skew(self) -> FrameLike:
         def skew(scol: Column) -> Column:
-            sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
             return F.when(
                 F.row_number().over(self._unbounded_window) >= self._min_periods,
-                Column(sql_utils.pandasSkewness(scol._jc)).over(self._window),
+                SF.skew(scol).over(self._window),
             ).otherwise(SF.lit(None))
 
         return self._apply_as_series_or_frame(skew)
 
     def kurt(self) -> FrameLike:
         def kurt(scol: Column) -> Column:
-            sql_utils = SparkContext._active_spark_context._jvm.PythonSQLUtils
             return F.when(
                 F.row_number().over(self._unbounded_window) >= self._min_periods,
-                Column(sql_utils.pandasKurtosis(scol._jc)).over(self._window),
+                SF.kurt(scol).over(self._window),
             ).otherwise(SF.lit(None))
 
         return self._apply_as_series_or_frame(kurt)


### PR DESCRIPTION
init

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
`pandasSkewness` and `pandasKurtosis` are used in `generic`,`groupby`,`window`.

move them into `SF` for reuse

### Why are the changes needed?
code clean up


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing UT