### PR TITLE
[SPARK-39446][MLLIB] Add relevance score for nDCG evaluation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -66,9 +66,8 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def precisionAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, _) =>
-        countRelevantItemRatio(pred, lab, k, k)
-    }
-    .mean()
+      countRelevantItemRatio(pred, lab, k, k)
+    }.mean()
   }
 
   /**
@@ -79,11 +78,10 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   @Since("1.2.0")
   lazy val meanAveragePrecision: Double = {
     predictionAndLabels.map { case (pred, lab, _) =>
-        val labSet = lab.toSet
-        val k = math.max(pred.length, labSet.size)
-        averagePrecision(pred, labSet, k)
-    }
-    .mean()
+      val labSet = lab.toSet
+      val k = math.max(pred.length, labSet.size)
+      averagePrecision(pred, labSet, k)
+    }.mean()
   }
 
   /**
@@ -97,9 +95,8 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def meanAveragePrecisionAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, _) =>
-        averagePrecision(pred, lab.toSet, k)
-    }
-    .mean()
+      averagePrecision(pred, lab.toSet, k)
+    }.mean()
   }
 
   /**
@@ -199,8 +196,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
         logWarning("Empty ground truth set, check input data")
         0.0
       }
-    }
-    .mean()
+    }.mean()
   }
 
   /**
@@ -224,9 +220,8 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def recallAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, _) =>
-        countRelevantItemRatio(pred, lab, k, lab.toSet.size)
-    }
-    .mean()
+      countRelevantItemRatio(pred, lab, k, lab.toSet.size)
+    }.mean()
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -164,7 +164,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
           val useBinary = rel.isEmpty
           val labSet = lab.toSet
           val relMap = (lab zip rel).toMap
-          if (lab.size != rel.size) {
+          if (useBinary && lab.size != rel.size) {
             logWarning(
               "# of ground truth set and # of relevance value set should be equal, " +
                 "check input data")
@@ -188,7 +188,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
                   maxDcg += gain
                 }
               } else {
-                if (i < pred.length && labSet.contains(pred(i))) {
+                if (i < pred.length) {
                   dcg += (math.pow(2.0, relMap.getOrElse(pred(i), 0.0)) - 1) / math.log(i + 2)
                 }
                 if (i < labSetSize) {

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -66,9 +66,9 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def precisionAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, _) =>
-          countRelevantItemRatio(pred, lab, k, k)
-      }
-      .mean()
+        countRelevantItemRatio(pred, lab, k, k)
+    }
+    .mean()
   }
 
   /**
@@ -79,11 +79,11 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   @Since("1.2.0")
   lazy val meanAveragePrecision: Double = {
     predictionAndLabels.map { case (pred, lab, _) =>
-          val labSet = lab.toSet
-          val k = math.max(pred.length, labSet.size)
-          averagePrecision(pred, labSet, k)
-      }
-      .mean()
+        val labSet = lab.toSet
+        val k = math.max(pred.length, labSet.size)
+        averagePrecision(pred, labSet, k)
+    }
+    .mean()
   }
 
   /**
@@ -97,9 +97,9 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def meanAveragePrecisionAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, _) =>
-          averagePrecision(pred, lab.toSet, k)
-      }
-      .mean()
+        averagePrecision(pred, lab.toSet, k)
+    }
+    .mean()
   }
 
   /**
@@ -153,54 +153,54 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def ndcgAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, rel) =>
-          val useBinary = rel.isEmpty
-          val labSet = lab.toSet
-          val relMap = lab.zip(rel).toMap
-          if (useBinary && lab.size != rel.size) {
-            logWarning(
-              "# of ground truth set and # of relevance value set should be equal, " +
-                "check input data")
-          }
+      val useBinary = rel.isEmpty
+      val labSet = lab.toSet
+      val relMap = lab.zip(rel).toMap
+      if (useBinary && lab.size != rel.size) {
+        logWarning(
+          "# of ground truth set and # of relevance value set should be equal, " +
+            "check input data")
+      }
 
-          if (labSet.nonEmpty) {
-            val labSetSize = labSet.size
-            val n = math.min(math.max(pred.length, labSetSize), k)
-            var maxDcg = 0.0
-            var dcg = 0.0
-            var i = 0
-            while (i < n) {
-              if (useBinary) {
-                // Base of the log doesn't matter for calculating NDCG,
-                // if the relevance value is binary.
-                val gain = 1.0 / math.log(i + 2)
-                if (i < pred.length && labSet.contains(pred(i))) {
-                  dcg += gain
-                }
-                if (i < labSetSize) {
-                  maxDcg += gain
-                }
-              } else {
-                if (i < pred.length) {
-                  dcg += (math.pow(2.0, relMap.getOrElse(pred(i), 0.0)) - 1) / math.log(i + 2)
-                }
-                if (i < labSetSize) {
-                  maxDcg += (math.pow(2.0, relMap.getOrElse(lab(i), 0.0)) - 1) / math.log(i + 2)
-                }
-              }
-              i += 1
+      if (labSet.nonEmpty) {
+        val labSetSize = labSet.size
+        val n = math.min(math.max(pred.length, labSetSize), k)
+        var maxDcg = 0.0
+        var dcg = 0.0
+        var i = 0
+        while (i < n) {
+          if (useBinary) {
+            // Base of the log doesn't matter for calculating NDCG,
+            // if the relevance value is binary.
+            val gain = 1.0 / math.log(i + 2)
+            if (i < pred.length && labSet.contains(pred(i))) {
+              dcg += gain
             }
-            if (maxDcg == 0.0) {
-              logWarning("Maximum of relevance of ground truth set is zero, check input data")
-              0.0
-            } else {
-              dcg / maxDcg
+            if (i < labSetSize) {
+              maxDcg += gain
             }
           } else {
-            logWarning("Empty ground truth set, check input data")
-            0.0
+            if (i < pred.length) {
+              dcg += (math.pow(2.0, relMap.getOrElse(pred(i), 0.0)) - 1) / math.log(i + 2)
+            }
+            if (i < labSetSize) {
+              maxDcg += (math.pow(2.0, relMap.getOrElse(lab(i), 0.0)) - 1) / math.log(i + 2)
+            }
           }
+          i += 1
+        }
+        if (maxDcg == 0.0) {
+          logWarning("Maximum of relevance of ground truth set is zero, check input data")
+          0.0
+        } else {
+          dcg / maxDcg
+        }
+      } else {
+        logWarning("Empty ground truth set, check input data")
+        0.0
       }
-      .mean()
+    }
+    .mean()
   }
 
   /**
@@ -224,9 +224,9 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   def recallAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
     predictionAndLabels.map { case (pred, lab, _) =>
-          countRelevantItemRatio(pred, lab, k, lab.toSet.size)
-      }
-      .mean()
+        countRelevantItemRatio(pred, lab, k, lab.toSet.size)
+    }
+    .mean()
   }
 
   /**
@@ -274,7 +274,7 @@ object RankingMetrics {
   def of[E, T <: jl.Iterable[E]](predictionAndLabels: JavaRDD[(T, T)]): RankingMetrics[E] = {
     implicit val tag = JavaSparkContext.fakeClassTag[E]
     val rdd = predictionAndLabels.rdd.map { case (predictions, labels) =>
-        (predictions.asScala.toArray, labels.asScala.toArray)
+      (predictions.asScala.toArray, labels.asScala.toArray)
     }
     new RankingMetrics(rdd)
   }

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -65,9 +65,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   @Since("1.2.0")
   def precisionAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
-    predictionAndLabels
-      .map {
-        case (pred, lab, _) =>
+    predictionAndLabels.map { case (pred, lab, _) =>
           countRelevantItemRatio(pred, lab, k, k)
       }
       .mean()
@@ -80,9 +78,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
    */
   @Since("1.2.0")
   lazy val meanAveragePrecision: Double = {
-    predictionAndLabels
-      .map {
-        case (pred, lab, _) =>
+    predictionAndLabels.map { case (pred, lab, _) =>
           val labSet = lab.toSet
           val k = math.max(pred.length, labSet.size)
           averagePrecision(pred, labSet, k)
@@ -100,9 +96,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   @Since("3.0.0")
   def meanAveragePrecisionAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
-    predictionAndLabels
-      .map {
-        case (pred, lab, _) =>
+    predictionAndLabels.map { case (pred, lab, _) =>
           averagePrecision(pred, lab.toSet, k)
       }
       .mean()
@@ -158,9 +152,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   @Since("1.2.0")
   def ndcgAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
-    predictionAndLabels
-      .map {
-        case (pred, lab, rel) =>
+    predictionAndLabels.map { case (pred, lab, rel) =>
           val useBinary = rel.isEmpty
           val labSet = lab.toSet
           val relMap = (lab zip rel).toMap
@@ -231,9 +223,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
   @Since("3.0.0")
   def recallAt(k: Int): Double = {
     require(k > 0, "ranking position k should be positive")
-    predictionAndLabels
-      .map {
-        case (pred, lab, _) =>
+    predictionAndLabels.map { case (pred, lab, _) =>
           countRelevantItemRatio(pred, lab, k, lab.toSet.size)
       }
       .mean()
@@ -283,8 +273,7 @@ object RankingMetrics {
   @Since("1.4.0")
   def of[E, T <: jl.Iterable[E]](predictionAndLabels: JavaRDD[(T, T)]): RankingMetrics[E] = {
     implicit val tag = JavaSparkContext.fakeClassTag[E]
-    val rdd = predictionAndLabels.rdd.map {
-      case (predictions, labels) =>
+    val rdd = predictionAndLabels.rdd.map { case (predictions, labels) =>
         (predictions.asScala.toArray, labels.asScala.toArray)
     }
     new RankingMetrics(rdd)

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -32,7 +32,9 @@ import org.apache.spark.rdd.RDD
  *
  * Java users should use `RankingMetrics$.of` to create a [[RankingMetrics]] instance.
  *
- * @param predictionAndLabels an RDD of (predicted ranking, ground truth set) pairs.
+ * @param predictionAndLabels an RDD of (predicted ranking, ground truth set) pair
+ *                            or (predicted ranking, ground truth set, relevance value of ground truth set).
+ *                            Since 3.4.0, it supports ndcg evaluation with relevance value.
  */
 @Since("1.2.0")
 class RankingMetrics[T: ClassTag] @Since("3.4.0") (
@@ -136,7 +138,7 @@ class RankingMetrics[T: ClassTag] @Since("3.4.0") (
    * The discounted cumulative gain at position k is computed as:
    *    sum,,i=1,,^k^ (2^{relevance of ''i''th item}^ - 1) / log(i + 1),
    * and the NDCG is obtained by dividing the DCG value on the ground truth set. In the current
-   * implementation, the relevance value is binary.
+   * implementation, the relevance value is binary if the relevance value is empty.
 
    * If a query has an empty ground truth set, zero will be used as ndcg together with
    * a log warning.

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -35,10 +35,12 @@ import org.apache.spark.rdd.RDD
  * @param predictionAndLabels an RDD of (predicted ranking, ground truth set) pairs.
  */
 @Since("1.2.0")
-class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], Array[Double])])
+class RankingMetrics[T: ClassTag] @Since("3.4.0") (
+    predictionAndLabels: RDD[(Array[T], Array[T], Array[Double])])
     extends Logging
     with Serializable {
 
+  @Since("1.2.0")
   def this(predictionAndLabelsWithoutRelevance: => RDD[(Array[T], Array[T])]) = {
     this(predictionAndLabelsWithoutRelevance.map {
       case (pred, lab) => (pred, lab, Array.empty[Double])

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -33,7 +33,8 @@ import org.apache.spark.rdd.RDD
  * Java users should use `RankingMetrics$.of` to create a [[RankingMetrics]] instance.
  *
  * @param predictionAndLabels an RDD of (predicted ranking, ground truth set) pair
- *                            or (predicted ranking, ground truth set, relevance value of ground truth set).
+ *                            or (predicted ranking, ground truth set,
+ * .                          relevance value of ground truth set).
  *                            Since 3.4.0, it supports ndcg evaluation with relevance value.
  */
 @Since("1.2.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -185,7 +185,7 @@ class RankingMetrics[T: ClassTag](
                 }
               } else {
                 if (i < pred.length && labSet.contains(pred(i))) {
-                  dcg += (math.pow(2.0, relMap.getOrElse(pred(i), 0.0)) - 1 )/ math.log(i + 2)
+                  dcg += (math.pow(2.0, relMap.getOrElse(pred(i), 0.0)) - 1) / math.log(i + 2)
                 }
                 if (i < labSetSize) {
                   maxDcg += (math.pow(2.0, relMap.getOrElse(lab(i), 0.0)) - 1) / math.log(i + 2)

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -35,14 +35,13 @@ import org.apache.spark.rdd.RDD
  * @param predictionAndLabels an RDD of (predicted ranking, ground truth set) pairs.
  */
 @Since("1.2.0")
-class RankingMetrics[T: ClassTag](
-    predictionAndLabels: RDD[(Array[T], Array[T], Array[(T, Double)])])
+class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], Array[Double])])
     extends Logging
     with Serializable {
 
   def this(predictionAndLabelsWithoutRelevance: => RDD[(Array[T], Array[T])]) = {
     this(predictionAndLabelsWithoutRelevance.map {
-      case (pred, lab) => (pred, lab, Array.empty[(T, Double)])
+      case (pred, lab) => (pred, lab, Array.empty[Double])
     })
   }
 
@@ -164,7 +163,12 @@ class RankingMetrics[T: ClassTag](
         case (pred, lab, rel) =>
           val useBinary = rel.isEmpty
           val labSet = lab.toSet
-          val relMap = rel.toMap
+          val relMap = (lab zip rel).toMap
+          if (lab.size != rel.size) {
+            logWarning(
+              "# of ground truth set and # of relevance value set should be equal, " +
+                "check input data")
+          }
 
           if (labSet.nonEmpty) {
             val labSetSize = labSet.size

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/RankingMetrics.scala
@@ -155,7 +155,7 @@ class RankingMetrics[T: ClassTag](predictionAndLabels: RDD[(Array[T], Array[T], 
     predictionAndLabels.map { case (pred, lab, rel) =>
           val useBinary = rel.isEmpty
           val labSet = lab.toSet
-          val relMap = (lab zip rel).toMap
+          val relMap = lab.zip(rel).toMap
           if (useBinary && lab.size != rel.size) {
             logWarning(
               "# of ground truth set and # of relevance value set should be equal, " +

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
@@ -28,20 +28,20 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
       Seq(
         (Array(1, 6, 2, 7, 8, 3, 9, 10, 4, 5), Array(1, 2, 3, 4, 5)),
         (Array(4, 1, 5, 6, 2, 7, 3, 8, 9, 10), Array(1, 2, 3)),
-        (Array(1, 2, 3, 4, 5), Array.empty[Int])
-      ), 2)
-    val eps = 1.0E-5
+        (Array(1, 2, 3, 4, 5), Array.empty[Int])),
+      2)
+    val eps = 1.0e-5
 
     val metrics = new RankingMetrics(predictionAndLabels)
     val map = metrics.meanAveragePrecision
 
-    assert(metrics.precisionAt(1) ~== 1.0/3 absTol eps)
-    assert(metrics.precisionAt(2) ~== 1.0/3 absTol eps)
-    assert(metrics.precisionAt(3) ~== 1.0/3 absTol eps)
-    assert(metrics.precisionAt(4) ~== 0.75/3 absTol eps)
-    assert(metrics.precisionAt(5) ~== 0.8/3 absTol eps)
-    assert(metrics.precisionAt(10) ~== 0.8/3 absTol eps)
-    assert(metrics.precisionAt(15) ~== 8.0/45 absTol eps)
+    assert(metrics.precisionAt(1) ~== 1.0 / 3 absTol eps)
+    assert(metrics.precisionAt(2) ~== 1.0 / 3 absTol eps)
+    assert(metrics.precisionAt(3) ~== 1.0 / 3 absTol eps)
+    assert(metrics.precisionAt(4) ~== 0.75 / 3 absTol eps)
+    assert(metrics.precisionAt(5) ~== 0.8 / 3 absTol eps)
+    assert(metrics.precisionAt(10) ~== 0.8 / 3 absTol eps)
+    assert(metrics.precisionAt(15) ~== 8.0 / 45 absTol eps)
 
     assert(map ~== 0.355026 absTol eps)
 
@@ -49,18 +49,18 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(metrics.meanAveragePrecisionAt(2) ~== 0.25 absTol eps)
     assert(metrics.meanAveragePrecisionAt(3) ~== 0.24074 absTol eps)
 
-    assert(metrics.ndcgAt(3) ~== 1.0/3 absTol eps)
+    assert(metrics.ndcgAt(3) ~== 1.0 / 3 absTol eps)
     assert(metrics.ndcgAt(5) ~== 0.328788 absTol eps)
     assert(metrics.ndcgAt(10) ~== 0.487913 absTol eps)
     assert(metrics.ndcgAt(15) ~== metrics.ndcgAt(10) absTol eps)
 
-    assert(metrics.recallAt(1) ~== 1.0/15 absTol eps)
-    assert(metrics.recallAt(2) ~== 8.0/45 absTol eps)
-    assert(metrics.recallAt(3) ~== 11.0/45 absTol eps)
-    assert(metrics.recallAt(4) ~== 11.0/45 absTol eps)
-    assert(metrics.recallAt(5) ~== 16.0/45 absTol eps)
-    assert(metrics.recallAt(10) ~== 2.0/3 absTol eps)
-    assert(metrics.recallAt(15) ~== 2.0/3 absTol eps)
+    assert(metrics.recallAt(1) ~== 1.0 / 15 absTol eps)
+    assert(metrics.recallAt(2) ~== 8.0 / 45 absTol eps)
+    assert(metrics.recallAt(3) ~== 11.0 / 45 absTol eps)
+    assert(metrics.recallAt(4) ~== 11.0 / 45 absTol eps)
+    assert(metrics.recallAt(5) ~== 16.0 / 45 absTol eps)
+    assert(metrics.recallAt(10) ~== 2.0 / 3 absTol eps)
+    assert(metrics.recallAt(15) ~== 2.0 / 3 absTol eps)
   }
 
   test("Ranking metrics: NDCG with relevance") {
@@ -111,11 +111,9 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   test("MAP, NDCG, Recall with few predictions (SPARK-14886)") {
     val predictionAndLabels = sc.parallelize(
-      Seq(
-        (Array(1, 6, 2), Array(1, 2, 3, 4, 5)),
-        (Array.empty[Int], Array(1, 2, 3))
-      ), 2)
-    val eps = 1.0E-5
+      Seq((Array(1, 6, 2), Array(1, 2, 3, 4, 5)), (Array.empty[Int], Array(1, 2, 3))),
+      2)
+    val eps = 1.0e-5
 
     val metrics = new RankingMetrics(predictionAndLabels)
     assert(metrics.precisionAt(1) ~== 0.5 absTol eps)

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
@@ -69,12 +69,9 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
         (
           Array(1, 6, 2, 7, 8, 3, 9, 10, 4, 5),
           Array(1, 2, 3, 4, 5),
-          Array((1, 3.0), (2, 2.0), (3, 1.0), (4, 1.0), (5, 1.0))),
-        (
-          Array(4, 1, 5, 6, 2, 7, 3, 8, 9, 10),
-          Array(1, 2, 3),
-          Array((1, 2.0), (2, 0.0), (3, 0.0))),
-        (Array(1, 2, 3, 4, 5), Array.empty[Int], Array((1, 2.0)))),
+          Array(3.0, 2.0, 1.0, 1.0, 1.0)),
+        (Array(4, 1, 5, 6, 2, 7, 3, 8, 9, 10), Array(1, 2, 3), Array(2.0, 0.0, 0.0)),
+        (Array(1, 2, 3, 4, 5), Array.empty[Int], Array.empty[Double])),
       2)
     val eps = 1.0e-5
 

--- a/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala
@@ -63,6 +63,52 @@ class RankingMetricsSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(metrics.recallAt(15) ~== 2.0/3 absTol eps)
   }
 
+  test("Ranking metrics: NDCG with relevance") {
+    val predictionAndLabels = sc.parallelize(
+      Seq(
+        (
+          Array(1, 6, 2, 7, 8, 3, 9, 10, 4, 5),
+          Array(1, 2, 3, 4, 5),
+          Array((1, 3.0), (2, 2.0), (3, 1.0), (4, 1.0), (5, 1.0))),
+        (
+          Array(4, 1, 5, 6, 2, 7, 3, 8, 9, 10),
+          Array(1, 2, 3),
+          Array((1, 2.0), (2, 0.0), (3, 0.0))),
+        (Array(1, 2, 3, 4, 5), Array.empty[Int], Array((1, 2.0)))),
+      2)
+    val eps = 1.0e-5
+
+    val metrics = new RankingMetrics(predictionAndLabels)
+    val map = metrics.meanAveragePrecision
+
+    assert(metrics.precisionAt(1) ~== 1.0 / 3 absTol eps)
+    assert(metrics.precisionAt(2) ~== 1.0 / 3 absTol eps)
+    assert(metrics.precisionAt(3) ~== 1.0 / 3 absTol eps)
+    assert(metrics.precisionAt(4) ~== 0.75 / 3 absTol eps)
+    assert(metrics.precisionAt(5) ~== 0.8 / 3 absTol eps)
+    assert(metrics.precisionAt(10) ~== 0.8 / 3 absTol eps)
+    assert(metrics.precisionAt(15) ~== 8.0 / 45 absTol eps)
+
+    assert(map ~== 0.355026 absTol eps)
+
+    assert(metrics.meanAveragePrecisionAt(1) ~== 0.333334 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(2) ~== 0.25 absTol eps)
+    assert(metrics.meanAveragePrecisionAt(3) ~== 0.24074 absTol eps)
+
+    assert(metrics.ndcgAt(3) ~== 0.511959 absTol eps)
+    assert(metrics.ndcgAt(5) ~== 0.487806 absTol eps)
+    assert(metrics.ndcgAt(10) ~== 0.518700 absTol eps)
+    assert(metrics.ndcgAt(15) ~== metrics.ndcgAt(10) absTol eps)
+
+    assert(metrics.recallAt(1) ~== 1.0 / 15 absTol eps)
+    assert(metrics.recallAt(2) ~== 8.0 / 45 absTol eps)
+    assert(metrics.recallAt(3) ~== 11.0 / 45 absTol eps)
+    assert(metrics.recallAt(4) ~== 11.0 / 45 absTol eps)
+    assert(metrics.recallAt(5) ~== 16.0 / 45 absTol eps)
+    assert(metrics.recallAt(10) ~== 2.0 / 3 absTol eps)
+    assert(metrics.recallAt(15) ~== 2.0 / 3 absTol eps)
+  }
+
   test("MAP, NDCG, Recall with few predictions (SPARK-14886)") {
     val predictionAndLabels = sc.parallelize(
       Seq(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
- To add relevance score to evaluate nDCG in the function `ndcgAt`.
- To extend the interface of constructor of `RankingMetrics` class.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
- The precise definition of nDCG is [here on Wikipedia](https://en.wikipedia.org/wiki/Discounted_cumulative_gain), where relevance score is used. Currently, the implementation of nDCG on spark (MLlib) treats this as binary (0 or 1). This PR is to extend the `ndcgAt` function to be able to treat relevance score.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
- I extended the interface of `RankingMetrics` class for `ndcgAt` function, so now it accepts `RDD[(Array[T], Array[T], Array[Double])]` or `RDD[(Array[T], Array[T])])` as the constructor arguments while the `RDD[(Array[T], Array[T])])` was only accepted.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
- One test was added in [mllib/src/test/scala/org/apache/spark/mllib/evaluation/RankingMetricsSuite.scala](https://github.com/apache/spark/pull/36843/files#diff-b85de09fb1428c03471c7c46305ebb9171964e9743d3ac5f4cd9bcb14bdcf6fd)
 <!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->