### PR TITLE
[SPARK-39333][SQL] Change to use `foreach` when `map` doesn't produce results

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -512,7 +512,7 @@ case class ResolveDefaultColumns(
       case r: UnresolvedCatalogRelation => r
     }
     // Check if the target table is already resolved. If so, return the computed schema.
-    source.map { r =>
+    source.foreach { r =>
       if (r.schema.fields.nonEmpty) {
         return Some(r.schema)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
@@ -57,7 +57,7 @@ object CustomMetrics {
     currentMetricsValues.foreach { metric =>
       val metricName = metric.name()
       val metricValue = metric.value()
-      customMetrics.get(metricName).map(_.set(metricValue))
+      customMetrics.get(metricName).foreach(_.set(metricValue))
 
       if (BUILTIN_OUTPUT_METRICS.contains(metricName)) {
         Option(TaskContext.get()).map(_.taskMetrics().outputMetrics).foreach { outputMetrics =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -619,7 +619,7 @@ class SymmetricHashJoinStateManager(
             val keyWithIndex = keyWithIndexRow(key, index)
             val valuePair = valueRowConverter.convertValue(stateStore.get(keyWithIndex))
             if (valuePair == null && storeConf.skipNullsForStreamStreamJoins) {
-              skippedNullValueCount.map(_ += 1L)
+              skippedNullValueCount.foreach(_ += 1L)
               index += 1
             } else {
               keyWithIndexAndValue.withNew(key, index, valuePair)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to use `foreach` when `map` doesn't produce results in Spark code.


### Why are the changes needed?
Use appropriate api.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions.
