### PR TITLE
[SPARK-36252][CORE]: Add log files rolling policy for driver running in cluster mode with spark standalone cluster

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/DriverRunner.scala
@@ -38,8 +38,8 @@ import org.apache.spark.internal.config.Worker.WORKER_DRIVER_TERMINATE_TIMEOUT
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.rpc.RpcEndpointRef
 import org.apache.spark.ui.UIUtils
-import org.apache.spark.util.logging.FileAppender
 import org.apache.spark.util.{Clock, ShutdownHookManager, SystemClock, Utils}
+import org.apache.spark.util.logging.FileAppender
 
 /**
  * Manages the execution of one driver, including automatically restarting the driver on failure.


### PR DESCRIPTION
In this PR, the DriverRunner has been enhanced to use the same rolling policy as ExecutorRunner.
There are two opions for this enhancement:
1. use the same configuration as executor
2. create a new set of configuration prefixed by spark.driver.logs.rolling
To minimize the configurations and, the PR chooses 1. 

### What changes were proposed in this pull request?
The DriverRunner will now use the following configuration to roll the stdout and stderr logs
```
spark.executor.logs.rolling.maxRetainedFiles
spark.executor.logs.rolling.enableCompression
spark.executor.logs.rolling.maxSize
spark.executor.logs.rolling.strategy
spark.executor.logs.rolling.time.interval
```

### Why are the changes needed?
The log file (stdout/stderr) of driver in cluster mode on Spark standalone cluster will never get cleaned and will use all the disk space


### Does this PR introduce _any_ user-facing change?
If user doesn't set "spark.executor.logs.rolling.*" on spark worker, there is no impaction, if user did specify those settings, then the driver's stdout/stderr will be rolling, user may not see the full log as before.


### How was this patch tested?
Hard to add unit test since we need a complete application
