### PR TITLE
[SPARK-39561][CORE] Improve `SparkContext` to propagate`java.net.preferIPv6Addresses`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -407,6 +407,7 @@ class SparkContext(config: SparkConf) extends Logging {
     SparkContext.fillMissingMagicCommitterConfsIfNeeded(_conf)
 
     SparkContext.supplementJavaModuleOptions(_conf)
+    SparkContext.supplementJavaIPv6Options(_conf)
 
     _driverLogger = DriverLogger(_conf)
 
@@ -3043,6 +3044,18 @@ object SparkContext extends Logging {
       val v = conf.get(key) match {
         case Some(opts) => s"${JavaModuleOptions.defaultModuleOptions()} $opts"
         case None => JavaModuleOptions.defaultModuleOptions()
+      }
+      conf.set(key.key, v)
+    }
+    supplement(DRIVER_JAVA_OPTIONS)
+    supplement(EXECUTOR_JAVA_OPTIONS)
+  }
+
+  private def supplementJavaIPv6Options(conf: SparkConf): Unit = {
+    def supplement(key: OptionalConfigEntry[String]): Unit = {
+      val v = conf.get(key) match {
+        case Some(opts) => s"-Djava.net.preferIPv6Addresses=${Utils.preferIPv6} $opts"
+        case None => s"-Djava.net.preferIPv6Addresses=${Utils.preferIPv6}"
       }
       conf.set(key.key, v)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `SparkContext` to propagate `java.net.preferIPv6Addresses`.

### Why are the changes needed?

This helps IPv6-only Spark applications by removing the explicit JVM setting burden.

### Does this PR introduce _any_ user-facing change?

No. There is no change for IPv4 users.

### How was this patch tested?

Pass the CIs.