### PR TITLE
[SPARK-39574][PS] Better error message when `ps.Index` is used for DataFrame/Series creation

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -452,6 +452,13 @@ class DataFrame(Frame, Generic[T]):
                 assert not copy
                 pdf = data
             else:
+                from pyspark.pandas.indexes.base import Index
+
+                if isinstance(index, Index):
+                    raise TypeError(
+                        "The given index cannot be a pandas-on-Spark index. "
+                        "Try pandas.Index or array-like."
+                    )
                 pdf = pd.DataFrame(data=data, index=index, columns=columns, dtype=dtype, copy=copy)
             internal = InternalFrame.from_pandas(pdf)
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -457,7 +457,7 @@ class DataFrame(Frame, Generic[T]):
                 if isinstance(index, Index):
                     raise TypeError(
                         "The given index cannot be a pandas-on-Spark index. "
-                        "Try pandas.Index or array-like."
+                        "Try pandas index or array-like."
                     )
                 pdf = pd.DataFrame(data=data, index=index, columns=columns, dtype=dtype, copy=copy)
             internal = InternalFrame.from_pandas(pdf)

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -410,7 +410,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 if isinstance(index, Index):
                     raise TypeError(
                         "The given index cannot be a pandas-on-Spark index. "
-                        "Try pandas.Index or array-like."
+                        "Try pandas index or array-like."
                     )
 
                 s = pd.Series(

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -405,6 +405,14 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 assert not fastpath
                 s = data
             else:
+                from pyspark.pandas.indexes.base import Index
+
+                if isinstance(index, Index):
+                    raise TypeError(
+                        "The given index cannot be a pandas-on-Spark index. "
+                        "Try pandas.Index or array-like."
+                    )
+
                 s = pd.Series(
                     data=data, index=index, dtype=dtype, name=name, copy=copy, fastpath=fastpath
                 )

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -96,6 +96,13 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         index_cols = pdf.columns[column_mask]
         self.assert_eq(psdf[index_cols], pdf[index_cols])
 
+    def test_creation_index(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "The given index cannot be a pandas-on-Spark index. Try pandas.Index or array-like.",
+        ):
+            ps.DataFrame([1, 2], index=ps.Index([1, 2]))
+
     def _check_extension(self, psdf, pdf):
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
             self.assert_eq(psdf, pdf, check_exact=False)

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -97,11 +97,13 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         self.assert_eq(psdf[index_cols], pdf[index_cols])
 
     def test_creation_index(self):
-        with self.assertRaisesRegex(
-            TypeError,
-            "The given index cannot be a pandas-on-Spark index. Try pandas.Index or array-like.",
-        ):
+        err_msg = (
+            "The given index cannot be a pandas-on-Spark index. Try pandas index or array-like."
+        )
+        with self.assertRaisesRegex(TypeError, err_msg):
             ps.DataFrame([1, 2], index=ps.Index([1, 2]))
+        with self.assertRaisesRegex(TypeError, err_msg):
+            ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
 
     def _check_extension(self, psdf, pdf):
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -54,6 +54,13 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
+    def test_creation_index(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "The given index cannot be a pandas-on-Spark index. Try pandas.Index or array-like.",
+        ):
+            ps.Series([1, 2], index=ps.Index([1, 2]))
+
     def test_series_ops(self):
         pser = self.pser
         psser = self.psser

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -55,11 +55,14 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         return ps.from_pandas(self.pser)
 
     def test_creation_index(self):
-        with self.assertRaisesRegex(
-            TypeError,
-            "The given index cannot be a pandas-on-Spark index. Try pandas.Index or array-like.",
-        ):
+        err_msg = (
+            "The given index cannot be a pandas-on-Spark index. Try pandas index or array-like."
+        )
+        with self.assertRaisesRegex(TypeError, err_msg):
             ps.Series([1, 2], index=ps.Index([1, 2]))
+
+        with self.assertRaisesRegex(TypeError, err_msg):
+            ps.Series([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
 
     def test_series_ops(self):
         pser = self.pser


### PR DESCRIPTION
### What changes were proposed in this pull request?
Better error message when `ps.Index` is used for DataFrame/Series creation.


### Why are the changes needed?
As part of [SPARK-39581](https://issues.apache.org/jira/browse/SPARK-39581).

The current error message is confusing and is from the pandas library. We should improve that.


### Does this PR introduce _any_ user-facing change?
Yes. 
**From:**
```py
>>> ps.DataFrame([1, 2], index=ps.Index([1, 2]))
Traceback (most recent call last):
...
ValueError: The truth value of a Int64Index is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().

>>> ps.Series([1, 2], index=ps.Index([1, 2]))
Traceback (most recent call last):
...
ValueError: The truth value of a Int64Index is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

**To:**
```py
>>> ps.DataFrame([1, 2], index=ps.Index([1, 2]))
Traceback (most recent call last):
...
TypeError: The given index cannot be a pandas-on-Spark index. Try pandas index or array-like.

>>> ps.Series([1, 2], index=ps.Index([1, 2]))
Traceback (most recent call last):
...
TypeError: The given index cannot be a pandas-on-Spark index. Try pandas index or array-like.
```

### How was this patch tested?
Unit tests.
