### PR TITLE
[SPARK-39509][INFRA] Support `DEFAULT_ARTIFACT_REPOSITORY` in `check-license`

### DIFF
--- a/dev/check-license
+++ b/dev/check-license
@@ -20,7 +20,7 @@
 
 acquire_rat_jar () {
 
-  URL="https://maven-central.storage-download.googleapis.com/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+  URL="${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
 
   JAR="$rat_jar"
 

--- a/dev/check-license
+++ b/dev/check-license
@@ -20,7 +20,7 @@
 
 acquire_rat_jar () {
 
-  URL="https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+  URL="https://maven-central.storage-download.googleapis.com/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
 
   JAR="$rat_jar"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `check-license` script to support IPv6 environment via `DEFAULT_ARTIFACT_REPOSITORY`

### Why are the changes needed?

Apache Maven Central repository has two separate URLs.
- https://repo.maven.apache.org/maven2/ (IPv4)
- https://ipv6.repo1.maven.org/maven2/ (IPv6)

`DEFAULT_ARTIFACT_REPOSITORY` allows IPv6 users to use `ipv6.repo1.maven.org` or Google Maven Central Mirror according to their needs.

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the CIs.