### PR TITLE
[SPARK-39616][BUILD][ML][FOLLOWUP] Fix flaky doctests

### DIFF
--- a/python/pyspark/mllib/linalg/distributed.py
+++ b/python/pyspark/mllib/linalg/distributed.py
@@ -423,7 +423,7 @@ class RowMatrix(DistributedMatrix):
         [DenseVector([-0.7071, 0.7071]), DenseVector([-0.7071, -0.7071])]
         >>> svd_model.s
         DenseVector([3.4641, 3.1623])
-        >>> svd_model.V # doctest: +ELLIPSIS
+        >>> svd_model.V # doctest: +SKIP
         DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, 0.0], 0)
         """
         j_model = self._java_matrix_wrapper.call("computeSVD", int(k), bool(computeU), float(rCond))
@@ -857,7 +857,7 @@ class IndexedRowMatrix(DistributedMatrix):
         IndexedRow(1, [-0.707106781187,-0.707106781187])]
         >>> svd_model.s
         DenseVector([3.4641, 3.1623])
-        >>> svd_model.V # doctest: +ELLIPSIS
+        >>> svd_model.V # doctest: +SKIP
         DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, 0.0], 0)
         """
         j_model = self._java_matrix_wrapper.call("computeSVD", int(k), bool(computeU), float(rCond))

--- a/python/pyspark/mllib/linalg/distributed.py
+++ b/python/pyspark/mllib/linalg/distributed.py
@@ -423,8 +423,8 @@ class RowMatrix(DistributedMatrix):
         [DenseVector([-0.7071, 0.7071]), DenseVector([-0.7071, -0.7071])]
         >>> svd_model.s
         DenseVector([3.4641, 3.1623])
-        >>> svd_model.V # doctest: +SKIP
-        DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, 0.0], 0)
+        >>> svd_model.V
+        DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, ...0.0], 0)
         """
         j_model = self._java_matrix_wrapper.call("computeSVD", int(k), bool(computeU), float(rCond))
         return SingularValueDecomposition(j_model)
@@ -857,8 +857,8 @@ class IndexedRowMatrix(DistributedMatrix):
         IndexedRow(1, [-0.707106781187,-0.707106781187])]
         >>> svd_model.s
         DenseVector([3.4641, 3.1623])
-        >>> svd_model.V # doctest: +SKIP
-        DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, 0.0], 0)
+        >>> svd_model.V
+        DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, ...0.0], 0)
         """
         j_model = self._java_matrix_wrapper.call("computeSVD", int(k), bool(computeU), float(rCond))
         return SingularValueDecomposition(j_model)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip flaky doctests


### Why are the changes needed?
```
File "/__w/spark/spark/python/pyspark/mllib/linalg/distributed.py", line 859, in __main__.IndexedRowMatrix.computeSVD
Failed example:
    svd_model.V # doctest: +ELLIPSIS
Expected:
    DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, 0.0], 0)
Got:
    DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, -0.0], 0)
**********************************************************************
File "/__w/spark/spark/python/pyspark/mllib/linalg/distributed.py", line 426, in __main__.RowMatrix.computeSVD
Failed example:
    svd_model.V # doctest: +ELLIPSIS
Expected:
    DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, 0.0], 0)
Got:
    DenseMatrix(3, 2, [-0.4082, -0.8165, -0.4082, 0.8944, -0.4472, -0.0], 0)
**********************************************************************
   1 of   6 in __main__.IndexedRowMatrix.computeSVD
   1 of   6 in __main__.RowMatrix.computeSVD
***Test Failed*** 2 failures.
Had test failures in pyspark.mllib.linalg.distributed with python3.9; see logs.
```

https://github.com/apache/spark/pull/37002 occasionally cause above tests output `-0.0` instead of `0.0`, I think they are both acceptable.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
updated doctests
