### PR TITLE
[SPARK-39442][SQL][TESTS] Update `PlanStabilitySuite` comments with `SPARK_ANSI_SQL_MODE`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/PlanStabilitySuite.scala
@@ -48,22 +48,24 @@ import org.apache.spark.tags.ExtendedSQLTest
  *
  * To run the entire test suite:
  * {{{
- *   build/sbt "sql/testOnly *PlanStability[WithStats]Suite"
+ *   build/sbt "sql/testOnly *PlanStability*Suite"
  * }}}
  *
  * To run a single test file upon change:
  * {{{
- *   build/sbt "sql/testOnly *PlanStability[WithStats]Suite -- -z (tpcds-v1.4/q49)"
+ *   build/sbt "sql/testOnly *PlanStability*Suite -- -z (tpcds-v1.4/q49)"
  * }}}
  *
  * To re-generate golden files for entire suite, run:
  * {{{
- *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *PlanStability[WithStats]Suite"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *PlanStability*Suite"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 SPARK_ANSI_SQL_MODE=true build/sbt "sql/testOnly *PlanStability*Suite"
  * }}}
  *
  * To re-generate golden file for a single test, run:
  * {{{
- *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *PlanStability[WithStats]Suite -- -z (tpcds-v1.4/q49)"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly *PlanStability*Suite -- -z (tpcds-v1.4/q49)"
+ *   SPARK_GENERATE_GOLDEN_FILES=1 SPARK_ANSI_SQL_MODE=true build/sbt "sql/testOnly *PlanStability*Suite -- -z (tpcds-v1.4/q49)"
  * }}}
  */
 // scalastyle:on line.size.limit


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `PlanStabilitySuite` direction to prevent future mistakes.

1. Add `SPARK_ANSI_SQL_MODE=true` explicitly because Apache Spark 3.3+ test coverage has ANSI and non-ANSI modes. We need to make it sure that both results are synced at the same time.
```
- SPARK_GENERATE_GOLDEN_FILES=1 build/sbt ...
+ SPARK_GENERATE_GOLDEN_FILES=1 build/sbt ...
+ SPARK_GENERATE_GOLDEN_FILES=1 SPARK_ANSI_SQL_MODE=true ...
```

2. The existing commands are human-readable but is not working. So, we had better have more simple command which is *copy-and-pasteable*.
```
- build/sbt "sql/testOnly *PlanStability[WithStats]Suite"
+ build/sbt "sql/testOnly *PlanStability*Suite"
```

### Why are the changes needed?

This will help us update the test results more easily by preventing mistakes.

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only doc.

### How was this patch tested?

Manual review.