### PR TITLE
[SPARK-38474][CORE] Use error class in org.apache.spark.security

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -11,8 +11,8 @@
     ],
     "sqlState" : "22003"
   },
-  "AUTHENTICATION_FAILED": {
-    "message": [
+  "AUTHENTICATION_FAILED" : {
+    "message" : [
       "Failed to authenticate <host>."
     ]
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -11,6 +11,11 @@
     ],
     "sqlState" : "22003"
   },
+  "AUTHENTICATION_FAILED": {
+    "message": [
+      "Failed to authenticate <host>."
+    ]
+  },
   "CANNOT_CAST_DATATYPE" : {
     "message" : [
       "Cannot cast <sourceType> to <targetType>."

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -346,6 +346,11 @@
     ],
     "sqlState" : "22023"
   },
+  "STREAM_CLOSED" : {
+    "message" : [
+      "<streamType> stream is closed."
+    ]
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [
       "Unable to acquire <requestedBytes> bytes of memory, got <receivedBytes>"

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeoutException
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkException, TaskNotSerializableException}
+import org.apache.spark.{SparkException, SparkIllegalArgumentException, TaskNotSerializableException}
 import org.apache.spark.scheduler.{BarrierJobRunWithDynamicAllocationException, BarrierJobSlotsNumberCheckFailed, BarrierJobUnsupportedRDDChainException}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockNotFoundException, BlockSavedOnDecommissionedBlockManagerException, RDDBlockId, UnrecognizedBlockId}
@@ -327,8 +327,8 @@ private[spark] object SparkCoreErrors {
   }
 
   def authenticationFailedError(hostType: String): Throwable = {
-    new SparkException(errorClass = "AUTHENTICATION_FAILED",
-      messageParameters = Array(hostType), cause = null)
+    new SparkIllegalArgumentException(errorClass = "AUTHENTICATION_FAILED",
+      messageParameters = Array(hostType))
   }
 
   def streamClosed(streamType: String): Throwable = {

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -331,7 +331,8 @@ private[spark] object SparkCoreErrors {
       messageParameters = Array(hostType), cause = null)
   }
 
-  def streamClosed(): Throwable = {
-    new SparkException("Cipher stream is closed.")
+  def streamClosed(streamType: String): Throwable = {
+    new SparkException(errorClass = "STREAM_CLOSED",
+      messageParameters = Array(streamType), cause = null)
   }
 }

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeoutException
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkException, SparkIllegalArgumentException, TaskNotSerializableException}
+import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkIOException, TaskNotSerializableException}
 import org.apache.spark.scheduler.{BarrierJobRunWithDynamicAllocationException, BarrierJobSlotsNumberCheckFailed, BarrierJobUnsupportedRDDChainException}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleManager}
 import org.apache.spark.storage.{BlockId, BlockManagerId, BlockNotFoundException, BlockSavedOnDecommissionedBlockManagerException, RDDBlockId, UnrecognizedBlockId}
@@ -332,7 +332,7 @@ private[spark] object SparkCoreErrors {
   }
 
   def streamClosed(streamType: String): Throwable = {
-    new SparkException(errorClass = "STREAM_CLOSED",
-      messageParameters = Array(streamType), cause = null)
+    new SparkIOException(errorClass = "STREAM_CLOSED",
+      messageParameters = Array(streamType))
   }
 }

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -325,4 +325,13 @@ private[spark] object SparkCoreErrors {
     new SparkException(errorClass = "GRAPHITE_SINK_PROPERTY_MISSING",
       messageParameters = Array(missingProperty), cause = null)
   }
+
+  def authenticationFailedError(hostType: String): Throwable = {
+    new SparkException(errorClass = "AUTHENTICATION_FAILED",
+      messageParameters = Array(hostType), cause = null)
+  }
+
+  def streamClosed(): Throwable = {
+    new SparkException("Cipher stream is closed.")
+  }
 }

--- a/core/src/main/scala/org/apache/spark/security/CryptoStreamUtils.scala
+++ b/core/src/main/scala/org/apache/spark/security/CryptoStreamUtils.scala
@@ -191,7 +191,7 @@ private[spark] object CryptoStreamUtils extends Logging {
 
     protected def safeCall[T](fn: => T): T = {
       if (closed) {
-        throw SparkCoreErrors.streamClosed()
+        throw SparkCoreErrors.streamClosed("Cipher")
       }
       try {
         fn

--- a/core/src/main/scala/org/apache/spark/security/CryptoStreamUtils.scala
+++ b/core/src/main/scala/org/apache/spark/security/CryptoStreamUtils.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.security
 
-import java.io.{Closeable, InputStream, IOException, OutputStream}
+import java.io.{Closeable, InputStream, OutputStream}
 import java.nio.ByteBuffer
 import java.nio.channels.{ReadableByteChannel, WritableByteChannel}
 import java.util.Properties
@@ -31,6 +31,7 @@ import org.apache.commons.crypto.random._
 import org.apache.commons.crypto.stream._
 
 import org.apache.spark.SparkConf
+import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.network.util.{CryptoUtils, JavaUtils}
@@ -190,7 +191,7 @@ private[spark] object CryptoStreamUtils extends Logging {
 
     protected def safeCall[T](fn: => T): T = {
       if (closed) {
-        throw new IOException("Cipher stream is closed.")
+        throw SparkCoreErrors.streamClosed()
       }
       try {
         fn

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthHelper.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthHelper.scala
@@ -22,6 +22,7 @@ import java.net.Socket
 import java.nio.charset.StandardCharsets.UTF_8
 
 import org.apache.spark.SparkConf
+import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.util.Utils
 
@@ -60,7 +61,7 @@ private[spark] class SocketAuthHelper(val conf: SparkConf) {
           shouldClose = false
         } else {
           writeUtf8("err", s)
-          throw new IllegalArgumentException("Authentication failed.")
+          throw SparkCoreErrors.authenticationFailedError("client")
         }
       } finally {
         s.setSoTimeout(currentTimeout)
@@ -87,7 +88,7 @@ private[spark] class SocketAuthHelper(val conf: SparkConf) {
 
       val reply = readUtf8(s)
       if (reply != "ok") {
-        throw new IllegalArgumentException("Authentication failed.")
+        throw SparkCoreErrors.authenticationFailedError("server")
       } else {
         shouldClose = false
       }

--- a/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
@@ -189,8 +189,7 @@ class CryptoStreamUtilsSuite extends SparkFunSuite {
       errorHandler.read(out)
     }
     assert(e.getErrorClass === "STREAM_CLOSED")
-    assert(e.getMessage ===
-            "[STREAM_CLOSED] Cipher stream is closed.")
+    assert(e.getMessage === "[STREAM_CLOSED] Cipher stream is closed.")
     errorHandler.close()
 
     verify(decrypted, times(2)).read(any(classOf[ByteBuffer]))

--- a/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
@@ -185,7 +185,7 @@ class CryptoStreamUtilsSuite extends SparkFunSuite {
       errorHandler.read(out)
     }
 
-    val e = intercept[SparkException] {
+    val e = intercept[SparkIOException] {
       errorHandler.read(out)
     }
     assert(e.getErrorClass === "STREAM_CLOSED")

--- a/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/CryptoStreamUtilsSuite.scala
@@ -185,10 +185,12 @@ class CryptoStreamUtilsSuite extends SparkFunSuite {
       errorHandler.read(out)
     }
 
-    val e = intercept[IOException] {
+    val e = intercept[SparkException] {
       errorHandler.read(out)
     }
-    assert(e.getMessage().contains("is closed"))
+    assert(e.getErrorClass === "STREAM_CLOSED")
+    assert(e.getMessage ===
+            "[STREAM_CLOSED] Cipher stream is closed.")
     errorHandler.close()
 
     verify(decrypted, times(2)).read(any(classOf[ByteBuffer]))

--- a/core/src/test/scala/org/apache/spark/security/SocketAuthHelperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/SocketAuthHelperSuite.scala
@@ -26,7 +26,6 @@ import org.apache.spark.{SparkConf, SparkFunSuite, SparkIllegalArgumentException
 import org.apache.spark.internal.config._
 import org.apache.spark.util.Utils
 
-
 class SocketAuthHelperSuite extends SparkFunSuite {
 
   private val conf = new SparkConf()
@@ -62,7 +61,7 @@ class SocketAuthHelperSuite extends SparkFunSuite {
     }
   }
 
-  test("failed to authenticate client") {
+  test("SPARK-38474: failed to authenticate client") {
     val mockedSocket = mock(classOf[Socket])
     val in = mock(classOf[InputStream])
     val out = mock(classOf[OutputStream])

--- a/core/src/test/scala/org/apache/spark/security/SocketAuthHelperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/SocketAuthHelperSuite.scala
@@ -18,11 +18,14 @@ package org.apache.spark.security
 
 import java.io.{Closeable, InputStream, OutputStream}
 import java.net._
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, when}
+
 import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.internal.config._
 import org.apache.spark.util.Utils
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{mock, when}
+
 
 class SocketAuthHelperSuite extends SparkFunSuite {
 

--- a/core/src/test/scala/org/apache/spark/security/SocketAuthHelperSuite.scala
+++ b/core/src/test/scala/org/apache/spark/security/SocketAuthHelperSuite.scala
@@ -22,7 +22,7 @@ import java.net._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
 
-import org.apache.spark.{SparkConf, SparkException, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.internal.config._
 import org.apache.spark.util.Utils
 
@@ -48,7 +48,7 @@ class SocketAuthHelperSuite extends SparkFunSuite {
     Utils.tryWithResource(new ServerThread()) { server =>
       Utils.tryWithResource(server.createClient()) { client =>
         val badHelper = new SocketAuthHelper(new SparkConf().set(AUTH_SECRET_BIT_LENGTH, 128))
-        val exception = intercept[SparkException] {
+        val exception = intercept[SparkIllegalArgumentException] {
           badHelper.authToServer(client)
         }
         assert(exception.getErrorClass === "AUTHENTICATION_FAILED")
@@ -71,7 +71,7 @@ class SocketAuthHelperSuite extends SparkFunSuite {
     when(mockedSocket.getInputStream()).thenReturn(in)
     when(mockedSocket.getOutputStream()).thenReturn(out)
     val helper = new SocketAuthHelper(new SparkConf().set(AUTH_SECRET_BIT_LENGTH, 128))
-    val exception = intercept[SparkException] {
+    val exception = intercept[SparkIllegalArgumentException] {
       helper.authClient(mockedSocket)
     }
     assert(exception.getErrorClass === "AUTHENTICATION_FAILED")


### PR DESCRIPTION

### Why are the changes needed?

Refactored exceptions thrown in the package `org.apache.spark.security` in to be in inline Spark error class framework

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Modified impacted testcases and added new test cases