### PR TITLE
[SPARK-39620][Web UI][WIP] Use same condition in history server page and API to filter applications

### DIFF
--- a/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/ApplicationListResource.scala
@@ -38,7 +38,7 @@ private[v1] class ApplicationListResource extends ApiRequestContext {
     val includeRunning = status.isEmpty || status.contains(ApplicationStatus.RUNNING)
 
     uiRoot.getApplicationInfoList.filter { app =>
-      val anyRunning = app.attempts.exists(!_.completed)
+      val anyRunning = app.attempts.isEmpty || !app.attempts.head.completed
       // if any attempt is still running, we consider the app to also still be running;
       // keep the app if *any* attempts fall in the right time window
       ((!anyRunning && includeCompleted) || (anyRunning && includeRunning)) &&


### PR DESCRIPTION
### What changes were proposed in this pull request?

Updated REST API `/api/v1/applications`, to use the same condition as history server page to filter completed/incomplete applications.

### Why are the changes needed?

When opening summary page, history server follows this logic:

If there's completed/incomplete application, page will add script in response, using AJAX to call the REST API to get the filtered list.
- If there's no such application, page will only return a message telling nothing found.
- Issue is that page and REST API are using different conditions to filter applications. In `HistoryPage`, an application is considered as completed as long as the last attempt is completed. But in `ApplicationListResource`, all attempts should be completed. This brings inconsistency and will cause issue in a corner case.

In driver, event queues have capacity to protect memory. When there's too many events, some of them will be dropped and the event log file will be incomplete. For an application with multiple attempts, there's possibility that the last attempt is completed, but the previous attempts is considered as incomplete due to loss of application end event.

For this type of application, page thinks it is completed, but the API thinks it is still running. When opening summary page:
- When checking completed applications, page will call script, but API returns nothing.
- When checking incomplete applications, page returns nothing.

So the user won't be able to see this app in history server.

### Does this PR introduce _any_ user-facing change?

Yes, there will be a change on `/api/v1/applications` API.

For application mentioned above, previously it is considered as running. After the change it is considered as completed. So the result will be different using same filter.

But I think this change should be OK. Because attempts are executed sequentially and incrementally. So if an attempt with bigger ID is completed, the previous attempts should also be completed.

### How was this patch tested?

WIP
