### PR TITLE
[SPARK-39672][SQL][3.1] Fix removing project before filter with correlated subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -746,6 +746,8 @@ object ColumnPruning extends Rule[LogicalPlan] {
       if p2.outputSet.subsetOf(child.outputSet) &&
         // We only remove attribute-only project.
         p2.projectList.forall(_.isInstanceOf[AttributeReference]) &&
+        // We can't remove project when the child has conflicting attributes
+        // with the subquery in filter predicate
         !hasConflictingAttrsWithSubquery(e, child) =>
       p1.copy(child = f.copy(child = child))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -750,8 +750,9 @@ object ColumnPruning extends Rule[LogicalPlan] {
       p1.copy(child = f.copy(child = child))
   }
 
-  private def hasConflictingAttrsWithSubquery(predicate: Expression,
-    child: LogicalPlan): Boolean = {
+  private def hasConflictingAttrsWithSubquery(
+      predicate: Expression,
+      child: LogicalPlan): Boolean = {
     predicate.find {
       case s: SubqueryExpression if s.plan.outputSet.intersect(child.outputSet).nonEmpty => true
       case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -746,8 +746,13 @@ object ColumnPruning extends Rule[LogicalPlan] {
       if p2.outputSet.subsetOf(child.outputSet) &&
         // We only remove attribute-only project.
         p2.projectList.forall(_.isInstanceOf[AttributeReference]) &&
-        !SubqueryExpression.hasInOrCorrelatedExistsSubquery(e) =>
+        !hasConflictingAttrsWithSubquery(e, child) =>
       p1.copy(child = f.copy(child = child))
+  }
+
+  private def hasConflictingAttrsWithSubquery(e: Expression, child: LogicalPlan): Boolean = {
+    SubqueryExpression.hasInOrCorrelatedExistsSubquery(e) &&
+      child.outputSet.intersect(e.references).nonEmpty
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -637,7 +637,7 @@ object PushProjectionThroughUnion extends Rule[LogicalPlan] with PredicateHelper
  *
  * p2 is usually inserted by this rule and useless, p1 could prune the columns anyway.
  */
-object ColumnPruning extends Rule[LogicalPlan] with PredicateHelper {
+object ColumnPruning extends Rule[LogicalPlan] {
 
   def apply(plan: LogicalPlan): LogicalPlan = removeProjectBeforeFilter(plan transform {
     // Prunes the unused columns from project list of Project/Aggregate/Expand
@@ -752,17 +752,10 @@ object ColumnPruning extends Rule[LogicalPlan] with PredicateHelper {
 
   private def hasConflictingAttrsWithSubquery(predicate: Expression,
     child: LogicalPlan): Boolean = {
-    def hasConflictingAttrs(s: SubqueryExpression): Boolean = {
-      s.references.intersect(child.outputSet).nonEmpty
-    }
-
-    splitConjunctivePredicates(predicate).exists { e =>
-      e.find {
-        case s: ListQuery if hasConflictingAttrs(s) => true
-        case s: Exists if e.children.nonEmpty && hasConflictingAttrs(s) => true
-        case _ => false
-      }.isDefined
-    }
+    predicate.find {
+      case s: SubqueryExpression if s.plan.outputSet.intersect(child.outputSet).nonEmpty => true
+      case _ => false
+    }.isDefined
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -742,10 +742,11 @@ object ColumnPruning extends Rule[LogicalPlan] {
    * order, otherwise lower Projects can be missed.
    */
   private def removeProjectBeforeFilter(plan: LogicalPlan): LogicalPlan = plan transformUp {
-    case p1 @ Project(_, f @ Filter(_, p2 @ Project(_, child)))
+    case p1 @ Project(_, f @ Filter(e, p2 @ Project(_, child)))
       if p2.outputSet.subsetOf(child.outputSet) &&
         // We only remove attribute-only project.
-        p2.projectList.forall(_.isInstanceOf[AttributeReference]) =>
+        p2.projectList.forall(_.isInstanceOf[AttributeReference]) &&
+        !SubqueryExpression.hasInOrCorrelatedExistsSubquery(e) =>
       p1.copy(child = f.copy(child = child))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1793,13 +1793,13 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     withTempView("v1", "v2") {
       Seq((1, 2, 3), (4, 5, 6)).toDF("a", "b", "c").createTempView("v1")
       Seq((1, 3, 5), (4, 5, 6)).toDF("a", "b", "c").createTempView("v2")
-      
+
       def findProjectExec(df: DataFrame): Seq[ProjectExec] = {
         df.queryExecution.sparkPlan.collect {
           case p: ProjectExec => p
         }
       }
- 
+
       // project before filter cannot be removed since subquery has conflicting attributes
       // with outer reference
       val df1 = sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add more checks to`removeProjectBeforeFilter` in `ColumnPruning` and only remove the project if
1. the filter condition contains correlated subquery
2. same attribute exists in both output of child of Project and subquery


### Why are the changes needed?

This is a legitimate self-join query and should not throw exception when de-duplicating attributes in subquery and outer values.

```sql
select * from
(
select v1.a, v1.b, v2.c
from v1
inner join v2
on v1.a=v2.a) t3
where not exists (
  select 1
  from v2
  where t3.a=v2.a and t3.b=v2.b and t3.c=v2.c
)
```

Here's what happens with the current code. The above query is analyzed into following `LogicalPlan` before `ColumnPruning`.
```
Project [a#250, b#251, c#268]
+- Filter NOT exists#272 [(a#250 = a#266) && (b#251 = b#267) && (c#268 = c#268#277)]
   :  +- Project [1 AS 1#273, _1#259 AS a#266, _2#260 AS b#267, _3#261 AS c#268#277]
   :     +- LocalRelation [_1#259, _2#260, _3#261]
   +- Project [a#250, b#251, c#268]
      +- Join Inner, (a#250 = a#266)
         :- Project [a#250, b#251]
         :  +- Project [_1#243 AS a#250, _2#244 AS b#251]
         :     +- LocalRelation [_1#243, _2#244, _3#245]
         +- Project [a#266, c#268]
            +- Project [_1#259 AS a#266, _3#261 AS c#268]
               +- LocalRelation [_1#259, _2#260, _3#261]
```

Then in `ColumnPruning`, the Project before Filter (between Filter and Join) is removed. This changes the `outputSet` of the child of Filter among which the same attribute also exists in the subquery. Later, when `RewritePredicateSubquery` de-duplicates conflicting attributes, it would complain `Found conflicting attributes a#266 in the condition joining outer plan`. 

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Add UT.