### PR TITLE
[SPARK-39490][K8S] Support `ipFamilyPolicy` and `ipFamilies` in Driver Service

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/Config.scala
@@ -63,6 +63,22 @@ private[spark] object Config extends Logging {
       .booleanConf
       .createWithDefault(true)
 
+  val KUBERNETES_DRIVER_SERVICE_IP_FAMILY_POLICY =
+    ConfigBuilder("spark.kubernetes.driver.service.ipFamilyPolicy")
+      .doc("K8s IP Family Policy for Driver Service")
+      .version("3.4.0")
+      .stringConf
+      .checkValues(Set("SingleStack", "PreferDualStack", "RequireDualStack"))
+      .createWithDefault("SingleStack")
+
+  val KUBERNETES_DRIVER_SERVICE_IP_FAMILIES =
+    ConfigBuilder("spark.kubernetes.driver.service.ipFamilies")
+      .doc("A list of IP families for K8s Driver Service")
+      .version("3.4.0")
+      .stringConf
+      .checkValues(Set("IPv4", "IPv6", "IPv4,IPv6", "IPv6,IPv4"))
+      .createWithDefault("IPv4")
+
   val KUBERNETES_DRIVER_OWN_PVC =
     ConfigBuilder("spark.kubernetes.driver.ownPersistentVolumeClaim")
       .doc("If true, driver pod becomes the owner of on-demand persistent volume claims " +

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
@@ -160,6 +160,66 @@ class DriverServiceFeatureStepSuite extends SparkFunSuite {
       " a Kubernetes service.")
   }
 
+  test("Support ipFamilies spec with default SingleStack and IPv4") {
+    val sparkConf = new SparkConf(false)
+    val kconf = KubernetesTestConf.createDriverConf(
+      sparkConf = sparkConf,
+      labels = DRIVER_LABELS,
+      serviceAnnotations = DRIVER_SERVICE_ANNOTATIONS)
+    val configurationStep = new DriverServiceFeatureStep(kconf)
+    assert(configurationStep.configurePod(SparkPod.initialPod()) === SparkPod.initialPod())
+    val driverService = configurationStep
+      .getAdditionalKubernetesResources()
+      .head
+      .asInstanceOf[Service]
+    assert(driverService.getSpec.getIpFamilyPolicy() == "SingleStack")
+    assert(driverService.getSpec.getIpFamilies.size() === 1)
+    assert(driverService.getSpec.getIpFamilies.get(0) == "IPv4")
+  }
+
+  test("Support ipFamilies spec with SingleStack and IPv6") {
+    val sparkConf = new SparkConf(false)
+      .set(KUBERNETES_DRIVER_SERVICE_IP_FAMILIES, "IPv6")
+    val kconf = KubernetesTestConf.createDriverConf(
+      sparkConf = sparkConf,
+      labels = DRIVER_LABELS,
+      serviceAnnotations = DRIVER_SERVICE_ANNOTATIONS)
+    val configurationStep = new DriverServiceFeatureStep(kconf)
+    assert(configurationStep.configurePod(SparkPod.initialPod()) === SparkPod.initialPod())
+    val driverService = configurationStep
+      .getAdditionalKubernetesResources()
+      .head
+      .asInstanceOf[Service]
+    assert(driverService.getSpec.getIpFamilyPolicy() == "SingleStack")
+    assert(driverService.getSpec.getIpFamilies.size() === 1)
+    assert(driverService.getSpec.getIpFamilies.get(0) == "IPv6")
+  }
+
+  test("Support ipFamilies spec with DualStack and ") {
+    Seq("PreferDualStack", "RequireDualStack").foreach { stack =>
+      val configAndAnswers = Seq(
+        ("IPv4,IPv6", Seq("IPv4", "IPv6")),
+        ("IPv6,IPv4", Seq("IPv6", "IPv4")))
+      configAndAnswers.foreach { case (config, answer) =>
+        val sparkConf = new SparkConf(false)
+          .set(KUBERNETES_DRIVER_SERVICE_IP_FAMILY_POLICY, stack)
+          .set(KUBERNETES_DRIVER_SERVICE_IP_FAMILIES, config)
+        val kconf = KubernetesTestConf.createDriverConf(
+          sparkConf = sparkConf,
+          labels = DRIVER_LABELS,
+          serviceAnnotations = DRIVER_SERVICE_ANNOTATIONS)
+        val configurationStep = new DriverServiceFeatureStep(kconf)
+        assert(configurationStep.configurePod(SparkPod.initialPod()) === SparkPod.initialPod())
+        val driverService = configurationStep
+          .getAdditionalKubernetesResources()
+          .head
+          .asInstanceOf[Service]
+        assert(driverService.getSpec.getIpFamilyPolicy() == stack)
+        assert(driverService.getSpec.getIpFamilies === answer.asJava)
+      }
+    }
+  }
+
   private def verifyService(
       driverPort: Int,
       blockManagerPort: Int,

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
@@ -195,7 +195,7 @@ class DriverServiceFeatureStepSuite extends SparkFunSuite {
     assert(driverService.getSpec.getIpFamilies.get(0) == "IPv6")
   }
 
-  test("Support ipFamilies spec with DualStack and ") {
+  test("Support DualStack") {
     Seq("PreferDualStack", "RequireDualStack").foreach { stack =>
       val configAndAnswers = Seq(
         ("IPv4,IPv6", Seq("IPv4", "IPv6")),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `iFamilyPolicy` and `ipFamilies` K8s Service feature in Spark Driver Service in order to support `IPv6`-only environment. After this PR, we can control `ipFamilyPolicy` and `ipFamilies`.

```yaml
$ kubectl get svc spark-xxx-driver-svc -oyaml
apiVersion: v1
kind: Service
metadata:
  ...
spec:
  clusterIP: None
  ipFamilyPolicy: SingleStack
  ipFamilies:
  - IPv4
...
```

### Why are the changes needed?

K8s IPv4/IPv6 dual-stack Feature reached `Stable` stage at v1.23.
- https://kubernetes.io/docs/concepts/services-networking/dual-stack/
  - v1.16 [alpha]
  - v1.21 [beta]
  - v1.23 [stable]


According to [EKS milestone](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html), K8s v1.23 will be GA on August.

Kubernetes version | Upstream release | Amazon EKS release | Amazon EKS end of support
-- | -- | -- | --
1.20 | December 8, 2020 | May 18, 2021 | September 2022
1.21 | April 8, 2021 | July 19, 2021 | February 2023
1.22 | August 4, 2021 | April 4, 2022 | May 2023
1.23 | December 7, 2021 | August 2022 | October 2023

Note that 
- [EKS started IPv6 since January 2022.](https://aws.amazon.com/blogs/containers/amazon-eks-launches-ipv6-support/)
- [Docker Desktop supports IPv6 only on Linux.](https://docs.docker.com/config/daemon/ipv6/)
- [Minikube doesn't support IPv6 yet](https://github.com/kubernetes/minikube/issues/8535) unfortunately.

### Does this PR introduce _any_ user-facing change?

Yes, this is a new feature.

### How was this patch tested?

Pass the CIs with newly added test cases.