### PR TITLE
[MINOR] Make the 'sep' description better in read_csv of pyspark p…

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -238,7 +238,7 @@ def read_csv(
     path : str
         The path string storing the CSV file to be read.
     sep : str, default ‘,’
-        Delimiter to use. Must be a single character.
+        Delimiter to use. Non empty string.
     header : int, default ‘infer’
         Whether to to use as the column names, and the start of the data.
         Default behavior is to infer the column names: if no names are passed


### PR DESCRIPTION
The 'sep' parameter supports a seperated string, which length is larger
than 1. So it doesn't only support a single character, but also a string
contains multiple characters.