### PR TITLE
[SPARK-39639][SQL] Fix possible null pointer in MySQLDialect listIndexes

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLIntegrationSuite.scala
@@ -119,6 +119,8 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest
 
   override def supportsIndex: Boolean = true
 
+  override def supportListIndexes: Boolean = true
+
   override def indexOptions: String = "KEY_BLOCK_SIZE=10"
 
   testVarPop()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -197,6 +197,8 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   def supportsIndex: Boolean = false
 
+  def supportListIndexes: Boolean = false
+
   def indexOptions: String = ""
 
   test("SPARK-36895: Test INDEX Using SQL") {
@@ -219,11 +221,17 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
           s" The supported Index Types are:"))
 
         sql(s"CREATE index i1 ON $catalogName.new_table USING BTREE (col1)")
+        assert(jdbcTable.indexExists("i1") == true)
+        if (supportListIndexes) {
+          assert(jdbcTable.listIndexes().size == 1)
+        }
+
         sql(s"CREATE index i2 ON $catalogName.new_table (col2, col3, col5)" +
           s" OPTIONS ($indexOptions)")
-
-        assert(jdbcTable.indexExists("i1") == true)
         assert(jdbcTable.indexExists("i2") == true)
+        if (supportListIndexes) {
+          assert(jdbcTable.listIndexes().size == 2)
+        }
 
         // This should pass without exception
         sql(s"CREATE index IF NOT EXISTS i1 ON $catalogName.new_table (col1)")
@@ -234,10 +242,16 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
         assert(m.contains("Failed to create index i1 in new_table"))
 
         sql(s"DROP index i1 ON $catalogName.new_table")
-        sql(s"DROP index i2 ON $catalogName.new_table")
-
         assert(jdbcTable.indexExists("i1") == false)
+        if (supportListIndexes) {
+          assert(jdbcTable.listIndexes().size == 1)
+        }
+
+        sql(s"DROP index i2 ON $catalogName.new_table")
         assert(jdbcTable.indexExists("i2") == false)
+        if (supportListIndexes) {
+          assert(jdbcTable.listIndexes().size == 0)
+        }
 
         // This should pass without exception
         sql(s"DROP index IF EXISTS i1 ON $catalogName.new_table")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -23,6 +23,8 @@ import java.util.Locale
 
 import scala.collection.mutable.ArrayBuilder
 
+import org.apache.commons.lang3.StringUtils
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NoSuchIndexException}
@@ -217,7 +219,7 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
             // The only property we are building here is `COMMENT` because it's the only one
             // we can get from `SHOW INDEXES`.
             val properties = new util.Properties();
-            if (indexComment.nonEmpty) properties.put("COMMENT", indexComment)
+            if (StringUtils.isNotEmpty(indexComment)) properties.put("COMMENT", indexComment)
             val index = new TableIndex(indexName, indexType, Array(FieldReference(colName)),
               new util.HashMap[NamedReference, util.Properties](), properties)
             indexMap += (indexName -> index)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix possible null pointer in MySQLDialect listIndexes


### Why are the changes needed?
Code as follow:
https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala#L203~L232

### when: 
> val indexComment = rs.getString("Index_comment") 
>> **return null**

FYI:
>> String  ResultSet.getString(String columnLabel) throws SQLException;
>> return the column value; if the value is SQL NULL, the value returned is null

### then: 
> if (indexComment.nonEmpty) properties.put("COMMENT", indexComment) 
>> **throw NullPointerException**
### finally: 
> MySQLDialect.listIndexes 
>> return incorrect result(ignore exist index).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Update exist UT & Pass GA
