### PR TITLE
[SPARK-39369][INFRA] Use JAVA_OPTS for AppVeyer build to increase the memory properly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,10 +50,12 @@ build_script:
   # See SPARK-28759.
   # Ideally we should check the tests related to Hive in SparkR as well (SPARK-31745).
   - cmd: set SBT_MAVEN_PROFILES=-Psparkr
-  - cmd: set SBT_OPTS=-Djna.nosys=true -Dfile.encoding=UTF-8 -Xms4096m -Xms4096m -XX:ReservedCodeCacheSize=128m
+  - cmd: set SBT_OPTS=-Djna.nosys=true -Dfile.encoding=UTF-8 -XX:ReservedCodeCacheSize=128m
+  - cmd: set JAVA_OPTS=-Xms4096m -Xms4096m
   - cmd: sbt package
   - cmd: set SBT_MAVEN_PROFILES=
   - cmd: set SBT_OPTS=
+  - cmd: set JAVA_OPTS=
 
 environment:
   NOT_CRAN: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark/builds/43740704

AppVeyor build is being failed because of the lack of memory.
This PR proposes to use JAVA_OPTS to make the memory configured properly.

### Why are the changes needed?

To make the build pass.

### Does this PR introduce _any_ user-facing change?

No, dev/test-only.

### How was this patch tested?

CI in this PR should test it out.