### PR TITLE
[SPARK-26052] Add type comments to exposed Prometheus metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusServlet.scala
+++ b/core/src/main/scala/org/apache/spark/metrics/sink/PrometheusServlet.scala
@@ -36,6 +36,7 @@ import org.apache.spark.ui.JettyUtils._
 private[spark] class PrometheusServlet(
     val property: Properties, val registry: MetricRegistry) extends Sink {
 
+
   val SERVLET_KEY_PATH = "path"
 
   val servletPath = property.getProperty(SERVLET_KEY_PATH)
@@ -50,71 +51,134 @@ private[spark] class PrometheusServlet(
   def getMetricsSnapshot(request: HttpServletRequest): String = {
     import scala.collection.JavaConverters._
 
-    val gaugesLabel = """{type="gauges"}"""
     val countersLabel = """{type="counters"}"""
     val metersLabel = countersLabel
-    val histogramslabels = """{type="histograms"}"""
     val timersLabels = """{type="timers"}"""
 
     val sb = new StringBuilder()
     registry.getGauges.asScala.foreach { case (k, v) =>
       if (!v.getValue.isInstanceOf[String]) {
-        sb.append(s"${normalizeKey(k)}Number$gaugesLabel ${v.getValue}\n")
-        sb.append(s"${normalizeKey(k)}Value$gaugesLabel ${v.getValue}\n")
+        sb.append(s"# TYPE ${normalizeKey(k)}Number gauge\n")
+        sb.append(s"${normalizeKey(k)}Number ${v.getValue}\n")
+
+        sb.append(s"# TYPE ${normalizeKey(k)}Value gauge\n")
+        sb.append(s"${normalizeKey(k)}Value ${v.getValue}\n")
       }
     }
     registry.getCounters.asScala.foreach { case (k, v) =>
-      sb.append(s"${normalizeKey(k)}Count$countersLabel ${v.getCount}\n")
+      sb.append(s"# TYPE ${normalizeKey(k)}Number counter\n")
+      sb.append(s"${normalizeKey(k)}Count ${v.getCount}\n")
     }
+
     registry.getHistograms.asScala.foreach { case (k, h) =>
       val snapshot = h.getSnapshot
       val prefix = normalizeKey(k)
-      sb.append(s"${prefix}Count$histogramslabels ${h.getCount}\n")
-      sb.append(s"${prefix}Max$histogramslabels ${snapshot.getMax}\n")
-      sb.append(s"${prefix}Mean$histogramslabels ${snapshot.getMean}\n")
-      sb.append(s"${prefix}Min$histogramslabels ${snapshot.getMin}\n")
-      sb.append(s"${prefix}50thPercentile$histogramslabels ${snapshot.getMedian}\n")
-      sb.append(s"${prefix}75thPercentile$histogramslabels ${snapshot.get75thPercentile}\n")
-      sb.append(s"${prefix}95thPercentile$histogramslabels ${snapshot.get95thPercentile}\n")
-      sb.append(s"${prefix}98thPercentile$histogramslabels ${snapshot.get98thPercentile}\n")
-      sb.append(s"${prefix}99thPercentile$histogramslabels ${snapshot.get99thPercentile}\n")
-      sb.append(s"${prefix}999thPercentile$histogramslabels ${snapshot.get999thPercentile}\n")
-      sb.append(s"${prefix}StdDev$histogramslabels ${snapshot.getStdDev}\n")
+
+      sb.append(s"# TYPE ${prefix}Count histogram\n")
+      sb.append(s"${prefix}Count ${h.getCount}\n")
+
+      sb.append(s"# TYPE ${prefix}Max histogram\n")
+      sb.append(s"${prefix}Max ${snapshot.getMax}\n")
+
+      sb.append(s"# TYPE ${prefix}Mean histogram\n")
+      sb.append(s"${prefix}Mean ${snapshot.getMean}\n")
+
+      sb.append(s"# TYPE ${prefix}Min histogram\n")
+      sb.append(s"${prefix}Min ${snapshot.getMin}\n")
+
+      sb.append(s"# TYPE ${prefix}50thPercentile histogram\n")
+      sb.append(s"${prefix}50thPercentile ${snapshot.getMedian}\n")
+
+      sb.append(s"# TYPE ${prefix}75thPercentile histogram\n")
+      sb.append(s"${prefix}75thPercentile ${snapshot.get75thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}95thPercentile histogram\n")
+      sb.append(s"${prefix}95thPercentile ${snapshot.get95thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}98thPercentile histogram\n")
+      sb.append(s"${prefix}98thPercentile ${snapshot.get98thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}99thPercentile histogram\n")
+      sb.append(s"${prefix}99thPercentile ${snapshot.get99thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}999thPercentile histogram\n")
+      sb.append(s"${prefix}999thPercentile ${snapshot.get999thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}StdDev histogram\n")
+      sb.append(s"${prefix}StdDev ${snapshot.getStdDev}\n")
     }
     registry.getMeters.entrySet.iterator.asScala.foreach { kv =>
       val prefix = normalizeKey(kv.getKey)
       val meter = kv.getValue
-      sb.append(s"${prefix}Count$metersLabel ${meter.getCount}\n")
-      sb.append(s"${prefix}MeanRate$metersLabel ${meter.getMeanRate}\n")
-      sb.append(s"${prefix}OneMinuteRate$metersLabel ${meter.getOneMinuteRate}\n")
-      sb.append(s"${prefix}FiveMinuteRate$metersLabel ${meter.getFiveMinuteRate}\n")
-      sb.append(s"${prefix}FifteenMinuteRate$metersLabel ${meter.getFifteenMinuteRate}\n")
+      sb.append(s"# TYPE ${prefix}Count counter\n" )
+      sb.append(s"${prefix}Count ${meter.getCount}\n")
+
+      sb.append(s"# TYPE ${prefix}MeanRate counter\n" )
+      sb.append(s"${prefix}MeanRate ${meter.getMeanRate}\n")
+
+      sb.append(s"# TYPE ${prefix}OneMinuteRate counter\n" )
+      sb.append(s"${prefix}OneMinuteRate ${meter.getOneMinuteRate}\n")
+
+      sb.append(s"# TYPE ${prefix}FiveMinuteRate counter\n" )
+      sb.append(s"${prefix}FiveMinuteRate ${meter.getFiveMinuteRate}\n")
+
+      sb.append(s"# TYPE ${prefix}FifteenMinuteRate counter\n" )
+      sb.append(s"${prefix}FifteenMinuteRate ${meter.getFifteenMinuteRate}\n")
     }
     registry.getTimers.entrySet.iterator.asScala.foreach { kv =>
       val prefix = normalizeKey(kv.getKey)
       val timer = kv.getValue
       val snapshot = timer.getSnapshot
-      sb.append(s"${prefix}Count$timersLabels ${timer.getCount}\n")
-      sb.append(s"${prefix}Max$timersLabels ${snapshot.getMax}\n")
-      sb.append(s"${prefix}Mean$timersLabels ${snapshot.getMean}\n")
-      sb.append(s"${prefix}Min$timersLabels ${snapshot.getMin}\n")
-      sb.append(s"${prefix}50thPercentile$timersLabels ${snapshot.getMedian}\n")
-      sb.append(s"${prefix}75thPercentile$timersLabels ${snapshot.get75thPercentile}\n")
-      sb.append(s"${prefix}95thPercentile$timersLabels ${snapshot.get95thPercentile}\n")
-      sb.append(s"${prefix}98thPercentile$timersLabels ${snapshot.get98thPercentile}\n")
-      sb.append(s"${prefix}99thPercentile$timersLabels ${snapshot.get99thPercentile}\n")
-      sb.append(s"${prefix}999thPercentile$timersLabels ${snapshot.get999thPercentile}\n")
-      sb.append(s"${prefix}StdDev$timersLabels ${snapshot.getStdDev}\n")
-      sb.append(s"${prefix}FifteenMinuteRate$timersLabels ${timer.getFifteenMinuteRate}\n")
-      sb.append(s"${prefix}FiveMinuteRate$timersLabels ${timer.getFiveMinuteRate}\n")
-      sb.append(s"${prefix}OneMinuteRate$timersLabels ${timer.getOneMinuteRate}\n")
-      sb.append(s"${prefix}MeanRate$timersLabels ${timer.getMeanRate}\n")
+      sb.append(s"# TYPE ${prefix}Count gauge\n" )
+      sb.append(s"${prefix}Count ${timer.getCount}\n")
+
+      sb.append(s"# TYPE ${prefix}Max gauge\n" )
+      sb.append(s"${prefix}Max ${snapshot.getMax}\n")
+
+      sb.append(s"# TYPE ${prefix}Mean gauge\n" )
+      sb.append(s"${prefix}Mean ${snapshot.getMean}\n")
+
+      sb.append(s"# TYPE ${prefix}Min gauge\n" )
+      sb.append(s"${prefix}Min ${snapshot.getMin}\n")
+
+      sb.append(s"# TYPE ${prefix}50thPercentile gauge\n" )
+      sb.append(s"${prefix}50thPercentile ${snapshot.getMedian}\n")
+
+      sb.append(s"# TYPE ${prefix}75thPercentile gauge\n" )
+      sb.append(s"${prefix}75thPercentile ${snapshot.get75thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}95thPercentile gauge\n" )
+      sb.append(s"${prefix}95thPercentile ${snapshot.get95thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}98thPercentile gauge\n" )
+      sb.append(s"${prefix}98thPercentile ${snapshot.get98thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}99thPercentile gauge\n" )
+      sb.append(s"${prefix}99thPercentile ${snapshot.get99thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}999thPercentile gauge\n" )
+      sb.append(s"${prefix}999thPercentile ${snapshot.get999thPercentile}\n")
+
+      sb.append(s"# TYPE ${prefix}StdDev gauge\n" )
+      sb.append(s"${prefix}StdDev ${snapshot.getStdDev}\n")
+
+      sb.append(s"# TYPE ${prefix}FifteenMinuteRate gauge\n" )
+      sb.append(s"${prefix}FifteenMinuteRate ${timer.getFifteenMinuteRate}\n")
+
+      sb.append(s"# TYPE ${prefix}FiveMinuteRate gauge\n" )
+      sb.append(s"${prefix}FiveMinuteRate ${timer.getFiveMinuteRate}\n")
+
+      sb.append(s"# TYPE ${prefix}OneMinuteRate gauge\n" )
+      sb.append(s"${prefix}OneMinuteRate ${timer.getOneMinuteRate}\n")
+
+      sb.append(s"# TYPE ${prefix}MeanRate gauge\n" )
+      sb.append(s"${prefix}MeanRate ${timer.getMeanRate}\n")
     }
     sb.toString()
   }
 
   private def normalizeKey(key: String): String = {
-    s"metrics_${key.replaceAll("[^a-zA-Z0-9]", "_")}_"
+    s"metrics_${key.replaceAll("[^a-zA-Z\\d]", "_")}_"
   }
 
   override def start(): Unit = { }

--- a/core/src/main/scala/org/apache/spark/status/api/v1/PrometheusResource.scala
+++ b/core/src/main/scala/org/apache/spark/status/api/v1/PrometheusResource.scala
@@ -52,26 +52,64 @@ private[v1] class PrometheusResource extends ApiRequestContext {
         "application_name" -> store.applicationInfo.name,
         "executor_id" -> executor.id
       ).map { case (k, v) => s"""$k="$v"""" }.mkString("{", ", ", "}")
+
+      sb.append(s"# TYPE ${prefix}rddBlocks gauge\n")
       sb.append(s"${prefix}rddBlocks$labels ${executor.rddBlocks}\n")
+
+      sb.append(s"# TYPE ${prefix}memoryUsed_bytes gauge\n")
       sb.append(s"${prefix}memoryUsed_bytes$labels ${executor.memoryUsed}\n")
+
+      sb.append(s"# TYPE ${prefix}diskUsed_bytes gauge\n")
       sb.append(s"${prefix}diskUsed_bytes$labels ${executor.diskUsed}\n")
+
+      sb.append(s"# TYPE ${prefix}totalCores gauge\n")
       sb.append(s"${prefix}totalCores$labels ${executor.totalCores}\n")
+
+      sb.append(s"# TYPE ${prefix}maxTasks gauge\n")
       sb.append(s"${prefix}maxTasks$labels ${executor.maxTasks}\n")
+
+      sb.append(s"# TYPE ${prefix}activeTasks gauge\n")
       sb.append(s"${prefix}activeTasks$labels ${executor.activeTasks}\n")
+
+      sb.append(s"# TYPE ${prefix}failedTasks_total gauge\n")
       sb.append(s"${prefix}failedTasks_total$labels ${executor.failedTasks}\n")
+
+      sb.append(s"# TYPE ${prefix}completedTasks_total gauge\n")
       sb.append(s"${prefix}completedTasks_total$labels ${executor.completedTasks}\n")
+
+      sb.append(s"# TYPE ${prefix}totalTasks_total gauge\n")
       sb.append(s"${prefix}totalTasks_total$labels ${executor.totalTasks}\n")
+
+      sb.append(s"# TYPE ${prefix}totalDuration_seconds_total gauge\n")
       sb.append(s"${prefix}totalDuration_seconds_total$labels ${executor.totalDuration * 0.001}\n")
+
+      sb.append(s"# TYPE ${prefix}totalGCTime_seconds_total gauge\n")
       sb.append(s"${prefix}totalGCTime_seconds_total$labels ${executor.totalGCTime * 0.001}\n")
+
+      sb.append(s"# TYPE ${prefix}totalInputBytes_bytes_total gauge\n")
       sb.append(s"${prefix}totalInputBytes_bytes_total$labels ${executor.totalInputBytes}\n")
+
+      sb.append(s"# TYPE ${prefix}totalShuffleRead_bytes_total gauge\n")
       sb.append(s"${prefix}totalShuffleRead_bytes_total$labels ${executor.totalShuffleRead}\n")
+
+      sb.append(s"# TYPE ${prefix}totalShuffleWrite_bytes_total gauge\n")
       sb.append(s"${prefix}totalShuffleWrite_bytes_total$labels ${executor.totalShuffleWrite}\n")
+
+      sb.append(s"# TYPE ${prefix}maxMemory_bytes gauge\n")
       sb.append(s"${prefix}maxMemory_bytes$labels ${executor.maxMemory}\n")
       executor.executorLogs.foreach { case (k, v) => }
       executor.memoryMetrics.foreach { m =>
+
+        sb.append(s"# TYPE ${prefix}usedOnHeapStorageMemory_bytes gauge\n")
         sb.append(s"${prefix}usedOnHeapStorageMemory_bytes$labels ${m.usedOnHeapStorageMemory}\n")
+
+        sb.append(s"# TYPE ${prefix}usedOffHeapStorageMemory_bytes gauge\n")
         sb.append(s"${prefix}usedOffHeapStorageMemory_bytes$labels ${m.usedOffHeapStorageMemory}\n")
+
+        sb.append(s"# TYPE ${prefix}totalOnHeapStorageMemory_bytes gauge\n")
         sb.append(s"${prefix}totalOnHeapStorageMemory_bytes$labels ${m.totalOnHeapStorageMemory}\n")
+
+        sb.append(s"# TYPE ${prefix}totalOffHeapStorageMemory_bytes gauge\n")
         sb.append(s"${prefix}totalOffHeapStorageMemory_bytes$labels " +
           s"${m.totalOffHeapStorageMemory}\n")
       }
@@ -95,12 +133,15 @@ private[v1] class PrometheusResource extends ApiRequestContext {
           "ProcessTreeOtherRSSMemory"
         )
         names.foreach { name =>
+          sb.append(s"# TYPE $prefix${name}_bytes gauge\n")
           sb.append(s"$prefix${name}_bytes$labels ${m.getMetricValue(name)}\n")
         }
         Seq("MinorGCCount", "MajorGCCount").foreach { name =>
+          sb.append(s"# TYPE $prefix${name}_total counter\n")
           sb.append(s"$prefix${name}_total$labels ${m.getMetricValue(name)}\n")
         }
         Seq("MinorGCTime", "MajorGCTime").foreach { name =>
+          sb.append(s"# TYPE $prefix${name}_seconds_total counter\n")
           sb.append(s"$prefix${name}_seconds_total$labels ${m.getMetricValue(name) * 0.001}\n")
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a `# TYPE` comment for every exposed Prometheus metric

### Why are the changes needed?

According to [Prometheus' exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md), a type comment is expected before every metric.

The PrometheusServlet exposed the metrics with types as lables, which is not in accordance with the expected format.
This causes tools such Cloudwatch agent to treat such metrics as untyped and discard them.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manually tested by letting CloudWatch agent scrape the Prometheus endpoint of a modified spark driver.
All metrics reported with a type, which were previously discarded, have been added to CW:

![image](https://user-images.githubusercontent.com/11798914/178227039-716597cb-eb18-47bc-9da1-d894f830362d.png)



