### PR TITLE
[SPARK-39231][SQL][FOLLOWUP] Move `ColumnVectorUtils.allocateColumns` to `VectorizedParquetRecordReader`

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.spark.sql.execution.vectorized.*;
 import scala.collection.JavaConverters;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -38,6 +37,11 @@ import org.apache.parquet.schema.Type;
 
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
+import org.apache.spark.sql.execution.vectorized.ConstantColumnVector;
+import org.apache.spark.sql.execution.vectorized.OffHeapColumnVector;
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.types.StructField;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.spark.sql.execution.vectorized.*;
 import scala.collection.JavaConverters;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -36,9 +38,6 @@ import org.apache.parquet.schema.Type;
 
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.execution.vectorized.ColumnVectorUtils;
-import org.apache.spark.sql.execution.vectorized.ConstantColumnVector;
-import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.types.StructField;
@@ -251,7 +250,7 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
       constantColumnLength = partitionColumns.fields().length;
     }
 
-    ColumnVector[] vectors = ColumnVectorUtils.allocateColumns(
+    ColumnVector[] vectors = allocateColumns(
       capacity, batchSchema, memMode == MemoryMode.OFF_HEAP, constantColumnLength);
 
     columnarBatch = new ColumnarBatch(vectors);
@@ -414,5 +413,37 @@ public class VectorizedParquetRecordReader extends SpecificParquetRecordReaderBa
         }
       }
     }
+  }
+
+  /**
+   * <b>This method assumes that all constant column are at the end of schema
+   * and `constantColumnLength` represents the number of constant column.<b/>
+   *
+   * This method allocates columns to store elements of each field of the schema,
+   * the data columns use `OffHeapColumnVector` when `useOffHeap` is true and
+   * use `OnHeapColumnVector` when `useOffHeap` is false, the constant columns
+   * always use `ConstantColumnVector`.
+   *
+   * Capacity is the initial capacity of the vector, and it will grow as necessary.
+   * Capacity is in number of elements, not number of bytes.
+   */
+  private ColumnVector[] allocateColumns(
+      int capacity, StructType schema, boolean useOffHeap, int constantColumnLength) {
+    StructField[] fields = schema.fields();
+    int fieldsLength = fields.length;
+    ColumnVector[] vectors = new ColumnVector[fieldsLength];
+    if (useOffHeap) {
+      for (int i = 0; i < fieldsLength - constantColumnLength; i++) {
+        vectors[i] = new OffHeapColumnVector(capacity, fields[i].dataType());
+      }
+    } else {
+      for (int i = 0; i < fieldsLength - constantColumnLength; i++) {
+        vectors[i] = new OnHeapColumnVector(capacity, fields[i].dataType());
+      }
+    }
+    for (int i = fieldsLength - constantColumnLength; i < fieldsLength; i++) {
+      vectors[i] = new ConstantColumnVector(capacity, fields[i].dataType());
+    }
+    return vectors;
   }
 }

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedParquetRecordReader.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import scala.collection.JavaConverters;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
@@ -30,7 +30,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.*;
-import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.vectorized.ColumnarMap;
@@ -291,37 +290,4 @@ public class ColumnVectorUtils {
     batch.setNumRows(n);
     return batch;
   }
-
-  /**
-   * <b>This method assumes that all constant column are at the end of schema
-   * and `constantColumnLength` represents the number of constant column.<b/>
-   *
-   * This method allocates columns to store elements of each field of the schema,
-   * the data columns use `OffHeapColumnVector` when `useOffHeap` is true and
-   * use `OnHeapColumnVector` when `useOffHeap` is false, the constant columns
-   * always use `ConstantColumnVector`.
-   *
-   * Capacity is the initial capacity of the vector, and it will grow as necessary.
-   * Capacity is in number of elements, not number of bytes.
-   */
-  public static ColumnVector[] allocateColumns(
-      int capacity, StructType schema, boolean useOffHeap, int constantColumnLength) {
-    StructField[] fields = schema.fields();
-    int fieldsLength = fields.length;
-    ColumnVector[] vectors = new ColumnVector[fieldsLength];
-    if (useOffHeap) {
-      for (int i = 0; i < fieldsLength - constantColumnLength; i++) {
-        vectors[i] = new OffHeapColumnVector(capacity, fields[i].dataType());
-      }
-    } else {
-      for (int i = 0; i < fieldsLength - constantColumnLength; i++) {
-        vectors[i] = new OnHeapColumnVector(capacity, fields[i].dataType());
-      }
-    }
-    for (int i = fieldsLength - constantColumnLength; i < fieldsLength; i++) {
-      vectors[i] = new ConstantColumnVector(capacity, fields[i].dataType());
-    }
-    return vectors;
-  }
-
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr move `allocateColumns` method from `ColumnVectorUtils`  to `VectorizedParquetRecordReader` and change the access scope from `public static` to `private`


### Why are the changes needed?
Code refactor, `ColumnVectorUtils.allocateColumns` method introduced in https://github.com/apache/spark/pull/36616 only be used by `VectorizedParquetRecordReader`,  no need to put it into the helper class


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions