### PR TITLE
[SPARK-39707][SQL][DOCS] Add SQL reference for aggregate functions

### DIFF
--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -23,10 +23,6 @@ license: |
 
 Aggregate functions operate on values across rows to perform mathematical calculations such as sum, average, counting, minimum/maximum values, standard deviation, and estimation, as well as some non-mathematical operations.
 
-### General Aggregation
-
-These aggregate Functions use general syntax.
-
 #### Syntax
 
 ```sql

--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -34,8 +34,7 @@ These aggregate Functions use different syntax than the other aggregate function
 #### Syntax
 
 ```sql
-{ PERCENTILE_CONT | PERCENTILE_DISC }(percentile) WITHIN GROUP (ORDER BY order_by_expr) OVER
-( [  PARTITION BY partition_col_name = partition_col_val ( [ , ... ] ) ])
+{ PERCENTILE_CONT | PERCENTILE_DISC }(percentile) WITHIN GROUP (ORDER BY { order_by_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] }) FILTER (WHERE boolean_expression)
 ```
 
 #### Parameters
@@ -44,13 +43,13 @@ These aggregate Functions use different syntax than the other aggregate function
 
     The percentile of the value that you want to find. The percentile must be a constant between 0.0 and 1.0.
 
-* **order_by_expr**
+* **order_by_expression**
 
     The expression (typically a column name) by which to order the values.
 
-* **partition_col_name**
+* **boolean_expression**
 
-    This is the optional expression used to group rows into partitions.
+    Specifies any expression that evaluates to a result type boolean. Two or more expressions may be combined together using the logical operators ( AND, OR ).
 
 #### Examples
 
@@ -99,37 +98,26 @@ SELECT * FROM basic_pays;
 +-----------------+----------+------+
 
 SELECT
-    employee_name,
     department,
-    salary,
-    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary) OVER w AS p1,
-    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary) OVER w AS p2,
-    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary DESC) OVER w AS p3,
-    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary DESC) OVER w AS p4
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary) AS pc1,
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary) FILTER (WHERE employee_name LIKE '%Bo%') AS pc2,
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary DESC) AS pc3,
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary DESC) FILTER (WHERE employee_name LIKE '%Bo%') AS pc4,
+    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary) AS pd1,
+    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary) FILTER (WHERE employee_name LIKE '%Bo%') AS pd2,
+    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary DESC) AS pd3,
+    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary DESC) FILTER (WHERE employee_name LIKE '%Bo%') AS pd4
 FROM basic_pays
-WINDOW w AS (PARTITION BY department)
-ORDER BY salary;
-+-----------------+----------+------+-------+-------+-------+-------+
-|    employee_name|department|salary|     p1|     p2|     p3|     p4|
-+-----------------+----------+------+-------+-------+-------+-------+
-|  Leslie Thompson|        IT|  5186|5917.75| 5186.0|7381.25| 8113.0|
-|      Anthony Bow|Accounting|  6627|8543.75| 8435.0| 9746.5| 9998.0|
-|   Foon Yue Tseng|     Sales|	6660|8550.75| 6660.0| 9721.5|10563.0|
-| Gerard Hernandez|       SCM|	6949|10449.0|10449.0|11303.0|11303.0|
-|  Leslie Jennings|        IT|	8113|5917.75| 5186.0|7381.25| 8113.0|
-|     Diane Murphy|Accounting|	8435|8543.75| 8435.0| 9746.5| 9998.0|
-|William Patterson|Accounting|	8870|8543.75| 8435.0| 9746.5| 9998.0|
-|    Jeff Firrelli|Accounting|	8992|8543.75| 8435.0| 9746.5| 9998.0|
-|   Julie Firrelli|     Sales|	9181|8550.75| 6660.0| 9721.5|10563.0|
-|  Steve Patterson|     Sales|	9441|8550.75| 6660.0| 9721.5|10563.0|
-|   Mary Patterson|Accounting|	9998|8543.75| 8435.0| 9746.5| 9998.0|
-|      Loui Bondur|       SCM| 10449|10449.0|10449.0|11303.0|11303.0|
-|    George Vanauf|     Sales| 10563|8550.75| 6660.0| 9721.5|10563.0|
-|      Barry Jones|       SCM| 10586|10449.0|10449.0|11303.0|11303.0|
-|  Pamela Castillo|       SCM| 11303|10449.0|10449.0|11303.0|11303.0|
-|    Gerard Bondur|Accounting| 11472|8543.75| 8435.0| 9746.5| 9998.0|
-|       Larry Bott|    	  SCM| 11798|10449.0|10449.0|11303.0|11303.0|
-+-----------------+----------+------+-------+-------+-------+-------+
+GROUP BY department
+ORDER BY department;
++----------+-------+--------+-------+--------+-----+-----+-----+-----+
+|department|    pc1|     pc2|    pc3|     pc4|  pd1|  pd2|  pd3|  pd4|
++----------+-------+--------+-------+--------+-----+-----+-----+-----+
+|Accounting|8543.75| 7838.25| 9746.5|10260.75| 8435| 6627| 9998|11472|
+|        IT|5917.75|    NULL|7381.25|    NULL| 5186| NULL| 8113| NULL|
+|     Sales|8550.75|    NULL| 9721.5|    NULL| 6660| NULL|10563| NULL|
+|       SCM|10449.0|10786.25|11303.0|11460.75|10449|10449|11303|11798|
++----------+-------+--------+-------+--------+-----+-----+-----+-----+
 ```
 
 ### Related Statements

--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -25,7 +25,27 @@ Aggregate functions operate on values across rows to perform mathematical calcul
 
 ### General Aggregation
 
-Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for a complete list of Spark aggregate functions.
+These aggregate Functions use general syntax.
+
+#### Syntax
+
+```sql
+aggregate_function FILTER (WHERE boolean_expression)
+```
+
+#### Parameters
+
+* **aggregate_function**
+
+    Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for a complete list of Spark aggregate functions.
+
+* **boolean_expression**
+
+    Specifies any expression that evaluates to a result type boolean. Two or more expressions may be combined together using the logical operators ( AND, OR ).
+
+#### Examples
+
+Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for all the examples of Spark aggregate functions.
 
 ### Ordered-Set Aggregate Functions
 
@@ -45,7 +65,7 @@ These aggregate Functions use different syntax than the other aggregate function
 
 * **order_by_expression**
 
-    The expression (typically a column name) by which to order the values.
+    The expression (typically a column name) by which to order the values before aggregating them.
 
 * **boolean_expression**
 

--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -23,13 +23,13 @@ license: |
 
 Aggregate functions operate on values across rows to perform mathematical calculations such as sum, average, counting, minimum/maximum values, standard deviation, and estimation, as well as some non-mathematical operations.
 
-#### Syntax
+### Syntax
 
 ```sql
 aggregate_function FILTER (WHERE boolean_expression)
 ```
 
-#### Parameters
+### Parameters
 
 * **aggregate_function**
 
@@ -39,7 +39,7 @@ aggregate_function FILTER (WHERE boolean_expression)
 
     Specifies any expression that evaluates to a result type boolean. Two or more expressions may be combined together using the logical operators ( AND, OR ).
 
-#### Examples
+### Examples
 
 Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for all the examples of Spark aggregate functions.
 

--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -1,0 +1,137 @@
+---
+layout: global
+title: Aggregate Functions
+displayTitle: Aggregate Functions
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+ 
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+### Description
+
+Aggregate functions operate on values across rows to perform mathematical calculations such as sum, average, counting, minimum/maximum values, standard deviation, and estimation, as well as some non-mathematical operations.
+
+### General Aggregation
+
+Please refer to the [Built-in Aggregation Functions](sql-ref-functions-builtin.html#aggregate-functions) document for a complete list of Spark aggregate functions.
+
+### Ordered-Set Aggregate Functions
+
+These aggregate Functions use different syntax than the other aggregate functions so that to specify an expression (typically a column name) by which to order the values.
+
+#### Syntax
+
+```sql
+{ PERCENTILE_CONT | PERCENTILE_DISC }(percentile) WITHIN GROUP (ORDER BY order_by_expr) OVER
+( [  PARTITION BY partition_col_name = partition_col_val ( [ , ... ] ) ])
+```
+
+#### Parameters
+
+* **percentile**
+
+    The percentile of the value that you want to find. The percentile must be a constant between 0.0 and 1.0.
+
+* **order_by_expr**
+
+    The expression (typically a column name) by which to order the values.
+
+* **partition_col_name**
+
+    This is the optional expression used to group rows into partitions.
+
+#### Examples
+
+```sql
+CREATE OR REPLACE TEMPORARY VIEW basic_pays AS SELECT * FROM VALUES
+('Diane Murphy','Accounting',8435),
+('Mary Patterson','Accounting',9998),
+('Jeff Firrelli','Accounting',8992),
+('William Patterson','Accounting',8870),
+('Gerard Bondur','Accounting',11472),
+('Anthony Bow','Accounting',6627),
+('Leslie Jennings','IT',8113),
+('Leslie Thompson','IT',5186),
+('Julie Firrelli','Sales',9181),
+('Steve Patterson','Sales',9441),
+('Foon Yue Tseng','Sales',6660),
+('George Vanauf','Sales',10563),
+('Loui Bondur','SCM',10449),
+('Gerard Hernandez','SCM',6949),
+('Pamela Castillo','SCM',11303),
+('Larry Bott','SCM',11798),
+('Barry Jones','SCM',10586)
+AS basic_pays(employee_name, department, salary);
+
+SELECT * FROM basic_pays;
++-----------------+----------+------+
+|    employee_name|department|salary|
++-----------------+----------+------+
+|      Anthony Bow|Accounting|	6627|
+|      Barry Jones|	      SCM| 10586|
+|     Diane Murphy|Accounting|	8435|
+|   Foon Yue Tseng|	    Sales|	6660|
+|    George Vanauf|	    Sales| 10563|
+|    Gerard Bondur|Accounting| 11472|
+| Gerard Hernandez|	      SCM|	6949|
+|    Jeff Firrelli|Accounting|	8992|
+|   Julie Firrelli|	    Sales|	9181|
+|       Larry Bott|	      SCM| 11798|
+|  Leslie Jennings|        IT|	8113|
+|  Leslie Thompson|	       IT|	5186|
+|      Loui Bondur|	      SCM| 10449|
+|   Mary Patterson|Accounting|	9998|
+|  Pamela Castillo|	      SCM| 11303|
+|  Steve Patterson|	    Sales|	9441|
+|William Patterson|Accounting|	8870|
++-----------------+----------+------+
+
+SELECT
+    employee_name,
+    department,
+    salary,
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary) OVER w AS p1,
+    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary) OVER w AS p2,
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY salary DESC) OVER w AS p3,
+    percentile_disc(0.25) WITHIN GROUP (ORDER BY salary DESC) OVER w AS p4
+FROM basic_pays
+WINDOW w AS (PARTITION BY department)
+ORDER BY salary;
++-----------------+----------+------+-------+-------+-------+-------+
+|    employee_name|department|salary|     p1|     p2|     p3|     p4|
++-----------------+----------+------+-------+-------+-------+-------+
+|  Leslie Thompson|        IT|  5186|5917.75| 5186.0|7381.25| 8113.0|
+|      Anthony Bow|Accounting|  6627|8543.75| 8435.0| 9746.5| 9998.0|
+|   Foon Yue Tseng|	    Sales|	6660|8550.75| 6660.0| 9721.5|10563.0|
+| Gerard Hernandez|	      SCM|	6949|10449.0|10449.0|11303.0|11303.0|
+|  Leslie Jennings|	       IT|	8113|5917.75| 5186.0|7381.25| 8113.0|
+|     Diane Murphy|Accounting|	8435|8543.75| 8435.0| 9746.5| 9998.0|
+|William Patterson|Accounting|	8870|8543.75| 8435.0| 9746.5| 9998.0|
+|    Jeff Firrelli|Accounting|	8992|8543.75| 8435.0| 9746.5| 9998.0|
+|   Julie Firrelli|	    Sales|	9181|8550.75| 6660.0| 9721.5|10563.0|
+|  Steve Patterson|	    Sales|	9441|8550.75| 6660.0| 9721.5|10563.0|
+|   Mary Patterson|Accounting|	9998|8543.75| 8435.0| 9746.5| 9998.0|
+|      Loui Bondur|	      SCM| 10449|10449.0|10449.0|11303.0|11303.0|
+|    George Vanauf|	    Sales| 10563|8550.75| 6660.0| 9721.5|10563.0|
+|      Barry Jones|	      SCM| 10586|10449.0|10449.0|11303.0|11303.0|
+|  Pamela Castillo|	      SCM| 11303|10449.0|10449.0|11303.0|11303.0|
+|    Gerard Bondur|Accounting| 11472|8543.75| 8435.0| 9746.5| 9998.0|
+|       Larry Bott|    	  SCM| 11798|10449.0|10449.0|11303.0|11303.0|
++-----------------+----------+------+-------+-------+-------+-------+
+```
+
+### Related Statements
+
+* [SELECT](sql-ref-syntax-qry-select.html)

--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -80,21 +80,21 @@ SELECT * FROM basic_pays;
 |    employee_name|department|salary|
 +-----------------+----------+------+
 |      Anthony Bow|Accounting|	6627|
-|      Barry Jones|	      SCM| 10586|
+|      Barry Jones|       SCM| 10586|
 |     Diane Murphy|Accounting|	8435|
-|   Foon Yue Tseng|	    Sales|	6660|
-|    George Vanauf|	    Sales| 10563|
+|   Foon Yue Tseng|     Sales|	6660|
+|    George Vanauf|     Sales| 10563|
 |    Gerard Bondur|Accounting| 11472|
-| Gerard Hernandez|	      SCM|	6949|
+| Gerard Hernandez|       SCM|	6949|
 |    Jeff Firrelli|Accounting|	8992|
-|   Julie Firrelli|	    Sales|	9181|
-|       Larry Bott|	      SCM| 11798|
+|   Julie Firrelli|     Sales|	9181|
+|       Larry Bott|       SCM| 11798|
 |  Leslie Jennings|        IT|	8113|
-|  Leslie Thompson|	       IT|	5186|
-|      Loui Bondur|	      SCM| 10449|
+|  Leslie Thompson|        IT|	5186|
+|      Loui Bondur|       SCM| 10449|
 |   Mary Patterson|Accounting|	9998|
-|  Pamela Castillo|	      SCM| 11303|
-|  Steve Patterson|	    Sales|	9441|
+|  Pamela Castillo|       SCM| 11303|
+|  Steve Patterson|     Sales|	9441|
 |William Patterson|Accounting|	8870|
 +-----------------+----------+------+
 
@@ -114,19 +114,19 @@ ORDER BY salary;
 +-----------------+----------+------+-------+-------+-------+-------+
 |  Leslie Thompson|        IT|  5186|5917.75| 5186.0|7381.25| 8113.0|
 |      Anthony Bow|Accounting|  6627|8543.75| 8435.0| 9746.5| 9998.0|
-|   Foon Yue Tseng|	    Sales|	6660|8550.75| 6660.0| 9721.5|10563.0|
-| Gerard Hernandez|	      SCM|	6949|10449.0|10449.0|11303.0|11303.0|
-|  Leslie Jennings|	       IT|	8113|5917.75| 5186.0|7381.25| 8113.0|
+|   Foon Yue Tseng|     Sales|	6660|8550.75| 6660.0| 9721.5|10563.0|
+| Gerard Hernandez|       SCM|	6949|10449.0|10449.0|11303.0|11303.0|
+|  Leslie Jennings|        IT|	8113|5917.75| 5186.0|7381.25| 8113.0|
 |     Diane Murphy|Accounting|	8435|8543.75| 8435.0| 9746.5| 9998.0|
 |William Patterson|Accounting|	8870|8543.75| 8435.0| 9746.5| 9998.0|
 |    Jeff Firrelli|Accounting|	8992|8543.75| 8435.0| 9746.5| 9998.0|
-|   Julie Firrelli|	    Sales|	9181|8550.75| 6660.0| 9721.5|10563.0|
-|  Steve Patterson|	    Sales|	9441|8550.75| 6660.0| 9721.5|10563.0|
+|   Julie Firrelli|     Sales|	9181|8550.75| 6660.0| 9721.5|10563.0|
+|  Steve Patterson|     Sales|	9441|8550.75| 6660.0| 9721.5|10563.0|
 |   Mary Patterson|Accounting|	9998|8543.75| 8435.0| 9746.5| 9998.0|
-|      Loui Bondur|	      SCM| 10449|10449.0|10449.0|11303.0|11303.0|
-|    George Vanauf|	    Sales| 10563|8550.75| 6660.0| 9721.5|10563.0|
-|      Barry Jones|	      SCM| 10586|10449.0|10449.0|11303.0|11303.0|
-|  Pamela Castillo|	      SCM| 11303|10449.0|10449.0|11303.0|11303.0|
+|      Loui Bondur|       SCM| 10449|10449.0|10449.0|11303.0|11303.0|
+|    George Vanauf|     Sales| 10563|8550.75| 6660.0| 9721.5|10563.0|
+|      Barry Jones|       SCM| 10586|10449.0|10449.0|11303.0|11303.0|
+|  Pamela Castillo|       SCM| 11303|10449.0|10449.0|11303.0|11303.0|
 |    Gerard Bondur|Accounting| 11472|8543.75| 8435.0| 9746.5| 9998.0|
 |       Larry Bott|    	  SCM| 11798|10449.0|10449.0|11303.0|11303.0|
 +-----------------+----------+------+-------+-------+-------+-------+

--- a/docs/sql-ref-syntax-qry-select-aggregate.md
+++ b/docs/sql-ref-syntax-qry-select-aggregate.md
@@ -26,7 +26,7 @@ Aggregate functions operate on values across rows to perform mathematical calcul
 ### Syntax
 
 ```sql
-aggregate_function FILTER (WHERE boolean_expression)
+aggregate_function(input1 [, input2, ...]) FILTER (WHERE boolean_expression)
 ```
 
 ### Parameters

--- a/docs/sql-ref-syntax.md
+++ b/docs/sql-ref-syntax.md
@@ -76,6 +76,7 @@ ability to generate logical and physical plan for a given query using
    * [TABLESAMPLE](sql-ref-syntax-qry-select-sampling.html)
    * [Table-valued Function](sql-ref-syntax-qry-select-tvf.html)
    * [WHERE Clause](sql-ref-syntax-qry-select-where.html)
+   * [Aggregate Function](sql-ref-syntax-qry-select-aggregate.html)
    * [Window Function](sql-ref-syntax-qry-select-window.html)
    * [CASE Clause](sql-ref-syntax-qry-select-case.html)
    * [PIVOT Clause](sql-ref-syntax-qry-select-pivot.html)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark have a lot of built-in aggregate functions.
But the SQL Reference cannot find these aggregate functions directly and cannot describe the special syntax for PERCENTILE_CONT and PERCENTILE_DISC.


### Why are the changes needed?
Add SQL reference for aggregate functions


### Does this PR introduce _any_ user-facing change?
'Yes'.
Users can find these aggregate functions directly and the special syntax for PERCENTILE_CONT and PERCENTILE_DISC.

Before this PR, the part 'Data Retrieval Statements' of 'SQL Syntax' show below.
![image](https://user-images.githubusercontent.com/8486025/177722840-b3b6cee3-cb73-467d-8ccb-f8eb00e87304.png)
After this PR, the part 'Data Retrieval Statements' of 'SQL Syntax' show below.
![image](https://user-images.githubusercontent.com/8486025/177723000-55bb175b-9379-4f50-9ff8-87f89f30bd9a.png)

The page 'Aggregate Functions' show below.
![image](https://user-images.githubusercontent.com/8486025/178441142-6c41cbd6-8b29-4670-9263-732dca512fb9.png)
![image](https://user-images.githubusercontent.com/8486025/178438338-523130a1-6568-4098-b3c5-0c716732825a.png)
![image](https://user-images.githubusercontent.com/8486025/178438408-30c77409-9178-475a-bf41-a4aa2c4d422a.png)
![image](https://user-images.githubusercontent.com/8486025/178438467-c0a7414c-2de4-4fec-9b1e-9fcd109e256d.png)


### How was this patch tested?
N/A
