### PR TITLE
[SPARK-39582][SQL] Fix "Since" marker for `array_agg`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -491,7 +491,7 @@ object FunctionRegistry {
     expression[VariancePop]("var_pop"),
     expression[VarianceSamp]("var_samp"),
     expression[CollectList]("collect_list"),
-    expression[CollectList]("array_agg", true),
+    expression[CollectList]("array_agg", true, Some("3.3.0")),
     expression[CollectSet]("collect_set"),
     expression[CountMinSketchAgg]("count_min_sketch"),
     expression[BoolAnd]("every", true),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the docs for `array_agg`.

### Why are the changes needed?

The "Since" marker is incorrect, leading to user confusion when they think they should be able to use `array_agg` on their version of Spark but don't find it available.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the docs for `array_agg`.

### How was this patch tested?

I didn't test it, since it's so small as to be presumptively correct. (Happy to generate the docs and double check, if a maintainer so wishes.)