### PR TITLE
[SPARK-39613][BUILD] Upgrade shapeless to 2.3.9

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -242,7 +242,7 @@ scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
-shapeless_2.12/2.3.7//shapeless_2.12-2.3.7.jar
+shapeless_2.12/2.3.9//shapeless_2.12-2.3.9.jar
 shims/0.9.28//shims-0.9.28.jar
 slf4j-api/1.7.32//slf4j-api-1.7.32.jar
 snakeyaml/1.30//snakeyaml-1.30.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -231,7 +231,7 @@ scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
-shapeless_2.12/2.3.7//shapeless_2.12-2.3.7.jar
+shapeless_2.12/2.3.9//shapeless_2.12-2.3.9.jar
 shims/0.9.28//shims-0.9.28.jar
 slf4j-api/1.7.32//slf4j-api-1.7.32.jar
 snakeyaml/1.30//snakeyaml-1.30.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1095,7 +1095,7 @@
       <dependency>
         <groupId>com.chuusai</groupId>
         <artifactId>shapeless_${scala.binary.version}</artifactId>
-        <version>2.3.7</version>
+        <version>2.3.9</version>
       </dependency>
       <dependency>
         <groupId>org.json4s</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade shapeless from 2.3.7 to 2.3.9.

### Why are the changes needed?
This will bring some bug fix of shapeless, release note: https://github.com/milessabin/shapeless/releases/tag/v2.3.9
- Fix Generic materialization for type aliases (series/2.3) 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GA