### PR TITLE
[SPARK-39700][SQL][DOCS] Update two-parameter `listColumns/getTable/getFunction/tableExists/functionExists` functions docs to mention limitation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -105,6 +105,7 @@ abstract class Catalog {
    * @param tableName is an unqualified name that designates a table/view.
    * @since 2.0.0
    */
+  @deprecated("use listColumns(tableName) instead", "3.4.0")
   @throws[AnalysisException]("database or table does not exist")
   def listColumns(dbName: String, tableName: String): Dataset[Column]
 
@@ -135,6 +136,7 @@ abstract class Catalog {
    *
    * @since 2.1.0
    */
+  @deprecated("use getTable(tableName) instead", "3.4.0")
   @throws[AnalysisException]("database or table does not exist")
   def getTable(dbName: String, tableName: String): Table
 
@@ -158,6 +160,7 @@ abstract class Catalog {
    * @param functionName is an unqualified name that designates a function in the specified database
    * @since 2.1.0
    */
+  @deprecated("use getFunction(functionName) instead", "3.4.0")
   @throws[AnalysisException]("database or function does not exist")
   def getFunction(dbName: String, functionName: String): Function
 
@@ -186,6 +189,7 @@ abstract class Catalog {
    * @param tableName is an unqualified name that designates a table.
    * @since 2.1.0
    */
+  @deprecated("use tableExists(tableName) instead", "3.4.0")
   def tableExists(dbName: String, tableName: String): Boolean
 
   /**
@@ -206,6 +210,7 @@ abstract class Catalog {
    * @param functionName is an unqualified name that designates a function.
    * @since 2.1.0
    */
+  @deprecated("use functionExists(functionName) instead", "3.4.0")
   def functionExists(dbName: String, functionName: String): Boolean
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/Catalog.scala
@@ -101,11 +101,13 @@ abstract class Catalog {
   /**
    * Returns a list of columns for the given table/view in the specified database.
    *
+   * This API does not support 3 layer namespace since 3.4.0. To use 3 layer namespace,
+   * use listColumns(tableName) instead.
+   *
    * @param dbName is a name that designates a database.
    * @param tableName is an unqualified name that designates a table/view.
    * @since 2.0.0
    */
-  @deprecated("use listColumns(tableName) instead", "3.4.0")
   @throws[AnalysisException]("database or table does not exist")
   def listColumns(dbName: String, tableName: String): Dataset[Column]
 
@@ -134,9 +136,11 @@ abstract class Catalog {
    * Get the table or view with the specified name in the specified database. This throws an
    * AnalysisException when no Table can be found.
    *
+   * This API does not support 3 layer namespace since 3.4.0. To use 3 layer namespace,
+   * use getTable(tableName) instead.
+   *
    * @since 2.1.0
    */
-  @deprecated("use getTable(tableName) instead", "3.4.0")
   @throws[AnalysisException]("database or table does not exist")
   def getTable(dbName: String, tableName: String): Table
 
@@ -156,11 +160,13 @@ abstract class Catalog {
    * Get the function with the specified name. This throws an AnalysisException when the function
    * cannot be found.
    *
+   * This API does not support 3 layer namespace since 3.4.0. To use 3 layer namespace,
+   * use getFunction(functionName) instead.
+   *
    * @param dbName is a name that designates a database.
    * @param functionName is an unqualified name that designates a function in the specified database
    * @since 2.1.0
    */
-  @deprecated("use getFunction(functionName) instead", "3.4.0")
   @throws[AnalysisException]("database or function does not exist")
   def getFunction(dbName: String, functionName: String): Function
 
@@ -185,11 +191,13 @@ abstract class Catalog {
   /**
    * Check if the table or view with the specified name exists in the specified database.
    *
+   * This API does not support 3 layer namespace since 3.4.0. To use 3 layer namespace,
+   * use tableExists(tableName) instead.
+   *
    * @param dbName is a name that designates a database.
    * @param tableName is an unqualified name that designates a table.
    * @since 2.1.0
    */
-  @deprecated("use tableExists(tableName) instead", "3.4.0")
   def tableExists(dbName: String, tableName: String): Boolean
 
   /**
@@ -206,11 +214,13 @@ abstract class Catalog {
   /**
    * Check if the function with the specified name exists in the specified database.
    *
+   * This API does not support 3 layer namespace since 3.4.0. To use 3 layer namespace,
+   * use functionExists(functionName) instead.
+   *
    * @param dbName is a name that designates a database.
    * @param functionName is an unqualified name that designates a function.
    * @since 2.1.0
    */
-  @deprecated("use functionExists(functionName) instead", "3.4.0")
   def functionExists(dbName: String, functionName: String): Boolean
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update two-parameter `listColumns/getTable/getFunction/tableExists/functionExists` function's doc to mention the limitation. To use 3 layer namespace, the users can use single parameter functions.

### Why are the changes needed?

We can support the existing users without any overhead and advertise new 3 layer namespace API at the same time.

### Does this PR introduce _any_ user-facing change?

No. This is a doc change.

### How was this patch tested?

N/A