### PR TITLE
[SPARK-39322][DOCS] Remove `Experimental` from `spark.dynamicAllocation.shuffleTracking.enabled`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2719,7 +2719,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.dynamicAllocation.shuffleTracking.enabled</code></td>
   <td><code>false</code></td>
   <td>
-    Experimental. Enables shuffle file tracking for executors, which allows dynamic allocation
+    Enables shuffle file tracking for executors, which allows dynamic allocation
     without the need for an external shuffle service. This option will try to keep alive executors
     that are storing shuffle data for active jobs.
   </td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Experimental` from `spark.dynamicAllocation.shuffleTracking.enabled`.

### Why are the changes needed?

`spark.dynamicAllocation.shuffleTracking.enabled` was added at Apache Spark 3.0.0 and has been used with K8s resource manager.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation only change.

### How was this patch tested?

Manual.