### PR TITLE
[SPARK-39772][SQL] namespace should be null when database is null in the old constructors

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalog/interface.scala
@@ -98,23 +98,22 @@ class Table(
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
 
+  if (namespace != null) {
+    assert(namespace.forall(_ != null))
+  }
+
   def this(
       name: String,
       database: String,
       description: String,
       tableType: String,
       isTemporary: Boolean) = {
-    this(name, null, Array(database), description, tableType, isTemporary)
+    this(name, null, if (database != null) Array(database) else null,
+      description, tableType, isTemporary)
   }
 
   def database: String = {
-    if (namespace == null) {
-      null
-    } else if (namespace.length == 1) {
-      namespace(0)
-    } else {
-      null
-    }
+    if (namespace != null && namespace.length == 1) namespace(0) else null
   }
 
   override def toString: String = {
@@ -185,13 +184,18 @@ class Function(
     val isTemporary: Boolean)
   extends DefinedByConstructorParams {
 
+  if (namespace != null) {
+    assert(namespace.forall(_ != null))
+  }
+
   def this(
       name: String,
       database: String,
       description: String,
       className: String,
       isTemporary: Boolean) = {
-    this(name, null, Array(database), description, className, isTemporary)
+    this(name, null, if (database != null) Array(database) else null,
+      description, className, isTemporary)
   }
 
   def database: String = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
in the old constructors, when `database` is `null`, initialize `namespace` with `null` instead of `Array(null)`


### Why are the changes needed?
`namespace` should be `null` when database is `null` in the old constructors of `Table` and `Function`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing UT
