### PR TITLE
[SPARK-39686][INFRA][FOLLOW-UP] Disable SparkR build in branch-3.2 with Scala 2.13

### DIFF
--- a/.github/workflows/build_branch32.yml
+++ b/.github/workflows/build_branch32.yml
@@ -36,12 +36,12 @@ jobs:
         {
           "SCALA_PROFILE": "scala2.13"
         }
+      # TODO(SPARK-39712): Reenable "sparkr": "true"
       # TODO(SPARK-39685): Reenable "lint": "true"
       # TODO(SPARK-39681): Reenable "pyspark": "true"
       # TODO(SPARK-39682): Reenable "docker-integration-tests": "true"
       jobs: >-
         {
           "build": "true",
-          "sparkr": "true",
           "tpcds-1g": "true"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/37091 that disables the SparkR build that has never passed in history at branch-3.2 with Scala 2.13.

See also SPARK-39712 (https://github.com/apache/spark/runs/7228058532?check_suite_focus=true)

### Why are the changes needed?

To have the very first green in the build.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in the scheduled jobs should test it out.