### PR TITLE
[SPARK-39612][SQL][TESTS] DataFrame.exceptAll followed by count should work

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -3239,6 +3239,11 @@ class DataFrameSuite extends QueryTest
       }
     }
   }
+
+  test("SPARK-39612: exceptAll with following count should work") {
+    val d1 = Seq("a").toDF
+    assert(d1.exceptAll(d1).count() === 0)
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a test case broken by https://github.com/apache/spark/commit/4b9343593eca780ca30ffda45244a71413577884 which was reverted in https://github.com/apache/spark/commit/161c596cafea9c235b5c918d8999c085401d73a9.

### Why are the changes needed?

To prevent a regression in the future. This was a regression in Apache Spark 3.3 that used to work in Apache Spark 3.2.

### Does this PR introduce _any_ user-facing change?

Yes, it makes `DataFrame.exceptAll` followed by `count` working.

### How was this patch tested?

The unit test was added.