### PR TITLE
[SPARK-39351][SQL] SHOW CREATE TABLE should redact properties

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowCreateTableExec.scala
@@ -133,7 +133,7 @@ case class ShowCreateTableExec(
         && !key.startsWith(TableCatalog.OPTION_PREFIX)
         && !tableOptions.contains(key))
     if (showProps.nonEmpty) {
-      val props = showProps.toSeq.sortBy(_._1).map {
+      val props = conf.redactOptions(showProps.toMap).toSeq.sortBy(_._1).map {
         case (key, value) =>
           s"'${escapeSingleQuotedString(key)}' = '${escapeSingleQuotedString(value)}'"
       }

--- a/sql/core/src/test/resources/sql-tests/inputs/show-create-table.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/show-create-table.sql
@@ -7,7 +7,7 @@ DROP TABLE tbl;
 
 -- options
 CREATE TABLE tbl (a INT, b STRING, c INT) USING parquet
-OPTIONS ('a' 1);
+OPTIONS ('a' 1, 'password' = 'password');
 
 SHOW CREATE TABLE tbl;
 DROP TABLE tbl;
@@ -55,7 +55,7 @@ DROP TABLE tbl;
 
 -- tblproperties
 CREATE TABLE tbl (a INT, b STRING, c INT) USING parquet
-TBLPROPERTIES ('a' = '1');
+TBLPROPERTIES ('a' = '1', 'password' = 'password');
 
 SHOW CREATE TABLE tbl;
 DROP TABLE tbl;

--- a/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-create-table.sql.out
@@ -32,7 +32,7 @@ struct<>
 
 -- !query
 CREATE TABLE tbl (a INT, b STRING, c INT) USING parquet
-OPTIONS ('a' 1)
+OPTIONS ('a' 1, 'password' = 'password')
 -- !query schema
 struct<>
 -- !query output
@@ -50,7 +50,8 @@ CREATE TABLE default.tbl (
   c INT)
 USING parquet
 OPTIONS (
-  'a' = '1')
+  'a' = '1',
+  'password' = '*********(redacted)')
 
 
 -- !query
@@ -215,7 +216,7 @@ struct<>
 
 -- !query
 CREATE TABLE tbl (a INT, b STRING, c INT) USING parquet
-TBLPROPERTIES ('a' = '1')
+TBLPROPERTIES ('a' = '1', 'password' = 'password')
 -- !query schema
 struct<>
 -- !query output
@@ -233,7 +234,8 @@ CREATE TABLE default.tbl (
   c INT)
 USING parquet
 TBLPROPERTIES (
-  'a' = '1')
+  'a' = '1',
+  'password' = '*********(redacted)')
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowCreateTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowCreateTableSuite.scala
@@ -82,7 +82,12 @@ class ShowCreateTableSuite extends command.ShowCreateTableSuiteBase with Command
            |  to = 1,
            |  via = 2)
            |COMMENT 'This is a comment'
-           |TBLPROPERTIES ('prop1' = '1', 'prop2' = '2', 'prop3' = 3, 'prop4' = 4)
+           |TBLPROPERTIES (
+           |  'prop1' = '1',
+           |  'prop2' = '2',
+           |  'prop3' = 3,
+           |  'prop4' = 4,
+           |  'password' = 'password')
            |PARTITIONED BY (a)
            |LOCATION '/tmp'
         """.stripMargin)
@@ -103,6 +108,7 @@ class ShowCreateTableSuite extends command.ShowCreateTableSuiteBase with Command
         "COMMENT 'This is a comment'",
         "LOCATION 'file:/tmp'",
         "TBLPROPERTIES (",
+        "'password' = '*********(redacted)',",
         "'prop1' = '1',",
         "'prop2' = '2',",
         "'prop3' = '3',",


### PR DESCRIPTION

### What changes were proposed in this pull request?
`SHOW CREATE TABLE` should redact properties


### Why are the changes needed?
Protect sensitive properties


### Does this PR introduce _any_ user-facing change?
When user use `SHOW CREATE TABLE`, sensitive properties will be redacted.

### How was this patch tested?
Added UT