### PR TITLE
[SPARK-39445][SQL] Remove the window if windowExpressions is empty in column pruning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -894,8 +894,9 @@ object ColumnPruning extends Rule[LogicalPlan] {
 
     // Prune unnecessary window expressions
     case p @ Project(_, w: Window) if !w.windowOutputSet.subsetOf(p.references) =>
-      p.copy(child = w.copy(
-        windowExpressions = w.windowExpressions.filter(p.references.contains)))
+      val windowExprs = w.windowExpressions.filter(p.references.contains)
+      val newChild = if (windowExprs.isEmpty) w.child else w.copy(windowExpressions = windowExprs)
+      p.copy(child = newChild)
 
     // Prune WithCTE
     case p @ Project(_, w: WithCTE) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the window if windowExpressions is empty in column pruning.

### Why are the changes needed?

It will throw exception if user `set spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.RemoveNoopOperators` before running this query:
```sql
SELECT id
FROM   (SELECT id,
               Row_number()
                 OVER (
                   partition BY id
                   ORDER BY id) AS rn
        FROM   Range(3)) t
```
Exception:
```
org.apache.spark.sql.AnalysisException: Window expression is empty in Window [id#11L], [id#11L ASC NULLS FIRST]
+- Project [id#11L]
   +- Range (0, 5, step=1, splits=None)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.