### PR TITLE
[SPARK-39686][INFRA] Disable scheduled builds that did not pass even once

### DIFF
--- a/.github/workflows/build_branch32.yml
+++ b/.github/workflows/build_branch32.yml
@@ -36,8 +36,8 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13"
         }
-      # TODO(SPARK-39681): Reenable "lint": "true"
-      # TODO(SPARK-39685): Reenable "pyspark": "true"
+      # TODO(SPARK-39685): Reenable "lint": "true"
+      # TODO(SPARK-39681): Reenable "pyspark": "true"
       # TODO(SPARK-39682): Reenable "docker-integration-tests": "true"
       jobs: >-
         {

--- a/.github/workflows/build_branch32.yml
+++ b/.github/workflows/build_branch32.yml
@@ -36,12 +36,12 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13"
         }
+      # TODO(SPARK-39681): Reenable "lint": "true"
+      # TODO(SPARK-39685): Reenable "pyspark": "true"
+      # TODO(SPARK-39682): Reenable "docker-integration-tests": "true"
       jobs: >-
         {
           "build": "true",
-          "pyspark": "true",
           "sparkr": "true",
-          "tpcds-1g": "true",
-          "docker-integration-tests": "true",
-          "lint" : "true"
+          "tpcds-1g": "true"
         }

--- a/.github/workflows/build_hadoop2.yml
+++ b/.github/workflows/build_hadoop2.yml
@@ -32,11 +32,11 @@ jobs:
       java: 8
       branch: master
       hadoop: hadoop2
+      # TODO(SPARK-39684): Reenable "docker-integration-tests": "true"
       jobs: >-
         {
           "build": "true",
           "pyspark": "true",
           "sparkr": "true",
-          "tpcds-1g": "true",
-          "docker-integration-tests": "true"
+          "tpcds-1g": "true"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip the builds that have never passed in history. https://github.com/apache/spark/pull/36940 added some more combinations to check if they passed, and this PR disables some of them that do not pass.

See also:
- SPARK-39681 (https://github.com/apache/spark/runs/7189972241?check_suite_focus=true)
- SPARK-39685 (https://github.com/apache/spark/runs/7189971643?check_suite_focus=true)
- SPARK-39682 (https://github.com/apache/spark/runs/7189971505?check_suite_focus=true)
- SPARK-39684 (https://github.com/apache/spark/runs/7054055518?check_suite_focus=true)

### Why are the changes needed?

In order to check the test status easily with each combination of profile and branch.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Virtually configuration changes. Will be checked after it's merged.
