### PR TITLE
[SPARK-39648][PYTHON][PS][DOC] Fix type hints of `like`, `rlike`, `ilike` of Column

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5024,7 +5024,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         else:
             if regex:
                 # to_replace must be a string
-                cond = self.spark.column.rlike(to_replace)
+                cond = self.spark.column.rlike(cast(str, to_replace))
             else:
                 cond = self.spark.column.isin(to_replace)
                 # to_replace may be a scalar

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -150,18 +150,27 @@ def _bin_func_op(
 def _bin_op(
     name: str,
     doc: str = "binary operator",
+    is_other_str: bool = False,
 ) -> Callable[
     ["Column", Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"]], "Column"
 ]:
     """Create a method for given binary operator"""
 
-    def _(
-        self: "Column",
-        other: Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"],
-    ) -> "Column":
-        jc = other._jc if isinstance(other, Column) else other
-        njc = getattr(self._jc, name)(jc)
-        return Column(njc)
+    if is_other_str:
+        def _(
+            self: "Column",
+            other: str,
+        ) -> "Column":
+            njc = getattr(self._jc, name)(other)
+            return Column(njc)
+    else:
+        def _(
+            self: "Column",
+            other: Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"],
+        ) -> "Column":
+            jc = other._jc if isinstance(other, Column) else other
+            njc = getattr(self._jc, name)(jc)
+            return Column(njc)
 
     _.__doc__ = doc
     return _
@@ -656,9 +665,9 @@ class Column:
     """
 
     contains = _bin_op("contains", _contains_doc)
-    rlike = _bin_op("rlike", _rlike_doc)
-    like = _bin_op("like", _like_doc)
-    ilike = _bin_op("ilike", _ilike_doc)
+    rlike = _bin_op("rlike", _rlike_doc, is_other_str=True)
+    like = _bin_op("like", _like_doc, is_other_str=True)
+    ilike = _bin_op("ilike", _ilike_doc, is_other_str=True)
     startswith = _bin_op("startsWith", _startswith_doc)
     endswith = _bin_op("endsWith", _endswith_doc)
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -147,33 +147,40 @@ def _bin_func_op(
     return _
 
 
+def _bin_op_other_str(
+    name: str,
+    doc: str = "binary operator",
+) -> Callable[
+    ["Column", Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"]], "Column"
+]:
+    """Create a method for given binary operator, where the `other` operand is a str"""
+
+    def _(
+        self: "Column",
+        other: str,
+    ) -> "Column":
+        njc = getattr(self._jc, name)(other)
+        return Column(njc)
+
+    _.__doc__ = doc
+    return _
+
+
 def _bin_op(
     name: str,
     doc: str = "binary operator",
-    is_other_str: bool = False,
 ) -> Callable[
     ["Column", Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"]], "Column"
 ]:
     """Create a method for given binary operator"""
 
-    if is_other_str:
-
-        def _(
-            self: "Column",
-            other: str,
-        ) -> "Column":
-            njc = getattr(self._jc, name)(other)
-            return Column(njc)
-
-    else:
-
-        def _(
-            self: "Column",
-            other: Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"],
-        ) -> "Column":
-            jc = other._jc if isinstance(other, Column) else other
-            njc = getattr(self._jc, name)(jc)
-            return Column(njc)
+    def _(
+        self: "Column",
+        other: Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"],
+    ) -> "Column":
+        jc = other._jc if isinstance(other, Column) else other
+        njc = getattr(self._jc, name)(jc)
+        return Column(njc)
 
     _.__doc__ = doc
     return _
@@ -668,9 +675,9 @@ class Column:
     """
 
     contains = _bin_op("contains", _contains_doc)
-    rlike = _bin_op("rlike", _rlike_doc, is_other_str=True)
-    like = _bin_op("like", _like_doc, is_other_str=True)
-    ilike = _bin_op("ilike", _ilike_doc, is_other_str=True)
+    rlike = _bin_op_other_str("rlike", _rlike_doc)
+    like = _bin_op_other_str("like", _like_doc)
+    ilike = _bin_op_other_str("ilike", _ilike_doc)
     startswith = _bin_op("startsWith", _startswith_doc)
     endswith = _bin_op("endsWith", _endswith_doc)
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -157,13 +157,16 @@ def _bin_op(
     """Create a method for given binary operator"""
 
     if is_other_str:
+
         def _(
             self: "Column",
             other: str,
         ) -> "Column":
             njc = getattr(self._jc, name)(other)
             return Column(njc)
+
     else:
+
         def _(
             self: "Column",
             other: Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"],

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -147,25 +147,6 @@ def _bin_func_op(
     return _
 
 
-def _bin_op_other_str(
-    name: str,
-    doc: str = "binary operator",
-) -> Callable[
-    ["Column", Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"]], "Column"
-]:
-    """Create a method for given binary operator, where the `other` operand is a str"""
-
-    def _(
-        self: "Column",
-        other: str,
-    ) -> "Column":
-        njc = getattr(self._jc, name)(other)
-        return Column(njc)
-
-    _.__doc__ = doc
-    return _
-
-
 def _bin_op(
     name: str,
     doc: str = "binary operator",
@@ -592,57 +573,6 @@ class Column:
     >>> df.filter(df.name.contains('o')).collect()
     [Row(age=5, name='Bob')]
     """
-    _rlike_doc = """
-    SQL RLIKE expression (LIKE with Regex). Returns a boolean :class:`Column` based on a regex
-    match.
-
-    Parameters
-    ----------
-    other : str
-        an extended regex expression
-
-    Examples
-    --------
-    >>> df.filter(df.name.rlike('ice$')).collect()
-    [Row(age=2, name='Alice')]
-    """
-    _like_doc = """
-    SQL like expression. Returns a boolean :class:`Column` based on a SQL LIKE match.
-
-    Parameters
-    ----------
-    other : str
-        a SQL LIKE pattern
-
-    See Also
-    --------
-    pyspark.sql.Column.rlike
-
-    Examples
-    --------
-    >>> df.filter(df.name.like('Al%')).collect()
-    [Row(age=2, name='Alice')]
-    """
-    _ilike_doc = """
-    SQL ILIKE expression (case insensitive LIKE). Returns a boolean :class:`Column`
-    based on a case insensitive match.
-
-    .. versionadded:: 3.3.0
-
-    Parameters
-    ----------
-    other : str
-        a SQL LIKE pattern
-
-    See Also
-    --------
-    pyspark.sql.Column.rlike
-
-    Examples
-    --------
-    >>> df.filter(df.name.ilike('%Ice')).collect()
-    [Row(age=2, name='Alice')]
-    """
     _startswith_doc = """
     String starts with. Returns a boolean :class:`Column` based on a string match.
 
@@ -675,11 +605,71 @@ class Column:
     """
 
     contains = _bin_op("contains", _contains_doc)
-    rlike = _bin_op_other_str("rlike", _rlike_doc)
-    like = _bin_op_other_str("like", _like_doc)
-    ilike = _bin_op_other_str("ilike", _ilike_doc)
     startswith = _bin_op("startsWith", _startswith_doc)
     endswith = _bin_op("endsWith", _endswith_doc)
+
+    def like(self: "Column", other: str) -> "Column":
+        """
+        SQL like expression. Returns a boolean :class:`Column` based on a SQL LIKE match.
+
+        Parameters
+        ----------
+        other : str
+            a SQL LIKE pattern
+
+        See Also
+        --------
+        pyspark.sql.Column.rlike
+
+        Examples
+        --------
+        >>> df.filter(df.name.like('Al%')).collect()
+        [Row(age=2, name='Alice')]
+        """
+        njc = getattr(self._jc, "like")(other)
+        return Column(njc)
+
+    def rlike(self: "Column", other: str) -> "Column":
+        """
+        SQL RLIKE expression (LIKE with Regex). Returns a boolean :class:`Column` based on a regex
+        match.
+
+        Parameters
+        ----------
+        other : str
+            an extended regex expression
+
+        Examples
+        --------
+        >>> df.filter(df.name.rlike('ice$')).collect()
+        [Row(age=2, name='Alice')]
+        """
+        njc = getattr(self._jc, "rlike")(other)
+        return Column(njc)
+
+    def ilike(self: "Column", other: str) -> "Column":
+        """
+        SQL ILIKE expression (case insensitive LIKE). Returns a boolean :class:`Column`
+        based on a case insensitive match.
+
+        .. versionadded:: 3.3.0
+
+        Parameters
+        ----------
+        other : str
+            a SQL LIKE pattern
+
+        See Also
+        --------
+        pyspark.sql.Column.rlike
+
+        Examples
+        --------
+        >>> df.filter(df.name.ilike('%Ice')).collect()
+        [Row(age=2, name='Alice')]
+        """
+        njc = getattr(self._jc, "ilike")(other)
+        return Column(njc)
 
     @overload
     def substr(self, startPos: int, length: int) -> "Column":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix type hints of `like`, `rlike`, `ilike` of Column.

### Why are the changes needed?
Current type hints are incorrect so the doc is confusing: `Union["Column", "LiteralType", "DecimalLiteral", "DateTimeLiteral"]]` is hinted whereas only `str` is accepted.

The PR is proposed to adjust the above issue by introducing `_bin_op_other_str`.

### Does this PR introduce _any_ user-facing change?
No. Doc change only.

### How was this patch tested?
Manual tests.
