### PR TITLE
[SPARK-39572][PYTHON][TESTS] Fix `test_daemon.py` to support IPv6

### DIFF
--- a/python/pyspark/tests/test_daemon.py
+++ b/python/pyspark/tests/test_daemon.py
@@ -24,10 +24,13 @@ from pyspark.serializers import read_int
 
 class DaemonTests(unittest.TestCase):
     def connect(self, port):
-        from socket import socket, AF_INET, SOCK_STREAM
+        from socket import socket, AF_INET, AF_INET6, SOCK_STREAM
 
-        sock = socket(AF_INET, SOCK_STREAM)
-        sock.connect(("127.0.0.1", port))
+        family, host = AF_INET, "127.0.0.1"
+        if os.environ.get("SPARK_PREFER_IPV6", "false").lower() == "true":
+            family, host = AF_INET6, "::1"
+        sock = socket(family, SOCK_STREAM)
+        sock.connect((host, port))
         # send a split index of -1 to shutdown the worker
         sock.send(b"\xFF\xFF\xFF\xFF")
         sock.close()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `test_deamon.py` to support both IPv6 additionally.

### Why are the changes needed?

To add IPv6-only test coverage.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and do the following manually.
```
$ build/sbt package
$ SPARK_PREFER_IPV6=true python/run-tests.py --modules pyspark-core
```