### PR TITLE
[SPARK-39481][SQL] Do not push down complex filter condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1565,22 +1565,46 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     // state and all the input rows processed before. In another word, the order of input rows
     // matters for non-deterministic expressions, while pushing down predicates changes the order.
     // This also applies to Aggregate.
-    case Filter(condition, project @ Project(fields, grandChild))
+    case f @ Filter(condition, project @ Project(fields, grandChild))
       if fields.forall(_.deterministic) && canPushThroughCondition(grandChild, condition) =>
       val aliasMap = getAliasMap(project)
-      val complexExpressionsKeys = aliasMap.filter(_._2.child match {
-        case _: CreateNamedStruct => false // special case, filters may push through it.
-        case e => !e.foldable && e.children.nonEmpty
-      }).keySet
-      if (complexExpressionsKeys.nonEmpty && doNotPushComplexPredicate(grandChild)) {
-        val predicates = splitConjunctivePredicates(condition)
+      if (doNotPushComplexPredicate(grandChild)) {
+        val complexExpsKeys = AttributeSet(
+          aliasMap.filter { case (_, alias) =>
+            alias.child match {
+              case _: CreateNamedStruct => false // special case, filters may push through it.
+              case e => !e.foldable && e.children.nonEmpty
+            }
+          }.keys)
+        // Complex expression keys used by filter
+        val complexFilterExpsKeys = complexExpsKeys.filter(condition.references.contains)
+
         val (remainingPredicates, pushedPredicates) =
-          predicates.partition(_.references.exists(complexExpressionsKeys.contains))
-        val pushedFilter = pushedPredicates.map(replaceAlias(_, aliasMap)).reduceLeftOption(And)
-          .map(e => project.copy(child = Filter(e, grandChild)))
-          .getOrElse(project)
-        remainingPredicates.reduceLeftOption(And).map(Filter(_, pushedFilter))
-          .getOrElse(pushedFilter)
+          splitConjunctivePredicates(condition)
+            .partition(_.references.exists(complexFilterExpsKeys.contains))
+
+        if (pushedPredicates.nonEmpty ||
+          (remainingPredicates.nonEmpty && !complexExpsKeys.subsetOf(complexFilterExpsKeys))) {
+          // The list includes complex expressions used by filter and other expressions's references
+          val complexExpsProjectList = ExpressionSet(fields.flatMap { ne =>
+            if (complexFilterExpsKeys.contains(ne)) ne :: Nil else ne.references
+          }).toSeq.map(_.asInstanceOf[NamedExpression])
+          val newProjectList = fields.map { ne =>
+            // toAttribute to avoid re-evaluating complex expressions used by filters
+            if (complexFilterExpsKeys.contains(ne)) ne.toAttribute else ne
+          }
+
+          val pushedFilter = pushedPredicates.map(replaceAlias(_, aliasMap))
+            .reduceLeftOption(And).map(c => Project(complexExpsProjectList, Filter(c, grandChild)))
+            .getOrElse(Project(complexExpsProjectList, grandChild))
+
+          val remainingFilter =
+            remainingPredicates.reduceLeftOption(And).map(Filter(_, pushedFilter))
+              .getOrElse(pushedFilter)
+          Project(newProjectList, remainingFilter)
+        } else {
+          f
+        }
       } else {
         project.copy(child = Filter(replaceAlias(condition, aliasMap), grandChild))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -350,6 +350,16 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]] extends Product with Tre
   }
 
   /**
+   * Test whether all the [[TreeNode]] satisfies the conditions specified in `f`.
+   * The condition is recursively applied to this node and all of its children (pre-order).
+   */
+  def forall(f: BaseType => Boolean): Boolean = if (!f(this)) {
+    false
+  } else {
+    children.forall(_.forall(f))
+  }
+
+  /**
    * Runs the given function on this node and then recursively on [[children]].
    * @param f the function to be applied to each node in the tree.
    */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -1430,9 +1430,27 @@ class FilterPushdownSuite extends PlanTest {
 
   test("SPARK-39481: Do not push down complex filter condition") {
     val originalQuery =
-      testRelation.select(('a + 1).as("new_a"), 'a).where('new_a > 1 && 'a.in(1, 2, 3))
-    val correctAnswer = testRelation.where('a.in(1, 2, 3)).select(('a + 1).as("new_a"), 'a)
-      .where('new_a > 1)
+      testRelation.select(('a + 1).as("na"), 'a).where('na > 1 && 'a.in(1, 2, 3))
+    val correctAnswer = testRelation.where('a.in(1, 2, 3)).select(('a + 1).as("na"), 'a)
+      .where('na > 1).select('na, 'a)
+
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+  }
+
+  test("SPARK-39481: Push down if current project contains other complex expression") {
+    val originalQuery = testRelation.select(('a + 1).as("na1"), ('a + 2).as("na2"), 'b)
+      .where('na1 > 1)
+    val correctAnswer = testRelation.select(('a + 1).as("na1"), 'a, 'b)
+      .where('na1 > 1).select('na1, ('a + 2).as("na2"), 'b)
+
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+  }
+
+  test("SPARK-39481: Mixed case: Push down non-complex filter and other complex expression") {
+    val originalQuery = testRelation.select(('a + 1).as("na1"), ('a + 2).as("na2"), 'b)
+      .where('na1 > 1 && 'a.in(1, 2, 3))
+    val correctAnswer = testRelation.where('a.in(1, 2, 3)).select(('a + 1).as("na1"), 'a, 'b)
+      .where('na1 > 1).select('na1, ('a + 2).as("na2"), 'b)
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
   }
@@ -1460,6 +1478,18 @@ class FilterPushdownSuite extends PlanTest {
       testRelation.select(CreateNamedStruct(Seq("na", 'a)).as("col1"), 'a).where($"col1.na" > 1)
     val correctAnswer = testRelation.where('a > 1)
       .select(CreateNamedStruct(Seq("na", 'a)).as("col1"), 'a)
+
+    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+  }
+
+  test("SPARK-39481: Mixed case: Push down if current project contains other complex expressions") {
+    val originalQuery =
+      testRelation.select(CreateNamedStruct(Seq("na", 'a)).as("col1"), ('a + 1).as("na1"),
+        ('a + 2).as("na2"), 'a)
+        .where($"col1.na" > 1 && 'na1 > 1)
+    val correctAnswer = testRelation.where('a > 1)
+      .select('a, ('a + 1).as("na1")).where('na1 > 1)
+      .select(CreateNamedStruct(Seq("na", 'a)).as("col1"), 'na1, ('a + 2).as("na2"), 'a)
 
     comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -151,9 +151,9 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
       .join(t2, Inner, Some("t.a".attr === "t2.a".attr && "t.int_col".attr === "t2.a".attr))
       .analyze
     val correctAnswer = t1
-      .where(IsNotNull($"a"))
-      .select($"a", Coalesce(Seq($"a", $"b")).as("int_col"))
-      .where('int_col.isNotNull && 'int_col === 'a).as("t")
+      .where(IsNotNull($"a") && IsNotNull(Coalesce(Seq($"a", $"b"))) &&
+        $"a" === Coalesce(Seq($"a", $"b")))
+      .select($"a", Coalesce(Seq($"a", $"b")).as("int_col")).as("t")
       .join(t2.where(IsNotNull($"a")), Inner,
         Some("t.a".attr === "t2.a".attr && "t.int_col".attr === "t2.a".attr))
       .analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/InferFiltersFromConstraintsSuite.scala
@@ -151,9 +151,9 @@ class InferFiltersFromConstraintsSuite extends PlanTest {
       .join(t2, Inner, Some("t.a".attr === "t2.a".attr && "t.int_col".attr === "t2.a".attr))
       .analyze
     val correctAnswer = t1
-      .where(IsNotNull($"a") && IsNotNull(Coalesce(Seq($"a", $"b"))) &&
-        $"a" === Coalesce(Seq($"a", $"b")))
-      .select($"a", Coalesce(Seq($"a", $"b")).as("int_col")).as("t")
+      .where(IsNotNull($"a"))
+      .select($"a", Coalesce(Seq($"a", $"b")).as("int_col"))
+      .where('int_col.isNotNull && 'int_col === 'a).as("t")
       .join(t2.where(IsNotNull($"a")), Inner,
         Some("t.a".attr === "t2.a".attr && "t.int_col".attr === "t2.a".attr))
       .analyze

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -645,14 +645,14 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
         """
           |(2) Filter [codegen id : 2]
           |Input [1]: [id#xL]
-          |Condition : ((id#xL > Subquery subquery#x, [id=#x]) AND isnotnull((id#xL % 10)))
+          |Condition : (id#xL > Subquery subquery#x, [id=#x])
           |""".stripMargin,
         """
-          |(6) BroadcastQueryStage
+          |(7) BroadcastQueryStage
           |Output [1]: [id#xL]
           |Arguments: 0""".stripMargin,
         """
-          |(12) AdaptiveSparkPlan
+          |(13) AdaptiveSparkPlan
           |Output [2]: [key#xL, value#xL]
           |Arguments: isFinalPlan=true
           |""".stripMargin,
@@ -660,11 +660,11 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
           |Subquery:1 Hosting operator id = 2 Hosting Expression = Subquery subquery#x, [id=#x]
           |""".stripMargin,
         """
-          |(16) ShuffleQueryStage
+          |(17) ShuffleQueryStage
           |Output [1]: [max#xL]
           |Arguments: 0""".stripMargin,
         """
-          |(20) AdaptiveSparkPlan
+          |(21) AdaptiveSparkPlan
           |Output [1]: [max(id)#xL]
           |Arguments: isFinalPlan=true
           |""".stripMargin


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances `PushPredicateThroughNonJoin` to make it do not push down complex filter condition if current project does not contain other complex expressions and `grandChild` only contains `LeafNode`, `Filter` and `Project`. For example:
```scala
spark.sql("CREATE TABLE t1(a int, b int, c int) using parquet")
spark.sql("SELECT * FROM (SELECT a, b + 1 AS b1, c + 2 AS c2 FROM t1) t WHERE a > 1 AND b1 > 10").explain(true)
```
Before this PR:
```
== Optimized Logical Plan ==
Project [a#1, (b#2 + 1) AS b1#0, c#3]
+- Filter ((isnotnull(a#1) AND isnotnull(b#2)) AND ((a#1 > 1) AND ((b#2 + 1) > 10)))
   +- Relation default.t1[a#1,b#2,c#3] parquet
```

After this PR:
```
== Optimized Logical Plan ==
Filter (isnotnull(b1#0) AND (b1#0 > 10))
+- Project [a#1, (b#2 + 1) AS b1#0, c#3]
   +- Filter (isnotnull(a#1) AND (a#1 > 1))
      +- Relation default.t1[a#1,b#2,c#3] parquet
```

### Why are the changes needed?

Reduce complex expression evaluation.

1. Case from [SPARK-39481](https://issues.apache.org/jira/browse/SPARK-39481?focusedCommentId=17556219&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17556219):

   Before this PR:
   ```
   == Optimized Logical Plan ==
   Project [int_col#0, string_col#1, pythonUDF0#10 AS int_col_copy#5]
   +- ArrowEvalPython [copy_int_col(int_col#0)#4], [pythonUDF0#10], 200
      +- Project [int_col#0, string_col#1]
         +- Filter (pythonUDF0#9 >= 3)
            +- ArrowEvalPython [copy_int_col(int_col#0)#4], [pythonUDF0#9], 200
               +- LogicalRDD [int_col#0, string_col#1], false
   ```

   After this PR:
   ```
   == Optimized Logical Plan ==
   Project [int_col#0, string_col#1, pythonUDF0#9 AS int_col_copy#5]
   +- Filter (isnotnull(pythonUDF0#9) AND (pythonUDF0#9 >= 3))
      +- ArrowEvalPython [copy_int_col(int_col#0)#4], [pythonUDF0#9], 200
         +- LogicalRDD [int_col#0, string_col#1], false
   ```

2. Case from [SPARK-36290](https://github.com/apache/spark/pull/33522/files/4aebe0a19fdf84516e30ab917eb149d39c4d4ac6#r743625946):

   Before this PR:
   ```
   == Optimized Logical Plan ==
   Project [a#225, b#226, c#236, d#237]
   +- Join Inner, (CAST(udf(cast(a as string)) AS INT)#250 = CAST(udf(cast(c as string)) AS INT)#251)
      :- Project [_1#220 AS a#225, _2#221 AS b#226, cast(pythonUDF0#253 as int) AS CAST(udf(cast(a as string)) AS INT)#250]
      :  +- BatchEvalPython [udf(cast(_1#220 as string))], [pythonUDF0#253]
      :     +- Project [_1#220, _2#221]
      :        +- Filter isnotnull(cast(pythonUDF0#252 as int))
      :           +- BatchEvalPython [udf(cast(_1#220 as string))], [pythonUDF0#252]
      :              +- LocalRelation [_1#220, _2#221]
      +- Project [_1#231 AS c#236, _2#232 AS d#237, cast(pythonUDF0#255 as int) AS CAST(udf(cast(c as string)) AS INT)#251]
         +- BatchEvalPython [udf(cast(_1#231 as string))], [pythonUDF0#255]
            +- Project [_1#231, _2#232]
               +- Filter isnotnull(cast(pythonUDF0#254 as int))
                  +- BatchEvalPython [udf(cast(_1#231 as string))], [pythonUDF0#254]
                     +- LocalRelation [_1#231, _2#232]
   ```
   
   After this PR:
   ```
   == Optimized Logical Plan ==
   Project [a#225, b#226, c#236, d#237]
   +- Join Inner, (CAST(udf(cast(a as string)) AS INT)#250 = CAST(udf(cast(c as string)) AS INT)#251)
      :- Project [_1#220 AS a#225, _2#221 AS b#226, cast(pythonUDF0#252 as int) AS CAST(udf(cast(a as string)) AS INT)#250]
      :  +- Filter isnotnull(cast(pythonUDF0#252 as int))
      :     +- BatchEvalPython [udf(cast(_1#220 as string))], [pythonUDF0#252]
      :        +- LocalRelation [_1#220, _2#221]
      +- Project [_1#231 AS c#236, _2#232 AS d#237, cast(pythonUDF0#253 as int) AS CAST(udf(cast(c as string)) AS INT)#251]
         +- Filter isnotnull(cast(pythonUDF0#253 as int))
            +- BatchEvalPython [udf(cast(_1#231 as string))], [pythonUDF0#253]
               +- LocalRelation [_1#231, _2#232]
   ```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.