### PR TITLE
[SPARK-39326][PYTHON][PS] replace "NaN" with real  "None" value in indexes

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -555,7 +555,7 @@ class DataFrame(Frame, Generic[T]):
                max_speed  shield
         cobra          1       2
         viper          4       5
-        NaN            7       8
+        None           7       8
         >>> df.ndim
         2
         """
@@ -7227,22 +7227,22 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         >>> df = ps.DataFrame({'A': [2, 1, np.nan]}, index=['b', 'a', np.nan])
 
         >>> df.sort_index()
-               A
-        a    1.0
-        b    2.0
-        NaN  NaN
+                A
+        a     1.0
+        b     2.0
+        None  NaN
 
         >>> df.sort_index(ascending=False)
-               A
-        b    2.0
-        a    1.0
-        NaN  NaN
+                A
+        b     2.0
+        a     1.0
+        None  NaN
 
         >>> df.sort_index(na_position='first')
-               A
-        NaN  NaN
-        a    1.0
-        b    2.0
+                A
+        None  NaN
+        a     1.0
+        b     2.0
 
         >>> df.sort_index(ignore_index=True)
              A
@@ -7252,10 +7252,10 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
 
         >>> df.sort_index(inplace=True)
         >>> df
-               A
-        a    1.0
-        b    2.0
-        NaN  NaN
+                A
+        a     1.0
+        b     2.0
+        None  NaN
 
         >>> df = ps.DataFrame({'A': range(4), 'B': range(4)[::-1]},
         ...                   index=[['b', 'b', 'a', 'a'], [1, 0, 1, 0]],

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -551,7 +551,7 @@ class DataFrame(Frame, Generic[T]):
         >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', None],
         ...                   columns=['max_speed', 'shield'])
-        >>> df
+        >>> df  # doctest: +SKIP
                max_speed  shield
         cobra          1       2
         viper          4       5
@@ -7226,19 +7226,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         >>> df = ps.DataFrame({'A': [2, 1, np.nan]}, index=['b', 'a', np.nan])
 
-        >>> df.sort_index()
+        >>> df.sort_index()  # doctest: +SKIP
                 A
         a     1.0
         b     2.0
         None  NaN
 
-        >>> df.sort_index(ascending=False)
+        >>> df.sort_index(ascending=False)  # doctest: +SKIP
                 A
         b     2.0
         a     1.0
         None  NaN
 
-        >>> df.sort_index(na_position='first')
+        >>> df.sort_index(na_position='first')  # doctest: +SKIP
                 A
         None  NaN
         a     1.0
@@ -7251,7 +7251,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  NaN
 
         >>> df.sort_index(inplace=True)
-        >>> df
+        >>> df  # doctest: +SKIP
                 A
         a     1.0
         b     2.0

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1163,7 +1163,7 @@ class Index(IndexOpsMixin):
         >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', None],
         ...                   columns=['max_speed', 'shield'])
-        >>> df
+        >>> df  # doctest: +SKIP
                max_speed  shield
         cobra          1       2
         viper          4       5

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1167,7 +1167,7 @@ class Index(IndexOpsMixin):
                max_speed  shield
         cobra          1       2
         viper          4       5
-        NaN            7       8
+        None           7       8
 
         >>> df.index.dropna()
         Index(['cobra', 'viper'], dtype='object')

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2963,7 +2963,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         >>> s = ps.Series([2, 1, np.nan], index=['b', 'a', np.nan])
 
-        >>> s.sort_index()
+        >>> s.sort_index()  # doctest: +SKIP
         a       1.0
         b       2.0
         None    NaN
@@ -2975,20 +2975,20 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    NaN
         dtype: float64
 
-        >>> s.sort_index(ascending=False)
+        >>> s.sort_index(ascending=False)  # doctest: +SKIP
         b       2.0
         a       1.0
         None    NaN
         dtype: float64
 
-        >>> s.sort_index(na_position='first')
+        >>> s.sort_index(na_position='first')  # doctest: +SKIP
         None    NaN
         a       1.0
         b       2.0
         dtype: float64
 
         >>> s.sort_index(inplace=True)
-        >>> s
+        >>> s  # doctest: +SKIP
         a       1.0
         b       2.0
         None    NaN

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2964,9 +2964,9 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         >>> s = ps.Series([2, 1, np.nan], index=['b', 'a', np.nan])
 
         >>> s.sort_index()
-        a      1.0
-        b      2.0
-        NaN    NaN
+        a       1.0
+        b       2.0
+        None    NaN
         dtype: float64
 
         >>> s.sort_index(ignore_index=True)
@@ -2976,22 +2976,22 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         dtype: float64
 
         >>> s.sort_index(ascending=False)
-        b      2.0
-        a      1.0
-        NaN    NaN
+        b       2.0
+        a       1.0
+        None    NaN
         dtype: float64
 
         >>> s.sort_index(na_position='first')
-        NaN    NaN
-        a      1.0
-        b      2.0
+        None    NaN
+        a       1.0
+        b       2.0
         dtype: float64
 
         >>> s.sort_index(inplace=True)
         >>> s
-        a      1.0
-        b      2.0
-        NaN    NaN
+        a       1.0
+        b       2.0
+        None    NaN
         dtype: float64
 
         Multi-index series.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since pandas 1.4 https://github.com/pandas-dev/pandas/commit/aaba0efd630ed607c5aaaef7b5f43d2fe90ca81c

> Series.__repr__() and DataFrame.__repr__() no longer replace all null-values in indexes with “NaN” but use their real string-representations. “NaN” is used only for float("nan")

We need to fix the doctest in PS


### Why are the changes needed?
follow pandas behavior

### Does this PR introduce _any_ user-facing change?
Yes, follow pandas behavior

### How was this patch tested?
CI passed
