### PR TITLE
[SPARK-39463][CORE][TESTS] Use `UUID` for test database location in `JavaJdbcRDDSuite`

### DIFF
--- a/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
+++ b/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
@@ -22,6 +22,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.UUID;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -32,6 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class JavaJdbcRDDSuite implements Serializable {
+  private String dbName = UUID.randomUUID().toString();
   private transient JavaSparkContext sc;
 
   @Before
@@ -41,7 +43,7 @@ public class JavaJdbcRDDSuite implements Serializable {
     Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
 
     try (Connection connection = DriverManager.getConnection(
-        "jdbc:derby:target/JavaJdbcRDDSuiteDb;create=true")) {
+        "jdbc:derby:target/" + dbName + ";create=true")) {
 
       try (Statement create = connection.createStatement()) {
         create.execute(
@@ -67,7 +69,7 @@ public class JavaJdbcRDDSuite implements Serializable {
   @After
   public void tearDown() throws SQLException {
     try {
-      DriverManager.getConnection("jdbc:derby:target/JavaJdbcRDDSuiteDb;shutdown=true");
+      DriverManager.getConnection("jdbc:derby:target/" + dbName + ";shutdown=true");
     } catch(SQLException e) {
       // Throw if not normal single database shutdown
       // https://db.apache.org/derby/docs/10.2/ref/rrefexcept71493.html
@@ -84,7 +86,7 @@ public class JavaJdbcRDDSuite implements Serializable {
   public void testJavaJdbcRDD() throws Exception {
     JavaRDD<Integer> rdd = JdbcRDD.create(
       sc,
-      () -> DriverManager.getConnection("jdbc:derby:target/JavaJdbcRDDSuiteDb"),
+      () -> DriverManager.getConnection("jdbc:derby:target/" + dbName),
       "SELECT DATA FROM FOO WHERE ? <= ID AND ID <= ?",
       1, 100, 1,
       r -> r.getInt(1)

--- a/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
+++ b/core/src/test/java/org/apache/spark/JavaJdbcRDDSuite.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class JavaJdbcRDDSuite implements Serializable {
-  private String dbName = UUID.randomUUID().toString();
+  private String dbName = "db_" + UUID.randomUUID().toString().replace('-', '_');
   private transient JavaSparkContext sc;
 
   @Before


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use UUID instead of a fixed test database location in `JavaJdbcRDDSuite`.

### Why are the changes needed?

Although there exists a clean-up logic in `JavaJdbcRDDSuite`, the location is not removed cleanly when the tests are interrupted. After this PR, we can avoid the conflicts due to the leftover.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.