### PR TITLE
[SPARK-39649][PYTHON] Make listDatabases / getDatabase / listColumns / refreshTable in PySpark support 3-layer-namespace

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -365,7 +365,7 @@ class Catalog:
         else:
             warnings.warn(
                 "`dbName` has been deprecated since Spark 3.4 and might be removed in "
-                "a future version. Use tableExists(`dbName.tableName`) instead.",
+                "a future version. Use listColumns(`dbName.tableName`) instead.",
                 FutureWarning,
             )
             iter = self._jcatalog.listColumns(dbName, tableName).toLocalIterator()

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -128,11 +128,7 @@ class Catalog:
 
     @since(2.0)
     def setCurrentDatabase(self, dbName: str) -> None:
-        """Sets the current default database in this session.
-
-        .. versionchanged:: 3.4
-           Allowed ``dbName`` to be qualified with catalog name.
-        """
+        """Sets the current default database in this session."""
         return self._jcatalog.setCurrentDatabase(dbName)
 
     @since(2.0)

--- a/python/pyspark/sql/tests/test_catalog.py
+++ b/python/pyspark/sql/tests/test_catalog.py
@@ -53,6 +53,14 @@ class CatalogTests(ReusedSQLTestCase):
             self.assertTrue(spark.catalog.databaseExists("spark_catalog.some_db"))
             self.assertFalse(spark.catalog.databaseExists("spark_catalog.some_db2"))
 
+    def test_get_database(self):
+        spark = self.spark
+        with self.database("some_db"):
+            spark.sql("CREATE DATABASE some_db")
+            db = spark.catalog.getDatabase("spark_catalog.some_db")
+            self.assertEqual(db.name, "some_db")
+            self.assertEqual(db.catalog, "spark_catalog")
+
     def test_list_tables(self):
         from pyspark.sql.catalog import Table
 
@@ -245,7 +253,9 @@ class CatalogTests(ReusedSQLTestCase):
                 spark.sql(
                     "CREATE TABLE some_db.tab2 (nickname STRING, tolerance FLOAT) USING parquet"
                 )
-                columns = sorted(spark.catalog.listColumns("tab1"), key=lambda c: c.name)
+                columns = sorted(
+                    spark.catalog.listColumns("spark_catalog.default.tab1"), key=lambda c: c.name
+                )
                 columnsDefault = sorted(
                     spark.catalog.listColumns("tab1", "default"), key=lambda c: c.name
                 )


### PR DESCRIPTION
### What changes were proposed in this pull request?

make following commands in pyspark support 3-layer-namespace

- ~setCurrentDatabase~ (per the comments https://github.com/apache/spark/pull/36969/files#diff-e6c98e62b4d35c54acd0481006733a84d6a12dec0a59b3d3024e103d708fae88R70-R71, skip `setCurrentDatabase`)
- listDatabases
- getDatabase
- listColumns
- refreshTable



### Why are the changes needed?
to support 3-layer-namespace


### Does this PR introduce _any_ user-facing change?
yes, new api added

### How was this patch tested?
updated UT