### PR TITLE
[SPARK-39398][GRAPHX]message checkpointer support storage level

### DIFF
--- a/graphx/src/main/scala/org/apache/spark/graphx/Pregel.scala
+++ b/graphx/src/main/scala/org/apache/spark/graphx/Pregel.scala
@@ -135,7 +135,7 @@ object Pregel extends Logging {
     // compute the messages
     var messages = GraphXUtils.mapReduceTriplets(g, sendMsg, mergeMsg)
     val messageCheckpointer = new PeriodicRDDCheckpointer[(VertexId, A)](
-      checkpointInterval, graph.vertices.sparkContext)
+      checkpointInterval, graph.vertices.sparkContext, graph.vertices.getStorageLevel)
     messageCheckpointer.update(messages.asInstanceOf[RDD[(VertexId, A)]])
     var isActiveMessagesNonEmpty = !messages.isEmpty()
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
1.  in spark-30502, it already support PeriodicRDDCheckpointer set the checkpoint storage level ,  now in pregel, messageCheckpointer also add storage level setting

### Why are the changes needed?
1. without setting the messageCheckpointer storage level, it will use default memory storage level,  which maybe cause oom

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing testsuites