### PR TITLE
[SPARK-39709][SQL] The result of executeCollect and doExecute of TakeOrderedAndProjectExec should be the same

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -283,20 +283,7 @@ case class TakeOrderedAndProjectExec(
   }
 
   override def executeCollect(): Array[InternalRow] = {
-    val orderingSatisfies = SortOrder.orderingSatisfies(child.outputOrdering, sortOrder)
-    val ord = new LazilyGeneratedOrdering(sortOrder, child.output)
-    val limited = if (orderingSatisfies) {
-      child.execute().mapPartitionsInternal(_.map(_.copy()).take(limit)).takeOrdered(limit)(ord)
-    } else {
-      child.execute().mapPartitionsInternal(_.map(_.copy())).takeOrdered(limit)(ord)
-    }
-    val data = if (offset > 0) limited.drop(offset) else limited
-    if (projectList != child.output) {
-      val proj = UnsafeProjection.create(projectList, child.output)
-      data.map(r => proj(r).copy())
-    } else {
-      data
-    }
+    doExecute().mapPartitionsInternal(_.map(_.copy())).collect()
   }
 
   private val serializer: Serializer = new UnsafeRowSerializer(child.output.size)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `TakeOrderedAndProjectExec`'s `executeCollect` use `doExecute()`'s result.

### Why are the changes needed?

To make the result of `executeCollect` and `doExecute` of `TakeOrderedAndProjectExec` the same. For example:
```scala
import testImplicits._

Seq((1, 1), (1, 2), (2, 3), (2, 4), (3, 5), (3, 6), (3, 7)).toDF("a", "b")
  .orderBy("a")
  .selectExpr("b")
  .limit(6)
  .show()/.collect().foreach(println)
```
`.show()` will use `doExecute` and the result is:
```
+---+
|  b|
+---+
|  1|
|  2|
|  3|
|  4|
|  5|
|  6|
+---+
```
`.collect().foreach(println)` will use `executeCollect` and the result is:
```
[2]
[1]
[3]
[4]
[7]
[6]
```



### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.