### PR TITLE
[SPARK-39750][SQL] Enable `spark.sql.cbo.enabled` by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -58,6 +58,7 @@ case class FilterEstimation(plan: Filter) extends Logging {
         rowsAfterFilter = filteredRowCount)
     }
     val filteredSizeInBytes: BigInt = getOutputSize(plan.output, filteredRowCount, newColStats)
+      .min(plan.child.stats.sizeInBytes)
 
     Some(childStats.copy(sizeInBytes = filteredSizeInBytes, rowCount = Some(filteredRowCount),
       attributeStats = newColStats))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2395,7 +2395,7 @@ object SQLConf {
       .doc("Enables CBO for estimation of plan statistics when set true.")
       .version("2.2.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val PLAN_STATS_ENABLED =
     buildConf("spark.sql.cbo.planStats.enabled")

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -209,11 +209,13 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
     // `MergeScalarSubqueries` can duplicate subqueries in the optimized plan and would make testing
     // complicated.
     conf.setConfString(SQLConf.OPTIMIZER_EXCLUDED_RULES.key, MergeScalarSubqueries.ruleName)
+    conf.setConf(SQLConf.CBO_ENABLED, false)
   }
 
   protected override def afterAll(): Unit = try {
     conf.setConfString(SQLConf.OPTIMIZER_EXCLUDED_RULES.key,
       SQLConf.OPTIMIZER_EXCLUDED_RULES.defaultValueString)
+    conf.unsetConf(SQLConf.CBO_ENABLED)
 
     sql("DROP TABLE IF EXISTS bf1")
     sql("DROP TABLE IF EXISTS bf2")

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.hive.execution.HiveTableScanExec
 import org.apache.spark.sql.hive.test.TestHiveSingleton
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 
 abstract class DynamicPartitionPruningHiveScanSuiteBase
@@ -40,6 +41,16 @@ abstract class DynamicPartitionPruningHiveScanSuiteBase
       }
       case _ => Nil
     }
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    conf.setConf(SQLConf.CBO_ENABLED, false)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.beforeAll()
+    conf.unsetConf(SQLConf.CBO_ENABLED)
   }
 }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/DynamicPartitionPruningHiveScanSuite.scala
@@ -49,7 +49,7 @@ abstract class DynamicPartitionPruningHiveScanSuiteBase
   }
 
   override protected def afterAll(): Unit = {
-    super.beforeAll()
+    super.afterAll()
     conf.unsetConf(SQLConf.CBO_ENABLED)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enable `spark.sql.cbo.enabled` by default.

### Why are the changes needed?

1. Enable CBO to get better performance, we've enabled it over 3 years.
2. Benchmark related tests also enabled it:https://github.com/apache/spark/blob/e83f8a872a16d4f049cefb1fc445f91cf84443ad/sql/core/src/test/scala/org/apache/spark/sql/TPCBase.scala#L32

### Does this PR introduce _any_ user-facing change?

I don't think this PR could introduce any user-facing changes, we've fixed related bugs before, for example: https://github.com/apache/spark/pull/29894.

### How was this patch tested?

Fix existing tests.