### PR TITLE
[SPARK-39261][CORE][FOLLOWUP] Improve newline formatting for error messages

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import java.util.IllegalFormatException
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
@@ -89,7 +90,7 @@ class SparkThrowableSuite extends SparkFunSuite {
       if (rewrittenString.trim != errorClassFileContents.trim) {
         val errorClassesFile = new File(errorClassDir, new File(errorClassesUrl.getPath).getName)
         logInfo(s"Regenerating error class file $errorClassesFile")
-        FileUtils.delete(errorClassesFile)
+        Files.delete(errorClassesFile.toPath)
         FileUtils.writeStringToFile(errorClassesFile, rewrittenString, StandardCharsets.UTF_8)
       }
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `java.nio.file.Files.delete` instead of `org.apache.commons.io.FileUtils#delete`

### Why are the changes needed?
`org.apache.commons.io.FileUtils#delete` is a method only available in version 2.9, hadoop2 uses version 2.4 of commons-io.

Build failed
```
./dev/make-distribution.sh --tgz -Pyarn -Phive -Phive-thriftserver -Phadoop-2 -DskipTests -Dmaven.javadoc.skip=true
```
```
spark/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala:92: value delete is not a member of object org.apache.commons.io.FileUtils
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exist UT
