### PR TITLE
[SPARK-37623][SPARK-39230][SQL][FOLLOW-UP] Make regr_slope and regr_intercept safe with ANSI mode

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
@@ -278,7 +278,8 @@ case class RegrSlope(left: Expression, right: Expression) extends DeclarativeAgg
     covarPop.mergeExpressions ++ varPop.mergeExpressions
 
   override lazy val evaluateExpression: Expression = {
-    If(covarPop.n === 0.0, Literal.create(null, DoubleType), covarPop.ck / varPop.m2)
+    If(Or(covarPop.n === 0.0, varPop.m2 === 0.0),
+      Literal.create(null, DoubleType), covarPop.ck / varPop.m2)
   }
 
   override lazy val inputAggBufferAttributes: Seq[AttributeReference] =
@@ -331,7 +332,7 @@ case class RegrIntercept(left: Expression, right: Expression) extends Declarativ
     covarPop.mergeExpressions ++ varPop.mergeExpressions
 
   override lazy val evaluateExpression: Expression = {
-    If(covarPop.n === 0.0, Literal.create(null, DoubleType),
+    If(Or(covarPop.n === 0.0, varPop.m2 === 0.0), Literal.create(null, DoubleType),
       covarPop.yAvg - covarPop.ck / varPop.m2 * covarPop.xAvg)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
@@ -278,8 +278,7 @@ case class RegrSlope(left: Expression, right: Expression) extends DeclarativeAgg
     covarPop.mergeExpressions ++ varPop.mergeExpressions
 
   override lazy val evaluateExpression: Expression = {
-    If(Or(covarPop.n === 0.0, varPop.m2 === 0.0),
-      Literal.create(null, DoubleType), covarPop.ck / varPop.m2)
+    If(varPop.m2 === 0.0, Literal.create(null, DoubleType), covarPop.ck / varPop.m2)
   }
 
   override lazy val inputAggBufferAttributes: Seq[AttributeReference] =
@@ -332,7 +331,7 @@ case class RegrIntercept(left: Expression, right: Expression) extends Declarativ
     covarPop.mergeExpressions ++ varPop.mergeExpressions
 
   override lazy val evaluateExpression: Expression = {
-    If(Or(covarPop.n === 0.0, varPop.m2 === 0.0), Literal.create(null, DoubleType),
+    If(varPop.m2 === 0.0, Literal.create(null, DoubleType),
       covarPop.yAvg - covarPop.ck / varPop.m2 * covarPop.xAvg)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `regr_slope` and `regr_intercept` ANSI-safe by checking zero to avoid divide-by-zero exceptions when ANSI mode is on.

### Why are the changes needed?

To make both expressions working regardless of ANSI mode.

### Does this PR introduce _any_ user-facing change?

No, both functions are not released yet.

### How was this patch tested?

`JDBCV2Suite` already covers it when ASNI mode is on. This was found by a broken test case, see also https://github.com/apache/spark/pull/36773/files#r916607535