### PR TITLE
[SPARK-39419][SQL] Fix ArraySort to throw an exception when the comparator returns null

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -551,5 +551,10 @@
       "Writing job aborted"
     ],
     "sqlState" : "40000"
+  },
+  "NULL_COMPARISON_RESULT" : {
+    "message" : [
+      "The comparison result is null. If you want to handle null as 0 (equal), you can set \"<config>\" to \"<value>\"."
+    ]
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -296,6 +296,11 @@
       "UDF class <class> doesn't implement any UDF interface"
     ]
   },
+  "NULL_COMPARISON_RESULT" : {
+    "message" : [
+      "The comparison result is null. If you want to handle null as 0 (equal), you can set \"spark.sql.legacy.allowNullComparisonResultInArraySort\" to \"true\"."
+    ]
+  },
   "PARSE_CHAR_MISSING_LENGTH" : {
     "message" : [
       "DataType <type> requires a length parameter, for example <type>(10). Please specify the length."
@@ -551,10 +556,5 @@
       "Writing job aborted"
     ],
     "sqlState" : "40000"
-  },
-  "NULL_COMPARISON_RESULT" : {
-    "message" : [
-      "The comparison result is null. If you want to handle null as 0 (equal), you can set \"<config>\" to \"<value>\"."
-    ]
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -376,14 +376,14 @@ case class ArrayTransform(
 case class ArraySort(
     argument: Expression,
     function: Expression,
-    failOnNullComparisonResult: Boolean)
+    allowNullComparisonResult: Boolean)
   extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
 
   def this(argument: Expression, function: Expression) = {
     this(
       argument,
       function,
-      SQLConf.get.getConf(SQLConf.LEGACY_ARRAY_SORT_FAILS_ON_NULL_COMPARISON_RESULT))
+      SQLConf.get.getConf(SQLConf.LEGACY_ALLOW_NULL_COMPARISON_RESULT_IN_ARRAY_SORT))
   }
 
   def this(argument: Expression) = this(argument, ArraySort.defaultComparator)
@@ -425,10 +425,8 @@ case class ArraySort(
       firstElemVar.value.set(o1)
       secondElemVar.value.set(o2)
       val cmp = f.eval(inputRow)
-      if (failOnNullComparisonResult && cmp == null) {
-        throw QueryExecutionErrors.nullComparisonResultError(
-          SQLConf.LEGACY_ARRAY_SORT_FAILS_ON_NULL_COMPARISON_RESULT.key, "false"
-        )
+      if (!allowNullComparisonResult && cmp == null) {
+        throw QueryExecutionErrors.nullComparisonResultError()
       }
       cmp.asInstanceOf[Int]
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/higherOrderFunctions.scala
@@ -357,9 +357,9 @@ case class ArrayTransform(
     Since 3.0.0 this function also sorts and returns the array based on the
     given comparator function. The comparator will take two arguments representing
     two elements of the array.
-    It returns -1, 0, or 1 as the first element is less than, equal to, or greater
-    than the second element. If the comparator function returns other
-    values (including null), the function will fail and raise an error.
+    It returns a negative integer, 0, or a positive integer as the first element is less than,
+    equal to, or greater than the second element. If the comparator function returns null,
+    the function will fail and raise an error.
     """,
   examples = """
     Examples:
@@ -375,8 +375,16 @@ case class ArrayTransform(
 // scalastyle:on line.size.limit
 case class ArraySort(
     argument: Expression,
-    function: Expression)
+    function: Expression,
+    handleComparisonResultNullAsZero: Boolean)
   extends ArrayBasedSimpleHigherOrderFunction with CodegenFallback {
+
+  def this(argument: Expression, function: Expression) = {
+    this(
+      argument,
+      function,
+      SQLConf.get.getConf(SQLConf.LEGACY_ARRAY_SORT_HANDLES_COMPARISON_RESULT_NULL_VALUE_AS_ZERO))
+  }
 
   def this(argument: Expression) = this(argument, ArraySort.defaultComparator)
 
@@ -416,7 +424,11 @@ case class ArraySort(
     (o1: Any, o2: Any) => {
       firstElemVar.value.set(o1)
       secondElemVar.value.set(o2)
-      f.eval(inputRow).asInstanceOf[Int]
+      val cmp = f.eval(inputRow)
+      if (!handleComparisonResultNullAsZero && cmp == null) {
+        throw QueryExecutionErrors.comparisonResultIsNullError()
+      }
+      cmp.asInstanceOf[Int]
     }
   }
 
@@ -436,6 +448,10 @@ case class ArraySort(
 }
 
 object ArraySort {
+
+  def apply(argument: Expression, function: Expression): ArraySort = {
+    new ArraySort(argument, function)
+  }
 
   def comparator(left: Expression, right: Expression): Expression = {
     val lit0 = Literal(0)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2013,8 +2013,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "MULTI_VALUE_SUBQUERY_ERROR", messageParameters = Array(plan), cause = null)
   }
 
-  def nullComparisonResultError(config: String, value: String): Throwable = {
+  def nullComparisonResultError(): Throwable = {
     new SparkException(errorClass = "NULL_COMPARISON_RESULT",
-      messageParameters = Array(config, value), cause = null)
+      messageParameters = Array(), cause = null)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2013,11 +2013,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       errorClass = "MULTI_VALUE_SUBQUERY_ERROR", messageParameters = Array(plan), cause = null)
   }
 
-  def comparisonResultIsNullError(): Throwable = {
-    new NullPointerException(
-      "The comparison result is null. " +
-      "If you want to handle null as 0 (equal), you can set " +
-      SQLConf.LEGACY_ARRAY_SORT_HANDLES_COMPARISON_RESULT_NULL_VALUE_AS_ZERO.key +
-      " to \"true\".")
+  def nullComparisonResultError(config: String, value: String): Throwable = {
+    new SparkException(errorClass = "NULL_COMPARISON_RESULT",
+      messageParameters = Array(config, value), cause = null)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2012,4 +2012,12 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
     new SparkException(
       errorClass = "MULTI_VALUE_SUBQUERY_ERROR", messageParameters = Array(plan), cause = null)
   }
+
+  def comparisonResultIsNullError(): Throwable = {
+    new NullPointerException(
+      "The comparison result is null. " +
+      "If you want to handle null as 0 (equal), you can set " +
+      SQLConf.LEGACY_ARRAY_SORT_HANDLES_COMPARISON_RESULT_NULL_VALUE_AS_ZERO.key +
+      " to \"true\".")
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3828,6 +3828,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_ARRAY_SORT_HANDLES_COMPARISON_RESULT_NULL_VALUE_AS_ZERO =
+    buildConf("spark.sql.legacy.arraySortHandlesComparisonResultNullAsZero")
+      .internal()
+      .doc("When set to true, it throws an error if the comparator function returns null. " +
+        "If set to true, it restores the legacy behavior that handles null as zero (equal).")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3831,7 +3831,7 @@ object SQLConf {
   val LEGACY_ARRAY_SORT_HANDLES_COMPARISON_RESULT_NULL_VALUE_AS_ZERO =
     buildConf("spark.sql.legacy.arraySortHandlesComparisonResultNullAsZero")
       .internal()
-      .doc("When set to true, it throws an error if the comparator function returns null. " +
+      .doc("When set to false, it throws an error if the comparator function returns null. " +
         "If set to true, it restores the legacy behavior that handles null as zero (equal).")
       .version("3.4.0")
       .booleanConf

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3828,14 +3828,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val LEGACY_ARRAY_SORT_HANDLES_COMPARISON_RESULT_NULL_VALUE_AS_ZERO =
-    buildConf("spark.sql.legacy.arraySortHandlesComparisonResultNullAsZero")
+  val LEGACY_ARRAY_SORT_FAILS_ON_NULL_COMPARISON_RESULT =
+    buildConf("spark.sql.legacy.arraySortFailsOnNullComparisonResult")
       .internal()
-      .doc("When set to false, it throws an error if the comparator function returns null. " +
-        "If set to true, it restores the legacy behavior that handles null as zero (equal).")
-      .version("3.4.0")
+      .doc("When set to true, it throws an error if the comparator function returns null. " +
+        "If set to false, it restores the legacy behavior that handles null as zero (equal).")
+      .version("3.2.2")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   /**
    * Holds information about keys that have been deprecated.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3828,14 +3828,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val LEGACY_ARRAY_SORT_FAILS_ON_NULL_COMPARISON_RESULT =
-    buildConf("spark.sql.legacy.arraySortFailsOnNullComparisonResult")
+  val LEGACY_ALLOW_NULL_COMPARISON_RESULT_IN_ARRAY_SORT =
+    buildConf("spark.sql.legacy.allowNullComparisonResultInArraySort")
       .internal()
-      .doc("When set to true, it throws an error if the comparator function returns null. " +
-        "If set to false, it restores the legacy behavior that handles null as zero (equal).")
+      .doc("When set to false, `array_sort` function throws an error " +
+        "if the comparator function returns null. " +
+        "If set to true, it restores the legacy behavior that handles null as zero (equal).")
       .version("3.2.2")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   /**
    * Holds information about keys that have been deprecated.

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -847,13 +847,13 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
     }
 
     withSQLConf(
-        SQLConf.LEGACY_ARRAY_SORT_FAILS_ON_NULL_COMPARISON_RESULT.key -> "true") {
+        SQLConf.LEGACY_ALLOW_NULL_COMPARISON_RESULT_IN_ARRAY_SORT.key -> "false") {
       checkExceptionInExpression[SparkException](
         arraySort(Literal.create(Seq(3, 1, 1, 2)), comparator), "The comparison result is null")
     }
 
     withSQLConf(
-        SQLConf.LEGACY_ARRAY_SORT_FAILS_ON_NULL_COMPARISON_RESULT.key -> "false") {
+        SQLConf.LEGACY_ALLOW_NULL_COMPARISON_RESULT_IN_ARRAY_SORT.key -> "true") {
       checkEvaluation(arraySort(Literal.create(Seq(3, 1, 1, 2)), comparator),
         Seq(1, 1, 2, 3))
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HigherOrderFunctionsSuite.scala
@@ -839,7 +839,7 @@ class HigherOrderFunctionsSuite extends SparkFunSuite with ExpressionEvalHelper 
       Seq(1d, 2d, Double.NaN, null))
   }
 
-  test("SPARK-39419: ArraySort should throw an exception when the comparison result is null") {
+  test("SPARK-39419: ArraySort should throw an exception when the comparator returns null") {
     val comparator = {
       val comp = ArraySort.comparator _
       (left: Expression, right: Expression) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes `ArraySort` to throw an exception when the comparator returns `null`.

Also updates the doc to follow the corrected behavior.

### Why are the changes needed?

When the comparator of `ArraySort` returns `null`, currently it handles it as `0` (equal).

According to the doc, 

```
It returns -1, 0, or 1 as the first element is less than, equal to, or greater than
the second element. If the comparator function returns other
values (including null), the function will fail and raise an error.
```

It's fine to return non -1, 0, 1 integers to follow the Java convention (still need to update the doc, though), but it should throw an exception for `null` result.

### Does this PR introduce _any_ user-facing change?

Yes, if a user uses a comparator that returns `null`, it will throw an error after this PR.

The legacy flag `spark.sql.legacy.allowNullComparisonResultInArraySort` can be used to restore the legacy behavior that handles `null` as `0` (equal).

### How was this patch tested?

Added some tests.
