### PR TITLE
[SPARK-39507][CORE] `SocketAuthServer` should respect Java IPv6 options

### DIFF
--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -49,7 +49,7 @@ private[spark] abstract class SocketAuthServer[T](
 
   private def startServer(): (Int, String) = {
     logTrace("Creating listening socket")
-    val serverSocket = new ServerSocket(0, 1, InetAddress.getByAddress(Array(127, 0, 0, 1)))
+    val serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())
     // Close the socket if no connection in the configured seconds
     val timeout = authHelper.conf.get(PYTHON_AUTH_SOCKET_TIMEOUT).toInt
     logTrace(s"Setting timeout to $timeout sec")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `SocketAuthServer` to respect Java IPv6 option, `java.net.preferIPv6Addresses=true`.

### Why are the changes needed?

This can be tested easily on all systems.

**BEFORE**
```
$ SPARK_LOCAL_IP=::1 SBT_OPTS=-Djava.net.preferIPv6Addresses=true build/sbt "core/testOnly *.PythonRDDSuite -- -z server"
[info] PythonRDDSuite:
[info] - python server error handling *** FAILED *** (63 milliseconds)
[info]   java.net.ConnectException: Connection refused (Connection refused)
[info]   at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
...
[info]   at java.base/java.net.Socket.<init>(Socket.java:264)
[info]   at org.apache.spark.api.python.PythonRDDSuite.$anonfun$new$3(PythonRDDSuite.scala:81)
...
[info] Run completed in 1 second, 434 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
```

**AFTER**
```
$ SPARK_LOCAL_IP=::1 SBT_OPTS=-Djava.net.preferIPv6Addresses=true build/sbt "core/testOnly *.PythonRDDSuite -- -z server"
[info] PythonRDDSuite:
[info] - python server error handling (75 milliseconds)
[info] Run completed in 1 second, 35 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Does this PR introduce _any_ user-facing change?

In general, there is no side effect because this only affects the users who already have `java.net.preferIPv6Addresses=true`. For those users, the new behavior is correct.

### How was this patch tested?

Pass the CIs and manually run this command.
```
SPARK_LOCAL_IP=::1 SBT_OPTS=-Djava.net.preferIPv6Addresses=true build/sbt "core/testOnly *.PythonRDDSuite -- -z server"
```

