### PR TITLE
[SPARK-39735][INFRA] Enable base image build in lint job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -255,10 +255,18 @@ jobs:
     name: "Base image build"
     needs: precondition
     # Currently, only enable docker build from cache for `master` branch jobs
-    if: fromJson(needs.precondition.outputs.required).pyspark == 'true' && inputs.branch == 'master'
+    if: >-
+      (fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
+      fromJson(needs.precondition.outputs.required).lint == 'true') &&
+      inputs.branch == 'master'
     runs-on: ubuntu-latest
     outputs:
-      image_url: ${{ steps.infra-image-outputs.outputs.image_url }}
+      # Currently, only enable docker build from cache for `master` branch jobs
+      image_url: >-
+        ${{
+          (inputs.branch == 'master' && steps.infra-image-outputs.outputs.image_url)
+          || 'dongjoon/apache-spark-github-action-image:20220207'
+        }}
     steps:
       - name: Generate image name and url
         id: infra-image-outputs
@@ -311,11 +319,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       # Currently, only enable docker build from cache for `master` branch jobs
-      image: >-
-        ${{
-          (inputs.branch == 'master' && needs.infra-image.outputs.image_url)
-          || 'dongjoon/apache-spark-github-action-image:20220207'
-        }}
+      image: ${{ needs.infra-image.outputs.image_url }}
     strategy:
       fail-fast: false
       matrix:
@@ -485,8 +489,9 @@ jobs:
 
   # Static analysis, and documentation build
   lint:
-    needs: precondition
-    if: fromJson(needs.precondition.outputs.required).lint == 'true'
+    needs: [precondition, infra-image]
+    # always run if lint == 'true', even infra-image is skip (such as non-master job)
+    if: always() && fromJson(needs.precondition.outputs.required).lint == 'true'
     name: Linters, licenses, dependencies and documentation generation
     runs-on: ubuntu-20.04
     env:
@@ -495,7 +500,7 @@ jobs:
       PYSPARK_DRIVER_PYTHON: python3.9
       PYSPARK_PYTHON: python3.9
     container:
-      image: dongjoon/apache-spark-github-action-image:20220207
+      image: ${{ needs.infra-image.outputs.image_url }}
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -261,7 +261,6 @@ jobs:
       inputs.branch == 'master'
     runs-on: ubuntu-latest
     outputs:
-      # Currently, only enable docker build from cache for `master` branch jobs
       image_url: >-
         ${{
           (inputs.branch == 'master' && steps.infra-image-outputs.outputs.image_url)
@@ -318,7 +317,6 @@ jobs:
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
-      # Currently, only enable docker build from cache for `master` branch jobs
       image: ${{ needs.infra-image.outputs.image_url }}
     strategy:
       fail-fast: false

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -54,3 +54,5 @@ RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-c
 RUN apt update
 RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
 RUN Rscript -e "install.packages(c('knitr', 'markdown', 'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
+
+ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -55,4 +55,5 @@ RUN apt update
 RUN $APT_INSTALL r-base libcurl4-openssl-dev qpdf libssl-dev zlib1g-dev
 RUN Rscript -e "install.packages(c('knitr', 'markdown', 'rmarkdown', 'testthat', 'devtools', 'e1071', 'survival', 'arrow', 'roxygen2', 'xml2'), repos='https://cloud.r-project.org/')"
 
+# See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"


### PR DESCRIPTION
### What changes were proposed in this pull request?
![image](https://user-images.githubusercontent.com/1736354/178188601-d90be215-e252-44bd-ad77-576d91cfaa15.png)

https://docs.google.com/document/d/1_uiId-U1DODYyYZejAZeyz2OAjxcnA-xfwjynDF6vd0/

- Add base image build for lint job
- Fix a sparkr search paths env
  Add a ENV `ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"`:

### Why are the changes needed?

Since sparkr 4.2.x has [below new change](https://github.com/r-devel/r-svn/blob/e6be1f6b14838016e78d6a91f48f21acec7fa4c4/doc/NEWS.Rd#L376):
  > Environment variables R_LIBS_USER and R_LIBS_SITE are both now set to the R system default if unset or empty, and can be set to NULL to indicate an empty list of user or site library directories.

lastest ubuntu pkg also sync this change and has some changes on /etc/R/Renviron ():
```
$ docker run -ti ghcr.io/yikun/apache-spark-github-action-image:sparkr-master-2569799176 cat /etc/R/Renviron | grep R_LIBS_SITE

R_LIBS_SITE=${R_LIBS_SITE:-'%S'}

$ docker run -ti ghcr.io/yikun/apache-spark-github-action-image:sparkr-master-2569799176 cat /etc/R/Renviron.site | grep R_LIBS_SITE

## edd Jul 2007  Now use R_LIBS_SITE, not R_LIBS
## edd Mar 2022  Now in Renviron.site reflecting R_LIBS_SITE
R_LIBS_SITE="/usr/local/lib/R/site-library/:${R_LIBS_SITE}:/usr/lib/R/library"
```

So, we add `R_LIBS_SITE` to ENV from `/etc/R/Renviron.site` to make sure search paths right for sparkr.

otherwise, even if we install the `lintr` will cause error like due to `R_LIBS_SITE` wrong set:
```
$ dev/lint-r
Loading required namespace: SparkR
Loading required namespace: lintr
Failed with error:  'there is no package called 'lintr''
Installing package into '/usr/lib/R/site-library'
(as 'lib' is unspecified)
Error in contrib.url(repos, type) :
  trying to use CRAN without setting a mirror
Calls: install.packages -> startsWith -> contrib.url
Execution halted
```

[1] https://cran.r-project.org/doc/manuals/r-devel/NEWS.html
[2] https://stat.ethz.ch/R-manual/R-devel/library/base/html/libPaths.html


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed, a test on my local repo: https://github.com/Yikun/spark/pull/121
