### PR TITLE
[SPARK-39521][INFRA][FOLLOW-UP] Fix notify workload to detect the main build, and readme link

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -46,7 +46,7 @@ jobs:
             const params = {
               owner: context.payload.pull_request.head.repo.owner.login,
               repo: context.payload.pull_request.head.repo.name,
-              id: 'build_and_test.yml',
+              id: 'build_main.yml',
               branch: context.payload.pull_request.head.ref,
             }
             const check_run_params = {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and Structured Streaming for stream processing.
 
 <https://spark.apache.org/>
 
-[![GitHub Action Build](https://github.com/apache/spark/actions/workflows/build_and_test.yml/badge.svg?branch=master&event=push)](https://github.com/apache/spark/actions/workflows/build_and_test.yml?query=branch%3Amaster+event%3Apush)
+[![GitHub Actions Build](https://github.com/apache/spark/actions/workflows/build_main.yml/badge.svg)](https://github.com/apache/spark/actions/workflows/build_main.yml)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/ApacheSoftwareFoundation/spark/master.svg?style=plastic&logo=appveyor)](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark)
 [![PySpark Coverage](https://codecov.io/gh/apache/spark/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/spark)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the notify_test_workflow.yml to detect build_main.yml that is for PR builds.

In addition, this PR fixes the link of build status in README.md.

### Why are the changes needed?

To make the build fixed.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

N/A. Should better be merged fixed and tested since it's already broken.