### PR TITLE
[SPARK-39666][SQL] Use UnsafeProjection.create to respect `spark.sql.codegen.factoryMode` in ExpressionEncoder

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.catalyst.{InternalRow, JavaTypeInference, ScalaRefle
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, GetColumnByOrdinal, SimpleAnalyzer, UnresolvedAttribute, UnresolvedExtractValue}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder.{Deserializer, Serializer}
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.catalyst.expressions.objects.{AssertNotNull, InitializeJavaBean, Invoke, NewInstance}
 import org.apache.spark.sql.catalyst.optimizer.{ReassignLambdaVariableID, SimplifyCasts}
 import org.apache.spark.sql.catalyst.plans.logical.{CatalystSerde, DeserializeToObject, LeafNode, LocalRelation}
@@ -201,7 +200,7 @@ object ExpressionEncoder {
     override def apply(t: T): InternalRow = try {
       if (extractProjection == null) {
         inputRow = new GenericInternalRow(1)
-        extractProjection = GenerateUnsafeProjection.generate(expressions)
+        extractProjection = UnsafeProjection.create(expressions)
       }
       inputRow(0) = t
       extractProjection(inputRow)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is sort of a followup of https://github.com/apache/spark/commit/88d8de9260edf6e9d5449ff7ef6e35d16051fc9f to respect interpreted projections in `ExpressionEncoder`. Similar fix was made before in deserialization side at https://github.com/apache/spark/commit/26128484228089c74517cd15cef0bb4166a4186f, and this PR completes it in serialization side too.

### Why are the changes needed?

This is a symmetry with https://github.com/apache/spark/commit/26128484228089c74517cd15cef0bb4166a4186f. We should make the configurations respected consistently.

### Does this PR introduce _any_ user-facing change?

No, by default.
Yes, when users set `spark.sql.codegen.factoryMode` to other values. The operations such as DSv1, DSv2, or object conversions such as `MapObjects` will respect the value.

### How was this patch tested?

Existing test cases at `RowEncoderSuite extends CodegenInterpretedPlanTest` and `ExpressionEncoderSuite extends CodegenInterpretedPlanTest` should cover this.