### PR TITLE
[SPARK-39385][SQL] Translate linear regression aggregate functions for pushdown

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/aggregate/GeneralAggregateFunc.java
@@ -35,6 +35,10 @@ import org.apache.spark.sql.internal.connector.ToStringSQLBuilder;
  *  <li><pre>COVAR_POP(input1, input2)</pre> Since 3.3.0</li>
  *  <li><pre>COVAR_SAMP(input1, input2)</pre> Since 3.3.0</li>
  *  <li><pre>CORR(input1, input2)</pre> Since 3.3.0</li>
+ *  <li><pre>REGR_INTERCEPT(input1, input2)</pre> Since 3.4.0</li>
+ *  <li><pre>REGR_R2(input1, input2)</pre> Since 3.4.0</li>
+ *  <li><pre>REGR_SLOPE(input1, input2)</pre> Since 3.4.0</li>
+ *  <li><pre>REGR_SXY(input1, input2)</pre> Since 3.4.0</li>
  * </ol>
  *
  * @since 3.3.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
 import org.apache.spark.sql.catalyst.util.{ResolveDefaultColumns, V2ExpressionBuilder}
 import org.apache.spark.sql.connector.catalog.SupportsRead
 import org.apache.spark.sql.connector.catalog.TableCapability._
-import org.apache.spark.sql.connector.expressions.{Expression => V2Expression, FieldReference, NullOrdering, SortDirection, SortOrder => V2SortOrder, SortValue}
+import org.apache.spark.sql.connector.expressions.{Expression => V2Expression, NullOrdering, SortDirection, SortOrder => V2SortOrder, SortValue}
 import org.apache.spark.sql.connector.expressions.aggregate.{AggregateFunc, Aggregation, Avg, Count, CountStar, GeneralAggregateFunc, Max, Min, Sum, UserDefinedAggregateFunc}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.{InSubqueryExec, RowDataSourceScanExec, SparkPlan}
@@ -727,46 +727,28 @@ object DataSourceStrategy
           }
         case aggregate.Sum(PushableExpression(expr), _) => Some(new Sum(expr, agg.isDistinct))
         case aggregate.Average(PushableExpression(expr), _) => Some(new Avg(expr, agg.isDistinct))
-        case aggregate.VariancePop(PushableColumnWithoutNestedColumn(name), _) =>
-          Some(new GeneralAggregateFunc(
-            "VAR_POP", agg.isDistinct, Array(FieldReference.column(name))))
-        case aggregate.VarianceSamp(PushableColumnWithoutNestedColumn(name), _) =>
-          Some(new GeneralAggregateFunc(
-            "VAR_SAMP", agg.isDistinct, Array(FieldReference.column(name))))
-        case aggregate.StddevPop(PushableColumnWithoutNestedColumn(name), _) =>
-          Some(new GeneralAggregateFunc(
-            "STDDEV_POP", agg.isDistinct, Array(FieldReference.column(name))))
-        case aggregate.StddevSamp(PushableColumnWithoutNestedColumn(name), _) =>
-          Some(new GeneralAggregateFunc(
-            "STDDEV_SAMP", agg.isDistinct, Array(FieldReference.column(name))))
-        case aggregate.CovPopulation(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right), _) =>
-          Some(new GeneralAggregateFunc("COVAR_POP", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
-        case aggregate.CovSample(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right), _) =>
-          Some(new GeneralAggregateFunc("COVAR_SAMP", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
-        case aggregate.Corr(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right), _) =>
-          Some(new GeneralAggregateFunc("CORR", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
-        case aggregate.RegrIntercept(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right)) =>
-          Some(new GeneralAggregateFunc("REGR_INTERCEPT", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
-        case aggregate.RegrR2(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right)) =>
-          Some(new GeneralAggregateFunc("REGR_R2", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
-        case aggregate.RegrSlope(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right)) =>
-          Some(new GeneralAggregateFunc("REGR_SLOPE", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
-        case aggregate.RegrSXY(PushableColumnWithoutNestedColumn(left),
-        PushableColumnWithoutNestedColumn(right)) =>
-          Some(new GeneralAggregateFunc("REGR_SXY", agg.isDistinct,
-            Array(FieldReference.column(left), FieldReference.column(right))))
+        case aggregate.VariancePop(PushableExpression(expr), _) =>
+          Some(new GeneralAggregateFunc("VAR_POP", agg.isDistinct, Array(expr)))
+        case aggregate.VarianceSamp(PushableExpression(expr), _) =>
+          Some(new GeneralAggregateFunc("VAR_SAMP", agg.isDistinct, Array(expr)))
+        case aggregate.StddevPop(PushableExpression(expr), _) =>
+          Some(new GeneralAggregateFunc("STDDEV_POP", agg.isDistinct, Array(expr)))
+        case aggregate.StddevSamp(PushableExpression(expr), _) =>
+          Some(new GeneralAggregateFunc("STDDEV_SAMP", agg.isDistinct, Array(expr)))
+        case aggregate.CovPopulation(PushableExpression(left), PushableExpression(right), _) =>
+          Some(new GeneralAggregateFunc("COVAR_POP", agg.isDistinct, Array(left, right)))
+        case aggregate.CovSample(PushableExpression(left), PushableExpression(right), _) =>
+          Some(new GeneralAggregateFunc("COVAR_SAMP", agg.isDistinct, Array(left, right)))
+        case aggregate.Corr(PushableExpression(left), PushableExpression(right), _) =>
+          Some(new GeneralAggregateFunc("CORR", agg.isDistinct, Array(left, right)))
+        case aggregate.RegrIntercept(PushableExpression(left), PushableExpression(right)) =>
+          Some(new GeneralAggregateFunc("REGR_INTERCEPT", agg.isDistinct, Array(left, right)))
+        case aggregate.RegrR2(PushableExpression(left), PushableExpression(right)) =>
+          Some(new GeneralAggregateFunc("REGR_R2", agg.isDistinct, Array(left, right)))
+        case aggregate.RegrSlope(PushableExpression(left), PushableExpression(right)) =>
+          Some(new GeneralAggregateFunc("REGR_SLOPE", agg.isDistinct, Array(left, right)))
+        case aggregate.RegrSXY(PushableExpression(left), PushableExpression(right)) =>
+          Some(new GeneralAggregateFunc("REGR_SXY", agg.isDistinct, Array(left, right)))
         case aggregate.V2Aggregator(aggrFunc, children, _, _) =>
           val translatedExprs = children.flatMap(PushableExpression.unapply(_))
           if (translatedExprs.length == children.length) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -751,6 +751,22 @@ object DataSourceStrategy
         PushableColumnWithoutNestedColumn(right), _) =>
           Some(new GeneralAggregateFunc("CORR", agg.isDistinct,
             Array(FieldReference.column(left), FieldReference.column(right))))
+        case aggregate.RegrIntercept(PushableColumnWithoutNestedColumn(left),
+        PushableColumnWithoutNestedColumn(right)) =>
+          Some(new GeneralAggregateFunc("REGR_INTERCEPT", agg.isDistinct,
+            Array(FieldReference.column(left), FieldReference.column(right))))
+        case aggregate.RegrR2(PushableColumnWithoutNestedColumn(left),
+        PushableColumnWithoutNestedColumn(right)) =>
+          Some(new GeneralAggregateFunc("REGR_R2", agg.isDistinct,
+            Array(FieldReference.column(left), FieldReference.column(right))))
+        case aggregate.RegrSlope(PushableColumnWithoutNestedColumn(left),
+        PushableColumnWithoutNestedColumn(right)) =>
+          Some(new GeneralAggregateFunc("REGR_SLOPE", agg.isDistinct,
+            Array(FieldReference.column(left), FieldReference.column(right))))
+        case aggregate.RegrSXY(PushableColumnWithoutNestedColumn(left),
+        PushableColumnWithoutNestedColumn(right)) =>
+          Some(new GeneralAggregateFunc("REGR_SXY", agg.isDistinct,
+            Array(FieldReference.column(left), FieldReference.column(right))))
         case aggregate.V2Aggregator(aggrFunc, children, _, _) =>
           val translatedExprs = children.flatMap(PushableExpression.unapply(_))
           if (translatedExprs.length == children.length) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -71,6 +71,26 @@ private[sql] object H2Dialect extends JdbcDialect {
         case f: GeneralAggregateFunc if f.name() == "CORR" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"CORR(${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_INTERCEPT" =>
+          assert(f.children().length == 2)
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"REGR_INTERCEPT($distinct${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_R2" =>
+          assert(f.children().length == 2)
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"REGR_R2($distinct${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_SLOPE" =>
+          assert(f.children().length == 2)
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"REGR_SLOPE($distinct${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_SXX" =>
+          assert(f.children().length == 2)
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"REGR_SXX($distinct${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_SXY" =>
+          assert(f.children().length == 2)
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"REGR_SXY($distinct${f.children().head}, ${f.children().last})")
         case _ => None
       }
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -71,16 +71,16 @@ private[sql] object H2Dialect extends JdbcDialect {
         case f: GeneralAggregateFunc if f.name() == "CORR" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"CORR(${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_INTERCEPT" =>
+        case f: GeneralAggregateFunc if f.name() == "REGR_INTERCEPT" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"REGR_INTERCEPT(${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_R2" && f.isDistinct == false =>
+        case f: GeneralAggregateFunc if f.name() == "REGR_R2" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"REGR_R2(${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_SLOPE" && f.isDistinct == false =>
+        case f: GeneralAggregateFunc if f.name() == "REGR_SLOPE" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"REGR_SLOPE(${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_SXY" && f.isDistinct == false =>
+        case f: GeneralAggregateFunc if f.name() == "REGR_SXY" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"REGR_SXY(${f.children().head}, ${f.children().last})")
         case _ => None

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -62,15 +62,18 @@ private[sql] object H2Dialect extends JdbcDialect {
           assert(f.children().length == 1)
           val distinct = if (f.isDistinct) "DISTINCT " else ""
           Some(s"STDDEV_SAMP($distinct${f.children().head})")
-        case f: GeneralAggregateFunc if f.name() == "COVAR_POP" && !f.isDistinct =>
+        case f: GeneralAggregateFunc if f.name() == "COVAR_POP" =>
           assert(f.children().length == 2)
-          Some(s"COVAR_POP(${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "COVAR_SAMP" && !f.isDistinct =>
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"COVAR_POP($distinct${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "COVAR_SAMP" =>
           assert(f.children().length == 2)
-          Some(s"COVAR_SAMP(${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "CORR" && !f.isDistinct =>
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"COVAR_SAMP($distinct${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "CORR" =>
           assert(f.children().length == 2)
-          Some(s"CORR(${f.children().head}, ${f.children().last})")
+          val distinct = if (f.isDistinct) "DISTINCT " else ""
+          Some(s"CORR($distinct${f.children().head}, ${f.children().last})")
         case f: GeneralAggregateFunc if f.name() == "REGR_INTERCEPT" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"REGR_INTERCEPT(${f.children().head}, ${f.children().last})")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -73,24 +73,16 @@ private[sql] object H2Dialect extends JdbcDialect {
           Some(s"CORR(${f.children().head}, ${f.children().last})")
         case f: GeneralAggregateFunc if f.name() == "REGR_INTERCEPT" =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"REGR_INTERCEPT($distinct${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_R2" =>
+          Some(s"REGR_INTERCEPT(${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_R2" && f.isDistinct == false =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"REGR_R2($distinct${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_SLOPE" =>
+          Some(s"REGR_R2(${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_SLOPE" && f.isDistinct == false =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"REGR_SLOPE($distinct${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_SXX" =>
+          Some(s"REGR_SLOPE(${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "REGR_SXY" && f.isDistinct == false =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"REGR_SXX($distinct${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "REGR_SXY" =>
-          assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"REGR_SXY($distinct${f.children().head}, ${f.children().last})")
+          Some(s"REGR_SXY(${f.children().head}, ${f.children().last})")
         case _ => None
       }
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -62,18 +62,15 @@ private[sql] object H2Dialect extends JdbcDialect {
           assert(f.children().length == 1)
           val distinct = if (f.isDistinct) "DISTINCT " else ""
           Some(s"STDDEV_SAMP($distinct${f.children().head})")
-        case f: GeneralAggregateFunc if f.name() == "COVAR_POP" =>
+        case f: GeneralAggregateFunc if f.name() == "COVAR_POP" && !f.isDistinct =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"COVAR_POP($distinct${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "COVAR_SAMP" =>
+          Some(s"COVAR_POP(${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "COVAR_SAMP" && !f.isDistinct =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"COVAR_SAMP($distinct${f.children().head}, ${f.children().last})")
-        case f: GeneralAggregateFunc if f.name() == "CORR" =>
+          Some(s"COVAR_SAMP(${f.children().head}, ${f.children().last})")
+        case f: GeneralAggregateFunc if f.name() == "CORR" && !f.isDistinct =>
           assert(f.children().length == 2)
-          val distinct = if (f.isDistinct) "DISTINCT " else ""
-          Some(s"CORR($distinct${f.children().head}, ${f.children().last})")
+          Some(s"CORR(${f.children().head}, ${f.children().last})")
         case f: GeneralAggregateFunc if f.name() == "REGR_INTERCEPT" && !f.isDistinct =>
           assert(f.children().length == 2)
           Some(s"REGR_INTERCEPT(${f.children().head}, ${f.children().last})")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1632,23 +1632,47 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("scan with aggregate push-down: VAR_POP VAR_SAMP with filter and group by") {
-    val df = sql("SELECT VAR_POP(bonus), VAR_SAMP(bonus) FROM h2.test.employee WHERE dept > 0" +
-      " GROUP BY DePt")
+    val df = sql(
+      """
+        |SELECT
+        |  VAR_POP(bonus),
+        |  VAR_POP(DISTINCT bonus),
+        |  VAR_SAMP(bonus),
+        |  VAR_SAMP(DISTINCT bonus)
+        |FROM h2.test.employee WHERE dept > 0 GROUP BY DePt""".stripMargin)
     checkFiltersRemoved(df)
     checkAggregateRemoved(df)
-    checkPushedInfo(df, "PushedAggregates: [VAR_POP(BONUS), VAR_SAMP(BONUS)], " +
-      "PushedFilters: [DEPT IS NOT NULL, DEPT > 0], PushedGroupByExpressions: [DEPT]")
-    checkAnswer(df, Seq(Row(10000d, 20000d), Row(2500d, 5000d), Row(0d, null)))
+    checkPushedInfo(df,
+     """
+       |PushedAggregates: [VAR_POP(BONUS), VAR_POP(DISTINCT BONUS),
+       |VAR_SAMP(BONUS), VAR_SAMP(DISTINCT BONUS)],
+       |PushedFilters: [DEPT IS NOT NULL, DEPT > 0],
+       |PushedGroupByExpressions: [DEPT],
+       |""".stripMargin.replaceAll("\n", " "))
+    checkAnswer(df, Seq(Row(10000d, 10000d, 20000d, 20000d),
+      Row(2500d, 2500d, 5000d, 5000d), Row(0d, 0d, null, null)))
   }
 
   test("scan with aggregate push-down: STDDEV_POP STDDEV_SAMP with filter and group by") {
-    val df = sql("SELECT STDDEV_POP(bonus), STDDEV_SAMP(bonus) FROM h2.test.employee" +
-      " WHERE dept > 0 GROUP BY DePt")
+    val df = sql(
+      """
+        |SELECT
+        |  STDDEV_POP(bonus),
+        |  STDDEV_POP(DISTINCT bonus),
+        |  STDDEV_SAMP(bonus),
+        |  STDDEV_SAMP(DISTINCT bonus)
+        |FROM h2.test.employee WHERE dept > 0 GROUP BY DePt""".stripMargin)
     checkFiltersRemoved(df)
     checkAggregateRemoved(df)
-    checkPushedInfo(df, "PushedAggregates: [STDDEV_POP(BONUS), STDDEV_SAMP(BONUS)], " +
-      "PushedFilters: [DEPT IS NOT NULL, DEPT > 0], PushedGroupByExpressions: [DEPT]")
-    checkAnswer(df, Seq(Row(100d, 141.4213562373095d), Row(50d, 70.71067811865476d), Row(0d, null)))
+    checkPushedInfo(df,
+      """
+        |PushedAggregates: [STDDEV_POP(BONUS), STDDEV_POP(DISTINCT BONUS),
+        |STDDEV_SAMP(BONUS), STDDEV_SAMP(DISTINCT BONUS)],
+        |PushedFilters: [DEPT IS NOT NULL, DEPT > 0],
+        |PushedGroupByExpressions: [DEPT],
+        |""".stripMargin.replaceAll("\n", " "))
+    checkAnswer(df, Seq(Row(100d, 100d, 141.4213562373095d, 141.4213562373095d),
+      Row(50d, 50d, 70.71067811865476d, 70.71067811865476d), Row(0d, 0d, null, null)))
   }
 
   test("scan with aggregate push-down: COVAR_POP COVAR_SAMP with filter and group by") {
@@ -1686,24 +1710,38 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
   }
 
   test("scan with aggregate push-down: linear regression functions with filter and group by") {
-    val df = sql(
+    val df1 = sql(
       """
         |SELECT
         |  REGR_INTERCEPT(bonus, bonus),
         |  REGR_R2(bonus, bonus),
         |  REGR_SLOPE(bonus, bonus),
         |  REGR_SXY(bonus, bonus)
-        |FROM h2.test.employee where dept > 0 group by DePt""".stripMargin)
-    checkFiltersRemoved(df)
-    checkAggregateRemoved(df)
-    checkPushedInfo(df,
+        |FROM h2.test.employee WHERE dept > 0 GROUP BY DePt""".stripMargin)
+    checkFiltersRemoved(df1)
+    checkAggregateRemoved(df1)
+    checkPushedInfo(df1,
       """
         |PushedAggregates: [REGR_INTERCEPT(BONUS, BONUS), REGR_R2(BONUS, BONUS),
         |REGR_SLOPE(BONUS, BONUS), REGR_SXY(BONUS, B...,
         |PushedFilters: [DEPT IS NOT NULL, DEPT > 0],
         |PushedGroupByExpressions: [DEPT],
         |""".stripMargin.replaceAll("\n", " "))
-    checkAnswer(df,
+    checkAnswer(df1,
+      Seq(Row(0.0, 1.0, 1.0, 20000.0), Row(0.0, 1.0, 1.0, 5000.0), Row(null, null, null, 0.0)))
+
+    val df2 = sql(
+      """
+        |SELECT
+        |  REGR_INTERCEPT(DISTINCT bonus, bonus),
+        |  REGR_R2(DISTINCT bonus, bonus),
+        |  REGR_SLOPE(DISTINCT bonus, bonus),
+        |  REGR_SXY(DISTINCT bonus, bonus)
+        |FROM h2.test.employee WHERE dept > 0 GROUP BY DePt""".stripMargin)
+    checkFiltersRemoved(df2)
+    checkAggregateRemoved(df2, false)
+    checkPushedInfo(df2, "PushedFilters: [DEPT IS NOT NULL, DEPT > 0], ReadSchema:")
+    checkAnswer(df2,
       Seq(Row(0.0, 1.0, 1.0, 20000.0), Row(0.0, 1.0, 1.0, 5000.0), Row(null, null, null, 0.0)))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Spark supports a lot of linear regression aggregate functions now.
Because `REGR_AVGX`, `REGR_AVGY`, `REGR_COUNT`, `REGR_SXX` and `REGR_SXY` are replaced to other expression in runtime, This PR will only translate `REGR_INTERCEPT`, `REGR_R2`, `REGR_SLOPE`, `REGR_SXY` for pushdown.

After this job, users could override `JdbcDialect.compileAggregate` to implement some linear regression aggregate functions supported by some database.


### Why are the changes needed?
Make the implement of *Dialect could compile `REGR_INTERCEPT`, `REGR_R2`, `REGR_SLOPE`, `REGR_SXY`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New tests.