### PR TITLE
[SPARK-39482][DOCS] Add build and test documentation on IPv6

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -303,3 +303,17 @@ If use an individual repository or a repository on GitHub Enterprise, export bel
   </td>
 </tr>
 </table>
+
+### Building and testing on IPv6-only environment
+
+Use Apache Spark GitBox URL because GitHub doesn't support IPv6 yet.
+
+    https://gitbox.apache.org/repos/asf/spark.git
+
+To build and run tests on IPv6-only environment, the following configurations are required.
+
+    export SPARK_LOCAL_HOSTNAME="your-IPv6-address" # e.g. '[2600:1700:232e:3de0:...]'
+    export DEFAULT_ARTIFACT_REPOSITORY=https://ipv6.repo1.maven.org/maven2/
+    export MAVEN_OPTS="-Djava.net.preferIPv6Addresses=true"
+    export SBT_OPTS="-Djava.net.preferIPv6Addresses=true"
+    export SERIAL_SBT_TESTS=1


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a documentation about building and testing on IPv6 environment.

### Why are the changes needed?

Without building and testing, we cannot move forward.
This will help us achieve our goal to support IPv6-only environment.

### Does this PR introduce _any_ user-facing change?

No. This is a doc-only.

### How was this patch tested?

Manually review.