### PR TITLE
[SPARK-39761][K8S][DOCS] Add Apache Spark images info in running-on-kubernetes doc

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -113,6 +113,8 @@ $ ./bin/docker-image-tool.sh -r <repo> -t my-tag -p ./kubernetes/dockerfiles/spa
 $ ./bin/docker-image-tool.sh -r <repo> -t my-tag -R ./kubernetes/dockerfiles/spark/bindings/R/Dockerfile build
 ```
 
+You can also use the [Apache Spark docker images](https://hub.docker.com/r/apache/spark) (such as `apache/spark:<version>`) directly.
+
 ## Cluster Mode
 
 To launch Spark Pi in cluster mode,

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -113,7 +113,7 @@ $ ./bin/docker-image-tool.sh -r <repo> -t my-tag -p ./kubernetes/dockerfiles/spa
 $ ./bin/docker-image-tool.sh -r <repo> -t my-tag -R ./kubernetes/dockerfiles/spark/bindings/R/Dockerfile build
 ```
 
-You can also use the [Apache Spark docker images](https://hub.docker.com/r/apache/spark) (such as `apache/spark:<version>`) directly.
+You can also use the [Apache Spark Docker images](https://hub.docker.com/r/apache/spark) (such as `apache/spark:<version>`) directly.
 
 ## Cluster Mode
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Apache Spark images info in running-on-kubernetes doc

### Why are the changes needed?
We add the docker image in dockerhub for spark relese like: [v3.1.3,v3.2.1,v3.3.0](https://hub.docker.com/r/apache/spark/tags) and release steps on https://github.com/apache/spark-website/pull/400

It's better to add note it in running-on-kubernetes doc.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
SKIP_API=1 bundle exec jekyll serve --watch
![image](https://user-images.githubusercontent.com/1736354/178723931-d6d18b3c-f5ad-41da-9d45-f1afa1a76e29.png)


