### PR TITLE
[SPARK-39625][SPARK-38904][SQL] Add Dataset.as(StructType)

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -1,7 +1,7 @@
 {
-  "AMBIGUOUS_FIELD_NAME" : {
+  "AMBIGUOUS_COLUMN_OR_FIELD" : {
     "message" : [
-      "Field name <fieldName> is ambiguous and has <n> matching fields in the struct."
+      "Column or field <name> is ambiguous and has <n> matches."
     ],
     "sqlState" : "42000"
   },
@@ -207,6 +207,12 @@
       "Invalid bucket file: <path>"
     ]
   },
+  "INVALID_COLUMN_OR_FIELD_DATA_TYPE" : {
+    "message" : [
+      "Column or field <name> is of type <type> while it's required to be <expectedType>."
+    ],
+    "sqlState" : "42000"
+  },
   "INVALID_FIELD_NAME" : {
     "message" : [
       "Field name <fieldName> is invalid: <path> is not a struct."
@@ -294,6 +300,18 @@
       "UDF class <className> doesn't implement any UDF interface"
     ]
   },
+  "NULLABLE_ARRAY_OR_MAP_ELEMENT" : {
+    "message" : [
+      "Array or map at <columnPath> contains nullable element while it's required to be non-nullable."
+    ],
+    "sqlState" : "42000"
+  },
+  "NULLABLE_COLUMN_OR_FIELD" : {
+    "message" : [
+      "Column or field <name> is nullable while it's required to be non-nullable."
+    ],
+    "sqlState" : "42000"
+  },
   "NULL_COMPARISON_RESULT" : {
     "message" : [
       "The comparison result is null. If you want to handle null as 0 (equal), you can set \"spark.sql.legacy.allowNullComparisonResultInArraySort\" to \"true\"."
@@ -354,6 +372,12 @@
   "UNRESOLVED_COLUMN" : {
     "message" : [
       "A column or function parameter with name <objectName> cannot be resolved. Did you mean one of the following? [<objectList>]"
+    ],
+    "sqlState" : "42000"
+  },
+  "UNRESOLVED_FIELD" : {
+    "message" : [
+      "A field with name <fieldName> cannot be resolved with the struct-type column <columnPath>. Did you mean one of the following? [<proposal>]"
     ],
     "sqlState" : "42000"
   },

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -307,7 +307,7 @@ abstract class SparkFunSuite
   }
 
   protected def checkError(
-      exception: Exception with SparkThrowable,
+      exception: SparkThrowable,
       errorClass: String,
       errorSubClass: String,
       sqlState: String,
@@ -315,14 +315,14 @@ abstract class SparkFunSuite
     checkError(exception, errorClass, Some(errorSubClass), Some(sqlState), parameters)
 
   protected def checkError(
-      exception: Exception with SparkThrowable,
+      exception: SparkThrowable,
       errorClass: String,
       sqlState: String,
       parameters: Map[String, String]): Unit =
     checkError(exception, errorClass, None, Some(sqlState), parameters)
 
   protected def checkError(
-      exception: Exception with SparkThrowable,
+      exception: SparkThrowable,
       errorClass: String,
       parameters: Map[String, String]): Unit =
     checkError(exception, errorClass, None, None, parameters)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -156,6 +156,25 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       origin = origin)
   }
 
+  def unresolvedColumnError(
+      columnName: String,
+      proposal: Seq[String]): Throwable = {
+    val proposalStr = proposal.map(toSQLId).mkString(", ")
+    new AnalysisException(
+      errorClass = "UNRESOLVED_COLUMN",
+      messageParameters = Array(toSQLId(columnName), proposalStr))
+  }
+
+  def unresolvedFieldError(
+      fieldName: String,
+      columnPath: Seq[String],
+      proposal: Seq[String]): Throwable = {
+    val proposalStr = proposal.map(toSQLId).mkString(", ")
+    new AnalysisException(
+      errorClass = "UNRESOLVED_FIELD",
+      messageParameters = Array(toSQLId(fieldName), toSQLId(columnPath), proposalStr))
+  }
+
   def dataTypeMismatchForDeserializerError(
       dataType: DataType, desiredType: String): Throwable = {
     new AnalysisException(
@@ -1395,12 +1414,19 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
        """.stripMargin.replaceAll("\n", " "))
   }
 
-  def ambiguousFieldNameError(
-      fieldName: Seq[String], numMatches: Int, context: Origin): Throwable = {
+  def ambiguousColumnOrFieldError(
+      name: Seq[String], numMatches: Int, context: Origin): Throwable = {
     new AnalysisException(
-      errorClass = "AMBIGUOUS_FIELD_NAME",
-      messageParameters = Array(fieldName.quoted, numMatches.toString),
+      errorClass = "AMBIGUOUS_COLUMN_OR_FIELD",
+      messageParameters = Array(toSQLId(name), numMatches.toString),
       origin = context)
+  }
+
+  def ambiguousColumnOrFieldError(
+      name: Seq[String], numMatches: Int): Throwable = {
+    new AnalysisException(
+      errorClass = "AMBIGUOUS_COLUMN_OR_FIELD",
+      messageParameters = Array(toSQLId(name), numMatches.toString))
   }
 
   def cannotUseIntervalTypeInTableSchemaError(): Throwable = {
@@ -2480,5 +2506,26 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def defaultValuesMayNotContainSubQueryExpressions(): Throwable = {
     new AnalysisException(
       "Failed to execute command because subquery expressions are not allowed in DEFAULT values")
+  }
+
+  def nullableColumnOrFieldError(name: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "NULLABLE_COLUMN_OR_FIELD",
+      messageParameters = Array(toSQLId(name)))
+  }
+
+  def nullableArrayOrMapElementError(path: Seq[String]): Throwable = {
+    new AnalysisException(
+      errorClass = "NULLABLE_ARRAY_OR_MAP_ELEMENT",
+      messageParameters = Array(toSQLId(path)))
+  }
+
+  def invalidColumnOrFieldDataTypeError(
+      name: Seq[String],
+      dt: DataType,
+      expected: DataType): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
+      messageParameters = Array(toSQLId(name), toSQLType(dt), toSQLType(expected)))
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -335,7 +335,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
       val searchName = searchPath.head
       val found = struct.fields.filter(f => resolver(searchName, f.name))
       if (found.length > 1) {
-        throw QueryCompilationErrors.ambiguousFieldNameError(fieldNames, found.length, context)
+        throw QueryCompilationErrors.ambiguousColumnOrFieldError(fieldNames, found.length, context)
       } else if (found.isEmpty) {
         None
       } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/StructTypeSuite.scala
@@ -328,8 +328,8 @@ class StructTypeSuite extends SparkFunSuite with SQLHelper {
     e = intercept[AnalysisException] {
       check(Seq("S2", "x"), None)
     }
-    assert(e.getMessage.contains(
-      "Field name S2.x is ambiguous and has 2 matching fields in the struct"))
+    checkError(e, "AMBIGUOUS_COLUMN_OR_FIELD",
+      Map("name" -> "`S2`.`x`", "n" -> "2"))
     caseSensitiveCheck(Seq("s2", "x"), Some(Seq("s2") -> StructField("x", IntegerType)))
 
     // simple map type

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAsSchemaSuite.scala
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  test("reorder columns by name") {
+    val schema = new StructType().add("j", StringType).add("i", StringType)
+    val df = Seq("a" -> "b").toDF("i", "j").as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row("b", "a"))
+  }
+
+  test("case insensitive: reorder columns by name") {
+    val schema = new StructType().add("J", StringType).add("I", StringType)
+    val df = Seq("a" -> "b").toDF("i", "j").as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row("b", "a"))
+  }
+
+  test("select part of the columns") {
+    val schema = new StructType().add("j", StringType)
+    val df = Seq("a" -> "b").toDF("i", "j").as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row("b"))
+  }
+
+  test("negative: column not found") {
+    val schema = new StructType().add("non_exist", StringType)
+    val e = intercept[SparkThrowable](Seq("a" -> "b").toDF("i", "j").as(schema))
+    checkError(
+      exception = e,
+      errorClass = "UNRESOLVED_COLUMN",
+      parameters = Map(
+        "objectName" -> "`non_exist`",
+        "objectList" -> "`i`, `j`"))
+  }
+
+  test("negative: ambiguous column") {
+    val schema = new StructType().add("i", StringType)
+    val e = intercept[SparkThrowable](Seq("a" -> "b").toDF("i", "I").as(schema))
+    checkError(
+      exception = e,
+      errorClass = "AMBIGUOUS_COLUMN_OR_FIELD",
+      parameters = Map(
+        "name" -> "`i`",
+        "n" -> "2"))
+  }
+
+  test("keep the nullability of the original column") {
+    val schema = new StructType().add("j", IntegerType)
+    val data = Seq("a" -> 1).toDF("i", "j")
+    assert(!data.schema.fields(1).nullable)
+    val df = data.as(schema)
+    val finalSchema = new StructType().add("j", IntegerType, nullable = false)
+    assert(df.schema == finalSchema)
+    checkAnswer(df, Row(1))
+  }
+
+  test("negative: incompatible column nullability") {
+    val schema = new StructType().add("i", IntegerType, nullable = false)
+    val data = sql("SELECT i FROM VALUES 1, NULL as t(i)")
+    assert(data.schema.fields(0).nullable)
+    val e = intercept[SparkThrowable](data.as(schema))
+    checkError(
+      exception = e,
+      errorClass = "NULLABLE_COLUMN_OR_FIELD",
+      parameters = Map("name" -> "`i`"))
+  }
+
+  test("upcast the original column") {
+    val schema = new StructType().add("j", LongType, nullable = false)
+    val df = Seq("a" -> 1).toDF("i", "j").as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(1L))
+  }
+
+  test("negative: column cannot upcast") {
+    val schema = new StructType().add("i", IntegerType)
+    val e = intercept[SparkThrowable](Seq("a" -> 1).toDF("i", "j").as(schema))
+    checkError(
+      exception = e,
+      errorClass = "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
+      parameters = Map(
+        "name" -> "`i`",
+        "type" -> "\"STRING\"",
+        "expectedType" -> "\"INT\"")
+    )
+  }
+
+  test("column carries the metadata") {
+    val metadata1 = new MetadataBuilder().putString("a", "1").putString("b", "2").build()
+    val metadata2 = new MetadataBuilder().putString("b", "3").putString("c", "4").build()
+    val schema = new StructType().add("i", IntegerType, nullable = true, metadata = metadata2)
+    val df = Seq((1)).toDF("i").select($"i".as("i", metadata1)).as(schema)
+    // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
+    val resultMetadata = new MetadataBuilder()
+      .putString("a", "1").putString("b", "3").putString("c", "4").build()
+    assert(df.schema(0).metadata == resultMetadata)
+  }
+
+
+  test("reorder inner fields by name") {
+    val innerFields = new StructType().add("j", StringType).add("i", StringType)
+    val schema = new StructType().add("struct", innerFields, nullable = false)
+    val df = Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Row("b", "a")))
+  }
+
+  test("case insensitive: reorder inner fields by name") {
+    val innerFields = new StructType().add("J", StringType).add("I", StringType)
+    val schema = new StructType().add("struct", innerFields, nullable = false)
+    val df = Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Row("b", "a")))
+  }
+
+  test("negative: field not found") {
+    val innerFields = new StructType().add("non_exist", StringType)
+    val schema = new StructType().add("struct", innerFields, nullable = false)
+    val e = intercept[SparkThrowable] {
+      Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    }
+    checkError(
+      exception = e,
+      errorClass = "UNRESOLVED_FIELD",
+      parameters = Map(
+        "fieldName" -> "`non_exist`",
+        "columnPath" -> "`struct`",
+        "proposal" -> "`i`, `j`"))
+  }
+
+  test("keep the nullability of the original field") {
+    val innerFields = new StructType().add("j", IntegerType)
+    val schema = new StructType().add("struct", innerFields)
+    val data = Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct"))
+    assert(!data.schema.fields(0).nullable)
+    assert(!data.schema.fields(0).dataType.asInstanceOf[StructType].fields(1).nullable)
+    val df = data.as(schema)
+    val finalFields = new StructType().add("j", IntegerType, nullable = false)
+    val finalSchema = new StructType().add("struct", finalFields, nullable = false)
+    assert(df.schema == finalSchema)
+    checkAnswer(df, Row(Row(1)))
+  }
+
+  test("negative: incompatible field nullability") {
+    val innerFields = new StructType().add("i", IntegerType, nullable = false)
+    val schema = new StructType().add("struct", innerFields)
+    val data = sql("SELECT i FROM VALUES 1, NULL as t(i)").select(struct($"i").as("struct"))
+    assert(!data.schema.fields(0).nullable)
+    assert(data.schema.fields(0).dataType.asInstanceOf[StructType].fields(0).nullable)
+    val e = intercept[SparkThrowable](data.as(schema))
+    checkError(
+      exception = e,
+      errorClass = "NULLABLE_COLUMN_OR_FIELD",
+      parameters = Map("name" -> "`struct`.`i`"))
+  }
+
+  test("upcast the original field") {
+    val innerFields = new StructType().add("j", LongType, nullable = false)
+    val schema = new StructType().add("struct", innerFields, nullable = false)
+    val df = Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Row(1L)))
+  }
+
+  test("negative: field cannot upcast") {
+    val innerFields = new StructType().add("i", IntegerType)
+    val schema = new StructType().add("struct", innerFields, nullable = false)
+    val e = intercept[SparkThrowable] {
+      Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    }
+    checkError(
+      exception = e,
+      errorClass = "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
+      parameters = Map(
+        "name" -> "`struct`.`i`",
+        "type" -> "\"STRING\"",
+        "expectedType" -> "\"INT\"")
+    )
+  }
+
+  test("inner field carries the metadata") {
+    val metadata1 = new MetadataBuilder().putString("a", "1").putString("b", "2").build()
+    val metadata2 = new MetadataBuilder().putString("b", "3").putString("c", "4").build()
+    val innerFields = new StructType().add("i", LongType, nullable = true, metadata = metadata2)
+    val schema = new StructType().add("struct", innerFields)
+    val df = Seq((1)).toDF("i")
+      .select($"i".as("i", metadata1))
+      .select(struct($"i").as("struct"))
+      .as(schema)
+    // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
+    val resultMetadata = new MetadataBuilder()
+      .putString("a", "1").putString("b", "3").putString("c", "4").build()
+    assert(df.schema(0).dataType.asInstanceOf[StructType].fields(0).metadata == resultMetadata)
+  }
+
+  test("array element: reorder inner fields by name") {
+    val innerFields = new StructType().add("j", StringType).add("i", StringType)
+    val arr = ArrayType(innerFields, containsNull = false)
+    val schema = new StructType().add("arr", arr, nullable = false)
+    val df = Seq("a" -> "b").toDF("i", "j")
+      .select(array(struct($"i", $"j")).as("arr"))
+      .as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Seq(Row("b", "a"))))
+  }
+
+  test("array element: upcast the original field") {
+    val innerFields = new StructType().add("j", LongType, nullable = false)
+    val arr = ArrayType(innerFields, containsNull = false)
+    val schema = new StructType().add("arr", arr, nullable = false)
+    val df = Seq("a" -> 1).toDF("i", "j")
+      .select(array(struct($"i", $"j")).as("arr"))
+      .as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Seq(Row(1L))))
+  }
+
+  test("array element: incompatible array nullability") {
+    val arr = ArrayType(IntegerType, containsNull = false)
+    val schema = new StructType().add("arr", arr)
+    val data = sql("SELECT i FROM VALUES 1, NULL as t(i)").select(array($"i").as("arr"))
+    assert(data.schema.fields(0).dataType.asInstanceOf[ArrayType].containsNull)
+    val e = intercept[SparkThrowable](data.as(schema))
+    checkError(
+      exception = e,
+      errorClass = "NULLABLE_ARRAY_OR_MAP_ELEMENT",
+      parameters = Map("columnPath" -> "`arr`"))
+  }
+
+  test("array element: array itself carries the metadata") {
+    val metadata1 = new MetadataBuilder().putString("a", "1").putString("b", "2").build()
+    val metadata2 = new MetadataBuilder().putString("b", "3").putString("c", "4").build()
+    val innerFields = new StructType().add("i", LongType)
+    val arr = ArrayType(innerFields, containsNull = true)
+    val schema = new StructType().add("arr", arr, nullable = false, metadata = metadata2)
+    val df = Seq((1)).toDF("i")
+      .select($"i")
+      .select(array(struct($"i")).as("arr", metadata1))
+      .as(schema)
+    // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
+    val resultMetadata = new MetadataBuilder()
+      .putString("a", "1").putString("b", "3").putString("c", "4").build()
+    assert(df.schema(0).metadata == resultMetadata)
+  }
+
+  test("array element: inner field inside array carries the metadata") {
+    val metadata1 = new MetadataBuilder().putString("a", "1").putString("b", "2").build()
+    val metadata2 = new MetadataBuilder().putString("b", "3").putString("c", "4").build()
+    val innerFields = new StructType().add("i", LongType, nullable = true, metadata = metadata2)
+    val arr = ArrayType(innerFields, containsNull = true)
+    val schema = new StructType().add("arr", arr, nullable = false)
+    val df = Seq((1)).toDF("i")
+      .select($"i".as("i", metadata1))
+      .select(array(struct($"i")).as("arr"))
+      .as(schema)
+    // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
+    val resultMetadata = new MetadataBuilder()
+      .putString("a", "1").putString("b", "3").putString("c", "4").build()
+    assert(df.schema(0).dataType.asInstanceOf[ArrayType].elementType
+      .asInstanceOf[StructType].fields(0).metadata == resultMetadata)
+  }
+
+  test("map key: reorder inner fields by name") {
+    val innerFields = new StructType().add("j", StringType).add("i", StringType)
+    val m = MapType(innerFields, StringType)
+    val schema = new StructType().add("map", m, nullable = false)
+    val df = Seq("a" -> "b").toDF("i", "j")
+      .select(map(struct($"i", $"j"), $"i").as("map"))
+      .as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Map(Row("b", "a") -> "a")))
+  }
+
+  test("map value: reorder inner fields by name") {
+    val innerFields = new StructType().add("j", StringType).add("i", StringType)
+    val m = MapType(StringType, innerFields, valueContainsNull = false)
+    val schema = new StructType().add("map", m, nullable = false)
+    val df = Seq("a" -> "b").toDF("i", "j")
+      .select(map($"i", struct($"i", $"j")).as("map"))
+      .as(schema)
+    assert(df.schema == schema)
+    checkAnswer(df, Row(Map("a" -> Row("b", "a"))))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -477,18 +477,18 @@ class QueryCompilationErrorsSuite
     }
   }
 
-  test("AMBIGUOUS_FIELD_NAME: alter column matching multi fields in the struct") {
+  test("AMBIGUOUS_COLUMN_OR_FIELD: alter column matching multi fields in the struct") {
     withTable("t") {
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
         sql("CREATE TABLE t(c struct<X:String, x:String>) USING parquet")
       }
 
-      checkErrorClass(
+      checkError(
         exception = intercept[AnalysisException] {
           sql("ALTER TABLE t CHANGE COLUMN c.X COMMENT 'new comment'")
         },
-        errorClass = "AMBIGUOUS_FIELD_NAME",
-        msg = "Field name c.X is ambiguous and has 2 matching fields in the struct.; line 1 pos 0")
+        errorClass = "AMBIGUOUS_COLUMN_OR_FIELD",
+        parameters = Map("name" -> "`c`.`X`", "n" -> "2"))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new API `Dataset.as(StructType)` to "cast" the entire dataframe to the specified schema. Its behavior is very similar to table insertion where we need to adjust the input query to match the table schema, but it's extended to work for inner fields as well:
* Reorder columns and/or inner fields to match the specified schema
* Project away columns and/or inner fields that are not needed by the specified schema
* Cast the columns and/or inner fields to match the data types in the specified schema

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For lakehouse tables, schema evolution is a common feature. It's more robust to specify the expected schema at the beginning so that the data pipeline can always be run with the same input schema.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it adds a new API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
a new test suite