### PR TITLE
[SPARK-39409][BUILD] Upgrade scala-maven-plugin to 4.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
       See: SPARK-36547, SPARK-38394.
        -->
 
-    <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.6.2</scala-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade scala-maven-plugin to 4.6.2


### Why are the changes needed?
This version brings some bug fix related to `Incremental compile`, although it seems that Spark has not encountered these issue:

- [Fix incremental compiler not being able to find JDK classes when compiler macros with Java 11, close #502](https://github.com/davidB/scala-maven-plugin/pull/608)
- [Fix incremental compilation on Java 11+, close #600](https://github.com/davidB/scala-maven-plugin/pull/609)

all changes as follows:

- https://github.com/davidB/scala-maven-plugin/compare/4.6.1...4.6.2


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions