### PR TITLE
[SPARK-39624][SQL] Support coalesce partition through CartesianProduct

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{ShufflePartitionSpec, SparkPlan, UnaryExecNode, UnionExec}
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, REBALANCE_PARTITIONS_BY_COL, REBALANCE_PARTITIONS_BY_NONE, REPARTITION_BY_COL, ShuffleExchangeLike, ShuffleOrigin}
+import org.apache.spark.sql.execution.joins.CartesianProductExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
@@ -132,6 +133,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
       Seq(collectShuffleStageInfos(r))
     case unary: UnaryExecNode => collectCoalesceGroups(unary.child)
     case union: UnionExec => union.children.flatMap(collectCoalesceGroups)
+    case cartesian: CartesianProductExec => cartesian.children.flatMap(collectCoalesceGroups)
     // If not all leaf nodes are query stages, it's not safe to reduce the number of shuffle
     // partitions, because we may break the assumption that all children of a spark plan have
     // same number of output partitions.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -76,9 +76,9 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
       conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_SIZE)
     }
 
-    // Sub-plans under the Union operator can be coalesced independently, so we can divide them
-    // into independent "coalesce groups", and all shuffle stages within each group have to be
-    // coalesced together.
+    // Sub-plans under the Union operator and CartesianProduct operator can be coalesced
+    // independently, so we can divide them into independent "coalesce groups",
+    // and all shuffle stages within each group have to be coalesced together.
     val coalesceGroups = collectCoalesceGroups(plan)
 
     // Divide minimum task parallelism among coalesce groups according to their data sizes.
@@ -124,7 +124,7 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
 
   /**
    * Gather all coalesce-able groups such that the shuffle stages in each child of a Union operator
-   * are in their independent groups if:
+   * or a Cartesian Product are in their independent groups if:
    * 1) all leaf nodes of this child are shuffle stages; and
    * 2) all these shuffle stages support coalescing.
    */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2630,11 +2630,9 @@ class AdaptiveQueryExecSuite
         checkResultPartition(
           sql("""
                 |SELECT * FROM
-                |(SELECT * FROM t3) t3
-                |join (
+                |t3 join (
                 |SELECT t1.key, t2.value FROM
-                |(SELECT * FROM t1 ) t1
-                |join (SELECT * FROM t2) t2
+                |t1 join t2
                 |on t1.value = t2.value) t
                 |on t3.key = t.key or t3.value=t.value
             """.stripMargin),
@@ -2644,10 +2642,9 @@ class AdaptiveQueryExecSuite
         checkResultPartition(
           sql("""
                 |SELECT * FROM
-                |(SELECT * FROM t1)
-                |t1 join (SELECT * FROM t2)
-                |t2 on t1.key = t2.key
-                |or t1.value=t2.value
+                |t1 join t2
+                |on t1.key = t2.key
+                |or t1.value = t2.value
                 """.stripMargin),
           numShuffleReader = 0,
           numPartition = 8

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2604,11 +2604,11 @@ class AdaptiveQueryExecSuite
   }
 
   test("SPARK-39624 Support coalesce partition through CartesianProduct") {
-    def checkResultPartition(df: Dataset[Row],
-                             numShuffleReader: Int,
-                             numPartition: Int): Unit = {
+    def checkResultPartition(
+       df: Dataset[Row],
+       numShuffleReader: Int,
+       numPartition: Int): Unit = {
       df.collect()
-      print(df.queryExecution.executedPlan)
       assert(collect(df.queryExecution.executedPlan) {
         case r: AQEShuffleReadExec => r
       }.size === numShuffleReader)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2607,7 +2607,7 @@ class AdaptiveQueryExecSuite
     def checkResultPartition(
         df: Dataset[Row],
         numShuffleReader: Int,
-       numPartition: Int): Unit = {
+        numPartition: Int): Unit = {
       df.collect()
       assert(collect(df.queryExecution.executedPlan) {
         case r: AQEShuffleReadExec => r

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2605,8 +2605,8 @@ class AdaptiveQueryExecSuite
 
   test("SPARK-39624 Support coalesce partition through CartesianProduct") {
     def checkResultPartition(
-       df: Dataset[Row],
-       numShuffleReader: Int,
+        df: Dataset[Row],
+        numShuffleReader: Int,
        numPartition: Int): Unit = {
       df.collect()
       assert(collect(df.queryExecution.executedPlan) {
@@ -2638,7 +2638,7 @@ class AdaptiveQueryExecSuite
             """.stripMargin),
           numShuffleReader = 2,
           numPartition = 4)
-        // negative test
+        // negative test: children of cartesian product do not have shuffles
         checkResultPartition(
           sql("""
                 |SELECT * FROM


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Coalesce paritition for every group


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
With CartesianProduct,  CoalesceShufflePartitions can not optimize it.

Such as sql like this, if CoalesceShufflePartitions can not apply ,`t1 join t2` will produce a lot partition, the result partition will be `left partition * right partition` which can be quite large.

```sql
SELECT * FROM ( SELECT * FROM t3) t3
    JOIN (
        SELECT t1.key, t2.value FROM
         ( SELECT * FROM t1) t1
            JOIN
         ( SELECT * FROM t2) t2
            ON t1.value = t2.value
    ) t ON t3.key = t.key OR t3.value = t.value
```

It's better to support partial optimize with CartesianProductExec.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add test.