### PR TITLE
[SPARK-39368][SQL] Move `RewritePredicateSubquery` into `InjectRuntimeFilter`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -290,7 +290,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
       !conf.runtimeFilterBloomFilterEnabled => plan
     case _ =>
       val newPlan = tryInjectRuntimeFilter(plan)
-      if (conf.runtimeFilterSemiJoinReductionEnabled) {
+      if (conf.runtimeFilterSemiJoinReductionEnabled && !plan.fastEquals(newPlan)) {
         RewritePredicateSubquery(newPlan)
       } else {
         newPlan

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -288,7 +288,13 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
     case s: Subquery if s.correlated => plan
     case _ if !conf.runtimeFilterSemiJoinReductionEnabled &&
       !conf.runtimeFilterBloomFilterEnabled => plan
-    case _ => tryInjectRuntimeFilter(plan)
+    case _ =>
+      val newPlan = tryInjectRuntimeFilter(plan)
+      if (conf.runtimeFilterSemiJoinReductionEnabled) {
+        RewritePredicateSubquery(newPlan)
+      } else {
+        newPlan
+      }
   }
 
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -52,8 +52,7 @@ class SparkOptimizer(
     Batch("PartitionPruning", Once,
       PartitionPruning) :+
     Batch("InjectRuntimeFilter", FixedPoint(1),
-      InjectRuntimeFilter,
-      RewritePredicateSubquery) :+
+      InjectRuntimeFilter) :+
     Batch("MergeScalarSubqueries", Once,
       MergeScalarSubqueries) :+
     Batch("Pushdown Filters from PartitionPruning", fixedPoint,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR moves `RewritePredicateSubquery` into `InjectRuntimeFilter`.

### Why are the changes needed?

Reduce the number of `RewritePredicateSubquery` runs, since `spark.sql.optimizer.runtimeFilter.semiJoinReduction.enabled` is disabled by default. For example:
```
build/sbt "sql/testOnly *TPCDSQuerySuite"
```
Before this PR:
```
...
org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery                      17978319 / 31026106                             26 / 624
...
```
After this PR:
```
...
org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery                      16680901 / 18994542                             26 / 312
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test.