### PR TITLE
[MINOR][INFRA] Remove branch and types in GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,7 @@ jobs:
 
   # Build: build Spark and run the tests for specified modules.
   build:
-    name: "Build modules (${{ format('{0}, {1} job', inputs.branch, inputs.type) }}): ${{ matrix.modules }} ${{ matrix.comment }} (JDK ${{ matrix.java }}, ${{ matrix.hadoop }}, ${{ matrix.hive }})"
+    name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     needs: precondition
     # Run scheduled jobs for Apache Spark only
     # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
@@ -234,7 +234,7 @@ jobs:
       inputs.type == 'pyspark-coverage-scheduled'
       || (inputs.type == 'scheduled' && inputs.java == '17')
       || (inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).pyspark == 'true')
-    name: "Build modules (${{ format('{0}, {1} job', inputs.branch, inputs.type) }}): ${{ matrix.modules }}"
+    name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
       image: dongjoon/apache-spark-github-action-image:20220207


### PR DESCRIPTION
### What changes were proposed in this pull request?

After SPARK-39521, we don't need such information anymore because they are all classified under Actions as below:

<img width="416" alt="Screen Shot 2022-06-21 at 9 05 13 AM" src="https://user-images.githubusercontent.com/6477701/174708227-62a54a73-2679-49e8-b017-22f98d789400.png">

### Why are the changes needed?

To remove unnecessary information

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Tested as below:

<img width="288" alt="Screen Shot 2022-06-21 at 1 36 13 PM" src="https://user-images.githubusercontent.com/6477701/174717053-a387949e-88b5-44c0-a478-f7525e0c7019.png">

