### PR TITLE
[SPARK-39718][INFRA][FOLLOWUP] Remove redundant wrap in parts of the condition

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -254,7 +254,7 @@ jobs:
   infra-image:
     needs: precondition
     # Currently, only enable docker build from cache for `master` branch jobs
-    if: fromJson(needs.precondition.outputs.required).pyspark == 'true' && ${{ inputs.branch }} == 'master'
+    if: fromJson(needs.precondition.outputs.required).pyspark == 'true' && inputs.branch == 'master'
     runs-on: ubuntu-latest
     outputs:
       image_url: ${{ steps.infra-image-outputs.outputs.image_url }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove wrap in parts of the condition to infra image job avoid always execute

### Why are the changes needed?

Infra image job should skip when it's not a pyspark job such as [link](https://github.com/zhengruifeng/spark/runs/7250331184)(a R only job, but infra image triggered), but redundant wrap in parts of the condition has influence on condition

See also:
[1] https://github.community/t/multiple-if-conditional-with-always-is-always-true/128840/3

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed: https://github.com/Yikun/spark/runs/7251008418?check_suite_focus=true