### PR TITLE
[SPARK-39533][ML] Deprecate scoreLabelsWeight in BinaryClassificationMetrics

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -45,6 +45,8 @@ class BinaryClassificationMetrics @Since("3.0.0") (
     @Since("1.3.0") val scoreAndLabels: RDD[_ <: Product],
     @Since("1.3.0") val numBins: Int = 1000)
   extends Logging {
+
+  @deprecated("this variable should be private and will be removed in 4.0.0.", "3.4.0")
   val scoreLabelsWeight: RDD[(Double, (Double, Double))] = scoreAndLabels.map {
     case (prediction: Double, label: Double, weight: Double) =>
       require(weight >= 0.0, s"instance weight, $weight has to be >= 0.0")

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -46,7 +46,7 @@ class BinaryClassificationMetrics @Since("3.0.0") (
     @Since("1.3.0") val numBins: Int = 1000)
   extends Logging {
 
-  @deprecated("The variable scoreLabelsWeight should be private and " +
+  @deprecated("The variable `scoreLabelsWeight` should be private and " +
     "will be removed in 4.0.0.", "3.4.0")
   val scoreLabelsWeight: RDD[(Double, (Double, Double))] = scoreAndLabels.map {
     case (prediction: Double, label: Double, weight: Double) =>

--- a/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/evaluation/BinaryClassificationMetrics.scala
@@ -46,7 +46,8 @@ class BinaryClassificationMetrics @Since("3.0.0") (
     @Since("1.3.0") val numBins: Int = 1000)
   extends Logging {
 
-  @deprecated("this variable should be private and will be removed in 4.0.0.", "3.4.0")
+  @deprecated("The variable scoreLabelsWeight should be private and " +
+    "will be removed in 4.0.0.", "3.4.0")
   val scoreLabelsWeight: RDD[(Double, (Double, Double))] = scoreAndLabels.map {
     case (prediction: Double, label: Double, weight: Double) =>
       require(weight >= 0.0, s"instance weight, $weight has to be >= 0.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Deprecate `scoreLabelsWeight` in `BinaryClassificationMetrics`


### Why are the changes needed?

`scoreLabelsWeight` in `BinaryClassificationMetrics` is a public variable, but it should be private since it is only for internal purpose.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
existing UT
