### PR TITLE
[SPARK-39597][PYTHON] Make GetTable, TableExists and DatabaseExists in the python side support 3-layer-namespace

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -365,9 +365,7 @@ class Catalog:
         False
         """
         if dbName is None:
-            return self._jcatalog.tableExists(tableName) or self._jcatalog.tableExists(
-                self.currentDatabase(), tableName
-            )
+            return self._jcatalog.tableExists(tableName)
         else:
             warnings.warn(
                 "`dbName` has been deprecated since Spark 3.4 and might be removed in "

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -193,13 +193,13 @@ class Catalog:
         --------
         >>> df = spark.sql("CREATE TABLE tab1 (name STRING, age INT) USING parquet")
         >>> spark.catalog.getTable("tab1")
-        Table(name='tab1', catalog='spark_catalog', namespace=['default'], description=None, tableType='MANAGED', isTemporary=False)
+        Table(name='tab1', catalog='spark_catalog', namespace=['default'], ...
         >>> spark.catalog.getTable("default.tab1")
-        Table(name='tab1', catalog='spark_catalog', namespace=['default'], description=None, tableType='MANAGED', isTemporary=False)
+        Table(name='tab1', catalog='spark_catalog', namespace=['default'], ...
         >>> spark.catalog.getTable("spark_catalog.default.tab1")
-        Table(name='tab1', catalog='spark_catalog', namespace=['default'], description=None, tableType='MANAGED', isTemporary=False)
+        Table(name='tab1', catalog='spark_catalog', namespace=['default'], ...
         >>> spark.catalog.getTable("tab1", "default")
-        Table(name='tab1', catalog='spark_catalog', namespace=['default'], description=None, tableType='MANAGED', isTemporary=False)
+        Table(name='tab1', catalog='spark_catalog', namespace=['default'], ...
         >>> df = spark.sql("DROP TABLE tab1")
         >>> spark.catalog.getTable("tab1")
         Traceback (most recent call last):

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -50,6 +50,8 @@ class CatalogTests(ReusedSQLTestCase):
             self.assertFalse(spark.catalog.databaseExists("some_db"))
             spark.sql("CREATE DATABASE some_db")
             self.assertTrue(spark.catalog.databaseExists("some_db"))
+            self.assertTrue(spark.catalog.databaseExists("spark_catalog.some_db"))
+            self.assertFalse(spark.catalog.databaseExists("spark_catalog.some_db2"))
 
     def test_list_tables(self):
         from pyspark.sql.catalog import Table
@@ -316,8 +318,26 @@ class CatalogTests(ReusedSQLTestCase):
                 self.assertFalse(spark.catalog.tableExists("tab2", "some_db"))
                 spark.sql("CREATE TABLE tab1 (name STRING, age INT) USING parquet")
                 self.assertTrue(spark.catalog.tableExists("tab1"))
+                self.assertTrue(spark.catalog.tableExists("default.tab1"))
+                self.assertTrue(spark.catalog.tableExists("spark_catalog.default.tab1"))
+                self.assertTrue(spark.catalog.tableExists("tab1", "default"))
                 spark.sql("CREATE TABLE some_db.tab2 (name STRING, age INT) USING parquet")
+                self.assertFalse(spark.catalog.tableExists("tab2"))
+                self.assertTrue(spark.catalog.tableExists("some_db.tab2"))
+                self.assertTrue(spark.catalog.tableExists("spark_catalog.some_db.tab2"))
                 self.assertTrue(spark.catalog.tableExists("tab2", "some_db"))
+
+    def test_get_table(self):
+        spark = self.spark
+        with self.database("some_db"):
+            spark.sql("CREATE DATABASE some_db")
+            with self.table("tab1"):
+                spark.sql("CREATE TABLE tab1 (name STRING, age INT) USING parquet")
+                self.assertEqual(spark.catalog.getTable("tab1").name, "tab1")
+                self.assertEqual(
+                    spark.catalog.getTable("spark_catalog.default.tab1").catalog, "spark_catalog"
+                )
+                self.assertEqual(spark.catalog.getTable("tab1", "default").database, "default")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -333,11 +333,9 @@ class CatalogTests(ReusedSQLTestCase):
             spark.sql("CREATE DATABASE some_db")
             with self.table("tab1"):
                 spark.sql("CREATE TABLE tab1 (name STRING, age INT) USING parquet")
-                self.assertEqual(spark.catalog.getTable("tab1").name, "tab1")
-                self.assertEqual(
-                    spark.catalog.getTable("spark_catalog.default.tab1").catalog, "spark_catalog"
-                )
-                self.assertEqual(spark.catalog.getTable("tab1", "default").database, "default")
+                self.assertEqual(spark.catalog.getTable("tab1").database, "default")
+                self.assertEqual(spark.catalog.getTable("default.tab1").catalog, "spark_catalog")
+                self.assertEqual(spark.catalog.getTable("spark_catalog.default.tab1").name, "tab1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

corresponding changes in the python side to  https://issues.apache.org/jira/browse/SPARK-39263

1, make TableExists and DatabaseExists support 3-layer-namespace
2, add GetTable in the python side


### Why are the changes needed?
to support 3-layer-namespace


### Does this PR introduce _any_ user-facing change?
Yes, In `TableExists`, when `dbName` is empty, will first try to treat `tabelName` as a multi-layer-namespace.


### How was this patch tested?
added UT
