### PR TITLE
[SPARK-39344][SQL] Only disable bucketing when autoBucketedScan is enabled if bucket columns are not in scan output

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -723,7 +723,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
 
       checkKeywordsExistsInExplain(
         df1.select("j"),
-        "Bucketed: false (bucket column(s) not read)")
+        "Bucketed: false (disabled by query planner)")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, bucketed scan is disabled if bucket columns are not in scan output. This PR proposes to move the check into `DisableUnnecessaryBucketedScan` and only disable bucketing when autoBucketedScan is enabled.


### Why are the changes needed?
The current behavior was brought in by https://github.com/apache/spark/pull/27924, which could break 
existing applications whose input size is huge by creating too many FilePartitions and causing driver hang. By moving the check into `DisableUnnecessaryBucketedScan`, we can keep backward compatibility by disabling autoBucketedScan.

### Does this PR introduce _any_ user-facing change?
Yes when user disables autoBucketedScan.

### How was this patch tested?
Update existing test.
