### PR TITLE
[SPARK-39647][CORE] Register the executor with ESS before registering the BlockManager

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -2178,7 +2178,6 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
   }
 
   test("SPARK-39647: Failure to register with ESS should prevent registering the BM") {
-    val timeoutExec = "timeoutExec"
     val handler = new NoOpRpcHandler {
       override def receive(
           client: TransportClient,
@@ -2186,7 +2185,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
           callback: RpcResponseCallback): Unit = {
         val msgObj = BlockTransferMessage.Decoder.fromByteBuffer(message)
         msgObj match {
-          case exec: RegisterExecutor => () // No reply to generate client-side timeout
+          case _: RegisterExecutor => () // No reply to generate client-side timeout
         }
       }
     }
@@ -2205,7 +2204,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
       conf.set(SHUFFLE_REGISTRATION_TIMEOUT.key, "40")
       conf.set(SHUFFLE_REGISTRATION_MAX_ATTEMPTS.key, "1")
       val e = intercept[SparkException] {
-        makeBlockManager(8000, timeoutExec)
+        makeBlockManager(8000, "timeoutExec")
       }.getMessage
       assert(e.contains("TimeoutException"))
       verify(master, times(0))

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -2177,6 +2177,46 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with BeforeAndAfterE
     assert(kryoException.getMessage === "java.io.IOException: Input/output error")
   }
 
+  test("SPARK-39647: Failure to register with ESS should prevent registering the BM") {
+    val timeoutExec = "timeoutExec"
+    val handler = new NoOpRpcHandler {
+      override def receive(
+          client: TransportClient,
+          message: ByteBuffer,
+          callback: RpcResponseCallback): Unit = {
+        val msgObj = BlockTransferMessage.Decoder.fromByteBuffer(message)
+        msgObj match {
+
+          case exec: RegisterExecutor if exec.execId == timeoutExec =>
+            () // No reply to generate client-side timeout
+        }
+      }
+    }
+    val transConf = SparkTransportConf.fromSparkConf(conf, "shuffle", numUsableCores = 0)
+    Utils.tryWithResource(new TransportContext(transConf, handler, true)) { transCtx =>
+      // a server which delays response 50ms and must try twice for success.
+      def newShuffleServer(port: Int): (TransportServer, Int) = {
+        (transCtx.createServer(port, Seq.empty[TransportServerBootstrap].asJava), port)
+      }
+
+      val candidatePort = RandomUtils.nextInt(1024, 65536)
+      val (server, shufflePort) = Utils.startServiceOnPort(candidatePort,
+        newShuffleServer, conf, "ShuffleServer")
+
+      conf.set(SHUFFLE_SERVICE_ENABLED.key, "true")
+      conf.set(SHUFFLE_SERVICE_PORT.key, shufflePort.toString)
+      conf.set(SHUFFLE_REGISTRATION_TIMEOUT.key, "40")
+      conf.set(SHUFFLE_REGISTRATION_MAX_ATTEMPTS.key, "1")
+      var e = intercept[SparkException] {
+        makeBlockManager(8000, timeoutExec)
+      }.getMessage
+      assert(e.contains("TimeoutException"))
+      verify(master, times(0))
+        .registerBlockManager(mc.any(), mc.any(), mc.any(), mc.any(), mc.any())
+      server.close()
+    }
+  }
+
   private def createKryoSerializerWithDiskCorruptedInputStream(): KryoSerializer = {
     class TestDiskCorruptedInputStream extends InputStream {
       override def read(): Int = throw new IOException("Input/output error")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently the executors register with the ESS after the `BlockManager` registration with the `BlockManagerMaster`.  This order creates a problem with the push-based shuffle. A registered BlockManager node is picked up by the driver as a merger but the shuffle service on that node is not yet ready to merge the data which causes block pushes to fail until the local executor registers with it. This fix is to reverse the order, that is, register with the ESS before registering the `BlockManager`

### Why are the changes needed?
They are needed to fix the issue which causes block pushes to fail. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added a UT.
