### PR TITLE
[SPARK-39610][INFRA] Add GITHUB_WORKSPACE to git trust safe.directory for container based job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -289,6 +289,9 @@ jobs:
         fetch-depth: 0
         repository: apache/spark
         ref: ${{ inputs.branch }}
+    - name: Add GITHUB_WORKSPACE to git trust safe.directory
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -374,6 +377,9 @@ jobs:
         fetch-depth: 0
         repository: apache/spark
         ref: ${{ inputs.branch }}
+    - name: Add GITHUB_WORKSPACE to git trust safe.directory
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |
@@ -439,6 +445,9 @@ jobs:
         fetch-depth: 0
         repository: apache/spark
         ref: ${{ inputs.branch }}
+    - name: Add GITHUB_WORKSPACE to git trust safe.directory
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
     - name: Sync the current branch with the latest in Apache Spark
       if: github.repository != 'apache/spark'
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch add GITHUB_WORKSPACE to git trust safe.directory for container based job.

There are 3 container based job in Spark Infra:
- sparkr
- lint
- pyspark

### Why are the changes needed?

When upgrade `git >= 2.35.2` (such as latest dev docker image in my case), fix a [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/#cve-2022-24765) , and it has been backported [latest ubuntu git](https://github.com/actions/checkout/issues/760#issuecomment-1099355820)

The `GITHUB_WORKSPACE` is belong to action user (in host), but the container user is `root` (in container) (root is required in our spark job), so cause the error like:
```
fatal: unsafe repository ('/__w/spark/spark' is owned by someone else)
To add an exception for this directory, call:
    git config --global --add safe.directory /__w/spark/spark
fatal: unsafe repository ('/__w/spark/spark' is owned by someone else)
To add an exception for this directory, call:
    git config --global --add safe.directory /__w/spark/spark
```

The solution is from `action/checkout` https://github.com/actions/checkout/issues/760 , just add `GITHUB_WORKSPACE` to git trust safe.directory to make container user can checkout successfully.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed.
CI passed with latest ubuntu hosted runner, here is a simple e2e test for pyspark job https://github.com/apache/spark/pull/37005
