### PR TITLE
[SPARK-39382][WEBUI] UI show the duration of the failed task when the executor lost

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -856,6 +856,8 @@ $(document).ready(function () {
               data : function (row, type) {
                 if (row.taskMetrics && row.taskMetrics.executorRunTime) {
                   return type === 'display' ? formatDuration(row.taskMetrics.executorRunTime) : row.taskMetrics.executorRunTime;
+                } else if (row.duration && row.status === 'FAILED') {
+                  return type === 'display' ? formatDuration(row.duration) : row.duration;
                 } else {
                   return "";
                 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When task status is failed and `executorRunTime` has no value, try to use `duration`.


### Why are the changes needed?
When the executor is lost due to OOM or other reasons, the metrics of these failed tasks do not `have executorRunTime`, which results in that the duration cannot be displayed in the UI.
Sometimes it is not very intuitive to see how long this task runs before it fails.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
manual test
