### PR TITLE
[WIP][SPARK-39319][SQL] Make query context as part of SparkThrowable

### DIFF
--- a/core/src/main/java/org/apache/spark/QueryContext.java
+++ b/core/src/main/java/org/apache/spark/QueryContext.java
@@ -20,7 +20,7 @@ package org.apache.spark;
 import org.apache.spark.annotation.Evolving;
 
 /**
- * SQL Query context of a Spark throwable exception. It helps users understand where the error
+ * SQL Query context of a {@link SparkThrowable}. It helps users understand where the error
  * occurs within the SQL query.
  *
  * @since 3.4.0

--- a/core/src/main/java/org/apache/spark/QueryContext.java
+++ b/core/src/main/java/org/apache/spark/QueryContext.java
@@ -35,7 +35,7 @@ public interface QueryContext {
     // For example, it can be the name of a "VIEW".
     String objectName();
 
-    // The starting index in the SQL query which throws the exception.
+    // The starting index in the SQL query text which throws the exception.
     // Note the index starts from 0.
     int startIndex();
 

--- a/core/src/main/java/org/apache/spark/QueryContext.java
+++ b/core/src/main/java/org/apache/spark/QueryContext.java
@@ -28,11 +28,14 @@ import org.apache.spark.annotation.Evolving;
 @Evolving
 public interface QueryContext {
     // The object type of the SQL query which throws the exception.
-    // For example, it can be empty, or a "VIEW", or a SQL "FUNCTION".
+    // If the exception is directly from the main query, it should be an empty string.
+    // Otherwise, it should be the exact object type in upper case. For example, a "VIEW",
+    // or a SQL "FUNCTION".
     String objectType();
 
     // The object name of the SQL query which throws the exception.
-    // For example, it can be the name of a "VIEW".
+    // If the exception is directly from the main query, it should be an empty string.
+    // Otherwise, it should be the object name. For example, a view name "V1".
     String objectName();
 
     // The starting index in the SQL query text which throws the exception.

--- a/core/src/main/java/org/apache/spark/QueryContext.java
+++ b/core/src/main/java/org/apache/spark/QueryContext.java
@@ -23,17 +23,26 @@ import org.apache.spark.annotation.Evolving;
  * SQL Query context of a Spark throwable exception. It helps users understand where the error
  * occurs within the SQL query.
  *
- * @since 3.2.0
+ * @since 3.4.0
  */
 @Evolving
 public interface QueryContext {
+    // The object type of the SQL query which throws the exception.
+    // For example, it can be empty, or a "VIEW", or a SQL "FUNCTION".
     String objectType();
 
+    // The object name of the SQL query which throws the exception.
+    // For example, it can be the name of a "VIEW".
     String objectName();
 
+    // The starting index in the SQL query which throws the exception.
+    // Note the index starts from 0.
     int startIndex();
 
+    // The stopping index in the SQL query which throws the exception.
+    // The index starts from 0.
     int stopIndex();
 
+    // The corresponding fragment of the SQL query which throws the exception.
     String fragment();
 }

--- a/core/src/main/java/org/apache/spark/QueryContext.java
+++ b/core/src/main/java/org/apache/spark/QueryContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark;
+
+import org.apache.spark.annotation.Evolving;
+
+/**
+ * SQL Query context of a Spark throwable exception. It helps users understand where the error
+ * occurs within the SQL query.
+ *
+ * @since 3.2.0
+ */
+@Evolving
+public interface QueryContext {
+    String objectType();
+
+    String objectName();
+
+    int startIndex();
+
+    int stopIndex();
+
+    String fragment();
+}

--- a/core/src/main/java/org/apache/spark/SparkThrowable.java
+++ b/core/src/main/java/org/apache/spark/SparkThrowable.java
@@ -42,7 +42,7 @@ public interface SparkThrowable {
     return SparkThrowableHelper.getSqlState(this.getErrorClass());
   }
 
-  default QueryContext getQueryContext() { return null; }
+  default QueryContext[] getQueryContext() { return new QueryContext[0]; }
 
   // True if this error is an internal error.
   default boolean isInternalError() {

--- a/core/src/main/java/org/apache/spark/SparkThrowable.java
+++ b/core/src/main/java/org/apache/spark/SparkThrowable.java
@@ -42,6 +42,8 @@ public interface SparkThrowable {
     return SparkThrowableHelper.getSqlState(this.getErrorClass());
   }
 
+  default QueryContext getQueryContext() { return null; }
+
   // True if this error is an internal error.
   default boolean isInternalError() {
     return SparkThrowableHelper.isInternalError(this.getErrorClass());

--- a/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryError.java
+++ b/core/src/main/java/org/apache/spark/memory/SparkOutOfMemoryError.java
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.memory;
 
+import org.apache.spark.QueryContext;
 import org.apache.spark.SparkThrowable;
 import org.apache.spark.SparkThrowableHelper;
 import org.apache.spark.annotation.Private;
@@ -39,7 +40,7 @@ public final class SparkOutOfMemoryError extends OutOfMemoryError implements Spa
     }
 
     public SparkOutOfMemoryError(String errorClass, String[] messageParameters) {
-        super(SparkThrowableHelper.getMessage(errorClass, messageParameters, ""));
+        super(SparkThrowableHelper.getMessage(errorClass, messageParameters));
         this.errorClass = errorClass;
         this.messageParameters = messageParameters;
     }

--- a/core/src/main/scala/org/apache/spark/ErrorInfo.scala
+++ b/core/src/main/scala/org/apache/spark/ErrorInfo.scala
@@ -71,10 +71,13 @@ private[spark] object SparkThrowableHelper {
     mapper.readValue(errorClassesUrl, new TypeReference[SortedMap[String, ErrorInfo]]() {})
   }
 
+  def getMessage(errorClass: String, messageParameters: Array[String]): String =
+    getMessage(errorClass, messageParameters, None)
+
   def getMessage(
       errorClass: String,
       messageParameters: Array[String],
-      queryContext: String = ""): String = {
+      queryContext: Option[QueryContext]): String = {
     val errorInfo = errorClassToInfoMap.getOrElse(errorClass,
       throw new IllegalArgumentException(s"Cannot find error class '$errorClass'"))
     val (displayClass, displayMessageParameters, displayFormat) = if (errorInfo.subClass.isEmpty) {
@@ -90,11 +93,7 @@ private[spark] object SparkThrowableHelper {
     val displayMessage = String.format(
       displayFormat.replaceAll("<[a-zA-Z0-9_-]+>", "%s"),
       displayMessageParameters : _*)
-    val displayQueryContext = if (queryContext.isEmpty) {
-      ""
-    } else {
-      s"\n$queryContext"
-    }
+    val displayQueryContext = queryContext.map(q => "\n" + q.fragment()).getOrElse("")
     s"[$displayClass] $displayMessage$displayQueryContext"
   }
 

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -94,7 +94,7 @@ private[spark] class SparkArithmeticException(
 
   override def getErrorClass: String = errorClass
 
-  override def getQueryContext: QueryContext = queryContext.orNull
+  override def getQueryContext: Array[QueryContext] = queryContext.toArray
 }
 
 /**
@@ -148,7 +148,7 @@ private[spark] class SparkDateTimeException(
 
   override def getErrorClass: String = errorClass
 
-  override def getQueryContext: QueryContext = queryContext.orNull
+  override def getQueryContext: Array[QueryContext] = queryContext.toArray
 }
 
 /**
@@ -188,7 +188,7 @@ private[spark] class SparkNumberFormatException(
 
   override def getErrorClass: String = errorClass
 
-  override def getQueryContext: QueryContext = queryContext.orNull
+  override def getQueryContext: Array[QueryContext] = queryContext.toArray
 }
 
 /**
@@ -250,7 +250,7 @@ private[spark] class SparkRuntimeException(
 
   override def getErrorClass: String = errorClass
 
-  override def getQueryContext: QueryContext = queryContext.orNull
+  override def getQueryContext: Array[QueryContext] = queryContext.toArray
 }
 
 /**
@@ -302,7 +302,7 @@ private[spark] class SparkNoSuchElementException(
 
   override def getErrorClass: String = errorClass
 
-  override def getQueryContext: QueryContext = queryContext.orNull
+  override def getQueryContext: Array[QueryContext] = queryContext.toArray
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/SparkException.scala
+++ b/core/src/main/scala/org/apache/spark/SparkException.scala
@@ -87,12 +87,14 @@ private[spark] class SparkUpgradeException(
 private[spark] class SparkArithmeticException(
     errorClass: String,
     messageParameters: Array[String],
-    queryContext: String = "")
+    queryContext: Option[QueryContext] = None)
   extends ArithmeticException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters, queryContext))
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass
+
+  override def getQueryContext: QueryContext = queryContext.orNull
 }
 
 /**
@@ -139,12 +141,14 @@ private[spark] class SparkConcurrentModificationException(
 private[spark] class SparkDateTimeException(
     errorClass: String,
     messageParameters: Array[String],
-    queryContext: String = "")
+    queryContext: Option[QueryContext] = None)
   extends DateTimeException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters, queryContext))
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass
+
+  override def getQueryContext: QueryContext = queryContext.orNull
 }
 
 /**
@@ -177,12 +181,14 @@ private[spark] class SparkFileNotFoundException(
 private[spark] class SparkNumberFormatException(
     errorClass: String,
     messageParameters: Array[String],
-    queryContext: String)
+    queryContext: Option[QueryContext])
   extends NumberFormatException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters, queryContext))
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass
+
+  override def getQueryContext: QueryContext = queryContext.orNull
 }
 
 /**
@@ -237,12 +243,14 @@ private[spark] class SparkRuntimeException(
     errorClass: String,
     messageParameters: Array[String],
     cause: Throwable = null,
-    queryContext: String = "")
+    queryContext: Option[QueryContext] = None)
   extends RuntimeException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters, queryContext), cause)
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass
+
+  override def getQueryContext: QueryContext = queryContext.orNull
 }
 
 /**
@@ -287,12 +295,14 @@ private[spark] class SparkSQLException(
 private[spark] class SparkNoSuchElementException(
     errorClass: String,
     messageParameters: Array[String],
-    queryContext: String)
+    queryContext: Option[QueryContext])
   extends NoSuchElementException(
     SparkThrowableHelper.getMessage(errorClass, messageParameters, queryContext))
     with SparkThrowable {
 
   override def getErrorClass: String = errorClass
+
+  override def getQueryContext: QueryContext = queryContext.orNull
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.Cast.resolvableNullability
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, TreeNodeTag}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -310,10 +310,12 @@ abstract class CastBase extends UnaryExpression
 
   protected def ansiEnabled: Boolean
 
-  override def initQueryContext(): String = if (ansiEnabled) {
-    origin.context
-  } else {
-    ""
+  override def initQueryContext(): Option[SQLQueryContext] = {
+    if (ansiEnabled) {
+      Some(origin.context)
+    } else {
+      None
+    }
   }
 
   // When this cast involves TimeZone, it's only resolved if the timeZoneId is set;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.Cast.resolvableNullability
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, TreeNodeTag}
+import org.apache.spark.sql.catalyst.trees.{QueryContextImpl, TreeNodeTag}
 import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -310,7 +310,7 @@ abstract class CastBase extends UnaryExpression
 
   protected def ansiEnabled: Boolean
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (ansiEnabled) {
       Some(origin.context)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.{BinaryLike, LeafLike, QuaternaryLike, TernaryLike, TreeNode, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{BinaryLike, LeafLike, QuaternaryLike, SQLQueryContext, TernaryLike, TreeNode, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -593,9 +593,9 @@ abstract class UnaryExpression extends Expression with UnaryLike[Expression] {
  * to executors. It will also be kept after rule transforms.
  */
 trait SupportQueryContext extends Expression with Serializable {
-  protected var queryContext: String = initQueryContext()
+  protected var queryContext: Option[SQLQueryContext] = initQueryContext()
 
-  def initQueryContext(): String
+  def initQueryContext(): Option[SQLQueryContext]
 
   // Note: Even though query contexts are serialized to executors, it will be regenerated from an
   //       empty "Origin" during rule transforms since "Origin"s are not serialized to executors

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.{BinaryLike, LeafLike, QuaternaryLike, SQLQueryContext, TernaryLike, TreeNode, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{BinaryLike, LeafLike, QuaternaryLike, QueryContextImpl, TernaryLike, TreeNode, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern}
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -593,9 +593,9 @@ abstract class UnaryExpression extends Expression with UnaryLike[Expression] {
  * to executors. It will also be kept after rule transforms.
  */
 trait SupportQueryContext extends Expression with Serializable {
-  protected var queryContext: Option[SQLQueryContext] = initQueryContext()
+  protected var queryContext: Option[QueryContextImpl] = initQueryContext()
 
-  def initQueryContext(): Option[SQLQueryContext]
+  def initQueryContext(): Option[QueryContextImpl]
 
   // Note: Even though query contexts are serialized to executors, it will be regenerated from an
   //       empty "Origin" during rule transforms since "Origin"s are not serialized to executors

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import org.apache.spark.sql.catalyst.analysis.{DecimalPrecision, FunctionRegistry, TypeCheckResult}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{AVERAGE, TreePattern}
-import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -135,10 +135,12 @@ case class Average(
 
   override lazy val evaluateExpression: Expression = getEvaluateExpression(queryContext)
 
-  override def initQueryContext(): String = if (useAnsiAdd) {
-    origin.context
-  } else {
-    ""
+  override def initQueryContext(): Option[SQLQueryContext] = {
+    if (useAnsiAdd) {
+      Some(origin.context)
+    } else {
+      None
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Average.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import org.apache.spark.sql.catalyst.analysis.{DecimalPrecision, FunctionRegistry, TypeCheckResult}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{QueryContextImpl, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{AVERAGE, TreePattern}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
@@ -81,7 +81,7 @@ abstract class AverageBase
 
   // If all input are nulls, count will be 0 and we will get null after the division.
   // We can't directly use `/` as it throws an exception under ansi mode.
-  protected def getEvaluateExpression(queryContext: Option[SQLQueryContext]) = {
+  protected def getEvaluateExpression(queryContext: Option[QueryContextImpl]) = {
     child.dataType match {
       case _: DecimalType =>
         DecimalPrecision.decimalAndDecimal()(
@@ -138,7 +138,7 @@ case class Average(
 
   override lazy val evaluateExpression: Expression = getEvaluateExpression(queryContext)
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (useAnsiAdd) {
       Some(origin.context)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{QueryContextImpl, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{SUM, TreePattern}
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
@@ -143,7 +143,7 @@ abstract class SumBase(child: Expression) extends DeclarativeAggregate
    * So now, if ansi is enabled, then throw exception, if not then return null.
    * If sum is not null, then return the sum.
    */
-  protected def getEvaluateExpression(queryContext: Option[SQLQueryContext]): Expression = {
+  protected def getEvaluateExpression(queryContext: Option[QueryContextImpl]): Expression = {
     resultType match {
       case d: DecimalType =>
         val checkOverflowInSum =
@@ -191,7 +191,7 @@ case class Sum(
 
   override lazy val evaluateExpression: Expression = getEvaluateExpression(queryContext)
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (useAnsiAdd) {
       Some(origin.context)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.catalyst.expressions.aggregate
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{SUM, TreePattern}
-import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -189,10 +189,12 @@ case class Sum(
 
   override lazy val evaluateExpression: Expression = getEvaluateExpression(queryContext)
 
-  override def initQueryContext(): String = if (useAnsiAdd) {
-    origin.context
-  } else {
-    ""
+  override def initQueryContext(): Option[SQLQueryContext] = {
+    if (useAnsiAdd) {
+      Some(origin.context)
+    } else {
+      None
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_ARITHMETIC, TreePattern, UNARY_POSITIVE}
 import org.apache.spark.sql.catalyst.util.{IntervalUtils, MathUtils, TypeUtils}
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -220,7 +220,7 @@ abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant
 
   override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (failOnError) {
       Some(origin.context)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, TypeCheckResult, TypeCoercion}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.catalyst.trees.TreePattern.{BINARY_ARITHMETIC, TreePattern, UNARY_POSITIVE}
 import org.apache.spark.sql.catalyst.util.{IntervalUtils, MathUtils, TypeUtils}
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -219,11 +220,11 @@ abstract class BinaryArithmetic extends BinaryOperator with NullIntolerant
 
   override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess
 
-  override def initQueryContext(): String = {
+  override def initQueryContext(): Option[SQLQueryContext] = {
     if (failOnError) {
-      origin.context
+      Some(origin.context)
     } else {
-      ""
+      None
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion, Un
 import org.apache.spark.sql.catalyst.expressions.ArraySortLike.NullOrder
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.{BinaryLike, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{BinaryLike, SQLQueryContext, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{ARRAYS_ZIP, CONCAT, TreePattern}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -2262,10 +2262,12 @@ case class ElementAt(
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): ElementAt = copy(left = newLeft, right = newRight)
 
-  override def initQueryContext(): String = if (failOnError) {
-    origin.context
-  } else {
-    ""
+  override def initQueryContext(): Option[SQLQueryContext] = {
+    if (failOnError) {
+      Some(origin.context)
+    } else {
+      None
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.{TypeCheckResult, TypeCoercion, Un
 import org.apache.spark.sql.catalyst.expressions.ArraySortLike.NullOrder
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.{BinaryLike, SQLQueryContext, UnaryLike}
+import org.apache.spark.sql.catalyst.trees.{BinaryLike, QueryContextImpl, UnaryLike}
 import org.apache.spark.sql.catalyst.trees.TreePattern.{ARRAYS_ZIP, CONCAT, TreePattern}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
@@ -2262,7 +2262,7 @@ case class ElementAt(
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): ElementAt = copy(left = newLeft, right = newRight)
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (failOnError) {
       Some(origin.context)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXTRACT_VALUE, TreePattern}
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, ArrayData, GenericArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
@@ -490,9 +491,11 @@ case class GetMapValue(
       newLeft: Expression, newRight: Expression): GetMapValue =
     copy(child = newLeft, key = newRight)
 
-  override def initQueryContext(): String = if (failOnError) {
-    origin.context
-  } else {
-    ""
+  override def initQueryContext(): Option[SQLQueryContext] = {
+    if (failOnError) {
+      Some(origin.context)
+    } else {
+      None
+    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXTRACT_VALUE, TreePattern}
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, ArrayData, GenericArrayData, MapData, TypeUtils}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
@@ -491,7 +491,7 @@ case class GetMapValue(
       newLeft: Expression, newRight: Expression): GetMapValue =
     copy(child = newLeft, key = newRight)
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (failOnError) {
       Some(origin.context)
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -179,7 +179,7 @@ case class CheckOverflowInSum(
     child: Expression,
     dataType: DecimalType,
     nullOnOverflow: Boolean,
-    queryContext: String = "") extends UnaryExpression {
+    queryContext: Option[SQLQueryContext] = None) extends UnaryExpression {
 
   override def nullable: Boolean = true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -165,7 +165,7 @@ case class CheckOverflow(
   override protected def withNewChildInternal(newChild: Expression): CheckOverflow =
     copy(child = newChild)
 
-  override def initQueryContext(): Option[SQLQueryContext] = {
+  override def initQueryContext(): Option[QueryContextImpl] = {
     if (!nullOnOverflow) {
       Some(origin.context)
     } else {
@@ -179,7 +179,7 @@ case class CheckOverflowInSum(
     child: Expression,
     dataType: DecimalType,
     nullOnOverflow: Boolean,
-    queryContext: Option[SQLQueryContext] = None) extends UnaryExpression {
+    queryContext: Option[QueryContextImpl] = None) extends UnaryExpression {
 
   override def nullable: Boolean = true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/decimalExpressions.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -164,10 +165,12 @@ case class CheckOverflow(
   override protected def withNewChildInternal(newChild: Expression): CheckOverflow =
     copy(child = newChild)
 
-  override def initQueryContext(): String = if (nullOnOverflow) {
-    ""
-  } else {
-    origin.context
+  override def initQueryContext(): Option[SQLQueryContext] = {
+    if (!nullOnOverflow) {
+      Some(origin.context)
+    } else {
+      None
+    }
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -23,6 +23,7 @@ import java.util.Locale
 import com.google.common.math.{DoubleMath, IntMath, LongMath}
 
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MONTHS_PER_YEAR
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.catalyst.util.IntervalUtils._
@@ -603,7 +604,7 @@ trait IntervalDivide {
       minValue: Any,
       num: Expression,
       numValue: Any,
-      context: String): Unit = {
+      context: Option[SQLQueryContext]): Unit = {
     if (value == minValue && num.dataType.isInstanceOf[IntegralType]) {
       if (numValue.asInstanceOf[Number].longValue() == -1) {
         throw QueryExecutionErrors.overflowInIntegralDivideError(context)
@@ -611,10 +612,12 @@ trait IntervalDivide {
     }
   }
 
-  def divideByZeroCheck(dataType: DataType, num: Any, context: String): Unit = dataType match {
-    case _: DecimalType =>
-      if (num.asInstanceOf[Decimal].isZero) throw QueryExecutionErrors.divideByZeroError(context)
-    case _ => if (num == 0) throw QueryExecutionErrors.divideByZeroError(context)
+  def divideByZeroCheck(dataType: DataType, num: Any, context: Option[SQLQueryContext]): Unit = {
+    dataType match {
+      case _: DecimalType =>
+        if (num.asInstanceOf[Decimal].isZero) throw QueryExecutionErrors.divideByZeroError(context)
+      case _ => if (num == 0) throw QueryExecutionErrors.divideByZeroError(context)
+    }
   }
 
   def divideByZeroCheckCodegen(
@@ -656,8 +659,8 @@ case class DivideYMInterval(
   }
 
   override def nullSafeEval(interval: Any, num: Any): Any = {
-    checkDivideOverflow(interval.asInstanceOf[Int], Int.MinValue, right, num, origin.context)
-    divideByZeroCheck(right.dataType, num, origin.context)
+    checkDivideOverflow(interval.asInstanceOf[Int], Int.MinValue, right, num, Some(origin.context))
+    divideByZeroCheck(right.dataType, num, Some(origin.context))
     evalFunc(interval.asInstanceOf[Int], num)
   }
 
@@ -733,8 +736,9 @@ case class DivideDTInterval(
   }
 
   override def nullSafeEval(interval: Any, num: Any): Any = {
-    checkDivideOverflow(interval.asInstanceOf[Long], Long.MinValue, right, num, origin.context)
-    divideByZeroCheck(right.dataType, num, origin.context)
+    checkDivideOverflow(interval.asInstanceOf[Long], Long.MinValue, right, num,
+      Some(origin.context))
+    divideByZeroCheck(right.dataType, num, Some(origin.context))
     evalFunc(interval.asInstanceOf[Long], num)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/intervalExpressions.scala
@@ -23,7 +23,7 @@ import java.util.Locale
 import com.google.common.math.{DoubleMath, IntMath, LongMath}
 
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.catalyst.util.DateTimeConstants.MONTHS_PER_YEAR
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.catalyst.util.IntervalUtils._
@@ -604,7 +604,7 @@ trait IntervalDivide {
       minValue: Any,
       num: Expression,
       numValue: Any,
-      context: Option[SQLQueryContext]): Unit = {
+      context: Option[QueryContextImpl]): Unit = {
     if (value == minValue && num.dataType.isInstanceOf[IntegralType]) {
       if (numValue.asInstanceOf[Number].longValue() == -1) {
         throw QueryExecutionErrors.overflowInIntegralDivideError(context)
@@ -612,7 +612,7 @@ trait IntervalDivide {
     }
   }
 
-  def divideByZeroCheck(dataType: DataType, num: Any, context: Option[SQLQueryContext]): Unit = {
+  def divideByZeroCheck(dataType: DataType, num: Any, context: Option[QueryContextImpl]): Unit = {
     dataType match {
       case _: DecimalType =>
         if (num.asInstanceOf[Decimal].isZero) throw QueryExecutionErrors.divideByZeroError(context)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
 
 import sun.util.calendar.ZoneInfo
 
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime._
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -452,14 +452,14 @@ object DateTimeUtils {
   def stringToTimestampAnsi(
       s: UTF8String,
       timeZoneId: ZoneId,
-      errorContext: Option[SQLQueryContext] = None): Long = {
+      errorContext: Option[QueryContextImpl] = None): Long = {
     stringToTimestamp(s, timeZoneId).getOrElse {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         s, StringType, TimestampType, errorContext)
     }
   }
 
-  def doubleToTimestampAnsi(d: Double, errorContext: Option[SQLQueryContext]): Long = {
+  def doubleToTimestampAnsi(d: Double, errorContext: Option[QueryContextImpl]): Long = {
     if (d.isNaN || d.isInfinite) {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         d, DoubleType, TimestampType, errorContext)
@@ -511,7 +511,7 @@ object DateTimeUtils {
 
   def stringToTimestampWithoutTimeZoneAnsi(
       s: UTF8String,
-      errorContext: Option[SQLQueryContext]): Long = {
+      errorContext: Option[QueryContextImpl]): Long = {
     stringToTimestampWithoutTimeZone(s, true).getOrElse {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         s, StringType, TimestampNTZType, errorContext)
@@ -630,7 +630,7 @@ object DateTimeUtils {
     }
   }
 
-  def stringToDateAnsi(s: UTF8String, errorContext: Option[SQLQueryContext] = None): Int = {
+  def stringToDateAnsi(s: UTF8String, errorContext: Option[QueryContextImpl] = None): Int = {
     stringToDate(s).getOrElse {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         s, StringType, DateType, errorContext)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -27,6 +27,7 @@ import scala.util.control.NonFatal
 
 import sun.util.calendar.ZoneInfo
 
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.RebaseDateTime._
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -448,14 +449,17 @@ object DateTimeUtils {
     }
   }
 
-  def stringToTimestampAnsi(s: UTF8String, timeZoneId: ZoneId, errorContext: String = ""): Long = {
+  def stringToTimestampAnsi(
+      s: UTF8String,
+      timeZoneId: ZoneId,
+      errorContext: Option[SQLQueryContext] = None): Long = {
     stringToTimestamp(s, timeZoneId).getOrElse {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         s, StringType, TimestampType, errorContext)
     }
   }
 
-  def doubleToTimestampAnsi(d: Double, errorContext: String): Long = {
+  def doubleToTimestampAnsi(d: Double, errorContext: Option[SQLQueryContext]): Long = {
     if (d.isNaN || d.isInfinite) {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         d, DoubleType, TimestampType, errorContext)
@@ -505,7 +509,9 @@ object DateTimeUtils {
     stringToTimestampWithoutTimeZone(s, true)
   }
 
-  def stringToTimestampWithoutTimeZoneAnsi(s: UTF8String, errorContext: String): Long = {
+  def stringToTimestampWithoutTimeZoneAnsi(
+      s: UTF8String,
+      errorContext: Option[SQLQueryContext]): Long = {
     stringToTimestampWithoutTimeZone(s, true).getOrElse {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         s, StringType, TimestampNTZType, errorContext)
@@ -624,7 +630,7 @@ object DateTimeUtils {
     }
   }
 
-  def stringToDateAnsi(s: UTF8String, errorContext: String = ""): Int = {
+  def stringToDateAnsi(s: UTF8String, errorContext: Option[SQLQueryContext] = None): Int = {
     stringToDate(s).getOrElse {
       throw QueryExecutionErrors.invalidInputInCastToDatetimeError(
         s, StringType, DateType, errorContext)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -733,7 +733,7 @@ object IntervalUtils {
    * @throws ArithmeticException if the result overflows any field value or divided by zero
    */
   def divideExact(interval: CalendarInterval, num: Double): CalendarInterval = {
-    if (num == 0) throw QueryExecutionErrors.divideByZeroError("")
+    if (num == 0) throw QueryExecutionErrors.divideByZeroError()
     fromDoubles(interval.months / num, interval.days / num, interval.microseconds / num)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.errors.QueryExecutionErrors
 
 /**
@@ -27,32 +27,32 @@ object MathUtils {
 
   def addExact(a: Int, b: Int): Int = withOverflow(Math.addExact(a, b))
 
-  def addExact(a: Int, b: Int, errorContext: Option[SQLQueryContext]): Int =
+  def addExact(a: Int, b: Int, errorContext: Option[QueryContextImpl]): Int =
     withOverflow(Math.addExact(a, b), hint = "try_add", errorContext = errorContext)
 
   def addExact(a: Long, b: Long): Long = withOverflow(Math.addExact(a, b))
 
-  def addExact(a: Long, b: Long, errorContext: Option[SQLQueryContext]): Long =
+  def addExact(a: Long, b: Long, errorContext: Option[QueryContextImpl]): Long =
     withOverflow(Math.addExact(a, b), hint = "try_add", errorContext = errorContext)
 
   def subtractExact(a: Int, b: Int): Int = withOverflow(Math.subtractExact(a, b))
 
-  def subtractExact(a: Int, b: Int, errorContext: Option[SQLQueryContext]): Int =
+  def subtractExact(a: Int, b: Int, errorContext: Option[QueryContextImpl]): Int =
     withOverflow(Math.subtractExact(a, b), hint = "try_subtract", errorContext = errorContext)
 
   def subtractExact(a: Long, b: Long): Long = withOverflow(Math.subtractExact(a, b))
 
-  def subtractExact(a: Long, b: Long, errorContext: Option[SQLQueryContext]): Long =
+  def subtractExact(a: Long, b: Long, errorContext: Option[QueryContextImpl]): Long =
     withOverflow(Math.subtractExact(a, b), hint = "try_subtract", errorContext = errorContext)
 
   def multiplyExact(a: Int, b: Int): Int = withOverflow(Math.multiplyExact(a, b))
 
-  def multiplyExact(a: Int, b: Int, errorContext: Option[SQLQueryContext]): Int =
+  def multiplyExact(a: Int, b: Int, errorContext: Option[QueryContextImpl]): Int =
     withOverflow(Math.multiplyExact(a, b), hint = "try_multiply", errorContext = errorContext)
 
   def multiplyExact(a: Long, b: Long): Long = withOverflow(Math.multiplyExact(a, b))
 
-  def multiplyExact(a: Long, b: Long, errorContext: Option[SQLQueryContext]): Long =
+  def multiplyExact(a: Long, b: Long, errorContext: Option[QueryContextImpl]): Long =
     withOverflow(Math.multiplyExact(a, b), hint = "try_multiply", errorContext = errorContext)
 
   def negateExact(a: Int): Int = withOverflow(Math.negateExact(a))
@@ -72,7 +72,7 @@ object MathUtils {
   private def withOverflow[A](
       f: => A,
       hint: String = "",
-      errorContext: Option[SQLQueryContext] = None): A = {
+      errorContext: Option[QueryContextImpl] = None): A = {
     try {
       f
     } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.errors.QueryExecutionErrors
 
 /**
@@ -26,32 +27,32 @@ object MathUtils {
 
   def addExact(a: Int, b: Int): Int = withOverflow(Math.addExact(a, b))
 
-  def addExact(a: Int, b: Int, errorContext: String): Int =
+  def addExact(a: Int, b: Int, errorContext: Option[SQLQueryContext]): Int =
     withOverflow(Math.addExact(a, b), hint = "try_add", errorContext = errorContext)
 
   def addExact(a: Long, b: Long): Long = withOverflow(Math.addExact(a, b))
 
-  def addExact(a: Long, b: Long, errorContext: String): Long =
+  def addExact(a: Long, b: Long, errorContext: Option[SQLQueryContext]): Long =
     withOverflow(Math.addExact(a, b), hint = "try_add", errorContext = errorContext)
 
   def subtractExact(a: Int, b: Int): Int = withOverflow(Math.subtractExact(a, b))
 
-  def subtractExact(a: Int, b: Int, errorContext: String): Int =
+  def subtractExact(a: Int, b: Int, errorContext: Option[SQLQueryContext]): Int =
     withOverflow(Math.subtractExact(a, b), hint = "try_subtract", errorContext = errorContext)
 
   def subtractExact(a: Long, b: Long): Long = withOverflow(Math.subtractExact(a, b))
 
-  def subtractExact(a: Long, b: Long, errorContext: String): Long =
+  def subtractExact(a: Long, b: Long, errorContext: Option[SQLQueryContext]): Long =
     withOverflow(Math.subtractExact(a, b), hint = "try_subtract", errorContext = errorContext)
 
   def multiplyExact(a: Int, b: Int): Int = withOverflow(Math.multiplyExact(a, b))
 
-  def multiplyExact(a: Int, b: Int, errorContext: String): Int =
+  def multiplyExact(a: Int, b: Int, errorContext: Option[SQLQueryContext]): Int =
     withOverflow(Math.multiplyExact(a, b), hint = "try_multiply", errorContext = errorContext)
 
   def multiplyExact(a: Long, b: Long): Long = withOverflow(Math.multiplyExact(a, b))
 
-  def multiplyExact(a: Long, b: Long, errorContext: String): Long =
+  def multiplyExact(a: Long, b: Long, errorContext: Option[SQLQueryContext]): Long =
     withOverflow(Math.multiplyExact(a, b), hint = "try_multiply", errorContext = errorContext)
 
   def negateExact(a: Int): Int = withOverflow(Math.negateExact(a))
@@ -68,7 +69,10 @@ object MathUtils {
 
   def floorMod(a: Long, b: Long): Long = withOverflow(Math.floorMod(a, b))
 
-  private def withOverflow[A](f: => A, hint: String = "", errorContext: String = ""): A = {
+  private def withOverflow[A](
+      f: => A,
+      hint: String = "",
+      errorContext: Option[SQLQueryContext] = None): A = {
     try {
       f
     } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UTF8StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UTF8StringUtils.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.{ByteType, DataType, IntegerType, LongType, ShortType}
 import org.apache.spark.unsafe.types.UTF8String
@@ -27,21 +27,21 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 object UTF8StringUtils {
 
-  def toLongExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Long =
+  def toLongExact(s: UTF8String, errorContext: Option[QueryContextImpl]): Long =
     withException(s.toLongExact, errorContext, LongType, s)
 
-  def toIntExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Int =
+  def toIntExact(s: UTF8String, errorContext: Option[QueryContextImpl]): Int =
     withException(s.toIntExact, errorContext, IntegerType, s)
 
-  def toShortExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Short =
+  def toShortExact(s: UTF8String, errorContext: Option[QueryContextImpl]): Short =
     withException(s.toShortExact, errorContext, ShortType, s)
 
-  def toByteExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Byte =
+  def toByteExact(s: UTF8String, errorContext: Option[QueryContextImpl]): Byte =
     withException(s.toByteExact, errorContext, ByteType, s)
 
   private def withException[A](
       f: => A,
-      errorContext: Option[SQLQueryContext],
+      errorContext: Option[QueryContextImpl],
       to: DataType,
       s: UTF8String): A = {
     try {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UTF8StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/UTF8StringUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.util
 
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.{ByteType, DataType, IntegerType, LongType, ShortType}
 import org.apache.spark.unsafe.types.UTF8String
@@ -26,19 +27,23 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 object UTF8StringUtils {
 
-  def toLongExact(s: UTF8String, errorContext: String): Long =
+  def toLongExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Long =
     withException(s.toLongExact, errorContext, LongType, s)
 
-  def toIntExact(s: UTF8String, errorContext: String): Int =
+  def toIntExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Int =
     withException(s.toIntExact, errorContext, IntegerType, s)
 
-  def toShortExact(s: UTF8String, errorContext: String): Short =
+  def toShortExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Short =
     withException(s.toShortExact, errorContext, ShortType, s)
 
-  def toByteExact(s: UTF8String, errorContext: String): Byte =
+  def toByteExact(s: UTF8String, errorContext: Option[SQLQueryContext]): Byte =
     withException(s.toByteExact, errorContext, ByteType, s)
 
-  private def withException[A](f: => A, errorContext: String, to: DataType, s: UTF8String): A = {
+  private def withException[A](
+      f: => A,
+      errorContext: Option[SQLQueryContext],
+      to: DataType,
+      s: UTF8String): A = {
     try {
       f
     } catch {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.ValueInterval
-import org.apache.spark.sql.catalyst.trees.{SQLQueryContext, TreeNode}
+import org.apache.spark.sql.catalyst.trees.{QueryContextImpl, TreeNode}
 import org.apache.spark.sql.catalyst.util.{sideBySide, BadRecordException, DateTimeUtils, FailFastMode}
 import org.apache.spark.sql.connector.catalog.{CatalogNotFoundException, Identifier, Table, TableProvider}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
@@ -97,7 +97,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
       value: Decimal,
       decimalPrecision: Int,
       decimalScale: Int,
-      context: Option[SQLQueryContext]): ArithmeticException = {
+      context: Option[QueryContextImpl]): ArithmeticException = {
     new SparkArithmeticException(
       errorClass = "CANNOT_CHANGE_DECIMAL_PRECISION",
       messageParameters = Array(
@@ -112,7 +112,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
       value: Any,
       from: DataType,
       to: DataType,
-      errorContext: Option[SQLQueryContext]): Throwable = {
+      errorContext: Option[QueryContextImpl]): Throwable = {
     new SparkDateTimeException(
       errorClass = "CAST_INVALID_INPUT",
       messageParameters = Array(
@@ -125,7 +125,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
 
   def invalidInputSyntaxForBooleanError(
       s: UTF8String,
-      errorContext: Option[SQLQueryContext]): SparkRuntimeException = {
+      errorContext: Option[QueryContextImpl]): SparkRuntimeException = {
     new SparkRuntimeException(
       errorClass = "CAST_INVALID_INPUT",
       messageParameters = Array(
@@ -139,7 +139,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
   def invalidInputInCastToNumberError(
       to: DataType,
       s: UTF8String,
-      errorContext: Option[SQLQueryContext]): SparkNumberFormatException = {
+      errorContext: Option[QueryContextImpl]): SparkNumberFormatException = {
     new SparkNumberFormatException(
       errorClass = "CAST_INVALID_INPUT",
       messageParameters = Array(
@@ -177,7 +177,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
       messageParameters = Array(funcCls, inputTypes, outputType), e)
   }
 
-  def divideByZeroError(context: Option[SQLQueryContext] = None): ArithmeticException = {
+  def divideByZeroError(context: Option[QueryContextImpl] = None): ArithmeticException = {
     new SparkArithmeticException(
       errorClass = "DIVIDE_BY_ZERO",
       messageParameters = Array(toSQLConf(SQLConf.ANSI_ENABLED.key)),
@@ -217,7 +217,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
   def mapKeyNotExistError(
       key: Any,
       dataType: DataType,
-      context: Option[SQLQueryContext]): NoSuchElementException = {
+      context: Option[QueryContextImpl]): NoSuchElementException = {
     new SparkNoSuchElementException(
       errorClass = "MAP_KEY_DOES_NOT_EXIST",
       messageParameters = Array(
@@ -260,11 +260,11 @@ object QueryExecutionErrors extends QueryErrorsBase {
     ansiIllegalArgumentError(e.getMessage)
   }
 
-  def overflowInSumOfDecimalError(context: Option[SQLQueryContext]): ArithmeticException = {
+  def overflowInSumOfDecimalError(context: Option[QueryContextImpl]): ArithmeticException = {
     arithmeticOverflowError("Overflow in sum of decimals", errorContext = context)
   }
 
-  def overflowInIntegralDivideError(context: Option[SQLQueryContext]): ArithmeticException = {
+  def overflowInIntegralDivideError(context: Option[QueryContextImpl]): ArithmeticException = {
     arithmeticOverflowError("Overflow in integral divide", "try_divide", context)
   }
 
@@ -479,7 +479,7 @@ object QueryExecutionErrors extends QueryErrorsBase {
   def arithmeticOverflowError(
       message: String,
       hint: String = "",
-      errorContext: Option[SQLQueryContext] = None): ArithmeticException = {
+      errorContext: Option[QueryContextImpl] = None): ArithmeticException = {
     val alternative = if (hint.nonEmpty) s" To return NULL instead, use '$hint'." else ""
     new SparkArithmeticException(
       errorClass = "ARITHMETIC_OVERFLOW",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -22,7 +22,7 @@ import java.math.{BigDecimal => JavaBigDecimal, BigInteger, MathContext, Roundin
 import scala.util.Try
 
 import org.apache.spark.annotation.Unstable
-import org.apache.spark.sql.catalyst.trees.SQLQueryContext
+import org.apache.spark.sql.catalyst.trees.QueryContextImpl
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.unsafe.types.UTF8String
@@ -365,7 +365,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
       scale: Int,
       roundMode: BigDecimal.RoundingMode.Value = ROUND_HALF_UP,
       nullOnOverflow: Boolean = true,
-      context: Option[SQLQueryContext] = None): Decimal = {
+      context: Option[QueryContextImpl] = None): Decimal = {
     val copy = clone()
     if (copy.changePrecision(precision, scale, roundMode)) {
       copy
@@ -625,7 +625,7 @@ object Decimal {
   def fromStringANSI(
       str: UTF8String,
       to: DecimalType = DecimalType.USER_DEFAULT,
-      errorContext: Option[SQLQueryContext] = None): Decimal = {
+      errorContext: Option[QueryContextImpl] = None): Decimal = {
     try {
       val bigDecimal = stringToJavaBigDecimal(str)
       // We fast fail because constructing a very large JavaBigDecimal to Decimal is very slow.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -22,6 +22,7 @@ import java.math.{BigDecimal => JavaBigDecimal, BigInteger, MathContext, Roundin
 import scala.util.Try
 
 import org.apache.spark.annotation.Unstable
+import org.apache.spark.sql.catalyst.trees.SQLQueryContext
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.unsafe.types.UTF8String
@@ -364,7 +365,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
       scale: Int,
       roundMode: BigDecimal.RoundingMode.Value = ROUND_HALF_UP,
       nullOnOverflow: Boolean = true,
-      context: String = ""): Decimal = {
+      context: Option[SQLQueryContext] = None): Decimal = {
     val copy = clone()
     if (copy.changePrecision(precision, scale, roundMode)) {
       copy
@@ -624,7 +625,7 @@ object Decimal {
   def fromStringANSI(
       str: UTF8String,
       to: DecimalType = DecimalType.USER_DEFAULT,
-      errorContext: String = ""): Decimal = {
+      errorContext: Option[SQLQueryContext] = None): Decimal = {
     try {
       val bigDecimal = stringToJavaBigDecimal(str)
       // We fast fail because constructing a very large JavaBigDecimal to Decimal is very slow.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DecimalExpressionSuite.scala
@@ -99,7 +99,8 @@ class DecimalExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
     checkExceptionInExpression[ArithmeticException](expr1, query)
 
-    val expr2 = CheckOverflowInSum(Literal(d), DecimalType(4, 3), false, queryContext = query)
+    val expr2 = CheckOverflowInSum(Literal(d), DecimalType(4, 3), false,
+      queryContext = Some(origin.context))
     checkExceptionInExpression[ArithmeticException](expr2, query)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -886,6 +886,10 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
         |""".stripMargin
 
     assert(origin.context.fragment == expected)
+    assert(origin.context.startIndex == origin.startIndex.get)
+    assert(origin.context.stopIndex == origin.stopIndex.get)
+    assert(origin.context.objectType == origin.objectType.get)
+    assert(origin.context.objectName == origin.objectName.get)
   }
 
   test("SPARK-39046: Return an empty context string if TreeNode.origin is wrongly set") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -875,7 +875,7 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
       sqlText = Some(text),
       objectType = Some("VIEW"),
       objectName = Some("some_view"))
-    val expected =
+    val expectedSummary =
       """== SQL of VIEW some_view(line 3, position 39) ==
         |...7890 + 1234567890 + 1234567890, cast('a'
         |                                   ^^^^^^^^
@@ -885,11 +885,16 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
         |^^^^^
         |""".stripMargin
 
-    assert(origin.context.fragment == expected)
+    val expectedFragment =
+      """cast('a'
+        |as /* comment */
+        |int)""".stripMargin
+    assert(origin.context.summary == expectedSummary)
     assert(origin.context.startIndex == origin.startIndex.get)
     assert(origin.context.stopIndex == origin.stopIndex.get)
     assert(origin.context.objectType == origin.objectType.get)
     assert(origin.context.objectName == origin.objectName.get)
+    assert(origin.context.fragment == expectedFragment)
   }
 
   test("SPARK-39046: Return an empty context string if TreeNode.origin is wrongly set") {
@@ -926,6 +931,7 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
       sqlText = text)
     Seq(origin1, origin2, origin3, origin4, origin5, origin6).foreach { origin =>
       assert(origin.context.fragment.isEmpty)
+      assert(origin.context.summary.isEmpty)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/trees/TreeNodeSuite.scala
@@ -885,7 +885,7 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
         |^^^^^
         |""".stripMargin
 
-    assert(origin.context == expected)
+    assert(origin.context.fragment == expected)
   }
 
   test("SPARK-39046: Return an empty context string if TreeNode.origin is wrongly set") {
@@ -921,7 +921,7 @@ class TreeNodeSuite extends SparkFunSuite with SQLHelper {
       stopIndex = Some(1),
       sqlText = text)
     Seq(origin1, origin2, origin3, origin4, origin5, origin6).foreach { origin =>
-      assert(origin.context.isEmpty)
+      assert(origin.context.fragment.isEmpty)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR is to add a new method `getQueryContext` in `SparkThrowable`. 
It also refactors the data type of `Origin.context` from `String` to a case class `SQLQueryContext`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This enriches the information of the error message. With the change, it is possible to have a new pretty printing format error message like
```
> SELECT * FROM v1;

{
  “errorClass” : [ “DIVIDE_BY_ZERO” ],
  “parameters” : [ { 
                   “name” = “config”, 
                   “value” = “spark.sql.ansi.enabled” 
                 }
                 ],
  “sqlState” : “42000”,
  “context” : {
      “objectType” : “VIEW”,
      “objectName” : “default.v1”
      “indexStart” : 36,
      “indexEnd” : 41,
      “fragment” : “1 / 0” }
   }
}
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT