### PR TITLE
[SPARK-39449][SQL] Propagate empty relation through Window

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -158,6 +158,7 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
       // Generators like Hive-style UDTF may return their records within `close`.
       case Generate(_: Explode, _, _, _, _, _) => empty(p)
       case Expand(_, _, _) => empty(p)
+      case _: Window => empty(p)
       case _ => p
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for propagating empty relation through `Window` if its child is empty. For example:
```sql
SELECT id,
       Count(*)
         OVER (
           ORDER BY id)
FROM   (SELECT /*+ REPARTITION(3) */ *
        FROM   Range(100)
        WHERE  id < 0) t 
```

After this PR:
```
== Physical Plan ==
AdaptiveSparkPlan (10)
+- == Final Plan ==
   LocalTableScan (1)
+- == Initial Plan ==
   CollectLimit (9)
   +- Project (8)
      +- Window (7)
         +- Sort (6)
            +- Exchange (5)
               +- Exchange (4)
                  +- Filter (3)
                     +- Range (2)
```

### Why are the changes needed?

Improve query performance.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.