### PR TITLE
[SPARK-39431][DOCS][PYTHON] Update PySpark dependencies in Installation doc

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -155,12 +155,11 @@ Dependencies
 Package       Minimum supported version Note
 ============= ========================= ======================================
 `pandas`      1.0.5                     Optional for Spark SQL
-`NumPy`       1.7                       Required for MLlib DataFrame-based API
 `pyarrow`     1.0.0                     Optional for Spark SQL
-`Py4J`        0.10.9.5                  Required
+`py4j`        0.10.9.5                  Required
 `pandas`      1.0.5                     Required for pandas API on Spark
 `pyarrow`     1.0.0                     Required for pandas API on Spark
-`Numpy`       1.14                      Required for pandas API on Spark
+`numpy`       1.15                      Required for pandas API on Spark and MLLib DataFrame-based API
 ============= ========================= ======================================
 
 Note that PySpark requires Java 8 or later with ``JAVA_HOME`` properly set.  


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `PySpark dependencies` section in Installation document.
- https://dist.apache.org/repos/dist/dev/spark/v3.3.0-rc5-docs/_site/api/python/getting_started/install.html#dependencies

### Why are the changes needed?

Apache Spark 3.3 requires `numpy` 1.15.
https://github.com/apache/spark/blob/8765eea1c08bc58a0cfc22b7cfbc0b5645cc81f9/python/setup.py#L270-L274
https://github.com/apache/spark/blob/8765eea1c08bc58a0cfc22b7cfbc0b5645cc81f9/python/setup.py#L264-L265

So,
- We need to update `numpy` to 1.15 from 1.14 accordingly in documentation.
- We had better remove the duplicated NumPy packages (with two versions) because both `MLlib` and `pandas API on Spark` requires the same version.
- We should use package names consistently.

### Does this PR introduce _any_ user-facing change?

This is a doc-only change.

### How was this patch tested?

Manual review.