### PR TITLE
[SPARK-39559][CORE][WEBUI] Support IPv6 in WebUI

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala
@@ -246,6 +246,7 @@ private[spark] object JettyUtils extends Logging {
       serverName: String = "",
       poolSize: Int = 200): ServerInfo = {
 
+    logInfo(s"Start Jetty $hostName:$port for $serverName")
     // Start the server first, with no connectors.
     val pool = new QueuedThreadPool(poolSize)
     if (serverName.nonEmpty) {

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -149,11 +149,10 @@ private[spark] abstract class WebUI(
   def bind(): Unit = {
     assert(serverInfo.isEmpty, s"Attempted to bind $className more than once!")
     try {
-      val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
       val server = initServer()
       handlers.foreach(server.addHandler(_, securityManager))
       serverInfo = Some(server)
-      logInfo(s"Bound $className to $host, and started at $webUrl")
+      logInfo(s"Bound $className to ${Utils.localHostNameForURI()}, and started at $webUrl")
     } catch {
       case e: Exception =>
         logError(s"Failed to bind $className", e)

--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -140,8 +140,8 @@ private[spark] abstract class WebUI(
   def initialize(): Unit
 
   def initServer(): ServerInfo = {
-    val host = Option(conf.getenv("SPARK_LOCAL_IP")).getOrElse("0.0.0.0")
-    val server = startJettyServer(host, port, sslOptions, conf, name, poolSize)
+    val hostName = Utils.localHostNameForURI()
+    val server = startJettyServer(hostName, port, sslOptions, conf, name, poolSize)
     server
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support IPv6 in WebUI.

Since `startJettyServer` expects `hostName`, we use `Utils.localHostNameForURI`.
https://github.com/apache/spark/blob/59eee98024dac42309f2e7196c7e68832317f284/core/src/main/scala/org/apache/spark/ui/JettyUtils.scala#L241-L242

### Why are the changes needed?

To support IPv6-only environment.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.