### PR TITLE
[SPARK-39617][CORE] Driver cores mult be a positive number fix

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -253,7 +253,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         && Try(JavaUtils.byteStringAsBytes(executorMemory)).getOrElse(-1L) <= 0) {
       error("Executor memory must be a positive number")
     }
-    if (driverCores != null && Try(driverCores.toInt).getOrElse(-1) <= 0) {
+    if (driverCores != null && Try(driverCores.toDouble.toInt).getOrElse(-1) <= 0) {
       error("Driver cores must be a positive number")
     }
     if (executorCores != null && Try(executorCores.toInt).getOrElse(-1) <= 0) {


### PR DESCRIPTION


### What changes were proposed in this pull request?

Hello, according to this [problem](https://issues.apache.org/jira/browse/SPARK-39617 ) raised also by me, and highlighted by two other persons on Stack Overflow ([this](https://stackoverflow.com/questions/71691292/driver-cores-must-be-a-positive-number) and [this](https://stackoverflow.com/questions/72473151/exception-in-thread-main-org-apache-spark-sparkexception-driver-cores-must-be)) and thanks to this [feature](https://issues.apache.org/jira/browse/SPARK-35013) we are currently unable to run Spark 3.2.x with Mesos in Cluster Mode.

From what I saw, it happends because of the **_MesosClusterDispatcher_** and its components which treat the driverCores variable as a Double and in the end it's passed to SparkSubmit as a double and this makes the check by **_SparkSubmitArguments_** to fail.

I'm proposing this quick fix because I think it's a quick & safe way to go with.

### Why are the changes needed?
To be able to run Spark 3.2.x in Cluster Mode with Mesos

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
It's a very small change, basically the Cast from String to Int is safe now.

Thank you!
