### PR TITLE
[SPARK-38997][SPARK-39037][SQL][FOLLOWUP] `PushableColumnWithoutNestedColumn` need be translated to predicate too

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -49,18 +49,16 @@ class V2ExpressionBuilder(
     case Literal(true, BooleanType) => Some(new AlwaysTrue())
     case Literal(false, BooleanType) => Some(new AlwaysFalse())
     case Literal(value, dataType) => Some(LiteralValue(value, dataType))
-    case col @ pushableColumn(name) if nestedPredicatePushdownEnabled =>
-      if (isPredicate && col.dataType.isInstanceOf[BooleanType]) {
-        Some(new V2Predicate("=", Array(FieldReference(name), LiteralValue(true, BooleanType))))
+    case col @ pushableColumn(name) =>
+      val ref = if (nestedPredicatePushdownEnabled) {
+        FieldReference(name)
       } else {
-        Some(FieldReference(name))
+        FieldReference.column(name)
       }
-    case col @ pushableColumn(name) if !nestedPredicatePushdownEnabled =>
       if (isPredicate && col.dataType.isInstanceOf[BooleanType]) {
-        Some(new V2Predicate("=",
-          Array(FieldReference.column(name), LiteralValue(true, BooleanType))))
+        Some(new V2Predicate("=", Array(ref, LiteralValue(true, BooleanType))))
       } else {
-        Some(FieldReference.column(name))
+        Some(ref)
       }
     case in @ InSet(child, hset) =>
       generateExpression(child).map { v =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/35768 assume the expression in `And`, `Or` and `Not` must be predicate.
https://github.com/apache/spark/pull/36370 and https://github.com/apache/spark/pull/36325 supported push down expressions in `GROUP BY` and `ORDER BY`. But the children of `And`, `Or` and `Not` can be `FieldReference.column(name)`.
`FieldReference.column(name)` is not a predicate, so the assert may fail.


### Why are the changes needed?
This PR fix the bug for `PushableColumnWithoutNestedColumn`.


### Does this PR introduce _any_ user-facing change?
'Yes'.
Let the push-down framework more correctly.


### How was this patch tested?
New tests
