### PR TITLE
[SPARK-37730][PYTHON][FOLLOWUP] Split comments to comply pycodestyle check

### DIFF
--- a/python/pyspark/pandas/plot/matplotlib.py
+++ b/python/pyspark/pandas/plot/matplotlib.py
@@ -392,7 +392,8 @@ class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
             kwds = self.kwds.copy()
 
             label = pprint_thing(label if len(label) > 1 else label[0])
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             label = (
                 self._mark_right_label(label, index=i)
                 if hasattr(self, "_mark_right_label")
@@ -406,7 +407,8 @@ class PandasOnSparkHistPlot(PandasHistPlot, HistogramPlotBase):
 
             kwds = self._make_plot_keywords(kwds, y)
             artists = self._plot(ax, y, column_num=i, stacking_id=stacking_id, **kwds)
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             self._append_legend_handles_labels(artists[0], label) if hasattr(
                 self, "_append_legend_handles_labels"
             ) else self._add_legend_handle(artists[0], label, index=i)
@@ -492,7 +494,8 @@ class PandasOnSparkKdePlot(PandasKdePlot, KdePlotBase):
             kwds = self.kwds.copy()
 
             label = pprint_thing(label if len(label) > 1 else label[0])
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             label = (
                 self._mark_right_label(label, index=i)
                 if hasattr(self, "_mark_right_label")
@@ -506,7 +509,8 @@ class PandasOnSparkKdePlot(PandasKdePlot, KdePlotBase):
 
             kwds = self._make_plot_keywords(kwds, y)
             artists = self._plot(ax, y, column_num=i, stacking_id=stacking_id, **kwds)
-            # `if hasattr(...)` makes plotting compatible with pandas < 1.3, see pandas-dev/pandas#40078.
+            # `if hasattr(...)` makes plotting compatible with pandas < 1.3,
+            # see pandas-dev/pandas#40078.
             self._append_legend_handles_labels(artists[0], label) if hasattr(
                 self, "_append_legend_handles_labels"
             ) else self._add_legend_handle(artists[0], label, index=i)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of a backporting commit, https://github.com/apache/spark/commit/bc54a3f0c2e08893702c3929bfe7a9d543a08cdb .

### Why are the changes needed?

The original commit doesn't pass the linter check because there was no lint check between SPARK-37380 and SPARK-37834. The content of this PR is a part of SPARK-37834.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the Python Linter.