### PR TITLE
[SPARK-39598][PYTHON] Make *cache*, *catalog* in the python side support 3-layer-namespace

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
     from pyspark.sql.types import DataType
 
 
+class CatalogMetadata(NamedTuple):
+    name: str
+    description: Optional[str]
+
+
 class Database(NamedTuple):
     name: str
     description: Optional[str]
@@ -78,6 +83,42 @@ class Catalog:
         self._sparkSession = sparkSession
         self._jsparkSession = sparkSession._jsparkSession
         self._jcatalog = sparkSession._jsparkSession.catalog()
+
+    def currentCatalog(self) -> str:
+        """Returns the current default catalog in this session.
+
+        .. versionadded:: 3.4.0
+
+        Examples
+        --------
+        >>> spark.catalog.currentCatalog()
+        'spark_catalog'
+        """
+        return self._jcatalog.currentCatalog()
+
+    def setCurrentCatalog(self, catalogName: str) -> None:
+        """Sets the current default catalog in this session.
+
+        .. versionadded:: 3.4.0
+
+        Parameters
+        ----------
+        catalogName : str
+            name of the catalog to set
+        """
+        return self._jcatalog.setCurrentCatalog(catalogName)
+
+    def listCatalogs(self) -> List[CatalogMetadata]:
+        """Returns a list of catalogs in this session.
+
+        .. versionadded:: 3.4.0
+        """
+        iter = self._jcatalog.listCatalogs().toLocalIterator()
+        catalogs = []
+        while iter.hasNext():
+            jcatalog = iter.next()
+            catalogs.append(CatalogMetadata(name=jcatalog.name, description=jcatalog.description))
+        return catalogs
 
     @since(2.0)
     def currentDatabase(self) -> str:
@@ -517,17 +558,29 @@ class Catalog:
 
     @since(2.0)
     def isCached(self, tableName: str) -> bool:
-        """Returns true if the table is currently cached in-memory."""
+        """Returns true if the table is currently cached in-memory.
+
+        .. versionchanged:: 3.4
+           Allowed ``tableName`` to be qualified with catalog name.
+        """
         return self._jcatalog.isCached(tableName)
 
     @since(2.0)
     def cacheTable(self, tableName: str) -> None:
-        """Caches the specified table in-memory."""
+        """Caches the specified table in-memory.
+
+        .. versionchanged:: 3.4
+           Allowed ``tableName`` to be qualified with catalog name.
+        """
         self._jcatalog.cacheTable(tableName)
 
     @since(2.0)
     def uncacheTable(self, tableName: str) -> None:
-        """Removes the specified table from the in-memory cache."""
+        """Removes the specified table from the in-memory cache.
+
+        .. versionchanged:: 3.4
+           Allowed ``tableName`` to be qualified with catalog name.
+        """
         self._jcatalog.uncacheTable(tableName)
 
     @since(2.0)

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -308,6 +308,21 @@ class CatalogTests(ReusedSQLTestCase):
                     lambda: spark.catalog.listColumns("does_not_exist"),
                 )
 
+    def test_table_cache(self):
+        spark = self.spark
+        with self.database("some_db"):
+            spark.sql("CREATE DATABASE some_db")
+            with self.table("tab1"):
+                spark.sql("CREATE TABLE some_db.tab1 (name STRING, age INT) USING parquet")
+                self.assertFalse(spark.catalog.isCached("some_db.tab1"))
+                self.assertFalse(spark.catalog.isCached("spark_catalog.some_db.tab1"))
+                spark.catalog.cacheTable("spark_catalog.some_db.tab1")
+                self.assertTrue(spark.catalog.isCached("some_db.tab1"))
+                self.assertTrue(spark.catalog.isCached("spark_catalog.some_db.tab1"))
+                spark.catalog.uncacheTable("spark_catalog.some_db.tab1")
+                self.assertFalse(spark.catalog.isCached("some_db.tab1"))
+                self.assertFalse(spark.catalog.isCached("spark_catalog.some_db.tab1"))
+
     def test_table_exists(self):
         # SPARK-36176: testing that table_exists returns correct boolean
         spark = self.spark


### PR DESCRIPTION
### What changes were proposed in this pull request?
corresponding changes in pyspark to [CacheTable, isCached, UncacheTable, setCurrentCatalog, currentCatalog, listCatalogs](https://issues.apache.org/jira/browse/SPARK-39506)

1, add method `currentCatalog`, `setCurrentCatalog`, `listCatalogs`;
2, update the document of `CacheTable`, `isCached`, `UncacheTable`, and add a UT

### Why are the changes needed?
to support 3-layer-namespace


### Does this PR introduce _any_ user-facing change?
yes, new api added


### How was this patch tested?
added ut
