### PR TITLE
[SPARK-38910][YARN][FOLLOWUP] Unmanaged AM should clean staging dir before unregister

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -327,8 +327,8 @@ private[spark] class ApplicationMaster(
           ApplicationMaster.EXIT_UNCAUGHT_EXCEPTION,
           "Uncaught exception: " + StringUtils.stringifyException(e))
         if (!unregistered) {
-          unregister(finalStatus, finalMsg)
           cleanupStagingDir(stagingDir)
+          unregister(finalStatus, finalMsg)
         }
     } finally {
       try {
@@ -348,8 +348,8 @@ private[spark] class ApplicationMaster(
       finish(FinalApplicationStatus.SUCCEEDED, ApplicationMaster.EXIT_SUCCESS)
     }
     if (!unregistered) {
-      unregister(finalStatus, finalMsg)
       cleanupStagingDir(stagingDir)
+      unregister(finalStatus, finalMsg)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Unmanaged AM should clean staging dir before unregister, since unregister may throw timeout exception  caused by yarn's bad performance


### Why are the changes needed?
Clan staging dir


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Not need
