### PR TITLE
[SPARK-39407][SQL][TESTS] Fix ParquetIOSuite to handle the case where DNS responses on `nonexistent`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1181,7 +1181,8 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
     val errorMessage = intercept[Throwable] {
       spark.read.parquet("hdfs://nonexistent")
     }.toString
-    assert(errorMessage.contains("UnknownHostException"))
+    assert(errorMessage.contains("UnknownHostException") ||
+        errorMessage.contains("is not a valid DFS filename"))
   }
 
   test("SPARK-7837 Do not close output writer twice when commitTask() fails") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `ParquetIOSuite` to handle the case where DNS responses on `nonexistent`.

### Why are the changes needed?

In some environment, DNS responses on `nonexists` hostname of `hdfs://nonexistent`.
```
% ping nonexists
PING nonexists (....): 56 data bytes
64 bytes from ...: icmp_seq=0 ttl=56 time=8.718 ms
```

This leads to a test case failure like the following.
```
- SPARK-6330 regression test *** FAILED ***
  "java.lang.IllegalArgumentException: Pathname  from hdfs://nonexistent is not a valid DFS filename." did not contain "UnknownHostException" (ParquetIOSuite.scala:1184)
```

### Does this PR introduce _any_ user-facing change?

No. This is a test case change.

### How was this patch tested?

Pass the CIs and manually tests.