### PR TITLE
[SPARK-39322][CORE][FOLLOWUP] Revise log messages for dynamic allocation and shuffle decommission

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -204,13 +204,11 @@ private[spark] class ExecutorAllocationManager(
         s"s${DYN_ALLOCATION_SUSTAINED_SCHEDULER_BACKLOG_TIMEOUT.key} must be > 0!")
     }
     if (!conf.get(config.SHUFFLE_SERVICE_ENABLED)) {
-      // If dynamic allocation shuffle tracking or worker decommissioning along with
-      // storage shuffle decommissioning is enabled we have *experimental* support for
-      // decommissioning without a shuffle service.
-      if (conf.get(config.DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED) ||
-          (decommissionEnabled &&
-            conf.get(config.STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED))) {
-        logWarning("Dynamic allocation without a shuffle service is an experimental feature.")
+      if (conf.get(config.DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED)) {
+        logInfo("Dynamic allocation is enabled without a shuffle service.")
+      } else if (decommissionEnabled &&
+          conf.get(config.STORAGE_DECOMMISSION_SHUFFLE_BLOCKS_ENABLED)) {
+        logInfo("Shuffle data decommission is enabled without a shuffle service.")
       } else if (!testing) {
         throw new SparkException("Dynamic allocation of executors requires the external " +
           "shuffle service. You may enable this through spark.shuffle.service.enabled.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up for #36705 to revise the missed log message change.

### Why are the changes needed?

Like the documentation, this PR updates the log message correspondingly.
- Lower log level to `INFO` from `WARN`
- Provide a specific message according to the configurations.

### Does this PR introduce _any_ user-facing change?

No. This is a log-message-only change.

### How was this patch tested?

Pass the CIs.