### PR TITLE
[SPARK-39710][SQL] Support push local topK through outer join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -229,6 +229,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
       // non-nullable when an empty relation child of a Union is removed
       UpdateAttributeNullability) :+
     Batch("Optimize One Row Plan", fixedPoint, OptimizeOneRowPlan) :+
+    // We should only push down local topK to the bottom outer join, so here make FixedPoint(1)
+    // instead of Once to skip idempotence enforcement.
+    Batch("Push Local TopK Through Outer Join", FixedPoint(1), PushLocalTopKThroughOuterJoin) :+
     // The following batch should be executed after batch "Join Reorder" and "LocalRelation".
     Batch("Check Cartesian Products", Once,
       CheckCartesianProducts) :+

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushLocalTopKThroughOuterJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushLocalTopKThroughOuterJoin.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{Literal, SortOrder}
+import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, ExtractTopK}
+import org.apache.spark.sql.catalyst.plans.{JoinType, LeftOuter, RightOuter}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LocalLimit, LogicalPlan, Project, RebalancePartitions, Repartition, RepartitionByExpression, Sort, Union}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.{LIMIT, OUTER_JOIN, SORT}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * This rule supports push down local limit and local sort from TopK through outer join:
+ *   - for a left outer join, the references of ordering of TopK come from the left side and
+ *     the limits of TopK is smaller than left side max rows
+ *   - for a right outer join, the references of ordering of TopK come from the right side and
+ *     the limits of TopK is smaller than right side max rows
+ *
+ * Note that, this rule only push down local topK to the bottom outer join which is different with
+ * [[LimitPushDown]]. This is to avoid regression due to the overhead of local sort.
+ */
+object PushLocalTopKThroughOuterJoin extends Rule[LogicalPlan] {
+  private def smallThan(limits: Int, maxRowsOpt: Option[Long]): Boolean = maxRowsOpt match {
+    case Some(maxRows) => limits < maxRows
+    case _ => true
+  }
+
+  private def canPushThroughOuterJoin(
+      joinType: JoinType,
+      order: Seq[SortOrder],
+      leftChild: LogicalPlan,
+      rightChild: LogicalPlan,
+      limits: Int): Boolean = joinType match {
+    case LeftOuter =>
+      order.forall(_.references.subsetOf(leftChild.outputSet)) &&
+        smallThan(limits, leftChild.maxRowsPerPartition)
+    case RightOuter =>
+      order.forall(_.references.subsetOf(rightChild.outputSet)) &&
+        smallThan(limits, rightChild.maxRowsPerPartition)
+    case _ => false
+  }
+
+  private def findOuterJoin(limits: Int, order: Seq[SortOrder], child: LogicalPlan): Seq[Join] = {
+    child match {
+      case j @ ExtractEquiJoinKeys(joinType, _, _, _, _, leftChild, rightChild, _)
+          if canPushThroughOuterJoin(joinType, order, leftChild, rightChild, limits) =>
+        // find the bottom outer join to push down local topK
+        val childOuterJoins = joinType match {
+          case LeftOuter => findOuterJoin(limits, order, leftChild)
+          case RightOuter => findOuterJoin(limits, order, rightChild)
+          case _ => Seq.empty
+        }
+        if (childOuterJoins.nonEmpty) {
+          childOuterJoins
+        } else {
+          j :: Nil
+        }
+      case u: Union => u.children.flatMap(child => findOuterJoin(limits, order, child))
+      case p: Project if p.projectList.forall(_.deterministic) =>
+        findOuterJoin(limits, order, p.child)
+      case r: RepartitionByExpression if r.partitionExpressions.forall(_.deterministic) =>
+        findOuterJoin(limits, order, r.child)
+      case r: RebalancePartitions if r.partitionExpressions.forall(_.deterministic) =>
+        findOuterJoin(limits, order, r.child)
+      case r: Repartition => findOuterJoin(limits, order, r.child)
+      case _ => Seq.empty
+    }
+  }
+
+  private def pushLocalTopK(limits: Int, order: Seq[SortOrder], join: Join): Join = {
+    val (newLeft, newRight) = join.joinType match {
+      case LeftOuter =>
+        (LocalLimit(Literal(limits), Sort(order, false, join.left)), join.right)
+
+      case RightOuter =>
+        (join.left, LocalLimit(Literal(limits), Sort(order, false, join.right)))
+
+      case _ => (join.left, join.right)
+    }
+
+    Join(newLeft, newRight, join.joinType, join.condition, join.hint)
+  }
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.transformWithPruning(_.containsAllPatterns(LIMIT, SORT, OUTER_JOIN), ruleId) {
+      case topK @ ExtractTopK(limits, order, _, child, _)
+          if limits <= conf.getConf(SQLConf.PUSH_DOWN_LOCAL_TOPK_LIMIT_THRESHOLD) =>
+        val outerJoins = findOuterJoin(limits, order, child)
+        if (outerJoins.nonEmpty) {
+          val identifierMap = new java.util.IdentityHashMap[Join, Join]
+          outerJoins.foreach { j =>
+            identifierMap.put(j, pushLocalTopK(limits, order, j))
+          }
+
+          topK.transformWithPruning(_.containsPattern(OUTER_JOIN)) {
+            case j: Join if identifierMap.containsKey(j) => identifierMap.get(j)
+          }
+        } else {
+          topK
+        }
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -135,6 +135,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.PushExtraPredicateThroughJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.PushFoldableIntoBranches" ::
       "org.apache.spark.sql.catalyst.optimizer.PushLeftSemiLeftAntiThroughJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.PushLocalTopKThroughOuterJoin" ::
       "org.apache.spark.sql.catalyst.optimizer.ReassignLambdaVariableID" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveDispensableExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.RemoveLiteralFromGroupExpressions" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -420,6 +420,14 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val PUSH_DOWN_LOCAL_TOPK_LIMIT_THRESHOLD =
+    buildConf("spark.sql.optimizer.pushDownLocalTopKLimitThreshold")
+      .doc("If the limit number is not larger than this threshold, Spark will try to push " +
+        "down local topK through outer join. Negative number means do not push down.")
+      .version("3.4.0")
+      .intConf
+      .createWithDefault(10000)
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushLocalTopKThroughOuterJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/PushLocalTopKThroughOuterJoinSuite.scala
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class PushLocalTopKThroughOuterJoinSuite extends PlanTest {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Push TopK Through Outer Join", FixedPoint(1),
+        PushDownPredicates,
+        PushLocalTopKThroughOuterJoin) :: Nil
+  }
+
+  private val testRelation1 = RelationWithoutMaxRows(Seq($"a".int, $"b".int, $"c".int))
+  private val testRelation2 = RelationWithoutMaxRows(Seq($"x".int, $"y".int, $"z".int))
+  private val testRelation3 = RelationWithoutMaxRows(Seq($"l".int, $"m".int, $"n".int))
+  private val emptyRelation = EmptyRelation(Seq($"x".int, $"y".int, $"z".int))
+
+  test("left outer join") {
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
+
+    def checkPushThrough(f: LogicalPlan => LogicalPlan): Unit = {
+      val input = f(x.join(y, LeftOuter, Some($"a" === $"x")))
+        .where($"a" > 1)
+        .orderBy($"a".asc, $"b".asc).limit(10)
+      val expected =
+        f(LocalLimit(10, x.where($"a" > 1).sortBy($"a".asc, $"b".asc))
+          .join(y, LeftOuter, Some($"a" === $"x")))
+          .orderBy($"a".asc, $"b".asc).limit(10)
+      comparePlans(Optimize.execute(input.analyze), expected.analyze)
+    }
+
+    checkPushThrough(identity)
+    checkPushThrough(Project(Seq($"a", $"a" as "a1"), _))
+    checkPushThrough(Repartition(2, true, _))
+    checkPushThrough(RepartitionByExpression(Seq.empty, _, None))
+    checkPushThrough(RebalancePartitions(Seq.empty, _))
+  }
+
+  test("right outer join") {
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
+
+    def checkPushThrough(f: LogicalPlan => LogicalPlan): Unit = {
+      val input = f(x.join(y, RightOuter, Some($"a" === $"x")))
+        .where($"x" > 0)
+        .orderBy($"x".asc).limit(10)
+      val expected = f(x.join(
+        LocalLimit(10, y.where($"x" > 0).sortBy($"x".asc)), RightOuter, Some($"a" === $"x")))
+        .orderBy($"x".asc).limit(10)
+      comparePlans(Optimize.execute(input.analyze), expected.analyze)
+    }
+
+    checkPushThrough(identity)
+    checkPushThrough(Project(Seq($"x", $"x" as "x1"), _))
+    checkPushThrough(Repartition(2, true, _))
+    checkPushThrough(RepartitionByExpression(Seq.empty, _, None))
+    checkPushThrough(RebalancePartitions(Seq.empty, _))
+  }
+
+  test("union outer join") {
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
+    val z = testRelation3.subquery("z")
+
+    val input = Union(
+      x.join(y, LeftOuter, Some($"a" === $"x"))
+        .select($"a", $"x", $"y").orderBy($"a".asc, $"b".asc).limit(10),
+      x)
+    val expected = Union(
+      LocalLimit(10, x.sortBy($"a".asc, $"b".asc)).join(y, LeftOuter, Some($"a" === $"x"))
+        .select($"a", $"x", $"y").orderBy($"a".asc, $"b".asc).limit(10),
+      x)
+    comparePlans(Optimize.execute(input.analyze), expected.analyze)
+
+    val input2 = Union(
+      x.join(y, LeftOuter, Some($"a" === $"x")).orderBy($"a".asc, $"b".asc).limit(10),
+      x.join(y, RightOuter, Some($"a" === $"x")).orderBy($"x".asc).limit(10))
+    val expected2 = Union(
+      LocalLimit(10, x.sortBy($"a".asc, $"b".asc)).join(y, LeftOuter, Some($"a" === $"x"))
+        .orderBy($"a".asc, $"b".asc).limit(10),
+      x.join(LocalLimit(10, y.sortBy($"x".asc)), RightOuter, Some($"a" === $"x"))
+        .orderBy($"x".asc).limit(10))
+    comparePlans(Optimize.execute(input2.analyze), expected2.analyze)
+
+    val input3 = Union(x, y).join(z, LeftOuter, Some($"a" === $"l"))
+      .orderBy($"a".asc).limit(10)
+    val expected3 = LocalLimit(10, Union(x, y).sortBy($"a".asc))
+      .join(z, LeftOuter, Some($"a" === $"l"))
+      .orderBy($"a".asc).limit(10)
+    comparePlans(Optimize.execute(input3.analyze), expected3.analyze)
+  }
+
+  test("multi outer join") {
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
+    val z = testRelation3.subquery("z")
+
+    // GlobalLimit
+    //   LocalLimit
+    //     Sort global
+    //       Join LeftOuter
+    //         Join LeftOuter
+    //           x
+    //           y
+    //       z
+    // ==========>
+    // GlobalLimit
+    //   LocalLimit
+    //     Sort global
+    //       Join LeftOuter
+    //         Join LeftOuter
+    //           LocalLimit
+    //             Sort local
+    //               x
+    //           y
+    //       z
+    val input = x.join(y, LeftOuter, Some($"a" === $"x"))
+      .join(z, LeftOuter, Some($"a" === $"l"))
+      .orderBy($"a".asc, $"b".asc).limit(10)
+    val expected = LocalLimit(10, x.sortBy($"a".asc, $"b".asc))
+      .join(y, LeftOuter, Some($"a" === $"x"))
+      .join(z, LeftOuter, Some($"a" === $"l"))
+      .orderBy($"a".asc, $"b".asc).limit(10)
+    comparePlans(Optimize.execute(input.analyze), expected.analyze)
+  }
+
+  test("negative case with push through node") {
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
+
+    val input = x.join(y, LeftOuter, Some($"a" === $"x")).groupBy($"x")(count("*"))
+      .orderBy($"x".asc).limit(10)
+    comparePlans(Optimize.execute(input.analyze), input.analyze)
+
+    val input2 = x.join(y, LeftOuter, Some($"a" === $"x")).where($"x" > 0)
+      .orderBy($"x".asc).limit(10)
+    comparePlans(Optimize.execute(input2.analyze), input2.analyze)
+  }
+
+  test("negative case with reference") {
+    val x = testRelation1.subquery("x")
+    val y = testRelation2.subquery("y")
+
+    val input = x.join(y, LeftOuter, Some($"a" === $"x")).orderBy($"x".asc).limit(10)
+    comparePlans(Optimize.execute(input.analyze), input.analyze)
+
+    val input2 = x.join(y, RightOuter, Some($"a" === $"x")).orderBy($"b".asc).limit(10)
+    comparePlans(Optimize.execute(input2.analyze), input2.analyze)
+
+    val input3 = x.join(y, Inner, Some($"a" === $"x")).orderBy($"b".asc).limit(10)
+    comparePlans(Optimize.execute(input3.analyze), input3.analyze)
+  }
+
+  test("negative case with max rows") {
+    val x = testRelation1.subquery("x")
+    val y = emptyRelation.subquery("y")
+
+    val input = y.join(x, LeftOuter, Some($"a" === $"x")).orderBy($"a".asc).limit(10)
+    comparePlans(Optimize.execute(input.analyze), input.analyze)
+
+    val input2 = x.limit(5).join(y, LeftOuter, Some($"a" === $"x")).orderBy($"a".asc).limit(10)
+    comparePlans(Optimize.execute(input2.analyze), input2.analyze)
+  }
+}

--- a/sql/core/benchmarks/TakeOrderedAndProjectBenchmark-jdk11-results.txt
+++ b/sql/core/benchmarks/TakeOrderedAndProjectBenchmark-jdk11-results.txt
@@ -9,4 +9,15 @@ TakeOrderedAndProject with SMJ:                    Best Time(ms)   Avg Time(ms) 
 TakeOrderedAndProject with SMJ for doExecute                 521            537          14          0.0       52122.1       1.0X
 TakeOrderedAndProject with SMJ for executeCollect            247            300          48          0.0       24737.7       2.1X
 
+OpenJDK 64-Bit Server VM 11.0.15+10-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Push local topK through outer join:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------
+Push local topK through outer join for bhj - off           3563           3596          29          0.0      356329.9       1.0X
+Push local topK through outer join for shj - off           3518           3575          71          0.0      351785.7       1.0X
+Push local topK through outer join for smj - off           3333           3341          12          0.0      333321.4       1.1X
+Push local topK through outer join for bhj - on             238            241           6          0.0       23760.9      15.0X
+Push local topK through outer join for shj - on             189            207          20          0.1       18895.4      18.9X
+Push local topK through outer join for smj - on             169            183          12          0.1       16909.7      21.1X
+
 

--- a/sql/core/benchmarks/TakeOrderedAndProjectBenchmark-jdk17-results.txt
+++ b/sql/core/benchmarks/TakeOrderedAndProjectBenchmark-jdk17-results.txt
@@ -9,4 +9,15 @@ TakeOrderedAndProject with SMJ:                    Best Time(ms)   Avg Time(ms) 
 TakeOrderedAndProject with SMJ for doExecute                 339            364          30          0.0       33873.3       1.0X
 TakeOrderedAndProject with SMJ for executeCollect            129            146          22          0.1       12949.3       2.6X
 
+OpenJDK 64-Bit Server VM 17.0.3+7-LTS on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Push local topK through outer join:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------
+Push local topK through outer join for bhj - off           4083           4113          29          0.0      408275.6       1.0X
+Push local topK through outer join for shj - off           3640           3740         102          0.0      364040.1       1.1X
+Push local topK through outer join for smj - off           3506           3553          61          0.0      350553.1       1.2X
+Push local topK through outer join for bhj - on             181            194          11          0.1       18130.6      22.5X
+Push local topK through outer join for shj - on             205            225          21          0.0       20512.0      19.9X
+Push local topK through outer join for smj - on             199            216          15          0.1       19884.8      20.5X
+
 

--- a/sql/core/benchmarks/TakeOrderedAndProjectBenchmark-results.txt
+++ b/sql/core/benchmarks/TakeOrderedAndProjectBenchmark-results.txt
@@ -9,4 +9,15 @@ TakeOrderedAndProject with SMJ:                    Best Time(ms)   Avg Time(ms) 
 TakeOrderedAndProject with SMJ for doExecute                 287            337          43          0.0       28734.9       1.0X
 TakeOrderedAndProject with SMJ for executeCollect            150            170          30          0.1       15037.8       1.9X
 
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Push local topK through outer join:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------
+Push local topK through outer join for bhj - off           3694           3717          22          0.0      369361.5       1.0X
+Push local topK through outer join for shj - off           3761           3767          11          0.0      376057.4       1.0X
+Push local topK through outer join for smj - off           3469           3478          10          0.0      346945.6       1.1X
+Push local topK through outer join for bhj - on              97            109          10          0.1        9745.2      37.9X
+Push local topK through outer join for shj - on             162            176          17          0.1       16153.5      22.9X
+Push local topK through outer join for smj - on             160            163           3          0.1       15974.6      23.1X
+
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -103,33 +103,8 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
     }
 
     private def planTakeOrdered(plan: LogicalPlan): Option[SparkPlan] = plan match {
-      // We should match the combination of limit and offset first, to get the optimal physical
-      // plan, instead of planning limit and offset separately.
-      case LimitAndOffset(limit, offset, Sort(order, true, child))
-          if limit < conf.topKSortFallbackThreshold =>
-        Some(TakeOrderedAndProjectExec(
-          limit, order, child.output, planLater(child), offset))
-      case LimitAndOffset(limit, offset, Project(projectList, Sort(order, true, child)))
-          if limit < conf.topKSortFallbackThreshold =>
-        Some(TakeOrderedAndProjectExec(
-          limit, order, projectList, planLater(child), offset))
-      // 'Offset a' then 'Limit b' is the same as 'Limit a + b' then 'Offset a'.
-      case OffsetAndLimit(offset, limit, Sort(order, true, child))
-          if offset + limit < conf.topKSortFallbackThreshold =>
-        Some(TakeOrderedAndProjectExec(
-          offset + limit, order, child.output, planLater(child), offset))
-      case OffsetAndLimit(offset, limit, Project(projectList, Sort(order, true, child)))
-          if offset + limit < conf.topKSortFallbackThreshold =>
-        Some(TakeOrderedAndProjectExec(
-          offset + limit, order, projectList, planLater(child), offset))
-      case Limit(IntegerLiteral(limit), Sort(order, true, child))
-          if limit < conf.topKSortFallbackThreshold =>
-        Some(TakeOrderedAndProjectExec(
-          limit, order, child.output, planLater(child)))
-      case Limit(IntegerLiteral(limit), Project(projectList, Sort(order, true, child)))
-          if limit < conf.topKSortFallbackThreshold =>
-        Some(TakeOrderedAndProjectExec(
-          limit, order, projectList, planLater(child)))
+      case ExtractTopK(limit, order, projectList, child, offset) =>
+        Some(TakeOrderedAndProjectExec(limit, order, projectList, planLater(child), offset))
       case _ => None
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- Pull out the pattern of `TakeOrderedAndProjectExec` to `ExtractTopK`
- Add a new rule `PushLocalTopKThroughOuterJoin` which matches the  `ExtractTopK` pattern
- Add a new config `spark.sql.optimizer.pushDownLocalTopKLimitThreshold` to decide how big limit we allow push local topK. This is in case regression if the limit number is bigger than the acutally row count.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Supports push down local limit and local sort from TopK through other join:
  - for a left outer join, the references of ordering of TopK come from the left side and
  the limits of TopK is smaller than left side 
  - for a right outer join, the references of ordering of TopK come from the right side and
  the limits of TopK is smaller than right side 

If multi-join satisfy the rule, we should only push local topK to the bottom join.

An example for simple left outer join:
```scala
Limit global + local
  Sort global
    Join Left_Outer
       x
       y

=>

Limit global + local
  Sort global
    Join Left_Outer
       Limit local
         Sort local
           x
       y
```

Compared with shuffle + join, local sort should be faster

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no, only improve performance

```
val row = 10 * 1000
val df1 = spark.range(0, row, 1, 2).selectExpr("id % 3 as c1", "id % 7 as cx")
val df2 = spark.range(0, row, 1, 2).selectExpr("id % 3 as c2")

df1.join(df2.hint("shuffle_hash"), col("c1") === col("c2"), "left_outer")
              .orderBy(col("cx"))
              .limit(100)
              .noop()
```
```
OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Linux 5.13.0-1031-azure
Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
Push local topK through outer join:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
--------------------------------------------------------------------------------------------------------------------------------
Push local topK through outer join for bhj - off           3694           3717          22          0.0      369361.5       1.0X
Push local topK through outer join for shj - off           3761           3767          11          0.0      376057.4       1.0X
Push local topK through outer join for smj - off           3469           3478          10          0.0      346945.6       1.1X
Push local topK through outer join for bhj - on              97            109          10          0.1        9745.2      37.9X
Push local topK through outer join for shj - on             162            176          17          0.1       16153.5      22.9X
Push local topK through outer join for smj - on             160            163           3          0.1       15974.6      23.1X
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test