### PR TITLE
[SPARK-39331][PYTHON][TESTS][SS] Check None for offsets in SourceProgress

### DIFF
--- a/python/pyspark/sql/tests/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/test_streaming_listener.py
@@ -245,9 +245,9 @@ class StreamingListenerTests(ReusedSQLTestCase):
         except Exception:
             self.fail("'%s' is not a valid JSON.")
         self.assertTrue(isinstance(progress.description, str))
-        self.assertTrue(isinstance(progress.startOffset, str))
-        self.assertTrue(isinstance(progress.endOffset, str))
-        self.assertTrue(isinstance(progress.latestOffset, str))
+        self.assertTrue(isinstance(progress.startOffset, (str, type(None))))
+        self.assertTrue(isinstance(progress.endOffset, (str, type(None))))
+        self.assertTrue(isinstance(progress.latestOffset, (str, type(None))))
         self.assertTrue(isinstance(progress.numInputRows, int))
         self.assertTrue(isinstance(progress.inputRowsPerSecond, float))
         self.assertTrue(isinstance(progress.processedRowsPerSecond, float))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the flaky test (https://github.com/apache/spark/runs/6643112037):

```
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/tests/test_streaming_listener.py", line 121, in test_listener_events
    self.check_progress_event(progress_event)
  File "/__w/spark/spark/python/pyspark/sql/tests/test_streaming_listener.py", line 140, in check_progress_event
    self.check_streaming_query_progress(event.progress)
  File "/__w/spark/spark/python/pyspark/sql/tests/test_streaming_listener.py", line 198, in check_streaming_query_progress
    self.check_source_progress(so)
  File "/__w/spark/spark/python/pyspark/sql/tests/test_streaming_listener.py", line 248, in check_source_progress
    self.assertTrue(isinstance(progress.startOffset, str))
AssertionError: False is not true
```

`startOffset`, `endOffset` and `latestOffset` can be `None`, and this PR changes the possible types in the tests.

### Why are the changes needed?

To fix the flakiness.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

This PR fixes the test. We should monitor if it fixes the flakiness after it gets merged.
