### PR TITLE
[SPARK-39662][BUILD] Upgrade HtmlUnit and its related artifacts from 2.50.0 to 2.62.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     <antlr4.version>4.8</antlr4.version>
     <jpam.version>1.1</jpam.version>
     <selenium.version>3.141.59</selenium.version>
-    <htmlunit.version>2.50.0</htmlunit.version>
+    <htmlunit.version>2.62.0</htmlunit.version>
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades HtmlUnit and its related artifacts from 2.50.0 to 2.62.0.
The last upgrade occurred 1 year and 1 month ago. https://github.com/apache/spark/pull/32789

### Why are the changes needed?
We currently uses 2.50 but 2.51+ seem to include bunch of bug fixes and improvements especially for JavaScript and CSS.
Especially with the browser(Chrome/Edge/Firefox ) upgrade in the past year.
release notes: https://htmlunit.sourceforge.io/changes-report.html#a2.62.0


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
All the UISeleniumSuite which use HtmlUnit pass.