### PR TITLE
[SPARK-39600][SQL] Enhance pushdown limit through window

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushDownThroughWindow.scala
@@ -17,43 +17,101 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, CurrentRow, DenseRank, IntegerLiteral, NamedExpression, NTile, Rank, RowFrame, RowNumber, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
-import org.apache.spark.sql.catalyst.plans.logical.{Limit, LocalLimit, LogicalPlan, Project, Sort, Window}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AliasHelper, Ascending, Attribute, CurrentRow, DenseRank, Expression, IntegerLiteral, LessThan, LessThanOrEqual, NamedExpression, NTile, Rank, RowFrame, RowNumber, SortOrder, SpecifiedWindowFrame, UnboundedPreceding, WindowExpression, WindowSpecDefinition}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.{LIMIT, WINDOW}
 
 /**
- * Pushes down [[LocalLimit]] beneath WINDOW. This rule optimizes the following case:
+ * Pushes down [[Limit]] beneath WINDOW. This rule optimizes the following cases:
  * {{{
  *   SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM Tab1 LIMIT 5 ==>
  *   SELECT *, ROW_NUMBER() OVER(ORDER BY a) AS rn FROM (SELECT * FROM Tab1 ORDER BY a LIMIT 5) t
+ *
+ *   SELECT *, ROW_NUMBER() OVER(PARTITION BY a ORDER BY b) AS rn FROM Tab1 LIMIT 5 ==>
+ *   SELECT *,
+ *          row_number() OVER(partition BY a ORDER BY b) AS rn
+ *   FROM   (SELECT * FROM tab1 ORDER BY a, b LIMIT 5) t
+ *
+ *   SELECT *
+ *   FROM   (SELECT *, row_number() OVER(PARTITION BY a ORDER BY b) AS rn FROM tab1) t
+ *   WHERE  rn <= 5 LIMIT 5 ==>
+ *   SELECT *
+ *   FROM   (SELECT *,
+ *                  row_number() OVER(partition BY a ORDER BY b) AS rn
+ *           FROM   (SELECT * FROM tab1 ORDER BY a, b LIMIT 5) t)
+ *   WHERE rn <= 5 LIMIT 5
  * }}}
  */
-object LimitPushDownThroughWindow extends Rule[LogicalPlan] {
-  // The window frame of RankLike and RowNumberLike can only be UNBOUNDED PRECEDING to CURRENT ROW.
-  private def supportsPushdownThroughWindow(
+object LimitPushDownThroughWindow extends Rule[LogicalPlan] with AliasHelper {
+  // The window frame can only be UNBOUNDED PRECEDING to CURRENT ROW.
+  private def supportsPushdown(
       windowExpressions: Seq[NamedExpression]): Boolean = windowExpressions.forall {
     case Alias(WindowExpression(_: Rank | _: DenseRank | _: NTile | _: RowNumber,
-        WindowSpecDefinition(Nil, _,
+        WindowSpecDefinition(_, _,
         SpecifiedWindowFrame(RowFrame, UnboundedPreceding, CurrentRow))), _) => true
     case _ => false
+  }
+
+  private def supportsPushdownWithFilter(
+      filterAttr: Attribute, order: Seq[SortOrder], window: Window): Boolean = {
+    window.windowExpressions.size == 1 &&
+      getAliasMap(window.windowExpressions).get(filterAttr)
+        .exists(a => supportsPushdown(a :: Nil)) &&
+      (window.partitionSpec.size <= order.size || order.isEmpty) &&
+      window.partitionSpec.zip(order)
+        .forall { case (e: Expression, s: SortOrder) => s.child.semanticEquals(e) }
+  }
+
+  private def sortPartitionSpec(
+      partitionSpec: Seq[Expression], orderSpec: Seq[SortOrder]): Seq[SortOrder] = {
+    partitionSpec.map(SortOrder(_, Ascending)) ++ orderSpec
   }
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
     _.containsAllPatterns(WINDOW, LIMIT), ruleId) {
     // Adding an extra Limit below WINDOW when the partitionSpec of all window functions is empty.
-    case LocalLimit(limitExpr @ IntegerLiteral(limit),
-        window @ Window(windowExpressions, Nil, orderSpec, child))
-      if supportsPushdownThroughWindow(windowExpressions) && child.maxRows.forall(_ > limit) &&
+    case Limit(limitExpr @ IntegerLiteral(limit),
+        window @ Window(windowExpressions, partitionSpec, orderSpec, child))
+      if supportsPushdown(windowExpressions) && child.maxRows.forall(_ > limit) &&
         limit < conf.topKSortFallbackThreshold =>
       // Sort is needed here because we need global sort.
-      window.copy(child = Limit(limitExpr, Sort(orderSpec, true, child)))
+      window.copy(child = Limit(limitExpr,
+        Sort(sortPartitionSpec(partitionSpec, orderSpec), true, child)))
     // There is a Project between LocalLimit and Window if they do not have the same output.
-    case LocalLimit(limitExpr @ IntegerLiteral(limit), project @ Project(_,
-        window @ Window(windowExpressions, Nil, orderSpec, child)))
-      if supportsPushdownThroughWindow(windowExpressions) && child.maxRows.forall(_ > limit) &&
+    case Limit(limitExpr @ IntegerLiteral(limit), project @ Project(_,
+        window @ Window(windowExpressions, partitionSpec, orderSpec, child)))
+      if supportsPushdown(windowExpressions) && child.maxRows.forall(_ > limit) &&
         limit < conf.topKSortFallbackThreshold =>
       // Sort is needed here because we need global sort.
-      project.copy(child = window.copy(child = Limit(limitExpr, Sort(orderSpec, true, child))))
+      project.copy(child = window.copy(child = Limit(limitExpr,
+        Sort(sortPartitionSpec(partitionSpec, orderSpec), true, child))))
+
+    case Limit(limitExpr @ IntegerLiteral(limit),
+        f @ Filter(ExtractFilterCondition(attr, filterVal), window: Window))
+      if limit < filterVal && window.maxRows.forall(_ > limit) &&
+        limit < conf.topKSortFallbackThreshold && supportsPushdownWithFilter(attr, Nil, window) =>
+      val newWindow =
+        window.copy(child = Limit(limitExpr,
+          Sort(sortPartitionSpec(window.partitionSpec, window.orderSpec), true, window.child)))
+      f.copy(child = newWindow)
+    case Limit(limitExpr @ IntegerLiteral(limit), s @ Sort(order, _,
+        f @ Filter(ExtractFilterCondition(attr, filterVal), window: Window)))
+      if limit < filterVal && window.maxRows.forall(_ > limit) &&
+        limit < conf.topKSortFallbackThreshold && supportsPushdownWithFilter(attr, order, window) =>
+      val newWindow =
+        window.copy(child = Limit(limitExpr,
+          Sort(sortPartitionSpec(window.partitionSpec, window.orderSpec), true, window.child)))
+      s.copy(child = f.copy(child = newWindow))
+  }
+
+  private object ExtractFilterCondition {
+    def unapply(e: Expression): Option[(Attribute, Int)] = e match {
+      case LessThan(attr: Attribute, IntegerLiteral(value)) =>
+        Some((attr, value))
+      case LessThanOrEqual(attr: Attribute, IntegerLiteral(value)) =>
+        Some((attr, value + 1))
+      case _ => None
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support more cases for pushing down limit through window.
1. Window's partition specification is not empty. It will push down top N with global sort by partition specification and order specification.
   ```sql
   -- Origin query
   SELECT *, ROW_NUMBER() OVER(PARTITION BY a ORDER BY b) AS rn FROM Tab1 LIMIT 5;
   -- Equivalent push down limit query
   SELECT *,
          row_number() OVER(partition BY a ORDER BY b) AS rn
   FROM   (SELECT * FROM tab1 ORDER BY a, b LIMIT 5) t
   ```
2. It has `less than` or `less than or equal` filter condition on that pushable window and limit number less than or equal with that filter condition.
   ```sql
   -- Origin query
   SELECT *
   FROM   (SELECT *, row_number() OVER(PARTITION BY a ORDER BY b) AS rn FROM tab1) t
   WHERE  rn <= 5
   LIMIT 5
   -- Equivalent push down limit query
   SELECT *
   FROM   (SELECT *,
                  row_number() OVER(partition BY a ORDER BY b) AS rn
           FROM   (SELECT * FROM tab1 ORDER BY a, b LIMIT 5) t)
   WHERE rn <= 5
   ```

### Why are the changes needed?

Improve query performance.

Impala also support it: https://issues.apache.org/jira/browse/IMPALA-9983

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

