### PR TITLE
[SPARK-39552][SQL] Unify v1 and v2 `DESCRIBE TABLE`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DescribeTableExec.scala
@@ -31,9 +31,9 @@ case class DescribeTableExec(
   override protected def run(): Seq[InternalRow] = {
     val rows = new ArrayBuffer[InternalRow]()
     addSchema(rows)
+    addPartitioning(rows)
 
     if (isExtended) {
-      addPartitioning(rows)
       addMetadataColumns(rows)
       addTableDetails(rows)
     }
@@ -80,8 +80,8 @@ case class DescribeTableExec(
   }
 
   private def addPartitioning(rows: ArrayBuffer[InternalRow]): Unit = {
-    rows += emptyRow()
     if (!table.partitioning.isEmpty) {
+      rows += emptyRow()
       rows += toCatalystRow("# Partitioning", "", "")
       rows ++= table.partitioning.zipWithIndex.map {
         case (transform, index) => toCatalystRow(s"Part $index", transform.describe(), "")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -44,7 +44,7 @@ trait DescribeTableSuiteBase extends QueryTest with DDLCommandTestUtils {
     }
   }
 
-  test("DESCRIBE TABLE with non-'partitioned-by' clause") {
+  test("DESCRIBE TABLE of a non-partitioned table") {
     withNamespaceAndTable("ns", "table") { tbl =>
       spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing")
       val descriptionDf = spark.sql(s"DESCRIBE TABLE $tbl")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -47,25 +47,6 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
       assert(e.message === "Partition not found in table 'table' database 'ns':\nid -> 1")
     }
   }
-
-  test("DESCRIBE TABLE of a partitioned table") {
-    withNamespaceAndTable("ns", "table") { tbl =>
-      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing PARTITIONED BY (id)")
-      val descriptionDf = spark.sql(s"DESCRIBE TABLE $tbl")
-      assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
-        ("col_name", StringType),
-        ("data_type", StringType),
-        ("comment", StringType)))
-      QueryTest.checkAnswer(
-        descriptionDf.filter("col_name != 'Created Time'"),
-        Seq(
-          Row("data", "string", null),
-          Row("id", "bigint", null),
-          Row("# Partition Information", "", ""),
-          Row("# col_name", "data_type", "comment"),
-          Row("id", "bigint", null)))
-    }
-  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.command.v1
 
+import java.util.Locale
+
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.execution.command
 import org.apache.spark.sql.types.StringType
@@ -32,6 +34,8 @@ import org.apache.spark.sql.types.StringType
  */
 trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
   with command.TestsV1AndV2Commands {
+
+  def getProvider(): String = defaultUsing.stripPrefix("USING").trim.toLowerCase(Locale.ROOT)
 
   test("Describing of a non-existent partition") {
     withNamespaceAndTable("ns", "table") { tbl =>
@@ -79,7 +83,7 @@ class DescribeTableSuite extends DescribeTableSuiteBase with CommandSuiteBase {
           Row("Last Access", "UNKNOWN", ""),
           Row("Created By", "Spark 3.4.0-SNAPSHOT", ""),
           Row("Type", "EXTERNAL", ""),
-          Row("Provider", "parquet", ""),
+          Row("Provider", getProvider(), ""),
           Row("Comment", "this is a test table", ""),
           Row("Table Properties", "[bar=baz]", ""),
           Row("Location", "file:/tmp/testcat/table_name", ""),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -33,23 +33,6 @@ import org.apache.spark.sql.types.StringType
 trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
   with command.TestsV1AndV2Commands {
 
-  test("DESCRIBE TABLE with non-'partitioned-by' clause") {
-    withNamespaceAndTable("ns", "table") { tbl =>
-      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing")
-      val descriptionDf = spark.sql(s"DESCRIBE TABLE $tbl")
-      assert(descriptionDf.schema.map(field => (field.name, field.dataType)) ===
-        Seq(
-          ("col_name", StringType),
-          ("data_type", StringType),
-          ("comment", StringType)))
-      QueryTest.checkAnswer(
-        descriptionDf,
-        Seq(
-          Row("data", "string", null),
-          Row("id", "bigint", null)))
-    }
-  }
-
   test("Describing a partition is not supported") {
     withNamespaceAndTable("ns", "table") { tbl =>
       spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing " +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -47,6 +47,25 @@ trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
       assert(e.message === "Partition not found in table 'table' database 'ns':\nid -> 1")
     }
   }
+
+  test("DESCRIBE TABLE of a partitioned table") {
+    withNamespaceAndTable("ns", "table") { tbl =>
+      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing PARTITIONED BY (id)")
+      val descriptionDf = spark.sql(s"DESCRIBE TABLE $tbl")
+      assert(descriptionDf.schema.map(field => (field.name, field.dataType)) === Seq(
+        ("col_name", StringType),
+        ("data_type", StringType),
+        ("comment", StringType)))
+      QueryTest.checkAnswer(
+        descriptionDf.filter("col_name != 'Created Time'"),
+        Seq(
+          Row("data", "string", null),
+          Row("id", "bigint", null),
+          Row("# Partition Information", "", ""),
+          Row("# col_name", "data_type", "comment"),
+          Row("id", "bigint", null)))
+    }
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.StringType
 trait DescribeTableSuiteBase extends command.DescribeTableSuiteBase
   with command.TestsV1AndV2Commands {
 
-  test("Describing a partition is not supported") {
+  test("Describing of a non-existent partition") {
     withNamespaceAndTable("ns", "table") { tbl =>
       spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing " +
         "PARTITIONED BY (id)")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -28,26 +28,6 @@ import org.apache.spark.util.Utils
  */
 class DescribeTableSuite extends command.DescribeTableSuiteBase with CommandSuiteBase {
 
-  test("DESCRIBE TABLE with non-'partitioned-by' clause") {
-    withNamespaceAndTable("ns", "table") { tbl =>
-      spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing")
-      val descriptionDf = spark.sql(s"DESCRIBE TABLE $tbl")
-      assert(descriptionDf.schema.map(field => (field.name, field.dataType)) ===
-        Seq(
-          ("col_name", StringType),
-          ("data_type", StringType),
-          ("comment", StringType)))
-      QueryTest.checkAnswer(
-        descriptionDf,
-        Seq(
-          Row("data", "string", ""),
-          Row("id", "bigint", ""),
-          Row("", "", ""),
-          Row("# Partitioning", "", ""),
-          Row("Not partitioned", "", "")))
-    }
-  }
-
   test("Describing a partition is not supported") {
     withNamespaceAndTable("ns", "table") { tbl =>
       spark.sql(s"CREATE TABLE $tbl (id bigint, data string) $defaultUsing " +
@@ -74,8 +54,8 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase with CommandSuit
       QueryTest.checkAnswer(
         descriptionDf,
         Seq(
-          Row("id", "bigint", ""),
-          Row("data", "string", ""),
+          Row("id", "bigint", null),
+          Row("data", "string", null),
           Row("", "", ""),
           Row("# Partitioning", "", ""),
           Row("Part 0", "id", ""),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -39,7 +39,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase with CommandSuit
     }
   }
 
-  test("DESCRIBE TABLE of a partitioned table by a nested column") {
+  test("DESCRIBE TABLE of a partitioned table by nested columns") {
     withNamespaceAndTable("ns", "table") { tbl =>
       sql(s"CREATE TABLE $tbl (s struct<id:INT, a:BIGINT>, data string) " +
         s"$defaultUsing PARTITIONED BY (s.id, s.a)")
@@ -83,6 +83,7 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase with CommandSuit
           Row("", "", ""),
           Row("# Detailed Table Information", "", ""),
           Row("Name", tbl, ""),
+          Row("Type", "MANAGED", ""),
           Row("Comment", "this is a test table", ""),
           Row("Location", "file:/tmp/testcat/table_name", ""),
           Row("Provider", "_", ""),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/DescribeTableSuite.scala
@@ -56,9 +56,9 @@ class DescribeTableSuite extends command.DescribeTableSuiteBase with CommandSuit
         Seq(
           Row("id", "bigint", null),
           Row("data", "string", null),
-          Row("", "", ""),
-          Row("# Partitioning", "", ""),
-          Row("Part 0", "id", ""),
+          Row("# Partition Information", "", ""),
+          Row("# col_name", "data_type", "comment"),
+          Row("id", "bigint", null),
           Row("", "", ""),
           Row("# Metadata Columns", "", ""),
           Row("index", "int", "Metadata column used to conflict with a data column"),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeTableSuite.scala
@@ -72,7 +72,7 @@ class DescribeTableSuite extends v1.DescribeTableSuiteBase with CommandSuiteBase
           Row("Last Access", "UNKNOWN", ""),
           Row("Created By", "Spark 3.4.0-SNAPSHOT", ""),
           Row("Type", "EXTERNAL", ""),
-          Row("Provider", "hive", ""),
+          Row("Provider", getProvider(), ""),
           Row("Comment", "this is a test table", ""),
           Row("Location", "file:/tmp/testcat/table_name", ""),
           Row("Serde Library", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe", ""),


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to change output of v2 `DESCRIBE TABLE`, and make it the same as v1. In particular:
1. Return NULL instead of empty strings when any comment doesn't exist in the schema info.
2. When a v2 table has identity transformations (partition by) only, output the partitioning info in v1 style. For instance:
```sql
> CREATE TABLE tbl (id bigint, data string) USING _;
> DESCRIBE TABLE tbl;
+-----------------------+---------+-------+
|col_name               |data_type|comment|
+-----------------------+---------+-------+
|id                     |bigint   |null   |
|data                   |string   |null   |
|# Partition Information|         |       |
|# col_name             |data_type|comment|
|id                     |bigint   |null   |
+-----------------------+---------+-------+
```

Also the PR moves/adds some tests to the base traits:
- "DESCRIBE TABLE of a non-partitioned table"
- "DESCRIBE TABLE of a partitioned table"

and addresses review comments in https://github.com/apache/spark/pull/35265.

### Why are the changes needed?
The changes unify outputs of v1 and v2 implementations, and make the migration process from the version v1 to v2 easier for Spark SQL users.

### Does this PR introduce _any_ user-facing change?
Yes, it changes outputs of v2 `DESCRIBE TABLE`.

### How was this patch tested?
By running the `DESCRIBE TABLE` test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *DescribeTableSuite"
```
and related test suites:
```
$ build/sbt "test:testOnly *DataSourceV2SQLSuite"
```