### PR TITLE
[SPARK-39377][SQL][TESTS] Normalize expr ids in ListQuery and Exists expressions

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/PlanTest.scala
@@ -76,9 +76,12 @@ trait PlanTestBase extends PredicateHelper with SQLHelper with SQLConfHelper { s
       case s: LateralSubquery =>
         s.copy(plan = normalizeExprIds(s.plan), exprId = ExprId(0))
       case e: Exists =>
-        e.copy(exprId = ExprId(0))
+        e.copy(plan = normalizeExprIds(e.plan), exprId = ExprId(0))
       case l: ListQuery =>
-        l.copy(exprId = ExprId(0))
+        l.copy(
+          plan = normalizeExprIds(l.plan),
+          exprId = ExprId(0),
+          childOutputs = l.childOutputs.map(_.withExprId(ExprId(0))))
       case a: AttributeReference =>
         AttributeReference(a.name, a.dataType, a.nullable)(exprId = ExprId(0))
       case OuterReference(a: AttributeReference) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it normalize expr ids in `ListQuery` and `Exists` expressions. For example:
```scala
val testRelation = LocalRelation($"a".int, $"b".int, $"c".int)
val x = testRelation.as("x")
val y = testRelation.as("y")

val originalQuery = x.where($"x.a".in(ListQuery(y.select($"b")))).analyze

println(Optimize.execute(normalizeExprIds(originalQuery)))
```
Before this PR:
```
Filter a#0 IN (list#0 [])
:  +- Project [b#15]
:     +- SubqueryAlias y
:        +- LocalRelation <empty>, [a#14, b#15, c#16]
+- LocalRelation <empty>, [a#0, b#0, c#0]               
```
After this PR:
```
Filter a#0 IN (list#0 [])
:  +- Project [b#0]
:     +- SubqueryAlias y
:        +- LocalRelation <empty>, [a#0, b#0, c#0]
+- LocalRelation <empty>, [a#0, b#0, c#0]
```

### Why are the changes needed?

`PlanTestBase.comparePlans` fails in some cases because the expr id not equal.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

manual test.