### PR TITLE
[SPARK-39579][PYTHON][FOLLOWUP] fix functionExists(functionName, dbName) when dbName is not None

### DIFF
--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -359,7 +359,7 @@ class Catalog:
                 "a future version. Use functionExists(`dbName.tableName`) instead.",
                 FutureWarning,
             )
-            return self._jcatalog.functionExists(self.currentDatabase(), functionName)
+            return self._jcatalog.functionExists(dbName, functionName)
 
     def getFunction(self, functionName: str) -> Function:
         """Get the function with the specified name. This function can be a temporary function or a


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix functionExists(functionName, dbName)


### Why are the changes needed?
https://github.com/apache/spark/pull/36977 introduce a bug in `functionExists(functionName, dbName)`, when dbName is not None, should call `self._jcatalog.functionExists(dbName, functionName)`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing testsuite
