### PR TITLE
[SPARK-39522][INFRA] Add Apache Spark infra GA image cache

### DIFF
--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Build (Infra Image Cache)
+
+on:
+  push:
+    branches:
+    - 'master'
+    paths:
+    - 'dev/infra/Dockerfile'
+    - '.github/workflows/build_infra_images_cache.yml'
+jobs:
+  main:
+    if: github.repository == 'apache/spark'
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout Spark repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./dev/infra/
+          push: true
+          tags: ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}
+          cache-to: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }},mode=max
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Image for building and testing Spark branches. Based on Ubuntu 20.04.
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+ARG APT_INSTALL="apt-get install --no-install-recommends -y"
+
+RUN apt-get clean
+RUN apt-get update
+RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget openjdk-8-jdk libpython3-dev python3-pip python3-setuptools python3.8 python3.9
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
+RUN python3.9 -m pip install numpy pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
+
+RUN add-apt-repository ppa:pypy/ppa
+RUN apt update
+RUN $APT_INSTALL pypy3 gfortran libopenblas-dev liblapack-dev
+
+RUN $APT_INSTALL build-essential pypy3-dev
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
+RUN pypy3 -m pip install numpy 'pandas<1.4.0' scipy coverage matplotlib
+
+RUN $APT_INSTALL gnupg ca-certificates pandoc
+RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list
+RUN gpg --keyserver keyserver.ubuntu.com --recv-key E298A3A825C0D65DFD57CBB651716619E084DAB9
+RUN gpg -a --export E084DAB9 | apt-key add -
+RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
+RUN apt update
+RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
+RUN Rscript -e "install.packages(c('knitr', 'markdown', 'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -29,15 +29,20 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
+RUN python3.9 -m pip install 'numpy<1.23.0' pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
-RUN $APT_INSTALL pypy3 gfortran libopenblas-dev liblapack-dev
+RUN $APT_INSTALL gfortran libopenblas-dev liblapack-dev
+RUN $APT_INSTALL build-essential
 
-RUN $APT_INSTALL build-essential pypy3-dev
+RUN mkdir -p /usr/local/pypy/pypy3.7 && \
+    curl -sqL https://downloads.python.org/pypy/pypy3.7-v7.3.7-linux64.tar.bz2 | tar xjf - -C /usr/local/pypy/pypy3.7 --strip-components=1 && \
+    ln -sf /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3.7 && \
+    ln -sf /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3
+
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'pandas<1.4.0' scipy coverage matplotlib
+RUN pypy3 -m pip install 'numpy<1.23.0' 'pandas<1.4.0' scipy coverage matplotlib
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list


### PR DESCRIPTION
### What changes were proposed in this pull request?
![image](https://user-images.githubusercontent.com/1736354/175946244-064edf38-6cbb-41e9-840e-ac234bbb4a53.png)

This patch added github action yaml to build infra image cache, this image cache would be used by pyspark/sparkr/lint job later.

See more in: https://docs.google.com/document/d/1_uiId-U1DODYyYZejAZeyz2OAjxcnA-xfwjynDF6vd0

After this PR, a ghcr docker cache image will be generated with:
- Image tag: `ghcr.io/apache/spark/apache-spark-github-action-image-cache:{branch}`
- Triggered by: push commit to `master` branch

The dockerfile is initialized from [dongjoon/Dockerfile](https://github.com/dongjoon-hyun/ApacheSparkGitHubActionImage/blob/ac09d7a4431b209caa86090c54bfccd4d744d0ce/Dockerfile#L1) with below changes https://github.com/apache/spark/pull/37003/commits/e105dff71fab70c9e85c3c6b3ab5b59c26898164:
1. Pin the pypy version to pypy3.7.
2. numpy < 1.23.0


### Why are the changes needed?
Help to speed up docker infra image build in each PR.

### Does this PR introduce _any_ user-facing change?
No, dev only

### How was this patch tested?
local test in my repo: https://github.com/Yikun/spark/pull/107

Copy the [original dockerfile](https://github.com/dongjoon-hyun/ApacheSparkGitHubActionImage/blob/main/Dockerfile) as initial dockerfile.

Co-authored-by: Dongjoon Hyun <dongjoon@apache.org>
Co-authored-by: Hyukjin Kwon <gurwls223@apache.org>