### PR TITLE
[SPARK-39653][SQL] Clean up `ColumnVectorUtils#populate(WritableColumnVector, InternalRow, int)` from `ColumnVectorUtils`

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/ColumnVectorUtils.java
@@ -42,68 +42,6 @@ import org.apache.spark.unsafe.types.UTF8String;
  * These utilities are mostly used to convert ColumnVectors into other formats.
  */
 public class ColumnVectorUtils {
-  /**
-   * Populates the entire `col` with `row[fieldIdx]`
-   */
-  public static void populate(WritableColumnVector col, InternalRow row, int fieldIdx) {
-    int capacity = col.capacity;
-    DataType t = col.dataType();
-
-    if (row.isNullAt(fieldIdx)) {
-      col.putNulls(0, capacity);
-    } else {
-      if (t == DataTypes.BooleanType) {
-        col.putBooleans(0, capacity, row.getBoolean(fieldIdx));
-      } else if (t == DataTypes.BinaryType) {
-        col.putByteArray(0, row.getBinary(fieldIdx));
-      } else if (t == DataTypes.ByteType) {
-        col.putBytes(0, capacity, row.getByte(fieldIdx));
-      } else if (t == DataTypes.ShortType) {
-        col.putShorts(0, capacity, row.getShort(fieldIdx));
-      } else if (t == DataTypes.IntegerType) {
-        col.putInts(0, capacity, row.getInt(fieldIdx));
-      } else if (t == DataTypes.LongType) {
-        col.putLongs(0, capacity, row.getLong(fieldIdx));
-      } else if (t == DataTypes.FloatType) {
-        col.putFloats(0, capacity, row.getFloat(fieldIdx));
-      } else if (t == DataTypes.DoubleType) {
-        col.putDoubles(0, capacity, row.getDouble(fieldIdx));
-      } else if (t == DataTypes.StringType) {
-        UTF8String v = row.getUTF8String(fieldIdx);
-        byte[] bytes = v.getBytes();
-        for (int i = 0; i < capacity; i++) {
-          col.putByteArray(i, bytes);
-        }
-      } else if (t instanceof DecimalType) {
-        DecimalType dt = (DecimalType)t;
-        Decimal d = row.getDecimal(fieldIdx, dt.precision(), dt.scale());
-        if (dt.precision() <= Decimal.MAX_INT_DIGITS()) {
-          col.putInts(0, capacity, (int)d.toUnscaledLong());
-        } else if (dt.precision() <= Decimal.MAX_LONG_DIGITS()) {
-          col.putLongs(0, capacity, d.toUnscaledLong());
-        } else {
-          final BigInteger integer = d.toJavaBigDecimal().unscaledValue();
-          byte[] bytes = integer.toByteArray();
-          for (int i = 0; i < capacity; i++) {
-            col.putByteArray(i, bytes, 0, bytes.length);
-          }
-        }
-      } else if (t instanceof CalendarIntervalType) {
-        CalendarInterval c = (CalendarInterval)row.get(fieldIdx, t);
-        col.getChild(0).putInts(0, capacity, c.months);
-        col.getChild(1).putInts(0, capacity, c.days);
-        col.getChild(2).putLongs(0, capacity, c.microseconds);
-      } else if (t instanceof DateType || t instanceof YearMonthIntervalType) {
-        col.putInts(0, capacity, row.getInt(fieldIdx));
-      } else if (t instanceof TimestampType || t instanceof TimestampNTZType ||
-        t instanceof DayTimeIntervalType) {
-        col.putLongs(0, capacity, row.getLong(fieldIdx));
-      } else {
-        throw new RuntimeException(String.format("DataType %s is not supported" +
-            " in column vectorized reader.", t.sql()));
-      }
-    }
-  }
 
   /**
    * Populates the value of `row[fieldIdx]` into `ConstantColumnVector`.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnVectorSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.columnar.ColumnAccessor
 import org.apache.spark.sql.execution.columnar.compression.ColumnBuilderHelper
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarArray
-import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+import org.apache.spark.unsafe.types.UTF8String
 
 class ColumnVectorSuite extends SparkFunSuite with BeforeAndAfterEach {
   private def withVector(
@@ -604,15 +604,6 @@ class ColumnVectorSuite extends SparkFunSuite with BeforeAndAfterEach {
         assert(rowCopy.get(0, dt) === i)
       }
     }
-  }
-
-  test("SPARK-38018: ColumnVectorUtils.populate to handle CalendarIntervalType correctly") {
-    val vector = new OnHeapColumnVector(5, CalendarIntervalType)
-    val row = new SpecificInternalRow(Array(CalendarIntervalType))
-    val interval = new CalendarInterval(3, 5, 1000000)
-    row.setInterval(0, interval)
-    ColumnVectorUtils.populate(vector, row, 0)
-    assert(vector.getInterval(0) === interval)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
After SPARK-39638 and SPARK-39231, `ColumnVectorUtils#populate(WritableColumnVector, InternalRow, int)` method in `ColumnVectorUtils` only used by  `ConstantColumnVectorBenchmark` and `ColumnVectorSuite`.  So this pr do following changes:

- Clean up `ColumnVectorUtils#populate(WritableColumnVector, InternalRow, int)` from `ColumnVectorUtils`
- Added a simplified version `populate` method for `ConstantColumnVectorBenchmark`
- Clean up `SPARK-38018: ColumnVectorUtils.populate to handle CalendarIntervalType correctly` from `ColumnVectorSuite` due this scenario no longer exists, and the similar scenarios using `ConstantColumnVector` have been covered by `fill calendar interval` in `ColumnVectorUtils`.


### Why are the changes needed?
Clean up useless code


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Execute `ConstantColumnVectorBenchmark` manually with [Benchmark GitHub Action](https://github.com/LuciferYang/spark/runs/7147111541), the result file can be produced successfully. Since the result has no obvious change, so not update in the current pr

