### PR TITLE
[SPARK-39317][PYTHON][PS] Add explicitly pdf/pser infer when infer schema in groupby.apply

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -1441,7 +1441,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
                 pser_or_pdf = grouped[name].apply(pandas_apply, *args, **kwargs)
             else:
                 pser_or_pdf = grouped.apply(pandas_apply, *args, **kwargs)
-            psser_or_psdf = ps.from_pandas(pser_or_pdf)
+            psser_or_psdf = ps.from_pandas(pser_or_pdf.infer_objects())
 
             if len(pdf) <= limit:
                 if isinstance(psser_or_psdf, ps.Series) and is_series_groupby:

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -2324,6 +2324,18 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         with ps.option_context("compute.shortcut_limit", 2):
             self.test_apply_return_series()
 
+    def test_apply_explicitly_infer(self):
+        # SPARK-39317
+        from pyspark.pandas.utils import SPARK_CONF_ARROW_ENABLED
+
+        def plus_min(x):
+            return x + x.min()
+
+        with self.sql_conf({SPARK_CONF_ARROW_ENABLED: False}):
+            df = ps.DataFrame({"A": ["a", "a", "b"], "B": [1, 2, 3]}, columns=["A", "B"])
+            g = df.groupby("A")
+            g.apply(plus_min).sort_index()
+
     def test_transform(self):
         pdf = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6], "b": [1, 1, 2, 3, 5, 8], "c": [1, 4, 9, 16, 25, 36]},


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add explicitly pdf/pser infer when infer schema groupby.apply for `groupby.apply` infer schema

### Why are the changes needed?

The root reason of [JIRA ](https://issues.apache.org/jira/browse/SPARK-39317) mentioned `TypeError: field B: LongType() can not accept object 2 in type <class 'numpy.int64'>` is PS doesn't support init pandas df with wrong dtype when arrow disable, see below example:

```python
import pandas as pd
import numpy as np
df = pd.DataFrame({'B': [np.int64(1), np.int64(2), np.int64(3)]}, dtype="object")
# Failed
ps.from_pandas(df)
# Passed
ps.from_pandas(df.infer_objects())
```

Given that this process is only used in PS's schema inference, relatively only small data is processed. So, we can reduce the possible of wrong dtypes by calling infer_objects explicitly.

**Why works with pandas < 1.4?** Unfortunately, the behavior changes of `series.replace({np.nan: None})` after Pandas 1.4:
```python
# Pandas >= 1.4
>>> import pandas as pd
>>> import numpy as np
>>> df = pd.DataFrame({'B': [np.int64(1), np.int64(2), np.int64(3)]}, dtype="object")
>>> df.replace({np.nan: None}).dtypes
B    object
dtype: object

# Pandas < 1.4
>>> df = pd.DataFrame({'B': [np.int64(1), np.int64(2), np.int64(3)]}, dtype="object")
>>> df.replace({np.nan: None}).dtypes
B    int64
dtype: object
```

This change impacts the PS behavior of groupby.apply infer schema process ([`ps.from_pandas(pser_or_pdf)`](https://github.com/apache/spark/blob/2a7a1b645b649d498d3e0a4d5508b8cd8d0912d2/python/pyspark/pandas/groupby.py#L1438) --> [`prepare_pandas_frame`](https://github.com/apache/spark/blob/2a7a1b645b649d498d3e0a4d5508b8cd8d0912d2/python/pyspark/pandas/internal.py#L1469) --> [`replace`](https://github.com/apache/spark/blob/2a7a1b645b649d498d3e0a4d5508b8cd8d0912d2/python/pyspark/pandas/data_type_ops/base.py#L492)) finally.

So, it includes an Implicit infer, this patch just add this infer back.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- CI
- new added UT passed with pandas 1.4+ and before 1.4