### PR TITLE
[SPARK-39461][INFRA] Print `SPARK_LOCAL_(HOSTNAME|IP)` in `build/(mvn|sbt)`

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -180,6 +180,13 @@ export MAVEN_OPTS=${MAVEN_OPTS:-"$_COMPILE_JVM_OPTS"}
 
 echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
 
+if [ ! -z "${SPARK_LOCAL_HOSTNAME}" ]; then
+  echo "Using SPARK_LOCAL_HOSTNAME=$SPARK_LOCAL_HOSTNAME" 1>&2
+fi
+if [ ! -z "${SPARK_LOCAL_IP}" ]; then
+  echo "Using SPARK_LOCAL_IP=$SPARK_LOCAL_IP" 1>&2
+fi
+
 # call the `mvn` command as usual
 # SPARK-25854
 "${MVN_BIN}" "$@"

--- a/build/sbt
+++ b/build/sbt
@@ -133,6 +133,13 @@ saveSttySettings() {
   fi
 }
 
+if [ ! -z "${SPARK_LOCAL_HOSTNAME}" ]; then
+  echo "Using SPARK_LOCAL_HOSTNAME=$SPARK_LOCAL_HOSTNAME" 1>&2
+fi
+if [ ! -z "${SPARK_LOCAL_IP}" ]; then
+  echo "Using SPARK_LOCAL_IP=$SPARK_LOCAL_IP" 1>&2
+fi
+
 saveSttySettings
 trap onExit INT
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to print `SPARK_LOCAL_(HOSTNAME|IP)` during building and testing at `build/{mvn|sbt}` if they are provided by the users.

### Why are the changes needed?

`SPARK_LOCAL_HOSTNAME` and `SPARK_LOCAL_IP` are used during testing and the test result depends on them.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and check GitHub Action logs.