### PR TITLE
[SPARK-39373][PYTHON][3.2] Recover branch-3.2 build broken by SPARK-39273 and SPARK-39252

### DIFF
--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2201,7 +2201,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser.index = pmidx
         psser = ps.from_pandas(pser)
 
-        self.assert_eq(pser.mad(), psser.mad())
+        self.assert_eq(pser.mad(), psser.mad(), check_exact=False)
 
     def test_to_frame(self):
         pser = pd.Series(["a", "b", "c"])

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -2201,7 +2201,7 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser.index = pmidx
         psser = ps.from_pandas(pser)
 
-        self.assert_eq(pser.mad(), psser.mad(), check_exact=False)
+        self.assert_eq(pser.mad(), psser.mad(), almost=True)
 
     def test_to_frame(self):
         pser = pd.Series(["a", "b", "c"])

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -21,7 +21,6 @@ import shutil
 import tempfile
 import time
 import unittest
-from typing import cast
 
 from pyspark.sql import SparkSession, Row
 from pyspark.sql.types import StringType, IntegerType, DoubleType, StructType, StructField, \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backporting SPARK-39273 and SPARK-39252 brought some mistakes together into branch-3.2. This PR fixes it. One is to avoid exact match (by a different pandas version). Another one is unused import.

### Why are the changes needed?

To recover the build

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test it out.

