### PR TITLE
[SPARK-39484][SQL] Fix field name case sensitivity for struct type in V2WriteCommand.outputResolved

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -53,7 +53,7 @@ trait V2WriteCommand extends UnaryCommand {
           val outType = CharVarcharUtils.getRawType(outAttr.metadata).getOrElse(outAttr.dataType)
           // names and types must match, nullability must be compatible
           inAttr.name == outAttr.name &&
-            DataType.equalsIgnoreCompatibleNullability(inAttr.dataType, outType) &&
+            DataType.equalsIgnoreCompatibleNullability(inAttr.dataType, outType, conf.resolver) &&
             (outAttr.nullable || !inAttr.nullable)
       })
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

When a V2 write uses an input with a struct type which contains differences in the casing of field names, the `caseSensitive` config is not being honored, always doing a strict case sensitive comparison.
 
This PR adds the resolver to the private method `DataType#equalsIgnoreCompatibleNullabilityWithNameResolution`, renamed from `DataType#equalsIgnoreCompatibleNullability` and uses that resolver to perform the field name comparison. The `config.resolver` is passed in the invocation via `V2WriteCommand.outputResolved`.

### Why are the changes needed?
I think the same case sensitivity configuration should be honored for field names, therefore this would be a bug.

Repro:
```
CREATE TABLE tmp.test_table_to (key int, object struct<shardId:int>) USING ICEBERG;
CREATE TABLE tmp.test_table_from (key int, object struct<shardid:int>) USING HIVE;
INSERT OVERWRITE tmp.test_table_to SELECT 1 as key, object FROM tmp.test_table_from;
```

The above results in Exception:
```
Error in query: unresolved operator 'OverwriteByExpression RelationV2[key#3, object#4] spark_catalog.tmp.test_table_to, true, false;
'OverwriteByExpression RelationV2[key#3, object#4] spark_catalog.tmp.test_table_to, true, false
+- Project [1 AS key#0, object#2]
   +- SubqueryAlias spark_catalog.tmp.test_table_from
      +- HiveTableRelation [`tmp`.`test_table_from`, org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe, Data Cols: [key#1, object#2], Partition Cols: []]
```

### Does this PR introduce _any_ user-facing change?
Yes, previously failing v2 write queries with mismatching casing in struct field names, now would respect the `caseSensitive` config, and if `caseSensitive = false` these queries would now work, as compared to before when they would always fail regardless of the `caseSensitive` config value.


### How was this patch tested?

- Added unit test
- Tested manually in distribution