### PR TITLE
[WIP] Support createDataFrame from a NumPy array

### DIFF
--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -445,7 +445,8 @@ class SparkConversionMixin:
             converted_data = self._convert_from_pandas(data, schema, timezone)
         else:
             converted_data, dtype = self._convert_from_numpy(data, schema, timezone)
-            schema = _infer_type(dtype)
+            if schema is None:
+                schema = _infer_type(dtype)
 
         return self._create_dataframe(converted_data, schema, samplingRatio, verifySchema)
 
@@ -544,7 +545,9 @@ class SparkConversionMixin:
         if len(np_records) > 0:
             record_dtype = self._get_numpy_record_dtype(np_records[0])
             if record_dtype is not None:
-                return [r.astype(record_dtype).tolist() for r in np_records], record_dtype
+                return [
+                    r.astype(record_dtype).tolist() for r in np_records
+                ], record_dtype if schema is None else None
 
         # Convert list of numpy records to python lists
         return [r.tolist() for r in np_records], None

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -543,7 +543,6 @@ class SparkConversionMixin:
         # Check if any columns need to be fixed for Spark to infer properly
         if len(np_records) > 0:
             record_dtype = self._get_numpy_record_dtype(np_records[0])
-            assert record_dtype == np.int64
             if record_dtype is not None:
                 return [r.astype(record_dtype).tolist() for r in np_records], record_dtype
 

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -522,8 +522,8 @@ class SparkConversionMixin:
         return [r.tolist() for r in np_records]
 
     def _convert_from_numpy(
-            self, np_arr, schema: Union[StructType, str, List[str]], timezone: str
-    ) -> Tuple[List, Optional[type]]:
+        self, np_arr, schema: Union[StructType, str, List[str]], timezone: str
+    ) -> Tuple[List, Optional["np.dtype"]]:
         """
         Convert a numpy.array to list of records that can be used to make a DataFrame
 

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -41,6 +41,30 @@ def require_minimum_pandas_version() -> None:
         )
 
 
+def require_minimum_numpy_version() -> None:
+    """Raise ImportError if minimum version of NumPy is not installed"""
+    minimum_numpy_version = "1.15"
+
+    from distutils.version import LooseVersion
+
+    try:
+        import numpy
+
+        have_numpy = True
+    except ImportError as error:
+        have_numpy = False
+        raised_error = error
+    if not have_numpy:
+        raise ImportError(
+            "NumPy >= %s must be installed; however, " "it was not found." % minimum_numpy_version
+        ) from raised_error
+    if LooseVersion(numpy.__version__) < LooseVersion(minimum_numpy_version):
+        raise ImportError(
+            "NumPy >= %s must be installed; however, "
+            "your version was %s." % (minimum_numpy_version, numpy.__version__)
+        )
+
+
 def require_minimum_pyarrow_version() -> None:
     """Raise ImportError if minimum version of pyarrow is not installed"""
     # TODO(HyukjinKwon): Relocate and deduplicate the version specification.

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -377,6 +377,44 @@ class SparkExtensionsTest(unittest.TestCase):
         )
 
 
+class CreateDataFrame(unittest.TestCase):
+    def test_from_numpy_array(self):
+        spark = SparkSession.builder.master("local").getOrCreate()
+        try:
+            import numpy as np
+
+            activeSession = SparkSession.getActiveSession()
+            data_collected_dtypes = [
+                (np.array([1, 2]), [Row(value=1), Row(value=2)], [("value", "bigint")]),
+                (
+                    np.array([1, 2]).astype(np.int8),
+                    [Row(value=0.1), Row(value=0.2)],
+                    [("value", "tinyint")],
+                ),
+                (
+                    np.array([1, 2]).astype(np.int32),
+                    [Row(value=0.1), Row(value=0.2)],
+                    [("value", "int")],
+                ),
+                (
+                    np.array([1, 2]).astype(np.int64),
+                    [Row(value=0.1), Row(value=0.2)],
+                    [("value", "bigint")],
+                ),
+                (
+                    np.array([1, 2]).astype(np.float32),
+                    [Row(value=0.1), Row(value=0.2)],
+                    [("value", "float")],
+                ),
+            ]
+            for data, collected, dtypes in data_collected_dtypes:
+                df = activeSession.createDataFrame(data)
+                self.assertEqual(df.collect(), collected)
+                self.assertEqual(df.dtypes, dtypes)
+        finally:
+            spark.stop()
+
+
 if __name__ == "__main__":
     from pyspark.sql.tests.test_session import *  # noqa: F401
 

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -411,6 +411,9 @@ class CreateDataFrame(unittest.TestCase):
                 df = activeSession.createDataFrame(data)
                 self.assertEqual(df.collect(), collected)
                 self.assertEqual(df.dtypes, dtypes)
+            with self.assertRaisesRegex(TypeError, "not supported type: numpy.float64"):
+                activeSession.createDataFrame(np.array([0.1, 0.2]))
+
         finally:
             spark.stop()
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1312,7 +1312,10 @@ def _infer_type(
                 infer_array_from_first_element=infer_array_from_first_element,
             )
         except TypeError:
-            raise TypeError("not supported type: %s" % type(obj))
+            if isinstance(obj, np.dtype):
+                raise TypeError("not supported type: numpy.%s" % obj)
+            else:
+                raise TypeError("not supported type: %s" % type(obj))
 
 
 def _infer_schema(

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -44,6 +44,8 @@ from typing import (
     TypeVar,
 )
 
+import numpy as np
+
 from py4j.protocol import register_input_converter
 from py4j.java_gateway import GatewayClient, JavaClass, JavaObject
 
@@ -1118,6 +1120,14 @@ def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
             raise ValueError("not supported type: %s" % tpe)
 
 
+_numpy_type_mappings = {
+    np.int64: LongType,
+    np.int32: IntegerType,
+    np.int8: ByteType,
+    np.float32: FloatType,
+}
+
+
 # Mapping Python types to Spark SQL DataType
 _type_mappings = {
     type(None): NullType,
@@ -1226,7 +1236,9 @@ def _infer_type(
     if hasattr(obj, "__UDT__"):
         return obj.__UDT__
 
-    dataType = _type_mappings.get(type(obj))
+    dataType = _numpy_type_mappings.get(obj)  # TODO: why always None
+    if dataType is None:
+        dataType = _type_mappings.get(type(obj))
     if dataType is DecimalType:
         # the precision and scale of `obj` may be different from row to row.
         return DecimalType(38, 18)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1121,10 +1121,10 @@ def _parse_datatype_json_value(json_value: Union[dict, str]) -> DataType:
 
 
 _numpy_type_mappings = {
-    np.int64: LongType,
-    np.int32: IntegerType,
-    np.int8: ByteType,
-    np.float32: FloatType,
+    np.dtype("int64"): LongType,
+    np.dtype("int32"): IntegerType,
+    np.dtype("int8"): ByteType,
+    np.dtype("float32"): FloatType,
 }
 
 
@@ -1236,7 +1236,7 @@ def _infer_type(
     if hasattr(obj, "__UDT__"):
         return obj.__UDT__
 
-    dataType = _numpy_type_mappings.get(obj)  # TODO: why always None
+    dataType = _numpy_type_mappings.get(obj)
     if dataType is None:
         dataType = _type_mappings.get(type(obj))
     if dataType is DecimalType:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support createDataFrame from a NumPy array.

The progress of changes proposed in this PR:
- [x] convert NumPy array to list internally
- [x] leverage NumPy dtype to skip inferring schema
- [x] accept input schema
- [ ] schema as a NumPy dtype string X
- [ ] timezone X
- [ ] Arrow optimization SEPARATE
- [ ] complete NumPy <> Spark type mapping
- [ ] 2-dimentional ndarray

### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
Yes. Users can Support createDataFrame from a NumPy array.

### How was this patch tested?
Unit tests.