### PR TITLE
[SPARK-39511][SQL] Enhance push down local limit 1 for right side of left semi/anti join if join condition is empty

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -235,6 +235,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
       CheckCartesianProducts) :+
     Batch("RewriteSubquery", Once,
       RewritePredicateSubquery,
+      PushPredicateThroughJoin,
+      LimitPushDown,
       ColumnPruning,
       CollapseProject,
       RemoveRedundantAliases,
@@ -710,15 +712,13 @@ object LimitPushDown extends Rule[LogicalPlan] {
           left = maybePushLocalLimit(limitExpr, join.left),
           right = maybePushLocalLimit(limitExpr, join.right))
       case LeftSemi | LeftAnti if join.condition.isEmpty =>
-        join.copy(
-          left = maybePushLocalLimit(limitExpr, join.left),
-          right = maybePushLocalLimit(Literal(1, IntegerType), join.right))
+        join.copy(left = maybePushLocalLimit(limitExpr, join.left))
       case _ => join
     }
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
-    _.containsPattern(LIMIT), ruleId) {
+    _.containsAnyPattern(LIMIT, LEFT_SEMI_OR_ANTI_JOIN), ruleId) {
     // Adding extra Limits below UNION ALL for children which are not Limit or do not have Limit
     // descendants whose maxRow is larger. This heuristic is valid assuming there does not exist any
     // Limit push-down rule that is unable to infer the value of maxRows.
@@ -753,6 +753,9 @@ object LimitPushDown extends Rule[LogicalPlan] {
     // Merge offset value and limit value into LocalLimit and pushes down LocalLimit through Offset.
     case LocalLimit(le, Offset(oe, grandChild)) =>
       Offset(oe, LocalLimit(Add(le, oe), grandChild))
+    // Push down limit 1 if join type is LeftSemiOrAnti and join condition is empty
+    case j @ Join(_, right, LeftSemiOrAnti(_), None, _) if !right.maxRows.exists(_ <= 1) =>
+      j.copy(right = Limit(Literal(1, IntegerType), right))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -753,9 +753,9 @@ object LimitPushDown extends Rule[LogicalPlan] {
     // Merge offset value and limit value into LocalLimit and pushes down LocalLimit through Offset.
     case LocalLimit(le, Offset(oe, grandChild)) =>
       Offset(oe, LocalLimit(Add(le, oe), grandChild))
-    // Push down limit 1 if join type is LeftSemiOrAnti and join condition is empty
+    // Push down local limit 1 if join type is LeftSemiOrAnti and join condition is empty.
     case j @ Join(_, right, LeftSemiOrAnti(_), None, _) if !right.maxRows.exists(_ <= 1) =>
-      j.copy(right = Limit(Literal(1, IntegerType), right))
+      j.copy(right = maybePushLocalLimit(Literal(1, IntegerType), right))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{Ascending, GenericRow, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.Filter
-import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{BinaryExecNode, FilterExec, ProjectExec, SortExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -1325,17 +1324,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
           val plan = sql(getAggQuery(selectExpr, joinType)).queryExecution.executedPlan
           assert(collect(plan) { case _: BroadcastNestedLoopJoinExec => true }.size === 1)
           // No extra shuffle before aggregation
-          if (joinType.equals("LEFT SEMI") || joinType.equals("LEFT ANTI")) {
-            assert(collect(plan) {
-              case s: ShuffleExchangeExec if s.outputPartitioning != SinglePartition => true
-            }.size === 0)
-            // Shuffle Exchange between LocalLimit and GlobalLimit
-            assert(collect(plan) {
-              case s: ShuffleExchangeExec if s.outputPartitioning == SinglePartition => true
-            }.size === 1)
-          } else {
-            assert(collect(plan) { case _: ShuffleExchangeExec => true }.size === 0)
-          }
+          assert(collect(plan) { case _: ShuffleExchangeExec => true }.size === 0)
       }
 
       // Test output partitioning is not preserved
@@ -1349,17 +1338,7 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
           val plan = sql(getAggQuery(selectExpr, joinType)).queryExecution.executedPlan
           assert(collect(plan) { case _: BroadcastNestedLoopJoinExec => true }.size === 1)
           // Have shuffle before aggregation
-          if (joinType.equals("LEFT SEMI") || joinType.equals("LEFT ANTI")) {
-            assert(collect(plan) {
-              case s: ShuffleExchangeExec if s.outputPartitioning != SinglePartition => true
-            }.size === 1)
-            // Shuffle Exchange between LocalLimit and GlobalLimit
-            assert(collect(plan) {
-              case s: ShuffleExchangeExec if s.outputPartitioning == SinglePartition => true
-            }.size === 1)
-          } else {
-            assert(collect(plan) { case _: ShuffleExchangeExec => true }.size === 1)
-          }
+          assert(collect(plan) { case _: ShuffleExchangeExec => true }.size === 1)
       }
 
       def getJoinQuery(selectExpr: String, joinType: String): String = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan, Sort}
-import org.apache.spark.sql.execution.{ColumnarToRowExec, ExecSubqueryExpression, FileSourceScanExec, InputAdapter, ReusedSubqueryExec, ScalarSubquery, SubqueryExec, WholeStageCodegenExec}
+import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecution}
 import org.apache.spark.sql.execution.datasources.FileScanRDD
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -2203,5 +2203,21 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
             |)
             |""".stripMargin),
       Row("2022-06-01"))
+  }
+
+  test("SPARK-39511: Push limit 1 to right side if join type is Left Semi/Anti") {
+    withTable("t1", "t2") {
+      withTempView("v1") {
+        spark.sql("CREATE TABLE t1(id int) using parquet")
+        spark.sql("CREATE TABLE t2(id int, type string) using parquet")
+        spark.sql("CREATE TEMP VIEW v1 AS SELECT id, 't' AS type FROM t1")
+        val df = spark.sql("SELECT * FROM v1 WHERE type IN (SELECT type FROM t2)")
+        val join =
+          df.queryExecution.sparkPlan.collectFirst { case b: BroadcastNestedLoopJoinExec => b }
+        assert(join.nonEmpty)
+        assert(join.head.right.isInstanceOf[GlobalLimitExec])
+        assert(join.head.right.asInstanceOf[GlobalLimitExec].limit === 1)
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2215,8 +2215,8 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         val join =
           df.queryExecution.sparkPlan.collectFirst { case b: BroadcastNestedLoopJoinExec => b }
         assert(join.nonEmpty)
-        assert(join.head.right.isInstanceOf[GlobalLimitExec])
-        assert(join.head.right.asInstanceOf[GlobalLimitExec].limit === 1)
+        assert(join.head.right.isInstanceOf[LocalLimitExec])
+        assert(join.head.right.asInstanceOf[LocalLimitExec].limit === 1)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances https://github.com/apache/spark/pull/35216 to support more cases. 

Before this PR it only supports left semi/anti join followed by limit:
```sql
SELECT * FROM t1 LEFT SEMI JOIN t2 LIMIT 10;
SELECT * FROM t1 LEFT ANTI JOIN t2 LIMIT 10;
```
After this PR it do not have this limitation and also support in / not in subquery:
```sql
SELECT * FROM t1 LEFT SEMI JOIN t2;
SELECT * FROM t1 LEFT ANTI JOIN t2;

SELECT * FROM v1 WHERE literal IN (SELECT id FROM t2);
SELECT * FROM v1 WHERE literal NOT IN (SELECT id FROM t2);
```

### Why are the changes needed?

Improve query performance. For example:
```sql
CREATE TABLE t1(id int) using parquet;
CREATE TABLE t2(id int, type string) using parquet;
CREATE TEMP VIEW v1 AS SELECT id, 't' AS type FROM t1;

EXPLAIN EXTENDED SELECT * FROM v1 WHERE type IN (SELECT type FROM t2);
```

Before this PR:
```
=== Result of Batch RewriteSubquery ===
 Project [id#241, t AS type#246]                            Project [id#241, t AS type#246]
!+- Filter t IN (list#243 [])                               +- Join LeftSemi, (t = type#248)
!   :  +- Project [type#248]                                   :- Relation default.t1[id#241] parquet
!   :     +- Relation default.t2[id#247,type#248] parquet      +- Project [type#248]
!   +- Relation default.t1[id#241] parquet                        +- Relation default.t2[id#247,type#248] parquet
```

After this PR:
```
=== Result of Batch RewriteSubquery ===
 Project [id#241, t AS type#246]                            Project [id#241, t AS type#246]
!+- Filter t IN (list#243 [])                               +- Join LeftSemi
!   :  +- Project [type#248]                                   :- Relation default.t1[id#241] parquet
!   :     +- Relation default.t2[id#247,type#248] parquet      +- GlobalLimit 1
!   +- Relation default.t1[id#241] parquet                        +- LocalLimit 1
!                                                                    +- Project
!                                                                       +- Filter (t = type#248)
!                                                                          +- Relation default.t2[id#247,type#248] parquet
```


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.