### PR TITLE
[SPARK-39338][SQL] Remove dynamic pruning subquery if pruningKey's references is empty

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
@@ -50,12 +50,13 @@ object CleanupDynamicPruningFilters extends Rule[LogicalPlan] with PredicateHelp
   private def removeUnnecessaryDynamicPruningSubquery(plan: LogicalPlan): LogicalPlan = {
     plan.transformWithPruning(_.containsPattern(DYNAMIC_PRUNING_SUBQUERY)) {
       case f @ Filter(condition, _) =>
-        val unnecessaryPruningKeys = ExpressionSet(collectEqualityConditionExpressions(condition))
+        lazy val unnecessaryPruningKeys =
+          ExpressionSet(collectEqualityConditionExpressions(condition))
         val newCondition = condition.transformWithPruning(
           _.containsPattern(DYNAMIC_PRUNING_SUBQUERY)) {
           case dynamicPruning: DynamicPruningSubquery
-              if unnecessaryPruningKeys.contains(dynamicPruning.pruningKey) ||
-                dynamicPruning.pruningKey.references.isEmpty =>
+              if dynamicPruning.pruningKey.references.isEmpty ||
+                unnecessaryPruningKeys.contains(dynamicPruning.pruningKey) =>
             TrueLiteral
         }
         f.copy(condition = newCondition)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/CleanupDynamicPruningFilters.scala
@@ -54,7 +54,8 @@ object CleanupDynamicPruningFilters extends Rule[LogicalPlan] with PredicateHelp
         val newCondition = condition.transformWithPruning(
           _.containsPattern(DYNAMIC_PRUNING_SUBQUERY)) {
           case dynamicPruning: DynamicPruningSubquery
-              if unnecessaryPruningKeys.contains(dynamicPruning.pruningKey) =>
+              if unnecessaryPruningKeys.contains(dynamicPruning.pruningKey) ||
+                dynamicPruning.pruningKey.references.isEmpty =>
             TrueLiteral
         }
         f.copy(condition = newCondition)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove dynamic pruning subquery if pruningKey's references is empty. For example:
```sql
SELECT f.store_id,
       f.date_id,
       s.state_province
FROM (SELECT   store_id,
               date_id,
               product_id
      FROM   fact_stats
      WHERE  date_id <= 1000
      UNION ALL
      SELECT 4 AS store_id,
               date_id,
               product_id
      FROM   fact_sk
      WHERE  date_id >= 1300) f
JOIN dim_store s
ON f.store_id = s.store_id
WHERE s.country IN ('US', 'NL')
```

Before this PR | After this PR
-- | --
![image](https://user-images.githubusercontent.com/5399861/170940803-b4d4b93d-96d7-47de-ac22-d13259f3447a.png) | ![image](https://user-images.githubusercontent.com/5399861/170941010-b7eec26e-9f93-4ae6-aa10-aacdde15af0d.png)

### Why are the changes needed?

Remove useless dynamic pruning subquery because it can't reduce partition.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.