### PR TITLE
[SPARK-39748][SQL][SS] Include the origin logical plan for LogicalRDD if it comes from DataFrame

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -705,6 +705,7 @@ class Dataset[T] private[sql](
         LogicalRDD(
           logicalPlan.output,
           internalRdd,
+          None,
           outputPartitioning,
           physicalPlan.outputOrdering,
           isStreaming


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to include the origin logical plan for LogicalRDD, if the LogicalRDD is built from DataFrame's RDD. Once the origin logical plan is available, LogicalRDD produces the stats from origin logical plan rather than default one.

Also, this PR applies the change to ForeachBatchSink, which seems to be the only case as of now in current codebase.

### Why are the changes needed?

The origin logical plan can be useful for several use cases, including:

1. wants to connect the two split logical plans into one (consider the case of foreachBatch sink: origin logical plan represents the plan for streaming query, and the logical plan for new Dataset represents the plan for batch query in user function)
2. inherits plan stats from origin logical plan

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New UT.