### PR TITLE
[SPARK-39327][K8S] ExecutorRollPolicy.ID should consider ID as a numerical value

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPlugin.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPlugin.scala
@@ -106,7 +106,8 @@ class ExecutorRollDriverPlugin extends DriverPlugin with Logging {
       .filter(_.totalTasks >= minTasks)
     val sortedList = policy match {
       case ExecutorRollPolicy.ID =>
-        listWithoutDriver.sortBy(_.id)
+        // We can convert to integer because EXECUTOR_ID_COUNTER uses AtomicInteger.
+        listWithoutDriver.sortBy(_.id.toInt)
       case ExecutorRollPolicy.ADD_TIME =>
         listWithoutDriver.sortBy(_.addTime)
       case ExecutorRollPolicy.TOTAL_GC_TIME =>

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPluginSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorRollPluginSuite.scala
@@ -109,9 +109,17 @@ class ExecutorRollPluginSuite extends SparkFunSuite with PrivateMethodTester {
     Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
     false, Set())
 
+  val execWithTwoDigitID = new ExecutorSummary("10", "host:port", true, 1,
+    10, 10, 1, 1, 1,
+    4, 0, 2, 280,
+    30, 100, 100,
+    10, false, 20, new Date(1639300001000L),
+    Option.empty, Option.empty, Map(), Option.empty, Set(), Option.empty, Map(), Map(), 1,
+    false, Set())
+
   val list = Seq(driverSummary, execWithSmallestID, execWithSmallestAddTime,
     execWithBiggestTotalGCTime, execWithBiggestTotalDuration, execWithBiggestFailedTasks,
-    execWithBiggestAverageDuration, execWithoutTasks, execNormal)
+    execWithBiggestAverageDuration, execWithoutTasks, execNormal, execWithTwoDigitID)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -147,6 +155,8 @@ class ExecutorRollPluginSuite extends SparkFunSuite with PrivateMethodTester {
 
   test("Policy: ID") {
     assert(plugin.invokePrivate(_choose(list, ExecutorRollPolicy.ID)).contains("1"))
+    assert(plugin.invokePrivate(_choose(list.filter(_.id != "1"), ExecutorRollPolicy.ID))
+      .contains("2"))
   }
 
   test("Policy: ADD_TIME") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to make `ExecutorRollPolicy.ID` should consider ID as a numerical value.


### Why are the changes needed?
Currently, the ExecutorRollPolicy chooses the smallest ID from string sorting. 


### Does this PR introduce _any_ user-facing change?
No, 3.3.0 is not released yet. 


### How was this patch tested?
Pass the CIs. 