### PR TITLE
[SPARK-39323][CORE] Hide empty `taskResourceAssignments` from INFO log

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -541,7 +541,8 @@ private[spark] class TaskSetManager(
     val tName = taskName(taskId)
     logInfo(s"Starting $tName ($host, executor ${info.executorId}, " +
       s"partition ${task.partitionId}, $taskLocality, ${serializedTask.limit()} bytes) " +
-      s"taskResourceAssignments ${taskResourceAssignments}")
+      (if (taskResourceAssignments.nonEmpty) s"taskResourceAssignments ${taskResourceAssignments}"
+      else ""))
 
     sched.dagScheduler.taskStarted(task, info)
     new TaskDescription(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to hide empty `taskResourceAssignments` info from INFO log.

### Why are the changes needed?

In case of empty Map, `Map()`, there is no much information to users.
```
22/05/27 23:41:21 INFO TaskSetManager: Starting task 70587.0 in stage 0.0 (TID 70587) (100.97.198.216, executor 1, partition 70587, PROCESS_LOCAL, 4452 bytes) taskResourceAssignments Map()
22/05/27 23:41:21 INFO TaskSetManager: Finished task 70571.0 in stage 0.0 (TID 70571) in 99 ms on 100.97.198.216 (executor 1) (70569/300000)
```

### Does this PR introduce _any_ user-facing change?

This is a INFO log only change.

### How was this patch tested?

Manually.


**BEFORE**
```scala
scala> sc.setLogLevel("INFO")
scala> spark.range(10).count()
...
22/05/27 16:50:41 INFO TaskSetManager: Starting task 0.0 in stage 0.0 (TID 0)
(172.16.0.31, executor driver, partition 0, PROCESS_LOCAL, 4587 bytes) taskResourceAssignments Map()
```

**AFTER**
```scala
scala> sc.setLogLevel("INFO")
scala> spark.range(10).count()
...
22/05/27 16:49:04 INFO TaskSetManager: Starting task 0.0 in stage 0.0 (TID 0)
(172.16.0.31, executor driver, partition 0, PROCESS_LOCAL, 4587 bytes)
```