### PR TITLE
[SPARK-39396][SQL] Fix LDAP login exception 'error code 49 - invalid credentials'

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -42,7 +42,7 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
     ldapURL = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_URL);
     baseDN = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_BASEDN);
     ldapDomain = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_DOMAIN);
-    userDNPattern = conf.get("hive.server2.authentication.ldap.userDNPattern");
+    userDNPattern = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_USERDNPATTERN);
   }
 
   @Override

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -16,12 +16,17 @@
  */
 package org.apache.hive.service.auth;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.directory.InitialDirContext;
 import javax.security.sasl.AuthenticationException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.service.ServiceUtils;
 
@@ -30,20 +35,18 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
   private final String ldapURL;
   private final String baseDN;
   private final String ldapDomain;
+  private final String userDNPattern;
 
   LdapAuthenticationProviderImpl() {
     HiveConf conf = new HiveConf();
     ldapURL = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_URL);
     baseDN = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_BASEDN);
     ldapDomain = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_DOMAIN);
+    userDNPattern = conf.get("hive.server2.authentication.ldap.userDNPattern");
   }
 
   @Override
   public void Authenticate(String user, String password) throws AuthenticationException {
-
-    Hashtable<String, Object> env = new Hashtable<String, Object>();
-    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-    env.put(Context.PROVIDER_URL, ldapURL);
 
     // If the domain is available in the config, then append it unless domain is
     // already part of the username. LDAP providers like Active Directory use a
@@ -58,22 +61,46 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
     }
 
     // setup the security principal
-    String bindDN;
-    if (baseDN == null) {
-      bindDN = user;
+    List<String> candidatePrincipals = new ArrayList<>();
+    if (StringUtils.isBlank(userDNPattern)) {
+      if (StringUtils.isNotBlank(baseDN)) {
+        String pattern = "uid=" + user + "," + baseDN;
+        candidatePrincipals.add(pattern);
+      }
     } else {
-      bindDN = "uid=" + user + "," + baseDN;
+      String[] patterns = userDNPattern.split(":");
+      for (String pattern : patterns) {
+        if (StringUtils.contains(pattern, ",") && StringUtils.contains(pattern, "=")) {
+          candidatePrincipals.add(pattern.replaceAll("%s", user));
+        }
+      }
     }
-    env.put(Context.SECURITY_AUTHENTICATION, "simple");
-    env.put(Context.SECURITY_PRINCIPAL, bindDN);
-    env.put(Context.SECURITY_CREDENTIALS, password);
 
-    try {
-      // Create initial context
-      Context ctx = new InitialDirContext(env);
-      ctx.close();
-    } catch (NamingException e) {
-      throw new AuthenticationException("Error validating LDAP user", e);
+    if (candidatePrincipals.isEmpty()) {
+      candidatePrincipals = Collections.singletonList(user);
+    }
+
+    for (Iterator<String> iterator = candidatePrincipals.iterator(); iterator.hasNext();) {
+      String principal = iterator.next();
+
+      Hashtable<String, Object> env = new Hashtable<String, Object>();
+      env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+      env.put(Context.PROVIDER_URL, ldapURL);
+      env.put(Context.SECURITY_AUTHENTICATION, "simple");
+      env.put(Context.SECURITY_PRINCIPAL, principal);
+      env.put(Context.SECURITY_CREDENTIALS, password);
+
+      try {
+
+        // Create initial context
+        Context ctx = new InitialDirContext(env);
+        ctx.close();
+        break;
+      } catch (NamingException e) {
+        if (!iterator.hasNext()) {
+          throw new AuthenticationException("Error validating LDAP user", e);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the PR, Fixed the problem that the DN is (cn=user,ou=people, dc=example, dc=com) LDAP login failure. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The hard coded DN in the org.apache.hive.service.auth.LdapAuthenticationProviderImpl#Authenticate()  is (uid=user,ou=people, dc=example, dc=com), resulting in LDAP authentication failure

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing test.