### PR TITLE
[SPARK-39594][CORE] Improve logs to show addresses in addition to ports

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportServer.java
@@ -149,8 +149,9 @@ public class TransportServer implements Closeable {
     channelFuture = bootstrap.bind(address);
     channelFuture.syncUninterruptibly();
 
-    port = ((InetSocketAddress) channelFuture.channel().localAddress()).getPort();
-    logger.debug("Shuffle server started on port: {}", port);
+    InetSocketAddress localAddress = (InetSocketAddress) channelFuture.channel().localAddress();
+    port = localAddress.getPort();
+    logger.debug("Shuffle server started on {} with port {}", localAddress.getHostString(), port);
   }
 
   public MetricSet getAllMetrics() {

--- a/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.api.python
 
 import java.io.{DataOutputStream, File, FileOutputStream}
+import java.net.InetAddress
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 
@@ -42,7 +43,8 @@ private[spark] object PythonGatewayServer extends Logging {
       logError(s"${gatewayServer.server.getClass} failed to bind; exiting")
       System.exit(1)
     } else {
-      logDebug(s"Started PythonGatewayServer on port $boundPort")
+      val address = InetAddress.getLoopbackAddress()
+      logDebug(s"Started PythonGatewayServer on $address with port $boundPort")
     }
 
     // Communicate the connection information back to the python process by writing the

--- a/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/RestSubmissionServer.scala
@@ -71,7 +71,7 @@ private[spark] abstract class RestSubmissionServer(
   def start(): Int = {
     val (server, boundPort) = Utils.startServiceOnPort[Server](requestedPort, doStart, masterConf)
     _server = Some(server)
-    logInfo(s"Started REST server for submitting applications on port $boundPort")
+    logInfo(s"Started REST server for submitting applications on $host with port $boundPort")
     boundPort
   }
 

--- a/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
+++ b/core/src/main/scala/org/apache/spark/network/netty/NettyBlockTransferService.scala
@@ -79,7 +79,11 @@ private[spark] class NettyBlockTransferService(
     server = createServer(serverBootstrap.toList)
     appId = conf.getAppId
 
-    logger.info(s"Server created on $hostName:${server.getPort}")
+    if (hostName.equals(bindAddress)) {
+      logger.info(s"Server created on $hostName:${server.getPort}")
+    } else {
+      logger.info(s"Server created on $hostName $bindAddress:${server.getPort}")
+    }
   }
 
   /** Creates and binds the TransportServer, possibly trying multiple ports. */

--- a/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
+++ b/core/src/main/scala/org/apache/spark/security/SocketAuthServer.scala
@@ -49,7 +49,8 @@ private[spark] abstract class SocketAuthServer[T](
 
   private def startServer(): (Int, String) = {
     logTrace("Creating listening socket")
-    val serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())
+    val address = InetAddress.getLoopbackAddress()
+    val serverSocket = new ServerSocket(0, 1, address)
     // Close the socket if no connection in the configured seconds
     val timeout = authHelper.conf.get(PYTHON_AUTH_SOCKET_TIMEOUT).toInt
     logTrace(s"Setting timeout to $timeout sec")
@@ -60,7 +61,7 @@ private[spark] abstract class SocketAuthServer[T](
       override def run(): Unit = {
         var sock: Socket = null
         try {
-          logTrace(s"Waiting for connection on port ${serverSocket.getLocalPort}")
+          logTrace(s"Waiting for connection on $address with port ${serverSocket.getLocalPort}")
           sock = serverSocket.accept()
           logTrace(s"Connection accepted from address ${sock.getRemoteSocketAddress}")
           authHelper.authClient(sock)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve logs to show address together in addition to ports.

### Why are the changes needed?

To provide used address information explicitly . 

1. For example, we can check if `IPv4` and `IPv6` is used correctly.

**IPv4**
```
StandaloneRestServer: Started REST server for submitting applications on 172.16.0.31 with port 54511
```

**IPv6**
```
StandaloneRestServer: Started REST server for submitting applications on [0:0:0:0:0:0:0:1] with port 54566
```

2. In `NettyBlockTrasferService`, `hostName` could be different from `bindAddress` like the following.
```
NettyBlockTransferService: Server created on otherHost localhost:54718
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.