### PR TITLE
[SPARK-39604][SQL][TESTS] Add UT for DerbyDialect getCatalystType method

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -924,6 +924,13 @@ class JDBCSuite extends QueryTest
     assert(derbyDialect.getJDBCType(BooleanType).map(_.databaseTypeDefinition).get == "BOOLEAN")
   }
 
+  test("SPARK-39604: DerbyDialect catalyst type mapping") {
+    val derbyDialect = JdbcDialects.get("jdbc:derby:db")
+    val metadata = new MetadataBuilder().putString("name", "test_column")
+    assert(derbyDialect.getCatalystType(java.sql.Types.REAL, "real",
+      0, metadata) == Some(FloatType))
+  }
+
   test("OracleDialect jdbc type mapping") {
     val oracleDialect = JdbcDialects.get("jdbc:oracle")
     val metadata = new MetadataBuilder().putString("name", "test_column").putLong("scale", -127)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add complemented UT for DerbyDialect

### Why are the changes needed?

Add UT for existed key function.
If conversion from original data source to Spark data type is needed, the `getCatalystType` method will be added to specific ${data-source}Dialect class. It's needed to add UT for each of them. Currently, all *Dialect class has UT to cover the method except DerbyDialect. 


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
Unit Test
