### PR TITLE
[SPARK-39460][CORE][TESTS] Fix `CoarseGrainedSchedulerBackendSuite` to handle fast allocations

### DIFF
--- a/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/CoarseGrainedSchedulerBackendSuite.scala
@@ -287,7 +287,7 @@ class CoarseGrainedSchedulerBackendSuite extends SparkFunSuite with LocalSparkCo
         "Exec allocation and request times don't make sense")
       assert(info.requestTime.get > testStartTime,
         "Exec allocation and request times don't make sense")
-      assert(info.registrationTime.get > info.requestTime.get,
+      assert(info.registrationTime.get >= info.requestTime.get,
         "Exec allocation and request times don't make sense")
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `CoarseGrainedSchedulerBackendSuite` to handle fast executor allocations.

### Why are the changes needed?

Currently, it fails when the executor allocation time is the same with the request time.
```
CoarseGrainedSchedulerBackendSuite:
...
- extra resources from executor *** FAILED ***
  1655156664041 was not greater than 1655156664041 Exec allocation and request times don't make sense (CoarseGrainedSchedulerBackendSuite.scala:290)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.