### PR TITLE
[SPARK-39472][SQL][TEST] Refactor InMemoryTableCatalog classes hierarchy

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/CatalogSuite.scala
@@ -40,8 +40,8 @@ class CatalogSuite extends SparkFunSuite {
       .add("id", IntegerType)
       .add("data", StringType)
 
-  private def newCatalog(): InMemoryCatalog = {
-    val newCatalog = new InMemoryCatalog
+  private def newCatalog(): InMemoryFunctionCatalog = {
+    val newCatalog = new InMemoryFunctionCatalog
     newCatalog.initialize("test", CaseInsensitiveStringMap.empty())
     newCatalog
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryFunctionCatalog.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryFunctionCatalog.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.catalyst.analysis.{NoSuchFunctionException, NoSuchNamespaceException}
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
 
-class InMemoryCatalog extends InMemoryTableCatalog with FunctionCatalog {
+class InMemoryFunctionCatalog extends InMemoryTableCatalog with FunctionCatalog {
   protected val functions: util.Map[Identifier, UnboundFunction] =
     new ConcurrentHashMap[Identifier, UnboundFunction]()
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2FunctionSuite.scala
@@ -28,8 +28,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode.{FALLBACK, NO_CODEGEN}
-import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, Identifier, InMemoryCatalog, SupportsNamespaces}
-import org.apache.spark.sql.connector.catalog.functions.{AggregateFunction, _}
+import org.apache.spark.sql.connector.catalog.{BasicInMemoryTableCatalog, Identifier, InMemoryFunctionCatalog, SupportsNamespaces}
+import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -117,7 +117,7 @@ class DataSourceV2FunctionSuite extends DatasourceV2SQLBase {
   private val emptyProps: java.util.Map[String, String] = Collections.emptyMap[String, String]
 
   private def addFunction(ident: Identifier, fn: UnboundFunction): Unit = {
-    catalog("testcat").asInstanceOf[InMemoryCatalog].createFunction(ident, fn)
+    catalog("testcat").asInstanceOf[InMemoryFunctionCatalog].createFunction(ident, fn)
   }
 
   test("undefined function") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DatasourceV2SQLBase.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.connector
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.connector.catalog.{CatalogPlugin, InMemoryCatalog, InMemoryPartitionTableCatalog, StagingInMemoryTableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, InMemoryFunctionCatalog, InMemoryPartitionTableCatalog, StagingInMemoryTableCatalog}
 import org.apache.spark.sql.internal.SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -32,11 +32,11 @@ trait DatasourceV2SQLBase
   }
 
   before {
-    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryCatalog].getName)
+    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryFunctionCatalog].getName)
     spark.conf.set("spark.sql.catalog.testpart", classOf[InMemoryPartitionTableCatalog].getName)
     spark.conf.set(
       "spark.sql.catalog.testcat_atomic", classOf[StagingInMemoryTableCatalog].getName)
-    spark.conf.set("spark.sql.catalog.testcat2", classOf[InMemoryCatalog].getName)
+    spark.conf.set("spark.sql.catalog.testcat2", classOf[InMemoryFunctionCatalog].getName)
     spark.conf.set(
       V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[InMemoryTableSessionCatalog].getName)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DistributionAndOrderingSuiteBase.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.physical
 import org.apache.spark.sql.catalyst.plans.physical._
-import org.apache.spark.sql.connector.catalog.InMemoryCatalog
+import org.apache.spark.sql.connector.catalog.InMemoryFunctionCatalog
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -36,7 +36,7 @@ abstract class DistributionAndOrderingSuiteBase
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryCatalog].getName)
+    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryFunctionCatalog].getName)
   }
 
   override def afterAll(): Unit = {
@@ -96,8 +96,8 @@ abstract class DistributionAndOrderingSuiteBase
     UnresolvedAttribute(name)
   }
 
-  protected def catalog: InMemoryCatalog = {
+  protected def catalog: InMemoryFunctionCatalog = {
     val catalog = spark.sessionState.catalogManager.catalog("testcat")
-    catalog.asTableCatalog.asInstanceOf[InMemoryCatalog]
+    catalog.asTableCatalog.asInstanceOf[InMemoryFunctionCatalog]
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/functions/V2FunctionBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/functions/V2FunctionBenchmark.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{BinaryArithmetic, Expression}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode._
 import org.apache.spark.sql.catalyst.util.TypeUtils
-import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryCatalog}
+import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryFunctionCatalog}
 import org.apache.spark.sql.connector.catalog.functions.{BoundFunction, ScalarFunction, UnboundFunction}
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.internal.SQLConf
@@ -64,7 +64,7 @@ object V2FunctionBenchmark extends SqlBasedBenchmark {
       N: Long,
       codegenEnabled: Boolean,
       resultNullable: Boolean): Unit = {
-    withSQLConf(s"spark.sql.catalog.$catalogName" -> classOf[InMemoryCatalog].getName) {
+    withSQLConf(s"spark.sql.catalog.$catalogName" -> classOf[InMemoryFunctionCatalog].getName) {
       createFunction("java_long_add_default",
         new JavaLongAdd(new JavaLongAddDefault(resultNullable)))
       createFunction("java_long_add_magic", new JavaLongAdd(new JavaLongAddMagic(resultNullable)))
@@ -97,7 +97,7 @@ object V2FunctionBenchmark extends SqlBasedBenchmark {
   private def createFunction(name: String, fn: UnboundFunction): Unit = {
     val catalog = spark.sessionState.catalogManager.catalog(catalogName)
     val ident = Identifier.of(Array.empty, name)
-    catalog.asInstanceOf[InMemoryCatalog].createFunction(ident, fn)
+    catalog.asInstanceOf[InMemoryFunctionCatalog].createFunction(ident, fn)
   }
 
   case class NativeAdd(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewTestSuite.scala
@@ -21,6 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.catalog.CatalogFunction
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.Repartition
@@ -489,7 +490,7 @@ class GlobalTempViewTestSuite extends TempViewTestSuite with SharedSparkSession 
   }
 }
 
-class OneTableCatalog extends InMemoryCatalog {
+class OneTableCatalog extends BasicInMemoryTableCatalog {
   override def loadTable(ident: Identifier): Table = {
     if (ident.namespace.isEmpty && ident.name == "t") {
       new InMemoryTable(
@@ -498,7 +499,7 @@ class OneTableCatalog extends InMemoryCatalog {
         Array.empty,
         Map.empty[String, String].asJava)
     } else {
-      super.loadTable(ident)
+      throw new NoSuchTableException(ident)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.connector.FakeV2Provider
-import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryCatalog}
+import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryFunctionCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.CatalogHelper
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
@@ -120,7 +120,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   before {
-    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryCatalog].getName)
+    spark.conf.set("spark.sql.catalog.testcat", classOf[InMemoryFunctionCatalog].getName)
   }
 
   after {
@@ -672,7 +672,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   test("list tables when there is `default` catalog") {
-    spark.conf.set("spark.sql.catalog.default", classOf[InMemoryCatalog].getName)
+    spark.conf.set("spark.sql.catalog.default", classOf[InMemoryFunctionCatalog].getName)
 
     assert(spark.catalog.listTables("default").collect().isEmpty)
     createTable("my_table1")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR proposes to change the test classes `*InMemoryTableCatalog` hierarchy and unify the class name style.

In detail, this PR renames `InMemoryCatalog` to `InMemoryFunctionCatalog` to unify the name style, changes `OneTableCatalog` from extends `InMemoryCatalog` to `BasicInMemoryTableCatalog` to minimize the functionality.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

before
```
BasicInMemoryTableCatalog (org.apache.spark.sql.connector.catalog)
  - InMemoryTableCatalog (org.apache.spark.sql.connector.catalog)
    - StagingInMemoryTableCatalog (org.apache.spark.sql.connector.catalog)
    - InMemoryPartitionTableCatalog (org.apache.spark.sql.connector.catalog)
    - InMemoryCatalog (org.apache.spark.sql.connector.catalog)
      - OneTableCatalog (org.apache.spark.sql.execution)
    - InMemoryStreamTableCatalog (org.apache.spark.sql.streaming.test)
    - InMemoryRowLevelOperationTableCatalog (org.apache.spark.sql.connector.catalog)
    - <anonymous> in getAnalyzer() in TableLookupCacheSuite (org.apache.spark.sql.catalyst.analysis)
  - TestLocalScanCatalog (org.apache.spark.sql.connector)
  - V1ReadFallbackCatalog (org.apache.spark.sql.connector)
```

after
```
BasicInMemoryTableCatalog (org.apache.spark.sql.connector.catalog)
  - InMemoryTableCatalog (org.apache.spark.sql.connector.catalog)
    - StagingInMemoryTableCatalog (org.apache.spark.sql.connector.catalog)
    - InMemoryPartitionTableCatalog (org.apache.spark.sql.connector.catalog)
    - InMemoryFunctionCatalog (org.apache.spark.sql.connector.catalog)
    - InMemoryStreamTableCatalog (org.apache.spark.sql.streaming.test)
    - InMemoryRowLevelOperationTableCatalog (org.apache.spark.sql.connector.catalog)
    - <anonymous> in getAnalyzer() in TableLookupCacheSuite (org.apache.spark.sql.catalyst.analysis)
  - TestLocalScanCatalog (org.apache.spark.sql.connector)
  - OneTableCatalog (org.apache.spark.sql.execution)
  - V1ReadFallbackCatalog (org.apache.spark.sql.connector)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT.