### PR TITLE
[SPARK-39341][K8S] KubernetesExecutorBackend should allow IPv6 pod IP

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -66,7 +66,8 @@ private[spark] object KubernetesExecutorBackend extends Logging {
 
     SparkHadoopUtil.get.runAsSparkUser { () =>
       // Debug code
-      Utils.checkHost(arguments.hostname)
+      assert(arguments.hostname != null &&
+          (arguments.hostname.indexOf(':') == -1 || arguments.hostname.split(":").length > 2))
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to make KubernetesExecutorBackend allow IPv6 pod IP.


### Why are the changes needed?
The `hostname` comes from `SPARK_EXECUTOR_POD_IP`.
```
resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh:      --hostname $SPARK_EXECUTOR_POD_IP
```

`SPARK_EXECUTOR_POD_IP` comes from `status.podIP` where it does not have `[]` in case of IPv6.
https://github.com/apache/spark/blob/1a54a2bd69e35ab5f0cbd83df673c6f1452df418/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala#L140-L145

- https://kubernetes.io/docs/concepts/services-networking/dual-stack/
- https://en.wikipedia.org/wiki/IPv6_address


### Does this PR introduce _any_ user-facing change?
No, this PR removes only the `[]` constraint from `checkHost`.

### How was this patch tested?

Pass the CIs.