### PR TITLE
[SPARK-39575][AVRO] add ByteBuffer#rewind after ByteBuffer#get in Avr…

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -195,6 +195,8 @@ private[sql] class AvroDeserializer(
           case b: ByteBuffer =>
             val bytes = new Array[Byte](b.remaining)
             b.get(bytes)
+            // Do not forget to reset the position
+            b.rewind()
             bytes
           case b: Array[Byte] => b
           case other =>

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -366,14 +366,12 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
   test("AvroDeserializer with binary type") {
     val jsonFormatSchema =
       """
-        |{ "type": "record",
+        |{
+        |  "type": "record",
         |  "name": "record",
-        |  "fields" : [{
-        |    "name": "a",
-        |    "type": {
-        |      "type": "bytes"
-        |    }
-        |  }]
+        |  "fields" : [
+        |    {"name": "a", "type": "bytes"}
+        |  ]
         |}
       """.stripMargin
     val avroSchema = new Schema.Parser().parse(jsonFormatSchema)

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroCatalystDataConversionSuite.scala
@@ -36,8 +36,6 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-import java.nio.ByteBuffer
-
 class AvroCatalystDataConversionSuite extends SparkFunSuite
   with SharedSparkSession
   with ExpressionEvalHelper {
@@ -376,7 +374,7 @@ class AvroCatalystDataConversionSuite extends SparkFunSuite
       """.stripMargin
     val avroSchema = new Schema.Parser().parse(jsonFormatSchema)
     val avroRecord = new GenericData.Record(avroSchema)
-    val bb = ByteBuffer.wrap(Array[Byte](97, 48, 53))
+    val bb = java.nio.ByteBuffer.wrap(Array[Byte](97, 48, 53))
     avroRecord.put("a", bb)
 
     val expected = InternalRow(Array[Byte](97, 48, 53))


### PR DESCRIPTION
…oDeserializer

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add ByteBuffer#rewind after ByteBuffer#get in AvroDeserializer.


### Why are the changes needed?
- HeapBuffer.get(bytes) puts the data from POS to the end into bytes, and sets POS as the end. The next call will return empty bytes. 
- The second call of AvroDeserializer will return an InternalRow with empty binary column when avro record has binary column. 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Add ut in AvroCatalystDataConversionSuite.
