### PR TITLE
[SPARK-39541][YARN]Diagnostics of yarn UI did not display the exception of driver when driver exit before regiserAM

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -395,7 +395,7 @@ private[spark] class ApplicationMaster(
           finalStatus = FinalApplicationStatus.FAILED
           exitCode = ApplicationMaster.EXIT_SC_NOT_INITED
           if(msg == null) {
-            errorMsg = "User did not initialize spark context"
+            errorMsg = "User did not initialize spark context!"
           }
         }
         logInfo(s"Final app status: $finalStatus, exitCode: $exitCode" +

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -394,8 +394,8 @@ private[spark] class ApplicationMaster(
         } else {
           finalStatus = FinalApplicationStatus.FAILED
           exitCode = ApplicationMaster.EXIT_SC_NOT_INITED
-          if(msg == null) {
-            errorMsg = "User did not initialize spark context!"
+          if (msg == null) {
+            errorMsg = "Failed to initialize Spark context"
           }
         }
         logInfo(s"Final app status: $finalStatus, exitCode: $exitCode" +

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -374,11 +374,11 @@ private[spark] class ApplicationMaster(
    */
   final def unregister(status: FinalApplicationStatus, diagnostics: String = null): Unit = {
     synchronized {
-      if (registered && !unregistered) {
+      if (!unregistered) {
         logInfo(s"Unregistering ApplicationMaster with $status" +
           Option(diagnostics).map(msg => s" (diag message: $msg)").getOrElse(""))
         unregistered = true
-        client.unregister(status, Option(diagnostics).getOrElse(""))
+        client.unregister(status, yarnConf, Option(diagnostics).getOrElse(""))
       }
     }
   }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -40,6 +40,7 @@ private[spark] class YarnRMClient extends Logging {
   private var amClient: AMRMClient[ContainerRequest] = _
   private var uiHistoryAddress: String = _
   private var registered: Boolean = false
+  private var amClientInited: Boolean = false
 
   /**
    * Registers the application master with the RM.
@@ -61,6 +62,7 @@ private[spark] class YarnRMClient extends Logging {
     amClient = AMRMClient.createAMRMClient()
     amClient.init(conf)
     amClient.start()
+    amClientInited = true
     this.uiHistoryAddress = uiHistoryAddress
 
     val trackingUrl = uiAddress.getOrElse {
@@ -93,10 +95,16 @@ private[spark] class YarnRMClient extends Logging {
    * @param status The final status of the AM.
    * @param diagnostics Diagnostics message to include in the final status.
    */
-  def unregister(status: FinalApplicationStatus, diagnostics: String = ""): Unit = synchronized {
-    if (registered) {
-      amClient.unregisterApplicationMaster(status, diagnostics, uiHistoryAddress)
+  def unregister(status: FinalApplicationStatus,
+                 conf: YarnConfiguration,
+                 diagnostics: String = ""): Unit = synchronized {
+    if (!amClientInited) {
+      amClient = AMRMClient.createAMRMClient()
+      amClient.init(conf)
+      amClient.start()
+      amClientInited = true
     }
+    amClient.unregisterApplicationMaster(status, diagnostics, uiHistoryAddress)
     if (amClient != null) {
       amClient.stop()
     }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -94,8 +94,8 @@ private[spark] class YarnRMClient extends Logging {
    * @param diagnostics Diagnostics message to include in the final status.
    */
   def unregister(status: FinalApplicationStatus,
-                 conf: YarnConfiguration,
-                 diagnostics: String = ""): Unit = synchronized {
+      conf: YarnConfiguration,
+      diagnostics: String = ""): Unit = synchronized {
     if (!registered) {
       amClient = AMRMClient.createAMRMClient()
       amClient.init(conf)

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/YarnRMClient.scala
@@ -96,7 +96,7 @@ private[spark] class YarnRMClient extends Logging {
   def unregister(status: FinalApplicationStatus,
                  conf: YarnConfiguration,
                  diagnostics: String = ""): Unit = synchronized {
-    if (registered) {
+    if (!registered) {
       amClient = AMRMClient.createAMRMClient()
       amClient.init(conf)
       amClient.start()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
If commit a job in yarn cluster mode and driver exited before registerAM，Diagnostics of yarn UI will show the actual reason instead of  "EXCODE 13"

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If commit a job in yarn cluster mode and driver exited before registerAM，Diagnostics of yarn UI did not show the exception that was throwed by driver .Yarn UI only show :
Application application_xxx failed 1 times (global limit =10; local limit is =1) due to AM Container for appattempt_xxx_000001 exited with exitCode: 13
![image](https://user-images.githubusercontent.com/46274164/174934394-08e5b39a-e3ff-43a5-93e4-134d1ddab5e9.png)

We must find the real reason by spark log :
![image](https://user-images.githubusercontent.com/46274164/174930472-f9e663fd-e9ca-4966-9c51-960452cdec0b.png)

The issue is caused by when dirver did not registerAM before throwing exception，it would not call unregisterAM,then yarn ui could not show the real reason.For example，user did not initialize sc or the class of user could not be found.

By this changes ，the diagnostics will show the real reason when this happen，like:
![image](https://user-images.githubusercontent.com/46274164/174934586-08896e4c-2246-4821-8656-cee1f9c0841f.png)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- Manual test
1. User jars packaging problem, throwing ClassNotFoundException
the diagnosis show the exception throwed by driver.
![image](https://user-images.githubusercontent.com/46274164/174934586-08896e4c-2246-4821-8656-cee1f9c0841f.png)


2. Exception during operation
the diagnosis show the exception throwed by driver.
![image](https://user-images.githubusercontent.com/46274164/174934701-e49d5962-d11f-4b49-8a48-aff5cc60c01d.png)

44c94d2455f7.png)
3. Properly run jobs
![image](https://user-images.githubusercontent.com/46274164/174934769-3b4c46e3-8e1f-4399-a4a8-8319ca75fcb5.png)

4. The user submission program ended directly, and sparkContext was not initialized during operation.
![image](https://user-images.githubusercontent.com/46274164/174935245-2f1fa27d-dfa5-4cfb-b056-5c8658e17cb5.png)
5. Before initializing SC, the thread sleeps for 600000ms
the diagnosis show the exception throwed by driver.
![image](https://user-images.githubusercontent.com/46274164/174935407-a61ea3cc-3c79-484b-a10e-2e0c658ef200.png)
6. When retrying multiple times and dirver throw exception.
Test for this problem:https://github.com/apache/spark/pull/18741
![image](https://user-images.githubusercontent.com/46274164/174935892-e1591892-7952-4f46-9d4a-6fddbb976919.png)
only th last time will unregisterAM and delete staging the spark staging directory.
spark log of the last time:
![image](https://user-images.githubusercontent.com/46274164/174936418-af4e411b-fc33-4973-9889-da5483b8c868.png)
others:
![image](https://user-images.githubusercontent.com/46274164/174936250-3984bfdc-a675-43b4-a11c-934fe3077a13.png)
And for normal jobs,they make no difference.

7.Interrupt exit in client mode
Test for this problem:https://github.com/apache/spark/pull/18788
yarn UI show SUCCEEDED，spark log shows that it unregisterAM and delete staging the spark staging directory.
![image](https://user-images.githubusercontent.com/46274164/174936744-19acdf30-736d-4d17-997f-39db8d9e2f70.png)
![image](https://user-images.githubusercontent.com/46274164/174936941-543143a7-c4f9-4496-9337-fc1d52727f81.png)

And for normal jobs,they make no difference.
