### PR TITLE
[SPARK-39680][CORE] Remove `hasSpaceForAnotherRecord` from `UnsafeExternalSorter` 

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -562,10 +562,6 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
     }
   }
 
-  @VisibleForTesting boolean hasSpaceForAnotherRecord() {
-    return inMemSorter.hasSpaceForAnotherRecord();
-  }
-
   private static void spillIterator(UnsafeSorterIterator inMemIterator,
       UnsafeSorterSpillWriter spillWriter) throws IOException {
     while (inMemIterator.hasNext()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove an unused `@VisibleForTesting` method from `UnsafeExternalSorter` .


### Why are the changes needed?
Code clean.

SPARK-21907 introduce `hasSpaceForAnotherRecord()` method for `UnsafeExternalSorter`,  it is identified as `@VisibleForTesting` and only used by `UnsafeExternalSorterSuite#testOOMDuringSpill`.  

After SPARK-32901, `testOOMDuringSpill` in `UnsafeExternalSorterSuite` rename to `testNoOOMDuringSpill` and `hasSpaceForAnotherRecord()` method is no longer used in current master now.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GitHub Actions.
