### PR TITLE
[SPARK-39437][FOLLOWUP][SQL][TESTS] Update q83.ansi result

### DIFF
--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.ansi/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.ansi/explain.txt
@@ -78,7 +78,7 @@ Condition : (isnotnull(i_item_sk#5) AND isnotnull(i_item_id#6))
 
 (7) BroadcastExchange
 Input [2]: [i_item_sk#5, i_item_id#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [id=#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_item_sk#1]
@@ -90,178 +90,178 @@ Output [3]: [sr_return_quantity#2, sr_returned_date_sk#3, i_item_id#6]
 Input [5]: [sr_item_sk#1, sr_return_quantity#2, sr_returned_date_sk#3, i_item_sk#5, i_item_id#6]
 
 (10) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#8]
+Output [1]: [d_date_sk#7]
 
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_returned_date_sk#3]
-Right keys [1]: [d_date_sk#8]
+Right keys [1]: [d_date_sk#7]
 Join condition: None
 
 (12) Project [codegen id : 5]
 Output [2]: [sr_return_quantity#2, i_item_id#6]
-Input [4]: [sr_return_quantity#2, sr_returned_date_sk#3, i_item_id#6, d_date_sk#8]
+Input [4]: [sr_return_quantity#2, sr_returned_date_sk#3, i_item_id#6, d_date_sk#7]
 
 (13) HashAggregate [codegen id : 5]
 Input [2]: [sr_return_quantity#2, i_item_id#6]
 Keys [1]: [i_item_id#6]
 Functions [1]: [partial_sum(sr_return_quantity#2)]
-Aggregate Attributes [1]: [sum#9]
-Results [2]: [i_item_id#6, sum#10]
+Aggregate Attributes [1]: [sum#8]
+Results [2]: [i_item_id#6, sum#9]
 
 (14) Exchange
-Input [2]: [i_item_id#6, sum#10]
-Arguments: hashpartitioning(i_item_id#6, 5), ENSURE_REQUIREMENTS, [id=#11]
+Input [2]: [i_item_id#6, sum#9]
+Arguments: hashpartitioning(i_item_id#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) HashAggregate [codegen id : 18]
-Input [2]: [i_item_id#6, sum#10]
+Input [2]: [i_item_id#6, sum#9]
 Keys [1]: [i_item_id#6]
 Functions [1]: [sum(sr_return_quantity#2)]
-Aggregate Attributes [1]: [sum(sr_return_quantity#2)#12]
-Results [2]: [i_item_id#6 AS item_id#13, sum(sr_return_quantity#2)#12 AS sr_item_qty#14]
+Aggregate Attributes [1]: [sum(sr_return_quantity#2)#10]
+Results [2]: [i_item_id#6 AS item_id#11, sum(sr_return_quantity#2)#10 AS sr_item_qty#12]
 
 (16) Scan parquet default.catalog_returns
-Output [3]: [cr_item_sk#15, cr_return_quantity#16, cr_returned_date_sk#17]
+Output [3]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cr_returned_date_sk#17), dynamicpruningexpression(cr_returned_date_sk#17 IN dynamicpruning#4)]
+PartitionFilters: [isnotnull(cr_returned_date_sk#15), dynamicpruningexpression(cr_returned_date_sk#15 IN dynamicpruning#4)]
 PushedFilters: [IsNotNull(cr_item_sk)]
 ReadSchema: struct<cr_item_sk:int,cr_return_quantity:int>
 
 (17) ColumnarToRow [codegen id : 10]
-Input [3]: [cr_item_sk#15, cr_return_quantity#16, cr_returned_date_sk#17]
+Input [3]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15]
 
 (18) Filter [codegen id : 10]
-Input [3]: [cr_item_sk#15, cr_return_quantity#16, cr_returned_date_sk#17]
-Condition : isnotnull(cr_item_sk#15)
+Input [3]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15]
+Condition : isnotnull(cr_item_sk#13)
 
 (19) ReusedExchange [Reuses operator id: 7]
-Output [2]: [i_item_sk#18, i_item_id#19]
+Output [2]: [i_item_sk#16, i_item_id#17]
 
 (20) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cr_item_sk#15]
-Right keys [1]: [i_item_sk#18]
+Left keys [1]: [cr_item_sk#13]
+Right keys [1]: [i_item_sk#16]
 Join condition: None
 
 (21) Project [codegen id : 10]
-Output [3]: [cr_return_quantity#16, cr_returned_date_sk#17, i_item_id#19]
-Input [5]: [cr_item_sk#15, cr_return_quantity#16, cr_returned_date_sk#17, i_item_sk#18, i_item_id#19]
+Output [3]: [cr_return_quantity#14, cr_returned_date_sk#15, i_item_id#17]
+Input [5]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15, i_item_sk#16, i_item_id#17]
 
 (22) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#20]
+Output [1]: [d_date_sk#18]
 
 (23) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cr_returned_date_sk#17]
-Right keys [1]: [d_date_sk#20]
+Left keys [1]: [cr_returned_date_sk#15]
+Right keys [1]: [d_date_sk#18]
 Join condition: None
 
 (24) Project [codegen id : 10]
-Output [2]: [cr_return_quantity#16, i_item_id#19]
-Input [4]: [cr_return_quantity#16, cr_returned_date_sk#17, i_item_id#19, d_date_sk#20]
+Output [2]: [cr_return_quantity#14, i_item_id#17]
+Input [4]: [cr_return_quantity#14, cr_returned_date_sk#15, i_item_id#17, d_date_sk#18]
 
 (25) HashAggregate [codegen id : 10]
-Input [2]: [cr_return_quantity#16, i_item_id#19]
-Keys [1]: [i_item_id#19]
-Functions [1]: [partial_sum(cr_return_quantity#16)]
-Aggregate Attributes [1]: [sum#21]
-Results [2]: [i_item_id#19, sum#22]
+Input [2]: [cr_return_quantity#14, i_item_id#17]
+Keys [1]: [i_item_id#17]
+Functions [1]: [partial_sum(cr_return_quantity#14)]
+Aggregate Attributes [1]: [sum#19]
+Results [2]: [i_item_id#17, sum#20]
 
 (26) Exchange
-Input [2]: [i_item_id#19, sum#22]
-Arguments: hashpartitioning(i_item_id#19, 5), ENSURE_REQUIREMENTS, [id=#23]
+Input [2]: [i_item_id#17, sum#20]
+Arguments: hashpartitioning(i_item_id#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (27) HashAggregate [codegen id : 11]
-Input [2]: [i_item_id#19, sum#22]
-Keys [1]: [i_item_id#19]
-Functions [1]: [sum(cr_return_quantity#16)]
-Aggregate Attributes [1]: [sum(cr_return_quantity#16)#24]
-Results [2]: [i_item_id#19 AS item_id#25, sum(cr_return_quantity#16)#24 AS cr_item_qty#26]
+Input [2]: [i_item_id#17, sum#20]
+Keys [1]: [i_item_id#17]
+Functions [1]: [sum(cr_return_quantity#14)]
+Aggregate Attributes [1]: [sum(cr_return_quantity#14)#21]
+Results [2]: [i_item_id#17 AS item_id#22, sum(cr_return_quantity#14)#21 AS cr_item_qty#23]
 
 (28) BroadcastExchange
-Input [2]: [item_id#25, cr_item_qty#26]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#27]
+Input [2]: [item_id#22, cr_item_qty#23]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=4]
 
 (29) BroadcastHashJoin [codegen id : 18]
-Left keys [1]: [item_id#13]
-Right keys [1]: [item_id#25]
+Left keys [1]: [item_id#11]
+Right keys [1]: [item_id#22]
 Join condition: None
 
 (30) Project [codegen id : 18]
-Output [3]: [item_id#13, sr_item_qty#14, cr_item_qty#26]
-Input [4]: [item_id#13, sr_item_qty#14, item_id#25, cr_item_qty#26]
+Output [3]: [item_id#11, sr_item_qty#12, cr_item_qty#23]
+Input [4]: [item_id#11, sr_item_qty#12, item_id#22, cr_item_qty#23]
 
 (31) Scan parquet default.web_returns
-Output [3]: [wr_item_sk#28, wr_return_quantity#29, wr_returned_date_sk#30]
+Output [3]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(wr_returned_date_sk#30), dynamicpruningexpression(wr_returned_date_sk#30 IN dynamicpruning#4)]
+PartitionFilters: [isnotnull(wr_returned_date_sk#26), dynamicpruningexpression(wr_returned_date_sk#26 IN dynamicpruning#4)]
 PushedFilters: [IsNotNull(wr_item_sk)]
 ReadSchema: struct<wr_item_sk:int,wr_return_quantity:int>
 
 (32) ColumnarToRow [codegen id : 16]
-Input [3]: [wr_item_sk#28, wr_return_quantity#29, wr_returned_date_sk#30]
+Input [3]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26]
 
 (33) Filter [codegen id : 16]
-Input [3]: [wr_item_sk#28, wr_return_quantity#29, wr_returned_date_sk#30]
-Condition : isnotnull(wr_item_sk#28)
+Input [3]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26]
+Condition : isnotnull(wr_item_sk#24)
 
 (34) ReusedExchange [Reuses operator id: 7]
-Output [2]: [i_item_sk#31, i_item_id#32]
+Output [2]: [i_item_sk#27, i_item_id#28]
 
 (35) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [wr_item_sk#28]
-Right keys [1]: [i_item_sk#31]
+Left keys [1]: [wr_item_sk#24]
+Right keys [1]: [i_item_sk#27]
 Join condition: None
 
 (36) Project [codegen id : 16]
-Output [3]: [wr_return_quantity#29, wr_returned_date_sk#30, i_item_id#32]
-Input [5]: [wr_item_sk#28, wr_return_quantity#29, wr_returned_date_sk#30, i_item_sk#31, i_item_id#32]
+Output [3]: [wr_return_quantity#25, wr_returned_date_sk#26, i_item_id#28]
+Input [5]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26, i_item_sk#27, i_item_id#28]
 
 (37) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#33]
+Output [1]: [d_date_sk#29]
 
 (38) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [wr_returned_date_sk#30]
-Right keys [1]: [d_date_sk#33]
+Left keys [1]: [wr_returned_date_sk#26]
+Right keys [1]: [d_date_sk#29]
 Join condition: None
 
 (39) Project [codegen id : 16]
-Output [2]: [wr_return_quantity#29, i_item_id#32]
-Input [4]: [wr_return_quantity#29, wr_returned_date_sk#30, i_item_id#32, d_date_sk#33]
+Output [2]: [wr_return_quantity#25, i_item_id#28]
+Input [4]: [wr_return_quantity#25, wr_returned_date_sk#26, i_item_id#28, d_date_sk#29]
 
 (40) HashAggregate [codegen id : 16]
-Input [2]: [wr_return_quantity#29, i_item_id#32]
-Keys [1]: [i_item_id#32]
-Functions [1]: [partial_sum(wr_return_quantity#29)]
-Aggregate Attributes [1]: [sum#34]
-Results [2]: [i_item_id#32, sum#35]
+Input [2]: [wr_return_quantity#25, i_item_id#28]
+Keys [1]: [i_item_id#28]
+Functions [1]: [partial_sum(wr_return_quantity#25)]
+Aggregate Attributes [1]: [sum#30]
+Results [2]: [i_item_id#28, sum#31]
 
 (41) Exchange
-Input [2]: [i_item_id#32, sum#35]
-Arguments: hashpartitioning(i_item_id#32, 5), ENSURE_REQUIREMENTS, [id=#36]
+Input [2]: [i_item_id#28, sum#31]
+Arguments: hashpartitioning(i_item_id#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (42) HashAggregate [codegen id : 17]
-Input [2]: [i_item_id#32, sum#35]
-Keys [1]: [i_item_id#32]
-Functions [1]: [sum(wr_return_quantity#29)]
-Aggregate Attributes [1]: [sum(wr_return_quantity#29)#37]
-Results [2]: [i_item_id#32 AS item_id#38, sum(wr_return_quantity#29)#37 AS wr_item_qty#39]
+Input [2]: [i_item_id#28, sum#31]
+Keys [1]: [i_item_id#28]
+Functions [1]: [sum(wr_return_quantity#25)]
+Aggregate Attributes [1]: [sum(wr_return_quantity#25)#32]
+Results [2]: [i_item_id#28 AS item_id#33, sum(wr_return_quantity#25)#32 AS wr_item_qty#34]
 
 (43) BroadcastExchange
-Input [2]: [item_id#38, wr_item_qty#39]
-Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [id=#40]
+Input [2]: [item_id#33, wr_item_qty#34]
+Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [plan_id=6]
 
 (44) BroadcastHashJoin [codegen id : 18]
-Left keys [1]: [item_id#13]
-Right keys [1]: [item_id#38]
+Left keys [1]: [item_id#11]
+Right keys [1]: [item_id#33]
 Join condition: None
 
 (45) Project [codegen id : 18]
-Output [8]: [item_id#13, sr_item_qty#14, (((cast(sr_item_qty#14 as double) / cast(((sr_item_qty#14 + cr_item_qty#26) + wr_item_qty#39) as double)) / 3.0) * 100.0) AS sr_dev#41, cr_item_qty#26, (((cast(cr_item_qty#26 as double) / cast(((sr_item_qty#14 + cr_item_qty#26) + wr_item_qty#39) as double)) / 3.0) * 100.0) AS cr_dev#42, wr_item_qty#39, (((cast(wr_item_qty#39 as double) / cast(((sr_item_qty#14 + cr_item_qty#26) + wr_item_qty#39) as double)) / 3.0) * 100.0) AS wr_dev#43, CheckOverflow((promote_precision(cast(((sr_item_qty#14 + cr_item_qty#26) + wr_item_qty#39) as decimal(21,1))) / 3.0), DecimalType(27,6)) AS average#44]
-Input [5]: [item_id#13, sr_item_qty#14, cr_item_qty#26, item_id#38, wr_item_qty#39]
+Output [8]: [item_id#11, sr_item_qty#12, (((cast(sr_item_qty#12 as double) / cast(((sr_item_qty#12 + cr_item_qty#23) + wr_item_qty#34) as double)) / 3.0) * 100.0) AS sr_dev#35, cr_item_qty#23, (((cast(cr_item_qty#23 as double) / cast(((sr_item_qty#12 + cr_item_qty#23) + wr_item_qty#34) as double)) / 3.0) * 100.0) AS cr_dev#36, wr_item_qty#34, (((cast(wr_item_qty#34 as double) / cast(((sr_item_qty#12 + cr_item_qty#23) + wr_item_qty#34) as double)) / 3.0) * 100.0) AS wr_dev#37, CheckOverflow((promote_precision(cast(((sr_item_qty#12 + cr_item_qty#23) + wr_item_qty#34) as decimal(21,1))) / 3.0), DecimalType(27,6)) AS average#38]
+Input [5]: [item_id#11, sr_item_qty#12, cr_item_qty#23, item_id#33, wr_item_qty#34]
 
 (46) TakeOrderedAndProject
-Input [8]: [item_id#13, sr_item_qty#14, sr_dev#41, cr_item_qty#26, cr_dev#42, wr_item_qty#39, wr_dev#43, average#44]
-Arguments: 100, [item_id#13 ASC NULLS FIRST, sr_item_qty#14 ASC NULLS FIRST], [item_id#13, sr_item_qty#14, sr_dev#41, cr_item_qty#26, cr_dev#42, wr_item_qty#39, wr_dev#43, average#44]
+Input [8]: [item_id#11, sr_item_qty#12, sr_dev#35, cr_item_qty#23, cr_dev#36, wr_item_qty#34, wr_dev#37, average#38]
+Arguments: 100, [item_id#11 ASC NULLS FIRST, sr_item_qty#12 ASC NULLS FIRST], [item_id#11, sr_item_qty#12, sr_dev#35, cr_item_qty#23, cr_dev#36, wr_item_qty#34, wr_dev#37, average#38]
 
 ===== Subqueries =====
 
@@ -285,78 +285,78 @@ BroadcastExchange (62)
 
 
 (47) Scan parquet default.date_dim
-Output [2]: [d_date_sk#8, d_date#45]
+Output [2]: [d_date_sk#7, d_date#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (48) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#8, d_date#45]
+Input [2]: [d_date_sk#7, d_date#39]
 
 (49) Filter [codegen id : 3]
-Input [2]: [d_date_sk#8, d_date#45]
-Condition : isnotnull(d_date_sk#8)
+Input [2]: [d_date_sk#7, d_date#39]
+Condition : isnotnull(d_date_sk#7)
 
 (50) Scan parquet default.date_dim
-Output [2]: [d_date#46, d_week_seq#47]
+Output [2]: [d_date#40, d_week_seq#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 ReadSchema: struct<d_date:date,d_week_seq:int>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [2]: [d_date#46, d_week_seq#47]
+Input [2]: [d_date#40, d_week_seq#41]
 
 (52) Scan parquet default.date_dim
-Output [2]: [d_date#48, d_week_seq#49]
+Output [2]: [d_date#42, d_week_seq#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_date, [2000-06-30,2000-09-27,2000-11-17])]
 ReadSchema: struct<d_date:date,d_week_seq:int>
 
 (53) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date#48, d_week_seq#49]
+Input [2]: [d_date#42, d_week_seq#43]
 
 (54) Filter [codegen id : 1]
-Input [2]: [d_date#48, d_week_seq#49]
-Condition : d_date#48 IN (2000-06-30,2000-09-27,2000-11-17)
+Input [2]: [d_date#42, d_week_seq#43]
+Condition : d_date#42 IN (2000-06-30,2000-09-27,2000-11-17)
 
 (55) Project [codegen id : 1]
-Output [1]: [d_week_seq#49]
-Input [2]: [d_date#48, d_week_seq#49]
+Output [1]: [d_week_seq#43]
+Input [2]: [d_date#42, d_week_seq#43]
 
 (56) BroadcastExchange
-Input [1]: [d_week_seq#49]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#50]
+Input [1]: [d_week_seq#43]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 (57) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#47]
-Right keys [1]: [d_week_seq#49]
+Left keys [1]: [d_week_seq#41]
+Right keys [1]: [d_week_seq#43]
 Join condition: None
 
 (58) Project [codegen id : 2]
-Output [1]: [d_date#46]
-Input [2]: [d_date#46, d_week_seq#47]
+Output [1]: [d_date#40]
+Input [2]: [d_date#40, d_week_seq#41]
 
 (59) BroadcastExchange
-Input [1]: [d_date#46]
-Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [id=#51]
+Input [1]: [d_date#40]
+Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_id=8]
 
 (60) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [d_date#45]
-Right keys [1]: [d_date#46]
+Left keys [1]: [d_date#39]
+Right keys [1]: [d_date#40]
 Join condition: None
 
 (61) Project [codegen id : 3]
-Output [1]: [d_date_sk#8]
-Input [2]: [d_date_sk#8, d_date#45]
+Output [1]: [d_date_sk#7]
+Input [2]: [d_date_sk#7, d_date#39]
 
 (62) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [id=#52]
+Input [1]: [d_date_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 16 Hosting Expression = cr_returned_date_sk#17 IN dynamicpruning#4
+Subquery:2 Hosting operator id = 16 Hosting Expression = cr_returned_date_sk#15 IN dynamicpruning#4
 
-Subquery:3 Hosting operator id = 31 Hosting Expression = wr_returned_date_sk#30 IN dynamicpruning#4
+Subquery:3 Hosting operator id = 31 Hosting Expression = wr_returned_date_sk#26 IN dynamicpruning#4
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/36827 to update `q83.ansi` result.

### Why are the changes needed?

ANSI mode unit tests are not covered on GitHub Action on PRs.
- https://github.com/apache/spark/commits/master

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This should be tested manually because `GitHub Action` doesn't test this.

```
$ SPARK_ANSI_SQL_MODE=true build/sbt "sql/testOnly *PlanStabilitySuite"
```