### PR TITLE
[SPARK-33274][SS] Stop query in cp mode when total cores less than total kafka partition

### DIFF
--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousSourceSuite.scala
@@ -19,14 +19,23 @@ package org.apache.spark.sql.kafka010
 
 import org.apache.kafka.clients.producer.ProducerRecord
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.execution.datasources.v2.ContinuousScanExec
 import org.apache.spark.sql.execution.streaming.ContinuousTrigger
 import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.test.TestSparkSession
 
 // Run tests in KafkaSourceSuiteBase in continuous execution mode.
 class KafkaContinuousSourceSuite extends KafkaSourceSuiteBase with KafkaContinuousTest {
   import testImplicits._
+
+  override protected def createSparkSession = new TestSparkSession(
+    new SparkContext(
+      "local[10]",
+      "continuous-stream-kafka-source",
+      sparkConf.set("spark.executor.cores", "10")
+    ))
 
   test("read Kafka transactional messages: read_committed") {
     val table = "kafka_continuous_source_test"
@@ -231,6 +240,11 @@ class KafkaContinuousSourceTopicDeletionSuite extends KafkaContinuousTest {
 
 class KafkaContinuousSourceStressForDontFailOnDataLossSuite
     extends KafkaSourceStressForDontFailOnDataLossSuite {
+
+  override protected def sparkConf() = {
+    super.sparkConf.set("spark.executor.cores", "20")
+  }
+
   override protected def startStream(ds: Dataset[Int]) = {
     ds.writeStream
       .format("memory")

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousTest.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaContinuousTest.scala
@@ -36,7 +36,9 @@ trait KafkaContinuousTest extends KafkaSourceTest {
     new SparkContext(
       "local[10]",
       "continuous-stream-test-sql-context",
-      sparkConf.set("spark.sql.testkey", "true")))
+      sparkConf.set("spark.sql.testkey", "true")
+        .set("spark.executor.cores", "10")
+    ))
 
   // In addition to setting the partitions in Kafka, we have to wait until the query has
   // reconfigured to the new count so the test framework can hook in properly.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
@@ -274,7 +274,7 @@ private[continuous] class EpochCoordinator(
     val numExecutors = session.conf.get(config.EXECUTOR_INSTANCES.key, "1").toInt
     val coresPerExecutor = session.conf.get(config.EXECUTOR_CORES.key, "1").toInt
     val cpusPerTask = session.conf.get(config.CPUS_PER_TASK.key, "1").toInt
-    val maxCores = session.conf.get(config.CORES_MAX.key).toInt
+    val maxCores = session.conf.getOption(config.CORES_MAX.key).map(_.toInt).getOrElse(Int.MaxValue)
     val totalRequestedCores = numExecutors * coresPerExecutor
     val totalAvailableCores = Math.min(totalRequestedCores, maxCores)
     val neededCores = numReaderPartitions * cpusPerTask

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/EpochCoordinator.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, PartitionOffset}
@@ -257,6 +258,7 @@ private[continuous] class EpochCoordinator(
 
     case SetReaderPartitions(numPartitions) =>
       numReaderPartitions = numPartitions
+      checkTotalCores()
       context.reply(())
 
     case SetWriterPartitions(numPartitions) =>
@@ -266,5 +268,26 @@ private[continuous] class EpochCoordinator(
     case StopContinuousExecutionWrites =>
       queryWritesStopped = true
       context.reply(())
+  }
+
+  private def checkTotalCores(): Unit = {
+    val numExecutors = session.conf.get(config.EXECUTOR_INSTANCES.key, "1").toInt
+    val coresPerExecutor = session.conf.get(config.EXECUTOR_CORES.key, "1").toInt
+    val cpusPerTask = session.conf.get(config.CPUS_PER_TASK.key, "1").toInt
+    val maxCores = session.conf.get(config.CORES_MAX.key).toInt
+    val totalRequestedCores = numExecutors * coresPerExecutor
+    val totalAvailableCores = Math.min(totalRequestedCores, maxCores)
+    val neededCores = numReaderPartitions * cpusPerTask
+    val INSTRUCTION_FOR_FEWER_CORES =
+      s"""
+        |Total $numReaderPartitions (kafka partitions) * $cpusPerTask (cpus per task) =
+        |$neededCores needed,
+        |but only have min($numExecutors (executors) * $coresPerExecutor (cores per executor) =
+        |$totalRequestedCores, spark.cores.max = $maxCores) = $totalAvailableCores (total cores).
+        |Please increase total number of executor cores to at least $neededCores.
+    """.stripMargin.replaceAll("\n", " ")
+    if (totalAvailableCores < neededCores) {
+      query.stopInNewThread(new IllegalStateException(INSTRUCTION_FOR_FEWER_CORES))
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/WriteDistributionAndOrderingSuite.scala
@@ -52,6 +52,10 @@ class WriteDistributionAndOrderingSuite extends DistributionAndOrderingSuiteBase
     .add("id", IntegerType)
     .add("data", StringType)
 
+  override protected def sparkConf = {
+    super.sparkConf.set("spark.executor.cores", "2")
+  }
+
   test("ordered distribution and sort with same exprs: append") {
     checkOrderedDistributionAndSortWithSameExprs("append")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -444,6 +444,7 @@ class StreamSuite extends StreamTest {
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set("spark.redaction.string.regex", "file:/[\\w_]+")
+    .set("spark.executor.cores", "2")
 
   test("explain - redaction") {
     val replacement = "*********"

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/ContinuousSuite.scala
@@ -36,7 +36,13 @@ class ContinuousSuiteBase extends StreamTest {
     new SparkContext(
       "local[10]",
       "continuous-stream-test-sql-context",
-      sparkConf.set("spark.sql.testkey", "true")))
+      sparkConf
+    ))
+
+  override protected def sparkConf = {
+    super.sparkConf.set("spark.sql.testkey", "true")
+      .set("spark.executor.cores", "10")
+  }
 
   protected def waitForRateSourceTriggers(query: ContinuousExecution, numTriggers: Int): Unit = {
     query.awaitEpoch(0)
@@ -425,7 +431,7 @@ class ContinuousEpochBacklogSuite extends ContinuousSuiteBase {
     new SparkContext(
       "local[1]",
       "continuous-stream-test-sql-context",
-      sparkConf.set("spark.sql.testkey", "true")))
+      sparkConf))
 
   // This test forces the backlog to overflow by not standing up enough executors for the query
   // to make progress.

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/EpochCoordinatorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/continuous/EpochCoordinatorSuite.scala
@@ -252,6 +252,11 @@ class EpochCoordinatorSuite
     verifyStoppedWithException("Size of the epoch queue has exceeded its maximum")
   }
 
+  test("SPARK-33274: check total cores is enough for all kafka partitions") {
+    setReaderPartitions(2)
+    verifyStoppedWithException("Please increase total number of executor cores")
+  }
+
   private def setWriterPartitions(numPartitions: Int): Unit = {
     epochCoordinator.askSync[Unit](SetWriterPartitions(numPartitions))
   }


### PR DESCRIPTION
What changes were proposed in this pull request?
Add check for total executor cores when SetReaderPartitions message received.

Why are the changes needed?
In continuous processing mode, EpochCoordinator won't add offsets to query until got ReportPartitionOffset from all partitions. Normally, each kafka topic partition will be handled by one core, if total cores is smaller than total kafka topic partition counts, the job will hang without any error message.

Does this PR introduce any user-facing change?
Yes, if total executor cores is smaller than total kafka partition count, the exception with below error will be thrown:
`
Total $numReaderPartitions (kafka partitions) * $cpusPerTask (cpus per task) =
$neededCores needed,
but only have min($numExecutors (executors) * $coresPerExecutor (cores per executor) =
$totalRequestedCores, spark.cores.max = $maxCores) = $totalAvailableCores (total cores).
Please increase total number of executor cores to at least $neededCores.
`

How was this patch tested?
Added test in EpochCoordinatorSuite