### PR TITLE
[SPARK-39758][SQL] Fix NPE from the regexp functions on invalid patterns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -752,9 +752,10 @@ abstract class RegExpExtractBase
   protected def getLastMatcher(s: Any, p: Any): Matcher = {
     if (p != lastRegex) {
       // regex value changed
-      lastRegex = p.asInstanceOf[UTF8String].clone()
-      pattern = try {
-        Pattern.compile(lastRegex.toString)
+      try {
+        val r = p.asInstanceOf[UTF8String].clone()
+        pattern = Pattern.compile(r.toString)
+        lastRegex = r
       } catch {
         case e: PatternSyntaxException =>
           throw QueryExecutionErrors.invalidPatternError(prettyName, e.getPattern)
@@ -776,9 +777,10 @@ abstract class RegExpExtractBase
     s"""
       |if (!$regexp.equals($termLastRegex)) {
       |  // regex value changed
-      |  $termLastRegex = $regexp.clone();
       |  try {
-      |    $termPattern = $classNamePattern.compile($termLastRegex.toString());
+      |    UTF8String r = $regexp.clone();
+      |    $termPattern = $classNamePattern.compile(r.toString());
+      |    $termLastRegex = r;
       |  } catch (java.util.regex.PatternSyntaxException e) {
       |    throw QueryExecutionErrors.invalidPatternError("$prettyName", e.getPattern());
       |  }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -852,7 +852,6 @@ case class RegExpExtract(subject: Expression, regexp: Expression, idx: Expressio
     val classNameRegExpExtractBase = classOf[RegExpExtractBase].getCanonicalName
     val matcher = ctx.freshName("matcher")
     val matchResult = ctx.freshName("matchResult")
-
     val setEvNotNull = if (nullable) {
       s"${ev.isNull} = false;"
     } else {
@@ -943,16 +942,11 @@ case class RegExpExtractAll(subject: Expression, regexp: Expression, idx: Expres
   override def prettyName: String = "regexp_extract_all"
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val classNamePattern = classOf[Pattern].getCanonicalName
     val classNameRegExpExtractBase = classOf[RegExpExtractBase].getCanonicalName
     val arrayClass = classOf[GenericArrayData].getName
     val matcher = ctx.freshName("matcher")
     val matchResult = ctx.freshName("matchResult")
     val matchResults = ctx.freshName("matchResults")
-
-    val termLastRegex = ctx.addMutableState("UTF8String", "lastRegex")
-    val termPattern = ctx.addMutableState(classNamePattern, "pattern")
-
     val setEvNotNull = if (nullable) {
       s"${ev.isNull} = false;"
     } else {
@@ -1106,12 +1100,7 @@ case class RegExpInStr(subject: Expression, regexp: Expression, idx: Expression)
   override def prettyName: String = "regexp_instr"
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val classNamePattern = classOf[Pattern].getCanonicalName
     val matcher = ctx.freshName("matcher")
-
-    val termLastRegex = ctx.addMutableState("UTF8String", "lastRegex")
-    val termPattern = ctx.addMutableState(classNamePattern, "pattern")
-
     val setEvNotNull = if (nullable) {
       s"${ev.isNull} = false;"
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2031,4 +2031,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
     new SparkException(errorClass = "NULL_COMPARISON_RESULT",
       messageParameters = Array(), cause = null)
   }
+
+  def invalidPatternError(funcName: String, pattern: String): RuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "INVALID_PARAMETER_VALUE",
+      messageParameters = Array(
+        "regexp",
+        toSQLId(funcName),
+        pattern))
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/inputs/regexp-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/regexp-functions.sql
@@ -14,6 +14,7 @@ SELECT regexp_extract('1a 2b 14m', '(\\d+)([a-z]+)', 3);
 SELECT regexp_extract('1a 2b 14m', '(\\d+)([a-z]+)', -1);
 SELECT regexp_extract('1a 2b 14m', '(\\d+)?([a-z]+)', 1);
 SELECT regexp_extract('a b m', '(\\d+)?([a-z]+)', 1);
+SELECT regexp_extract('1a 2b 14m', '(?l)');
 
 -- regexp_extract_all
 SELECT regexp_extract_all('1a 2b 14m', '\\d+');
@@ -31,6 +32,7 @@ SELECT regexp_extract_all('1a 2b 14m', '(\\d+)([a-z]+)', 3);
 SELECT regexp_extract_all('1a 2b 14m', '(\\d+)([a-z]+)', -1);
 SELECT regexp_extract_all('1a 2b 14m', '(\\d+)?([a-z]+)', 1);
 SELECT regexp_extract_all('a 2b 14m', '(\\d+)?([a-z]+)', 1);
+SELECT regexp_extract_all('abc', col0, 1) FROM VALUES('], [') AS t(col0);
 
 -- regexp_replace
 SELECT regexp_replace('healthy, wealthy, and wise', '\\w+thy', 'something');
@@ -77,3 +79,4 @@ SELECT regexp_instr('ABC', '(?-i)b');
 SELECT regexp_instr('1a 2b 14m', '\\d{2}(a|b|m)');
 SELECT regexp_instr('abc', null);
 SELECT regexp_instr(null, 'b');
+SELECT regexp_instr('abc', col0, 1) FROM VALUES(') ?') AS t(col0);

--- a/sql/core/src/test/resources/sql-tests/results/regexp-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/regexp-functions.sql.out
@@ -126,6 +126,15 @@ struct<regexp_extract(a b m, (\d+)?([a-z]+), 1):string>
 
 
 -- !query
+SELECT regexp_extract('1a 2b 14m', '(?l)')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+[INVALID_PARAMETER_VALUE] The value of parameter(s) 'regexp' in `regexp_extract` is invalid: (?l)
+
+
+-- !query
 SELECT regexp_extract_all('1a 2b 14m', '\\d+')
 -- !query schema
 struct<>
@@ -249,6 +258,15 @@ SELECT regexp_extract_all('a 2b 14m', '(\\d+)?([a-z]+)', 1)
 struct<regexp_extract_all(a 2b 14m, (\d+)?([a-z]+), 1):array<string>>
 -- !query output
 ["","2","14"]
+
+
+-- !query
+SELECT regexp_extract_all('abc', col0, 1) FROM VALUES('], [') AS t(col0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+[INVALID_PARAMETER_VALUE] The value of parameter(s) 'regexp' in `regexp_extract_all` is invalid: ], [
 
 
 -- !query
@@ -539,3 +557,12 @@ SELECT regexp_instr(null, 'b')
 struct<regexp_instr(NULL, b, 0):int>
 -- !query output
 NULL
+
+
+-- !query
+SELECT regexp_instr('abc', col0, 1) FROM VALUES(') ?') AS t(col0)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkRuntimeException
+[INVALID_PARAMETER_VALUE] The value of parameter(s) 'regexp' in `regexp_instr` is invalid: ) ?


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to catch `PatternSyntaxException` while compiling the regexp pattern by the `regexp_extract`, `regexp_extract_all` and `regexp_instr`, and substitute the exception by Spark's exception w/ the error class `INVALID_PARAMETER_VALUE`. In this way, Spark SQL will output the error in the form:
```sql
org.apache.spark.SparkRuntimeException
[INVALID_PARAMETER_VALUE] The value of parameter(s) 'regexp' in `regexp_instr` is invalid: ) ?
``` 
instead of (on Spark 3.3.0):
```java
java.lang.NullPointerException: null
```
Also I propose to set `lastRegex` only after the compilation of the regexp pattern completes successfully.

### Why are the changes needed?
The changes fix NPE portrayed by the code on Spark 3.3.0:
```sql
spark-sql> SELECT regexp_extract('1a 2b 14m', '(?l)');
22/07/12 19:07:21 ERROR SparkSQLDriver: Failed in [SELECT regexp_extract('1a 2b 14m', '(?l)')]
java.lang.NullPointerException: null
	at org.apache.spark.sql.catalyst.expressions.RegExpExtractBase.getLastMatcher(regexpExpressions.scala:768) ~[spark-catalyst_2.12-3.3.0.jar:3.3.0]
```
This should improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
No. In regular cases, the behavior is the same but users will observe different exceptions (error messages) after the changes.

### How was this patch tested?
By running new tests:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z regexp-functions.sql"
$ build/sbt "test:testOnly *.RegexpExpressionsSuite"
$ build/sbt "sql/test:testOnly org.apache.spark.sql.expressions.ExpressionInfoSuite"
```