### PR TITLE
[SPARK-39721][R] Make recoverPartitions/listColumns in SparkR support 3L namespace

### DIFF
--- a/R/pkg/R/catalog.R
+++ b/R/pkg/R/catalog.R
@@ -410,6 +410,8 @@ listTables <- function(databaseName = NULL) {
 #' @param tableName the qualified or unqualified name that designates a table/view. If no database
 #'                  identifier is provided, it refers to a table/view in the current database.
 #'                  If \code{databaseName} parameter is specified, this must be an unqualified name.
+#'                  Since 3.4.0 it is allowed to be qualified with catalog name, when databaseName
+#'                  is NULL.
 #' @param databaseName (optional) name of the database
 #' @return a SparkDataFrame of the list of column descriptions.
 #' @rdname listColumns
@@ -417,7 +419,7 @@ listTables <- function(databaseName = NULL) {
 #' @examples
 #' \dontrun{
 #' sparkR.session()
-#' listColumns("mytable")
+#' listColumns("spark_catalog.default.mytable")
 #' }
 #' @note since 2.2.0
 listColumns <- function(tableName, databaseName = NULL) {
@@ -470,12 +472,13 @@ listFunctions <- function(databaseName = NULL) {
 #'
 #' @param tableName the qualified or unqualified name that designates a table. If no database
 #'                  identifier is provided, it refers to a table in the current database.
+#'                  Since 3.4.0 it is allowed to be qualified with catalog name.
 #' @rdname recoverPartitions
 #' @name recoverPartitions
 #' @examples
 #' \dontrun{
 #' sparkR.session()
-#' recoverPartitions("myTable")
+#' recoverPartitions("spark_catalog.default.myTable")
 #' }
 #' @note since 2.2.0
 recoverPartitions <- function(tableName) {

--- a/R/pkg/tests/fulltests/test_sparkSQL.R
+++ b/R/pkg/tests/fulltests/test_sparkSQL.R
@@ -4049,7 +4049,7 @@ test_that("catalog APIs, listTables, listColumns, listFunctions", {
   expect_error(listTables("bar"),
                "Error in listTables : no such database - Database 'bar' not found")
 
-  c <- listColumns("cars")
+  c <- listColumns("spark_catalog.default.cars")
   expect_equal(nrow(c), 2)
   expect_equal(colnames(c),
                c("name", "description", "dataType", "nullable", "isPartition", "isBucket"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make recoverPartitions/listColumns in SparkR support 3L namespace


### Why are the changes needed?
for 3L namespace


### Does this PR introduce _any_ user-facing change?
Yes, tableName now support 3L


### How was this patch tested?
updated UT