### PR TITLE
[SPARK-36979][SQL][TESTS][FOLLOWUP] Move the test from `SQLQuerySuite` to `SQLQueryTestSuite`

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/non-excludable-rule.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/non-excludable-rule.sql
@@ -13,3 +13,7 @@ WITH tmp AS (
   SELECT id FROM range(4)
 )
 SELECT id FROM range(3) WHERE id > (SELECT max(id) FROM tmp);
+
+-- SPARK-36979
+SET spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.RewriteLateralSubquery;
+SELECT * FROM testData, LATERAL (SELECT * FROM testData) LIMIT 1;

--- a/sql/core/src/test/resources/sql-tests/results/non-excludable-rule.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/non-excludable-rule.sql.out
@@ -37,3 +37,19 @@ SELECT id FROM range(3) WHERE id > (SELECT max(id) FROM tmp)
 struct<id:bigint>
 -- !query output
 2
+
+
+-- !query
+SET spark.sql.optimizer.excludedRules=org.apache.spark.sql.catalyst.optimizer.RewriteLateralSubquery
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.optimizer.excludedRules	org.apache.spark.sql.catalyst.optimizer.RewriteLateralSubquery
+
+
+-- !query
+SELECT * FROM testData, LATERAL (SELECT * FROM testData) LIMIT 1
+-- !query schema
+struct<key:int,value:string,key:int,value:string>
+-- !query output
+1	1	1	1

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4225,13 +4225,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     checkAnswer(sql("""SELECT from_json(R'{"a": "\\"}', 'a string')"""), Row(Row("\\")))
   }
 
-  test("SPARK-36979: Add RewriteLateralSubquery rule into nonExcludableRules") {
-    withSQLConf(SQLConf.OPTIMIZER_EXCLUDED_RULES.key ->
-      "org.apache.spark.sql.catalyst.optimizer.RewriteLateralSubquery") {
-      sql("SELECT * FROM testData, LATERAL (SELECT * FROM testData)").collect()
-    }
-  }
-
   test("TABLE SAMPLE") {
     withTable("test") {
       sql("CREATE TABLE test(c int) USING PARQUET")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Move the test from `SQLQuerySuite` to `SQLQueryTestSuite`.

### Why are the changes needed?

Make the code easier to maintain.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A