### PR TITLE
[SPARK-39529][INFRA] Refactor and merge all related job selection logic into precondition

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,24 +27,27 @@ on:
         type: string
         default: 8
       branch:
-        description: 'Branch to run the build against'
+        description: Branch to run the build against
         required: false
         type: string
         default: master
       hadoop:
-        description: 'Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.'
+        description: Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.
         required: false
         type: string
         default: hadoop3
       envs:
-        description: 'Additional environment variables to set when running the tests. Should be in JSON format.'
+        description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false
         type: string
-        default: "{}"
+        default: '{}'
       jobs:
-        description: 'Jobs to run, and should be in JSON format. See precondition job below.'
+        description: >-
+          Jobs to run, and should be in JSON format. The values should be matched with the job's key defined
+          in this file, e.g., build. See precondition job below.
         required: false
         type: string
+        default: ''
 jobs:
   precondition:
     name: Check changes
@@ -72,28 +75,45 @@ jobs:
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
           # is-changed.py is missing in branch-3.2, and it might run in scheduled build, see also SPARK-39517
-          build=true; pyspark=true; sparkr=true; tpcds=true; docker=true;
+          pyspark=true; sparkr=true; tpcds=true; docker=true;
           if [ -f "./dev/is-changed.py" ]; then
-            # 'build' is always true because 1. it dose not save significant time and 2. most of PRs trigger the build.
-            pyspark_modules=`python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`
-            pyspark=`./dev/is-changed.py -c -m $pyspark_modules`
-            sparkr=`./dev/is-changed.py -c -m sparkr`
-            tpcds=`./dev/is-changed.py -c -m sql`
-            docker=`./dev/is-changed.py -c -m docker-integration-tests`
+            pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`
+            pyspark=`./dev/is-changed.py -m $pyspark_modules`
+            sparkr=`./dev/is-changed.py -m sparkr`
+            tpcds=`./dev/is-changed.py -m sql`
+            docker=`./dev/is-changed.py -m docker-integration-tests`
           fi
-          precondition="{\"build\": \"$build\", \"pyspark\": \"$pyspark\", \"sparkr\": \"$sparkr\", \"tpcds-1g\": \"$tpcds\", \"docker-integration-tests\": \"$docker\"}"
+          # 'build', 'scala-213', and 'java-11-17' are always true for now.
+          # It does not save significant time and most of PRs trigger the build.
+          precondition="
+            {
+              \"build\": \"true\",
+              \"pyspark\": \"$pyspark\",
+              \"sparkr\": \"$sparkr\",
+              \"tpcds-1g\": \"$tpcds\",
+              \"docker-integration-tests\": \"$docker\",
+              \"scala-213\": \"true\",
+              \"java-11-17\": \"true\",
+              \"lint\" : \"true\"
+            }"
           echo $precondition # For debugging
+          # GitHub Actions set-output doesn't take newlines
+          # https://github.community/t/set-output-truncates-multiline-strings/16852/3
+          precondition="${precondition//$'\n'/'%0A'}"
           echo "::set-output name=required::$precondition"
         else
           # This is usually set by scheduled jobs.
-          echo "::set-output name=required::${{ inputs.jobs }}
+          precondition='${{ inputs.jobs }}'
+          echo $precondition # For debugging
+          precondition="${precondition//$'\n'/'%0A'}"
+          echo "::set-output name=required::$precondition"
         fi
 
   # Build: build Spark and run the tests for specified modules.
   build:
     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     needs: precondition
-    if: fromJson(needs.precondition.outputs.required).build == 'true')
+    if: fromJson(needs.precondition.outputs.required).build == 'true'
     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
     runs-on: ubuntu-20.04
     strategy:
@@ -233,9 +253,6 @@ jobs:
 
   pyspark:
     needs: precondition
-    # Run PySpark coverage scheduled jobs for Apache Spark only
-    # Run scheduled jobs with JDK 17 in Apache Spark
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if pyspark changes exist
     if: fromJson(needs.precondition.outputs.required).pyspark == 'true'
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
@@ -338,8 +355,6 @@ jobs:
 
   sparkr:
     needs: precondition
-    # Run scheduled jobs with JDK 17 in Apache Spark
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if sparkr changes exist
     if: fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
@@ -406,6 +421,8 @@ jobs:
 
   # Static analysis, and documentation build
   lint:
+    needs: precondition
+    if: fromJson(needs.precondition.outputs.required).lint == 'true'
     name: Linters, licenses, dependencies and documentation generation
     runs-on: ubuntu-20.04
     env:
@@ -520,7 +537,7 @@ jobs:
 
   java-11-17:
     needs: precondition
-    if: fromJson(needs.precondition.outputs.required).build == 'true'
+    if: fromJson(needs.precondition.outputs.required).java-11-17 == 'true'
     name: Java ${{ matrix.java }} build with Maven
     strategy:
       fail-fast: false
@@ -575,7 +592,7 @@ jobs:
 
   scala-213:
     needs: precondition
-    if: fromJson(needs.precondition.outputs.required).build == 'true'
+    if: fromJson(needs.precondition.outputs.required).scala-213 == 'true'
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,21 +27,24 @@ on:
         type: string
         default: 8
       branch:
+        description: 'Branch to run the build against'
         required: false
         type: string
         default: master
       hadoop:
+        description: 'Hadoop version to run with. HADOOP_PROFILE environment variable should accept it.'
         required: false
         type: string
         default: hadoop3
-      type:
-        required: false
-        type: string
-        default: regular
       envs:
+        description: 'Additional environment variables to set when running the tests. Should be in JSON format.'
         required: false
         type: string
         default: "{}"
+      jobs:
+        description: 'Jobs to run, and should be in JSON format. See precondition job below.'
+        required: false
+        type: string
 jobs:
   precondition:
     name: Check changes
@@ -67,27 +70,30 @@ jobs:
     - name: Check all modules
       id: set-outputs
       run: |
-        # is-changed.py is missing in branch-3.2, and it might run in scheduled build, see also SPARK-39517
-        build=true; pyspark=true; sparkr=true; tpcds=true; docker=true;
-        if [ -f "./dev/is-changed.py" ]; then
-          build=`./dev/is-changed.py -m avro,build,catalyst,core,docker-integration-tests,examples,graphx,hadoop-cloud,hive,hive-thriftserver,kubernetes,kvstore,launcher,mesos,mllib,mllib-local,network-common,network-shuffle,pyspark-core,pyspark-ml,pyspark-mllib,pyspark-pandas,pyspark-pandas-slow,pyspark-resource,pyspark-sql,pyspark-streaming,repl,sketch,spark-ganglia-lgpl,sparkr,sql,sql-kafka-0-10,streaming,streaming-kafka-0-10,streaming-kinesis-asl,tags,unsafe,yarn`
-          pyspark=`./dev/is-changed.py -m avro,build,catalyst,core,graphx,hive,kvstore,launcher,mllib,mllib-local,network-common,network-shuffle,pyspark-core,pyspark-ml,pyspark-mllib,pyspark-pandas,pyspark-pandas-slow,pyspark-resource,pyspark-sql,pyspark-streaming,repl,sketch,sql,tags,unsafe`
-          sparkr=`./dev/is-changed.py -m avro,build,catalyst,core,hive,kvstore,launcher,mllib,mllib-local,network-common,network-shuffle,repl,sketch,sparkr,sql,tags,unsafe`
-          tpcds=`./dev/is-changed.py -m build,catalyst,core,hive,kvstore,launcher,network-common,network-shuffle,repl,sketch,sql,tags,unsafe`
-          docker=`./dev/is-changed.py -m build,catalyst,core,docker-integration-tests,hive,kvstore,launcher,network-common,network-shuffle,repl,sketch,sql,tags,unsafe`
+        if [ -z "${{ inputs.jobs }}" ]; then
+          # is-changed.py is missing in branch-3.2, and it might run in scheduled build, see also SPARK-39517
+          build=true; pyspark=true; sparkr=true; tpcds=true; docker=true;
+          if [ -f "./dev/is-changed.py" ]; then
+            # 'build' is always true because 1. it dose not save significant time and 2. most of PRs trigger the build.
+            pyspark_modules=`python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`
+            pyspark=`./dev/is-changed.py -c -m $pyspark_modules`
+            sparkr=`./dev/is-changed.py -c -m sparkr`
+            tpcds=`./dev/is-changed.py -c -m sql`
+            docker=`./dev/is-changed.py -c -m docker-integration-tests`
+          fi
+          precondition="{\"build\": \"$build\", \"pyspark\": \"$pyspark\", \"sparkr\": \"$sparkr\", \"tpcds-1g\": \"$tpcds\", \"docker-integration-tests\": \"$docker\"}"
+          echo $precondition # For debugging
+          echo "::set-output name=required::$precondition"
+        else
+          # This is usually set by scheduled jobs.
+          echo "::set-output name=required::${{ inputs.jobs }}
         fi
-        echo "{\"build\": \"$build\", \"pyspark\": \"$pyspark\", \"sparkr\": \"$sparkr\", \"tpcds\": \"$tpcds\", \"docker\": \"$docker\"}" > required.json
-        cat required.json
-        echo "::set-output name=required::$(cat required.json)"
 
   # Build: build Spark and run the tests for specified modules.
   build:
     name: "Build modules: ${{ matrix.modules }} ${{ matrix.comment }}"
     needs: precondition
-    # Run scheduled jobs for Apache Spark only
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
-    if: >-
-      inputs.type == 'scheduled' || (inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true')
+    if: fromJson(needs.precondition.outputs.required).build == 'true')
     # Ubuntu 20.04 is the latest LTS. The next LTS is 22.04.
     runs-on: ubuntu-20.04
     strategy:
@@ -230,10 +236,7 @@ jobs:
     # Run PySpark coverage scheduled jobs for Apache Spark only
     # Run scheduled jobs with JDK 17 in Apache Spark
     # Run regular jobs for commit in both Apache Spark and forked repository, but only if pyspark changes exist
-    if: >-
-      inputs.type == 'pyspark-coverage-scheduled'
-      || (inputs.type == 'scheduled' && inputs.java == '17')
-      || (inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).pyspark == 'true')
+    if: fromJson(needs.precondition.outputs.required).pyspark == 'true'
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
@@ -337,9 +340,7 @@ jobs:
     needs: precondition
     # Run scheduled jobs with JDK 17 in Apache Spark
     # Run regular jobs for commit in both Apache Spark and forked repository, but only if sparkr changes exist
-    if: >-
-      (inputs.type == 'scheduled' && inputs.java == '17')
-      || (inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).sparkr == 'true')
+    if: fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
@@ -405,7 +406,6 @@ jobs:
 
   # Static analysis, and documentation build
   lint:
-    if: inputs.type == 'regular'
     name: Linters, licenses, dependencies and documentation generation
     runs-on: ubuntu-20.04
     env:
@@ -520,8 +520,7 @@ jobs:
 
   java-11-17:
     needs: precondition
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
-    if: inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
+    if: fromJson(needs.precondition.outputs.required).build == 'true'
     name: Java ${{ matrix.java }} build with Maven
     strategy:
       fail-fast: false
@@ -576,8 +575,7 @@ jobs:
 
   scala-213:
     needs: precondition
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if changes exist
-    if: inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).build == 'true'
+    if: fromJson(needs.precondition.outputs.required).build == 'true'
     name: Scala 2.13 build with SBT
     runs-on: ubuntu-20.04
     steps:
@@ -622,8 +620,7 @@ jobs:
 
   tpcds-1g:
     needs: precondition
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if tpcds changes exist
-    if: inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).tpcds == 'true'
+    if: fromJson(needs.precondition.outputs.required).tpcds-1g == 'true'
     name: Run TPC-DS queries with SF=1
     runs-on: ubuntu-20.04
     env:
@@ -720,8 +717,7 @@ jobs:
 
   docker-integration-tests:
     needs: precondition
-    # Run regular jobs for commit in both Apache Spark and forked repository, but only if docker changes exist
-    if: inputs.type == 'regular' && fromJson(needs.precondition.outputs.required).docker == 'true'
+    if: fromJson(needs.precondition.outputs.required).docker-integration-tests == 'true'
     name: Run Docker integration tests
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/build_ansi.yml
+++ b/.github/workflows/build_ansi.yml
@@ -36,3 +36,11 @@ jobs:
         {
           "SPARK_ANSI_SQL_MODE": "true",
         }
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true"
+        }

--- a/.github/workflows/build_ansi.yml
+++ b/.github/workflows/build_ansi.yml
@@ -32,7 +32,6 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop3
-      type: scheduled
       envs: >-
         {
           "SPARK_ANSI_SQL_MODE": "true",

--- a/.github/workflows/build_branch32.yml
+++ b/.github/workflows/build_branch32.yml
@@ -36,3 +36,12 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13"
         }
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true",
+          "lint" : "true"
+        }

--- a/.github/workflows/build_branch32.yml
+++ b/.github/workflows/build_branch32.yml
@@ -32,7 +32,6 @@ jobs:
       java: 8
       branch: branch-3.2
       hadoop: hadoop3.2
-      type: scheduled
       envs: >-
         {
           "SCALA_PROFILE": "scala2.13"

--- a/.github/workflows/build_branch33.yml
+++ b/.github/workflows/build_branch33.yml
@@ -36,3 +36,12 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13"
         }
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true",
+          "lint" : "true"
+        }

--- a/.github/workflows/build_branch33.yml
+++ b/.github/workflows/build_branch33.yml
@@ -32,7 +32,6 @@ jobs:
       java: 8
       branch: branch-3.3
       hadoop: hadoop3
-      type: scheduled
       envs: >-
         {
           "SCALA_PROFILE": "scala2.13"

--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -32,7 +32,10 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop3
-      type: pyspark-coverage-scheduled
+      jobs: >-
+        {
+          "pyspark": "true"
+        }
       envs: >-
         {
           "PYSPARK_CODECOV": "true"

--- a/.github/workflows/build_coverage.yml
+++ b/.github/workflows/build_coverage.yml
@@ -32,11 +32,11 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop3
-      jobs: >-
-        {
-          "pyspark": "true"
-        }
       envs: >-
         {
           "PYSPARK_CODECOV": "true"
+        }
+      jobs: >-
+        {
+          "pyspark": "true"
         }

--- a/.github/workflows/build_hadoop2.yml
+++ b/.github/workflows/build_hadoop2.yml
@@ -32,3 +32,11 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop2
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true"
+        }

--- a/.github/workflows/build_hadoop2.yml
+++ b/.github/workflows/build_hadoop2.yml
@@ -32,4 +32,3 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop2
-      type: scheduled

--- a/.github/workflows/build_java11.yml
+++ b/.github/workflows/build_java11.yml
@@ -37,3 +37,11 @@ jobs:
           "SKIP_MIMA": "true",
           "SKIP_UNIDOC": "true"
         }
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true"
+        }

--- a/.github/workflows/build_java11.yml
+++ b/.github/workflows/build_java11.yml
@@ -32,7 +32,6 @@ jobs:
       java: 11
       branch: master
       hadoop: hadoop3
-      type: scheduled
       envs: >-
         {
           "SKIP_MIMA": "true",

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -37,3 +37,11 @@ jobs:
           "SKIP_MIMA": "true",
           "SKIP_UNIDOC": "true"
         }
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true"
+        }

--- a/.github/workflows/build_java17.yml
+++ b/.github/workflows/build_java17.yml
@@ -32,7 +32,6 @@ jobs:
       java: 17
       branch: master
       hadoop: hadoop3
-      type: scheduled
       envs: >-
         {
           "SKIP_MIMA": "true",

--- a/.github/workflows/build_scala213.yml
+++ b/.github/workflows/build_scala213.yml
@@ -36,3 +36,12 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13"
         }
+      jobs: >-
+        {
+          "build": "true",
+          "pyspark": "true",
+          "sparkr": "true",
+          "tpcds-1g": "true",
+          "docker-integration-tests": "true",
+          "lint" : "true"
+        }

--- a/.github/workflows/build_scala213.yml
+++ b/.github/workflows/build_scala213.yml
@@ -32,7 +32,6 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop3
-      type: scheduled
       envs: >-
         {
           "SCALA_PROFILE": "scala2.13"

--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -34,9 +34,6 @@ def parse_opts():
     parser.add_argument(
         "-f", "--fail", action="store_true", help="Exit with 1 if there is no relevant change."
     )
-    parser.add_argument(
-        "-c", "--check-dependent-modules", action="store_true", help="Check dependent modules."
-    )
 
     default_value = ",".join(sorted([m.name for m in modules.all_modules]))
     parser.add_argument(
@@ -55,6 +52,8 @@ def parse_opts():
 
 def main():
     opts = parse_opts()
+
+    test_modules = opts.modules.split(",")
     changed_files = []
     if os.environ.get("APACHE_SPARK_REF"):
         changed_files = identify_changed_files_from_git_commits(
@@ -64,23 +63,17 @@ def main():
         changed_files = identify_changed_files_from_git_commits(
             os.environ["GITHUB_SHA"], target_ref=os.environ["GITHUB_PREV_SHA"]
         )
-
-    str_test_modules = [m.strip() for m in opts.modules.split(",")]
-    test_modules = [m for m in modules.all_modules if m.name in str_test_modules]
-    if opts.check_dependent_modules:
-        test_modules = determine_modules_to_test(test_modules, deduplicated=False)
-
     changed_modules = determine_modules_to_test(
         determine_modules_for_files(changed_files), deduplicated=False
     )
-
+    module_names = [m.name for m in changed_modules]
     if len(changed_modules) == 0:
         print("false")
         if opts.fail:
             sys.exit(1)
-    elif modules.root in test_modules or modules.root in changed_modules:
+    elif "root" in test_modules or modules.root in changed_modules:
         print("true")
-    elif len(set(test_modules).intersection(changed_modules)) == 0:
+    elif len(set(test_modules).intersection(module_names)) == 0:
         print("false")
         if opts.fail:
             sys.exit(1)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR borrows the idea from https://github.com/apache/spark/pull/36928 but adds some more changes in order for scheduled jobs to share the `precondition` so all conditional logic is consolidated here.

This PR also adds a new option to `is-changed.py` so dependent modules can be checked together. In this way, we don't have to change `build_and_test.yml` often when we add a new module.

In addition, this PR removes `type` because `precondition` job now replaces it.

Lastly, this PR enables PySpark, SparkR TPC-DS and Docker integration tests for scheduled jobs when applicable.

Closes #36928

### Why are the changes needed?

To make it easier to read.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Tested locally and in my fork (https://github.com/HyukjinKwon/spark/actions)