### PR TITLE
[SPARK-39687][PYTHON][DOCS] Make sure new catalog methods listed in API reference

### DIFF
--- a/python/docs/source/reference/pyspark.sql/catalog.rst
+++ b/python/docs/source/reference/pyspark.sql/catalog.rst
@@ -29,12 +29,17 @@ Catalog
     Catalog.clearCache
     Catalog.createExternalTable
     Catalog.createTable
+    Catalog.currentCatalog
     Catalog.currentDatabase
     Catalog.databaseExists
     Catalog.dropGlobalTempView
     Catalog.dropTempView
     Catalog.functionExists
+    Catalog.getDatabase
+    Catalog.getFunction
+    Catalog.getTable
     Catalog.isCached
+    Catalog.listCatalogs
     Catalog.listColumns
     Catalog.listDatabases
     Catalog.listFunctions
@@ -43,6 +48,7 @@ Catalog
     Catalog.refreshByPath
     Catalog.refreshTable
     Catalog.registerFunction
+    Catalog.setCurrentCatalog
     Catalog.setCurrentDatabase
     Catalog.tableExists
     Catalog.uncacheTable

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -152,7 +152,7 @@ class Catalog:
 
     def getDatabase(self, dbName: str) -> Database:
         """Get the database with the specified name.
-        This throws an AnalysisException when the database cannot be found.
+        This throws an :class:`AnalysisException` when the database cannot be found.
 
         .. versionadded:: 3.4.0
 
@@ -244,7 +244,7 @@ class Catalog:
 
     def getTable(self, tableName: str) -> Table:
         """Get the table or view with the specified name. This table can be a temporary view or a
-        table/view. This throws an AnalysisException when no Table can be found.
+        table/view. This throws an :class:`AnalysisException` when no Table can be found.
 
         .. versionadded:: 3.4.0
 
@@ -363,7 +363,7 @@ class Catalog:
 
     def getFunction(self, functionName: str) -> Function:
         """Get the function with the specified name. This function can be a temporary function or a
-        function. This throws an AnalysisException when the function cannot be found.
+        function. This throws an :class:`AnalysisException` when the function cannot be found.
 
         .. versionadded:: 3.4.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, add new methods to `catalog.rst`;
2, follow sphinx synctax `AnalysisException` -> ``:class:`AnalysisException``


### Why are the changes needed?
Make sure new catalog methods listed in API reference


### Does this PR introduce _any_ user-facing change?
No, docs only


### How was this patch tested?
manually doc build and check, such as

![image](https://user-images.githubusercontent.com/7322292/177324325-63280b21-9e68-4780-a095-84bf9fd404ac.png)

![image](https://user-images.githubusercontent.com/7322292/177323978-59c527f5-108f-4559-821a-fa9480d76c1f.png)

![image](https://user-images.githubusercontent.com/7322292/177324089-669fdb2f-8696-4e50-b725-0af9f8516365.png)
