### PR TITLE
[SPARK-39642][SQL] Improve Expand statistics estimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/BasicStatsPlanVisitor.scala
@@ -50,7 +50,12 @@ object BasicStatsPlanVisitor extends LogicalPlanVisitor[Statistics] {
 
   override def visitExcept(p: Except): Statistics = fallback(p)
 
-  override def visitExpand(p: Expand): Statistics = fallback(p)
+  override def visitExpand(p: Expand): Statistics = {
+    val childStats = p.child.stats
+    fallback(p).copy(
+      rowCount = childStats.rowCount.map(_ * p.projections.size),
+      attributeStats = childStats.attributeStats)
+  }
 
   override def visitFilter(p: Filter): Statistics = {
     FilterEstimation(p).estimate.getOrElse(fallback(p))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/BasicStatsEstimationSuite.scala
@@ -363,6 +363,19 @@ class BasicStatsEstimationSuite extends PlanTest with StatsEstimationTestBase {
       expectedStatsCboOff = Statistics(sizeInBytes = expectedSize))
   }
 
+  test("SPARK-39642: Improve Expand statistics estimation") {
+    val expand = Expand(
+      Seq(
+        Seq(attribute, Literal.create(null, IntegerType), 1),
+        Seq(attribute, attribute, 2)),
+      Seq(attribute, attribute, $"gid".int),
+      plan)
+    checkStats(
+      expand,
+      expectedStatsCboOn = Statistics(400, Some(plan.rowCount * 2), plan.attributeStats),
+      expectedStatsCboOff = Statistics(sizeInBytes = 400))
+  }
+
   /** Check estimated stats when cbo is turned on/off. */
   private def checkStats(
       plan: LogicalPlan,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves `Expand` statistics estimation:
1. Update rowCount to child's rowCount * projections size.
2. Update attributeStats to child's attributeStats .

### Why are the changes needed?

To make stats more accurate.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.