### PR TITLE
[SPARK-39522][INFRA][FOLLOWUP] Rename infra cache image job to `Build / Cache base image`

### DIFF
--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Build (Infra Image Cache)
+name: Build / Cache base image
 
 on:
   push:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename infra cache image job to `Build / Cache base image`
https://github.com/apache/spark/pull/37003#discussion_r916576433

### Why are the changes needed?

Rename infra cache image job to `Build / Cache base image`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed