### PR TITLE
[SPARK-39268][FOLLOWUP] Move comment w.r.t. zipWithIndex to correct place

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceExec.scala
@@ -43,11 +43,11 @@ case class AttachDistributedSequenceExec(
   override protected def doExecute(): RDD[InternalRow] = {
     val childRDD = child.execute().map(_.copy())
     val checkpointed = if (childRDD.getNumPartitions > 1) {
-      // to avoid execute multiple jobs. zipWithIndex launches a Spark job.
       childRDD.localCheckpoint()
     } else {
       childRDD
     }
+    // to avoid execute multiple jobs. zipWithIndex launches a Spark job.
     checkpointed.zipWithIndex().mapPartitions { iter =>
       val unsafeProj = UnsafeProjection.create(output, output)
       val joinedRow = new JoinedRow


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR moves comment in AttachDistributedSequenceExec to its correct location.

### Why are the changes needed?
Commit f673ebd8afc94a3b434a0156b61366fede80b8f9 misplaced the comment.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test suite.