### PR TITLE
[SPARK-39495][SQL][TESTS] Support `SPARK_TEST_HIVE_CLIENT_VERSIONS` for `HiveClientVersions`

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientVersions.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientVersions.scala
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 private[client] trait HiveClientVersions {
   private val testVersions = sys.env.get("SPARK_TEST_HIVE_CLIENT_VERSIONS")
   protected val versions = if (testVersions.nonEmpty) {
-    testVersions.get.split(",").map(_.strip).filter(_.nonEmpty).toIndexedSeq
+    testVersions.get.split(",").map(_.trim).filter(_.nonEmpty).toIndexedSeq
   } else if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
     IndexedSeq("2.0", "2.1", "2.2", "2.3", "3.0", "3.1")
   } else {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientVersions.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientVersions.scala
@@ -22,7 +22,10 @@ import scala.collection.immutable.IndexedSeq
 import org.apache.commons.lang3.{JavaVersion, SystemUtils}
 
 private[client] trait HiveClientVersions {
-  protected val versions = if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+  private val testVersions = sys.env.get("SPARK_TEST_HIVE_CLIENT_VERSIONS")
+  protected val versions = if (testVersions.nonEmpty) {
+    testVersions.get.split(",").map(_.strip).filter(_.nonEmpty).toIndexedSeq
+  } else if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
     IndexedSeq("2.0", "2.1", "2.2", "2.3", "3.0", "3.1")
   } else {
     IndexedSeq("0.12", "0.13", "0.14", "1.0", "1.1", "1.2", "2.0", "2.1", "2.2", "2.3", "3.0",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to introduce a test environment variable `SPARK_TEST_HIVE_CLIENT_VERSIONS` to control the test target HiveClient Versions in `HiveClientVersions` trait.

### Why are the changes needed?

Currently, `HiveClientVersions` is used in three test suites.
```
$ git grep 'with HiveClientVersions'
sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala:class HiveClientSuites extends SparkFunSuite with HiveClientVersions {
sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuites.scala:class HiveClientUserNameSuites extends Suite with HiveClientVersions {
sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuites.scala:class HivePartitionFilteringSuites extends Suite with HiveClientVersions {
```

### Does this PR introduce _any_ user-facing change?

No. This is a test only change.

### How was this patch tested?

Pass the CIs and manually test like the following.
```
SPARK_TEST_HIVE_CLIENT_VERSIONS='' build/sbt "hive/testOnly *.HiveClientSuites" -Phive
SPARK_TEST_HIVE_CLIENT_VERSIONS=3.1 build/sbt "hive/testOnly *.HiveClientSuites" -Phive
SPARK_TEST_HIVE_CLIENT_VERSIONS=3.0,3.1 build/sbt "hive/testOnly *.HiveClientSuites" -Phive
```