### PR TITLE
[SPARK-39362][SQL] Fix v2 table not fully pruned in subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -184,6 +184,8 @@ abstract class Optimizer(catalogManager: CatalogManager)
     // Subquery batch applies the optimizer rules recursively. Therefore, it makes no sense
     // to enforce idempotence on it and we change this batch from Once to FixedPoint(1).
     Batch("Subquery", FixedPoint(1),
+      RewritePredicateSubquery,
+      ColumnPruning,
       OptimizeSubqueries) ::
     Batch("Replace Operators", fixedPoint,
       RewriteExceptAll,


### PR DESCRIPTION
### What changes were proposed in this pull request?
in this PR, fixed v2 table not fully pruned in `exist` sub-query

### Why are the changes needed?
currently, when optimizing sub-query columns are not fully pruned

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
new unit test added


