### PR TITLE
[SPARK-39532][INFRA] Move checkout and sync steps into re-usable action

### DIFF
--- a/.github/actions/checkout-and-sync/action.yml
+++ b/.github/actions/checkout-and-sync/action.yml
@@ -1,0 +1,31 @@
+name: 'Checkout and Sync sources'
+author: 'Apache Spark'
+description: 'A composite GitHub Action that git checkout sources and syncs with upstream'
+
+inputs:
+  branch:
+    description: "The branch"
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Checkout Spark repository
+    uses: actions/checkout@v2
+    with:
+      fetch-depth: 0
+      repository: apache/spark
+      ref: ${{ input.branch }}
+
+  - name: Sync the current branch with the latest in Apache Spark
+    if: github.repository != 'apache/spark'
+    shell: bash
+    run: |
+      echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
+      git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
+      git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+
+branding:
+  icon: 'check-circle'
+  color: 'green'

--- a/.github/actions/sync-fork-with-upstream/action.yml
+++ b/.github/actions/sync-fork-with-upstream/action.yml
@@ -1,23 +1,11 @@
-name: 'Checkout and Sync sources'
+name: 'Sync sources'
 author: 'Apache Spark'
-description: 'A composite GitHub Action that git checkout sources and syncs with upstream'
-
-inputs:
-  branch:
-    description: "The branch"
-    required: true
+description: 'A composite GitHub Action that syncs fork branch with Spark master'
 
 runs:
   using: 'composite'
   steps:
-  - name: Checkout Spark repository
-    uses: actions/checkout@v2
-    with:
-      fetch-depth: 0
-      repository: apache/spark
-      ref: ${{ input.branch }}
-
-  - name: Sync the current branch with the latest in Apache Spark
+  - name: Sync the current branch with the latest master in Apache Spark
     if: github.repository != 'apache/spark'
     shell: bash
     run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,10 +116,14 @@ jobs:
     outputs:
       required: ${{ steps.set-outputs.outputs.required }}
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     - name: Check all modules
       id: set-outputs
       run: |
@@ -206,10 +210,14 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -306,10 +314,14 @@ jobs:
       METASPACE_SIZE: 1g
       SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -386,10 +398,14 @@ jobs:
       SKIP_MIMA: true
       SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -441,10 +457,14 @@ jobs:
     container:
       image: dongjoon/apache-spark-github-action-image:20220207
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -548,10 +568,14 @@ jobs:
           - 17
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -590,10 +614,14 @@ jobs:
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -631,10 +659,14 @@ jobs:
       SPARK_LOCAL_IP: localhost
       SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -723,10 +755,14 @@ jobs:
       ORACLE_DOCKER_IMAGE_NAME: gvenzl/oracle-xe:21.3.0
       SKIP_MIMA: true
     steps:
-    - name: Checkout Spark repository and sync with latest master
-      uses: ./.github/actions/checkout-and-sync
+    - name: Checkout Spark repository
+      uses: actions/checkout@v2
       with:
-        branch: ${{ needs.configure-jobs.outputs.branch }}
+        fetch-depth: 0
+        repository: apache/spark
+        ref: ${{ needs.configure-jobs.outputs.branch }}
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/sync-fork-with-upstream
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,19 +116,10 @@ jobs:
     outputs:
       required: ${{ steps.set-outputs.outputs.required }}
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     - name: Check all modules
       id: set-outputs
       run: |
@@ -215,20 +206,10 @@ jobs:
       GITHUB_PREV_SHA: ${{ github.event.before }}
       SPARK_LOCAL_IP: localhost
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -325,20 +306,10 @@ jobs:
       METASPACE_SIZE: 1g
       SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -415,20 +386,10 @@ jobs:
       SKIP_MIMA: true
       SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
-      # In order to fetch changed files
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -480,18 +441,10 @@ jobs:
     container:
       image: dongjoon/apache-spark-github-action-image:20220207
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     # Cache local repositories. Note that GitHub Actions cache has a 2G limit.
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
@@ -595,18 +548,10 @@ jobs:
           - 17
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -645,18 +590,10 @@ jobs:
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -694,18 +631,10 @@ jobs:
       SPARK_LOCAL_IP: localhost
       SPARK_ANSI_SQL_MODE: ${{ inputs.ansi_enabled }}
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:
@@ -794,19 +723,10 @@ jobs:
       ORACLE_DOCKER_IMAGE_NAME: gvenzl/oracle-xe:21.3.0
       SKIP_MIMA: true
     steps:
-    - name: Checkout Spark repository
-      uses: actions/checkout@v2
+    - name: Checkout Spark repository and sync with latest master
+      uses: ./.github/actions/checkout-and-sync
       with:
-        fetch-depth: 0
-        repository: apache/spark
-        ref: ${{ needs.configure-jobs.outputs.branch }}
-    - name: Sync the current branch with the latest in Apache Spark
-      if: github.repository != 'apache/spark'
-      run: |
-        echo "APACHE_SPARK_REF=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        git fetch https://github.com/$GITHUB_REPOSITORY.git ${GITHUB_REF#refs/heads/}
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
-        git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
+        branch: ${{ needs.configure-jobs.outputs.branch }}
     - name: Cache Scala, SBT and Maven
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Steps "Checkout Spark repository" and "Sync the current branch with the latest in Apache Spark" are defined 9 times in `build-and-test.yml`. This moves these two steps into a composite action that is than reused.

### Why are the changes needed?
Simplifies workflow file and reduces code duplication.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested in fork CI.