### PR TITLE
[SPARK-39638][SQL] Change to use `ConstantColumnVector` to store partition columns in `OrcColumnarBatchReader`

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/orc/OrcColumnarBatchReader.java
@@ -34,6 +34,7 @@ import org.apache.orc.mapred.OrcInputFormat;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.orc.OrcShimUtils.VectorizedRowBatchWrap;
 import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
+import org.apache.spark.sql.execution.vectorized.ConstantColumnVector;
 import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
@@ -168,9 +169,8 @@ public class OrcColumnarBatchReader extends RecordReader<Void, ColumnarBatch> {
     for (int i = 0; i < requiredFields.length; i++) {
       DataType dt = requiredFields[i].dataType();
       if (requestedPartitionColIds[i] != -1) {
-        OnHeapColumnVector partitionCol = new OnHeapColumnVector(capacity, dt);
+        ConstantColumnVector partitionCol = new ConstantColumnVector(capacity, dt);
         ColumnVectorUtils.populate(partitionCol, partitionValues, requestedPartitionColIds[i]);
-        partitionCol.setIsConstant();
         orcVectorWrappers[i] = partitionCol;
       } else {
         int colId = requestedDataColIds[i];


### PR DESCRIPTION
### What changes were proposed in this pull request?
Similar of SPARK-39231, this pr change to use `ConstantColumnVector` to store partition columns in `OrcColumnarBatchReader`.


### Why are the changes needed?
Performance improvement and Memory saving, Similar to the description in https://github.com/apache/spark/pull/36616 



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub  Actions