### PR TITLE
[SPARK-39762][INFRA][PS] Support latest numpy in infra

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -31,7 +31,7 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install 'numpy<1.23.0' pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
+RUN python3.9 -m pip install numpy pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update
@@ -44,7 +44,7 @@ RUN mkdir -p /usr/local/pypy/pypy3.7 && \
     ln -sf /usr/local/pypy/pypy3.7/bin/pypy /usr/local/bin/pypy3
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install 'numpy<1.23.0' 'pandas<1.4.0' scipy coverage matplotlib
+RUN pypy3 -m pip install numpy 'pandas<1.4.0' scipy coverage matplotlib
 
 RUN $APT_INSTALL gnupg ca-certificates pandoc
 RUN echo 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/' >> /etc/apt/sources.list


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove infra numpy<1.23.0 version limit to support numpy 1.23+ (latest) in infra.


### Why are the changes needed?
After below two PRs merged:

https://github.com/apache/spark/pull/37117: Fix annotation: `python/pyspark/pandas/frame.py:9970: error: Need type annotation for "raveled_column_labels"  [var-annotated]`
https://github.com/apache/spark/pull/37078: Fix wrong aliases in __array_ufunc__: `NotImplementedError: pandas-on-Spark objects currently do not support <ufunc 'divide'>`

We can now remove limit on infra file to support numpy > 1.23.0.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed and [numpy 1.23.1](https://github.com/Yikun/spark/runs/7314545823?check_suite_focus=true#step:9:49) installed in CI