### PR TITLE
[SPARK-38961][DOCS][PYTHON][3.3] Enhance to automatically generate the pandas API support list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ python/coverage.xml
 python/deps
 python/docs/_site/
 python/docs/source/reference/**/api/
+python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst
 python/test_coverage/coverage_data
 python/test_coverage/htmlcov
 python/pyspark/python

--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -590,6 +590,7 @@ pyspark_pandas = Module(
         "pyspark.pandas.sql_processor",
         "pyspark.pandas.sql_formatter",
         "pyspark.pandas.strings",
+        "pyspark.pandas.supported_api_gen",
         "pyspark.pandas.utils",
         "pyspark.pandas.window",
         "pyspark.pandas.indexes.base",

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -22,6 +22,15 @@ import errno
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
 
+# generate user_guide/pandas_on_spark/supported_pandas_api.rst
+from pyspark.pandas.supported_api_gen import generate_supported_api
+
+output_rst_file_path = (
+    "%s/user_guide/pandas_on_spark/supported_pandas_api.rst"
+    % os.path.dirname(os.path.abspath(__file__))
+)
+generate_supported_api(output_rst_file_path)
+
 # Remove previously generated rst files. Ignore errors just in case it stops
 # generating whole docs.
 shutil.rmtree(

--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -1,0 +1,377 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Generate 'Supported pandas APIs' documentation file
+"""
+import warnings
+from distutils.version import LooseVersion
+from enum import Enum, unique
+from inspect import getmembers, isclass, isfunction, signature
+from typing import Any, Callable, Dict, List, NamedTuple, Set, TextIO, Tuple
+
+import pyspark.pandas as ps
+import pyspark.pandas.groupby as psg
+import pyspark.pandas.window as psw
+
+import pandas as pd
+import pandas.core.groupby as pdg
+import pandas.core.window as pdw
+
+MAX_MISSING_PARAMS_SIZE = 5
+COMMON_PARAMETER_SET = {
+    "kwargs",
+    "args",
+    "cls",
+}  # These are not counted as missing parameters.
+MODULE_GROUP_MATCH = [(pd, ps), (pdw, psw), (pdg, psg)]
+
+RST_HEADER = """
+=====================
+Supported pandas APIs
+=====================
+
+.. currentmodule:: pyspark.pandas
+
+The following table shows the pandas APIs that implemented or non-implemented from pandas API on
+Spark.
+
+Some pandas APIs do not implement full parameters, so the third column shows missing parameters for
+each API.
+
+'Y' in the second column means it's implemented including its whole parameter.
+'N' means it's not implemented yet.
+'P' means it's partially implemented with the missing of some parameters.
+
+If there is non-implemented pandas API or parameter you want, you can create an `Apache Spark
+JIRA <https://issues.apache.org/jira/projects/SPARK/summary>`__ to request or to contribute by your
+own.
+
+The API list is updated based on the `latest pandas official API
+reference <https://pandas.pydata.org/docs/reference/index.html#>`__.
+
+All implemented APIs listed here are distributed except the ones that requires the local
+computation by design. For example, `DataFrame.to_numpy() <https://spark.apache.org
+/docs/latest/api/python/reference/pyspark.pandas/api/pyspark.pandas.DataFrame.
+to_numpy.html>`__ requires to collect the data to the driver side.
+
+"""
+
+
+@unique
+class Implemented(Enum):
+    IMPLEMENTED = "Y"
+    NOT_IMPLEMENTED = "N"
+    PARTIALLY_IMPLEMENTED = "P"
+
+
+class SupportedStatus(NamedTuple):
+    """
+    Defines a supported status for a specific pandas API
+    """
+
+    implemented: str
+    missing: str
+
+
+def generate_supported_api(output_rst_file_path: str) -> None:
+    """
+    Generate supported APIs status dictionary.
+    Parameters
+    ----------
+    output_rst_file_path : str
+        The path to the document file in RST format.
+
+    Write supported APIs documentation.
+    """
+    if LooseVersion(pd.__version__) < LooseVersion("1.4.0"):
+        warnings.warn(
+            "Warning: Latest version of pandas(>=1.4.0) is required to generate the documentation; "
+            + "however, your version was %s" % pd.__version__,
+            UserWarning,
+        )
+
+    all_supported_status: Dict[Tuple[str, str], Dict[str, SupportedStatus]] = {}
+    for pd_module_group, ps_module_group in MODULE_GROUP_MATCH:
+        pd_modules = _get_pd_modules(pd_module_group)
+        _update_all_supported_status(
+            all_supported_status, pd_modules, pd_module_group, ps_module_group
+        )
+    _write_rst(output_rst_file_path, all_supported_status)
+
+
+def _create_supported_by_module(
+    module_name: str, pd_module_group: Any, ps_module_group: Any
+) -> Dict[str, SupportedStatus]:
+    """
+    Retrieves supported status of pandas module
+
+    Parameters
+    ----------
+    module_name : str
+        Class name that exists in the path of the module.
+    pd_module_group : Any
+        Specific path of importable pandas module.
+    ps_module_group: Any
+        Specific path of importable pyspark.pandas module.
+    """
+    pd_module = getattr(pd_module_group, module_name) if module_name else pd_module_group
+    try:
+        ps_module = getattr(ps_module_group, module_name) if module_name else ps_module_group
+    except AttributeError:
+        # module not implemented
+        return {}
+
+    pd_funcs = dict([m for m in getmembers(pd_module, isfunction) if not m[0].startswith("_")])
+    if not pd_funcs:
+        return {}
+
+    ps_funcs = dict([m for m in getmembers(ps_module, isfunction) if not m[0].startswith("_")])
+
+    return _organize_by_implementation_status(
+        module_name, pd_funcs, ps_funcs, pd_module_group, ps_module_group
+    )
+
+
+def _organize_by_implementation_status(
+    module_name: str,
+    pd_funcs: Dict[str, Callable],
+    ps_funcs: Dict[str, Callable],
+    pd_module_group: Any,
+    ps_module_group: Any,
+) -> Dict[str, SupportedStatus]:
+    """
+    Check the implementation status and parameters of both modules.
+
+    Parmeters
+    ---------
+    module_name : str
+        Class name that exists in the path of the module.
+    pd_funcs: Dict[str, Callable]
+        function name and function object mapping of pandas module.
+    ps_funcs: Dict[str, Callable]
+        function name and function object mapping of pyspark.pandas module.
+    pd_module_group : Any
+        Specific path of importable pandas module.
+    ps_module_group: Any
+        Specific path of importable pyspark.pandas module.
+    """
+    pd_dict = {}
+    for pd_func_name, pd_func in pd_funcs.items():
+        ps_func = ps_funcs.get(pd_func_name)
+        if ps_func:
+            missing_set = (
+                set(signature(pd_func).parameters)
+                - set(signature(ps_func).parameters)
+                - COMMON_PARAMETER_SET
+            )
+            if missing_set:
+                # partially implemented
+                pd_dict[pd_func_name] = SupportedStatus(
+                    implemented=Implemented.PARTIALLY_IMPLEMENTED.value,
+                    missing=_transform_missing(
+                        module_name,
+                        pd_func_name,
+                        missing_set,
+                        pd_module_group.__name__,
+                        ps_module_group.__name__,
+                    ),
+                )
+            else:
+                # implemented including it's whole parameter
+                pd_dict[pd_func_name] = SupportedStatus(
+                    implemented=Implemented.IMPLEMENTED.value, missing=""
+                )
+        else:
+            # not implemented yet
+            pd_dict[pd_func_name] = SupportedStatus(
+                implemented=Implemented.NOT_IMPLEMENTED.value, missing=""
+            )
+    return pd_dict
+
+
+def _transform_missing(
+    module_name: str,
+    pd_func_name: str,
+    missing_set: Set[str],
+    pd_module_path: str,
+    ps_module_path: str,
+) -> str:
+    """
+    Transform missing parameters into table information string.
+
+    Parameters
+    ----------
+    module_name : str
+        Class name that exists in the path of the module.
+    pd_func_name : str
+        Name of pandas API.
+    missing_set : Set[str]
+        A set of parameters not yet implemented.
+    pd_module_path : str
+        Path string of pandas module.
+    ps_module_path : str
+        Path string of pyspark.pandas module.
+
+    Examples
+    --------
+    >>> _transform_missing("DataFrame", "add", {"axis", "fill_value", "level"},
+    ...                     "pandas.DataFrame", "pyspark.pandas.DataFrame")
+    '``axis`` , ``fill_value`` , ``level``'
+    """
+    missing_str = " , ".join("``%s``" % x for x in sorted(missing_set)[:MAX_MISSING_PARAMS_SIZE])
+    if len(missing_set) > MAX_MISSING_PARAMS_SIZE:
+        module_dot_func = "%s.%s" % (module_name, pd_func_name) if module_name else pd_func_name
+        additional_str = (
+            " and more. See the "
+            + "`%s.%s " % (pd_module_path, module_dot_func)
+            + "<https://pandas.pydata.org/docs/reference/api/"
+            + "%s.%s.html>`__ and " % (pd_module_path, module_dot_func)
+            + "`%s.%s " % (ps_module_path, module_dot_func)
+            + "<https://spark.apache.org/docs/latest/api/python/reference/pyspark.pandas/api/"
+            + "%s.%s.html>`__ for detail." % (ps_module_path, module_dot_func)
+        )
+        missing_str += additional_str
+    return missing_str
+
+
+def _get_pd_modules(pd_module_group: Any) -> List[str]:
+    """
+    Returns sorted pandas memeber list from pandas module path.
+
+    Parameters
+    ----------
+    pd_module_group : Any
+        Specific path of importable pandas module.
+    """
+    return sorted([m[0] for m in getmembers(pd_module_group, isclass) if not m[0].startswith("_")])
+
+
+def _update_all_supported_status(
+    all_supported_status: Dict[Tuple[str, str], Dict[str, SupportedStatus]],
+    pd_modules: List[str],
+    pd_module_group: Any,
+    ps_module_group: Any,
+) -> None:
+    """
+    Updates supported status across multiple module paths.
+
+    Parmeters
+    ---------
+    all_supported_status: Dict[Tuple[str, str], Dict[str, SupportedStatus]]
+        Data that stores the supported status across multiple module paths.
+    pd_modles: List[str]
+        Name list of pandas modules.
+    pd_module_group : Any
+        Specific path of importable pandas module.
+    ps_module_group: Any
+        Specific path of importable pyspark.pandas module.
+    """
+    pd_modules += [""]  # for General Function APIs
+    for module_name in pd_modules:
+        supported_status = _create_supported_by_module(
+            module_name, pd_module_group, ps_module_group
+        )
+        if supported_status:
+            all_supported_status[(module_name, ps_module_group.__name__)] = supported_status
+
+
+def _write_table(
+    module_name: str,
+    module_path: str,
+    supported_status: Dict[str, SupportedStatus],
+    w_fd: TextIO,
+) -> None:
+    """
+    Write table by using Sphinx list-table directive.
+    """
+    lines = []
+    lines.append("Supported ")
+    if module_name:
+        lines.append(module_name)
+    else:
+        lines.append("General Function")
+    lines.append(" APIs\n")
+    lines.append("-" * 100)
+    lines.append("\n")
+    lines.append(".. currentmodule:: %s" % module_path)
+    if module_name:
+        lines.append(".%s\n" % module_name)
+    else:
+        lines.append("\n")
+    lines.append("\n")
+    lines.append(".. list-table::\n")
+    lines.append("    :header-rows: 1\n")
+    lines.append("\n")
+    lines.append("    * - API\n")
+    lines.append("      - Implemented\n")
+    lines.append("      - Missing parameters\n")
+    for func_str, status in supported_status.items():
+        func_str = _escape_func_str(func_str)
+        if status.implemented == Implemented.NOT_IMPLEMENTED.value:
+            lines.append("    * - %s\n" % func_str)
+        else:
+            lines.append("    * - :func:`%s`\n" % func_str)
+        lines.append("      - %s\n" % status.implemented)
+        lines.append("      - \n") if not status.missing else lines.append(
+            "      - %s\n" % status.missing
+        )
+    w_fd.writelines(lines)
+
+
+def _escape_func_str(func_str: str) -> str:
+    """
+    Transforms which affecting rst data format.
+    """
+    # TODO: Take into account that this function can create links incorrectly
+    # We can create alias links or links to parent methods
+    if func_str.endswith("_"):
+        return func_str[:-1] + "\_"  # noqa: W605
+    else:
+        return func_str
+
+
+def _write_rst(
+    output_rst_file_path: str,
+    all_supported_status: Dict[Tuple[str, str], Dict[str, SupportedStatus]],
+) -> None:
+    """
+    Writes the documentation to the target file path.
+    """
+    with open(output_rst_file_path, "w") as w_fd:
+        w_fd.write(RST_HEADER)
+        for module_info, supported_status in all_supported_status.items():
+            module, module_path = module_info
+            if supported_status:
+                _write_table(module, module_path, supported_status, w_fd)
+                w_fd.write("\n")
+
+
+def _test() -> None:
+    import doctest
+    import sys
+
+    import pyspark.pandas.supported_api_gen
+
+    globs = pyspark.pandas.supported_api_gen.__dict__.copy()
+    (failure_count, test_count) = doctest.testmod(pyspark.pandas.supported_api_gen, globs=globs)
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/pandas/supported_api_gen.py
+++ b/python/pyspark/pandas/supported_api_gen.py
@@ -42,32 +42,30 @@ MODULE_GROUP_MATCH = [(pd, ps), (pdw, psw), (pdg, psg)]
 
 RST_HEADER = """
 =====================
-Supported pandas APIs
+Supported pandas API
 =====================
 
 .. currentmodule:: pyspark.pandas
 
 The following table shows the pandas APIs that implemented or non-implemented from pandas API on
-Spark.
+Spark. Some pandas API do not implement full parameters, so the third column shows missing
+parameters for each API.
 
-Some pandas APIs do not implement full parameters, so the third column shows missing parameters for
-each API.
+* 'Y' in the second column means it's implemented including its whole parameter.
+* 'N' means it's not implemented yet.
+* 'P' means it's partially implemented with the missing of some parameters.
 
-'Y' in the second column means it's implemented including its whole parameter.
-'N' means it's not implemented yet.
-'P' means it's partially implemented with the missing of some parameters.
+All API in the list below computes the data with distributed execution except the ones that require
+the local execution by design. For example, `DataFrame.to_numpy() <https://spark.apache.org/docs/
+latest/api/python/reference/pyspark.pandas/api/pyspark.pandas.DataFrame.to_numpy.html>`__
+requires to collect the data to the driver side.
 
 If there is non-implemented pandas API or parameter you want, you can create an `Apache Spark
-JIRA <https://issues.apache.org/jira/projects/SPARK/summary>`__ to request or to contribute by your
-own.
+JIRA <https://issues.apache.org/jira/projects/SPARK/summary>`__ to request or to contribute by
+your own.
 
-The API list is updated based on the `latest pandas official API
-reference <https://pandas.pydata.org/docs/reference/index.html#>`__.
-
-All implemented APIs listed here are distributed except the ones that requires the local
-computation by design. For example, `DataFrame.to_numpy() <https://spark.apache.org
-/docs/latest/api/python/reference/pyspark.pandas/api/pyspark.pandas.DataFrame.
-to_numpy.html>`__ requires to collect the data to the driver side.
+The API list is updated based on the `latest pandas official API reference
+<https://pandas.pydata.org/docs/reference/index.html#>`__.
 
 """
 
@@ -81,7 +79,7 @@ class Implemented(Enum):
 
 class SupportedStatus(NamedTuple):
     """
-    Defines a supported status for a specific pandas API
+    Defines a supported status for specific pandas API
     """
 
     implemented: str
@@ -91,6 +89,7 @@ class SupportedStatus(NamedTuple):
 def generate_supported_api(output_rst_file_path: str) -> None:
     """
     Generate supported APIs status dictionary.
+
     Parameters
     ----------
     output_rst_file_path : str
@@ -300,12 +299,11 @@ def _write_table(
     Write table by using Sphinx list-table directive.
     """
     lines = []
-    lines.append("Supported ")
     if module_name:
         lines.append(module_name)
     else:
         lines.append("General Function")
-    lines.append(" APIs\n")
+    lines.append(" API\n")
     lines.append("-" * 100)
     lines.append("\n")
     lines.append(".. currentmodule:: %s" % module_path)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->



### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to automatically generate a list of supported APIs when building a page called "Supported pandas APIs" documentation.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Supported pandas APIs list is maintained manually, so it is recommended to generate the list automatically to reduce maintenance costs.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, the "Supported pandas APIs" page has changed as below. A list of APIs is created automatically.
<img width="1026" alt="Screen Shot 2022-05-30 at 10 51 12 PM" src="https://user-images.githubusercontent.com/7010554/171085952-9ba07017-f0f7-46bc-88d5-f39a84b21f1a.png">


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually check the links in the documents & the existing doc build should be passed.