### PR TITLE
[SPARK-39453][SQL][TESTS][FOLLOWUP] Let `RAND` in filter is more meaningful.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -856,11 +856,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     val df11 = sql(
       """
         |SELECT * FROM h2.test.employee
-        |WHERE GREATEST(bonus, 1100) > 1200 AND LEAST(salary, 10000) > 9000 AND RAND(1) < 1
+        |WHERE GREATEST(bonus, 1100) > 1200 AND RAND(1) < bonus
         |""".stripMargin)
     checkFiltersRemoved(df11)
     checkPushedInfo(df11, "PushedFilters: " +
-      "[(GREATEST(BONUS, 1100.0)) > 1200.0, (LEAST(SALARY, 10000.00)) > 9000.00, RAND(1) < 1.0]")
+      "[BONUS IS NOT NULL, (GREATEST(BONUS, 1100.0)) > 1200.0, RAND(1) < BONUS]")
     checkAnswer(df11, Row(2, "david", 10000, 1300, true))
 
     val df12 = sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/36830 makes DS V2 supports push down misc non-aggregate functions(non ANSI).
But he `Rand` in test case looks no meaningful.


### Why are the changes needed?
Let `Rand` in filter is more meaningful.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update test case.


### How was this patch tested?
Just update test case.
