### PR TITLE
[SPARK-39468][CORE][FOLLOWUP] Use `lazy val` for `host`

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcAddress.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcAddress.scala
@@ -25,7 +25,7 @@ import org.apache.spark.util.Utils
  */
 private[spark] case class RpcAddress(_host: String, port: Int) {
 
-  val host: String = Utils.addBracketsIfNeeded(_host)
+  lazy val host: String = Utils.addBracketsIfNeeded(_host)
 
   def hostPort: String = host + ":" + port
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `lazy val host` instead of `val host`.

### Why are the changes needed?

To address the review comments about `RpcAddress` object size.
- https://github.com/apache/spark/pull/36868#discussion_r898235985
- https://github.com/apache/spark/pull/36868#discussion_r898332785

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.