### PR TITLE
[SPARK-39691][TESTS] Update `MapStatusesConvertBenchmark` result files

### DIFF
--- a/core/benchmarks/MapStatusesConvertBenchmark-jdk11-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-jdk11-results.txt
@@ -2,12 +2,12 @@
 MapStatuses Convert Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
 Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
 MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Num Maps: 50000 Fetch partitions:500               1001           1033          36          0.0  1000638934.0       1.0X
-Num Maps: 50000 Fetch partitions:1000              1699           1705           7          0.0  1699358972.0       0.6X
-Num Maps: 50000 Fetch partitions:1500              2647           2855         314          0.0  2646904255.0       0.4X
+Num Maps: 50000 Fetch partitions:500               1324           1333           7          0.0  1324283680.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              2650           2670          32          0.0  2650318387.0       0.5X
+Num Maps: 50000 Fetch partitions:1500              4018           4059          53          0.0  4017921009.0       0.3X
 
 

--- a/core/benchmarks/MapStatusesConvertBenchmark-jdk17-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-jdk17-results.txt
@@ -1,0 +1,13 @@
+================================================================================================
+MapStatuses Convert Benchmark
+================================================================================================
+
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz
+MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Num Maps: 50000 Fetch partitions:500               1092           1104          22          0.0  1091691925.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              2172           2192          29          0.0  2171702137.0       0.5X
+Num Maps: 50000 Fetch partitions:1500              3268           3291          27          0.0  3267904436.0       0.3X
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -819,10 +819,6 @@
         <version>${protobuf.version}</version>
         <scope>${hadoop.deps.scope}</scope>
       </dependency>
-      <!--
-        When upgrading `RoaringBitmap`, the results of `MapStatusesConvertBenchmark`
-        and `MapStatusesSerDeserBenchmark` should to be updated.
-      -->
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -819,6 +819,10 @@
         <version>${protobuf.version}</version>
         <scope>${hadoop.deps.scope}</scope>
       </dependency>
+      <!--
+        When upgrading `RoaringBitmap`, the results of `MapStatusesConvertBenchmark`
+        and `MapStatusesSerDeserBenchmark` should to be updated
+      -->
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -821,7 +821,7 @@
       </dependency>
       <!--
         When upgrading `RoaringBitmap`, the results of `MapStatusesConvertBenchmark`
-        and `MapStatusesSerDeserBenchmark` should to be updated
+        and `MapStatusesSerDeserBenchmark` should to be updated.
       -->
       <dependency>
         <groupId>org.roaringbitmap</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
SPARK-39325 add `MapStatusesConvertBenchmark` but only upload result file generated by Java 8, so this pr supplement `MapStatusesConvertBenchmark` result generated by Java 11 and 17. 

On the other hand, SPARK-39626 upgraded `RoaringBitmap` from `0.9.28` to `0.9.30` and from the `IntelliJ Profiler` sampling, the hotspot path of `MapStatusesConvertBenchmark` contains `RoaringBitmap#contains`, so this pr also updated the result file generated by Java 8.


### Why are the changes needed?
Update `MapStatusesConvertBenchmark` result files


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions