### PR TITLE
[SPARK-39596][INFRA] Install `ggplot2` for GitHub Action linter job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -484,6 +484,7 @@ jobs:
         apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev
         Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
         Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')"
+        Rscript -e "install.packages(c('ggplot2'), repos='https://cloud.r-project.org/')"
         ./R/install-dev.sh
     - name: Instll JavaScript linter dependencies
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix GitHub Action linter job by installing `ggplot2`.

### Why are the changes needed?

It starts to fail like the following.
- https://github.com/apache/spark/runs/7047294196?check_suite_focus=true
```
x Failed to parse Rd in histogram.Rd
ℹ there is no package called ‘ggplot2’
```

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the GitHub Action linter job.