### PR TITLE
[SPARK-39494][PYTHON] Support `createDataFrame` from a list of scalars when schema is not provided

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1023,7 +1023,7 @@ class SparkSession(SparkConversionMixin):
 
         if isinstance(data, RDD):
             rdd, struct = self._createFromRDD(data.map(prepare), schema, samplingRatio)
-        elif isinstance(data, list):
+        elif isinstance(data, list) and schema is None:
             # Wrap each element with a tuple if there is any scalar in the list
             has_scalar = any(isinstance(x, str) or not isinstance(x, Sized) for x in data)
             converted_data = [(x,) for x in data] if has_scalar else data

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1025,7 +1025,15 @@ class SparkSession(SparkConversionMixin):
             rdd, struct = self._createFromRDD(data.map(prepare), schema, samplingRatio)
         elif isinstance(data, list) and schema is None:
             # Wrap each element with a tuple if there is any scalar in the list
-            has_scalar = any(isinstance(x, str) or not isinstance(x, Sized) for x in data)
+
+            has_scalar = any(
+                isinstance(x, str)
+                or (
+                    not isinstance(x, Sized)
+                    and (type(x).__module__ == object.__module__)  # built-in
+                )
+                for x in data
+            )
             converted_data = [(x,) for x in data] if has_scalar else data
 
             rdd, struct = self._createFromLocal(map(prepare, converted_data), schema)

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1026,11 +1026,7 @@ class SparkSession(SparkConversionMixin):
         else:
             if isinstance(data, list):
                 # Wrap each element with a tuple if there is any scalar in the list
-                has_scalar = False
-                for x in data:
-                    if isinstance(x, str) or not hasattr(x, "__len__"):  # Scalar
-                        has_scalar = True
-                        break
+                has_scalar = any(isinstance(x, str) or not hasattr(x, "__len__") for x in data)
                 converted_data = [(x,) for x in data] if has_scalar else data
 
                 rdd, struct = self._createFromLocal(map(prepare, converted_data), schema)

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -385,6 +385,10 @@ class CreateDataFrameTest(ReusedSQLTestCase):
             self.spark.createDataFrame([1, 2, 3]).collect(),
             self.spark.createDataFrame([(1,), (2,), (3,)]).collect(),
         )
+        self.assertEqual(
+            self.spark.createDataFrame([1]).collect(),
+            self.spark.createDataFrame([(1,)]).collect(),
+        )
 
         self.assertEqual(
             self.spark.createDataFrame(["x", "y"]).collect(),

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -21,7 +21,7 @@ import unittest
 from pyspark import SparkConf, SparkContext
 from pyspark.sql import SparkSession, SQLContext, Row
 from pyspark.sql.functions import col
-from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.sqlutils import ReusedSQLTestCase, MyObject
 from pyspark.testing.utils import PySparkTestCase
 
 
@@ -404,6 +404,12 @@ class CreateDataFrameTest(ReusedSQLTestCase):
             self.spark.createDataFrame([(1,), ("x",)])
         with self.assertRaisesRegex(TypeError, expected_err_msg_regex):
             self.spark.createDataFrame([1, "x"])  # Same error message as its above case
+
+    def test_create_dataframe_from_objects(self):
+        data = [MyObject(1, "1"), MyObject(2, "2")]
+        df = self.spark.createDataFrame(data)
+        self.assertEqual(df.dtypes, [("key", "bigint"), ("value", "string")])
+        self.assertEqual(df.first(), Row(key=1, value="1"))
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -379,6 +379,29 @@ class SparkExtensionsTest(unittest.TestCase):
         )
 
 
+class CreateDataFrameTest(ReusedSQLTestCase):
+    def test_from_list_of_scalars(self):
+        self.assertEqual(
+            self.spark.createDataFrame([1, 2, 3]).collect(),
+            self.spark.createDataFrame([(1,), (2,), (3,)]).collect(),
+        )
+
+        self.assertEqual(
+            self.spark.createDataFrame(["x", "y"]).collect(),
+            self.spark.createDataFrame([("x",), ("y",)]).collect(),
+        )
+
+        expected_err_msg_regex = ".*Can not merge type.*"
+        with self.assertRaisesRegex(TypeError, expected_err_msg_regex):
+            self.spark.createDataFrame([(1,), ((2,),), ([3],)])
+        with self.assertRaisesRegex(TypeError, expected_err_msg_regex):
+            self.spark.createDataFrame([1, (2,), [3]])  # Same error message as its above case
+        with self.assertRaisesRegex(TypeError, expected_err_msg_regex):
+            self.spark.createDataFrame([(1,), ("x",)])
+        with self.assertRaisesRegex(TypeError, expected_err_msg_regex):
+            self.spark.createDataFrame([1, "x"])  # Same error message as its above case
+
+
 if __name__ == "__main__":
     from pyspark.sql.tests.test_session import *  # noqa: F401
 

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -405,7 +405,7 @@ class CreateDataFrameTest(ReusedSQLTestCase):
         with self.assertRaisesRegex(TypeError, expected_err_msg_regex):
             self.spark.createDataFrame([1, "x"])  # Same error message as its above case
 
-    def test_create_dataframe_from_objects(self):
+    def test_from_list_of_objects(self):
         data = [MyObject(1, "1"), MyObject(2, "2")]
         df = self.spark.createDataFrame(data)
         self.assertEqual(df.dtypes, [("key", "bigint"), ("value", "string")])

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -62,7 +62,6 @@ from pyspark.testing.sqlutils import (
     PythonOnlyUDT,
     ExamplePoint,
     PythonOnlyPoint,
-    MyObject,
 )
 
 
@@ -373,12 +372,6 @@ class TypesTests(ReusedSQLTestCase):
             self.assertEqual(actual, [0, 10])
         finally:
             self.spark.sql("set spark.sql.legacy.allowNegativeScaleOfDecimal=false")
-
-    def test_create_dataframe_from_objects(self):
-        data = [MyObject(1, "1"), MyObject(2, "2")]
-        df = self.spark.createDataFrame(data)
-        self.assertEqual(df.dtypes, [("key", "bigint"), ("value", "string")])
-        self.assertEqual(df.first(), Row(key=1, value="1"))
 
     def test_apply_schema(self):
         from datetime import date, datetime, timedelta


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Support `createDataFrame` from a list of python native scalars (when schema is not provided).

- Standardize error messages when the input list contains (any number of) scalars.


### Why are the changes needed?
Currently, DataFrame creation from a list of scalars is unsupported in PySpark, for example,
```py
>>> spark.createDataFrame([1, 2]).collect()
Traceback (most recent call last):
...
TypeError: Can not infer schema for type: <class 'int'>
```

However, Spark DataFrame Scala API supports that:
```
scala> Seq(1, 2).toDF().collect()
res6: Array[org.apache.spark.sql.Row] = Array([1], [2])
```

To maintain API consistency, we propose to support DataFrame creation from a list of scalars. 

See more [here](https://docs.google.com/document/d/1Rd20PVbVxNrLfOmDtetVRxkgJQhgAAtJp6XAAZfGQgc/edit?usp=sharing).

### Does this PR introduce _any_ user-facing change?
Yes.

1. `createDataFrame` from a list of scalars is supported.

**Before**
```py
>>> spark.createDataFrame([1, 2]).collect()
Traceback (most recent call last):
...
TypeError: Can not infer schema for type: <class 'int'>
```

**After**
```py
>>> spark.createDataFrame([1, 2]).collect()
[Row(_1=1), Row(_1=2)]       
```
3. Standardized error messages when the input list contains any scalars.

**Before**
```py
>>> spark.createDataFrame([1, 'x'])
Traceback (most recent call last):
...
TypeError: Can not infer schema for type: <class 'int'>
>>> spark.createDataFrame([1, (2,)])
Traceback (most recent call last):
...
TypeError: Can not infer schema for type: <class 'int'>
```

**After**
```py
>>> spark.createDataFrame([1, 'x'])
Traceback (most recent call last):
...
TypeError: field _1: Can not merge type <class 'pyspark.sql.types.LongType'> and <class 'pyspark.sql.types.StringType'>

>>> spark.createDataFrame([1, (2,)])
Traceback (most recent call last):
...
TypeError: field _1: Can not merge type <class 'pyspark.sql.types.LongType'> and <class 'pyspark.sql.types.StructType'>
```


### How was this patch tested?
Unit tests.
