### PR TITLE
[SPARK-39483][PYTHON] Construct the schema from `np.dtype` when `createDataFrame` from a NumPy array

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -50,6 +50,7 @@ from pyspark.sql.streaming import DataStreamReader
 from pyspark.sql.types import (
     AtomicType,
     DataType,
+    StructField,
     StructType,
     _make_type_verifier,
     _infer_schema,
@@ -981,11 +982,9 @@ class SparkSession(SparkConversionMixin):
                 # TODO: Apply the logic below when self._jconf.arrowPySparkEnabled() is True
                 spark_type = _from_numpy_type(data.dtype)
                 if spark_type is not None:
-
-                    struct = StructType()
-                    for name in column_names:
-                        struct.add(name, spark_type, nullable=True)
-                    schema = struct
+                    schema = StructType(
+                        [StructField(name, spark_type, nullable=True) for name in column_names]
+                    )
 
             data = pd.DataFrame(data, columns=column_names)
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -57,6 +57,7 @@ from pyspark.sql.types import (
     _merge_type,
     _create_converter,
     _parse_datatype_string,
+    _from_numpy_type,
 )
 from pyspark.sql.utils import install_exception_handler, is_timestamp_ntz_preferred
 
@@ -975,6 +976,15 @@ class SparkSession(SparkConversionMixin):
             if data.ndim not in [1, 2]:
                 raise ValueError("NumPy array input should be of 1 or 2 dimensions.")
             column_names = ["value"] if data.ndim == 1 else ["_1", "_2"]
+            if schema is None and not self._jconf.arrowPySparkEnabled():
+                spark_type = _from_numpy_type(data.dtype)
+                if spark_type is not None:
+
+                    struct = StructType()
+                    for name in column_names:
+                        struct.add(name, spark_type, nullable=True)
+                    schema = struct
+
             data = pd.DataFrame(data, columns=column_names)
 
         if has_pandas and isinstance(data, pd.DataFrame):

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -977,6 +977,8 @@ class SparkSession(SparkConversionMixin):
                 raise ValueError("NumPy array input should be of 1 or 2 dimensions.")
             column_names = ["value"] if data.ndim == 1 else ["_1", "_2"]
             if schema is None and not self._jconf.arrowPySparkEnabled():
+                # Construct `schema` from `np.dtype` of the input NumPy array
+                # TODO: Apply the logic below when self._jconf.arrowPySparkEnabled() is True
                 spark_type = _from_numpy_type(data.dtype)
                 if spark_type is not None:
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -184,9 +184,17 @@ class ArrowTests(ReusedSQLTestCase):
     @property
     def create_np_arrs(self):
         return [
+            np.array([1, 2]).astype("int8"),
+            np.array([1, 2]).astype("int16"),
+            np.array([1, 2]).astype("int32"),
             np.array([1, 2]),  # dtype('int64')
+            np.array([0.1, 0.2]).astype("float32"),
             np.array([0.1, 0.2]),  # dtype('float64')
+            np.array([[1, 2], [3, 4]]).astype("int8"),
+            np.array([[1, 2], [3, 4]]).astype("int16"),
+            np.array([[1, 2], [3, 4]]).astype("int32"),
             np.array([[1, 2], [3, 4]]),  # dtype('int64')
+            np.array([[0.1, 0.2], [0.3, 0.4]]).astype("float32"),
             np.array([[0.1, 0.2], [0.3, 0.4]]),  # dtype('float64')
         ]
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -183,20 +183,14 @@ class ArrowTests(ReusedSQLTestCase):
 
     @property
     def create_np_arrs(self):
-        return [
-            np.array([1, 2]).astype("int8"),
-            np.array([1, 2]).astype("int16"),
-            np.array([1, 2]).astype("int32"),
-            np.array([1, 2]),  # dtype('int64')
-            np.array([0.1, 0.2]).astype("float32"),
-            np.array([0.1, 0.2]),  # dtype('float64')
-            np.array([[1, 2], [3, 4]]).astype("int8"),
-            np.array([[1, 2], [3, 4]]).astype("int16"),
-            np.array([[1, 2], [3, 4]]).astype("int32"),
-            np.array([[1, 2], [3, 4]]),  # dtype('int64')
-            np.array([[0.1, 0.2], [0.3, 0.4]]).astype("float32"),
-            np.array([[0.1, 0.2], [0.3, 0.4]]),  # dtype('float64')
-        ]
+        int_dtypes = ["int8", "int16", "int32", "int64"]
+        float_dtypes = ["float32", "float64"]
+        return (
+            [np.array([1, 2]).astype(t) for t in int_dtypes]
+            + [np.array([0.1, 0.2]).astype(t) for t in float_dtypes]
+            + [np.array([[1, 2], [3, 4]]).astype(t) for t in int_dtypes]
+            + [np.array([[0.1, 0.2], [0.3, 0.4]]).astype(t) for t in float_dtypes]
+        )
 
     def test_toPandas_fallback_enabled(self):
         ts = datetime.datetime(2015, 11, 1, 0, 30)
@@ -515,19 +509,17 @@ class ArrowTests(ReusedSQLTestCase):
         self.assertEqual(self.schema, schema_rt)
 
     def test_createDataFrame_with_ndarray(self):
-        arrs = self.create_np_arrs
-        collected_dtypes = [
-            ([Row(value=1), Row(value=2)], [("value", "bigint")]),
-            ([Row(value=0.1), Row(value=0.2)], [("value", "double")]),
-            ([Row(_1=1, _2=2), Row(_1=3, _2=4)], [("_1", "bigint"), ("_2", "bigint")]),
-            ([Row(_1=0.1, _2=0.2), Row(_1=0.3, _2=0.4)], [("_1", "double"), ("_2", "double")]),
+        dtypes = ["tinyint", "smallint", "int", "bigint", "float", "double"]
+        expected_dtypes = [[("value", t)] for t in dtypes] + [
+            [("_1", t), ("_2", t)] for t in dtypes
         ]
-        for arr, [collected, dtypes] in zip(arrs, collected_dtypes):
+        arrs = self.create_np_arrs
+
+        for arr, dtypes in zip(arrs, expected_dtypes):
             df, df_arrow = self._createDataFrame_toggle(arr)
-            self.assertEqual(df.dtypes, dtypes)
+            self.assertEqual(df.dtypes, df_arrow.dtypes)
             self.assertEqual(df_arrow.dtypes, dtypes)
-            self.assertEqual(df.collect(), collected)
-            self.assertEqual(df_arrow.collect(), collected)
+            self.assertEqual(df.collect(), df_arrow.collect())
 
         with self.assertRaisesRegex(ValueError, "NumPy array input should be of 1 or 2 dimensions"):
             self.spark.createDataFrame(np.array(0))

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1218,9 +1218,7 @@ if sys.version_info[0] < 4:
     _array_type_mappings["u"] = StringType
 
 
-def _from_numpy_type(
-    nt: "np.dtype",
-) -> DataType:
+def _from_numpy_type(nt: "np.dtype") -> Optional[DataType]:
     """Convert NumPy type to Spark data type."""
     import numpy as np
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -42,6 +42,7 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
+    TYPE_CHECKING,
 )
 
 from py4j.protocol import register_input_converter
@@ -74,6 +75,10 @@ __all__ = [
     "StructField",
     "StructType",
 ]
+
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class DataType:
@@ -1211,6 +1216,29 @@ for _typecode in _array_unsigned_int_typecode_ctype_mappings.keys():
 # removed in version 4.0. See: https://docs.python.org/3/library/array.html
 if sys.version_info[0] < 4:
     _array_type_mappings["u"] = StringType
+
+
+def _from_numpy_type(
+    nt: "np.dtype",
+) -> DataType:
+    """Convert NumPy type to Spark data type."""
+    import numpy as np
+
+    spark_type: DataType = None
+    if nt == np.dtype("int8"):
+        spark_type = ByteType()
+    elif nt == np.dtype("int16"):
+        spark_type = ShortType()
+    elif nt == np.dtype("int32"):
+        spark_type = IntegerType()
+    elif nt == np.dtype("int64"):
+        spark_type = LongType()
+    elif nt == np.dtype("float32"):
+        spark_type = FloatType()
+    elif nt == np.dtype("float64"):
+        spark_type = DecimalType(38, 18)
+
+    return spark_type
 
 
 def _infer_type(

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1224,21 +1224,20 @@ def _from_numpy_type(
     """Convert NumPy type to Spark data type."""
     import numpy as np
 
-    spark_type: DataType = None
     if nt == np.dtype("int8"):
-        spark_type = ByteType()
+        return ByteType()
     elif nt == np.dtype("int16"):
-        spark_type = ShortType()
+        return ShortType()
     elif nt == np.dtype("int32"):
-        spark_type = IntegerType()
+        return IntegerType()
     elif nt == np.dtype("int64"):
-        spark_type = LongType()
+        return LongType()
     elif nt == np.dtype("float32"):
-        spark_type = FloatType()
+        return FloatType()
     elif nt == np.dtype("float64"):
-        spark_type = DoubleType()
+        return DoubleType()
 
-    return spark_type
+    return None
 
 
 def _infer_type(

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1236,7 +1236,7 @@ def _from_numpy_type(
     elif nt == np.dtype("float32"):
         spark_type = FloatType()
     elif nt == np.dtype("float64"):
-        spark_type = DecimalType(38, 18)
+        spark_type = DoubleType()
 
     return spark_type
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Construct the schema from `np.dtype` when `createDataFrame` from a NumPy array, when Arrow execution is diabled, that is, the Spark config `spark.sql.execution.arrow.pyspark.enabled` is `false`.

In addition, NumPy arrays of `"int8", "int16", "int32", "float32"` dtypes are supported in this PR. 

Non-goals:
- More NumPy dtypes should be supported in follow-up PRs. 
- To enable pandas DataFrame to accept `"int8", "int16", "int32", "float32"` dtypes will be a follow-up PR, since it may be considered a breaking change.

### Why are the changes needed?
As part of [SPARK-39405](https://issues.apache.org/jira/browse/SPARK-39405) for NumPy support in SQL.

When Arrow execution is disabled, `createDataFrame` from a NumPy array only accepts numeric dtypes `int64` and `float64`.

We may resolve the issue by
- convert numeric dtypes of the input NumPy array to respective Spark types
- construct the schema accordingly

That approach also saves us from inferring the schema.

**Note:** 
When Arrow execution is enabled, conversion from NumPy dtypes to Spark types is implemented already [here](https://github.com/apache/spark/blob/master/python/pyspark/sql/pandas/types.py), that works as below:
<img width="882" alt="image" src="https://user-images.githubusercontent.com/47337188/173945957-3bc88a1f-8ce9-4200-b210-4ab986cba6f6.png">

This PR avoids touching that code path, instead, expecting results when Arrow execution is disabled to be the same as those when Arrow execution is enabled.

### Does this PR introduce _any_ user-facing change?
Yes. Now users can `createDataFrame` from NumPy arrays of `"int8", "int16", "int32", "float32"` dtypes.

### How was this patch tested?
Unit tests.