### PR TITLE
[SPARK-39265][SQL][FOLLOWUP] Fix test failure when SPARK_ANSI_SQL_MODE is enabled

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1572,7 +1572,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
       withTableT {
         sql("alter table t add columns (" +
           "s boolean default true, " +
-          "t byte default cast('a' as byte), " +
+          "t byte default cast(null as byte), " +
           "u short default cast(42 as short), " +
           "v float default 0, " +
           "w double default 0, " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix test failure when `SPARK_ANSI_SQL_MODE` is enabled:
```
2022-05-28T21:02:01.9025896Z - INSERT rows, ALTER TABLE ADD COLUMNS with DEFAULTs, then SELECT them *** FAILED *** (1 second, 260 milliseconds)
2022-05-28T21:02:01.9112619Z   org.apache.spark.SparkNumberFormatException: [CAST_INVALID_INPUT] The value 'a' of the type "STRING" cannot be cast to "TINYINT" because it is malformed. Correct the value as per the syntax, or change its target type. To return NULL instead, use `try_cast`. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error
```

### Why are the changes needed?

To make CI test pass when `SPARK_ANSI_SQL_MODE` is enabled.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A