### PR TITLE
[SPARK-39412][SQL][FOLLOWUP][TESTS][3.3] Check `IllegalStateException` instead of Spark's internal errors

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Sort}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ExecSubqueryExpression, FileSourceScanExec, InputAdapter, ReusedSubqueryExec, ScalarSubquery, SubqueryExec, WholeStageCodegenExec}
@@ -147,12 +146,11 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("runtime error when the number of rows is greater than 1") {
-    val e = intercept[SparkException] {
+    val e = intercept[IllegalStateException] {
       sql("select (select a from (select 1 as a union all select 2 as a) t) as b").collect()
     }
     // TODO(SPARK-39167): Throw an exception w/ an error class for multiple rows from a subquery
-    assert(e.getErrorClass ===  "INTERNAL_ERROR")
-    assert(e.getCause.getMessage.contains(
+    assert(e.getMessage.contains(
       "more than one row returned by a subquery used as an expression"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -23,7 +23,6 @@ import java.net.URI
 import org.apache.logging.log4j.Level
 import org.scalatest.PrivateMethodTester
 
-import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent, SparkListenerJobStart}
 import org.apache.spark.sql.{Dataset, QueryTest, Row, SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight}
@@ -857,13 +856,12 @@ class AdaptiveQueryExecSuite
         df1.write.parquet(tableDir.getAbsolutePath)
 
         val aggregated = spark.table("bucketed_table").groupBy("i").count()
-        val error = intercept[SparkException] {
+        val error = intercept[IllegalStateException] {
           aggregated.count()
         }
         // TODO(SPARK-39163): Throw an exception w/ error class for an invalid bucket file
-        assert(error.getErrorClass === "INTERNAL_ERROR")
-        assert(error.getCause.toString contains "Invalid bucket file")
-        assert(error.getCause.getSuppressed.size === 0)
+        assert(error.toString contains "Invalid bucket file")
+        assert(error.getSuppressed.size === 0)
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/BucketedReadSuite.scala
@@ -22,7 +22,6 @@ import java.net.URI
 
 import scala.util.Random
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions
@@ -842,12 +841,11 @@ abstract class BucketedReadSuite extends QueryTest with SQLTestUtils with Adapti
       df1.write.parquet(tableDir.getAbsolutePath)
 
       val aggregated = spark.table("bucketed_table").groupBy("i").count()
-      val e = intercept[SparkException] {
+      val e = intercept[IllegalStateException] {
         aggregated.count()
       }
       // TODO(SPARK-39163): Throw an exception w/ error class for an invalid bucket file
-      assert(e.getErrorClass === "INTERNAL_ERROR")
-      assert(e.getCause.toString contains "Invalid bucket file")
+      assert(e.toString contains "Invalid bucket file")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to correctly check `IllegalStateException` instead of `SparkException` w/ the `INTERNAL_ERROR` error class. The issues were introduced by https://github.com/apache/spark/pull/36804 merged to master and 3.3.

### Why are the changes needed?
To fix test failures in GAs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *BucketedReadWithoutHiveSupportSuite"
$ build/sbt "test:testOnly *.AdaptiveQueryExecSuite"
$ build/sbt "test:testOnly *.SubquerySuite"
```