### PR TITLE
[SPARK-39540][BUILD] Upgrade `mysql-connector-java` to 8.0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1218,7 +1218,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.27</version>
+        <version>8.0.28</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1218,7 +1218,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.28</version>
+        <version>8.0.29</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade mysql-connector-java from 8.0.27 to 8.0.29


### Why are the changes needed?
Improper Handling of Insufficient Permissions or Privileges in MySQL Connectors Java.

Vulnerability in the MySQL Connectors product of Oracle MySQL (component: Connector/J). Supported versions that are affected are 8.0.27 and prior. Difficult to exploit vulnerability allows high privileged attacker with network access via multiple protocols to compromise MySQL Connectors. Successful attacks of this vulnerability can result in takeover of MySQL Connectors. CVSS 3.1 Base Score 6.6 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H).

[CVE-2022-21363](https://nvd.nist.gov/vuln/detail/CVE-2022-21363)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA
