### PR TITLE
[SPARK-39408][SQL] Update the buildKeys for DynamicPruningSubquery.withNewPlan

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSuite.scala
@@ -39,6 +39,13 @@ class DynamicPruningSuite extends PlanTest {
     assert(withNewPlan.buildKeys.head.semanticEquals(testRelation.output.head))
   }
 
+  test("Test withNewPlan can successfully update buildKeys with Literal") {
+    val testRelation = LocalRelation($"x1".int, $"y1".long)
+    val withNewPlan =
+      originDynamicPruningSubquery.copy(buildKeys = Seq(x + 1)).withNewPlan(testRelation)
+    assert(withNewPlan.buildKeys.head.semanticEquals(testRelation.output.head + 1))
+  }
+
   test("Test withNewPlan can not update plan") {
     val e1 = intercept[AnalysisException] {
       originDynamicPruningSubquery.withNewPlan(LocalRelation($"x1".long, $"y1".long))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DynamicPruningSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical._
+
+class DynamicPruningSuite extends PlanTest {
+
+  private val pruningSideRelation = LocalRelation($"a".int, $"b".long, $"c".string)
+  private val a = pruningSideRelation.output(0)
+
+  private val originBuildSideRelation = LocalRelation($"x".int, $"y".long)
+  private val x = originBuildSideRelation.output(0)
+
+  private val originDynamicPruningSubquery =
+    DynamicPruningSubquery(a, originBuildSideRelation, Seq(x), 0, true, ExprId(0))
+
+  test("Test withNewPlan can successfully update buildKeys") {
+    val testRelation = LocalRelation($"x1".int, $"y1".long)
+    val withNewPlan = originDynamicPruningSubquery.withNewPlan(testRelation)
+    assert(withNewPlan.buildKeys.head.semanticEquals(testRelation.output.head))
+  }
+
+  test("Test withNewPlan can not update plan") {
+    val e1 = intercept[AnalysisException] {
+      originDynamicPruningSubquery.withNewPlan(LocalRelation($"x1".long, $"y1".long))
+    }
+    e1.getMessage.contains("Failed to update the plan")
+
+    val e2 = intercept[AnalysisException] {
+      originDynamicPruningSubquery.withNewPlan(LocalRelation($"x1".int))
+    }
+    e2.getMessage.contains("Failed to update the plan")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr updates the buildKeys for `DynamicPruningSubquery.withNewPlan`.

### Why are the changes needed?

Fix bug. Otherwise, the structural integrity of the plan is broken if `set spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.InlineCTE`:
```
After applying rule org.apache.spark.sql.catalyst.optimizer.ReplaceCTERefWithRepartition in batch Replace CTE with Repartition, the structural integrity of the plan is broken.
java.lang.RuntimeException: After applying rule org.apache.spark.sql.catalyst.optimizer.ReplaceCTERefWithRepartition in batch Replace CTE with Repartition, the structural integrity of the plan is broken.
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.