### PR TITLE
[SPARK-39394][DOCS][SS][3.3] Improve PySpark Structured Streaming page more readable

### DIFF
--- a/python/docs/source/reference/pyspark.ss/core_classes.rst
+++ b/python/docs/source/reference/pyspark.ss/core_classes.rst
@@ -29,4 +29,3 @@ Core Classes
     DataStreamWriter
     StreamingQuery
     StreamingQueryManager
-    StreamingQueryListener

--- a/python/docs/source/reference/pyspark.ss/core_classes.rst
+++ b/python/docs/source/reference/pyspark.ss/core_classes.rst
@@ -16,22 +16,17 @@
     under the License.
 
 
-=============
-API Reference
-=============
+============
+Core Classes
+============
 
-This page lists an overview of all public PySpark modules, classes, functions and methods.
+.. currentmodule:: pyspark.sql.streaming
 
-Pandas API on Spark follows the API specifications of pandas 1.3.
+.. autosummary::
+    :toctree: api/
 
-.. toctree::
-   :maxdepth: 2
-
-   pyspark.sql/index
-   pyspark.pandas/index
-   pyspark.ss/index
-   pyspark.ml
-   pyspark.streaming
-   pyspark.mllib
-   pyspark
-   pyspark.resource
+    DataStreamReader
+    DataStreamWriter
+    StreamingQuery
+    StreamingQueryManager
+    StreamingQueryListener

--- a/python/docs/source/reference/pyspark.ss/index.rst
+++ b/python/docs/source/reference/pyspark.ss/index.rst
@@ -16,22 +16,15 @@
     under the License.
 
 
-=============
-API Reference
-=============
+====================
+Structured Streaming
+====================
 
-This page lists an overview of all public PySpark modules, classes, functions and methods.
-
-Pandas API on Spark follows the API specifications of pandas 1.3.
+This page gives an overview of all public Structed Streaming API.
 
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 2
 
-   pyspark.sql/index
-   pyspark.pandas/index
-   pyspark.ss/index
-   pyspark.ml
-   pyspark.streaming
-   pyspark.mllib
-   pyspark
-   pyspark.resource
+    core_classes
+    io
+    query_management

--- a/python/docs/source/reference/pyspark.ss/io.rst
+++ b/python/docs/source/reference/pyspark.ss/io.rst
@@ -16,22 +16,32 @@
     under the License.
 
 
-=============
-API Reference
-=============
+============
+Input/Output
+============
 
-This page lists an overview of all public PySpark modules, classes, functions and methods.
+.. currentmodule:: pyspark.sql.streaming
 
-Pandas API on Spark follows the API specifications of pandas 1.3.
+.. autosummary::
+    :toctree: api/
 
-.. toctree::
-   :maxdepth: 2
-
-   pyspark.sql/index
-   pyspark.pandas/index
-   pyspark.ss/index
-   pyspark.ml
-   pyspark.streaming
-   pyspark.mllib
-   pyspark
-   pyspark.resource
+    DataStreamReader.csv
+    DataStreamReader.format
+    DataStreamReader.json
+    DataStreamReader.load
+    DataStreamReader.option
+    DataStreamReader.options
+    DataStreamReader.orc
+    DataStreamReader.parquet
+    DataStreamReader.schema
+    DataStreamReader.text
+    DataStreamWriter.foreach
+    DataStreamWriter.foreachBatch
+    DataStreamWriter.format
+    DataStreamWriter.option
+    DataStreamWriter.options
+    DataStreamWriter.outputMode
+    DataStreamWriter.partitionBy
+    DataStreamWriter.queryName
+    DataStreamWriter.start
+    DataStreamWriter.trigger

--- a/python/docs/source/reference/pyspark.ss/query_management.rst
+++ b/python/docs/source/reference/pyspark.ss/query_management.rst
@@ -38,8 +38,6 @@ Query Management
     StreamingQuery.status
     StreamingQuery.stop
     StreamingQueryManager.active
-    StreamingQueryManager.addListener
     StreamingQueryManager.awaitAnyTermination
     StreamingQueryManager.get
-    StreamingQueryManager.removeListener
     StreamingQueryManager.resetTerminated

--- a/python/docs/source/reference/pyspark.ss/query_management.rst
+++ b/python/docs/source/reference/pyspark.ss/query_management.rst
@@ -16,54 +16,9 @@
     under the License.
 
 
-====================
-Structured Streaming
-====================
-
-Core Classes
-------------
-
-.. currentmodule:: pyspark.sql.streaming
-
-.. autosummary::
-    :toctree: api/
-
-    DataStreamReader
-    DataStreamWriter
-    StreamingQuery
-    StreamingQueryManager
-
-Input and Output
-----------------
-
-.. currentmodule:: pyspark.sql.streaming
-
-.. autosummary::
-    :toctree: api/
-
-    DataStreamReader.csv
-    DataStreamReader.format
-    DataStreamReader.json
-    DataStreamReader.load
-    DataStreamReader.option
-    DataStreamReader.options
-    DataStreamReader.orc
-    DataStreamReader.parquet
-    DataStreamReader.schema
-    DataStreamReader.text
-    DataStreamWriter.foreach
-    DataStreamWriter.foreachBatch
-    DataStreamWriter.format
-    DataStreamWriter.option
-    DataStreamWriter.options
-    DataStreamWriter.outputMode
-    DataStreamWriter.partitionBy
-    DataStreamWriter.queryName
-    DataStreamWriter.start
-    DataStreamWriter.trigger
-
+================
 Query Management
-----------------
+================
 
 .. currentmodule:: pyspark.sql.streaming
 
@@ -83,6 +38,8 @@ Query Management
     StreamingQuery.status
     StreamingQuery.stop
     StreamingQueryManager.active
+    StreamingQueryManager.addListener
     StreamingQueryManager.awaitAnyTermination
     StreamingQueryManager.get
+    StreamingQueryManager.removeListener
     StreamingQueryManager.resetTerminated


### PR DESCRIPTION
### What changes were proposed in this pull request?

Hotfix https://github.com/apache/spark/pull/36782 for branch-3.3.


### Why are the changes needed?

The improvement of document readability will also improve the usability for PySpark Structured Streaming.

### Does this PR introduce _any_ user-facing change?

Yes, now the documentation is categorized by its class or their own purpose more clearly as below:

![Screen Shot 2022-06-07 at 12 30 01 PM](https://user-images.githubusercontent.com/44108233/172289737-bd6ebf0e-601c-4a80-a16a-cf885302e7b6.png)


### How was this patch tested?

The existing doc build in CI should cover.
