### PR TITLE
[SPARK-39414][BUILD] Upgrade Scala to 2.12.16

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -237,10 +237,10 @@ py4j/0.10.9.5//py4j-0.10.9.5.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 rocksdbjni/7.2.2//rocksdbjni-7.2.2.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
-scala-compiler/2.12.15//scala-compiler-2.12.15.jar
-scala-library/2.12.15//scala-library-2.12.15.jar
+scala-compiler/2.12.16//scala-compiler-2.12.16.jar
+scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
-scala-reflect/2.12.15//scala-reflect-2.12.15.jar
+scala-reflect/2.12.16//scala-reflect-2.12.16.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.7//shapeless_2.12-2.3.7.jar
 shims/0.9.28//shims-0.9.28.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -226,10 +226,10 @@ py4j/0.10.9.5//py4j-0.10.9.5.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
 rocksdbjni/7.2.2//rocksdbjni-7.2.2.jar
 scala-collection-compat_2.12/2.1.1//scala-collection-compat_2.12-2.1.1.jar
-scala-compiler/2.12.15//scala-compiler-2.12.15.jar
-scala-library/2.12.15//scala-library-2.12.15.jar
+scala-compiler/2.12.16//scala-compiler-2.12.16.jar
+scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
-scala-reflect/2.12.15//scala-reflect-2.12.15.jar
+scala-reflect/2.12.16//scala-reflect-2.12.16.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shapeless_2.12/2.3.7//shapeless_2.12-2.3.7.jar
 shims/0.9.28//shims-0.9.28.jar

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.16</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
     <!--
@@ -3573,7 +3573,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.16</scala.version>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2908,7 +2908,7 @@
               <compilerPlugin>
                 <groupId>com.github.ghik</groupId>
                 <artifactId>silencer-plugin_${scala.version}</artifactId>
-                <version>1.7.6</version>
+                <version>1.7.9</version>
               </compilerPlugin>
             </compilerPlugins>
           </configuration>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -203,12 +203,12 @@ object SparkBuild extends PomBuild {
   // Silencer: Scala compiler plugin for warning suppression
   // Aim: enable fatal warnings, but suppress ones related to using of deprecated APIs
   // depends on scala version:
-  // <2.13.2 - silencer 1.7.7 and compiler settings to enable fatal warnings
+  // <2.13.2 - silencer 1.7.9 and compiler settings to enable fatal warnings
   // 2.13.2+ - no silencer and configured warnings to achieve the same
   lazy val compilerWarningSettings: Seq[sbt.Def.Setting[_]] = Seq(
     libraryDependencies ++= {
       if (VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector("<2.13.2"))) {
-        val silencerVersion = "1.7.7"
+        val silencerVersion = "1.7.9"
         Seq(
           "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
           compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade Scala to 2.12.16



### Why are the changes needed?
This version bring some bug fix and  start to try to support Java 19

https://github.com/scala/scala/compare/v2.12.15...v2.12.16

- [Upgrade to asm 9.3, for JDK19 support](https://github.com/scala/scala/pull/10000)
- [Fix codegen for MH.invoke etc under JDK 17 -release](https://github.com/scala/scala/pull/9930)
- [Deprecation related SecurityManager on JDK 17 ](https://github.com/scala/scala/pull/9775)

### Does this PR introduce _any_ user-facing change?
Yes, this is a Scala version change.




### How was this patch tested?
Pass Github Actions