### PR TITLE
[SPARK-39742][core]Fix a problem with the result of adjusting resources is not exp…

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -763,7 +763,10 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
     val response = synchronized {
       val defaultProf = scheduler.sc.resourceProfileManager.defaultResourceProfile
-      val numExisting = requestedTotalExecutorsPerResourceProfile.getOrElse(defaultProf, 0)
+      val numExisting = requestedTotalExecutorsPerResourceProfile.get(defaultProf) match {
+        case Some(s) => s
+        case _ => scheduler.sc.getExecutorIds().size
+      }
       requestedTotalExecutorsPerResourceProfile(defaultProf) = numExisting + numAdditionalExecutors
       // Account for executors pending to be added or removed
       updateExecRequestTime(defaultProf.id, numAdditionalExecutors)
@@ -877,14 +880,12 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
         withLock {
           val rpId = executorDataMap(exec).resourceProfileId
           val rp = scheduler.sc.resourceProfileManager.resourceProfileFromId(rpId)
-          if (requestedTotalExecutorsPerResourceProfile.isEmpty) {
-            // Assume that we are killing an executor that was started by default and
-            // not through the request api
-            requestedTotalExecutorsPerResourceProfile(rp) = 0
+          val requestedTotalForRp = if (requestedTotalExecutorsPerResourceProfile.isEmpty) {
+            scheduler.sc.getExecutorIds().size
           } else {
-            val requestedTotalForRp = requestedTotalExecutorsPerResourceProfile(rp)
-            requestedTotalExecutorsPerResourceProfile(rp) = math.max(requestedTotalForRp - 1, 0)
+            requestedTotalExecutorsPerResourceProfile(rp)
           }
+          requestedTotalExecutorsPerResourceProfile(rp) = math.max(requestedTotalForRp - 1, 0)
         }
       }
       doRequestTotalExecutors(requestedTotalExecutorsPerResourceProfile.toMap)


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

When requestedTotalExecutorsPerResourceProfile is empty, numExisting is equal to the total number of current executors, not 0. 


### Why are the changes needed?
I used the killExecutors and requestExecutors function of SparkContext to dynamically adjust the resources, and found that the requestExecutors after killExecutors could not achieve the expected results.
In addition, when the executor exits abnormally, a new executor will be automatically restarted, but when the kill Executor function is called, it will not be automatically restarted.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New unit test in the StandaloneDynamicAllocationSuite.
