### PR TITLE
[SPARK-39508][CORE][PYTHON] Support IPv6 between JVM and Python Daemon in PySpark

### DIFF
--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -193,8 +193,10 @@ def local_connect_and_auth(port, auth_secret):
     sock = None
     errors = []
     # Support for both IPv4 and IPv6.
-    # On most of IPv6-ready systems, IPv6 will take precedence.
-    for res in socket.getaddrinfo("127.0.0.1", port, socket.AF_UNSPEC, socket.SOCK_STREAM):
+    addr = "127.0.0.1"
+    if os.environ.get("SPARK_PREFER_IPV6", "false").lower() == "true":
+        addr = "::1"
+    for res in socket.getaddrinfo(addr, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
         af, socktype, proto, _, sa = res
         try:
             sock = socket.socket(af, socktype, proto)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `IPv6` between Spark and Python Daemon in IPv6-only system.

Unlike `spark-shell`, `pyspark` starts Python shell and `java-gateway` first.
We need a new environment variable, `SPARK_PREFER_IPV6=True` in `pyspark` shell, like the following.
```
SPARK_PREFER_IPV6=True bin/pyspark --driver-java-options=-Djava.net.preferIPv6Addresses=true
```

### Why are the changes needed?

Currently, PySpark uses `127.0.0.1` for inter-communication between Python Daemon and JVM.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.