### PR TITLE
[SPARK-39748][SQL][FOLLOWUP] Add missing origin logical plan on DataFrame.checkpoint on building LogicalRDD

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -705,7 +705,7 @@ class Dataset[T] private[sql](
         LogicalRDD(
           logicalPlan.output,
           internalRdd,
-          None,
+          Some(queryExecution.analyzed),
           outputPartitioning,
           physicalPlan.outputOrdering,
           isStreaming


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds missing origin logical plan on building LogicalRDD in DataFrame.checkpoint, via review comment https://github.com/apache/spark/pull/37161#discussion_r919204026.

### Why are the changes needed?

This is missing spot on previous PR and @viirya helped to find out.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A