### PR TITLE
[SPARK-39402][SQL] Optimize ReplaceCTERefWithRepartition to support coalesce partitions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceCTERefWithRepartition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceCTERefWithRepartition.scala
@@ -53,7 +53,7 @@ object ReplaceCTERefWithRepartition extends Rule[LogicalPlan] {
             // scalar subquery, we do not need to add an extra repartition shuffle.
             inlined
           } else {
-            Repartition(conf.numShufflePartitions, shuffle = true, inlined)
+            RepartitionByExpression(Seq.empty, inlined, None)
           }
         cteMap.put(cteDef.id, withRepartition)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Optimize `ReplaceCTERefWithRepartition` to support coalesce partitions. For example:

Before this PR | After this PR
-- | --
![image](https://user-images.githubusercontent.com/5399861/172430973-feb5de0c-373b-4a66-be49-d25648dcd24a.png) | ![image](https://user-images.githubusercontent.com/5399861/172431034-5c5aa7c4-1cc5-4922-8fb0-a703cd6e9fec.png)

### Why are the changes needed?

Reduce the overhead of shuffle as much as possible.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.