### PR TITLE
[SPARK-39321][SQL][TESTS][FOLLOW-UP] Respect CastWithAnsiOffSuite.ansiEnabled in 'cast string to date #2'

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -65,11 +65,11 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   }
 
   test("cast string to date #2") {
-    checkEvaluation(Cast(Literal("2015-03-18X"), DateType), null)
-    checkEvaluation(Cast(Literal("2015/03/18"), DateType), null)
-    checkEvaluation(Cast(Literal("2015.03.18"), DateType), null)
-    checkEvaluation(Cast(Literal("20150318"), DateType), null)
-    checkEvaluation(Cast(Literal("2015-031-8"), DateType), null)
+    checkEvaluation(cast(Literal("2015-03-18X"), DateType), null)
+    checkEvaluation(cast(Literal("2015/03/18"), DateType), null)
+    checkEvaluation(cast(Literal("2015.03.18"), DateType), null)
+    checkEvaluation(cast(Literal("20150318"), DateType), null)
+    checkEvaluation(cast(Literal("2015-031-8"), DateType), null)
   }
 
   test("casting to fixed-precision decimals") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the test to make `CastWithAnsiOffSuite` properly respect `ansiEnabled` in `cast string to date #2` test by using `CastWithAnsiOffSuite.cast` instead of `Cast` expression.

### Why are the changes needed?

To make the tests pass. Currently it fails when ANSI mode is on:

https://github.com/apache/spark/runs/6786744647

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested in my IDE.