### PR TITLE
[SPARK-39334][BUILD] Exclude `slf4j-reload4j` from `hadoop-minikdc` test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1404,7 +1404,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-minikdc</artifactId>
+        <artifactId>hadoop-</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>
         <exclusions>
@@ -1418,7 +1418,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1418,6 +1418,10 @@
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -1404,7 +1404,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-</artifactId>
+        <artifactId>hadoop-minikdc</artifactId>
         <version>${hadoop.version}</version>
         <scope>test</scope>
         <exclusions>


### PR DESCRIPTION
### What changes were proposed in this pull request?
[HADOOP-18088 Replace log4j 1.x with reload4j](https://issues.apache.org/jira/browse/HADOOP-18088) , this pr adds the exclusion of `slf4j-reload4j` for `hadoop-minikdc` to clean up waring message about `Class path contains multiple SLF4J bindings` when run UTs.

### Why are the changes needed?
Cleanup `Class path contains multiple SLF4J bindings` waring when run UTs.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GA
- Manual test

for example, run `mvn clean test -pl core`

**Before** 

```
[INFO] Running test.org.apache.spark.Java8RDDAPISuite
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/xxx/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.17.2/log4j-slf4j-impl-2.17.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/xxx/.m2/repository/org/slf4j/slf4j-reload4j/1.7.36/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
```

**After**

no above warnings