### PR TITLE
[SPARK-39736][INFRA] Enable base image build in SparkR job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -270,7 +270,8 @@ jobs:
     # Currently, only enable docker build from cache for `master` branch jobs
     if: >-
       (fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
-      fromJson(needs.precondition.outputs.required).lint == 'true') &&
+      fromJson(needs.precondition.outputs.required).lint == 'true' ||
+      fromJson(needs.precondition.outputs.required).sparkr == 'true') &&
       inputs.branch == 'master'
     runs-on: ubuntu-latest
     steps:
@@ -416,12 +417,13 @@ jobs:
         path: "**/target/unit-tests.log"
 
   sparkr:
-    needs: precondition
-    if: fromJson(needs.precondition.outputs.required).sparkr == 'true'
+    needs: [precondition, infra-image]
+    # always run if sparkr == 'true', even infra-image is skip (such as non-master job)
+    if: always() && fromJson(needs.precondition.outputs.required).sparkr == 'true'
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
-      image: dongjoon/apache-spark-github-action-image:20220207
+      image: ${{ needs.precondition.outputs.image_url }}
     env:
       HADOOP_PROFILE: ${{ inputs.hadoop }}
       HIVE_PROFILE: hive2.3


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add base image build for SparkR job

<img width="689" alt="image" src="https://user-images.githubusercontent.com/1736354/178295594-6f057247-72ab-4ff1-bb69-48aba05dd06b.png">

See also: https://docs.google.com/document/d/1_uiId-U1DODYyYZejAZeyz2OAjxcnA-xfwjynDF6vd0

### Why are the changes needed?
Add base image build for SparkR job

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed.
Check SparkR job [image is right](https://github.com/Yikun/spark/runs/7284351028?check_suite_focus=true#step:2:19
)