### PR TITLE
[SPARK-39628][CORE] Fix a race condition when handling of IdleStateEvent again

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/client/TransportResponseHandler.java
@@ -276,7 +276,7 @@ public class TransportResponseHandler extends MessageHandler<ResponseMessage> {
   }
 
   /** Check if there are any outstanding requests (fetch requests + rpcs) */
-  public Boolean hasOutstandingRequests() {
+  public boolean hasOutstandingRequests() {
     return streamActive || !outstandingFetches.isEmpty() || !outstandingRpcs.isEmpty() ||
         !streamCallbacks.isEmpty();
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/server/TransportChannelHandler.java
@@ -158,10 +158,12 @@ public class TransportChannelHandler extends SimpleChannelInboundHandler<Message
       // To avoid a race between TransportClientFactory.createClient() and this code which could
       // result in an inactive client being returned, this needs to run in a synchronized block.
       synchronized (this) {
+        // Do not modify the order of hasInFlightRequests and isActuallyOverdue (see SPARK-27073)
+        boolean hasInFlightRequests = responseHandler.hasOutstandingRequests();
         boolean isActuallyOverdue =
           System.nanoTime() - responseHandler.getTimeOfLastRequestNs() > requestTimeoutNs;
         if (e.state() == IdleState.ALL_IDLE && isActuallyOverdue) {
-          if (responseHandler.hasOutstandingRequests()) {
+          if (hasInFlightRequests) {
             String address = getRemoteAddress(ctx.channel());
             logger.error("Connection to {} has been quiet for {} ms while there are outstanding " +
               "requests. Assuming connection is dead; please adjust" +


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a race condition when handling of IdleStateEvent.
https://github.com/apache/spark/pull/23989


### Why are the changes needed?
In [SPARK-27073](https://issues.apache.org/jira/browse/SPARK-27073), fix a race condition when handling of IdleStateEvent, but in [SPARK-37462](https://issues.apache.org/jira/browse/SPARK-37462) the call order is modified, which leads to a possible regression.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This problem has been encountered in our production environment, and it is difficult to test the race condition here.
