### PR TITLE
[SPARK-39645][SQL] Make getDatabase and listDatabases compatible with 3 layer namespace

### DIFF
--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -4018,7 +4018,7 @@ test_that("catalog APIs, currentDatabase, setCurrentDatabase, listDatabases", {
                paste0("Error in setCurrentDatabase : analysis error - Database ",
                "'zxwtyswklpf' does not exist"))
   dbs <- collect(listDatabases())
-  expect_equal(names(dbs), c("name", "description", "locationUri"))
+  expect_equal(names(dbs), c("name", "catalog", "description", "locationUri"))
   expect_equal(which(dbs[, 1] == "default"), 1)
 })
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -49,6 +49,7 @@ class CatalogMetadata(
  * A database in Spark, as returned by the `listDatabases` method defined in [[Catalog]].
  *
  * @param name name of the database.
+ * @param catalog name of the catalog that the table belongs to.
  * @param description description of the database.
  * @param locationUri path (in the form of a uri) to data files.
  * @since 2.0.0
@@ -56,13 +57,19 @@ class CatalogMetadata(
 @Stable
 class Database(
     val name: String,
+    @Nullable val catalog: String,
     @Nullable val description: String,
     val locationUri: String)
   extends DefinedByConstructorParams {
 
+  def this(name: String, description: String, locationUri: String) = {
+    this(name, null, description, locationUri)
+  }
+
   override def toString: String = {
     "Database[" +
       s"name='$name', " +
+      Option(catalog).map { c => s"catalog='$c', " }.getOrElse("") +
       Option(description).map { d => s"description='$d', " }.getOrElse("") +
       s"path='$locationUri']"
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -574,18 +574,10 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    * @since 2.0.0
    */
   override def dropTempView(viewName: String): Boolean = {
-    // `viewName` could be either a traditional database.view name (behavior in Spark 3.3 and prior)
-    // or a 3-part name. To maintain backwards compatibility, we first assume it's a traditional
-    // (2-part) name by checking
-    // Otherwise we try 3-part name parsing and locate the database. If the parased identifier
-    // contains both catalog name and database name, we then search the database in the catalog.
-    // if
     sparkSession.sessionState.catalog.getTempView(viewName).exists { viewDef =>
       uncacheView(viewDef)
       sessionCatalog.dropTempView(viewName)
     }
-    // 3-part name
-    // val ident = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(viewName)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTable, LocalRelation, RecoverPartitions, ShowNamespaces, ShowTables, SubqueryAlias, TableSpec, View}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier, SupportsNamespaces, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, Identifier, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, IdentifierHelper, TransformHelper}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
@@ -317,10 +317,17 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
           val metadata = catalog.loadNamespaceMetadata(namespace.toArray)
           new Database(
             name = namespace.mkString("."),
+            catalog = catalog.name,
             description = metadata.get(SupportsNamespaces.PROP_COMMENT),
             locationUri = metadata.get(SupportsNamespaces.PROP_LOCATION))
         // similar to databaseExists: if the catalog doesn't support namespaces, we assume it's an
         // implicit namespace, which exists but has no metadata.
+        case ResolvedNamespace(catalog: CatalogPlugin, namespace) =>
+          new Database(
+            name = dbName,
+            catalog = catalog.name,
+            description = null,
+            locationUri = null)
         case _ => new Database(name = dbName, description = null, locationUri = null)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTable, LocalRelation, RecoverPartitions, ShowNamespaces, ShowTables, SubqueryAlias, TableSpec, View}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, Identifier, SupportsNamespaces, TableCatalog}
-import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, IdentifierHelper, TransformHelper}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, IdentifierHelper, MultipartIdentifierHelper, TransformHelper}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -316,7 +316,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         case ResolvedNamespace(catalog: SupportsNamespaces, namespace) =>
           val metadata = catalog.loadNamespaceMetadata(namespace.toArray)
           new Database(
-            name = namespace.mkString("."),
+            name = namespace.quoted,
             catalog = catalog.name,
             description = metadata.get(SupportsNamespaces.PROP_COMMENT),
             locationUri = metadata.get(SupportsNamespaces.PROP_LOCATION))
@@ -324,7 +324,7 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
         // implicit namespace, which exists but has no metadata.
         case ResolvedNamespace(catalog: CatalogPlugin, namespace) =>
           new Database(
-            name = dbName,
+            name = namespace.quoted,
             catalog = catalog.name,
             description = null,
             locationUri = null)

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -312,17 +312,16 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       val ident = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(dbName)
       val plan = UnresolvedNamespace(ident)
       val resolved = sparkSession.sessionState.executePlan(plan).analyzed
-      val db = ident.tail
       resolved match {
-        case ResolvedNamespace(catalog: SupportsNamespaces, _) =>
-          val metadata = catalog.loadNamespaceMetadata(db.toArray)
+        case ResolvedNamespace(catalog: SupportsNamespaces, namespace) =>
+          val metadata = catalog.loadNamespaceMetadata(namespace.toArray)
           new Database(
-            name = db.mkString("."),
+            name = namespace.mkString("."),
             description = metadata.get(SupportsNamespaces.PROP_COMMENT),
             locationUri = metadata.get(SupportsNamespaces.PROP_LOCATION))
         // similar to databaseExists: if the catalog doesn't support namespaces, we assume it's an
         // implicit namespace, which exists but has no metadata.
-        case _ => new Database(name = db.mkString("."), description = null, locationUri = null)
+        case _ => new Database(name = dbName, description = null, locationUri = null)
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -309,17 +309,16 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
       val plan = UnresolvedNamespace(ident)
       val resolved = sparkSession.sessionState.executePlan(plan).analyzed
       val db = ident.tail
-      // metadata only includes 'owner' AFAICT in tests
       val metadata = resolved match {
-        // TODO unify this somehow?
         case ResolvedNamespace(catalog: SupportsNamespaces, _) =>
           catalog.loadNamespaceMetadata(db.toArray)
+        // TODO what to do if it doesn't support namespaces
         case _ => throw new RuntimeException(s"unexpected catalog resolved: $resolved")
       }
       new Database(
         name = db.mkString("."),
-        description = metadata.get("description"),
-        locationUri = metadata.get("locationUri"))
+        description = metadata.get("comment"),
+        locationUri = metadata.get("location"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -363,7 +363,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   test("catalog classes format in Dataset.show") {
-    val db = new Database("nama", "descripta", "locata")
+    val db = new Database("nama", "cataloa", "descripta", "locata")
     val table = new Table("nama", "cataloa", Array("databasa"), "descripta", "typa",
       isTemporary = false)
     val function = new Function("nama", "databasa", "descripta", "classa", isTemporary = false)
@@ -373,7 +373,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val tableFields = ScalaReflection.getConstructorParameterValues(table)
     val functionFields = ScalaReflection.getConstructorParameterValues(function)
     val columnFields = ScalaReflection.getConstructorParameterValues(column)
-    assert(dbFields == Seq("nama", "descripta", "locata"))
+    assert(dbFields == Seq("nama", "cataloa", "descripta", "locata"))
     assert(Seq(tableFields(0), tableFields(1), tableFields(3), tableFields(4), tableFields(5)) ==
       Seq("nama", "cataloa", "descripta", "typa", false))
     assert(tableFields(2).asInstanceOf[Array[String]].sameElements(Array("databasa")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -848,7 +848,6 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
     val db = spark.catalog.getDatabase(dbName)
     assert(db.name === dbName)
     assert(db.description === "hive database")
-    // TODO catalog check API?
   }
 
   test("get database when there is `default` catalog") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -818,10 +818,14 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   }
 
   test("three layer namespace compatibility - get database") {
-    Seq(("testcat", "somedb"), ("testcat", "ns.somedb")).foreach { case (catalog, db) =>
-      val qualifiedDb = s"$catalog.$db"
-      sql(s"CREATE NAMESPACE $qualifiedDb")
-      assert(spark.catalog.getDatabase(qualifiedDb).name === db)
+    Seq(("testcat", "somedb"), ("testcat", "ns.somedb")).foreach { case (catalog, dbName) =>
+      val qualifiedDb = s"$catalog.$dbName"
+      // TODO test properties? WITH DBPROPERTIES (prop='val')
+      sql(s"CREATE NAMESPACE $qualifiedDb COMMENT 'test comment' LOCATION '/test/location'")
+      val db = spark.catalog.getDatabase(qualifiedDb)
+      assert(db.name === dbName)
+      assert(db.description === "test comment")
+      assert(db.locationUri === "file:/test/location")
     }
     intercept[AnalysisException](spark.catalog.getDatabase("randomcat.db10"))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -829,12 +829,21 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       Seq(("testcat", "somedb"), ("testcat", "ns.somedb"), ("spark_catalog", "somedb"))
     catalogsAndDatabases.foreach { case (catalog, dbName) =>
       val qualifiedDb = s"$catalog.$dbName"
-      sql(s"CREATE NAMESPACE $qualifiedDb COMMENT 'test comment' LOCATION '/test/location'")
+      sql(s"CREATE NAMESPACE $qualifiedDb COMMENT '$qualifiedDb' LOCATION '/test/location'")
       val db = spark.catalog.getDatabase(qualifiedDb)
       assert(db.name === dbName)
-      assert(db.description === "test comment")
+      assert(db.description === qualifiedDb)
       assert(db.locationUri === "file:/test/location")
     }
+
+    // test without qualifier
+    val name = "testns"
+    sql(s"CREATE NAMESPACE testcat.$name COMMENT '$name'")
+    spark.catalog.setCurrentCatalog("testcat")
+    val db = spark.catalog.getDatabase(name)
+    assert(db.name === name)
+    assert(db.description === name)
+
     intercept[AnalysisException](spark.catalog.getDatabase("randomcat.db10"))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change `getDatabase` and `listDatabases` catalog API to support 3 layer namespace. If the database exists in the sessionCatalog, we return that. Otherwise, parse the name as 3 layer name and use V2 catalog. Furthermore, `Database` class is augmented with `catalog` (a nullable String). The original constructor is retained for backwards compatibilty.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`getDatabase`/`listDatabases` don't support 3 layer namespace.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This PR introduces a backwards-compatible API change to support 3 layer namespace (e.g. `catalog.database.table`). Additionally, the `Database` type includes a new field `catalog`.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT