### PR TITLE
[SPARK-39148][SQL] DS V2 aggregate push down can work with OFFSET or LIMIT

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedAggregation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedAggregation.scala
@@ -27,5 +27,5 @@ case class PushedAggregation(
     pushedAggregates: Option[Aggregation],
     resultExpressions: Seq[NamedExpression],
     aggregates: Seq[AggregateExpression],
-    normalizedGroupingExpressions: Seq[Expression],
+    groupingExpressions: Seq[Expression],
     aggExprToOutputOrdinal: HashMap[Expression, Int])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedAggregation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushedAggregation.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import scala.collection.mutable.HashMap
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
+
+case class PushedAggregation(
+    pushedAggregates: Option[Aggregation],
+    resultExpressions: Seq[NamedExpression],
+    aggregates: Seq[AggregateExpression],
+    normalizedGroupingExpressions: Seq[Expression],
+    aggExprToOutputOrdinal: HashMap[Expression, Int])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -179,7 +179,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
                     finalAggregates,
                     normalizedGroupingExpressions,
                     aggExprToOutputOrdinal))
-                  child
+                  sHolder
                 } else {
                   val (groupAttrs, aggOutput, groupByExprToOutputOrdinal, scanRelation) =
                     readScanSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -170,16 +170,18 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
                 if (pushedAggregates.isEmpty) {
                   aggNode // return original plan node
                 } else if (r.supportCompletePushDown(pushedAggregates.get)) {
+                  val newScanBuilderHolder = sHolder.copy(output = aggNode.schema.toAttributes)
+                  newScanBuilderHolder.pushedPredicates = sHolder.pushedPredicates
                   // If we can push down the aggregation completely, we need to consider
                   // pushing down the Limit or Offset operator, so keep the information about
                   // aggregation push down and push down aggregation later.
-                  sHolder.pushedAggregation = Some(PushedAggregation(
+                  newScanBuilderHolder.pushedAggregation = Some(PushedAggregation(
                     pushedAggregates,
                     finalResultExpressions,
                     finalAggregates,
                     normalizedGroupingExpressions,
                     aggExprToOutputOrdinal))
-                  sHolder
+                  newScanBuilderHolder
                 } else {
                   val (groupAttrs, aggOutput, groupByExprToOutputOrdinal, scanRelation) =
                     readScanSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -239,12 +239,12 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
 
   def pushDownAggregatesCompletely(plan: LogicalPlan): LogicalPlan = plan.transform {
     case Project(_, sHolder: ScanBuilderHolder) if sHolder.pushedAggregation.isDefined =>
-      parsePushedAggregation(sHolder)
+      rewriteAggregationAsProject(sHolder)
     case sHolder: ScanBuilderHolder if sHolder.pushedAggregation.isDefined =>
-      parsePushedAggregation(sHolder)
+      rewriteAggregationAsProject(sHolder)
   }
 
-  private def parsePushedAggregation(sHolder: ScanBuilderHolder): LogicalPlan = {
+  private def rewriteAggregationAsProject(sHolder: ScanBuilderHolder): LogicalPlan = {
     val pushedAggregation = sHolder.pushedAggregation.get
     val (groupAttrs, aggOutput, groupByExprToOutputOrdinal, scanRelation) =
       readScanSchema(sHolder, pushedAggregation.groupingExpressions,
@@ -342,7 +342,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper wit
          |Pushed Group by:
          | ${pushedAggregates.get.groupByExpressions.mkString(", ")}
          |Output: ${output.mkString(", ")}
-                      """.stripMargin)
+       """.stripMargin)
 
     val wrappedScan = getWrappedScan(scan, sHolder, pushedAggregates)
     val scanRelation =

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -190,9 +190,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .table("h2.test.employee")
       .groupBy("DEPT").sum("SALARY")
       .limit(1)
-    checkLimitRemoved(df4, false)
+    checkAggregateRemoved(df4)
+    checkLimitRemoved(df4)
     checkPushedInfo(df4,
-      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
+      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ",
+      "PushedLimit: LIMIT 1,")
     checkAnswer(df4, Seq(Row(1, 19000.00)))
 
     val name = udf { (x: String) => x.matches("cat|dav|amy") }
@@ -265,9 +267,10 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .table("h2.test.employee")
       .groupBy("DEPT").sum("SALARY")
       .offset(1)
-    checkOffsetRemoved(df5, false)
+    checkOffsetRemoved(df5)
     checkPushedInfo(df5,
-      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
+      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ",
+      "PushedOffset: OFFSET 1,")
     checkAnswer(df5, Seq(Row(2, 22000.00), Row(6, 12000.00)))
 
     val name = udf { (x: String) => x.matches("cat|dav|amy") }
@@ -402,10 +405,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .groupBy("DEPT").sum("SALARY")
       .limit(2)
       .offset(1)
-    checkLimitRemoved(df10, false)
-    checkOffsetRemoved(df10, false)
+    checkLimitRemoved(df10)
+    checkOffsetRemoved(df10)
     checkPushedInfo(df10,
-      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
+      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ",
+      "PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
     checkAnswer(df10, Seq(Row(2, 22000.00)))
 
     val name = udf { (x: String) => x.matches("cat|dav|amy") }
@@ -537,10 +541,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkAnswer(df9, Seq(Row(2, "david", 10000.00, 1300.0, true)))
 
     val df10 = sql("SELECT dept, sum(salary) FROM h2.test.employee group by dept LIMIT 1 OFFSET 1")
-    checkLimitRemoved(df10, false)
-    checkOffsetRemoved(df10, false)
+    checkLimitRemoved(df10)
+    checkOffsetRemoved(df10)
     checkPushedInfo(df10,
-      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
+      "PushedAggregates: [SUM(SALARY)], PushedFilters: [], PushedGroupByExpressions: [DEPT], ",
+      "PushedLimit: LIMIT 2, PushedOffset: OFFSET 1,")
     checkAnswer(df10, Seq(Row(2, 22000.00)))
 
     val name = udf { (x: String) => x.matches("cat|dav|amy") }
@@ -630,10 +635,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .groupBy("DEPT").sum("SALARY")
       .orderBy("DEPT")
       .limit(1)
-    checkSortRemoved(df6, false)
-    checkLimitRemoved(df6, false)
+    checkSortRemoved(df6)
+    checkLimitRemoved(df6)
     checkPushedInfo(df6, "PushedAggregates: [SUM(SALARY)]," +
-      " PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
+      " PushedFilters: [], PushedGroupByExpressions: [DEPT]," +
+      " PushedTopN: ORDER BY [DEPT ASC NULLS FIRST] LIMIT 1,")
     checkAnswer(df6, Seq(Row(1, 19000.00)))
 
     val name = udf { (x: String) => x.matches("cat|dav|amy") }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, DS V2 aggregate push-down cannot work with `OFFSET` and `LIMIT`.
If it can work with `OFFSET` or `LIMIT`, it will be better performance.


### Why are the changes needed?
Let DS V2 aggregate push down can work with `OFFSET` push down or `LIMIT` push down.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
Update tests cases.
