### PR TITLE
[SPARK-39343][SQL] DescribeTableExec should redact properties

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -51,7 +51,7 @@ case class DescribeTableExec(
       }
     })
     val properties =
-      table.properties.asScala.toList
+      conf.redactOptions(table.properties.asScala.toMap).toList
         .filter(kv => !CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(kv._1))
         .sortBy(_._1).map {
         case (key, value) => key + "=" + value

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -123,7 +123,7 @@ class DataSourceV2SQLSuite
     spark.sql("CREATE TABLE testcat.table_name (id bigint, data string)" +
       " USING foo" +
       " PARTITIONED BY (id)" +
-      " TBLPROPERTIES ('bar'='baz')" +
+      " TBLPROPERTIES ('bar'='baz', 'password' = 'password')" +
       " COMMENT 'this is a test table'" +
       " LOCATION 'file:/tmp/testcat/table_name'")
     val descriptionDf = spark.sql("DESCRIBE TABLE EXTENDED testcat.table_name")
@@ -151,7 +151,7 @@ class DataSourceV2SQLSuite
       Array("Location", "file:/tmp/testcat/table_name", ""),
       Array("Provider", "foo", ""),
       Array(TableCatalog.PROP_OWNER.capitalize, defaultUser, ""),
-      Array("Table Properties", "[bar=baz]", "")))
+      Array("Table Properties", "[bar=baz,password=*********(redacted)]", "")))
   }
 
   test("Describe column for v2 catalog") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
DescribeTableExec should redact properties


### Why are the changes needed?
DescribeTableExec should redact properties


### Does this PR introduce _any_ user-facing change?
When user use `DESCRIBE TABLE EXTENDED` in v2 catalog, sensitive properties will be redacted.


### How was this patch tested?
Added UT