### PR TITLE
[SPARK-39510][SQL][WIP] Leverage the natural partitioning and ordering of MonotonicallyIncreasingID

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -87,7 +87,8 @@ case class SortOrder(
   def satisfies(required: SortOrder): Boolean = {
     children.exists(required.child.semanticEquals) &&
       direction == required.direction &&
-      (!required.child.nullable || nullOrdering == required.nullOrdering)
+      (required.child.resolved && !required.child.nullable ||
+        nullOrdering == required.nullOrdering)
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): SortOrder =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/SortOrder.scala
@@ -86,7 +86,8 @@ case class SortOrder(
 
   def satisfies(required: SortOrder): Boolean = {
     children.exists(required.child.semanticEquals) &&
-      direction == required.direction && nullOrdering == required.nullOrdering
+      direction == required.direction &&
+      (!required.child.nullable || nullOrdering == required.nullOrdering)
   }
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): SortOrder =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -403,7 +403,8 @@ case class RangePartitioning(ordering: Seq[SortOrder], numPartitions: Int)
           //   greater(i.e. smaller or equal to) than any [a, b] in the following partition. Thus
           //   `RangePartitioning(a, b, c)` satisfies `OrderedDistribution(a, b)`.
           val minSize = Seq(requiredOrdering.size, ordering.size).min
-          requiredOrdering.take(minSize) == ordering.take(minSize)
+          ordering.take(minSize).zip(requiredOrdering.take(minSize))
+            .forall { case (s1, s2) => s1.satisfies(s2) }
         case c @ ClusteredDistribution(requiredClustering, requireAllClusterKeys, _) =>
           val expressions = ordering.map(_.child)
           if (requireAllClusterKeys) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. when `ProjectExec`'s `projectList` contains `MonotonicallyIncreasingID`, add a `RangePartitioning` to the  `outputPartitioning` and append a `SortOrder(..., Ascending, ...)` at the end of `outputOrdering`;
2. when the expression is **NOT** `nullable`, skip the `nullOrdering` comparison in `SortOrder.satisfies` and `RangePartitioning.satisfies0`


### Why are the changes needed?

In _Pandas-API-on-Spark_:

1. _MonotonicallyIncreasingID_ and _AttachDistributedSequence_ are used as the indexing type for distributed datasets, they naturally have **RangePartitioning** and **Ascending Ordering**.
2. Sorting by index seems a common scenario, such as:

- internally, _Window.orderBy(NATURAL_ORDER_COLUMN_NAME)_ is widely used in `GroupBy`, `Rolling`, `Expanding`, `ExponentialMoving`, etc;
- the  _sort_index()_ maybe a high frequently used function for end users;

So we should make MonotonicallyIncreasingID and AttachDistributedSequence provide the RangePartitioning and Ascending Ordering, so that the optimization rules (such as `EnsureRequirements` and `EliminateSorts`) may leverage them.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing UT for now