### PR TITLE
[SPARK-39514][CORE][TESTS] `LauncherBackendSuite` should add `java.net.preferIPv6Addresses` conf

### DIFF
--- a/core/src/test/scala/org/apache/spark/launcher/LauncherBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/launcher/LauncherBackendSuite.scala
@@ -50,7 +50,8 @@ class LauncherBackendSuite extends SparkFunSuite with Matchers {
       .setSparkHome(sys.props("spark.test.home"))
       .setConf(SparkLauncher.DRIVER_EXTRA_CLASSPATH, System.getProperty("java.class.path"))
       .setConf(UI_ENABLED.key, "false")
-      .setConf(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS, s"-Dtest.appender=console")
+      .setConf(SparkLauncher.DRIVER_EXTRA_JAVA_OPTIONS,
+        s"-Dtest.appender=console -Djava.net.preferIPv6Addresses=${Utils.preferIPv6}")
       .setMaster(master)
       .setAppResource(SparkLauncher.NO_RESOURCE)
       .setMainClass(TestApp.getClass.getName().stripSuffix("$"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `LauncherBackendSuite` should use `java.net.preferIPv6Addresses` conf during launching.

### Why are the changes needed?

**BEFORE**
```
$ SPARK_LOCAL_IP=::1 SBT_OPTS=-Djava.net.preferIPv6Addresses=true build/sbt "core/testOnly *.LauncherBackendSuite"
...
[info] LauncherBackendSuite:
[info] - local: launcher handle *** FAILED *** (30 seconds, 139 milliseconds)
[info]   The code passed to eventually never returned normally. Attempted 296 times over 30.078724458999996 seconds. Last failure message: The reference was null. (LauncherBackendSuite.scala:60)
...
```

**AFTER**
```
SPARK_LOCAL_IP=::1 SBT_OPTS=-Djava.net.preferIPv6Addresses=true build/sbt "core/testOnly *.LauncherBackendSuite"
...
[info] LauncherBackendSuite:
[info] - local: launcher handle (1 second, 432 milliseconds)
[info] - standalone/client: launcher handle (1 second, 600 milliseconds)
[info] Run completed in 3 seconds, 904 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs and do the manual test.