### PR TITLE
[SPARK-39419][SQL][3.3] Fix ArraySort to throw an exception when the comparator returns null

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -133,6 +133,9 @@
     "message" : [ "PARTITION clause cannot contain the non-partition column: <columnName>." ],
     "sqlState" : "42000"
   },
+  "NULL_COMPARISON_RESULT" : {
+    "message" : [ "The comparison result is null. If you want to handle null as 0 (equal), you can set \"spark.sql.legacy.allowNullComparisonResultInArraySort\" to \"true\"." ]
+  },
   "PARSE_CHAR_MISSING_LENGTH" : {
     "message" : [ "DataType <type> requires a length parameter, for example <type>(10). Please specify the length." ],
     "sqlState" : "42000"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2065,4 +2065,9 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         s"add ${toSQLValue(amount, IntegerType)} $unit to " +
         s"${toSQLValue(DateTimeUtils.microsToInstant(micros), TimestampType)}"))
   }
+
+  def nullComparisonResultError(): Throwable = {
+    new SparkException(errorClass = "NULL_COMPARISON_RESULT",
+      messageParameters = Array(), cause = null)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3748,6 +3748,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_ALLOW_NULL_COMPARISON_RESULT_IN_ARRAY_SORT =
+    buildConf("spark.sql.legacy.allowNullComparisonResultInArraySort")
+      .internal()
+      .doc("When set to false, `array_sort` function throws an error " +
+        "if the comparator function returns null. " +
+        "If set to true, it restores the legacy behavior that handles null as zero (equal).")
+      .version("3.2.2")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *


### PR DESCRIPTION
### What changes were proposed in this pull request?

Backport of #36812.

Fixes `ArraySort` to throw an exception when the comparator returns `null`.

Also updates the doc to follow the corrected behavior.

### Why are the changes needed?

When the comparator of `ArraySort` returns `null`, currently it handles it as `0` (equal).

According to the doc,

```
It returns -1, 0, or 1 as the first element is less than, equal to, or greater than
the second element. If the comparator function returns other
values (including null), the function will fail and raise an error.
```

It's fine to return non -1, 0, 1 integers to follow the Java convention (still need to update the doc, though), but it should throw an exception for `null` result.

### Does this PR introduce _any_ user-facing change?

Yes, if a user uses a comparator that returns `null`, it will throw an error after this PR.

The legacy flag `spark.sql.legacy.allowNullComparisonResultInArraySort` can be used to restore the legacy behavior that handles `null` as `0` (equal).

### How was this patch tested?

Added some tests.
