### PR TITLE
[SPARK-39535][SQL] Make `SchemaPruning` only pruning if it contains nested column

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SchemaPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SchemaPruning.scala
@@ -40,7 +40,8 @@ object SchemaPruning extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan =
     plan transformDown {
       case op @ PhysicalOperation(projects, filters,
-      l @ LogicalRelation(hadoopFsRelation: HadoopFsRelation, _, _, _)) =>
+      l @ LogicalRelation(hadoopFsRelation: HadoopFsRelation, _, _, _))
+          if canPruneDataSchema(hadoopFsRelation) =>
         prunePhysicalColumns(l, projects, filters, hadoopFsRelation,
           (prunedDataSchema, prunedMetadataSchema) => {
             val prunedHadoopRelation =
@@ -69,13 +70,7 @@ object SchemaPruning extends Rule[LogicalPlan] {
     // If requestedRootFields includes a nested field, continue. Otherwise,
     // return op
     if (requestedRootFields.exists { root: RootField => !root.derivedFromAtt }) {
-
-      val prunedDataSchema = if (canPruneDataSchema(hadoopFsRelation)) {
-        pruneSchema(hadoopFsRelation.dataSchema, requestedRootFields)
-      } else {
-        hadoopFsRelation.dataSchema
-      }
-
+      val prunedDataSchema = pruneSchema(hadoopFsRelation.dataSchema, requestedRootFields)
       val metadataSchema =
         relation.output.collect { case FileSourceMetadataAttribute(attr) => attr }.toStructType
       val prunedMetadataSchema = if (metadataSchema.nonEmpty) {
@@ -109,7 +104,11 @@ object SchemaPruning extends Rule[LogicalPlan] {
   private def canPruneDataSchema(fsRelation: HadoopFsRelation): Boolean =
     conf.nestedSchemaPruningEnabled && (
       fsRelation.fileFormat.isInstanceOf[ParquetFileFormat] ||
-        fsRelation.fileFormat.isInstanceOf[OrcFileFormat])
+        fsRelation.fileFormat.isInstanceOf[OrcFileFormat]) &&
+      fsRelation.schema.exists { _.dataType match {
+        case _: StructType | _: ArrayType |  _: MapType => true
+        case _ => false
+      }}
 
   /**
    * Normalizes the names of the attribute references in the given projects and filters to reflect


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `SchemaPruning` only pruning when `HadoopFsRelation`'s schema contains nested column.

### Why are the changes needed?

Speed up `SchemaPruning`.

`build/sbt "sql/testOnly *TPCDSQuerySuite"` result:

Before this PR:
```
org.apache.spark.sql.execution.datasources.SchemaPruning                              0 / 195986910                                   0 / 312
```

After this PR:
```
org.apache.spark.sql.execution.datasources.SchemaPruning                              0 / 44711956                                    0 / 312
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Benchmark test.