### PR TITLE
[CI] Check if tests are to be run for build and pyspark matrix jobs

### DIFF
--- a/.github/actions/build-and-test-spark/action.yml
+++ b/.github/actions/build-and-test-spark/action.yml
@@ -46,6 +46,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set env
+      shell: bash
       run: |
         echo "MODULES_TO_TEST=${{ inputs.modules }}" >> $GITHUB_ENV
         echo "EXCLUDED_TAGS=${{ inputs.excluded-tags }}" >> $GITHUB_ENV
@@ -93,13 +94,15 @@ runs:
 
     - name: Install Python packages (Python 3.8)
       if: (contains(inputs.modules, 'sql') && !contains(inputs.modules, 'sql-'))
+      shell: bash
       run: |
         python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy xmlrunner
         python3.8 -m pip list
 
     # Run the tests.
     - name: Run tests
-      env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
+      env: ${{ fromJSON(inputs.envs) }}
+      shell: bash
       run: |
         # Hive "other tests" test needs larger metaspace size based on experiment.
         if [[ "$MODULES_TO_TEST" == "hive" ]] && [[ "$EXCLUDED_TAGS" == "org.apache.spark.tags.SlowHiveTest" ]]; then export METASPACE_SIZE=2g; fi

--- a/.github/actions/build-and-test-spark/action.yml
+++ b/.github/actions/build-and-test-spark/action.yml
@@ -55,22 +55,6 @@ runs:
         echo "GITHUB_PREV_SHA=${{ github.event.before }}" >> $GITHUB_ENV
         echo "SPARK_LOCAL_IP=localhost" >> $GITHUB_ENV
 
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
-      with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ inputs.branch }}
-
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
-
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2

--- a/.github/actions/build-and-test-spark/action.yml
+++ b/.github/actions/build-and-test-spark/action.yml
@@ -1,0 +1,141 @@
+name: 'Build and Test Spark'
+author: 'Apache Spark'
+description: 'A composite GitHub Action that builds and tests a set of Spark modules'
+
+inputs:
+  job-type:
+    description: "The type of the job: regular, scheduled, pyspark-coverage-scheduled"
+    required: true
+  branch:
+    description: "The branch"
+    required: true
+  java-version:
+    description: "The Java version"
+    required: true
+  hadoop-version:
+    description: "The Hadoop version"
+    required: true
+  hive-version:
+    description: "The Hive version"
+    required: true
+  envs:
+    description: "Environment varias as JSON object"
+    required: false
+    default: "{}"
+  modules:
+    description: "The modules to be build and tested as a comma-separated list"
+    required: true
+  included-tags:
+    description: "Tags to include for testing"
+    required: false
+    default: ""
+  excluded-tags:
+    description: "Tags to exclude for testing"
+    required: false
+    default: ""
+  label:
+    description: "Job label"
+    required: false
+    default: ""
+  ansi_enabled:
+    description: "Use ANSI mode: 'true' or 'false'"
+    required: false
+    default: "false"
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set env
+      run: |
+        echo "MODULES_TO_TEST=${{ inputs.modules }}" >> $GITHUB_ENV
+        echo "EXCLUDED_TAGS=${{ inputs.excluded-tags }}" >> $GITHUB_ENV
+        echo "INCLUDED_TAGS=${{ inputs.included-tags }}" >> $GITHUB_ENV
+        echo "HADOOP_PROFILE=${{ inputs.hadoop-version }}" >> $GITHUB_ENV
+        echo "HIVE_PROFILE=${{ inputs.hive-version }}" >> $GITHUB_ENV
+        echo "GITHUB_PREV_SHA=${{ github.event.before }}" >> $GITHUB_ENV
+        echo "SPARK_LOCAL_IP=localhost" >> $GITHUB_ENV
+
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
+      # In order to fetch changed files
+      with:
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ inputs.branch }}
+
+    - name: Sync the current branch with the latest in Apache Spark
+      if: github.repository != 'apache/spark'
+      run: |
+        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+
+    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+    - name: Cache Scala, SBT and Maven
+      uses: actions/cache@v2
+      with:
+        path: |
+          build/apache-maven-*
+          build/scala-*
+          build/*.jar
+          ~/.sbt
+        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+        restore-keys: |
+          build-
+
+    - name: Cache Coursier local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/coursier
+        key: ${{ inputs.java-version }}-${{ inputs.hadoop-version }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+        restore-keys: |
+          ${{ inputs.java-version }}-${{ inputs.hadoop-version }}-coursier-
+
+    - name: Install Java ${{ inputs.java-version }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ inputs.java-version }}
+
+    - name: Install Python 3.8
+      uses: actions/setup-python@v2
+      # We should install one Python that is higher then 3+ for SQL and Yarn because:
+      # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
+      # - Yarn has a Python specific test too, for example, YarnClusterSuite.
+      if: contains(inputs.modules, 'yarn') || (contains(inputs.modules, 'sql') && !contains(inputs.modules, 'sql-'))
+      with:
+        python-version: 3.8
+        architecture: x64
+
+    - name: Install Python packages (Python 3.8)
+      if: (contains(inputs.modules, 'sql') && !contains(inputs.modules, 'sql-'))
+      run: |
+        python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy xmlrunner
+        python3.8 -m pip list
+
+    # Run the tests.
+    - name: Run tests
+      env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
+      run: |
+        # Hive "other tests" test needs larger metaspace size based on experiment.
+        if [[ "$MODULES_TO_TEST" == "hive" ]] && [[ "$EXCLUDED_TAGS" == "org.apache.spark.tags.SlowHiveTest" ]]; then export METASPACE_SIZE=2g; fi
+        export SERIAL_SBT_TESTS=1
+        ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
+
+    - name: Upload test results to report
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results-${{ inputs.modules }}-${{ inputs.comment }}-${{ inputs.java-version }}-${{ inputs.hadoop-version }}-${{ inputs.hive-version }}
+        path: "**/target/test-reports/*.xml"
+
+    - name: Upload unit tests log files
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: unit-tests-log-${{ inputs.modules }}-${{ inputs.comment }}-${{ inputs.java-version }}-${{ inputs.hadoop-version }}-${{ inputs.hive-version }}
+        path: "**/target/unit-tests.log"
+
+branding:
+  icon: 'check-circle'
+  color: 'green'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -241,9 +241,16 @@ jobs:
         git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+    - name: Check changes
+      id: changes
+      run: |
+        changed=$(./dev/is-changed.py -m "$MODULES_TO_TEST")
+        echo "Changes exist: $changed"
+        echo "::set-output name=exist::$changed"
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
+      if: steps.changes.outputs.exist != 'false'
       with:
         path: |
           build/apache-maven-*
@@ -255,6 +262,7 @@ jobs:
           build-
     - name: Cache Coursier local repository
       uses: actions/cache@v2
+      if: steps.changes.outputs.exist != 'false'
       with:
         path: ~/.cache/coursier
         key: ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
@@ -262,6 +270,7 @@ jobs:
           ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v1
+      if: steps.changes.outputs.exist != 'false'
       with:
         java-version: ${{ matrix.java }}
     - name: Install Python 3.8
@@ -269,17 +278,20 @@ jobs:
       # We should install one Python that is higher then 3+ for SQL and Yarn because:
       # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
       # - Yarn has a Python specific test too, for example, YarnClusterSuite.
-      if: contains(matrix.modules, 'yarn') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
+      if: >
+        steps.changes.outputs.exist != 'false' &&
+        (contains(matrix.modules, 'yarn') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-')))
       with:
         python-version: 3.8
         architecture: x64
     - name: Install Python packages (Python 3.8)
-      if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
+      if: steps.changes.outputs.exist != 'false' && (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
       run: |
         python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy xmlrunner
         python3.8 -m pip list
     # Run the tests.
     - name: Run tests
+      if: steps.changes.outputs.exist != 'false'
       env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
       run: |
         # Hive "other tests" test needs larger metaspace size based on experiment.
@@ -287,13 +299,13 @@ jobs:
         export SERIAL_SBT_TESTS=1
         ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
     - name: Upload test results to report
-      if: always()
+      if: always() && steps.changes.outputs.exist != 'false'
       uses: actions/upload-artifact@v2
       with:
         name: test-results-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/test-reports/*.xml"
     - name: Upload unit tests log files
-      if: failure()
+      if: failure() && steps.changes.outputs.exist != 'false'
       uses: actions/upload-artifact@v2
       with:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
@@ -351,9 +363,16 @@ jobs:
         git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+    - name: Check changes
+      id: changes
+      run: |
+        changed=$(./dev/is-changed.py -m "$MODULES_TO_TEST")
+        echo "Changes exist: $changed"
+        echo "::set-output name=exist::$changed"
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
+      if: steps.changes.outputs.exist != 'false'
       with:
         path: |
           build/apache-maven-*
@@ -365,6 +384,7 @@ jobs:
           build-
     - name: Cache Coursier local repository
       uses: actions/cache@v2
+      if: steps.changes.outputs.exist != 'false'
       with:
         path: ~/.cache/coursier
         key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
@@ -372,6 +392,7 @@ jobs:
           pyspark-coursier-
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v1
+      if: steps.changes.outputs.exist != 'false'
       with:
         java-version: ${{ matrix.java }}
     - name: List Python packages (Python 3.9, PyPy3)
@@ -379,30 +400,32 @@ jobs:
         python3.9 -m pip list
         pypy3 -m pip list
     - name: Install Conda for pip packaging test
+      if: steps.changes.outputs.exist != 'false'
       run: |
         curl -s https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
         bash miniconda.sh -b -p $HOME/miniconda
     # Run the tests.
     - name: Run tests
+      if: steps.changes.outputs.exist != 'false'
       env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
       run: |
         export PATH=$PATH:$HOME/miniconda/bin
         ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
     - name: Upload coverage to Codecov
-      if: needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled'
+      if: steps.changes.outputs.exist != 'false' && needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled'
       uses: codecov/codecov-action@v2
       with:
         files: ./python/coverage.xml
         flags: unittests
         name: PySpark
     - name: Upload test results to report
-      if: always()
+      if: always() && steps.changes.outputs.exist != 'false'
       uses: actions/upload-artifact@v2
       with:
         name: test-results-${{ matrix.modules }}--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
         path: "**/target/test-reports/*.xml"
     - name: Upload unit tests log files
-      if: failure()
+      if: failure() && steps.changes.outputs.exist != 'false'
       uses: actions/upload-artifact@v2
       with:
         name: unit-tests-log-${{ matrix.modules }}--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -223,10 +223,26 @@ jobs:
             label: "- other tests"
 
     steps:
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
+      # In order to fetch changed files
+      with:
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ inputs.branch }}
+
+    - name: Sync the current branch with the latest in Apache Spark
+      if: github.repository != 'apache/spark'
+      run: |
+        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+
     - name: "Check for changes"
       id: changes
       run: |
-        true
+        echo "::set-output name=exist::true"
 
     - name: "Build and test"
       uses: ./.github/actions/build-and-test-spark

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -153,128 +153,97 @@ jobs:
         cat required.json
         echo "::set-output name=required::$(cat required.json)"
 
-  spark-core:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
+  # Build Spark and run the tests for specified modules.
+  spark:
+    name: "Build modules (${{ needs.configure-jobs.outputs.branch }}, ${{ needs.configure-jobs.outputs.type }} job): ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
     needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-core-required == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-core-modules }}
-      included-tags: ""
-      excluded-tags: ""
-      comment: ""
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+    # Run scheduled jobs for Apache Spark only
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
+    if: >-
+      needs.configure-jobs.outputs.type == 'scheduled'
+      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
+    # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # TODO(SPARK-32246): We don't test 'streaming-kinesis-asl' for now.
+          # Kinesis tests depends on external Amazon kinesis service.
+          # Note that the modules below are from sparktestsupport/modules.py.
+          - modules: >-
+              core, unsafe, kvstore, avro,
+              network-common, network-shuffle, repl, launcher,
+              examples, sketch, graphx
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
 
-  spark-catalyst:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
-    needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-catalyst == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-catalyst-modules }}
-      included-tags: ""
-      excluded-tags: ""
-      comment: ""
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+          - modules: catalyst, hive-thriftserver
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
 
-  spark-streaming:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
-    needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-streaming == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-streaming-modules }}
-      included-tags: ""
-      excluded-tags: ""
-      comment: ""
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+          - modules: >-
+              streaming, sql-kafka-0-10, streaming-kafka-0-10,
+              mllib-local, mllib,
+              yarn, mesos, kubernetes, hadoop-cloud, spark-ganglia-lgpl
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
 
-  spark-hive:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
-    needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-hive == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-hive-modules }}
-      included-tags: ${{ matrix.included-tags }}
-      excluded-tags: ${{ matrix.excluded-tags }}
-      comment: ${{ matrix.comment }}
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+          # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
 
-  spark-hive-slow:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
-    needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-hive-slow == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-hive-slow-modules }}
-      included-tags: org.apache.spark.tags.SlowHiveTest
-      comment: "- slow tests"
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+          # Hive tests
+          - modules: hive
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
+            included-tags: org.apache.spark.tags.SlowHiveTest
+            label: "- slow tests"
+          - modules: hive
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
+            excluded-tags: org.apache.spark.tags.SlowHiveTest
+            label: "- other tests"
 
-  spark-sql:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
-    needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-sql == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-sql-modules }}
-      excluded-tags: org.apache.spark.tags.ExtendedSQLTest
-      comment: "- other tests"
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+          # SQL tests
+          - modules: sql
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
+            included-tags: org.apache.spark.tags.ExtendedSQLTest
+            label: "- slow tests"
+          - modules: sql
+            java: ${{ needs.configure-jobs.outputs.java }}
+            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
+            hive: hive2.3
+            excluded-tags: org.apache.spark.tags.ExtendedSQLTest
+            label: "- other tests"
 
-  spark-sql-slow:
-    name: "Build and Test"
-    uses: ./.github/workflows/build_and_test_spark.yml
-    needs: [configure-jobs, precondition]
-    if: needs.precondition.outputs.spark-sql-slow == 'true'
-    with:
-      job-type: ${{ needs.configure-jobs.outputs.type }}
-      branch: ${{ needs.configure-jobs.outputs.branch }}
-      java-version: ${{ needs.configure-jobs.outputs.java }}
-      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
-      hive-version: hive2.3
-      envs: ${{ needs.configure-jobs.outputs.envs }}
-      modules: ${{ needs.precondition.outputs.spark-sql-slow-modules }}
-      included-tags: org.apache.spark.tags.ExtendedSQLTest
-      comment: "- slow tests"
-      ansi_enabled: ${{ inputs.ansi_enabled }}
+    steps:
+    - name: "Check for changes"
+      id: changes
+      run: |
+        true
+
+    - name: "Build and test"
+      uses: ./.github/actions/build-and-test-spark
+      # should be 'true' if not 'false', but we want to fall back to running tests if output is unexpected
+      if: steps.changes.outputs.exist != 'false'
+      with:
+        job-type: ${{ needs.configure-jobs.outputs.type }}
+        branch: ${{ needs.configure-jobs.outputs.branch }}
+        java-version: ${{ needs.configure-jobs.outputs.java }}
+        hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+        hive-version: hive2.3
+        envs: ${{ needs.configure-jobs.outputs.envs }}
+        modules: ${{ matrix.modules }}
+        included-tags: ${{ matrix.included-tags }}
+        excluded-tags: ${{ matrix.excluded-tags }}
+        label: ${{ matrix.label }}
+        ansi_enabled: ${{ inputs.ansi_enabled }}
 
   sparkr:
     needs: [configure-jobs, precondition]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -153,283 +153,128 @@ jobs:
         cat required.json
         echo "::set-output name=required::$(cat required.json)"
 
-  # Build: build Spark and run the tests for specified modules.
-  build:
-    name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
+  spark-core:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
     needs: [configure-jobs, precondition]
-    # Run scheduled jobs for Apache Spark only
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
-    if: >-
-      needs.configure-jobs.outputs.type == 'scheduled'
-      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
-    # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        java:
-          - ${{ needs.configure-jobs.outputs.java }}
-        hadoop:
-          - ${{ needs.configure-jobs.outputs.hadoop }}
-        hive:
-          - hive2.3
-        # TODO(SPARK-32246): We don't test 'streaming-kinesis-asl' for now.
-        # Kinesis tests depends on external Amazon kinesis service.
-        # Note that the modules below are from sparktestsupport/modules.py.
-        modules:
-          - >-
-            core, unsafe, kvstore, avro,
-            network-common, network-shuffle, repl, launcher,
-            examples, sketch, graphx
-          - >-
-            catalyst, hive-thriftserver
-          - >-
-            streaming, sql-kafka-0-10, streaming-kafka-0-10,
-            mllib-local, mllib,
-            yarn, mesos, kubernetes, hadoop-cloud, spark-ganglia-lgpl
-        # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
-        included-tags: [""]
-        excluded-tags: [""]
-        comment: [""]
-        include:
-          # Hive tests
-          - modules: hive
-            java: ${{ needs.configure-jobs.outputs.java }}
-            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
-            hive: hive2.3
-            included-tags: org.apache.spark.tags.SlowHiveTest
-            comment: "- slow tests"
-          - modules: hive
-            java: ${{ needs.configure-jobs.outputs.java }}
-            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
-            hive: hive2.3
-            excluded-tags: org.apache.spark.tags.SlowHiveTest
-            comment: "- other tests"
-          # SQL tests
-          - modules: sql
-            java: ${{ needs.configure-jobs.outputs.java }}
-            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
-            hive: hive2.3
-            included-tags: org.apache.spark.tags.ExtendedSQLTest
-            comment: "- slow tests"
-          - modules: sql
-            java: ${{ needs.configure-jobs.outputs.java }}
-            hadoop: ${{ needs.configure-jobs.outputs.hadoop }}
-            hive: hive2.3
-            excluded-tags: org.apache.spark.tags.ExtendedSQLTest
-            comment: "- other tests"
-    env:
-      MODULES_TO_TEST: ${{ matrix.modules }}
-      EXCLUDED_TAGS: ${{ matrix.excluded-tags }}
-      INCLUDED_TAGS: ${{ matrix.included-tags }}
-      HADOOP_PROFILE: ${{ matrix.hadoop }}
-      HIVE_PROFILE: ${{ matrix.hive }}
-      GITHUB_PREV_SHA: ${{ github.event.before }}
-      SPARK_LOCAL_IP: localhost
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
-      with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
-    - name: Check changes
-      id: changes
-      run: |
-        changed=$(./dev/is-changed.py -m "$MODULES_TO_TEST")
-        echo "Changes exist: $changed"
-        echo "::set-output name=exist::$changed"
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache Scala, SBT and Maven
-      uses: actions/cache@v2
-      if: steps.changes.outputs.exist != 'false'
-      with:
-        path: |
-          build/apache-maven-*
-          build/scala-*
-          build/*.jar
-          ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
-        restore-keys: |
-          build-
-    - name: Cache Coursier local repository
-      uses: actions/cache@v2
-      if: steps.changes.outputs.exist != 'false'
-      with:
-        path: ~/.cache/coursier
-        key: ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          ${{ matrix.java }}-${{ matrix.hadoop }}-coursier-
-    - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      if: steps.changes.outputs.exist != 'false'
-      with:
-        java-version: ${{ matrix.java }}
-    - name: Install Python 3.8
-      uses: actions/setup-python@v2
-      # We should install one Python that is higher then 3+ for SQL and Yarn because:
-      # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
-      # - Yarn has a Python specific test too, for example, YarnClusterSuite.
-      if: >
-        steps.changes.outputs.exist != 'false' &&
-        (contains(matrix.modules, 'yarn') || (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-')))
-      with:
-        python-version: 3.8
-        architecture: x64
-    - name: Install Python packages (Python 3.8)
-      if: steps.changes.outputs.exist != 'false' && (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
-      run: |
-        python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy xmlrunner
-        python3.8 -m pip list
-    # Run the tests.
-    - name: Run tests
-      if: steps.changes.outputs.exist != 'false'
-      env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
-      run: |
-        # Hive "other tests" test needs larger metaspace size based on experiment.
-        if [[ "$MODULES_TO_TEST" == "hive" ]] && [[ "$EXCLUDED_TAGS" == "org.apache.spark.tags.SlowHiveTest" ]]; then export METASPACE_SIZE=2g; fi
-        export SERIAL_SBT_TESTS=1
-        ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
-    - name: Upload test results to report
-      if: always() && steps.changes.outputs.exist != 'false'
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
-        path: "**/target/test-reports/*.xml"
-    - name: Upload unit tests log files
-      if: failure() && steps.changes.outputs.exist != 'false'
-      uses: actions/upload-artifact@v2
-      with:
-        name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
-        path: "**/target/unit-tests.log"
+    if: needs.precondition.outputs.spark-core-required == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-core-modules }}
+      included-tags: ""
+      excluded-tags: ""
+      comment: ""
+      ansi_enabled: ${{ inputs.ansi_enabled }}
 
-  pyspark:
+  spark-catalyst:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
     needs: [configure-jobs, precondition]
-    # Run PySpark coverage scheduled jobs for Apache Spark only
-    # Run scheduled jobs with JDK 17 in Apache Spark
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if pyspark changes exist
-    if: >-
-      needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled'
-      || (needs.configure-jobs.outputs.type == 'scheduled' && needs.configure-jobs.outputs.java == '17')
-      || (needs.configure-jobs.outputs.type == 'regular' && fromJson(needs.precondition.outputs.required).pyspark == 'true')
-    name: "Build modules (${{ format('{0}, {1} job', needs.configure-jobs.outputs.branch, needs.configure-jobs.outputs.type) }}): ${{ matrix.modules }}"
-    runs-on: ubuntu-20.04
-    container:
-      image: dongjoon/apache-spark-github-action-image:20220207
-    strategy:
-      fail-fast: false
-      matrix:
-        java:
-          - ${{ needs.configure-jobs.outputs.java }}
-        modules:
-          - >-
-            pyspark-sql, pyspark-mllib, pyspark-resource
-          - >-
-            pyspark-core, pyspark-streaming, pyspark-ml
-          - >-
-            pyspark-pandas
-          - >-
-            pyspark-pandas-slow
-    env:
-      MODULES_TO_TEST: ${{ matrix.modules }}
-      HADOOP_PROFILE: ${{ needs.configure-jobs.outputs.hadoop }}
-      HIVE_PROFILE: hive2.3
-      GITHUB_PREV_SHA: ${{ github.event.before }}
-      SPARK_LOCAL_IP: localhost
-      SKIP_UNIDOC: true
-      SKIP_MIMA: true
-      METASPACE_SIZE: 1g
-      SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
-    steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
-      with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
-    - name: Check changes
-      id: changes
-      run: |
-        changed=$(./dev/is-changed.py -m "$MODULES_TO_TEST")
-        echo "Changes exist: $changed"
-        echo "::set-output name=exist::$changed"
-    # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
-    - name: Cache Scala, SBT and Maven
-      uses: actions/cache@v2
-      if: steps.changes.outputs.exist != 'false'
-      with:
-        path: |
-          build/apache-maven-*
-          build/scala-*
-          build/*.jar
-          ~/.sbt
-        key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
-        restore-keys: |
-          build-
-    - name: Cache Coursier local repository
-      uses: actions/cache@v2
-      if: steps.changes.outputs.exist != 'false'
-      with:
-        path: ~/.cache/coursier
-        key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
-        restore-keys: |
-          pyspark-coursier-
-    - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      if: steps.changes.outputs.exist != 'false'
-      with:
-        java-version: ${{ matrix.java }}
-    - name: List Python packages (Python 3.9, PyPy3)
-      run: |
-        python3.9 -m pip list
-        pypy3 -m pip list
-    - name: Install Conda for pip packaging test
-      if: steps.changes.outputs.exist != 'false'
-      run: |
-        curl -s https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
-        bash miniconda.sh -b -p $HOME/miniconda
-    # Run the tests.
-    - name: Run tests
-      if: steps.changes.outputs.exist != 'false'
-      env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
-      run: |
-        export PATH=$PATH:$HOME/miniconda/bin
-        ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
-    - name: Upload coverage to Codecov
-      if: steps.changes.outputs.exist != 'false' && needs.configure-jobs.outputs.type == 'pyspark-coverage-scheduled'
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./python/coverage.xml
-        flags: unittests
-        name: PySpark
-    - name: Upload test results to report
-      if: always() && steps.changes.outputs.exist != 'false'
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-${{ matrix.modules }}--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
-        path: "**/target/test-reports/*.xml"
-    - name: Upload unit tests log files
-      if: failure() && steps.changes.outputs.exist != 'false'
-      uses: actions/upload-artifact@v2
-      with:
-        name: unit-tests-log-${{ matrix.modules }}--8-${{ needs.configure-jobs.outputs.hadoop }}-hive2.3
-        path: "**/target/unit-tests.log"
+    if: needs.precondition.outputs.spark-catalyst == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-catalyst-modules }}
+      included-tags: ""
+      excluded-tags: ""
+      comment: ""
+      ansi_enabled: ${{ inputs.ansi_enabled }}
+
+  spark-streaming:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
+    needs: [configure-jobs, precondition]
+    if: needs.precondition.outputs.spark-streaming == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-streaming-modules }}
+      included-tags: ""
+      excluded-tags: ""
+      comment: ""
+      ansi_enabled: ${{ inputs.ansi_enabled }}
+
+  spark-hive:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
+    needs: [configure-jobs, precondition]
+    if: needs.precondition.outputs.spark-hive == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-hive-modules }}
+      included-tags: ${{ matrix.included-tags }}
+      excluded-tags: ${{ matrix.excluded-tags }}
+      comment: ${{ matrix.comment }}
+      ansi_enabled: ${{ inputs.ansi_enabled }}
+
+  spark-hive-slow:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
+    needs: [configure-jobs, precondition]
+    if: needs.precondition.outputs.spark-hive-slow == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-hive-slow-modules }}
+      included-tags: org.apache.spark.tags.SlowHiveTest
+      comment: "- slow tests"
+      ansi_enabled: ${{ inputs.ansi_enabled }}
+
+  spark-sql:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
+    needs: [configure-jobs, precondition]
+    if: needs.precondition.outputs.spark-sql == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-sql-modules }}
+      excluded-tags: org.apache.spark.tags.ExtendedSQLTest
+      comment: "- other tests"
+      ansi_enabled: ${{ inputs.ansi_enabled }}
+
+  spark-sql-slow:
+    name: "Build and Test"
+    uses: ./.github/workflows/build_and_test_spark.yml
+    needs: [configure-jobs, precondition]
+    if: needs.precondition.outputs.spark-sql-slow == 'true'
+    with:
+      job-type: ${{ needs.configure-jobs.outputs.type }}
+      branch: ${{ needs.configure-jobs.outputs.branch }}
+      java-version: ${{ needs.configure-jobs.outputs.java }}
+      hadoop-version: ${{ needs.configure-jobs.outputs.hadoop }}
+      hive-version: hive2.3
+      envs: ${{ needs.configure-jobs.outputs.envs }}
+      modules: ${{ needs.precondition.outputs.spark-sql-slow-modules }}
+      included-tags: org.apache.spark.tags.ExtendedSQLTest
+      comment: "- slow tests"
+      ansi_enabled: ${{ inputs.ansi_enabled }}
 
   sparkr:
     needs: [configure-jobs, precondition]

--- a/.github/workflows/build_and_test_pyspark.yml
+++ b/.github/workflows/build_and_test_pyspark.yml
@@ -1,0 +1,134 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build and test (PySpark)
+
+on:
+  workflow_call:
+    inputs:
+      job-type:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+      java-version:
+        required: true
+        type: string
+      hadoop-version:
+        required: true
+        type: string
+      envs:
+        required: true
+        type: string
+      modules:
+        required: true
+        type: string
+      ansi_enabled:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  pyspark:
+    name: "${{ inputs.branch }}, ${{ inputs.job-type }} job: ${{ inputs.modules }}"
+    runs-on: ubuntu-20.04
+    container:
+      image: dongjoon/apache-spark-github-action-image:20220207
+    env:
+      MODULES_TO_TEST: ${{ inputs.modules }}
+      HADOOP_PROFILE: ${{ inputs.hadoop-version }}
+      HIVE_PROFILE: hive2.3
+      GITHUB_PREV_SHA: ${{ github.event.before }}
+      SPARK_LOCAL_IP: localhost
+      SKIP_UNIDOC: true
+      SKIP_MIMA: true
+      METASPACE_SIZE: 1g
+      SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
+    steps:
+      - name: Checkout Spark repository
+        uses: actions/checkout@v2
+        # In order to fetch changed files
+        with:
+          fetch-depth: 0
+          repository: apache/spark
+          ref: ${{ inputs.branch }}
+      - name: Sync the current branch with the latest in Apache Spark
+        if: github.repository != 'apache/spark'
+        run: |
+          echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+      # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+      - name: Cache Scala, SBT and Maven
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/apache-maven-*
+            build/scala-*
+            build/*.jar
+            ~/.sbt
+          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          restore-keys: |
+            build-
+      - name: Cache Coursier local repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/coursier
+          key: pyspark-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          restore-keys: |
+            pyspark-coursier-
+      - name: Install Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: List Python packages (Python 3.9, PyPy3)
+        run: |
+          python3.9 -m pip list
+          pypy3 -m pip list
+      - name: Install Conda for pip packaging test
+        run: |
+          curl -s https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
+          bash miniconda.sh -b -p $HOME/miniconda
+      # Run the tests.
+      - name: Run tests
+        env: ${{ fromJSON(inputs.envs) }}
+        run: |
+          export PATH=$PATH:$HOME/miniconda/bin
+          ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST"
+      - name: Upload coverage to Codecov
+        if: inputs.job-type == 'pyspark-coverage-scheduled'
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./python/coverage.xml
+          flags: unittests
+          name: PySpark
+      - name: Upload test results to report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ inputs.modules }}--8-${{ inputs.hadoop-version }}-hive2.3
+          path: "**/target/test-reports/*.xml"
+      - name: Upload unit tests log files
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit-tests-log-${{ inputs.modules }}--8-${{ inputs.hadoop-version }}-hive2.3
+          path: "**/target/unit-tests.log"

--- a/.github/workflows/build_and_test_spark.yml
+++ b/.github/workflows/build_and_test_spark.yml
@@ -1,0 +1,154 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build and test (PySpark)
+
+on:
+  workflow_call:
+    inputs:
+      job-type:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+      java-version:
+        required: true
+        type: string
+      hadoop-version:
+        required: true
+        type: string
+      hive-version:
+        required: true
+        type: string
+      envs:
+        required: true
+        type: string
+      modules:
+        required: true
+        type: string
+      included-tags:
+        required: false
+        type: string
+        default: ""
+      excluded-tags:
+        required: false
+        type: string
+        default: ""
+      comment:
+        required: false
+        type: string
+        default: ""
+      ansi_enabled:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  # Build Spark and run the tests for specified modules.
+  build:
+    name: "${{ inputs.branch }}, ${{ inputs.job-type }} job: ${{ inputs.modules }} ${{ inputs.comment }} (JDK ${{ inputs.java-version }}, ${{ inputs.hadoop-version }}, ${{ inputs.hive-version }})"
+    needs: [configure-jobs, precondition]
+    # Run scheduled jobs for Apache Spark only
+    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
+    if: >-
+      inputs.job-type == 'scheduled'
+      || (inputs.job-type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
+    # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
+    runs-on: ubuntu-20.04
+    env:
+      MODULES_TO_TEST: ${{ inputs.modules }}
+      EXCLUDED_TAGS: ${{ inputs.excluded-tags }}
+      INCLUDED_TAGS: ${{ inputs.included-tags }}
+      HADOOP_PROFILE: ${{ inputs.hadoop-version }}
+      HIVE_PROFILE: ${{ inputs.hive-version }}
+      GITHUB_PREV_SHA: ${{ github.event.before }}
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - name: Checkout Spark repository
+        uses: actions/checkout@v2
+        # In order to fetch changed files
+        with:
+          fetch-depth: 0
+          repository: apache/spark
+          ref: ${{ inputs.branch }}
+      - name: Sync the current branch with the latest in Apache Spark
+        if: github.repository != 'apache/spark'
+        run: |
+          echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+          git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+          git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+      # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
+      - name: Cache Scala, SBT and Maven
+        uses: actions/cache@v2
+        with:
+          path: |
+            build/apache-maven-*
+            build/scala-*
+            build/*.jar
+            ~/.sbt
+          key: build-${{ hashFiles('**/pom.xml', 'project/build.properties', 'build/mvn', 'build/sbt', 'build/sbt-launch-lib.bash', 'build/spark-build-info') }}
+          restore-keys: |
+            build-
+      - name: Cache Coursier local repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/coursier
+          key: ${{ inputs.java-version }}-${{ inputs.hadoop-version }}-coursier-${{ hashFiles('**/pom.xml', '**/plugins.sbt') }}
+          restore-keys: |
+            ${{ inputs.java-version }}-${{ inputs.hadoop-version }}-coursier-
+      - name: Install Java ${{ inputs.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ inputs.java-version }}
+      - name: Install Python 3.8
+        uses: actions/setup-python@v2
+        # We should install one Python that is higher then 3+ for SQL and Yarn because:
+        # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
+        # - Yarn has a Python specific test too, for example, YarnClusterSuite.
+        if: contains(inputs.modules, 'yarn') || (contains(inputs.modules, 'sql') && !contains(inputs.modules, 'sql-'))
+        with:
+          python-version: 3.8
+          architecture: x64
+      - name: Install Python packages (Python 3.8)
+        if: (contains(inputs.modules, 'sql') && !contains(inputs.modules, 'sql-'))
+        run: |
+          python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy xmlrunner
+          python3.8 -m pip list
+      # Run the tests.
+      - name: Run tests
+        env: ${{ fromJSON(needs.configure-jobs.outputs.envs) }}
+        run: |
+          # Hive "other tests" test needs larger metaspace size based on experiment.
+          if [[ "$MODULES_TO_TEST" == "hive" ]] && [[ "$EXCLUDED_TAGS" == "org.apache.spark.tags.SlowHiveTest" ]]; then export METASPACE_SIZE=2g; fi
+          export SERIAL_SBT_TESTS=1
+          ./dev/run-tests --parallelism 1 --modules "$MODULES_TO_TEST" --included-tags "$INCLUDED_TAGS" --excluded-tags "$EXCLUDED_TAGS"
+      - name: Upload test results to report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ inputs.modules }}-${{ inputs.comment }}-${{ inputs.java-version }}-${{ inputs.hadoop-version }}-${{ inputs.hive-version }}
+          path: "**/target/test-reports/*.xml"
+      - name: Upload unit tests log files
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit-tests-log-${{ inputs.modules }}-${{ inputs.comment }}-${{ inputs.java-version }}-${{ inputs.hadoop-version }}-${{ inputs.hive-version }}
+          path: "**/target/unit-tests.log"

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -53,7 +53,7 @@ def parse_opts():
 def main():
     opts = parse_opts()
 
-    test_modules = opts.modules.split(",")
+    test_modules = [m.strip() for m in opts.modules.split(",")]
     changed_files = []
     if os.environ.get("APACHE_SPARK_REF"):
         changed_files = identify_changed_files_from_git_commits(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This makes the CI aware when instances of matrix jobs `build` and `pyspark` do actually not have any changes and there do not run any tests. Then, uploading files can be skipped as well, allowing to enable #36413.

This also makes the fact visible that tests for a matrix job are actually not run:
![grafik](https://user-images.githubusercontent.com/44700269/174037057-2060a97c-6dba-458f-9a46-6a989d82a837.png)
Though the job itself is run, the test step is skipped. Before, you would have to open the test step and see no tests were run.

Ideally, the whole job should be skipped. But that would require defining the module sets into the `precondition` job.

### Why are the changes needed?
All instances of matrix jobs `build` and `pyspark` are skipped if none of their respective modules have changes. When changes exists, all instances are run, but some instances then do not run any tests, as their sub-set of modules do not have changes.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested here:
- Run without changes (root being removed from changes): https://github.com/G-Research/spark/actions/runs/2511343840
- Run with pyspark changes: https://github.com/G-Research/spark/actions/runs/2511754796
- Run with streaming changes: https://github.com/G-Research/spark/actions/runs/2511785981