### PR TITLE
[SPARK-39631][SQL][TESTS] Update `FilterPushdownBenchmark` results

### DIFF
--- a/sql/core/benchmarks/FilterPushdownBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/FilterPushdownBenchmark-jdk11-results.txt
@@ -2,669 +2,733 @@
 Pushdown for many distinct value case
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 0 string row (value IS NULL):      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9287           9340          45          1.7         590.4       1.0X
-Parquet Vectorized (Pushdown)                       586            608          25         26.8          37.3      15.8X
-Native ORC Vectorized                              6930           7023         100          2.3         440.6       1.3X
-Native ORC Vectorized (Pushdown)                    482            500          24         32.7          30.6      19.3X
+Parquet Vectorized                                10439          10509          98          1.5         663.7       1.0X
+Parquet Vectorized (Pushdown)                       578            602          31         27.2          36.7      18.1X
+Native ORC Vectorized                              7076           7112          44          2.2         449.9       1.5X
+Native ORC Vectorized (Pushdown)                    487            496           7         32.3          31.0      21.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 0 string row ('7864320' < value < '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                            9454           9481          24          1.7         601.1       1.0X
-Parquet Vectorized (Pushdown)                                  575            594          18         27.4          36.6      16.4X
-Native ORC Vectorized                                         7092           7109          19          2.2         450.9       1.3X
-Native ORC Vectorized (Pushdown)                               493            500          12         31.9          31.3      19.2X
+Parquet Vectorized                                           10580          10604          17          1.5         672.7       1.0X
+Parquet Vectorized (Pushdown)                                  559            571           8         28.1          35.6      18.9X
+Native ORC Vectorized                                         7188           7208          21          2.2         457.0       1.5X
+Native ORC Vectorized (Pushdown)                               473            481           9         33.3          30.0      22.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 string row (value = '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9427           9460          22          1.7         599.3       1.0X
-Parquet Vectorized (Pushdown)                       563            598          36         27.9          35.8      16.7X
-Native ORC Vectorized                              7073           7090          10          2.2         449.7       1.3X
-Native ORC Vectorized (Pushdown)                    479            489           9         32.8          30.5      19.7X
+Parquet Vectorized                                10526          10540          20          1.5         669.2       1.0X
+Parquet Vectorized (Pushdown)                       545            554           9         28.9          34.6      19.3X
+Native ORC Vectorized                              7144           7189          33          2.2         454.2       1.5X
+Native ORC Vectorized (Pushdown)                    448            462           8         35.1          28.5      23.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 string row (value <=> '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  9418           9443          20          1.7         598.8       1.0X
-Parquet Vectorized (Pushdown)                        563            572           7         27.9          35.8      16.7X
-Native ORC Vectorized                               7238           7268          24          2.2         460.2       1.3X
-Native ORC Vectorized (Pushdown)                     467            477           9         33.7          29.7      20.2X
+Parquet Vectorized                                 10506          10515           9          1.5         667.9       1.0X
+Parquet Vectorized (Pushdown)                        529            537          10         29.8          33.6      19.9X
+Native ORC Vectorized                               7118           7156          23          2.2         452.6       1.5X
+Native ORC Vectorized (Pushdown)                     436            445          10         36.0          27.7      24.1X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 string row ('7864320' <= value <= '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              9433           9476          39          1.7         599.8       1.0X
-Parquet Vectorized (Pushdown)                                    568            573           6         27.7          36.1      16.6X
-Native ORC Vectorized                                           7117           7230          76          2.2         452.5       1.3X
-Native ORC Vectorized (Pushdown)                                 472            482           9         33.3          30.0      20.0X
+Parquet Vectorized                                             10505          10519          12          1.5         667.9       1.0X
+Parquet Vectorized (Pushdown)                                    517            528           8         30.4          32.9      20.3X
+Native ORC Vectorized                                           7232           7271          43          2.2         459.8       1.5X
+Native ORC Vectorized (Pushdown)                                 439            448           7         35.8          27.9      23.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select all string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  17447          17456           9          0.9        1109.2       1.0X
-Parquet Vectorized (Pushdown)                       17535          17548          12          0.9        1114.9       1.0X
-Native ORC Vectorized                               15176          15205          23          1.0         964.8       1.1X
-Native ORC Vectorized (Pushdown)                    15332          15368          31          1.0         974.8       1.1X
+Parquet Vectorized                                  19062          19147          82          0.8        1211.9       1.0X
+Parquet Vectorized (Pushdown)                       19151          19167          13          0.8        1217.6       1.0X
+Native ORC Vectorized                               15455          15470          15          1.0         982.6       1.2X
+Native ORC Vectorized (Pushdown)                    15605          15614           9          1.0         992.2       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 0 int row (value IS NULL):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 8956           8989          43          1.8         569.4       1.0X
-Parquet Vectorized (Pushdown)                       546            561          24         28.8          34.7      16.4X
-Native ORC Vectorized                              6480           6558          47          2.4         412.0       1.4X
-Native ORC Vectorized (Pushdown)                    451            461          10         34.9          28.7      19.8X
+Parquet Vectorized                                 9694           9721          30          1.6         616.3       1.0X
+Parquet Vectorized (Pushdown)                       475            484          10         33.1          30.2      20.4X
+Native ORC Vectorized                              6570           6598          32          2.4         417.7       1.5X
+Native ORC Vectorized (Pushdown)                    413            421           7         38.1          26.3      23.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 0 int row (7864320 < value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     9121           9177          35          1.7         579.9       1.0X
-Parquet Vectorized (Pushdown)                           552            561           7         28.5          35.1      16.5X
-Native ORC Vectorized                                  6522           6565          45          2.4         414.7       1.4X
-Native ORC Vectorized (Pushdown)                        458            463           6         34.4          29.1      19.9X
+Parquet Vectorized                                     9684           9695          15          1.6         615.7       1.0X
+Parquet Vectorized (Pushdown)                           494            501           7         31.8          31.4      19.6X
+Native ORC Vectorized                                  6590           6607          23          2.4         419.0       1.5X
+Native ORC Vectorized (Pushdown)                        418            432          11         37.6          26.6      23.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 int row (value = 7864320):       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9014           9036          18          1.7         573.1       1.0X
-Parquet Vectorized (Pushdown)                       556            573          17         28.3          35.3      16.2X
-Native ORC Vectorized                              6520           6591          53          2.4         414.5       1.4X
-Native ORC Vectorized (Pushdown)                    457            465          10         34.4          29.0      19.7X
+Parquet Vectorized                                 9720           9736          24          1.6         618.0       1.0X
+Parquet Vectorized (Pushdown)                       489            498           8         32.2          31.1      19.9X
+Native ORC Vectorized                              6665           6680          12          2.4         423.8       1.5X
+Native ORC Vectorized (Pushdown)                    423            427           6         37.2          26.9      23.0X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 int row (value <=> 7864320):     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9015           9024          15          1.7         573.1       1.0X
-Parquet Vectorized (Pushdown)                       550            567          25         28.6          35.0      16.4X
-Native ORC Vectorized                              6563           6587          23          2.4         417.3       1.4X
-Native ORC Vectorized (Pushdown)                    450            455           6         35.0          28.6      20.0X
+Parquet Vectorized                                 9728           9738          15          1.6         618.5       1.0X
+Parquet Vectorized (Pushdown)                       484            492           9         32.5          30.8      20.1X
+Native ORC Vectorized                              6672           6685          12          2.4         424.2       1.5X
+Native ORC Vectorized (Pushdown)                    418            426           8         37.6          26.6      23.3X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 int row (7864320 <= value <= 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       9010           9033          20          1.7         572.9       1.0X
-Parquet Vectorized (Pushdown)                             548            562          12         28.7          34.9      16.4X
-Native ORC Vectorized                                    6576           6608          26          2.4         418.1       1.4X
-Native ORC Vectorized (Pushdown)                          451            459           9         34.9          28.7      20.0X
+Parquet Vectorized                                       9732           9741           6          1.6         618.8       1.0X
+Parquet Vectorized (Pushdown)                             489            494           3         32.2          31.1      19.9X
+Native ORC Vectorized                                    6667           6682          15          2.4         423.9       1.5X
+Native ORC Vectorized (Pushdown)                          419            426           6         37.6          26.6      23.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 int row (7864319 < value < 7864321):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8998           9025          33          1.7         572.0       1.0X
-Parquet Vectorized (Pushdown)                           556            571          23         28.3          35.4      16.2X
-Native ORC Vectorized                                  6534           6577          33          2.4         415.4       1.4X
-Native ORC Vectorized (Pushdown)                        457            462           6         34.4          29.1      19.7X
+Parquet Vectorized                                     9733           9739           9          1.6         618.8       1.0X
+Parquet Vectorized (Pushdown)                           484            515          46         32.5          30.8      20.1X
+Native ORC Vectorized                                  6563           6578          15          2.4         417.2       1.5X
+Native ORC Vectorized (Pushdown)                        422            428           6         37.2          26.9      23.0X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% int rows (value < 1572864):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9817          10010         204          1.6         624.2       1.0X
-Parquet Vectorized (Pushdown)                      2196           2205          11          7.2         139.6       4.5X
-Native ORC Vectorized                              7341           7388          49          2.1         466.7       1.3X
-Native ORC Vectorized (Pushdown)                   1867           1879           8          8.4         118.7       5.3X
+Parquet Vectorized                                10574          10600          33          1.5         672.3       1.0X
+Parquet Vectorized (Pushdown)                      2263           2273          14          7.0         143.9       4.7X
+Native ORC Vectorized                              7420           7462          24          2.1         471.8       1.4X
+Native ORC Vectorized (Pushdown)                   1866           1876           8          8.4         118.6       5.7X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% int rows (value < 7864320):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                12672          12699          24          1.2         805.6       1.0X
-Parquet Vectorized (Pushdown)                      8390           8398          10          1.9         533.4       1.5X
-Native ORC Vectorized                             10113          10152          31          1.6         642.9       1.3X
-Native ORC Vectorized (Pushdown)                   7137           7147          10          2.2         453.8       1.8X
+Parquet Vectorized                                13597          13631          26          1.2         864.4       1.0X
+Parquet Vectorized (Pushdown)                      9042           9050           7          1.7         574.9       1.5X
+Native ORC Vectorized                             10326          10368          45          1.5         656.5       1.3X
+Native ORC Vectorized (Pushdown)                   7330           7345          16          2.1         466.0       1.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% int rows (value < 14155776):   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                15422          15497          55          1.0         980.5       1.0X
-Parquet Vectorized (Pushdown)                     14643          14650           6          1.1         931.0       1.1X
-Native ORC Vectorized                             12906          12951          28          1.2         820.5       1.2X
-Native ORC Vectorized (Pushdown)                  12454          12459           4          1.3         791.8       1.2X
+Parquet Vectorized                                16661          16679          13          0.9        1059.3       1.0X
+Parquet Vectorized (Pushdown)                     15807          15821          17          1.0        1005.0       1.1X
+Native ORC Vectorized                             13294          13314          34          1.2         845.2       1.3X
+Native ORC Vectorized (Pushdown)                  12779          12788           9          1.2         812.5       1.3X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select all int rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                16116          16132          15          1.0        1024.7       1.0X
-Parquet Vectorized (Pushdown)                     16176          16191          12          1.0        1028.4       1.0X
-Native ORC Vectorized                             13596          13609          10          1.2         864.4       1.2X
-Native ORC Vectorized (Pushdown)                  13741          13754           8          1.1         873.6       1.2X
+Parquet Vectorized                                17368          17394          23          0.9        1104.2       1.0X
+Parquet Vectorized (Pushdown)                     17456          17466           8          0.9        1109.8       1.0X
+Native ORC Vectorized                             13925          13947          24          1.1         885.3       1.2X
+Native ORC Vectorized (Pushdown)                  14073          14084          10          1.1         894.8       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select all int rows (value > -1):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                16166          16189          26          1.0        1027.8       1.0X
-Parquet Vectorized (Pushdown)                     16223          16233           9          1.0        1031.4       1.0X
-Native ORC Vectorized                             13584          13596           8          1.2         863.6       1.2X
-Native ORC Vectorized (Pushdown)                  13729          13739           8          1.1         872.9       1.2X
+Parquet Vectorized                                17396          17408           9          0.9        1106.0       1.0X
+Parquet Vectorized (Pushdown)                     17443          17458          12          0.9        1109.0       1.0X
+Native ORC Vectorized                             13993          13999           5          1.1         889.6       1.2X
+Native ORC Vectorized (Pushdown)                  14129          14136           7          1.1         898.3       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select all int rows (value != -1):        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                16117          16134          14          1.0        1024.7       1.0X
-Parquet Vectorized (Pushdown)                     16187          16197           9          1.0        1029.1       1.0X
-Native ORC Vectorized                             13612          13625          12          1.2         865.4       1.2X
-Native ORC Vectorized (Pushdown)                  13770          13782          10          1.1         875.5       1.2X
+Parquet Vectorized                                17392          17425          24          0.9        1105.8       1.0X
+Parquet Vectorized (Pushdown)                     17477          17483           5          0.9        1111.2       1.0X
+Native ORC Vectorized                             13960          14024          75          1.1         887.6       1.2X
+Native ORC Vectorized (Pushdown)                  14089          14106          20          1.1         895.8       1.2X
 
 
 ================================================================================================
 Pushdown for few distinct value case (use dictionary encoding)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 0 distinct string row (value IS NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8544           8581          31          1.8         543.2       1.0X
-Parquet Vectorized (Pushdown)                           475            483           8         33.1          30.2      18.0X
-Native ORC Vectorized                                  7688           7708          30          2.0         488.8       1.1X
-Native ORC Vectorized (Pushdown)                        839            843           4         18.8          53.3      10.2X
+Parquet Vectorized                                     8190           8235          67          1.9         520.7       1.0X
+Parquet Vectorized (Pushdown)                           420            426           7         37.4          26.7      19.5X
+Native ORC Vectorized                                  7879           7890           8          2.0         500.9       1.0X
+Native ORC Vectorized (Pushdown)                        774            782           8         20.3          49.2      10.6X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 0 distinct string row ('100' < value < '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                             8511           8530          13          1.8         541.1       1.0X
-Parquet Vectorized (Pushdown)                                   473            494          34         33.3          30.0      18.0X
-Native ORC Vectorized                                          7932           7943           7          2.0         504.3       1.1X
-Native ORC Vectorized (Pushdown)                                842            857          21         18.7          53.5      10.1X
+Parquet Vectorized                                             8292           8310          15          1.9         527.2       1.0X
+Parquet Vectorized (Pushdown)                                   424            431           6         37.1          27.0      19.5X
+Native ORC Vectorized                                          8107           8117          10          1.9         515.4       1.0X
+Native ORC Vectorized (Pushdown)                                776            786           7         20.3          49.3      10.7X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 distinct string row (value = '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8406           8427          21          1.9         534.4       1.0X
-Parquet Vectorized (Pushdown)                           537            548           9         29.3          34.1      15.7X
-Native ORC Vectorized                                  7886           7895          11          2.0         501.3       1.1X
-Native ORC Vectorized (Pushdown)                        897            906          12         17.5          57.0       9.4X
+Parquet Vectorized                                     8232           8245           8          1.9         523.4       1.0X
+Parquet Vectorized (Pushdown)                           494            501           8         31.8          31.4      16.7X
+Native ORC Vectorized                                  8073           8094          20          1.9         513.3       1.0X
+Native ORC Vectorized (Pushdown)                        833            843           6         18.9          53.0       9.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 distinct string row (value <=> '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       8399           8410          10          1.9         534.0       1.0X
-Parquet Vectorized (Pushdown)                             538            552          22         29.2          34.2      15.6X
-Native ORC Vectorized                                    7887           7895           6          2.0         501.4       1.1X
-Native ORC Vectorized (Pushdown)                          890            897           8         17.7          56.6       9.4X
+Parquet Vectorized                                       8209           8232          21          1.9         521.9       1.0X
+Parquet Vectorized (Pushdown)                             481            494          10         32.7          30.6      17.1X
+Native ORC Vectorized                                    8058           8068           6          2.0         512.3       1.0X
+Native ORC Vectorized (Pushdown)                          831            840           7         18.9          52.9       9.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 distinct string row ('100' <= value <= '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               8503           8521          13          1.8         540.6       1.0X
-Parquet Vectorized (Pushdown)                                     538            546           9         29.3          34.2      15.8X
-Native ORC Vectorized                                            7965           7966           1          2.0         506.4       1.1X
-Native ORC Vectorized (Pushdown)                                  897            902           7         17.5          57.0       9.5X
+Parquet Vectorized                                               8321           8330          12          1.9         529.0       1.0X
+Parquet Vectorized (Pushdown)                                     488            495           4         32.2          31.0      17.0X
+Native ORC Vectorized                                            8149           8156           9          1.9         518.1       1.0X
+Native ORC Vectorized (Pushdown)                                  841            846           5         18.7          53.5       9.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select all distinct string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           17851          17872          20          0.9        1134.9       1.0X
-Parquet Vectorized (Pushdown)                                17909          17919           6          0.9        1138.6       1.0X
-Native ORC Vectorized                                        17337          17351          14          0.9        1102.2       1.0X
-Native ORC Vectorized (Pushdown)                             17649          17703          76          0.9        1122.1       1.0X
+Parquet Vectorized                                           18379          18399          18          0.9        1168.5       1.0X
+Parquet Vectorized (Pushdown)                                18453          18469          19          0.9        1173.2       1.0X
+Native ORC Vectorized                                        17678          17685           8          0.9        1123.9       1.0X
+Native ORC Vectorized (Pushdown)                             17936          17943           4          0.9        1140.4       1.0X
 
 
 ================================================================================================
 Pushdown benchmark for StringStartsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 StringStartsWith filter: (value like '10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    9884           9952          44          1.6         628.4       1.0X
-Parquet Vectorized (Pushdown)                         1393           1436          32         11.3          88.6       7.1X
-Native ORC Vectorized                                 7347           7472         146          2.1         467.1       1.3X
-Native ORC Vectorized (Pushdown)                      7547           7573          18          2.1         479.8       1.3X
+Parquet Vectorized                                    9928           9964          43          1.6         631.2       1.0X
+Parquet Vectorized (Pushdown)                         1349           1367          25         11.7          85.8       7.4X
+Native ORC Vectorized                                 7484           7554          81          2.1         475.8       1.3X
+Native ORC Vectorized (Pushdown)                      7588           7598           8          2.1         482.4       1.3X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 StringStartsWith filter: (value like '1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      9668           9692          23          1.6         614.7       1.0X
-Parquet Vectorized (Pushdown)                            556            574          24         28.3          35.3      17.4X
-Native ORC Vectorized                                   7181           7214          33          2.2         456.6       1.3X
-Native ORC Vectorized (Pushdown)                        7317           7364          34          2.1         465.2       1.3X
+Parquet Vectorized                                      9751           9781          30          1.6         620.0       1.0X
+Parquet Vectorized (Pushdown)                            493            500           6         31.9          31.4      19.8X
+Native ORC Vectorized                                   7231           7254          15          2.2         459.7       1.3X
+Native ORC Vectorized (Pushdown)                        7359           7398          25          2.1         467.9       1.3X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 StringStartsWith filter: (value like '786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        9639           9676          23          1.6         612.8       1.0X
-Parquet Vectorized (Pushdown)                              544            550           7         28.9          34.6      17.7X
-Native ORC Vectorized                                     7218           7231           9          2.2         458.9       1.3X
-Native ORC Vectorized (Pushdown)                          7338           7373          30          2.1         466.5       1.3X
+Parquet Vectorized                                        9755           9772          15          1.6         620.2       1.0X
+Parquet Vectorized (Pushdown)                              483            492           8         32.6          30.7      20.2X
+Native ORC Vectorized                                     7212           7341         230          2.2         458.5       1.4X
+Native ORC Vectorized (Pushdown)                          7356           7393          21          2.1         467.7       1.3X
+
+
+================================================================================================
+Pushdown benchmark for StringEndsWith
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+StringEndsWith filter: (value like '%10'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                  8261           8282          27          1.9         525.2       1.0X
+Parquet Vectorized (Pushdown)                        595            603           6         26.4          37.8      13.9X
+Native ORC Vectorized                               8112           8128          13          1.9         515.7       1.0X
+Native ORC Vectorized (Pushdown)                    8368           8375           5          1.9         532.1       1.0X
+
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+StringEndsWith filter: (value like '%1000'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                    8208           8223          13          1.9         521.9       1.0X
+Parquet Vectorized (Pushdown)                          471            478           5         33.4          30.0      17.4X
+Native ORC Vectorized                                 8043           8056          11          2.0         511.4       1.0X
+Native ORC Vectorized (Pushdown)                      8305           8314          11          1.9         528.0       1.0X
+
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+StringEndsWith filter: (value like '%786432'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                      8197           8221          24          1.9         521.2       1.0X
+Parquet Vectorized (Pushdown)                            465            475          11         33.8          29.6      17.6X
+Native ORC Vectorized                                   8037           8049          15          2.0         511.0       1.0X
+Native ORC Vectorized (Pushdown)                        8308           8313           4          1.9         528.2       1.0X
+
+
+================================================================================================
+Pushdown benchmark for StringContains
+================================================================================================
+
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+StringContains filter: (value like '%10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                   8512           8545          42          1.8         541.2       1.0X
+Parquet Vectorized (Pushdown)                        1178           1198          22         13.4          74.9       7.2X
+Native ORC Vectorized                                8335           8349          13          1.9         529.9       1.0X
+Native ORC Vectorized (Pushdown)                     8590           8604          12          1.8         546.1       1.0X
+
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+StringContains filter: (value like '%1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                     8189           8215          26          1.9         520.7       1.0X
+Parquet Vectorized (Pushdown)                           463            473           8         34.0          29.4      17.7X
+Native ORC Vectorized                                  8036           8041           5          2.0         510.9       1.0X
+Native ORC Vectorized (Pushdown)                       8292           8301           9          1.9         527.2       1.0X
+
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+StringContains filter: (value like '%786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                       8203           8216          12          1.9         521.5       1.0X
+Parquet Vectorized (Pushdown)                             464            472           9         33.9          29.5      17.7X
+Native ORC Vectorized                                    8027           8036           5          2.0         510.3       1.0X
+Native ORC Vectorized (Pushdown)                         8301           8311          10          1.9         527.8       1.0X
 
 
 ================================================================================================
 Pushdown benchmark for decimal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 decimal(9, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     3177           3189          18          5.0         202.0       1.0X
-Parquet Vectorized (Pushdown)                           123            129           6        127.4           7.8      25.7X
-Native ORC Vectorized                                  4736           4821         141          3.3         301.1       0.7X
-Native ORC Vectorized (Pushdown)                        152            158           7        103.7           9.6      20.9X
+Parquet Vectorized                                     3552           3561          14          4.4         225.8       1.0X
+Parquet Vectorized (Pushdown)                           113            118           5        138.8           7.2      31.3X
+Native ORC Vectorized                                  4946           4953           8          3.2         314.5       0.7X
+Native ORC Vectorized (Pushdown)                        142            150           7        110.6           9.0      25.0X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% decimal(9, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        4821           4831           7          3.3         306.5       1.0X
-Parquet Vectorized (Pushdown)                             2367           2385          25          6.6         150.5       2.0X
-Native ORC Vectorized                                     6437           6448           9          2.4         409.2       0.7X
-Native ORC Vectorized (Pushdown)                          2772           2779           5          5.7         176.2       1.7X
+Parquet Vectorized                                        5246           5255           6          3.0         333.5       1.0X
+Parquet Vectorized (Pushdown)                             2472           2480           8          6.4         157.2       2.1X
+Native ORC Vectorized                                     6648           6652           4          2.4         422.7       0.8X
+Native ORC Vectorized (Pushdown)                          2797           2808          13          5.6         177.8       1.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% decimal(9, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       10194          10200           6          1.5         648.1       1.0X
-Parquet Vectorized (Pushdown)                             9807           9819          12          1.6         623.5       1.0X
-Native ORC Vectorized                                    12069          12077           5          1.3         767.3       0.8X
-Native ORC Vectorized (Pushdown)                         11497          11502           4          1.4         731.0       0.9X
+Parquet Vectorized                                       10788          10805          16          1.5         685.9       1.0X
+Parquet Vectorized (Pushdown)                            10330          10339           6          1.5         656.8       1.0X
+Native ORC Vectorized                                    12284          12352         132          1.3         781.0       0.9X
+Native ORC Vectorized (Pushdown)                         11707          11723          12          1.3         744.3       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% decimal(9, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        11617          11629          13          1.4         738.6       1.0X
-Parquet Vectorized (Pushdown)                             11658          11671          15          1.3         741.2       1.0X
-Native ORC Vectorized                                     13461          13485          20          1.2         855.8       0.9X
-Native ORC Vectorized (Pushdown)                          13520          13530           9          1.2         859.6       0.9X
+Parquet Vectorized                                        12126          12143          17          1.3         771.0       1.0X
+Parquet Vectorized (Pushdown)                             12179          12197          19          1.3         774.3       1.0X
+Native ORC Vectorized                                     13729          13745          12          1.1         872.8       0.9X
+Native ORC Vectorized (Pushdown)                          13791          13814          17          1.1         876.8       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 decimal(18, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      3394           3413          32          4.6         215.8       1.0X
-Parquet Vectorized (Pushdown)                            125            140          32        125.6           8.0      27.1X
-Native ORC Vectorized                                   4735           4753          30          3.3         301.0       0.7X
-Native ORC Vectorized (Pushdown)                         148            154           6        106.2           9.4      22.9X
+Parquet Vectorized                                      3764           3784          16          4.2         239.3       1.0X
+Parquet Vectorized (Pushdown)                            115            121           7        137.1           7.3      32.8X
+Native ORC Vectorized                                   4941           4960          21          3.2         314.2       0.8X
+Native ORC Vectorized (Pushdown)                         139            145           5        112.9           8.9      27.0X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% decimal(18, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         4266           4284          24          3.7         271.2       1.0X
-Parquet Vectorized (Pushdown)                              1325           1331           8         11.9          84.3       3.2X
-Native ORC Vectorized                                      5637           5649           7          2.8         358.4       0.8X
-Native ORC Vectorized (Pushdown)                           1499           1504           5         10.5          95.3       2.8X
+Parquet Vectorized                                         4659           4674          11          3.4         296.2       1.0X
+Parquet Vectorized (Pushdown)                              1356           1368          16         11.6          86.2       3.4X
+Native ORC Vectorized                                      5857           5876          15          2.7         372.4       0.8X
+Native ORC Vectorized (Pushdown)                           1501           1509          11         10.5          95.4       3.1X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% decimal(18, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         7643           7657          12          2.1         486.0       1.0X
-Parquet Vectorized (Pushdown)                              6057           6064           4          2.6         385.1       1.3X
-Native ORC Vectorized                                      9201           9209           7          1.7         585.0       0.8X
-Native ORC Vectorized (Pushdown)                           6861           6873          12          2.3         436.2       1.1X
+Parquet Vectorized                                         8098           8110           8          1.9         514.9       1.0X
+Parquet Vectorized (Pushdown)                              6292           6301           8          2.5         400.0       1.3X
+Native ORC Vectorized                                      9416           9433          14          1.7         598.7       0.9X
+Native ORC Vectorized (Pushdown)                           7014           7032          11          2.2         445.9       1.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% decimal(18, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         10877          10888           6          1.4         691.6       1.0X
-Parquet Vectorized (Pushdown)                              10611          10615           4          1.5         674.7       1.0X
-Native ORC Vectorized                                      12554          12564           9          1.3         798.2       0.9X
-Native ORC Vectorized (Pushdown)                           12065          12074           6          1.3         767.1       0.9X
+Parquet Vectorized                                         11443          11455          11          1.4         727.5       1.0X
+Parquet Vectorized (Pushdown)                              11093          11118          17          1.4         705.3       1.0X
+Native ORC Vectorized                                      12868          12886          23          1.2         818.1       0.9X
+Native ORC Vectorized (Pushdown)                           12401          12422          14          1.3         788.5       0.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 decimal(38, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      5000           5009          13          3.1         317.9       1.0X
-Parquet Vectorized (Pushdown)                            138            146          19        114.3           8.7      36.3X
-Native ORC Vectorized                                   4709           4731          22          3.3         299.4       1.1X
-Native ORC Vectorized (Pushdown)                         148            153           6        106.6           9.4      33.9X
+Parquet Vectorized                                      5430           5440           6          2.9         345.2       1.0X
+Parquet Vectorized (Pushdown)                            126            130           4        124.7           8.0      43.0X
+Native ORC Vectorized                                   4972           4986          27          3.2         316.1       1.1X
+Native ORC Vectorized (Pushdown)                         138            143           4        114.4           8.7      39.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% decimal(38, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         6147           6164          17          2.6         390.8       1.0X
-Parquet Vectorized (Pushdown)                              1738           1754          14          9.1         110.5       3.5X
-Native ORC Vectorized                                      5772           5779           7          2.7         367.0       1.1X
-Native ORC Vectorized (Pushdown)                           1651           1653           2          9.5         105.0       3.7X
+Parquet Vectorized                                         6513           6531          23          2.4         414.1       1.0X
+Parquet Vectorized (Pushdown)                              1765           1772           6          8.9         112.2       3.7X
+Native ORC Vectorized                                      6049           6053           3          2.6         384.6       1.1X
+Native ORC Vectorized (Pushdown)                           1675           1684           9          9.4         106.5       3.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% decimal(38, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        10534          10539           4          1.5         669.8       1.0X
-Parquet Vectorized (Pushdown)                              8085           8092           5          1.9         514.1       1.3X
-Native ORC Vectorized                                      9894           9904          10          1.6         629.0       1.1X
-Native ORC Vectorized (Pushdown)                           7626           7643          16          2.1         484.8       1.4X
+Parquet Vectorized                                        10962          10974           9          1.4         697.0       1.0X
+Parquet Vectorized (Pushdown)                              8358           8368           9          1.9         531.4       1.3X
+Native ORC Vectorized                                     10319          10343          31          1.5         656.1       1.1X
+Native ORC Vectorized (Pushdown)                           7923           7933           7          2.0         503.7       1.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% decimal(38, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         14726          14754          49          1.1         936.2       1.0X
-Parquet Vectorized (Pushdown)                              14309          14330          14          1.1         909.8       1.0X
-Native ORC Vectorized                                      13912          13927          12          1.1         884.5       1.1X
-Native ORC Vectorized (Pushdown)                           13510          13524          15          1.2         859.0       1.1X
+Parquet Vectorized                                         15327          15330           2          1.0         974.5       1.0X
+Parquet Vectorized (Pushdown)                              14830          14844           9          1.1         942.9       1.0X
+Native ORC Vectorized                                      14520          14568          91          1.1         923.2       1.1X
+Native ORC Vectorized (Pushdown)                           14066          14080          10          1.1         894.3       1.1X
 
 
 ================================================================================================
 Pushdown benchmark for InSet -> InFilters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 5, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               9132           9167          37          1.7         580.6       1.0X
-Parquet Vectorized (Pushdown)                                     555            578          24         28.3          35.3      16.4X
-Native ORC Vectorized                                            6587           6617          26          2.4         418.8       1.4X
-Native ORC Vectorized (Pushdown)                                  463            469           7         34.0          29.5      19.7X
+Parquet Vectorized                                               9158           9202          40          1.7         582.3       1.0X
+Parquet Vectorized (Pushdown)                                     494            502           7         31.9          31.4      18.6X
+Native ORC Vectorized                                            6735           6795          81          2.3         428.2       1.4X
+Native ORC Vectorized (Pushdown)                                  427            430           6         36.8          27.2      21.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 5, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               9148           9178          30          1.7         581.6       1.0X
-Parquet Vectorized (Pushdown)                                     554            562           7         28.4          35.2      16.5X
-Native ORC Vectorized                                            6581           6607          31          2.4         418.4       1.4X
-Native ORC Vectorized (Pushdown)                                  461            465           5         34.2          29.3      19.9X
+Parquet Vectorized                                               9194           9207          12          1.7         584.5       1.0X
+Parquet Vectorized (Pushdown)                                     494            500           6         31.8          31.4      18.6X
+Native ORC Vectorized                                            6727           6755          22          2.3         427.7       1.4X
+Native ORC Vectorized (Pushdown)                                  427            434          10         36.9          27.1      21.6X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 5, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               9158           9208          59          1.7         582.2       1.0X
-Parquet Vectorized (Pushdown)                                     556            578          30         28.3          35.3      16.5X
-Native ORC Vectorized                                            6458           6571          64          2.4         410.6       1.4X
-Native ORC Vectorized (Pushdown)                                  463            472          11         34.0          29.4      19.8X
+Parquet Vectorized                                               9190           9207          15          1.7         584.3       1.0X
+Parquet Vectorized (Pushdown)                                     502            507           4         31.4          31.9      18.3X
+Native ORC Vectorized                                            6717           6747          20          2.3         427.0       1.4X
+Native ORC Vectorized (Pushdown)                                  429            437           7         36.7          27.3      21.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 10, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                9198           9228          19          1.7         584.8       1.0X
-Parquet Vectorized (Pushdown)                                      572            582           9         27.5          36.4      16.1X
-Native ORC Vectorized                                             6592           6612          19          2.4         419.1       1.4X
-Native ORC Vectorized (Pushdown)                                   479            487           6         32.9          30.4      19.2X
+Parquet Vectorized                                                9243           9264          25          1.7         587.6       1.0X
+Parquet Vectorized (Pushdown)                                      525            535           7         29.9          33.4      17.6X
+Native ORC Vectorized                                             6741           6761          14          2.3         428.6       1.4X
+Native ORC Vectorized (Pushdown)                                   452            459           7         34.8          28.7      20.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 10, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8967           9004          26          1.8         570.1       1.0X
-Parquet Vectorized (Pushdown)                                      583            619          36         27.0          37.1      15.4X
-Native ORC Vectorized                                             6518           6601          49          2.4         414.4       1.4X
-Native ORC Vectorized (Pushdown)                                   483            491          10         32.6          30.7      18.6X
+Parquet Vectorized                                                9238           9279          81          1.7         587.3       1.0X
+Parquet Vectorized (Pushdown)                                      519            530          12         30.3          33.0      17.8X
+Native ORC Vectorized                                             6741           6784          48          2.3         428.6       1.4X
+Native ORC Vectorized (Pushdown)                                   449            457           6         35.0          28.6      20.6X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 10, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                9170           9197          20          1.7         583.0       1.0X
-Parquet Vectorized (Pushdown)                                      583            589           4         27.0          37.0      15.7X
-Native ORC Vectorized                                             6589           6602           9          2.4         418.9       1.4X
-Native ORC Vectorized (Pushdown)                                   481            489           9         32.7          30.6      19.1X
+Parquet Vectorized                                                9224           9250          26          1.7         586.5       1.0X
+Parquet Vectorized (Pushdown)                                      519            526           6         30.3          33.0      17.8X
+Native ORC Vectorized                                             6734           6766          20          2.3         428.1       1.4X
+Native ORC Vectorized (Pushdown)                                   449            456           6         35.0          28.5      20.6X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 50, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                9968          10003          25          1.6         633.8       1.0X
-Parquet Vectorized (Pushdown)                                     1397           1440          31         11.3          88.8       7.1X
-Native ORC Vectorized                                             6897           6950          38          2.3         438.5       1.4X
-Native ORC Vectorized (Pushdown)                                   619            633          22         25.4          39.3      16.1X
+Parquet Vectorized                                                9491           9500           9          1.7         603.4       1.0X
+Parquet Vectorized (Pushdown)                                     1294           1329          31         12.2          82.3       7.3X
+Native ORC Vectorized                                             7033           7051          21          2.2         447.1       1.3X
+Native ORC Vectorized (Pushdown)                                   582            588           7         27.0          37.0      16.3X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 50, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               10000          10037          42          1.6         635.8       1.0X
-Parquet Vectorized (Pushdown)                                     5187           5208          19          3.0         329.8       1.9X
-Native ORC Vectorized                                             6903           6945          29          2.3         438.9       1.4X
-Native ORC Vectorized (Pushdown)                                   632            641           8         24.9          40.2      15.8X
+Parquet Vectorized                                                9503           9520          16          1.7         604.2       1.0X
+Parquet Vectorized (Pushdown)                                     4804           4842          37          3.3         305.5       2.0X
+Native ORC Vectorized                                             7057           7085          24          2.2         448.7       1.3X
+Native ORC Vectorized (Pushdown)                                   612            618           7         25.7          38.9      15.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 50, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                9973          10017          33          1.6         634.0       1.0X
-Parquet Vectorized (Pushdown)                                     9003           9036          20          1.7         572.4       1.1X
-Native ORC Vectorized                                             6911           6971          74          2.3         439.4       1.4X
-Native ORC Vectorized (Pushdown)                                   647            663          21         24.3          41.1      15.4X
+Parquet Vectorized                                                9501           9510          10          1.7         604.0       1.0X
+Parquet Vectorized (Pushdown)                                     8354           8370          11          1.9         531.1       1.1X
+Native ORC Vectorized                                             7058           7090          27          2.2         448.7       1.3X
+Native ORC Vectorized (Pushdown)                                   627            631           3         25.1          39.9      15.2X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 100, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 9889           9955          53          1.6         628.8       1.0X
-Parquet Vectorized (Pushdown)                                      1448           1468          22         10.9          92.0       6.8X
-Native ORC Vectorized                                              6810           6824          18          2.3         433.0       1.5X
-Native ORC Vectorized (Pushdown)                                    732            759          25         21.5          46.5      13.5X
+Parquet Vectorized                                                 9423           9450          18          1.7         599.1       1.0X
+Parquet Vectorized (Pushdown)                                      1338           1375          30         11.8          85.1       7.0X
+Native ORC Vectorized                                              6988           7010          13          2.3         444.3       1.3X
+Native ORC Vectorized (Pushdown)                                    738            752          20         21.3          46.9      12.8X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 100, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 9926           9955          27          1.6         631.1       1.0X
-Parquet Vectorized (Pushdown)                                      5174           5223          29          3.0         329.0       1.9X
-Native ORC Vectorized                                              6799           6825          15          2.3         432.3       1.5X
-Native ORC Vectorized (Pushdown)                                    830            854          17         19.0          52.8      12.0X
+Parquet Vectorized                                                 9435           9468          23          1.7         599.9       1.0X
+Parquet Vectorized (Pushdown)                                      4934           4972          22          3.2         313.7       1.9X
+Native ORC Vectorized                                              6969           7001          24          2.3         443.1       1.4X
+Native ORC Vectorized (Pushdown)                                    800            813          21         19.7          50.9      11.8X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 InSet -> InFilters (values count: 100, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 9850           9953          94          1.6         626.2       1.0X
-Parquet Vectorized (Pushdown)                                      8653           8686          32          1.8         550.2       1.1X
-Native ORC Vectorized                                              6745           6782          34          2.3         428.8       1.5X
-Native ORC Vectorized (Pushdown)                                    826            846          41         19.0          52.5      11.9X
+Parquet Vectorized                                                 9460           9466           9          1.7         601.4       1.0X
+Parquet Vectorized (Pushdown)                                      8537           8562          18          1.8         542.8       1.1X
+Native ORC Vectorized                                              6991           7015          17          2.2         444.5       1.4X
+Native ORC Vectorized (Pushdown)                                    826            833           6         19.0          52.5      11.4X
 
 
 ================================================================================================
 Pushdown benchmark for tinyint
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 tinyint row (value = CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           3598           3613          11          4.4         228.7       1.0X
-Parquet Vectorized (Pushdown)                                 172            179           6         91.5          10.9      20.9X
-Native ORC Vectorized                                        3184           3205          24          4.9         202.4       1.1X
-Native ORC Vectorized (Pushdown)                              205            212           7         76.6          13.1      17.5X
+Parquet Vectorized                                           3993           4003          11          3.9         253.9       1.0X
+Parquet Vectorized (Pushdown)                                 163            169           7         96.5          10.4      24.5X
+Native ORC Vectorized                                        3381           3411          26          4.7         214.9       1.2X
+Native ORC Vectorized (Pushdown)                              193            201           6         81.4          12.3      20.7X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% tinyint rows (value < CAST(12 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              4352           4367          17          3.6         276.7       1.0X
-Parquet Vectorized (Pushdown)                                   1233           1243          10         12.8          78.4       3.5X
-Native ORC Vectorized                                           3848           3868          16          4.1         244.6       1.1X
-Native ORC Vectorized (Pushdown)                                1163           1172           8         13.5          74.0       3.7X
+Parquet Vectorized                                              4725           4747          42          3.3         300.4       1.0X
+Parquet Vectorized (Pushdown)                                   1244           1254          10         12.6          79.1       3.8X
+Native ORC Vectorized                                           4060           4087          34          3.9         258.1       1.2X
+Native ORC Vectorized (Pushdown)                                1163           1177          10         13.5          73.9       4.1X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% tinyint rows (value < CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              7477           7484           7          2.1         475.4       1.0X
-Parquet Vectorized (Pushdown)                                   5761           5769           5          2.7         366.3       1.3X
-Native ORC Vectorized                                           6686           6718          39          2.4         425.1       1.1X
-Native ORC Vectorized (Pushdown)                                5218           5225           8          3.0         331.8       1.4X
+Parquet Vectorized                                              7870           7878           8          2.0         500.4       1.0X
+Parquet Vectorized (Pushdown)                                   5961           5966           3          2.6         379.0       1.3X
+Native ORC Vectorized                                           6851           6884          29          2.3         435.6       1.1X
+Native ORC Vectorized (Pushdown)                                5311           5339          29          3.0         337.7       1.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% tinyint rows (value < CAST(114 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              10627          10638          12          1.5         675.7       1.0X
-Parquet Vectorized (Pushdown)                                   10341          10346           5          1.5         657.4       1.0X
-Native ORC Vectorized                                            9499           9543          36          1.7         603.9       1.1X
-Native ORC Vectorized (Pushdown)                                 9257           9266           6          1.7         588.5       1.1X
+Parquet Vectorized                                              10976          11000          14          1.4         697.8       1.0X
+Parquet Vectorized (Pushdown)                                   10637          10661          22          1.5         676.3       1.0X
+Native ORC Vectorized                                            9730           9749          16          1.6         618.6       1.1X
+Native ORC Vectorized (Pushdown)                                 9488           9494           3          1.7         603.3       1.2X
 
 
 ================================================================================================
 Pushdown benchmark for Timestamp
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 timestamp stored as INT96 row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                    3648           3658          14          4.3         232.0       1.0X
-Parquet Vectorized (Pushdown)                                                         3641           3656          12          4.3         231.5       1.0X
-Native ORC Vectorized                                                                 3053           3109          47          5.2         194.1       1.2X
-Native ORC Vectorized (Pushdown)                                                       123            127           5        128.1           7.8      29.7X
+Parquet Vectorized                                                                    4024           4033           8          3.9         255.9       1.0X
+Parquet Vectorized (Pushdown)                                                         4038           4058          15          3.9         256.7       1.0X
+Native ORC Vectorized                                                                 3374           3392          20          4.7         214.5       1.2X
+Native ORC Vectorized (Pushdown)                                                       117            122           5        134.9           7.4      34.5X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% timestamp stored as INT96 rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       4460           4474           9          3.5         283.6       1.0X
-Parquet Vectorized (Pushdown)                                                            4466           4475           7          3.5         283.9       1.0X
-Native ORC Vectorized                                                                    3841           3848           9          4.1         244.2       1.2X
-Native ORC Vectorized (Pushdown)                                                         1220           1230          10         12.9          77.6       3.7X
+Parquet Vectorized                                                                       4876           4889          10          3.2         310.0       1.0X
+Parquet Vectorized (Pushdown)                                                            4889           4895           5          3.2         310.9       1.0X
+Native ORC Vectorized                                                                    4155           4165          13          3.8         264.2       1.2X
+Native ORC Vectorized (Pushdown)                                                         1240           1252           8         12.7          78.8       3.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% timestamp stored as INT96 rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       7700           7713          10          2.0         489.5       1.0X
-Parquet Vectorized (Pushdown)                                                            7701           7705           5          2.0         489.6       1.0X
-Native ORC Vectorized                                                                    6945           6961          21          2.3         441.6       1.1X
-Native ORC Vectorized (Pushdown)                                                         5498           5504           7          2.9         349.6       1.4X
+Parquet Vectorized                                                                       8161           8185          16          1.9         518.9       1.0X
+Parquet Vectorized (Pushdown)                                                            8167           8179           8          1.9         519.2       1.0X
+Native ORC Vectorized                                                                    7253           7265           9          2.2         461.1       1.1X
+Native ORC Vectorized (Pushdown)                                                         5636           5644          10          2.8         358.4       1.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% timestamp stored as INT96 rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       10809          10817           5          1.5         687.2       1.0X
-Parquet Vectorized (Pushdown)                                                            10810          10815           6          1.5         687.3       1.0X
-Native ORC Vectorized                                                                     9958           9966           6          1.6         633.1       1.1X
-Native ORC Vectorized (Pushdown)                                                          9702           9713           6          1.6         616.9       1.1X
+Parquet Vectorized                                                                       11364          11372          10          1.4         722.5       1.0X
+Parquet Vectorized (Pushdown)                                                            11372          11376           4          1.4         723.0       1.0X
+Native ORC Vectorized                                                                    10310          10321           8          1.5         655.5       1.1X
+Native ORC Vectorized (Pushdown)                                                         10029          10044          12          1.6         637.7       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 timestamp stored as TIMESTAMP_MICROS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               3363           3386          24          4.7         213.8       1.0X
-Parquet Vectorized (Pushdown)                                                                     124            145          35        126.6           7.9      27.1X
-Native ORC Vectorized                                                                            3077           3086          14          5.1         195.6       1.1X
-Native ORC Vectorized (Pushdown)                                                                  122            126           5        129.0           7.8      27.6X
+Parquet Vectorized                                                                               3688           3702          10          4.3         234.5       1.0X
+Parquet Vectorized (Pushdown)                                                                     118            122           5        132.9           7.5      31.2X
+Native ORC Vectorized                                                                            3358           3369          19          4.7         213.5       1.1X
+Native ORC Vectorized (Pushdown)                                                                  116            120           5        136.0           7.4      31.9X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  4112           4135          35          3.8         261.5       1.0X
-Parquet Vectorized (Pushdown)                                                                       1268           1278           8         12.4          80.6       3.2X
-Native ORC Vectorized                                                                               3839           3860          23          4.1         244.1       1.1X
-Native ORC Vectorized (Pushdown)                                                                    1223           1228           7         12.9          77.8       3.4X
+Parquet Vectorized                                                                                  4515           4529          10          3.5         287.1       1.0X
+Parquet Vectorized (Pushdown)                                                                       1298           1312          11         12.1          82.5       3.5X
+Native ORC Vectorized                                                                               4159           4167           4          3.8         264.4       1.1X
+Native ORC Vectorized (Pushdown)                                                                    1234           1235           1         12.7          78.5       3.7X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  7334           7345          10          2.1         466.3       1.0X
-Parquet Vectorized (Pushdown)                                                                       5792           5798           4          2.7         368.2       1.3X
-Native ORC Vectorized                                                                               6939           6954          21          2.3         441.1       1.1X
-Native ORC Vectorized (Pushdown)                                                                    5496           5508           8          2.9         349.4       1.3X
+Parquet Vectorized                                                                                  7786           7806          16          2.0         495.0       1.0X
+Parquet Vectorized (Pushdown)                                                                       6041           6047           4          2.6         384.1       1.3X
+Native ORC Vectorized                                                                               7243           7256           8          2.2         460.5       1.1X
+Native ORC Vectorized (Pushdown)                                                                    5638           5645           9          2.8         358.5       1.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  10447          10451           4          1.5         664.2       1.0X
-Parquet Vectorized (Pushdown)                                                                       10175          10180           4          1.5         646.9       1.0X
-Native ORC Vectorized                                                                                9946          10087         262          1.6         632.4       1.1X
-Native ORC Vectorized (Pushdown)                                                                     9699           9706           5          1.6         616.7       1.1X
+Parquet Vectorized                                                                                  10990          10999          11          1.4         698.7       1.0X
+Parquet Vectorized (Pushdown)                                                                       10674          10680           7          1.5         678.7       1.0X
+Native ORC Vectorized                                                                               10307          10319          12          1.5         655.3       1.1X
+Native ORC Vectorized (Pushdown)                                                                    10041          10048           4          1.6         638.4       1.1X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 timestamp stored as TIMESTAMP_MILLIS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               3409           3421          16          4.6         216.7       1.0X
-Parquet Vectorized (Pushdown)                                                                     125            135          17        126.2           7.9      27.3X
-Native ORC Vectorized                                                                            3077           3093          32          5.1         195.6       1.1X
-Native ORC Vectorized (Pushdown)                                                                  121            126           5        129.5           7.7      28.1X
+Parquet Vectorized                                                                               3716           3755          71          4.2         236.3       1.0X
+Parquet Vectorized (Pushdown)                                                                     114            118           4        138.5           7.2      32.7X
+Native ORC Vectorized                                                                            3347           3355           8          4.7         212.8       1.1X
+Native ORC Vectorized (Pushdown)                                                                  113            117           4        138.8           7.2      32.8X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 10% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  4151           4160           7          3.8         263.9       1.0X
-Parquet Vectorized (Pushdown)                                                                       1271           1272           2         12.4          80.8       3.3X
-Native ORC Vectorized                                                                               3831           3852          28          4.1         243.6       1.1X
-Native ORC Vectorized (Pushdown)                                                                    1215           1220           8         12.9          77.3       3.4X
+Parquet Vectorized                                                                                  4546           4557          13          3.5         289.0       1.0X
+Parquet Vectorized (Pushdown)                                                                       1298           1316          13         12.1          82.5       3.5X
+Native ORC Vectorized                                                                               4140           4148          10          3.8         263.2       1.1X
+Native ORC Vectorized (Pushdown)                                                                    1230           1242           8         12.8          78.2       3.7X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 50% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  7365           7373           7          2.1         468.2       1.0X
-Parquet Vectorized (Pushdown)                                                                       5807           5812           3          2.7         369.2       1.3X
-Native ORC Vectorized                                                                               6941           6957          26          2.3         441.3       1.1X
-Native ORC Vectorized (Pushdown)                                                                    5492           5501           6          2.9         349.1       1.3X
+Parquet Vectorized                                                                                  7826           7841          17          2.0         497.6       1.0X
+Parquet Vectorized (Pushdown)                                                                       6053           6058           5          2.6         384.8       1.3X
+Native ORC Vectorized                                                                               7235           7238           5          2.2         460.0       1.1X
+Native ORC Vectorized (Pushdown)                                                                    5642           5653           8          2.8         358.7       1.4X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 90% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  10482          10486           4          1.5         666.4       1.0X
-Parquet Vectorized (Pushdown)                                                                       10208          10208           1          1.5         649.0       1.0X
-Native ORC Vectorized                                                                                9953           9965          10          1.6         632.8       1.1X
-Native ORC Vectorized (Pushdown)                                                                     9700           9711          10          1.6         616.7       1.1X
+Parquet Vectorized                                                                                  10998          11011           8          1.4         699.2       1.0X
+Parquet Vectorized (Pushdown)                                                                       10684          10693           6          1.5         679.3       1.0X
+Native ORC Vectorized                                                                               10296          10307           9          1.5         654.6       1.1X
+Native ORC Vectorized (Pushdown)                                                                    10024          10028           6          1.6         637.3       1.1X
 
 
 ================================================================================================
 Pushdown benchmark with many filters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 row with 1 filters:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  152            160           8          0.0   152064240.0       1.0X
-Parquet Vectorized (Pushdown)                       154            159           5          0.0   153810651.0       1.0X
-Native ORC Vectorized                               144            148           5          0.0   144416828.0       1.1X
-Native ORC Vectorized (Pushdown)                    155            162          10          0.0   154769410.0       1.0X
+Parquet Vectorized                                  141            147           5          0.0   141156296.0       1.0X
+Parquet Vectorized (Pushdown)                       141            146           4          0.0   141219096.0       1.0X
+Native ORC Vectorized                               135            139           5          0.0   135256253.0       1.0X
+Native ORC Vectorized (Pushdown)                    145            150           5          0.0   144968981.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 row with 250 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 1255           1322          59          0.0  1254527065.0       1.0X
-Parquet Vectorized (Pushdown)                      1309           1369          71          0.0  1308503240.0       1.0X
-Native ORC Vectorized                              1256           1318          64          0.0  1256393786.0       1.0X
-Native ORC Vectorized (Pushdown)                   1277           1300          19          0.0  1276552021.0       1.0X
+Parquet Vectorized                                 1547           1593          60          0.0  1546942527.0       1.0X
+Parquet Vectorized (Pushdown)                      1613           1648          37          0.0  1612664638.0       1.0X
+Native ORC Vectorized                              1553           1593          54          0.0  1552761511.0       1.0X
+Native ORC Vectorized (Pushdown)                   1575           1619          47          0.0  1574744637.0       1.0X
 
-OpenJDK 64-Bit Server VM 11.0.14+9-LTS on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 Select 1 row with 500 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 5400           5578         230          0.0  5399589388.0       1.0X
-Parquet Vectorized (Pushdown)                      5590           5724         179          0.0  5590208406.0       1.0X
-Native ORC Vectorized                              5403           5533         162          0.0  5402710816.0       1.0X
-Native ORC Vectorized (Pushdown)                   5442           5534         126          0.0  5442267827.0       1.0X
+Parquet Vectorized                                 6791           6927         175          0.0  6790722699.0       1.0X
+Parquet Vectorized (Pushdown)                      6996           7118         208          0.0  6996423296.0       1.0X
+Native ORC Vectorized                              6785           6897         203          0.0  6785074307.0       1.0X
+Native ORC Vectorized (Pushdown)                   6859           6945         159          0.0  6859258499.0       1.0X
 
 

--- a/sql/core/benchmarks/FilterPushdownBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/FilterPushdownBenchmark-jdk17-results.txt
@@ -2,669 +2,733 @@
 Pushdown for many distinct value case
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 string row (value IS NULL):      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                12765          12814          75          1.2         811.6       1.0X
-Parquet Vectorized (Pushdown)                       642            657          15         24.5          40.8      19.9X
-Native ORC Vectorized                              8167           8208          47          1.9         519.3       1.6X
-Native ORC Vectorized (Pushdown)                    608            624          11         25.9          38.6      21.0X
+Parquet Vectorized                                 8574           8745         248          1.8         545.1       1.0X
+Parquet Vectorized (Pushdown)                       521            540          14         30.2          33.1      16.4X
+Native ORC Vectorized                              7117           7171          76          2.2         452.5       1.2X
+Native ORC Vectorized (Pushdown)                    499            507          15         31.6          31.7      17.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 string row ('7864320' < value < '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           12909          12921           9          1.2         820.7       1.0X
-Parquet Vectorized (Pushdown)                                  647            669          38         24.3          41.1      19.9X
-Native ORC Vectorized                                         8325           8333           6          1.9         529.3       1.6X
-Native ORC Vectorized (Pushdown)                               592            612          26         26.6          37.7      21.8X
+Parquet Vectorized                                            8658           8673          12          1.8         550.4       1.0X
+Parquet Vectorized (Pushdown)                                  498            509          17         31.6          31.6      17.4X
+Native ORC Vectorized                                         7231           7238           8          2.2         459.7       1.2X
+Native ORC Vectorized (Pushdown)                               494            506          13         31.8          31.4      17.5X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 string row (value = '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                12915          12942          20          1.2         821.1       1.0X
-Parquet Vectorized (Pushdown)                       626            642          10         25.1          39.8      20.6X
-Native ORC Vectorized                              8332           8359          29          1.9         529.8       1.6X
-Native ORC Vectorized (Pushdown)                    579            585           6         27.2          36.8      22.3X
+Parquet Vectorized                                 8627           8642          13          1.8         548.5       1.0X
+Parquet Vectorized (Pushdown)                       496            509          13         31.7          31.5      17.4X
+Native ORC Vectorized                              7203           7212          11          2.2         457.9       1.2X
+Native ORC Vectorized (Pushdown)                    494            498           8         31.9          31.4      17.5X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 string row (value <=> '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 12881          12905          30          1.2         819.0       1.0X
-Parquet Vectorized (Pushdown)                        623            633           9         25.2          39.6      20.7X
-Native ORC Vectorized                               8363           8386          20          1.9         531.7       1.5X
-Native ORC Vectorized (Pushdown)                     579            598          32         27.2          36.8      22.2X
+Parquet Vectorized                                  8579           8612          32          1.8         545.4       1.0X
+Parquet Vectorized (Pushdown)                        479            487           7         32.8          30.5      17.9X
+Native ORC Vectorized                               7194           7211          17          2.2         457.4       1.2X
+Native ORC Vectorized (Pushdown)                     474            480           6         33.2          30.1      18.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 string row ('7864320' <= value <= '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                             12983          13017          44          1.2         825.4       1.0X
-Parquet Vectorized (Pushdown)                                    636            648          15         24.7          40.5      20.4X
-Native ORC Vectorized                                           8344           8376          33          1.9         530.5       1.6X
-Native ORC Vectorized (Pushdown)                                 578            583           6         27.2          36.7      22.5X
+Parquet Vectorized                                              8637           8644          10          1.8         549.1       1.0X
+Parquet Vectorized (Pushdown)                                    485            500          10         32.5          30.8      17.8X
+Native ORC Vectorized                                           7182           7192           8          2.2         456.6       1.2X
+Native ORC Vectorized (Pushdown)                                 469            474           4         33.5          29.8      18.4X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  23020          23057          29          0.7        1463.6       1.0X
-Parquet Vectorized (Pushdown)                       23149          23187          22          0.7        1471.8       1.0X
-Native ORC Vectorized                               18361          18387          18          0.9        1167.4       1.3X
-Native ORC Vectorized (Pushdown)                    18672          18719          36          0.8        1187.1       1.2X
+Parquet Vectorized                                  16691          16738          33          0.9        1061.2       1.0X
+Parquet Vectorized (Pushdown)                       16714          16745          26          0.9        1062.6       1.0X
+Native ORC Vectorized                               15315          15347          26          1.0         973.7       1.1X
+Native ORC Vectorized (Pushdown)                    15495          15524          35          1.0         985.1       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 int row (value IS NULL):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11761          11834          92          1.3         747.7       1.0X
-Parquet Vectorized (Pushdown)                       600            616          11         26.2          38.1      19.6X
-Native ORC Vectorized                              7481           7524          49          2.1         475.6       1.6X
-Native ORC Vectorized (Pushdown)                    543            548           3         29.0          34.5      21.7X
+Parquet Vectorized                                 8048           8096          82          2.0         511.7       1.0X
+Parquet Vectorized (Pushdown)                       462            473           8         34.1          29.4      17.4X
+Native ORC Vectorized                              6436           6479          47          2.4         409.2       1.3X
+Native ORC Vectorized (Pushdown)                    445            453           6         35.4          28.3      18.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 int row (7864320 < value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    11790          11806          10          1.3         749.6       1.0X
-Parquet Vectorized (Pushdown)                           616            626           8         25.5          39.2      19.1X
-Native ORC Vectorized                                  7555           7582          18          2.1         480.3       1.6X
-Native ORC Vectorized (Pushdown)                        558            566           8         28.2          35.5      21.1X
+Parquet Vectorized                                     8055           8072          13          2.0         512.1       1.0X
+Parquet Vectorized (Pushdown)                           471            485          11         33.4          29.9      17.1X
+Native ORC Vectorized                                  6425           6447          15          2.4         408.5       1.3X
+Native ORC Vectorized (Pushdown)                        456            459           2         34.5          29.0      17.7X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (value = 7864320):       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11858          11944         134          1.3         753.9       1.0X
-Parquet Vectorized (Pushdown)                       611            616           4         25.7          38.8      19.4X
-Native ORC Vectorized                              7590           7605          18          2.1         482.6       1.6X
-Native ORC Vectorized (Pushdown)                    547            554           6         28.8          34.8      21.7X
+Parquet Vectorized                                 8119           8128          11          1.9         516.2       1.0X
+Parquet Vectorized (Pushdown)                       473            479           4         33.2          30.1      17.1X
+Native ORC Vectorized                              6488           6497           9          2.4         412.5       1.3X
+Native ORC Vectorized (Pushdown)                    446            455           6         35.2          28.4      18.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (value <=> 7864320):     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11866          11882          17          1.3         754.4       1.0X
-Parquet Vectorized (Pushdown)                       607            616           9         25.9          38.6      19.6X
-Native ORC Vectorized                              7549           7567          13          2.1         480.0       1.6X
-Native ORC Vectorized (Pushdown)                    547            553           7         28.7          34.8      21.7X
+Parquet Vectorized                                 8098           8105           8          1.9         514.8       1.0X
+Parquet Vectorized (Pushdown)                       458            464           5         34.3          29.1      17.7X
+Native ORC Vectorized                              6504           6512           6          2.4         413.5       1.2X
+Native ORC Vectorized (Pushdown)                    455            461           4         34.6          28.9      17.8X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (7864320 <= value <= 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      11876          11913          39          1.3         755.1       1.0X
-Parquet Vectorized (Pushdown)                             606            611           6         25.9          38.5      19.6X
-Native ORC Vectorized                                    7578           7608          30          2.1         481.8       1.6X
-Native ORC Vectorized (Pushdown)                          543            553          10         29.0          34.5      21.9X
+Parquet Vectorized                                       8088           8110          20          1.9         514.2       1.0X
+Parquet Vectorized (Pushdown)                             467            472           4         33.7          29.7      17.3X
+Native ORC Vectorized                                    6486           6497          10          2.4         412.4       1.2X
+Native ORC Vectorized (Pushdown)                          446            450           3         35.3          28.4      18.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (7864319 < value < 7864321):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    11885          11913          32          1.3         755.6       1.0X
-Parquet Vectorized (Pushdown)                           602            610           6         26.1          38.3      19.7X
-Native ORC Vectorized                                  7563           7582          19          2.1         480.9       1.6X
-Native ORC Vectorized (Pushdown)                        541            559          19         29.0          34.4      22.0X
+Parquet Vectorized                                     8117           8135          18          1.9         516.0       1.0X
+Parquet Vectorized (Pushdown)                           457            465          11         34.4          29.1      17.8X
+Native ORC Vectorized                                  6533           6540           7          2.4         415.4       1.2X
+Native ORC Vectorized (Pushdown)                        445            450           4         35.3          28.3      18.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% int rows (value < 1572864):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                12837          12874          26          1.2         816.2       1.0X
-Parquet Vectorized (Pushdown)                      2745           2753           7          5.7         174.5       4.7X
-Native ORC Vectorized                              8541           8554          10          1.8         543.1       1.5X
-Native ORC Vectorized (Pushdown)                   2248           2264          10          7.0         143.0       5.7X
+Parquet Vectorized                                 8924           8937          18          1.8         567.4       1.0X
+Parquet Vectorized (Pushdown)                      2043           2104         128          7.7         129.9       4.4X
+Native ORC Vectorized                              7331           7338           6          2.1         466.1       1.2X
+Native ORC Vectorized (Pushdown)                   1891           1898           4          8.3         120.2       4.7X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% int rows (value < 7864320):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                16394          16422          18          1.0        1042.3       1.0X
-Parquet Vectorized (Pushdown)                     10836          10845           8          1.5         688.9       1.5X
-Native ORC Vectorized                             12096          12113          11          1.3         769.1       1.4X
-Native ORC Vectorized (Pushdown)                   8736           8745           9          1.8         555.4       1.9X
+Parquet Vectorized                                11730          11775          49          1.3         745.8       1.0X
+Parquet Vectorized (Pushdown)                      7984           7998          10          2.0         507.6       1.5X
+Native ORC Vectorized                             10196          10222          16          1.5         648.3       1.2X
+Native ORC Vectorized (Pushdown)                   7270           7288          26          2.2         462.2       1.6X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% int rows (value < 14155776):   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                19941          19973          22          0.8        1267.8       1.0X
-Parquet Vectorized (Pushdown)                     18899          18962          71          0.8        1201.6       1.1X
-Native ORC Vectorized                             15626          15639           8          1.0         993.5       1.3X
-Native ORC Vectorized (Pushdown)                  15207          15232          18          1.0         966.8       1.3X
+Parquet Vectorized                                14566          14601          26          1.1         926.1       1.0X
+Parquet Vectorized (Pushdown)                     13905          13931          28          1.1         884.0       1.0X
+Native ORC Vectorized                             13103          13143          32          1.2         833.1       1.1X
+Native ORC Vectorized (Pushdown)                  12662          12673          15          1.2         805.0       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all int rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                20800          20839          26          0.8        1322.4       1.0X
-Parquet Vectorized (Pushdown)                     20938          21045         140          0.8        1331.2       1.0X
-Native ORC Vectorized                             16524          16685         162          1.0        1050.6       1.3X
-Native ORC Vectorized (Pushdown)                  16759          16879         152          0.9        1065.5       1.2X
+Parquet Vectorized                                15339          15362          13          1.0         975.3       1.0X
+Parquet Vectorized (Pushdown)                     15433          15446          12          1.0         981.2       1.0X
+Native ORC Vectorized                             13781          13797          12          1.1         876.1       1.1X
+Native ORC Vectorized (Pushdown)                  13946          13953           8          1.1         886.7       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all int rows (value > -1):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                20830          20851          25          0.8        1324.3       1.0X
-Parquet Vectorized (Pushdown)                     20940          21030         113          0.8        1331.3       1.0X
-Native ORC Vectorized                             16530          16553          22          1.0        1050.9       1.3X
-Native ORC Vectorized (Pushdown)                  16691          16756          94          0.9        1061.2       1.2X
+Parquet Vectorized                                15314          15371          48          1.0         973.6       1.0X
+Parquet Vectorized (Pushdown)                     15440          15451           9          1.0         981.6       1.0X
+Native ORC Vectorized                             13805          13832          28          1.1         877.7       1.1X
+Native ORC Vectorized (Pushdown)                  13950          13975          22          1.1         886.9       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all int rows (value != -1):        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                20794          20854          54          0.8        1322.0       1.0X
-Parquet Vectorized (Pushdown)                     20845          20896          88          0.8        1325.3       1.0X
-Native ORC Vectorized                             16537          16558          14          1.0        1051.4       1.3X
-Native ORC Vectorized (Pushdown)                  16801          16810          12          0.9        1068.2       1.2X
+Parquet Vectorized                                15288          15327          29          1.0         972.0       1.0X
+Parquet Vectorized (Pushdown)                     15412          15434          13          1.0         979.9       1.0X
+Native ORC Vectorized                             13805          13824          16          1.1         877.7       1.1X
+Native ORC Vectorized (Pushdown)                  13997          14021          24          1.1         889.9       1.1X
 
 
 ================================================================================================
 Pushdown for few distinct value case (use dictionary encoding)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 distinct string row (value IS NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    11227          11272          51          1.4         713.8       1.0X
-Parquet Vectorized (Pushdown)                           533            544          11         29.5          33.9      21.1X
-Native ORC Vectorized                                  8937           8959          37          1.8         568.2       1.3X
-Native ORC Vectorized (Pushdown)                        991           1016          36         15.9          63.0      11.3X
+Parquet Vectorized                                     7565           7605          35          2.1         481.0       1.0X
+Parquet Vectorized (Pushdown)                           403            415          13         39.0          25.6      18.8X
+Native ORC Vectorized                                  7768           7781          19          2.0         493.8       1.0X
+Native ORC Vectorized (Pushdown)                        818            823           3         19.2          52.0       9.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 distinct string row ('100' < value < '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                            11419          11432          14          1.4         726.0       1.0X
-Parquet Vectorized (Pushdown)                                   529            538          10         29.7          33.7      21.6X
-Native ORC Vectorized                                          9244           9269          22          1.7         587.7       1.2X
-Native ORC Vectorized (Pushdown)                               1009           1030          39         15.6          64.1      11.3X
+Parquet Vectorized                                             7742           7755          10          2.0         492.2       1.0X
+Parquet Vectorized (Pushdown)                                   406            413           5         38.8          25.8      19.1X
+Native ORC Vectorized                                          8019           8030          11          2.0         509.8       1.0X
+Native ORC Vectorized (Pushdown)                                822            826           3         19.1          52.2       9.4X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 distinct string row (value = '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    11275          11304          19          1.4         716.9       1.0X
-Parquet Vectorized (Pushdown)                           615            639          40         25.6          39.1      18.3X
-Native ORC Vectorized                                  9160           9181          15          1.7         582.4       1.2X
-Native ORC Vectorized (Pushdown)                       1073           1079           4         14.7          68.2      10.5X
+Parquet Vectorized                                     7575           7582           6          2.1         481.6       1.0X
+Parquet Vectorized (Pushdown)                           459            468           7         34.3          29.2      16.5X
+Native ORC Vectorized                                  7934           7944          10          2.0         504.4       1.0X
+Native ORC Vectorized (Pushdown)                        879            889          16         17.9          55.9       8.6X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 distinct string row (value <=> '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      11263          11276          12          1.4         716.1       1.0X
-Parquet Vectorized (Pushdown)                             615            619           4         25.6          39.1      18.3X
-Native ORC Vectorized                                    9133           9158          17          1.7         580.6       1.2X
-Native ORC Vectorized (Pushdown)                         1064           1081          33         14.8          67.7      10.6X
+Parquet Vectorized                                       7590           7611          16          2.1         482.6       1.0X
+Parquet Vectorized (Pushdown)                             457            463           5         34.4          29.0      16.6X
+Native ORC Vectorized                                    7936           7942           6          2.0         504.6       1.0X
+Native ORC Vectorized (Pushdown)                          873            879           4         18.0          55.5       8.7X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 distinct string row ('100' <= value <= '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              11342          11441         148          1.4         721.1       1.0X
-Parquet Vectorized (Pushdown)                                     615            623           7         25.6          39.1      18.4X
-Native ORC Vectorized                                            9206           9221          12          1.7         585.3       1.2X
-Native ORC Vectorized (Pushdown)                                 1063           1071           6         14.8          67.6      10.7X
+Parquet Vectorized                                               7715           7724           8          2.0         490.5       1.0X
+Parquet Vectorized (Pushdown)                                     463            471           5         33.9          29.5      16.6X
+Native ORC Vectorized                                            8038           8043           7          2.0         511.1       1.0X
+Native ORC Vectorized (Pushdown)                                  874            884           8         18.0          55.6       8.8X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all distinct string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           22292          22350         104          0.7        1417.3       1.0X
-Parquet Vectorized (Pushdown)                                22393          22474          89          0.7        1423.7       1.0X
-Native ORC Vectorized                                        20424          20439          15          0.8        1298.6       1.1X
-Native ORC Vectorized (Pushdown)                             20750          20803          36          0.8        1319.3       1.1X
+Parquet Vectorized                                           16502          16555          40          1.0        1049.1       1.0X
+Parquet Vectorized (Pushdown)                                16597          16624          20          0.9        1055.2       1.0X
+Native ORC Vectorized                                        17396          17568         116          0.9        1106.0       0.9X
+Native ORC Vectorized (Pushdown)                             17437          17572         188          0.9        1108.6       0.9X
 
 
 ================================================================================================
 Pushdown benchmark for StringStartsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 StringStartsWith filter: (value like '10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                   13199          13292          80          1.2         839.2       1.0X
-Parquet Vectorized (Pushdown)                         1776           1785           8          8.9         112.9       7.4X
-Native ORC Vectorized                                 8608           8650          52          1.8         547.3       1.5X
-Native ORC Vectorized (Pushdown)                      8720           8742          22          1.8         554.4       1.5X
+Parquet Vectorized                                    8868           8996          74          1.8         563.8       1.0X
+Parquet Vectorized (Pushdown)                         1235           1272          36         12.7          78.5       7.2X
+Native ORC Vectorized                                 7295           7418         112          2.2         463.8       1.2X
+Native ORC Vectorized (Pushdown)                      7519           7620          82          2.1         478.0       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 StringStartsWith filter: (value like '1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     12843          12858          14          1.2         816.5       1.0X
-Parquet Vectorized (Pushdown)                            612            629          19         25.7          38.9      21.0X
-Native ORC Vectorized                                   8280           8288          10          1.9         526.4       1.6X
-Native ORC Vectorized (Pushdown)                        8436           8445           7          1.9         536.4       1.5X
+Parquet Vectorized                                      8767           8846          67          1.8         557.4       1.0X
+Parquet Vectorized (Pushdown)                            469            477           5         33.5          29.8      18.7X
+Native ORC Vectorized                                   7156           7273          78          2.2         454.9       1.2X
+Native ORC Vectorized (Pushdown)                        7483           7494          10          2.1         475.7       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 StringStartsWith filter: (value like '786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       12921          12946          19          1.2         821.5       1.0X
-Parquet Vectorized (Pushdown)                              599            609           7         26.2          38.1      21.6X
-Native ORC Vectorized                                     8291           8300          10          1.9         527.1       1.6X
-Native ORC Vectorized (Pushdown)                          8461           8480          21          1.9         537.9       1.5X
+Parquet Vectorized                                        8672           8843         108          1.8         551.4       1.0X
+Parquet Vectorized (Pushdown)                              461            466           5         34.1          29.3      18.8X
+Native ORC Vectorized                                     7029           7099          54          2.2         446.9       1.2X
+Native ORC Vectorized (Pushdown)                          7297           7374          63          2.2         464.0       1.2X
+
+
+================================================================================================
+Pushdown benchmark for StringEndsWith
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringEndsWith filter: (value like '%10'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                  7611           7660          63          2.1         483.9       1.0X
+Parquet Vectorized (Pushdown)                        551            581          29         28.6          35.0      13.8X
+Native ORC Vectorized                               7859           7965         103          2.0         499.6       1.0X
+Native ORC Vectorized (Pushdown)                    8131           8226          63          1.9         516.9       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringEndsWith filter: (value like '%1000'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                    7386           7511          72          2.1         469.6       1.0X
+Parquet Vectorized (Pushdown)                          461            469           5         34.1          29.3      16.0X
+Native ORC Vectorized                                 7813           7886          47          2.0         496.7       0.9X
+Native ORC Vectorized (Pushdown)                      7979           8222         312          2.0         507.3       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringEndsWith filter: (value like '%786432'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                      7521           7625         180          2.1         478.1       1.0X
+Parquet Vectorized (Pushdown)                            464            466           2         33.9          29.5      16.2X
+Native ORC Vectorized                                   7780           7873          60          2.0         494.6       1.0X
+Native ORC Vectorized (Pushdown)                        8166           8205          46          1.9         519.2       0.9X
+
+
+================================================================================================
+Pushdown benchmark for StringContains
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringContains filter: (value like '%10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                   7883           7893          16          2.0         501.2       1.0X
+Parquet Vectorized (Pushdown)                        1128           1132           7         13.9          71.7       7.0X
+Native ORC Vectorized                                8256           8280          27          1.9         524.9       1.0X
+Native ORC Vectorized (Pushdown)                     8522           8533           7          1.8         541.8       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringContains filter: (value like '%1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                     7576           7581           7          2.1         481.7       1.0X
+Parquet Vectorized (Pushdown)                           468            477           8         33.6          29.8      16.2X
+Native ORC Vectorized                                  7772           7899          99          2.0         494.1       1.0X
+Native ORC Vectorized (Pushdown)                       8069           8175          74          1.9         513.0       0.9X
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringContains filter: (value like '%786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                       7401           7461          36          2.1         470.5       1.0X
+Parquet Vectorized (Pushdown)                             464            471           5         33.9          29.5      16.0X
+Native ORC Vectorized                                    7720           7812          90          2.0         490.9       1.0X
+Native ORC Vectorized (Pushdown)                         8031           8176          82          2.0         510.6       0.9X
 
 
 ================================================================================================
 Pushdown benchmark for decimal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 decimal(9, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     6087           6102          23          2.6         387.0       1.0X
-Parquet Vectorized (Pushdown)                           150            158           8        104.5           9.6      40.5X
-Native ORC Vectorized                                  5614           5631          21          2.8         356.9       1.1X
-Native ORC Vectorized (Pushdown)                        184            188           4         85.3          11.7      33.0X
+Parquet Vectorized                                     3601           3623          25          4.4         229.0       1.0X
+Parquet Vectorized (Pushdown)                           118            122           5        132.9           7.5      30.4X
+Native ORC Vectorized                                  4979           4997          26          3.2         316.6       0.7X
+Native ORC Vectorized (Pushdown)                        155            159           5        101.7           9.8      23.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% decimal(9, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        8032           8051          18          2.0         510.7       1.0X
-Parquet Vectorized (Pushdown)                             3277           3284           6          4.8         208.3       2.5X
-Native ORC Vectorized                                     7586           7596           6          2.1         482.3       1.1X
-Native ORC Vectorized (Pushdown)                          3244           3255           8          4.8         206.3       2.5X
+Parquet Vectorized                                        5223           5232           9          3.0         332.0       1.0X
+Parquet Vectorized (Pushdown)                             2442           2453          13          6.4         155.3       2.1X
+Native ORC Vectorized                                     6650           6651           2          2.4         422.8       0.8X
+Native ORC Vectorized (Pushdown)                          2777           2781           3          5.7         176.6       1.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% decimal(9, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       14463          14475          16          1.1         919.5       1.0X
-Parquet Vectorized (Pushdown)                            13700          13816         217          1.1         871.0       1.1X
-Native ORC Vectorized                                    14172          14194          19          1.1         901.0       1.0X
-Native ORC Vectorized (Pushdown)                         13518          13537          19          1.2         859.4       1.1X
+Parquet Vectorized                                       10591          10617          33          1.5         673.3       1.0X
+Parquet Vectorized (Pushdown)                            10190          10200           8          1.5         647.9       1.0X
+Native ORC Vectorized                                    12103          12126          16          1.3         769.5       0.9X
+Native ORC Vectorized (Pushdown)                         11524          11533           7          1.4         732.6       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% decimal(9, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        16161          16182          15          1.0        1027.5       1.0X
-Parquet Vectorized (Pushdown)                             16195          16225          22          1.0        1029.6       1.0X
-Native ORC Vectorized                                     15883          15917          25          1.0        1009.8       1.0X
-Native ORC Vectorized (Pushdown)                          16004          16038          24          1.0        1017.5       1.0X
+Parquet Vectorized                                        11946          12068         197          1.3         759.5       1.0X
+Parquet Vectorized (Pushdown)                             12013          12030          15          1.3         763.7       1.0X
+Native ORC Vectorized                                     13455          13478          19          1.2         855.5       0.9X
+Native ORC Vectorized (Pushdown)                          13553          13577          21          1.2         861.7       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 decimal(18, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      6321           6349          29          2.5         401.9       1.0X
-Parquet Vectorized (Pushdown)                            149            158          10        105.5           9.5      42.4X
-Native ORC Vectorized                                   5584           5602          12          2.8         355.1       1.1X
-Native ORC Vectorized (Pushdown)                         180            186           8         87.5          11.4      35.2X
+Parquet Vectorized                                      3789           3802          14          4.2         240.9       1.0X
+Parquet Vectorized (Pushdown)                            118            123           5        133.3           7.5      32.1X
+Native ORC Vectorized                                   4973           4985          25          3.2         316.2       0.8X
+Native ORC Vectorized (Pushdown)                         150            155           5        104.9           9.5      25.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% decimal(18, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         7339           7379          45          2.1         466.6       1.0X
-Parquet Vectorized (Pushdown)                              1780           1790           7          8.8         113.1       4.1X
-Native ORC Vectorized                                      6664           6674           8          2.4         423.7       1.1X
-Native ORC Vectorized (Pushdown)                           1759           1775          15          8.9         111.8       4.2X
+Parquet Vectorized                                         4605           4623          20          3.4         292.8       1.0X
+Parquet Vectorized (Pushdown)                              1309           1320          20         12.0          83.2       3.5X
+Native ORC Vectorized                                      5829           5836           8          2.7         370.6       0.8X
+Native ORC Vectorized (Pushdown)                           1468           1473           4         10.7          93.3       3.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% decimal(18, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        11393          11414          19          1.4         724.3       1.0X
-Parquet Vectorized (Pushdown)                              8339           8350          11          1.9         530.2       1.4X
-Native ORC Vectorized                                     10815          10856          55          1.5         687.6       1.1X
-Native ORC Vectorized (Pushdown)                           8108           8122          16          1.9         515.5       1.4X
+Parquet Vectorized                                         7862           7871           8          2.0         499.8       1.0X
+Parquet Vectorized (Pushdown)                              6056           6064           9          2.6         385.0       1.3X
+Native ORC Vectorized                                      9165           9179          11          1.7         582.7       0.9X
+Native ORC Vectorized (Pushdown)                           6774           6781           6          2.3         430.7       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% decimal(18, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         15297          15319          21          1.0         972.6       1.0X
-Parquet Vectorized (Pushdown)                              14771          14794          22          1.1         939.1       1.0X
-Native ORC Vectorized                                      14853          14864          11          1.1         944.3       1.0X
-Native ORC Vectorized (Pushdown)                           14364          14376          11          1.1         913.2       1.1X
+Parquet Vectorized                                         11016          11026           8          1.4         700.4       1.0X
+Parquet Vectorized (Pushdown)                              10730          10744          12          1.5         682.2       1.0X
+Native ORC Vectorized                                      12419          12427           9          1.3         789.6       0.9X
+Native ORC Vectorized (Pushdown)                           12015          12030          12          1.3         763.9       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 decimal(38, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      8333           8368          43          1.9         529.8       1.0X
-Parquet Vectorized (Pushdown)                            162            172          14         97.0          10.3      51.4X
-Native ORC Vectorized                                   5561           5584          21          2.8         353.6       1.5X
-Native ORC Vectorized (Pushdown)                         180            184           4         87.6          11.4      46.4X
+Parquet Vectorized                                      5415           5429          17          2.9         344.3       1.0X
+Parquet Vectorized (Pushdown)                            127            132           5        123.9           8.1      42.7X
+Native ORC Vectorized                                   4982           4998          14          3.2         316.7       1.1X
+Native ORC Vectorized (Pushdown)                         152            156           4        103.2           9.7      35.5X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% decimal(38, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         9597           9614          18          1.6         610.2       1.0X
-Parquet Vectorized (Pushdown)                              2225           2241          12          7.1         141.5       4.3X
-Native ORC Vectorized                                      6778           6799          21          2.3         430.9       1.4X
-Native ORC Vectorized (Pushdown)                           1894           1898           5          8.3         120.4       5.1X
+Parquet Vectorized                                         6415           6445          31          2.5         407.9       1.0X
+Parquet Vectorized (Pushdown)                              1661           1663           3          9.5         105.6       3.9X
+Native ORC Vectorized                                      5923           5933           7          2.7         376.6       1.1X
+Native ORC Vectorized (Pushdown)                           1593           1594           1          9.9         101.3       4.0X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% decimal(38, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        14523          14644         239          1.1         923.3       1.0X
-Parquet Vectorized (Pushdown)                             10466          10492          30          1.5         665.4       1.4X
-Native ORC Vectorized                                     11500          11577         144          1.4         731.2       1.3X
-Native ORC Vectorized (Pushdown)                           8835           8879          75          1.8         561.7       1.6X
+Parquet Vectorized                                        10410          10426          16          1.5         661.9       1.0X
+Parquet Vectorized (Pushdown)                              7809           7819           9          2.0         496.5       1.3X
+Native ORC Vectorized                                      9825           9834           9          1.6         624.6       1.1X
+Native ORC Vectorized (Pushdown)                           7419           7426           9          2.1         471.7       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% decimal(38, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         19354          19459         206          0.8        1230.5       1.0X
-Parquet Vectorized (Pushdown)                              18751          18770          17          0.8        1192.2       1.0X
-Native ORC Vectorized                                      16128          16195          74          1.0        1025.4       1.2X
-Native ORC Vectorized (Pushdown)                           15596          15619          31          1.0         991.6       1.2X
+Parquet Vectorized                                         14383          14398          16          1.1         914.5       1.0X
+Parquet Vectorized (Pushdown)                              13876          13900          14          1.1         882.2       1.0X
+Native ORC Vectorized                                      13625          13638          12          1.2         866.2       1.1X
+Native ORC Vectorized (Pushdown)                           13194          13226          19          1.2         838.9       1.1X
 
 
 ================================================================================================
 Pushdown benchmark for InSet -> InFilters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 5, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              11822          11863          27          1.3         751.6       1.0X
-Parquet Vectorized (Pushdown)                                     626            649          37         25.1          39.8      18.9X
-Native ORC Vectorized                                            7601           7643          46          2.1         483.3       1.6X
-Native ORC Vectorized (Pushdown)                                  551            568          23         28.5          35.0      21.4X
+Parquet Vectorized                                               8086           8129          75          1.9         514.1       1.0X
+Parquet Vectorized (Pushdown)                                     472            484           9         33.3          30.0      17.1X
+Native ORC Vectorized                                            6513           6533          32          2.4         414.1       1.2X
+Native ORC Vectorized (Pushdown)                                  443            472          50         35.5          28.1      18.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 5, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              11775          11791          14          1.3         748.7       1.0X
-Parquet Vectorized (Pushdown)                                     631            645          19         24.9          40.1      18.7X
-Native ORC Vectorized                                            7530           7543          12          2.1         478.7       1.6X
-Native ORC Vectorized (Pushdown)                                  548            558          10         28.7          34.9      21.5X
+Parquet Vectorized                                               8079           8103          22          1.9         513.6       1.0X
+Parquet Vectorized (Pushdown)                                     468            476           6         33.6          29.7      17.3X
+Native ORC Vectorized                                            6487           6495           5          2.4         412.4       1.2X
+Native ORC Vectorized (Pushdown)                                  446            454           6         35.3          28.4      18.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 5, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              11764          11775          17          1.3         747.9       1.0X
-Parquet Vectorized (Pushdown)                                     631            649          27         24.9          40.1      18.6X
-Native ORC Vectorized                                            7509           7534          28          2.1         477.4       1.6X
-Native ORC Vectorized (Pushdown)                                  555            564          13         28.4          35.3      21.2X
+Parquet Vectorized                                               8016           8028           8          2.0         509.7       1.0X
+Parquet Vectorized (Pushdown)                                     473            477           5         33.3          30.1      17.0X
+Native ORC Vectorized                                            6488           6492           3          2.4         412.5       1.2X
+Native ORC Vectorized (Pushdown)                                  448            456           5         35.1          28.5      17.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 10, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               11822          11843          14          1.3         751.6       1.0X
-Parquet Vectorized (Pushdown)                                      660            676          26         23.8          42.0      17.9X
-Native ORC Vectorized                                             7548           7561          14          2.1         479.9       1.6X
-Native ORC Vectorized (Pushdown)                                   574            590          20         27.4          36.5      20.6X
+Parquet Vectorized                                                8057           8068           8          2.0         512.2       1.0X
+Parquet Vectorized (Pushdown)                                      484            491           5         32.5          30.8      16.7X
+Native ORC Vectorized                                             6519           6525           5          2.4         414.5       1.2X
+Native ORC Vectorized (Pushdown)                                   476            481           4         33.1          30.2      16.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 10, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               11841          11869          24          1.3         752.8       1.0X
-Parquet Vectorized (Pushdown)                                      672            681          15         23.4          42.8      17.6X
-Native ORC Vectorized                                             7561           7574          18          2.1         480.7       1.6X
-Native ORC Vectorized (Pushdown)                                   580            585           5         27.1          36.9      20.4X
+Parquet Vectorized                                                8126           8147          20          1.9         516.6       1.0X
+Parquet Vectorized (Pushdown)                                      495            501           5         31.8          31.5      16.4X
+Native ORC Vectorized                                             6501           6508           8          2.4         413.3       1.2X
+Native ORC Vectorized (Pushdown)                                   470            473           3         33.5          29.9      17.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 10, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               11788          11807          18          1.3         749.5       1.0X
-Parquet Vectorized (Pushdown)                                      661            678          34         23.8          42.0      17.8X
-Native ORC Vectorized                                             7545           7572          20          2.1         479.7       1.6X
-Native ORC Vectorized (Pushdown)                                   572            580           6         27.5          36.4      20.6X
+Parquet Vectorized                                                8088           8096           6          1.9         514.2       1.0X
+Parquet Vectorized (Pushdown)                                      498            500           2         31.6          31.7      16.2X
+Native ORC Vectorized                                             6489           6499           8          2.4         412.6       1.2X
+Native ORC Vectorized (Pushdown)                                   467            472           5         33.7          29.7      17.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 50, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               12133          12148          11          1.3         771.4       1.0X
-Parquet Vectorized (Pushdown)                                     1762           1771           6          8.9         112.1       6.9X
-Native ORC Vectorized                                             7857           7877          13          2.0         499.6       1.5X
-Native ORC Vectorized (Pushdown)                                   744            760          31         21.1          47.3      16.3X
+Parquet Vectorized                                                8388           8396           7          1.9         533.3       1.0X
+Parquet Vectorized (Pushdown)                                     1251           1259           7         12.6          79.5       6.7X
+Native ORC Vectorized                                             6763           6768           3          2.3         430.0       1.2X
+Native ORC Vectorized (Pushdown)                                   603            608           4         26.1          38.3      13.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 50, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               12137          12244         202          1.3         771.6       1.0X
-Parquet Vectorized (Pushdown)                                     6283           6302          12          2.5         399.5       1.9X
-Native ORC Vectorized                                             7856           7859           3          2.0         499.5       1.5X
-Native ORC Vectorized (Pushdown)                                   772            778           5         20.4          49.1      15.7X
+Parquet Vectorized                                                8422           8459          25          1.9         535.5       1.0X
+Parquet Vectorized (Pushdown)                                     4326           4329           3          3.6         275.0       1.9X
+Native ORC Vectorized                                             6833           6839           4          2.3         434.4       1.2X
+Native ORC Vectorized (Pushdown)                                   632            636           5         24.9          40.2      13.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 50, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               12112          12157          78          1.3         770.0       1.0X
-Parquet Vectorized (Pushdown)                                    10496          10511          14          1.5         667.3       1.2X
-Native ORC Vectorized                                             7842           7855          12          2.0         498.6       1.5X
-Native ORC Vectorized (Pushdown)                                   783            790          12         20.1          49.8      15.5X
+Parquet Vectorized                                                8395           8399           3          1.9         533.8       1.0X
+Parquet Vectorized (Pushdown)                                     7601           7780         162          2.1         483.3       1.1X
+Native ORC Vectorized                                             6768           6777           9          2.3         430.3       1.2X
+Native ORC Vectorized (Pushdown)                                   638            641           3         24.7          40.6      13.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 100, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                12049          12065          15          1.3         766.0       1.0X
-Parquet Vectorized (Pushdown)                                      1761           1769           7          8.9         111.9       6.8X
-Native ORC Vectorized                                              7880           7894          13          2.0         501.0       1.5X
-Native ORC Vectorized (Pushdown)                                    881            888           8         17.8          56.0      13.7X
+Parquet Vectorized                                                 8731           8759          22          1.8         555.1       1.0X
+Parquet Vectorized (Pushdown)                                      1282           1286           4         12.3          81.5       6.8X
+Native ORC Vectorized                                              6718           6762          38          2.3         427.1       1.3X
+Native ORC Vectorized (Pushdown)                                    724            730           8         21.7          46.0      12.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 100, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                12022          12052          24          1.3         764.3       1.0X
-Parquet Vectorized (Pushdown)                                      6298           6310          14          2.5         400.4       1.9X
-Native ORC Vectorized                                              7778           7789          10          2.0         494.5       1.5X
-Native ORC Vectorized (Pushdown)                                    959            989          49         16.4          61.0      12.5X
+Parquet Vectorized                                                 8738           8745           5          1.8         555.6       1.0X
+Parquet Vectorized (Pushdown)                                      4570           4588          12          3.4         290.5       1.9X
+Native ORC Vectorized                                              6759           6792          21          2.3         429.7       1.3X
+Native ORC Vectorized (Pushdown)                                    853            859           4         18.4          54.2      10.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 100, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                12050          12073          19          1.3         766.1       1.0X
-Parquet Vectorized (Pushdown)                                     10998          11013          18          1.4         699.3       1.1X
-Native ORC Vectorized                                              7777           7788           8          2.0         494.5       1.5X
-Native ORC Vectorized (Pushdown)                                    997           1006          13         15.8          63.4      12.1X
+Parquet Vectorized                                                 8671           8681           7          1.8         551.3       1.0X
+Parquet Vectorized (Pushdown)                                      7576           7581           6          2.1         481.7       1.1X
+Native ORC Vectorized                                              6710           6720           8          2.3         426.6       1.3X
+Native ORC Vectorized (Pushdown)                                    837            840           3         18.8          53.2      10.4X
 
 
 ================================================================================================
 Pushdown benchmark for tinyint
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 tinyint row (value = CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           6615           6664          58          2.4         420.6       1.0X
-Parquet Vectorized (Pushdown)                                 221            228           5         71.1          14.1      29.9X
-Native ORC Vectorized                                        3569           3596          35          4.4         226.9       1.9X
-Native ORC Vectorized (Pushdown)                              251            259           9         62.7          16.0      26.4X
+Parquet Vectorized                                           3958           3978          26          4.0         251.6       1.0X
+Parquet Vectorized (Pushdown)                                 166            171           6         94.8          10.5      23.9X
+Native ORC Vectorized                                        2992           3000          12          5.3         190.2       1.3X
+Native ORC Vectorized (Pushdown)                              205            208           3         76.7          13.0      19.3X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% tinyint rows (value < CAST(12 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              7480           7506          25          2.1         475.6       1.0X
-Parquet Vectorized (Pushdown)                                   1668           1675           7          9.4         106.0       4.5X
-Native ORC Vectorized                                           4416           4429          14          3.6         280.8       1.7X
-Native ORC Vectorized (Pushdown)                                1396           1402           6         11.3          88.7       5.4X
+Parquet Vectorized                                              4705           4714          11          3.3         299.1       1.0X
+Parquet Vectorized (Pushdown)                                   1235           1239           3         12.7          78.5       3.8X
+Native ORC Vectorized                                           3685           3691           4          4.3         234.3       1.3X
+Native ORC Vectorized (Pushdown)                                1155           1165          10         13.6          73.4       4.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% tinyint rows (value < CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                             11098          11116          12          1.4         705.6       1.0X
-Parquet Vectorized (Pushdown)                                   7947           7961          11          2.0         505.3       1.4X
-Native ORC Vectorized                                           7965           7972           5          2.0         506.4       1.4X
-Native ORC Vectorized (Pushdown)                                6308           6312           3          2.5         401.1       1.8X
+Parquet Vectorized                                              7695           7703           6          2.0         489.2       1.0X
+Parquet Vectorized (Pushdown)                                   5820           5830          14          2.7         370.0       1.3X
+Native ORC Vectorized                                           6567           6574           4          2.4         417.5       1.2X
+Native ORC Vectorized (Pushdown)                                5187           5193           5          3.0         329.8       1.5X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% tinyint rows (value < CAST(114 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              14771          14814          46          1.1         939.1       1.0X
-Parquet Vectorized (Pushdown)                                   14179          14193          12          1.1         901.5       1.0X
-Native ORC Vectorized                                           11496          11521          19          1.4         730.9       1.3X
-Native ORC Vectorized (Pushdown)                                11222          11248          18          1.4         713.5       1.3X
+Parquet Vectorized                                              10714          10724          11          1.5         681.2       1.0X
+Parquet Vectorized (Pushdown)                                   10379          10390          13          1.5         659.9       1.0X
+Native ORC Vectorized                                            9434           9444          10          1.7         599.8       1.1X
+Native ORC Vectorized (Pushdown)                                 9221           9242          15          1.7         586.3       1.2X
 
 
 ================================================================================================
 Pushdown benchmark for Timestamp
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 timestamp stored as INT96 row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                    6682           6692           9          2.4         424.9       1.0X
-Parquet Vectorized (Pushdown)                                                         6670           6687          17          2.4         424.0       1.0X
-Native ORC Vectorized                                                                 3709           3712           3          4.2         235.8       1.8X
-Native ORC Vectorized (Pushdown)                                                       150            155           5        104.8           9.5      44.5X
+Parquet Vectorized                                                                    4149           4162          13          3.8         263.8       1.0X
+Parquet Vectorized (Pushdown)                                                         4141           4151           9          3.8         263.2       1.0X
+Native ORC Vectorized                                                                 3080           3091          12          5.1         195.8       1.3X
+Native ORC Vectorized (Pushdown)                                                       123            128           4        127.4           7.9      33.6X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% timestamp stored as INT96 rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       7637           7737         194          2.1         485.5       1.0X
-Parquet Vectorized (Pushdown)                                                            7621           7651          26          2.1         484.5       1.0X
-Native ORC Vectorized                                                                    4623           4630           8          3.4         293.9       1.7X
-Native ORC Vectorized (Pushdown)                                                         1436           1439           3         11.0          91.3       5.3X
+Parquet Vectorized                                                                       4902           4923          13          3.2         311.7       1.0X
+Parquet Vectorized (Pushdown)                                                            4894           4899           5          3.2         311.2       1.0X
+Native ORC Vectorized                                                                    3851           3858          10          4.1         244.8       1.3X
+Native ORC Vectorized (Pushdown)                                                         1191           1194           4         13.2          75.7       4.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% timestamp stored as INT96 rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                      11468          11522          74          1.4         729.1       1.0X
-Parquet Vectorized (Pushdown)                                                           11474          11490          13          1.4         729.5       1.0X
-Native ORC Vectorized                                                                    8263           8267           5          1.9         525.3       1.4X
-Native ORC Vectorized (Pushdown)                                                         6526           6542          10          2.4         414.9       1.8X
+Parquet Vectorized                                                                       8112           8137          15          1.9         515.7       1.0X
+Parquet Vectorized (Pushdown)                                                            8092           8108          18          1.9         514.4       1.0X
+Native ORC Vectorized                                                                    6838           6842           4          2.3         434.7       1.2X
+Native ORC Vectorized (Pushdown)                                                         5377           5381           4          2.9         341.8       1.5X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% timestamp stored as INT96 rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       15138          15150          13          1.0         962.5       1.0X
-Parquet Vectorized (Pushdown)                                                            15137          15169          21          1.0         962.4       1.0X
-Native ORC Vectorized                                                                    11930          11943          12          1.3         758.5       1.3X
-Native ORC Vectorized (Pushdown)                                                         11658          11676          16          1.3         741.2       1.3X
+Parquet Vectorized                                                                       11222          11234          12          1.4         713.5       1.0X
+Parquet Vectorized (Pushdown)                                                            11234          11262          36          1.4         714.2       1.0X
+Native ORC Vectorized                                                                     9837           9847          11          1.6         625.4       1.1X
+Native ORC Vectorized (Pushdown)                                                          9599           9604           5          1.6         610.3       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 timestamp stored as TIMESTAMP_MICROS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               6205           6239          21          2.5         394.5       1.0X
-Parquet Vectorized (Pushdown)                                                                     147            151           6        107.0           9.3      42.2X
-Native ORC Vectorized                                                                            3712           3721           7          4.2         236.0       1.7X
-Native ORC Vectorized (Pushdown)                                                                  149            156           8        105.4           9.5      41.6X
+Parquet Vectorized                                                                               3663           3672          10          4.3         232.9       1.0X
+Parquet Vectorized (Pushdown)                                                                     115            118           4        137.2           7.3      31.9X
+Native ORC Vectorized                                                                            3079           3085           5          5.1         195.7       1.2X
+Native ORC Vectorized (Pushdown)                                                                  122            125           4        128.5           7.8      29.9X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  7186           7205          27          2.2         456.9       1.0X
-Parquet Vectorized (Pushdown)                                                                       1708           1717           8          9.2         108.6       4.2X
-Native ORC Vectorized                                                                               4617           4629           7          3.4         293.5       1.6X
-Native ORC Vectorized (Pushdown)                                                                    1433           1438           5         11.0          91.1       5.0X
+Parquet Vectorized                                                                                  4466           4476          13          3.5         284.0       1.0X
+Parquet Vectorized (Pushdown)                                                                       1266           1270           5         12.4          80.5       3.5X
+Native ORC Vectorized                                                                               3846           3851           5          4.1         244.5       1.2X
+Native ORC Vectorized (Pushdown)                                                                    1190           1193           3         13.2          75.6       3.8X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                 10971          11022          90          1.4         697.5       1.0X
-Parquet Vectorized (Pushdown)                                                                       7990           7998           7          2.0         508.0       1.4X
-Native ORC Vectorized                                                                               8276           8285          14          1.9         526.2       1.3X
-Native ORC Vectorized (Pushdown)                                                                    6527           6548          19          2.4         415.0       1.7X
+Parquet Vectorized                                                                                  7632           7648          18          2.1         485.2       1.0X
+Parquet Vectorized (Pushdown)                                                                       5900           5904           4          2.7         375.1       1.3X
+Native ORC Vectorized                                                                               6850           6856           7          2.3         435.5       1.1X
+Native ORC Vectorized (Pushdown)                                                                    5390           5396           7          2.9         342.7       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  14721          14817         102          1.1         935.9       1.0X
-Parquet Vectorized (Pushdown)                                                                       14084          14129          41          1.1         895.4       1.0X
-Native ORC Vectorized                                                                               11948          11957          14          1.3         759.6       1.2X
-Native ORC Vectorized (Pushdown)                                                                    11636          11644           9          1.4         739.8       1.3X
+Parquet Vectorized                                                                                  10772          10787          14          1.5         684.9       1.0X
+Parquet Vectorized (Pushdown)                                                                       10425          10436           8          1.5         662.8       1.0X
+Native ORC Vectorized                                                                                9836           9850          11          1.6         625.3       1.1X
+Native ORC Vectorized (Pushdown)                                                                     9578           9583           5          1.6         609.0       1.1X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 timestamp stored as TIMESTAMP_MILLIS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               6234           6276          57          2.5         396.4       1.0X
-Parquet Vectorized (Pushdown)                                                                     146            150           4        107.9           9.3      42.8X
-Native ORC Vectorized                                                                            3696           3712          18          4.3         235.0       1.7X
-Native ORC Vectorized (Pushdown)                                                                  149            154           5        105.6           9.5      41.8X
+Parquet Vectorized                                                                               3702           3713           8          4.2         235.4       1.0X
+Parquet Vectorized (Pushdown)                                                                     114            117           3        138.1           7.2      32.5X
+Native ORC Vectorized                                                                            3081           3089           8          5.1         195.9       1.2X
+Native ORC Vectorized (Pushdown)                                                                  121            125           4        129.6           7.7      30.5X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  7194           7228          29          2.2         457.4       1.0X
-Parquet Vectorized (Pushdown)                                                                       1719           1726           5          9.2         109.3       4.2X
-Native ORC Vectorized                                                                               4622           4632          17          3.4         293.8       1.6X
-Native ORC Vectorized (Pushdown)                                                                    1439           1446           6         10.9          91.5       5.0X
+Parquet Vectorized                                                                                  4489           4494           9          3.5         285.4       1.0X
+Parquet Vectorized (Pushdown)                                                                       1270           1282          14         12.4          80.7       3.5X
+Native ORC Vectorized                                                                               3846           3856           7          4.1         244.5       1.2X
+Native ORC Vectorized (Pushdown)                                                                    1187           1190           4         13.3          75.5       3.8X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                 11025          11081          89          1.4         700.9       1.0X
-Parquet Vectorized (Pushdown)                                                                       8024           8045          22          2.0         510.2       1.4X
-Native ORC Vectorized                                                                               8279           8300          27          1.9         526.4       1.3X
-Native ORC Vectorized (Pushdown)                                                                    6536           6550           9          2.4         415.6       1.7X
+Parquet Vectorized                                                                                  7663           7679          17          2.1         487.2       1.0X
+Parquet Vectorized (Pushdown)                                                                       5877           5891          11          2.7         373.6       1.3X
+Native ORC Vectorized                                                                               6847           6850           3          2.3         435.3       1.1X
+Native ORC Vectorized (Pushdown)                                                                    5373           5382           8          2.9         341.6       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  14737          14751          10          1.1         937.0       1.0X
-Parquet Vectorized (Pushdown)                                                                       14138          14163          15          1.1         898.9       1.0X
-Native ORC Vectorized                                                                               11952          12008         101          1.3         759.9       1.2X
-Native ORC Vectorized (Pushdown)                                                                    11616          11623           7          1.4         738.5       1.3X
+Parquet Vectorized                                                                                  10752          10862         206          1.5         683.6       1.0X
+Parquet Vectorized (Pushdown)                                                                       10471          10479           7          1.5         665.7       1.0X
+Native ORC Vectorized                                                                                9861           9868           9          1.6         627.0       1.1X
+Native ORC Vectorized (Pushdown)                                                                     9604           9614           7          1.6         610.6       1.1X
 
 
 ================================================================================================
 Pushdown benchmark with many filters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 row with 1 filters:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  199            203           6          0.0   198570345.0       1.0X
-Parquet Vectorized (Pushdown)                       200            206           6          0.0   200485033.0       1.0X
-Native ORC Vectorized                               193            208           8          0.0   193123650.0       1.0X
-Native ORC Vectorized (Pushdown)                    206            219           9          0.0   206190335.0       1.0X
+Parquet Vectorized                                  151            155           4          0.0   150695208.0       1.0X
+Parquet Vectorized (Pushdown)                       153            157           5          0.0   152853214.0       1.0X
+Native ORC Vectorized                               144            154           9          0.0   143923196.0       1.0X
+Native ORC Vectorized (Pushdown)                    152            159           8          0.0   152359467.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 row with 250 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 1631           1822         248          0.0  1631451389.0       1.0X
-Parquet Vectorized (Pushdown)                      1665           1705          56          0.0  1665363203.0       1.0X
-Native ORC Vectorized                              1596           1657          88          0.0  1595629417.0       1.0X
-Native ORC Vectorized (Pushdown)                   1627           1660          46          0.0  1626580577.0       1.0X
+Parquet Vectorized                                 1582           1614          31          0.0  1581508551.0       1.0X
+Parquet Vectorized (Pushdown)                      1626           1664          73          0.0  1625795573.0       1.0X
+Native ORC Vectorized                              1563           1586          23          0.0  1563053391.0       1.0X
+Native ORC Vectorized (Pushdown)                   1583           1619          64          0.0  1583075187.0       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.2+8-LTS on Linux 5.13.0-1021-azure
-Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 row with 500 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 7019           7077          68          0.0  7019082096.0       1.0X
-Parquet Vectorized (Pushdown)                      7256           7434         175          0.0  7255521503.0       1.0X
-Native ORC Vectorized                              7048           7298         228          0.0  7047696613.0       1.0X
-Native ORC Vectorized (Pushdown)                   7066           7258         169          0.0  7065891513.0       1.0X
+Parquet Vectorized                                 7027           7227         148          0.0  7026812316.0       1.0X
+Parquet Vectorized (Pushdown)                      7197           7404         199          0.0  7197391646.0       1.0X
+Native ORC Vectorized                              7143           7258         117          0.0  7143461935.0       1.0X
+Native ORC Vectorized (Pushdown)                   7137           7323         228          0.0  7137286231.0       1.0X
 
 

--- a/sql/core/benchmarks/FilterPushdownBenchmark-results.txt
+++ b/sql/core/benchmarks/FilterPushdownBenchmark-results.txt
@@ -2,669 +2,733 @@
 Pushdown for many distinct value case
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 string row (value IS NULL):      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 8874           9713        1323          1.8         564.2       1.0X
-Parquet Vectorized (Pushdown)                       607            617           9         25.9          38.6      14.6X
-Native ORC Vectorized                              6195           6885        1498          2.5         393.9       1.4X
-Native ORC Vectorized (Pushdown)                    522            554          39         30.1          33.2      17.0X
+Parquet Vectorized                                10541          10920         716          1.5         670.2       1.0X
+Parquet Vectorized (Pushdown)                       616            639          29         25.5          39.2      17.1X
+Native ORC Vectorized                              6367           7100        1513          2.5         404.8       1.7X
+Native ORC Vectorized (Pushdown)                    523            557          47         30.1          33.3      20.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 string row ('7864320' < value < '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                            9007           9112         197          1.7         572.6       1.0X
-Parquet Vectorized (Pushdown)                                  594            606          14         26.5          37.8      15.2X
-Native ORC Vectorized                                         6387           6398          11          2.5         406.1       1.4X
-Native ORC Vectorized (Pushdown)                               526            590          83         29.9          33.4      17.1X
+Parquet Vectorized                                           10524          10666         134          1.5         669.1       1.0X
+Parquet Vectorized (Pushdown)                                  585            609          20         26.9          37.2      18.0X
+Native ORC Vectorized                                         6429           6511          77          2.4         408.7       1.6X
+Native ORC Vectorized (Pushdown)                               524            551          32         30.0          33.3      20.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 string row (value = '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9065           9107          77          1.7         576.3       1.0X
-Parquet Vectorized (Pushdown)                       585            594          13         26.9          37.2      15.5X
-Native ORC Vectorized                              6421           6450          51          2.4         408.2       1.4X
-Native ORC Vectorized (Pushdown)                    508            533          31         31.0          32.3      17.9X
+Parquet Vectorized                                10295          10478         207          1.5         654.6       1.0X
+Parquet Vectorized (Pushdown)                       553            583          20         28.4          35.2      18.6X
+Native ORC Vectorized                              6201           6450         178          2.5         394.2       1.7X
+Native ORC Vectorized (Pushdown)                    502            528          39         31.4          31.9      20.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 string row (value <=> '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  9037           9086          90          1.7         574.5       1.0X
-Parquet Vectorized (Pushdown)                        581            590          12         27.1          36.9      15.6X
-Native ORC Vectorized                               6414           6423           6          2.5         407.8       1.4X
-Native ORC Vectorized (Pushdown)                     501            523          36         31.4          31.9      18.0X
+Parquet Vectorized                                 10360          10471         112          1.5         658.7       1.0X
+Parquet Vectorized (Pushdown)                        550            571          17         28.6          35.0      18.8X
+Native ORC Vectorized                               6465           6472           8          2.4         411.0       1.6X
+Native ORC Vectorized (Pushdown)                     520            571          62         30.2          33.1      19.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 string row ('7864320' <= value <= '7864320'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              9040           9074          36          1.7         574.8       1.0X
-Parquet Vectorized (Pushdown)                                    579            587          13         27.2          36.8      15.6X
-Native ORC Vectorized                                           6424           6443          19          2.4         408.4       1.4X
-Native ORC Vectorized (Pushdown)                                 506            524          36         31.1          32.2      17.9X
+Parquet Vectorized                                             10401          10562         106          1.5         661.3       1.0X
+Parquet Vectorized (Pushdown)                                    544            568          24         28.9          34.6      19.1X
+Native ORC Vectorized                                           6475           6544          65          2.4         411.7       1.6X
+Native ORC Vectorized (Pushdown)                                 508            533          31         31.0          32.3      20.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  16926          16949          19          0.9        1076.1       1.0X
-Parquet Vectorized (Pushdown)                       17017          17027          11          0.9        1081.9       1.0X
-Native ORC Vectorized                               14405          14426          18          1.1         915.8       1.2X
-Native ORC Vectorized (Pushdown)                    14547          14566          16          1.1         924.9       1.2X
+Parquet Vectorized                                  17904          18027         125          0.9        1138.3       1.0X
+Parquet Vectorized (Pushdown)                       17931          17979          48          0.9        1140.0       1.0X
+Native ORC Vectorized                               12862          13722         489          1.2         817.7       1.4X
+Native ORC Vectorized (Pushdown)                    14091          14156          55          1.1         895.9       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 int row (value IS NULL):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 8459           9267        1292          1.9         537.8       1.0X
-Parquet Vectorized (Pushdown)                       568            583          23         27.7          36.1      14.9X
-Native ORC Vectorized                              5805           6369        1208          2.7         369.1       1.5X
-Native ORC Vectorized (Pushdown)                    488            525          61         32.2          31.0      17.3X
+Parquet Vectorized                                 9693          10784        1430          1.6         616.2       1.0X
+Parquet Vectorized (Pushdown)                       538            555          20         29.2          34.2      18.0X
+Native ORC Vectorized                              5904           6535        1244          2.7         375.4       1.6X
+Native ORC Vectorized (Pushdown)                    484            531          67         32.5          30.8      20.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 int row (7864320 < value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8463           8541         156          1.9         538.0       1.0X
-Parquet Vectorized (Pushdown)                           577            589          15         27.3          36.7      14.7X
-Native ORC Vectorized                                  5824           5861          60          2.7         370.3       1.5X
-Native ORC Vectorized (Pushdown)                        492            512          38         32.0          31.3      17.2X
+Parquet Vectorized                                     9731          10023         498          1.6         618.7       1.0X
+Parquet Vectorized (Pushdown)                           549            584          33         28.7          34.9      17.7X
+Native ORC Vectorized                                  5916           5945          19          2.7         376.2       1.6X
+Native ORC Vectorized (Pushdown)                        482            510          40         32.7          30.6      20.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (value = 7864320):       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 8511           8560          78          1.8         541.1       1.0X
-Parquet Vectorized (Pushdown)                       575            584           8         27.4          36.5      14.8X
-Native ORC Vectorized                              5869           5881           7          2.7         373.1       1.5X
-Native ORC Vectorized (Pushdown)                    495            520          52         31.8          31.4      17.2X
+Parquet Vectorized                                 9773          10040         468          1.6         621.4       1.0X
+Parquet Vectorized (Pushdown)                       546            550           6         28.8          34.7      17.9X
+Native ORC Vectorized                              5765           5958         110          2.7         366.5       1.7X
+Native ORC Vectorized (Pushdown)                    477            535          49         33.0          30.3      20.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (value <=> 7864320):     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 8495           8523          46          1.9         540.1       1.0X
-Parquet Vectorized (Pushdown)                       569            577          11         27.7          36.2      14.9X
-Native ORC Vectorized                              5881           5883           2          2.7         373.9       1.4X
-Native ORC Vectorized (Pushdown)                    484            503          33         32.5          30.8      17.5X
+Parquet Vectorized                                 9747          10046         494          1.6         619.7       1.0X
+Parquet Vectorized (Pushdown)                       541            551          16         29.1          34.4      18.0X
+Native ORC Vectorized                              5983           6001          17          2.6         380.4       1.6X
+Native ORC Vectorized (Pushdown)                    475            517          46         33.1          30.2      20.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (7864320 <= value <= 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       8489           8510          28          1.9         539.7       1.0X
-Parquet Vectorized (Pushdown)                             570            576           9         27.6          36.3      14.9X
-Native ORC Vectorized                                    5883           5889           4          2.7         374.1       1.4X
-Native ORC Vectorized (Pushdown)                          490            508          31         32.1          31.1      17.3X
+Parquet Vectorized                                       9721           9838          98          1.6         618.1       1.0X
+Parquet Vectorized (Pushdown)                             548            564          15         28.7          34.9      17.7X
+Native ORC Vectorized                                    5975           5982           6          2.6         379.9       1.6X
+Native ORC Vectorized (Pushdown)                          479            500          40         32.9          30.4      20.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 int row (7864319 < value < 7864321):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8492           8502           6          1.9         539.9       1.0X
-Parquet Vectorized (Pushdown)                           570            579           9         27.6          36.3      14.9X
-Native ORC Vectorized                                  5879           5887           5          2.7         373.8       1.4X
-Native ORC Vectorized (Pushdown)                        487            507          34         32.3          31.0      17.4X
+Parquet Vectorized                                     9267           9697         243          1.7         589.2       1.0X
+Parquet Vectorized (Pushdown)                           543            556          15         28.9          34.5      17.1X
+Native ORC Vectorized                                  5821           5963          85          2.7         370.1       1.6X
+Native ORC Vectorized (Pushdown)                        477            525          49         33.0          30.3      19.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% int rows (value < 1572864):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 9264           9538         551          1.7         589.0       1.0X
-Parquet Vectorized (Pushdown)                      2118           2142          15          7.4         134.6       4.4X
-Native ORC Vectorized                              6645           6662          18          2.4         422.5       1.4X
-Native ORC Vectorized (Pushdown)                   1807           1831          15          8.7         114.9       5.1X
+Parquet Vectorized                                10522          10682         246          1.5         669.0       1.0X
+Parquet Vectorized (Pushdown)                      2111           2214          61          7.5         134.2       5.0X
+Native ORC Vectorized                              6657           6731          52          2.4         423.3       1.6X
+Native ORC Vectorized (Pushdown)                   1733           1813          72          9.1         110.2       6.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% int rows (value < 7864320):    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                11961          11975           9          1.3         760.5       1.0X
-Parquet Vectorized (Pushdown)                      8018           8027           7          2.0         509.8       1.5X
-Native ORC Vectorized                              9329           9340           8          1.7         593.2       1.3X
-Native ORC Vectorized (Pushdown)                   6739           6747           6          2.3         428.5       1.8X
+Parquet Vectorized                                13171          13221          75          1.2         837.4       1.0X
+Parquet Vectorized (Pushdown)                      8576           8601          17          1.8         545.2       1.5X
+Native ORC Vectorized                              8951           9351         230          1.8         569.1       1.5X
+Native ORC Vectorized (Pushdown)                   6567           6735          97          2.4         417.5       2.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% int rows (value < 14155776):   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                14621          14635          13          1.1         929.6       1.0X
-Parquet Vectorized (Pushdown)                     13884          13894          11          1.1         882.7       1.1X
-Native ORC Vectorized                             12085          12111          21          1.3         768.3       1.2X
-Native ORC Vectorized (Pushdown)                  11715          11723           6          1.3         744.8       1.2X
+Parquet Vectorized                                14256          15569         737          1.1         906.4       1.0X
+Parquet Vectorized (Pushdown)                     14932          14996          87          1.1         949.3       1.0X
+Native ORC Vectorized                             12178          12304          92          1.3         774.2       1.2X
+Native ORC Vectorized (Pushdown)                  11609          11719          94          1.4         738.1       1.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all int rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                15248          15266          12          1.0         969.4       1.0X
-Parquet Vectorized (Pushdown)                     15311          15320           7          1.0         973.4       1.0X
-Native ORC Vectorized                             12631          12650          18          1.2         803.1       1.2X
-Native ORC Vectorized (Pushdown)                  12816          12845          22          1.2         814.8       1.2X
+Parquet Vectorized                                16179          16414         134          1.0        1028.6       1.0X
+Parquet Vectorized (Pushdown)                     16469          16502          35          1.0        1047.0       1.0X
+Native ORC Vectorized                             12527          12717         170          1.3         796.5       1.3X
+Native ORC Vectorized (Pushdown)                  12259          12758         324          1.3         779.4       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all int rows (value > -1):         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                15223          15238          20          1.0         967.8       1.0X
-Parquet Vectorized (Pushdown)                     15273          15284          11          1.0         971.0       1.0X
-Native ORC Vectorized                             12636          12645           6          1.2         803.4       1.2X
-Native ORC Vectorized (Pushdown)                  12808          12825          10          1.2         814.3       1.2X
+Parquet Vectorized                                16485          16519          32          1.0        1048.1       1.0X
+Parquet Vectorized (Pushdown)                     16313          16530         155          1.0        1037.1       1.0X
+Native ORC Vectorized                             12357          12592         147          1.3         785.6       1.3X
+Native ORC Vectorized (Pushdown)                  12212          12625         237          1.3         776.4       1.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all int rows (value != -1):        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                15277          15403         257          1.0         971.3       1.0X
-Parquet Vectorized (Pushdown)                     15342          15354          15          1.0         975.4       1.0X
-Native ORC Vectorized                             12634          12644          10          1.2         803.2       1.2X
-Native ORC Vectorized (Pushdown)                  12805          12820          14          1.2         814.1       1.2X
+Parquet Vectorized                                14628          15501         735          1.1         930.0       1.0X
+Parquet Vectorized (Pushdown)                     16459          16488          34          1.0        1046.5       0.9X
+Native ORC Vectorized                             12628          12723          60          1.2         802.9       1.2X
+Native ORC Vectorized (Pushdown)                  11419          12132         626          1.4         726.0       1.3X
 
 
 ================================================================================================
 Pushdown for few distinct value case (use dictionary encoding)
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 distinct string row (value IS NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8114           8948        1033          1.9         515.9       1.0X
-Parquet Vectorized (Pushdown)                           498            503           8         31.6          31.6      16.3X
-Native ORC Vectorized                                  7355           7906        1198          2.1         467.6       1.1X
-Native ORC Vectorized (Pushdown)                        893            917          45         17.6          56.8       9.1X
+Parquet Vectorized                                     9249           9597         435          1.7         588.0       1.0X
+Parquet Vectorized (Pushdown)                           471            484          26         33.4          29.9      19.6X
+Native ORC Vectorized                                  7615           8225        1196          2.1         484.1       1.2X
+Native ORC Vectorized (Pushdown)                        872            934          66         18.0          55.4      10.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 0 distinct string row ('100' < value < '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                             8262           8279          16          1.9         525.3       1.0X
-Parquet Vectorized (Pushdown)                                   505            510           9         31.1          32.1      16.3X
-Native ORC Vectorized                                          7631           7653          25          2.1         485.1       1.1X
-Native ORC Vectorized (Pushdown)                                902            918          32         17.4          57.3       9.2X
+Parquet Vectorized                                             9078           9471         226          1.7         577.2       1.0X
+Parquet Vectorized (Pushdown)                                   478            490          15         32.9          30.4      19.0X
+Native ORC Vectorized                                          7763           7823          60          2.0         493.6       1.2X
+Native ORC Vectorized (Pushdown)                                816            892          77         19.3          51.9      11.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 distinct string row (value = '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     8178           8195          14          1.9         520.0       1.0X
-Parquet Vectorized (Pushdown)                           565            575          11         27.8          35.9      14.5X
-Native ORC Vectorized                                  7522           7534          12          2.1         478.2       1.1X
-Native ORC Vectorized (Pushdown)                        952            983          40         16.5          60.5       8.6X
+Parquet Vectorized                                     8486           9028         394          1.9         539.5       1.0X
+Parquet Vectorized (Pushdown)                           549            563          13         28.6          34.9      15.4X
+Native ORC Vectorized                                  7788           7844          80          2.0         495.1       1.1X
+Native ORC Vectorized (Pushdown)                        926            987          46         17.0          58.8       9.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 distinct string row (value <=> '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                       8170           8190          23          1.9         519.4       1.0X
-Parquet Vectorized (Pushdown)                             557            566           9         28.2          35.4      14.7X
-Native ORC Vectorized                                    7537           7550          11          2.1         479.2       1.1X
-Native ORC Vectorized (Pushdown)                          946            977          42         16.6          60.1       8.6X
+Parquet Vectorized                                       9384          10306         NaN          1.7         596.6       1.0X
+Parquet Vectorized (Pushdown)                             482            521          32         32.6          30.6      19.5X
+Native ORC Vectorized                                    7479           7771         167          2.1         475.5       1.3X
+Native ORC Vectorized (Pushdown)                          922            946          38         17.1          58.6      10.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 distinct string row ('100' <= value <= '100'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               8274           8287          10          1.9         526.1       1.0X
-Parquet Vectorized (Pushdown)                                     559            568          10         28.1          35.6      14.8X
-Native ORC Vectorized                                            7638           7649          14          2.1         485.6       1.1X
-Native ORC Vectorized (Pushdown)                                  951            985          43         16.5          60.4       8.7X
+Parquet Vectorized                                               8984           9473         301          1.8         571.2       1.0X
+Parquet Vectorized (Pushdown)                                     492            541          29         32.0          31.3      18.3X
+Native ORC Vectorized                                            7459           7812         198          2.1         474.2       1.2X
+Native ORC Vectorized (Pushdown)                                  928            990          79         17.0          59.0       9.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select all distinct string rows (value IS NOT NULL):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           16320          16340          21          1.0        1037.6       1.0X
-Parquet Vectorized (Pushdown)                                16350          16377          17          1.0        1039.5       1.0X
-Native ORC Vectorized                                        15504          15519          12          1.0         985.7       1.1X
-Native ORC Vectorized (Pushdown)                             15903          15915          14          1.0        1011.1       1.0X
+Parquet Vectorized                                           17691          17789          84          0.9        1124.7       1.0X
+Parquet Vectorized (Pushdown)                                17775          17863          72          0.9        1130.1       1.0X
+Native ORC Vectorized                                        15730          15964         203          1.0        1000.1       1.1X
+Native ORC Vectorized (Pushdown)                             16405          16521         106          1.0        1043.0       1.1X
 
 
 ================================================================================================
 Pushdown benchmark for StringStartsWith
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 StringStartsWith filter: (value like '10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                    9291          10470        1189          1.7         590.7       1.0X
-Parquet Vectorized (Pushdown)                         1382           1393          10         11.4          87.9       6.7X
-Native ORC Vectorized                                 6549           7152        1317          2.4         416.4       1.4X
-Native ORC Vectorized (Pushdown)                      6724           6728           3          2.3         427.5       1.4X
+Parquet Vectorized                                   11328          12986        1138          1.4         720.2       1.0X
+Parquet Vectorized (Pushdown)                         1315           1387          74         12.0          83.6       8.6X
+Native ORC Vectorized                                 6337           7318         NaN          2.5         402.9       1.8X
+Native ORC Vectorized (Pushdown)                      6808           6869          89          2.3         432.8       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 StringStartsWith filter: (value like '1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      9066           9124         110          1.7         576.4       1.0X
-Parquet Vectorized (Pushdown)                            575            583          10         27.3          36.6      15.8X
-Native ORC Vectorized                                   6364           6412          86          2.5         404.6       1.4X
-Native ORC Vectorized (Pushdown)                        6548           6559          11          2.4         416.3       1.4X
+Parquet Vectorized                                     10598          10792         374          1.5         673.8       1.0X
+Parquet Vectorized (Pushdown)                            545            555          13         28.9          34.6      19.5X
+Native ORC Vectorized                                   6241           6513         182          2.5         396.8       1.7X
+Native ORC Vectorized (Pushdown)                        6337           6632         176          2.5         402.9       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 StringStartsWith filter: (value like '786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        9056           9110         104          1.7         575.7       1.0X
-Parquet Vectorized (Pushdown)                              568            577          15         27.7          36.1      15.9X
-Native ORC Vectorized                                     6354           6364          10          2.5         403.9       1.4X
-Native ORC Vectorized (Pushdown)                          6527           6533           9          2.4         415.0       1.4X
+Parquet Vectorized                                        9642          10349         602          1.6         613.0       1.0X
+Parquet Vectorized (Pushdown)                              482            547          46         32.6          30.6      20.0X
+Native ORC Vectorized                                     6162           6470         193          2.6         391.8       1.6X
+Native ORC Vectorized (Pushdown)                          6634           6655          22          2.4         421.8       1.5X
+
+
+================================================================================================
+Pushdown benchmark for StringEndsWith
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringEndsWith filter: (value like '%10'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                  9713          10936         981          1.6         617.6       1.0X
+Parquet Vectorized (Pushdown)                        633            682          38         24.9          40.2      15.3X
+Native ORC Vectorized                               7075           8071        1484          2.2         449.8       1.4X
+Native ORC Vectorized (Pushdown)                    8120           8160          34          1.9         516.3       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringEndsWith filter: (value like '%1000'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                    8963           9371         232          1.8         569.8       1.0X
+Parquet Vectorized (Pushdown)                          539            554          18         29.2          34.3      16.6X
+Native ORC Vectorized                                 7745           7802          45          2.0         492.4       1.2X
+Native ORC Vectorized (Pushdown)                      7912           8118         147          2.0         503.0       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringEndsWith filter: (value like '%786432'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                      9440           9500          65          1.7         600.2       1.0X
+Parquet Vectorized (Pushdown)                            538            549          20         29.2          34.2      17.6X
+Native ORC Vectorized                                   7002           7473         303          2.2         445.2       1.3X
+Native ORC Vectorized (Pushdown)                        8052           8098          52          2.0         511.9       1.2X
+
+
+================================================================================================
+Pushdown benchmark for StringContains
+================================================================================================
+
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringContains filter: (value like '%10%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                   9782          10528         968          1.6         621.9       1.0X
+Parquet Vectorized (Pushdown)                        1297           1317          14         12.1          82.4       7.5X
+Native ORC Vectorized                                7995           8568        1153          2.0         508.3       1.2X
+Native ORC Vectorized (Pushdown)                     7814           8229         232          2.0         496.8       1.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringContains filter: (value like '%1000%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                     9408           9438          29          1.7         598.1       1.0X
+Parquet Vectorized (Pushdown)                           538            553          17         29.2          34.2      17.5X
+Native ORC Vectorized                                  7779           7847          91          2.0         494.6       1.2X
+Native ORC Vectorized (Pushdown)                       7669           7970         183          2.1         487.6       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+StringContains filter: (value like '%786432%'):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------
+Parquet Vectorized                                       9413           9491         137          1.7         598.4       1.0X
+Parquet Vectorized (Pushdown)                             530            542          17         29.7          33.7      17.7X
+Native ORC Vectorized                                    7626           7813         106          2.1         484.9       1.2X
+Native ORC Vectorized (Pushdown)                         8053           8139         105          2.0         512.0       1.2X
 
 
 ================================================================================================
 Pushdown benchmark for decimal
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 decimal(9, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                     3530           3593         113          4.5         224.4       1.0X
-Parquet Vectorized (Pushdown)                           135            141          12        116.3           8.6      26.1X
-Native ORC Vectorized                                  4375           4457         146          3.6         278.1       0.8X
-Native ORC Vectorized (Pushdown)                        169            180          35         93.2          10.7      20.9X
+Parquet Vectorized                                     4796           4822          33          3.3         304.9       1.0X
+Parquet Vectorized (Pushdown)                           136            142           9        115.8           8.6      35.3X
+Native ORC Vectorized                                  4364           4515          87          3.6         277.5       1.1X
+Native ORC Vectorized (Pushdown)                        167            178          20         94.2          10.6      28.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% decimal(9, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        4919           4930          12          3.2         312.7       1.0X
-Parquet Vectorized (Pushdown)                             2211           2217           8          7.1         140.6       2.2X
-Native ORC Vectorized                                     5758           5762           2          2.7         366.1       0.9X
-Native ORC Vectorized (Pushdown)                          2389           2400           7          6.6         151.9       2.1X
+Parquet Vectorized                                        6219           6274          48          2.5         395.4       1.0X
+Parquet Vectorized (Pushdown)                             2259           2493         136          7.0         143.6       2.8X
+Native ORC Vectorized                                     5867           5925          57          2.7         373.0       1.1X
+Native ORC Vectorized (Pushdown)                          2285           2437         130          6.9         145.3       2.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% decimal(9, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        9490           9502          12          1.7         603.4       1.0X
-Parquet Vectorized (Pushdown)                             9048           9057          13          1.7         575.2       1.0X
-Native ORC Vectorized                                    10320          10335          13          1.5         656.1       0.9X
-Native ORC Vectorized (Pushdown)                          9816           9827          11          1.6         624.1       1.0X
+Parquet Vectorized                                       10201          10778         341          1.5         648.6       1.0X
+Parquet Vectorized (Pushdown)                             9422           9912         362          1.7         599.0       1.1X
+Native ORC Vectorized                                    10277          10550         170          1.5         653.4       1.0X
+Native ORC Vectorized (Pushdown)                          9784           9985         161          1.6         622.1       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% decimal(9, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        10666          10694          25          1.5         678.1       1.0X
-Parquet Vectorized (Pushdown)                             10693          10705          13          1.5         679.9       1.0X
-Native ORC Vectorized                                     13144          13155           9          1.2         835.7       0.8X
-Native ORC Vectorized (Pushdown)                          13208          13219          15          1.2         839.8       0.8X
+Parquet Vectorized                                        11899          12161         163          1.3         756.5       1.0X
+Parquet Vectorized (Pushdown)                             11348          12024         409          1.4         721.5       1.0X
+Native ORC Vectorized                                     11676          11822          93          1.3         742.4       1.0X
+Native ORC Vectorized (Pushdown)                          11736          11847          90          1.3         746.2       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 decimal(18, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      3672           3696          20          4.3         233.5       1.0X
-Parquet Vectorized (Pushdown)                            136            140           5        115.5           8.7      27.0X
-Native ORC Vectorized                                   4377           4392          12          3.6         278.3       0.8X
-Native ORC Vectorized (Pushdown)                         164            170          15         95.8          10.4      22.4X
+Parquet Vectorized                                      4986           4990           5          3.2         317.0       1.0X
+Parquet Vectorized (Pushdown)                            138            143          10        114.3           8.8      36.2X
+Native ORC Vectorized                                   4586           4649          49          3.4         291.5       1.1X
+Native ORC Vectorized (Pushdown)                         163            176          27         96.3          10.4      30.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% decimal(18, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         4430           4458          34          3.6         281.7       1.0X
-Parquet Vectorized (Pushdown)                              1231           1239           6         12.8          78.3       3.6X
-Native ORC Vectorized                                      5101           5106           7          3.1         324.3       0.9X
-Native ORC Vectorized (Pushdown)                           1302           1311           7         12.1          82.8       3.4X
+Parquet Vectorized                                         5753           5836          76          2.7         365.8       1.0X
+Parquet Vectorized (Pushdown)                              1358           1380          19         11.6          86.3       4.2X
+Native ORC Vectorized                                      5117           5342         140          3.1         325.3       1.1X
+Native ORC Vectorized (Pushdown)                           1311           1337          36         12.0          83.3       4.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% decimal(18, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         7353           7373          15          2.1         467.5       1.0X
-Parquet Vectorized (Pushdown)                              5592           5601           7          2.8         355.5       1.3X
-Native ORC Vectorized                                      7943           7957          10          2.0         505.0       0.9X
-Native ORC Vectorized (Pushdown)                           5870           5880          13          2.7         373.2       1.3X
+Parquet Vectorized                                         8633           8649          21          1.8         548.9       1.0X
+Parquet Vectorized (Pushdown)                              5565           5736         371          2.8         353.8       1.6X
+Native ORC Vectorized                                      8083           8113          25          1.9         513.9       1.1X
+Native ORC Vectorized (Pushdown)                           5767           5968         114          2.7         366.7       1.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% decimal(18, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         10221          10235          14          1.5         649.9       1.0X
-Parquet Vectorized (Pushdown)                               9875           9907          29          1.6         627.8       1.0X
-Native ORC Vectorized                                      10756          10768           8          1.5         683.8       1.0X
-Native ORC Vectorized (Pushdown)                           10389          10400           9          1.5         660.5       1.0X
+Parquet Vectorized                                         10562          11064         425          1.5         671.5       1.0X
+Parquet Vectorized (Pushdown)                              10224          10722         393          1.5         650.1       1.0X
+Native ORC Vectorized                                      10843          10862          22          1.5         689.4       1.0X
+Native ORC Vectorized (Pushdown)                           10148          10381         177          1.5         645.2       1.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 decimal(38, 2) row (value = 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                      5580           5603          20          2.8         354.8       1.0X
-Parquet Vectorized (Pushdown)                            149            152           4        105.4           9.5      37.4X
-Native ORC Vectorized                                   4389           4399           7          3.6         279.0       1.3X
-Native ORC Vectorized (Pushdown)                         164            171          18         95.9          10.4      34.0X
+Parquet Vectorized                                      6258           6872         366          2.5         397.8       1.0X
+Parquet Vectorized (Pushdown)                            147            152           8        107.0           9.3      42.6X
+Native ORC Vectorized                                   4590           4651          50          3.4         291.8       1.4X
+Native ORC Vectorized (Pushdown)                         152            179          22        103.3           9.7      41.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% decimal(38, 2) rows (value < 1572864):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         6516           6534          16          2.4         414.3       1.0X
-Parquet Vectorized (Pushdown)                              1620           1623           3          9.7         103.0       4.0X
-Native ORC Vectorized                                      5284           5288           6          3.0         335.9       1.2X
-Native ORC Vectorized (Pushdown)                           1466           1473          12         10.7          93.2       4.4X
+Parquet Vectorized                                         7711           7916         173          2.0         490.3       1.0X
+Parquet Vectorized (Pushdown)                              1751           1773          18          9.0         111.3       4.4X
+Native ORC Vectorized                                      5327           5464          81          3.0         338.7       1.4X
+Native ORC Vectorized (Pushdown)                           1481           1499          36         10.6          94.1       5.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% decimal(38, 2) rows (value < 7864320):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                        10168          10189          18          1.5         646.4       1.0X
-Parquet Vectorized (Pushdown)                              7472           7517          33          2.1         475.0       1.4X
-Native ORC Vectorized                                      8782           8795          11          1.8         558.4       1.2X
-Native ORC Vectorized (Pushdown)                           6671           6696          21          2.4         424.2       1.5X
+Parquet Vectorized                                        11614          11665          56          1.4         738.4       1.0X
+Parquet Vectorized (Pushdown)                              7807           8159         237          2.0         496.3       1.5X
+Native ORC Vectorized                                      8932           8998         129          1.8         567.9       1.3X
+Native ORC Vectorized (Pushdown)                           6776           6841          48          2.3         430.8       1.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% decimal(38, 2) rows (value < 14155776):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                         13808          14420        1196          1.1         877.9       1.0X
-Parquet Vectorized (Pushdown)                              13319          13391          90          1.2         846.8       1.0X
-Native ORC Vectorized                                      12205          12227          24          1.3         776.0       1.1X
-Native ORC Vectorized (Pushdown)                           11830          11860          28          1.3         752.2       1.2X
+Parquet Vectorized                                         14324          14958         451          1.1         910.7       1.0X
+Parquet Vectorized (Pushdown)                              14529          14614          64          1.1         923.7       1.0X
+Native ORC Vectorized                                      12359          12471         113          1.3         785.8       1.2X
+Native ORC Vectorized (Pushdown)                           11961          12048          66          1.3         760.5       1.2X
 
 
 ================================================================================================
 Pushdown benchmark for InSet -> InFilters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 5, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               8737           9914         NaN          1.8         555.5       1.0X
-Parquet Vectorized (Pushdown)                                     585            618          72         26.9          37.2      14.9X
-Native ORC Vectorized                                            6016           6776        1444          2.6         382.5       1.5X
-Native ORC Vectorized (Pushdown)                                  497            536          81         31.6          31.6      17.6X
+Parquet Vectorized                                               9590          11618         NaN          1.6         609.7       1.0X
+Parquet Vectorized (Pushdown)                                     558            569          12         28.2          35.5      17.2X
+Native ORC Vectorized                                            5954           6612        1410          2.6         378.5       1.6X
+Native ORC Vectorized (Pushdown)                                  441            485          53         35.6          28.1      21.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 5, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               8522           8575          45          1.8         541.8       1.0X
-Parquet Vectorized (Pushdown)                                     583            590           7         27.0          37.1      14.6X
-Native ORC Vectorized                                            5907           5917          12          2.7         375.6       1.4X
-Native ORC Vectorized (Pushdown)                                  498            544          65         31.6          31.7      17.1X
+Parquet Vectorized                                               9258           9693         281          1.7         588.6       1.0X
+Parquet Vectorized (Pushdown)                                     563            584          15         28.0          35.8      16.5X
+Native ORC Vectorized                                            5926           5974          52          2.7         376.8       1.6X
+Native ORC Vectorized (Pushdown)                                  486            523          47         32.4          30.9      19.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 5, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               8505           8600         154          1.8         540.7       1.0X
-Parquet Vectorized (Pushdown)                                     585            589           8         26.9          37.2      14.5X
-Native ORC Vectorized                                            5909           5927          21          2.7         375.7       1.4X
-Native ORC Vectorized (Pushdown)                                  498            518          40         31.6          31.6      17.1X
+Parquet Vectorized                                               9787           9944         149          1.6         622.2       1.0X
+Parquet Vectorized (Pushdown)                                     558            564           7         28.2          35.5      17.5X
+Native ORC Vectorized                                            5954           6015          62          2.6         378.5       1.6X
+Native ORC Vectorized (Pushdown)                                  485            524          45         32.4          30.8      20.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 10, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8520           8631         184          1.8         541.7       1.0X
-Parquet Vectorized (Pushdown)                                      605            610           6         26.0          38.5      14.1X
-Native ORC Vectorized                                             5925           5936          11          2.7         376.7       1.4X
-Native ORC Vectorized (Pushdown)                                   515            534          35         30.5          32.8      16.5X
+Parquet Vectorized                                                9798          10304         801          1.6         622.9       1.0X
+Parquet Vectorized (Pushdown)                                      584            599          17         26.9          37.1      16.8X
+Native ORC Vectorized                                             5969           5984          13          2.6         379.5       1.6X
+Native ORC Vectorized (Pushdown)                                   501            519          36         31.4          31.8      19.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 10, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8532           8650         223          1.8         542.5       1.0X
-Parquet Vectorized (Pushdown)                                      614            617           3         25.6          39.0      13.9X
-Native ORC Vectorized                                             5951           5963          13          2.6         378.4       1.4X
-Native ORC Vectorized (Pushdown)                                   520            538          36         30.3          33.0      16.4X
+Parquet Vectorized                                                9452           9777         202          1.7         600.9       1.0X
+Parquet Vectorized (Pushdown)                                      581            595          17         27.1          37.0      16.3X
+Native ORC Vectorized                                             5968           5988          36          2.6         379.4       1.6X
+Native ORC Vectorized (Pushdown)                                   504            522          32         31.2          32.1      18.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 10, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8515           8550          27          1.8         541.3       1.0X
-Parquet Vectorized (Pushdown)                                      614            617           5         25.6          39.0      13.9X
-Native ORC Vectorized                                             5940           5950           8          2.6         377.7       1.4X
-Native ORC Vectorized (Pushdown)                                   513            532          33         30.6          32.6      16.6X
+Parquet Vectorized                                                9607           9792         170          1.6         610.8       1.0X
+Parquet Vectorized (Pushdown)                                      527            573          45         29.8          33.5      18.2X
+Native ORC Vectorized                                             5851           6087         133          2.7         372.0       1.6X
+Native ORC Vectorized (Pushdown)                                   500            521          38         31.4          31.8      19.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 50, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8854           8872          18          1.8         563.0       1.0X
-Parquet Vectorized (Pushdown)                                     1390           1396           6         11.3          88.4       6.4X
-Native ORC Vectorized                                             6241           6343          68          2.5         396.8       1.4X
-Native ORC Vectorized (Pushdown)                                   641            668          31         24.5          40.8      13.8X
+Parquet Vectorized                                                9469           9996         298          1.7         602.0       1.0X
+Parquet Vectorized (Pushdown)                                     1480           1493          14         10.6          94.1       6.4X
+Native ORC Vectorized                                             6265           6278          17          2.5         398.3       1.5X
+Native ORC Vectorized (Pushdown)                                   623            691          38         25.2          39.6      15.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 50, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8859           8863           3          1.8         563.2       1.0X
-Parquet Vectorized (Pushdown)                                     4449           4454           5          3.5         282.9       2.0X
-Native ORC Vectorized                                             6366           6379          11          2.5         404.7       1.4X
-Native ORC Vectorized (Pushdown)                                   654            675          39         24.1          41.6      13.6X
+Parquet Vectorized                                                9566          10022         334          1.6         608.2       1.0X
+Parquet Vectorized (Pushdown)                                     4660           5049         224          3.4         296.3       2.1X
+Native ORC Vectorized                                             6267           6303          50          2.5         398.5       1.5X
+Native ORC Vectorized (Pushdown)                                   656            704          42         24.0          41.7      14.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 50, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                8836           8845          13          1.8         561.8       1.0X
-Parquet Vectorized (Pushdown)                                     7934           7941           9          2.0         504.4       1.1X
-Native ORC Vectorized                                             6215           6220           4          2.5         395.1       1.4X
-Native ORC Vectorized (Pushdown)                                   666            698          36         23.6          42.3      13.3X
+Parquet Vectorized                                                9321           9914         371          1.7         592.6       1.0X
+Parquet Vectorized (Pushdown)                                     8505           8702         118          1.8         540.7       1.1X
+Native ORC Vectorized                                             6089           6240          85          2.6         387.1       1.5X
+Native ORC Vectorized (Pushdown)                                   654            695          37         24.0          41.6      14.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 100, distribution: 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 8769           8774           6          1.8         557.5       1.0X
-Parquet Vectorized (Pushdown)                                      1379           1391          12         11.4          87.6       6.4X
-Native ORC Vectorized                                              6142           6155          22          2.6         390.5       1.4X
-Native ORC Vectorized (Pushdown)                                    759            785          32         20.7          48.3      11.5X
+Parquet Vectorized                                                 9772           9993         127          1.6         621.3       1.0X
+Parquet Vectorized (Pushdown)                                      1345           1466         122         11.7          85.5       7.3X
+Native ORC Vectorized                                              6200           6267         103          2.5         394.2       1.6X
+Native ORC Vectorized (Pushdown)                                    744            783          33         21.1          47.3      13.1X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 100, distribution: 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 8763           8833         143          1.8         557.1       1.0X
-Parquet Vectorized (Pushdown)                                      4659           4674          10          3.4         296.2       1.9X
-Native ORC Vectorized                                              6133           6137           4          2.6         389.9       1.4X
-Native ORC Vectorized (Pushdown)                                    847            871          25         18.6          53.8      10.3X
+Parquet Vectorized                                                 9880          10074         152          1.6         628.1       1.0X
+Parquet Vectorized (Pushdown)                                      4670           5085         251          3.4         296.9       2.1X
+Native ORC Vectorized                                              5895           6129         131          2.7         374.8       1.7X
+Native ORC Vectorized (Pushdown)                                    849            934          68         18.5          54.0      11.6X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 InSet -> InFilters (values count: 100, distribution: 90):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                 8784          11179         870          1.8         558.5       1.0X
-Parquet Vectorized (Pushdown)                                      7928           7933           6          2.0         504.0       1.1X
-Native ORC Vectorized                                              6158           7225        1010          2.6         391.5       1.4X
-Native ORC Vectorized (Pushdown)                                    852            875          27         18.5          54.1      10.3X
+Parquet Vectorized                                                 9556           9926         213          1.6         607.6       1.0X
+Parquet Vectorized (Pushdown)                                      8856           8905          61          1.8         563.0       1.1X
+Native ORC Vectorized                                              6137           6173          51          2.6         390.2       1.6X
+Native ORC Vectorized (Pushdown)                                    836            898          49         18.8          53.2      11.4X
 
 
 ================================================================================================
 Pushdown benchmark for tinyint
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 tinyint row (value = CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                           3932           4116         221          4.0         250.0       1.0X
-Parquet Vectorized (Pushdown)                                 184            187           6         85.5          11.7      21.4X
-Native ORC Vectorized                                        2624           2642          35          6.0         166.8       1.5X
-Native ORC Vectorized (Pushdown)                              219            226          18         71.9          13.9      18.0X
+Parquet Vectorized                                           5197           5225          33          3.0         330.4       1.0X
+Parquet Vectorized (Pushdown)                                 190            195           7         82.8          12.1      27.3X
+Native ORC Vectorized                                        2550           2585          40          6.2         162.2       2.0X
+Native ORC Vectorized (Pushdown)                              212            228          27         74.3          13.5      24.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% tinyint rows (value < CAST(12 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              4574           4767         400          3.4         290.8       1.0X
-Parquet Vectorized (Pushdown)                                   1162           1171           6         13.5          73.9       3.9X
-Native ORC Vectorized                                           3250           3263          22          4.8         206.6       1.4X
-Native ORC Vectorized (Pushdown)                                1059           1070           9         14.9          67.3       4.3X
+Parquet Vectorized                                              5806           5866          58          2.7         369.1       1.0X
+Parquet Vectorized (Pushdown)                                   1254           1316          53         12.5          79.7       4.6X
+Native ORC Vectorized                                           3211           3215           4          4.9         204.1       1.8X
+Native ORC Vectorized (Pushdown)                                1062           1071          12         14.8          67.5       5.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% tinyint rows (value < CAST(63 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                              7254           7269          10          2.2         461.2       1.0X
-Parquet Vectorized (Pushdown)                                   5393           5402          14          2.9         342.9       1.3X
-Native ORC Vectorized                                           5798           5821          14          2.7         368.6       1.3X
-Native ORC Vectorized (Pushdown)                                4622           4627           4          3.4         293.8       1.6X
+Parquet Vectorized                                              8326           8498         123          1.9         529.3       1.0X
+Parquet Vectorized (Pushdown)                                   6037           6106          66          2.6         383.8       1.4X
+Native ORC Vectorized                                           5724           5796          45          2.7         363.9       1.5X
+Native ORC Vectorized (Pushdown)                                4638           4652          19          3.4         294.9       1.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% tinyint rows (value < CAST(114 AS tinyint)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                               9951           9964          11          1.6         632.7       1.0X
-Parquet Vectorized (Pushdown)                                    9603           9617          25          1.6         610.5       1.0X
-Native ORC Vectorized                                            8411           8432          27          1.9         534.8       1.2X
-Native ORC Vectorized (Pushdown)                                 8218           8226           7          1.9         522.5       1.2X
+Parquet Vectorized                                              10622          11327         418          1.5         675.3       1.0X
+Parquet Vectorized (Pushdown)                                   10144          10719         333          1.6         644.9       1.0X
+Native ORC Vectorized                                            7425           8222         463          2.1         472.1       1.4X
+Native ORC Vectorized (Pushdown)                                 7305           8035         409          2.2         464.5       1.5X
 
 
 ================================================================================================
 Pushdown benchmark for Timestamp
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 timestamp stored as INT96 row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                    4187           4209          27          3.8         266.2       1.0X
-Parquet Vectorized (Pushdown)                                                         4192           4197           5          3.8         266.5       1.0X
-Native ORC Vectorized                                                                 2748           2762          17          5.7         174.7       1.5X
-Native ORC Vectorized (Pushdown)                                                       138            144          16        114.2           8.8      30.4X
+Parquet Vectorized                                                                    5508           5573          69          2.9         350.2       1.0X
+Parquet Vectorized (Pushdown)                                                         5497           5544          89          2.9         349.5       1.0X
+Native ORC Vectorized                                                                 2420           2525         131          6.5         153.8       2.3X
+Native ORC Vectorized (Pushdown)                                                       137            144          15        115.1           8.7      40.3X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% timestamp stored as INT96 rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       4941           4959          12          3.2         314.1       1.0X
-Parquet Vectorized (Pushdown)                                                            4940           4950           9          3.2         314.1       1.0X
-Native ORC Vectorized                                                                    3441           3450           6          4.6         218.8       1.4X
-Native ORC Vectorized (Pushdown)                                                         1103           1114          10         14.3          70.1       4.5X
+Parquet Vectorized                                                                       6255           6330         100          2.5         397.7       1.0X
+Parquet Vectorized (Pushdown)                                                            6170           6252          61          2.5         392.3       1.0X
+Native ORC Vectorized                                                                    3365           3374           7          4.7         213.9       1.9X
+Native ORC Vectorized (Pushdown)                                                          959            976          13         16.4          61.0       6.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% timestamp stored as INT96 rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       7869           7883          17          2.0         500.3       1.0X
-Parquet Vectorized (Pushdown)                                                            7867           7881          10          2.0         500.2       1.0X
-Native ORC Vectorized                                                                    6200           6226          20          2.5         394.2       1.3X
-Native ORC Vectorized (Pushdown)                                                         4921           4937          18          3.2         312.9       1.6X
+Parquet Vectorized                                                                       9044           9134          59          1.7         575.0       1.0X
+Parquet Vectorized (Pushdown)                                                            8816           8965         146          1.8         560.5       1.0X
+Native ORC Vectorized                                                                    6038           6053          14          2.6         383.9       1.5X
+Native ORC Vectorized (Pushdown)                                                         4790           4810          16          3.3         304.6       1.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% timestamp stored as INT96 rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                       10750          10766           9          1.5         683.5       1.0X
-Parquet Vectorized (Pushdown)                                                            10737          10758          20          1.5         682.6       1.0X
-Native ORC Vectorized                                                                     8947           8981          49          1.8         568.9       1.2X
-Native ORC Vectorized (Pushdown)                                                          8720           8728           8          1.8         554.4       1.2X
+Parquet Vectorized                                                                       11786          11979         151          1.3         749.3       1.0X
+Parquet Vectorized (Pushdown)                                                            11463          11795         225          1.4         728.8       1.0X
+Native ORC Vectorized                                                                     8459           8709         156          1.9         537.8       1.4X
+Native ORC Vectorized (Pushdown)                                                          7979           8447         425          2.0         507.3       1.5X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 timestamp stored as TIMESTAMP_MICROS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               3610           3621          11          4.4         229.5       1.0X
-Parquet Vectorized (Pushdown)                                                                     135            139           6        116.2           8.6      26.7X
-Native ORC Vectorized                                                                            2741           2753          19          5.7         174.3       1.3X
-Native ORC Vectorized (Pushdown)                                                                  135            142          16        116.2           8.6      26.7X
+Parquet Vectorized                                                                               4436           4800         228          3.5         282.1       1.0X
+Parquet Vectorized (Pushdown)                                                                     137            143           7        114.5           8.7      32.3X
+Native ORC Vectorized                                                                            2676           2688          15          5.9         170.2       1.7X
+Native ORC Vectorized (Pushdown)                                                                  134            143          23        117.0           8.5      33.0X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  4365           4378           9          3.6         277.5       1.0X
-Parquet Vectorized (Pushdown)                                                                       1215           1226           9         13.0          77.2       3.6X
-Native ORC Vectorized                                                                               3434           3444           7          4.6         218.3       1.3X
-Native ORC Vectorized (Pushdown)                                                                    1095           1107          15         14.4          69.6       4.0X
+Parquet Vectorized                                                                                  5606           5657          60          2.8         356.5       1.0X
+Parquet Vectorized (Pushdown)                                                                       1334           1349          23         11.8          84.8       4.2X
+Native ORC Vectorized                                                                               3373           3408          62          4.7         214.5       1.7X
+Native ORC Vectorized (Pushdown)                                                                    1076           1110          33         14.6          68.4       5.2X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  7289           7310          24          2.2         463.4       1.0X
-Parquet Vectorized (Pushdown)                                                                       5567           5597          23          2.8         353.9       1.3X
-Native ORC Vectorized                                                                               6204           6243          33          2.5         394.4       1.2X
-Native ORC Vectorized (Pushdown)                                                                    4916           4938          21          3.2         312.6       1.5X
+Parquet Vectorized                                                                                  8446           8493          50          1.9         537.0       1.0X
+Parquet Vectorized (Pushdown)                                                                       6001           6108          67          2.6         381.5       1.4X
+Native ORC Vectorized                                                                               6034           6082          37          2.6         383.7       1.4X
+Native ORC Vectorized (Pushdown)                                                                    4791           4806          13          3.3         304.6       1.8X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% timestamp stored as TIMESTAMP_MICROS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  10119          10148          20          1.6         643.4       1.0X
-Parquet Vectorized (Pushdown)                                                                        9798           9824          21          1.6         622.9       1.0X
-Native ORC Vectorized                                                                                8953           8966           7          1.8         569.2       1.1X
-Native ORC Vectorized (Pushdown)                                                                     8730           8756          25          1.8         555.0       1.2X
+Parquet Vectorized                                                                                  11219          11315          84          1.4         713.3       1.0X
+Parquet Vectorized (Pushdown)                                                                       10295          10716         264          1.5         654.5       1.1X
+Native ORC Vectorized                                                                                8693           8798         112          1.8         552.7       1.3X
+Native ORC Vectorized (Pushdown)                                                                     7998           8362         239          2.0         508.5       1.4X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 timestamp stored as TIMESTAMP_MILLIS row (value = timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                               3782           3826          86          4.2         240.4       1.0X
-Parquet Vectorized (Pushdown)                                                                     135            138           6        116.4           8.6      28.0X
-Native ORC Vectorized                                                                            2733           2736           3          5.8         173.8       1.4X
-Native ORC Vectorized (Pushdown)                                                                  136            142          16        115.3           8.7      27.7X
+Parquet Vectorized                                                                               4622           5010         228          3.4         293.8       1.0X
+Parquet Vectorized (Pushdown)                                                                     121            136          15        129.7           7.7      38.1X
+Native ORC Vectorized                                                                            2395           2602         118          6.6         152.3       1.9X
+Native ORC Vectorized (Pushdown)                                                                  133            141          21        118.2           8.5      34.7X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 10% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(1572864)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  4521           4535          11          3.5         287.4       1.0X
-Parquet Vectorized (Pushdown)                                                                       1233           1244           9         12.8          78.4       3.7X
-Native ORC Vectorized                                                                               3428           3434           7          4.6         218.0       1.3X
-Native ORC Vectorized (Pushdown)                                                                    1094           1106          12         14.4          69.6       4.1X
+Parquet Vectorized                                                                                  5694           5797          68          2.8         362.0       1.0X
+Parquet Vectorized (Pushdown)                                                                       1296           1338          26         12.1          82.4       4.4X
+Native ORC Vectorized                                                                               3367           3408          52          4.7         214.1       1.7X
+Native ORC Vectorized (Pushdown)                                                                     960           1047          58         16.4          61.0       5.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 50% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(7864320)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  7434           7449          16          2.1         472.6       1.0X
-Parquet Vectorized (Pushdown)                                                                       5631           5664          23          2.8         358.0       1.3X
-Native ORC Vectorized                                                                               6194           6213          18          2.5         393.8       1.2X
-Native ORC Vectorized (Pushdown)                                                                    4912           4937          27          3.2         312.3       1.5X
+Parquet Vectorized                                                                                  8593           8688          77          1.8         546.3       1.0X
+Parquet Vectorized (Pushdown)                                                                       6022           6181         132          2.6         382.9       1.4X
+Native ORC Vectorized                                                                               5730           6013         195          2.7         364.3       1.5X
+Native ORC Vectorized (Pushdown)                                                                    4636           4813         103          3.4         294.8       1.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 90% timestamp stored as TIMESTAMP_MILLIS rows (value < timestamp_seconds(14155776)):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                                                                  10277          10290          12          1.5         653.4       1.0X
-Parquet Vectorized (Pushdown)                                                                        9939           9949           9          1.6         631.9       1.0X
-Native ORC Vectorized                                                                                8925           8932           5          1.8         567.4       1.2X
-Native ORC Vectorized (Pushdown)                                                                     8711           8722          13          1.8         553.8       1.2X
+Parquet Vectorized                                                                                  11111          11267          98          1.4         706.4       1.0X
+Parquet Vectorized (Pushdown)                                                                       10828          10901          83          1.5         688.4       1.0X
+Native ORC Vectorized                                                                                7966           8554         377          2.0         506.5       1.4X
+Native ORC Vectorized (Pushdown)                                                                     8306           8453         131          1.9         528.1       1.3X
 
 
 ================================================================================================
 Pushdown benchmark with many filters
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 row with 1 filters:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                  177            180           4          0.0   176597527.0       1.0X
-Parquet Vectorized (Pushdown)                       179            184           8          0.0   179049335.0       1.0X
-Native ORC Vectorized                               165            169           5          0.0   165392336.0       1.1X
-Native ORC Vectorized (Pushdown)                    177            181           5          0.0   177191031.0       1.0X
+Parquet Vectorized                                  165            181           9          0.0   165274170.0       1.0X
+Parquet Vectorized (Pushdown)                       182            193          22          0.0   182084552.0       0.9X
+Native ORC Vectorized                               154            169          10          0.0   153949658.0       1.1X
+Native ORC Vectorized (Pushdown)                    183            188           5          0.0   183334682.0       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 row with 250 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 1390           1660         299          0.0  1389636669.0       1.0X
-Parquet Vectorized (Pushdown)                      1448           1467          16          0.0  1447963287.0       1.0X
-Native ORC Vectorized                              1371           1396          19          0.0  1370726861.0       1.0X
-Native ORC Vectorized (Pushdown)                   1388           1415          20          0.0  1387966614.0       1.0X
+Parquet Vectorized                                 1655           2069         688          0.0  1655292270.0       1.0X
+Parquet Vectorized (Pushdown)                      1910           1918           9          0.0  1909884497.0       0.9X
+Native ORC Vectorized                              1848           1889          41          0.0  1847853824.0       0.9X
+Native ORC Vectorized (Pushdown)                   1862           1868           5          0.0  1861974825.0       0.9X
 
-OpenJDK 64-Bit Server VM 1.8.0_322-b06 on Linux 5.13.0-1021-azure
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
 Select 1 row with 500 filters:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Parquet Vectorized                                 6277           7015         918          0.0  6276800820.0       1.0X
-Parquet Vectorized (Pushdown)                      6398           6420          13          0.0  6398363663.0       1.0X
-Native ORC Vectorized                              6154           6202          28          0.0  6153717451.0       1.0X
-Native ORC Vectorized (Pushdown)                   6150           6191          29          0.0  6150438862.0       1.0X
+Parquet Vectorized                                 7721           8802        1054          0.0  7720771648.0       1.0X
+Parquet Vectorized (Pushdown)                      8444           8628         173          0.0  8443708092.0       0.9X
+Native ORC Vectorized                              7854           8339         283          0.0  7854189202.0       1.0X
+Native ORC Vectorized (Pushdown)                   7812           8325         310          0.0  7811643781.0       1.0X
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `FilterPushdownBenchmark` results.

### Why are the changes needed?

These PRs do not or do not fully update the `FilterPushdownBenchmark` results:
https://github.com/apache/spark/pull/36328
https://github.com/apache/spark/pull/36629
https://github.com/apache/spark/pull/36892

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.