### PR TITLE
[SPARK-39725][BUILD] Upgrade `jetty-http` from 9.4.46.v20220331 to 9.4.48.v20220622

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -145,7 +145,7 @@ jersey-hk2/2.35//jersey-hk2-2.35.jar
 jersey-server/2.35//jersey-server-2.35.jar
 jetty-sslengine/6.1.26//jetty-sslengine-6.1.26.jar
 jetty-util/6.1.26//jetty-util-6.1.26.jar
-jetty-util/9.4.46.v20220331//jetty-util-9.4.46.v20220331.jar
+jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
 jetty/6.1.26//jetty-6.1.26.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.13//joda-time-2.10.13.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -132,8 +132,8 @@ jersey-container-servlet/2.35//jersey-container-servlet-2.35.jar
 jersey-hk2/2.35//jersey-hk2-2.35.jar
 jersey-server/2.35//jersey-server-2.35.jar
 jettison/1.1//jettison-1.1.jar
-jetty-util-ajax/9.4.46.v20220331//jetty-util-ajax-9.4.46.v20220331.jar
-jetty-util/9.4.46.v20220331//jetty-util-9.4.46.v20220331.jar
+jetty-util-ajax/9.4.48.v20220622//jetty-util-ajax-9.4.48.v20220622.jar
+jetty-util/9.4.48.v20220622//jetty-util-9.4.48.v20220622.jar
 jline/2.14.6//jline-2.14.6.jar
 joda-time/2.10.13//joda-time-2.10.13.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>
     <orc.version>1.7.5</orc.version>
-    <jetty.version>9.4.46.v20220331</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>
     <ivy.version>2.5.0</ivy.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade `jetty-http` from 9.4.46.v20220331 to 9.4.48.v20220622


### Why are the changes needed?
[Release note](https://github.com/eclipse/jetty.project/releases)

[CVE-2022-2047](https://nvd.nist.gov/vuln/detail/CVE-2022-2047)

Info from Github dependabot

### Invalid URI parsing may produce invalid HttpURI.authority

### Description
URI use within Jetty's `HttpURI` class can parse invalid URIs such as `http://localhost;/path` as having an authority with a host of `localhost;`.

A URIs of the type `http://localhost;/path` should be interpreted to be either invalid or as `localhost;` to be the userinfo and no host.
However, `HttpURI.host` returns `localhost;` which is definitely wrong.

### Impact
This can lead to errors with Jetty's `HttpClient`, and Jetty's `ProxyServlet` / `AsyncProxyServlet` / `AsyncMiddleManServlet` wrongly interpreting an authority with no host as one with a host.

### Patches
Patched in PR https://github.com/eclipse/jetty.project/pull/8146 for Jetty version 9.4.47.
Patched in PR https://github.com/eclipse/jetty.project/pull/8015 for Jetty versions 10.0.10, and 11.0.10

### Workarounds
None.

### For more information
If you have any questions or comments about this advisory:

Email us at [security@webtide.com](mailto:security@webtide.com)."


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA