### PR TITLE
[SPARK-39724][CORE] Remove duplicate `.setAccessible(true)`  call in `kvstore.KVTypeInfo`

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/KVTypeInfo.java
@@ -48,7 +48,6 @@ public class KVTypeInfo {
         checkIndex(idx, indices);
         f.setAccessible(true);
         indices.put(idx.value(), idx);
-        f.setAccessible(true);
         accessors.put(idx.value(), new FieldAccessor(f));
       }
     }
@@ -61,7 +60,6 @@ public class KVTypeInfo {
           "Annotated method %s::%s should not have any parameters.", type.getName(), m.getName());
         m.setAccessible(true);
         indices.put(idx.value(), idx);
-        m.setAccessible(true);
         accessors.put(idx.value(), new MethodAccessor(m));
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just  remove duplicate `.setAccessible(true)`  call in `kvstore.KVTypeInfo`.


### Why are the changes needed?
Delete unnecessary method invokes



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions