### PR TITLE
[SPARK-39294][SQL] Support non-vectorized Orc scans with DEFAULT values

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1609,6 +1609,12 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           Config(
             Some(SQLConf.JSON_GENERATOR_IGNORE_NULL_FIELDS.key -> "false")))),
       TestCase(
+        dataSource = "orc",
+        Seq(
+          Config(
+            Some(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false"),
+            insertNullsToStorage = false))),
+      TestCase(
         dataSource = "parquet",
         Seq(
           Config(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Support non-vectorized Orc scans when the table schema has associated DEFAULT column values.

Example:

```
create table t(i int) using orc;
insert into t values(42);
alter table t add column s string default concat('abc', def');
select * from t;
> 42, 'abcdef'
```

### Why are the changes needed?

This change makes it easier to build, query, and maintain tables backed by Orc data.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

This PR includes new test coverage.