### PR TITLE
[SPARK-39776][SQL] JOIN verbose string should add Join type

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BaseJoinExec.scala
@@ -44,11 +44,13 @@ trait BaseJoinExec extends BinaryExecNode {
          |$formattedNodeName
          |${ExplainUtils.generateFieldString("Left keys", leftKeys)}
          |${ExplainUtils.generateFieldString("Right keys", rightKeys)}
+         |${ExplainUtils.generateFieldString("Join type", joinType.toString)}
          |${ExplainUtils.generateFieldString("Join condition", joinCondStr)}
          |""".stripMargin
     } else {
       s"""
          |$formattedNodeName
+         |${ExplainUtils.generateFieldString("Join type", joinType.toString)}
          |${ExplainUtils.generateFieldString("Join condition", joinCondStr)}
          |""".stripMargin
     }

--- a/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain-aqe.sql.out
@@ -308,6 +308,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (6) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: Inner
 Join condition: None
 
 (7) AdaptiveSparkPlan
@@ -357,6 +358,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (5) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: LeftOuter
 Join condition: None
 
 (6) AdaptiveSparkPlan
@@ -779,6 +781,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (6) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: Inner
 Join condition: None
 
 (7) AdaptiveSparkPlan
@@ -879,6 +882,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: Inner
 Join condition: None
 
 (13) AdaptiveSparkPlan

--- a/sql/core/src/test/resources/sql-tests/results/explain.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/explain.sql.out
@@ -316,6 +316,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: Inner
 Join condition: None
 
 
@@ -368,6 +369,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: LeftOuter
 Join condition: None
 
 
@@ -751,6 +753,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: Inner
 Join condition: None
 
 
@@ -828,6 +831,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [key#x]
 Right keys [1]: [key#x]
+Join type: Inner
 Join condition: None
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -92,6 +92,7 @@ Output [1]: [d_date_sk#9]
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -119,6 +120,7 @@ Output [1]: [d_date_sk#13]
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#12]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -138,6 +140,7 @@ Arguments: [customer_sk#10 ASC NULLS FIRST], false, 0
 (21) SortMergeJoin [codegen id : 8]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#10]
+Join type: LeftSemi
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.store_sales
@@ -161,6 +164,7 @@ Output [1]: [d_date_sk#17]
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#16]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -178,6 +182,7 @@ Arguments: [customer_sk#18 ASC NULLS FIRST], false, 0
 (30) SortMergeJoin [codegen id : 13]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (31) Project [codegen id : 13]
@@ -209,6 +214,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#19]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
@@ -236,6 +242,7 @@ Condition : isnotnull(cd_demo_sk#21)
 (43) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#21]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 14]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10/explain.txt
@@ -80,6 +80,7 @@ Output [1]: [d_date_sk#7]
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -107,6 +108,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -122,6 +124,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (18) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#8]
+Join type: LeftSemi
 Join condition: None
 
 (19) Scan parquet spark_catalog.default.store_sales
@@ -145,6 +148,7 @@ Output [1]: [d_date_sk#15]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -158,6 +162,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#16]
+Join type: LeftSemi
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -189,6 +194,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (33) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 9]
@@ -216,6 +222,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#19]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
@@ -80,6 +80,7 @@ Condition : ((isnotnull(ss_item_sk#4) AND isnotnull(ss_customer_sk#5)) AND isnot
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
@@ -107,6 +108,7 @@ Condition : (isnotnull(c_customer_sk#10) AND isnotnull(c_current_addr_sk#11))
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_customer_sk#5]
 Right keys [1]: [c_customer_sk#10]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -134,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 4]
@@ -161,6 +164,7 @@ Condition : (isnotnull(ca_address_sk#14) AND isnotnull(ca_zip#15))
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#11]
 Right keys [1]: [ca_address_sk#14]
+Join type: Inner
 Join condition: NOT (substr(ca_zip#15, 1, 5) = substr(s_zip#13, 1, 5))
 
 (28) Project [codegen id : 6]
@@ -192,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19/explain.txt
@@ -80,6 +80,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 6]
@@ -111,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -138,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#5]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 6]
@@ -165,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#16]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]
@@ -192,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#19]
+Join type: Inner
 Join condition: NOT (substr(ca_zip#18, 1, 5) = substr(s_zip#20, 1, 5))
 
 (35) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
@@ -95,6 +95,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -180,6 +183,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -225,6 +229,7 @@ Output [1]: [d_date_sk#10]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -256,6 +261,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
@@ -268,6 +274,7 @@ Output [1]: [cd_demo_sk#11]
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]
@@ -280,6 +287,7 @@ Output [2]: [i_item_sk#17, i_item_id#18]
 (46) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 11]
@@ -325,6 +333,7 @@ Output [1]: [d_date_sk#10]
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
@@ -337,6 +346,7 @@ Output [1]: [s_store_sk#15]
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -349,6 +359,7 @@ Output [1]: [cd_demo_sk#11]
 (61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]
@@ -376,6 +387,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27/explain.txt
@@ -114,6 +114,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -180,6 +183,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -225,6 +229,7 @@ Output [1]: [cd_demo_sk#10]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -237,6 +242,7 @@ Output [1]: [d_date_sk#14]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -268,6 +274,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]
@@ -280,6 +287,7 @@ Output [2]: [i_item_sk#17, i_item_id#18]
 (46) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 11]
@@ -325,6 +333,7 @@ Output [1]: [cd_demo_sk#10]
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
@@ -337,6 +346,7 @@ Output [1]: [d_date_sk#14]
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -349,6 +359,7 @@ Output [1]: [s_store_sk#15]
 (61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]
@@ -376,6 +387,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3.sf100/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Output [2]: [d_date_sk#9, d_year#10]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q3/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
@@ -57,6 +57,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -88,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -119,6 +121,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -180,6 +183,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34/explain.txt
@@ -54,6 +54,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -85,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -116,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -165,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42.sf100/explain.txt
@@ -62,6 +62,7 @@ Condition : isnotnull(ss_item_sk#4)
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q42/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43.sf100/explain.txt
@@ -62,6 +62,7 @@ Condition : isnotnull(ss_store_sk#4)
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q43/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/explain.txt
@@ -69,6 +69,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -100,6 +101,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -131,6 +133,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#13]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -170,6 +173,7 @@ Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 (28) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]
@@ -223,6 +227,7 @@ Arguments: [c_customer_sk#27 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#27]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 12]
@@ -247,6 +252,7 @@ Arguments: [ca_address_sk#31 ASC NULLS FIRST], false, 0
 (45) SortMergeJoin [codegen id : 16]
 Left keys [1]: [c_current_addr_sk#28]
 Right keys [1]: [ca_address_sk#31]
+Join type: Inner
 Join condition: NOT (ca_city#32 = bought_city#24)
 
 (46) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46/explain.txt
@@ -61,6 +61,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#13]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -150,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -195,6 +199,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#27]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -207,6 +212,7 @@ Output [2]: [ca_address_sk#31, ca_city#32]
 (37) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#28]
 Right keys [1]: [ca_address_sk#31]
+Join type: Inner
 Join condition: NOT (ca_city#32 = bought_city#24)
 
 (38) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52.sf100/explain.txt
@@ -62,6 +62,7 @@ Condition : isnotnull(ss_item_sk#4)
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q52/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/explain.txt
@@ -69,6 +69,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Output [2]: [d_date_sk#16, d_qoy#17]
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53/explain.txt
@@ -69,6 +69,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -81,6 +82,7 @@ Output [2]: [d_date_sk#15, d_qoy#16]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#17]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55.sf100/explain.txt
@@ -62,6 +62,7 @@ Condition : isnotnull(ss_item_sk#4)
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q55/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
@@ -91,6 +91,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -136,6 +137,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#37]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 10]
@@ -167,6 +169,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#41]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 10]
@@ -209,6 +212,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (33) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 6]
@@ -254,6 +258,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (42) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#66]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 9]
@@ -285,6 +290,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (49) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#69]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 9]
@@ -298,6 +304,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, in
 (52) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#44, d_week_seq1#43]
 Right keys [2]: [s_store_id2#71, (d_week_seq2#70 - 52)]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59/explain.txt
@@ -88,6 +88,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -133,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#35]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 10]
@@ -164,6 +166,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#39]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 10]
@@ -191,6 +194,7 @@ Output [3]: [d_date_sk#4, d_week_seq#5, d_day_name#6]
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 6]
@@ -236,6 +240,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#62]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 9]
@@ -267,6 +272,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (46) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#65]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 9]
@@ -280,6 +286,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, in
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#42, d_week_seq1#41]
 Right keys [2]: [s_store_id2#67, (d_week_seq2#66 - 52)]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/explain.txt
@@ -69,6 +69,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Output [2]: [d_date_sk#16, d_moy#17]
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63/explain.txt
@@ -69,6 +69,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -81,6 +82,7 @@ Output [2]: [d_date_sk#15, d_moy#16]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#17]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/explain.txt
@@ -61,6 +61,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -110,6 +111,7 @@ Output [1]: [d_date_sk#15]
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -163,6 +165,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [ss_store_sk#12]
+Join type: Inner
 Join condition: (cast(revenue#10 as decimal(23,7)) <= (0.1 * ave#25))
 
 (26) Project [codegen id : 7]
@@ -190,6 +193,7 @@ Condition : isnotnull(s_store_sk#26)
 (31) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#26]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 8]
@@ -217,6 +221,7 @@ Condition : isnotnull(i_item_sk#28)
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#28]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65/explain.txt
@@ -75,6 +75,7 @@ Output [1]: [d_date_sk#8]
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -110,6 +111,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [s_store_sk#1]
 Right keys [1]: [ss_store_sk#4]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 9]
@@ -137,6 +139,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#3]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 9]
@@ -164,6 +167,7 @@ Output [1]: [d_date_sk#22]
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#21]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -217,6 +221,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [ss_store_sk#19]
+Join type: Inner
 Join condition: (cast(revenue#12 as decimal(23,7)) <= (0.1 * ave#32))
 
 (38) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
@@ -67,6 +67,7 @@ Output [1]: [d_date_sk#11]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#9]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -129,6 +131,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -156,6 +159,7 @@ Condition : (isnotnull(ca_address_sk#17) AND isnotnull(ca_city#18))
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -201,6 +205,7 @@ Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#33))
 (34) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#32]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 7]
@@ -240,6 +245,7 @@ Arguments: [ca_address_sk#36 ASC NULLS FIRST], false, 0
 (43) SortMergeJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#33]
 Right keys [1]: [ca_address_sk#36]
+Join type: Inner
 Join condition: NOT (ca_city#37 = bought_city#28)
 
 (44) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68/explain.txt
@@ -61,6 +61,7 @@ Output [1]: [d_date_sk#11]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#9]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -150,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -195,6 +199,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#32]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -207,6 +212,7 @@ Output [2]: [ca_address_sk#36, ca_city#37]
 (37) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#33]
 Right keys [1]: [ca_address_sk#36]
+Join type: Inner
 Join condition: NOT (ca_city#37 = bought_city#28)
 
 (38) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/explain.txt
@@ -52,6 +52,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -83,6 +84,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -114,6 +116,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -83,6 +84,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -110,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
@@ -54,6 +54,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -85,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -116,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -165,6 +168,7 @@ Condition : isnotnull(c_customer_sk#18)
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73/explain.txt
@@ -54,6 +54,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -85,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -116,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -165,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79.sf100/explain.txt
@@ -55,6 +55,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -117,6 +119,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -174,6 +177,7 @@ Arguments: [c_customer_sk#25 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#25]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q79/explain.txt
@@ -52,6 +52,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -83,6 +84,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -114,6 +116,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -159,6 +162,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#25]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
@@ -49,6 +49,7 @@ Output [2]: [d_date_sk#6, d_moy#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -76,6 +77,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -103,6 +105,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89/explain.txt
@@ -64,6 +64,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -76,6 +77,7 @@ Output [2]: [d_date_sk#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -103,6 +105,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98.sf100/explain.txt
@@ -47,6 +47,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -86,6 +87,7 @@ Arguments: [i_item_sk#6 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q98/explain.txt
@@ -59,6 +59,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -71,6 +72,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1.sf100/explain.txt
@@ -65,6 +65,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -114,6 +115,7 @@ Output [1]: [d_date_sk#6]
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -167,6 +169,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ctr_store_sk#11]
 Right keys [1]: [ctr_store_sk#11#21]
+Join type: Inner
 Join condition: (cast(ctr_total_return#12 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#20)
 
 (26) Project [codegen id : 8]
@@ -198,6 +201,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ctr_store_sk#11]
 Right keys [1]: [s_store_sk#22]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 8]
@@ -237,6 +241,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (41) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ctr_customer_sk#10]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q1/explain.txt
@@ -62,6 +62,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -111,6 +112,7 @@ Output [1]: [d_date_sk#6]
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -164,6 +166,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ctr_store_sk#11]
 Right keys [1]: [ctr_store_sk#11#21]
+Join type: Inner
 Join condition: (cast(ctr_total_return#12 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#20)
 
 (26) Project [codegen id : 9]
@@ -195,6 +198,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ctr_store_sk#11]
 Right keys [1]: [s_store_sk#22]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]
@@ -222,6 +226,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ctr_customer_sk#10]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10.sf100/explain.txt
@@ -90,6 +90,7 @@ Output [1]: [d_date_sk#11]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#9]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -107,6 +108,7 @@ Arguments: [ss_customer_sk#8 ASC NULLS FIRST], false, 0
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#8]
+Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
@@ -125,6 +127,7 @@ Output [1]: [d_date_sk#14]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -142,6 +145,7 @@ Arguments: [ws_bill_customer_sk#12 ASC NULLS FIRST], false, 0
 (21) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ws_bill_customer_sk#12]
+Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.catalog_sales
@@ -160,6 +164,7 @@ Output [1]: [d_date_sk#17]
 (25) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#16]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 12]
@@ -177,6 +182,7 @@ Arguments: [cs_ship_customer_sk#15 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [cs_ship_customer_sk#15]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (30) Filter [codegen id : 15]
@@ -212,6 +218,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (37) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#18]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 15]
@@ -251,6 +258,7 @@ Arguments: [cd_demo_sk#20 ASC NULLS FIRST], false, 0
 (46) SortMergeJoin [codegen id : 19]
 Left keys [1]: [c_current_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 19]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q10/explain.txt
@@ -74,6 +74,7 @@ Output [1]: [d_date_sk#9]
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 2]
@@ -87,6 +88,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (11) Scan parquet spark_catalog.default.web_sales
@@ -105,6 +107,7 @@ Output [1]: [d_date_sk#12]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -118,6 +121,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ws_bill_customer_sk#10]
+Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.catalog_sales
@@ -136,6 +140,7 @@ Output [1]: [d_date_sk#15]
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -149,6 +154,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [cs_ship_customer_sk#13]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (25) Filter [codegen id : 9]
@@ -184,6 +190,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]
@@ -211,6 +218,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11.sf100/explain.txt
@@ -102,6 +102,7 @@ Output [2]: [d_date_sk#6, d_year#7]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -141,6 +142,7 @@ Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -198,6 +200,7 @@ Output [2]: [d_date_sk#26, d_year#27]
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#24]
 Right keys [1]: [d_date_sk#26]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -222,6 +225,7 @@ Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_customer_sk#21]
 Right keys [1]: [c_customer_sk#28]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 14]
@@ -257,6 +261,7 @@ Arguments: [customer_id#38 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 17]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#38]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 17]
@@ -284,6 +289,7 @@ Output [2]: [d_date_sk#45, d_year#46]
 (45) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#44]
 Right keys [1]: [d_date_sk#45]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 19]
@@ -308,6 +314,7 @@ Arguments: [c_customer_sk#47 ASC NULLS FIRST], false, 0
 (51) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#41]
 Right keys [1]: [c_customer_sk#47]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 23]
@@ -347,6 +354,7 @@ Arguments: [customer_id#58 ASC NULLS FIRST], false, 0
 (59) SortMergeJoin [codegen id : 26]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#58]
+Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 26]
@@ -374,6 +382,7 @@ Output [2]: [d_date_sk#64, d_year#65]
 (65) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ws_sold_date_sk#63]
 Right keys [1]: [d_date_sk#64]
+Join type: Inner
 Join condition: None
 
 (66) Project [codegen id : 28]
@@ -398,6 +407,7 @@ Arguments: [c_customer_sk#66 ASC NULLS FIRST], false, 0
 (71) SortMergeJoin [codegen id : 32]
 Left keys [1]: [ws_bill_customer_sk#60]
 Right keys [1]: [c_customer_sk#66]
+Join type: Inner
 Join condition: None
 
 (72) Project [codegen id : 32]
@@ -433,6 +443,7 @@ Arguments: [customer_id#76 ASC NULLS FIRST], false, 0
 (78) SortMergeJoin [codegen id : 35]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#76]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#59 > 0.00) THEN (year_total#77 / year_total#59) END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#40 / year_total#20) END)
 
 (79) Project [codegen id : 35]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q11/explain.txt
@@ -109,6 +109,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -121,6 +122,7 @@ Output [2]: [d_date_sk#14, d_year#15]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#12]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -185,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#21]
 Right keys [1]: [ss_customer_sk#29]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -197,6 +200,7 @@ Output [2]: [d_date_sk#34, d_year#35]
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#32]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -228,6 +232,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (33) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#38]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 16]
@@ -270,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#41]
 Right keys [1]: [ws_bill_customer_sk#49]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 10]
@@ -282,6 +288,7 @@ Output [2]: [d_date_sk#53, d_year#54]
 (45) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_sold_date_sk#52]
 Right keys [1]: [d_date_sk#53]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 10]
@@ -317,6 +324,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (52) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#58]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 16]
@@ -359,6 +367,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (61) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#60]
 Right keys [1]: [ws_bill_customer_sk#68]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 14]
@@ -371,6 +380,7 @@ Output [2]: [d_date_sk#72, d_year#73]
 (64) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#71]
 Right keys [1]: [d_date_sk#72]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 14]
@@ -402,6 +412,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (70) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#76]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#59 > 0.00) THEN (year_total#77 / year_total#59) END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#40 / year_total#20) END)
 
 (71) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
@@ -84,6 +85,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q12/explain.txt
@@ -57,6 +57,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -69,6 +70,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_cdemo_sk#1]
 Right keys [1]: [cd_demo_sk#12]
+Join type: Inner
 Join condition: ((((((cd_marital_status#13 = M) AND (cd_education_status#14 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) OR ((((cd_marital_status#13 = S) AND (cd_education_status#14 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00))) OR ((((cd_marital_status#13 = W) AND (cd_education_status#14 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)))
 
 (9) Project [codegen id : 6]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#15]
+Join type: Inner
 Join condition: (((((((cd_marital_status#13 = M) AND (cd_education_status#14 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) AND (hd_dep_count#16 = 3)) OR (((((cd_marital_status#13 = S) AND (cd_education_status#14 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00)) AND (hd_dep_count#16 = 1))) OR (((((cd_marital_status#13 = W) AND (cd_education_status#14 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)) AND (hd_dep_count#16 = 1)))
 
 (15) Project [codegen id : 6]
@@ -110,6 +112,7 @@ Output [1]: [d_date_sk#17]
 (17) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#10]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 6]
@@ -137,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#18]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -168,6 +172,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#19]
+Join type: Inner
 Join condition: ((((ca_state#20 IN (TX,OH) AND (ss_net_profit#9 >= 100.00)) AND (ss_net_profit#9 <= 200.00)) OR ((ca_state#20 IN (OR,NM,KY) AND (ss_net_profit#9 >= 150.00)) AND (ss_net_profit#9 <= 300.00))) OR ((ca_state#20 IN (VA,TX,MS) AND (ss_net_profit#9 >= 50.00)) AND (ss_net_profit#9 <= 250.00)))
 
 (31) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 6]
@@ -102,6 +103,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#13]
+Join type: Inner
 Join condition: ((((ca_state#14 IN (TX,OH) AND (ss_net_profit#9 >= 100.00)) AND (ss_net_profit#9 <= 200.00)) OR ((ca_state#14 IN (OR,NM,KY) AND (ss_net_profit#9 >= 150.00)) AND (ss_net_profit#9 <= 300.00))) OR ((ca_state#14 IN (VA,TX,MS) AND (ss_net_profit#9 >= 50.00)) AND (ss_net_profit#9 <= 250.00)))
 
 (16) Project [codegen id : 6]
@@ -114,6 +116,7 @@ Output [1]: [d_date_sk#16]
 (18) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#10]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_cdemo_sk#1]
 Right keys [1]: [cd_demo_sk#17]
+Join type: Inner
 Join condition: ((((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) OR ((((cd_marital_status#18 = S) AND (cd_education_status#19 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00))) OR ((((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)))
 
 (25) Project [codegen id : 6]
@@ -168,6 +172,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
 Join condition: (((((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) AND (hd_dep_count#21 = 3)) OR (((((cd_marital_status#18 = S) AND (cd_education_status#19 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00)) AND (hd_dep_count#21 = 1))) OR (((((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)) AND (hd_dep_count#21 = 1)))
 
 (31) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -182,6 +182,7 @@ Output [1]: [d_date_sk#13]
 (13) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 11]
@@ -231,6 +232,7 @@ Output [1]: [d_date_sk#20]
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
@@ -258,6 +260,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#21]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 8]
@@ -275,6 +278,7 @@ Arguments: [coalesce(i_brand_id#22, 0) ASC NULLS FIRST, isnull(i_brand_id#22) AS
 (34) SortMergeJoin [codegen id : 10]
 Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
 Right keys [6]: [coalesce(i_brand_id#22, 0), isnull(i_brand_id#22), coalesce(i_class_id#23, 0), isnull(i_class_id#23), coalesce(i_category_id#24, 0), isnull(i_category_id#24)]
+Join type: LeftSemi
 Join condition: None
 
 (35) BroadcastExchange
@@ -284,6 +288,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#14]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -337,6 +342,7 @@ Output [1]: [d_date_sk#30]
 (47) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 16]
@@ -349,6 +355,7 @@ Output [4]: [i_item_sk#31, i_brand_id#32, i_class_id#33, i_category_id#34]
 (50) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 16]
@@ -366,6 +373,7 @@ Arguments: [coalesce(i_brand_id#32, 0) ASC NULLS FIRST, isnull(i_brand_id#32) AS
 (54) SortMergeJoin [codegen id : 18]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#32, 0), isnull(i_brand_id#32), coalesce(i_class_id#33, 0), isnull(i_class_id#33), coalesce(i_category_id#34, 0), isnull(i_category_id#34)]
+Join type: LeftSemi
 Join condition: None
 
 (55) BroadcastExchange
@@ -375,6 +383,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 19]
@@ -392,6 +401,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (60) SortMergeJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (61) ReusedExchange [Reuses operator id: 147]
@@ -400,6 +410,7 @@ Output [1]: [d_date_sk#36]
 (62) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#36]
+Join type: Inner
 Join condition: None
 
 (63) Project [codegen id : 43]
@@ -438,6 +449,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (71) SortMergeJoin [codegen id : 42]
 Left keys [1]: [i_item_sk#37]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) BroadcastExchange
@@ -447,6 +459,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (73) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#37]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 43]
@@ -512,6 +525,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (87) SortMergeJoin [codegen id : 87]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (88) ReusedExchange [Reuses operator id: 147]
@@ -520,6 +534,7 @@ Output [1]: [d_date_sk#58]
 (89) BroadcastHashJoin [codegen id : 87]
 Left keys [1]: [cs_sold_date_sk#57]
 Right keys [1]: [d_date_sk#58]
+Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 87]
@@ -532,6 +547,7 @@ Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 (92) BroadcastHashJoin [codegen id : 87]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [i_item_sk#59]
+Join type: Inner
 Join condition: None
 
 (93) Project [codegen id : 87]
@@ -597,6 +613,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (106) SortMergeJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (107) ReusedExchange [Reuses operator id: 147]
@@ -605,6 +622,7 @@ Output [1]: [d_date_sk#78]
 (108) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
+Join type: Inner
 Join condition: None
 
 (109) Project [codegen id : 131]
@@ -617,6 +635,7 @@ Output [4]: [i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
 (111) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#79]
+Join type: Inner
 Join condition: None
 
 (112) Project [codegen id : 131]
@@ -717,6 +736,7 @@ Output [1]: [d_date_sk#112]
 (127) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#111]
 Right keys [1]: [d_date_sk#112]
+Join type: Inner
 Join condition: None
 
 (128) Project [codegen id : 2]
@@ -739,6 +759,7 @@ Output [1]: [d_date_sk#118]
 (132) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#117]
 Right keys [1]: [d_date_sk#118]
+Join type: Inner
 Join condition: None
 
 (133) Project [codegen id : 4]
@@ -761,6 +782,7 @@ Output [1]: [d_date_sk#124]
 (137) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#123]
 Right keys [1]: [d_date_sk#124]
+Join type: Inner
 Join condition: None
 
 (138) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
@@ -200,6 +200,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
 Right keys [1]: [i_item_sk#19]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 3]
@@ -212,6 +213,7 @@ Output [1]: [d_date_sk#23]
 (23) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#23]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 3]
@@ -225,6 +227,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
 Right keys [6]: [coalesce(i_brand_id#20, 0), isnull(i_brand_id#20), coalesce(i_class_id#21, 0), isnull(i_class_id#21), coalesce(i_category_id#22, 0), isnull(i_category_id#22)]
+Join type: LeftSemi
 Join condition: None
 
 (27) BroadcastExchange
@@ -234,6 +237,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]
@@ -246,6 +250,7 @@ Output [1]: [d_date_sk#24]
 (31) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 6]
@@ -291,6 +296,7 @@ Output [4]: [i_item_sk#30, i_brand_id#31, i_class_id#32, i_category_id#33]
 (40) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#30]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 9]
@@ -303,6 +309,7 @@ Output [1]: [d_date_sk#34]
 (43) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 9]
@@ -316,6 +323,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#31, 0), isnull(i_brand_id#31), coalesce(i_class_id#32, 0), isnull(i_class_id#32), coalesce(i_category_id#33, 0), isnull(i_category_id#33)]
+Join type: LeftSemi
 Join condition: None
 
 (47) BroadcastExchange
@@ -325,6 +333,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (48) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 11]
@@ -338,6 +347,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (51) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (52) Scan parquet spark_catalog.default.item
@@ -360,6 +370,7 @@ Output [1]: [ss_item_sk#35]
 (56) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [i_item_sk#36]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (57) BroadcastExchange
@@ -369,6 +380,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#36]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 25]
@@ -381,6 +393,7 @@ Output [1]: [d_date_sk#40]
 (61) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 25]
@@ -434,6 +447,7 @@ Output [1]: [ss_item_sk#35]
 (72) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (73) ReusedExchange [Reuses operator id: 57]
@@ -442,6 +456,7 @@ Output [4]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61]
 (74) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [i_item_sk#58]
+Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 51]
@@ -454,6 +469,7 @@ Output [1]: [d_date_sk#62]
 (77) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [cs_sold_date_sk#57]
 Right keys [1]: [d_date_sk#62]
+Join type: Inner
 Join condition: None
 
 (78) Project [codegen id : 51]
@@ -507,6 +523,7 @@ Output [1]: [ss_item_sk#35]
 (88) BroadcastHashJoin [codegen id : 77]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (89) ReusedExchange [Reuses operator id: 57]
@@ -515,6 +532,7 @@ Output [4]: [i_item_sk#78, i_brand_id#79, i_class_id#80, i_category_id#81]
 (90) BroadcastHashJoin [codegen id : 77]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#78]
+Join type: Inner
 Join condition: None
 
 (91) Project [codegen id : 77]
@@ -527,6 +545,7 @@ Output [1]: [d_date_sk#82]
 (93) BroadcastHashJoin [codegen id : 77]
 Left keys [1]: [ws_sold_date_sk#77]
 Right keys [1]: [d_date_sk#82]
+Join type: Inner
 Join condition: None
 
 (94) Project [codegen id : 77]
@@ -627,6 +646,7 @@ Output [1]: [d_date_sk#112]
 (109) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#111]
 Right keys [1]: [d_date_sk#112]
+Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 2]
@@ -649,6 +669,7 @@ Output [1]: [d_date_sk#118]
 (114) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#117]
 Right keys [1]: [d_date_sk#118]
+Join type: Inner
 Join condition: None
 
 (115) Project [codegen id : 4]
@@ -671,6 +692,7 @@ Output [1]: [d_date_sk#124]
 (119) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#123]
 Right keys [1]: [d_date_sk#124]
+Join type: Inner
 Join condition: None
 
 (120) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -158,6 +158,7 @@ Output [1]: [d_date_sk#13]
 (13) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 11]
@@ -207,6 +208,7 @@ Output [1]: [d_date_sk#20]
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
@@ -234,6 +236,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#21]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 8]
@@ -251,6 +254,7 @@ Arguments: [coalesce(i_brand_id#22, 0) ASC NULLS FIRST, isnull(i_brand_id#22) AS
 (34) SortMergeJoin [codegen id : 10]
 Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
 Right keys [6]: [coalesce(i_brand_id#22, 0), isnull(i_brand_id#22), coalesce(i_class_id#23, 0), isnull(i_class_id#23), coalesce(i_category_id#24, 0), isnull(i_category_id#24)]
+Join type: LeftSemi
 Join condition: None
 
 (35) BroadcastExchange
@@ -260,6 +264,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#14]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -313,6 +318,7 @@ Output [1]: [d_date_sk#30]
 (47) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 16]
@@ -325,6 +331,7 @@ Output [4]: [i_item_sk#31, i_brand_id#32, i_class_id#33, i_category_id#34]
 (50) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 16]
@@ -342,6 +349,7 @@ Arguments: [coalesce(i_brand_id#32, 0) ASC NULLS FIRST, isnull(i_brand_id#32) AS
 (54) SortMergeJoin [codegen id : 18]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#32, 0), isnull(i_brand_id#32), coalesce(i_class_id#33, 0), isnull(i_class_id#33), coalesce(i_category_id#34, 0), isnull(i_category_id#34)]
+Join type: LeftSemi
 Join condition: None
 
 (55) BroadcastExchange
@@ -351,6 +359,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 19]
@@ -368,6 +377,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (60) SortMergeJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (61) ReusedExchange [Reuses operator id: 123]
@@ -376,6 +386,7 @@ Output [1]: [d_date_sk#36]
 (62) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#36]
+Join type: Inner
 Join condition: None
 
 (63) Project [codegen id : 43]
@@ -414,6 +425,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (71) SortMergeJoin [codegen id : 42]
 Left keys [1]: [i_item_sk#37]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) BroadcastExchange
@@ -423,6 +435,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (73) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#37]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 43]
@@ -484,6 +497,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (86) SortMergeJoin [codegen id : 86]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (87) ReusedExchange [Reuses operator id: 137]
@@ -492,6 +506,7 @@ Output [1]: [d_date_sk#59]
 (88) BroadcastHashJoin [codegen id : 86]
 Left keys [1]: [ss_sold_date_sk#57]
 Right keys [1]: [d_date_sk#59]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 86]
@@ -504,6 +519,7 @@ Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 (91) BroadcastHashJoin [codegen id : 86]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [i_item_sk#60]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 86]
@@ -539,6 +555,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, t
 (98) BroadcastHashJoin [codegen id : 88]
 Left keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
 Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Join type: Inner
 Join condition: None
 
 (99) TakeOrderedAndProject
@@ -585,6 +602,7 @@ Output [1]: [d_date_sk#78]
 (103) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
+Join type: Inner
 Join condition: None
 
 (104) Project [codegen id : 2]
@@ -607,6 +625,7 @@ Output [1]: [d_date_sk#84]
 (108) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
+Join type: Inner
 Join condition: None
 
 (109) Project [codegen id : 4]
@@ -629,6 +648,7 @@ Output [1]: [d_date_sk#90]
 (113) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
+Join type: Inner
 Join condition: None
 
 (114) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b/explain.txt
@@ -179,6 +179,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
 Right keys [1]: [i_item_sk#19]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 3]
@@ -191,6 +192,7 @@ Output [1]: [d_date_sk#23]
 (23) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#23]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 3]
@@ -204,6 +206,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
 Right keys [6]: [coalesce(i_brand_id#20, 0), isnull(i_brand_id#20), coalesce(i_class_id#21, 0), isnull(i_class_id#21), coalesce(i_category_id#22, 0), isnull(i_category_id#22)]
+Join type: LeftSemi
 Join condition: None
 
 (27) BroadcastExchange
@@ -213,6 +216,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]
@@ -225,6 +229,7 @@ Output [1]: [d_date_sk#24]
 (31) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 6]
@@ -270,6 +275,7 @@ Output [4]: [i_item_sk#30, i_brand_id#31, i_class_id#32, i_category_id#33]
 (40) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#30]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 9]
@@ -282,6 +288,7 @@ Output [1]: [d_date_sk#34]
 (43) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 9]
@@ -295,6 +302,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#31, 0), isnull(i_brand_id#31), coalesce(i_class_id#32, 0), isnull(i_class_id#32), coalesce(i_category_id#33, 0), isnull(i_category_id#33)]
+Join type: LeftSemi
 Join condition: None
 
 (47) BroadcastExchange
@@ -304,6 +312,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (48) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 11]
@@ -317,6 +326,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (51) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (52) Scan parquet spark_catalog.default.item
@@ -339,6 +349,7 @@ Output [1]: [ss_item_sk#35]
 (56) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [i_item_sk#36]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (57) BroadcastExchange
@@ -348,6 +359,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#36]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 25]
@@ -360,6 +372,7 @@ Output [1]: [d_date_sk#40]
 (61) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 25]
@@ -409,6 +422,7 @@ Output [1]: [ss_item_sk#35]
 (71) BroadcastHashJoin [codegen id : 50]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) ReusedExchange [Reuses operator id: 57]
@@ -417,6 +431,7 @@ Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 (73) BroadcastHashJoin [codegen id : 50]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [i_item_sk#59]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 50]
@@ -429,6 +444,7 @@ Output [1]: [d_date_sk#63]
 (76) BroadcastHashJoin [codegen id : 50]
 Left keys [1]: [ss_sold_date_sk#57]
 Right keys [1]: [d_date_sk#63]
+Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 50]
@@ -464,6 +480,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, t
 (83) BroadcastHashJoin [codegen id : 52]
 Left keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
 Right keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Join type: Inner
 Join condition: None
 
 (84) TakeOrderedAndProject
@@ -510,6 +527,7 @@ Output [1]: [d_date_sk#78]
 (88) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 2]
@@ -532,6 +550,7 @@ Output [1]: [d_date_sk#84]
 (93) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
+Join type: Inner
 Join condition: None
 
 (94) Project [codegen id : 4]
@@ -554,6 +573,7 @@ Output [1]: [d_date_sk#90]
 (98) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
+Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15.sf100/explain.txt
@@ -50,6 +50,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -111,6 +112,7 @@ Arguments: [ca_address_sk#8 ASC NULLS FIRST], false, 0
 (19) SortMergeJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#7]
 Right keys [1]: [ca_address_sk#8]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 8]
@@ -128,6 +130,7 @@ Arguments: [c_customer_sk#6 ASC NULLS FIRST], false, 0
 (23) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#6]
+Join type: Inner
 Join condition: ((substr(ca_zip#10, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR ca_state#9 IN (CA,WA,GA)) OR (cs_sales_price#2 > 500.00))
 
 (24) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q15/explain.txt
@@ -59,6 +59,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_addr_sk#6]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: ((substr(ca_zip#9, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR ca_state#8 IN (CA,WA,GA)) OR (cs_sales_price#2 > 500.00))
 
 (15) Project [codegen id : 4]
@@ -98,6 +100,7 @@ Output [1]: [d_date_sk#10]
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -96,6 +96,7 @@ Arguments: [cs_order_number#16 ASC NULLS FIRST], false, 0
 (12) SortMergeJoin [codegen id : 5]
 Left keys [1]: [cs_order_number#5]
 Right keys [1]: [cs_order_number#16]
+Join type: LeftSemi
 Join condition: NOT (cs_warehouse_sk#4 = cs_warehouse_sk#15)
 
 (13) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Arguments: [cr_order_number#18 ASC NULLS FIRST], false, 0
 (19) SortMergeJoin [codegen id : 11]
 Left keys [1]: [cs_order_number#5]
 Right keys [1]: [cr_order_number#18]
+Join type: LeftAnti
 Join condition: None
 
 (20) Scan parquet spark_catalog.default.customer_address
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#20]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 11]
@@ -184,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_call_center_sk#3]
 Right keys [1]: [cc_call_center_sk#22]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
@@ -215,6 +219,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16/explain.txt
@@ -96,6 +96,7 @@ Arguments: [cs_order_number#10 ASC NULLS FIRST], false, 0
 (12) SortMergeJoin [codegen id : 5]
 Left keys [1]: [cs_order_number#5]
 Right keys [1]: [cs_order_number#10]
+Join type: LeftSemi
 Join condition: NOT (cs_warehouse_sk#4 = cs_warehouse_sk#9)
 
 (13) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Arguments: [cr_order_number#12 ASC NULLS FIRST], false, 0
 (19) SortMergeJoin [codegen id : 11]
 Left keys [1]: [cs_order_number#5]
 Right keys [1]: [cr_order_number#12]
+Join type: LeftAnti
 Join condition: None
 
 (20) Scan parquet spark_catalog.default.date_dim
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 11]
@@ -184,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
@@ -215,6 +219,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_call_center_sk#3]
 Right keys [1]: [cc_call_center_sk#18]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -137,6 +139,7 @@ Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -172,6 +175,7 @@ Output [1]: [d_date_sk#20]
 (28) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [sr_returned_date_sk#18]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
@@ -189,6 +193,7 @@ Arguments: [sr_customer_sk#15 ASC NULLS FIRST, sr_item_sk#14 ASC NULLS FIRST, sr
 (32) SortMergeJoin [codegen id : 12]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
 Right keys [3]: [sr_customer_sk#15, sr_item_sk#14, sr_ticket_number#16]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 12]
@@ -224,6 +229,7 @@ Output [1]: [d_date_sk#25]
 (40) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_sold_date_sk#24]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 15]
@@ -241,6 +247,7 @@ Arguments: [cs_bill_customer_sk#21 ASC NULLS FIRST, cs_item_sk#22 ASC NULLS FIRS
 (44) SortMergeJoin [codegen id : 17]
 Left keys [2]: [sr_customer_sk#15, sr_item_sk#14]
 Right keys [2]: [cs_bill_customer_sk#21, cs_item_sk#22]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17/explain.txt
@@ -78,6 +78,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, 
 (8) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
 Right keys [3]: [sr_customer_sk#9, sr_item_sk#8, sr_ticket_number#10]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 8]
@@ -106,6 +107,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false]
 (14) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [sr_customer_sk#9, sr_item_sk#8]
 Right keys [2]: [cs_bill_customer_sk#14, cs_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 8]
@@ -118,6 +120,7 @@ Output [1]: [d_date_sk#18]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -130,6 +133,7 @@ Output [1]: [d_date_sk#19]
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [sr_returned_date_sk#12]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
@@ -142,6 +146,7 @@ Output [1]: [d_date_sk#20]
 (23) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 8]
@@ -169,6 +174,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#21]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -196,6 +202,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
@@ -90,6 +90,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -102,6 +103,7 @@ Output [1]: [d_date_sk#15]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -129,6 +131,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
@@ -182,6 +185,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#20]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 7]
@@ -221,6 +225,7 @@ Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 11]
 Left keys [1]: [c_current_cdemo_sk#19]
 Right keys [1]: [cd_demo_sk#27]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -238,6 +243,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (43) SortMergeJoin [codegen id : 13]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18/explain.txt
@@ -84,6 +84,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 7]
@@ -115,6 +116,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 7]
@@ -142,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#16]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -169,6 +172,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 7]
@@ -181,6 +185,7 @@ Output [1]: [d_date_sk#25]
 (31) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 7]
@@ -208,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#26]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
@@ -82,6 +82,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Output [1]: [d_date_sk#13]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#14]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
@@ -182,6 +185,7 @@ Arguments: [ca_address_sk#18 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#18]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 10]
@@ -199,6 +203,7 @@ Arguments: [c_customer_sk#16 ASC NULLS FIRST], false, 0
 (36) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#16]
+Join type: Inner
 Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#15, 1, 5))
 
 (37) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19/explain.txt
@@ -80,6 +80,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[4, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 6]
@@ -111,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -138,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#5]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 6]
@@ -165,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#16]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]
@@ -192,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#19]
+Join type: Inner
 Join condition: NOT (substr(ca_zip#18, 1, 5) = substr(s_zip#20, 1, 5))
 
 (35) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2.sf100/explain.txt
@@ -103,6 +103,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -152,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#42]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 12]
@@ -209,6 +211,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
@@ -258,6 +261,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (45) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#68]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 11]
@@ -271,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as b
 (48) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq1#44]
 Right keys [1]: [(d_week_seq2#70 - 53)]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q2/explain.txt
@@ -89,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -138,6 +139,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#40]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 12]
@@ -179,6 +181,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (31) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [d_week_seq#10]
 Right keys [1]: [d_week_seq#57]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 11]
@@ -192,6 +195,7 @@ Arguments: HashedRelationBroadcastMode(List(cast((input[0, int, true] - 53) as b
 (34) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [d_week_seq1#42]
 Right keys [1]: [(d_week_seq2#59 - 53)]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
@@ -84,6 +85,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q20/explain.txt
@@ -57,6 +57,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -69,6 +70,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/explain.txt
@@ -65,6 +65,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -77,6 +78,7 @@ Output [2]: [d_date_sk#9, d_date#10]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -104,6 +106,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#11]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21/explain.txt
@@ -61,6 +61,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -104,6 +106,7 @@ Output [2]: [d_date_sk#11, d_date#12]
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22.sf100/explain.txt
@@ -63,6 +63,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -75,6 +76,7 @@ Output [1]: [d_date_sk#7]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -114,6 +116,7 @@ Arguments: [i_item_sk#8 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q22/explain.txt
@@ -45,6 +45,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -72,6 +73,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -99,6 +101,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a.sf100/explain.txt
@@ -130,6 +130,7 @@ Output [2]: [d_date_sk#10, d_date#11]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -169,6 +170,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (18) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#7]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 8]
@@ -204,6 +206,7 @@ Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
 (25) SortMergeJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (26) Project [codegen id : 9]
@@ -269,6 +272,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (40) SortMergeJoin [codegen id : 15]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 15]
@@ -304,6 +308,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (47) SortMergeJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (48) Project [codegen id : 17]
@@ -316,6 +321,7 @@ Output [1]: [d_date_sk#33]
 (50) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
@@ -357,6 +363,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (60) SortMergeJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#7]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 25]
@@ -392,6 +399,7 @@ Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
 (67) SortMergeJoin [codegen id : 26]
 Left keys [1]: [ws_item_sk#35]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (68) Project [codegen id : 26]
@@ -423,6 +431,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (75) SortMergeJoin [codegen id : 32]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (76) Project [codegen id : 32]
@@ -458,6 +467,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (82) SortMergeJoin [codegen id : 34]
 Left keys [1]: [ws_bill_customer_sk#36]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (83) Project [codegen id : 34]
@@ -470,6 +480,7 @@ Output [1]: [d_date_sk#40]
 (85) BroadcastHashJoin [codegen id : 34]
 Left keys [1]: [ws_sold_date_sk#39]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 34]
@@ -599,6 +610,7 @@ Output [1]: [d_date_sk#56]
 (105) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#54]
 Right keys [1]: [d_date_sk#56]
+Join type: Inner
 Join condition: None
 
 (106) Project [codegen id : 2]
@@ -623,6 +635,7 @@ Arguments: [c_customer_sk#57 ASC NULLS FIRST], false, 0
 (111) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#51]
 Right keys [1]: [c_customer_sk#57]
+Join type: Inner
 Join condition: None
 
 (112) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23a/explain.txt
@@ -98,6 +98,7 @@ Output [2]: [d_date_sk#10, d_date#11]
 (7) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 3]
@@ -125,6 +126,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#7]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -164,6 +166,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (22) Project [codegen id : 5]
@@ -217,6 +220,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (33) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 8]
@@ -256,6 +260,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (41) SortMergeJoin [codegen id : 11]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (42) Project [codegen id : 11]
@@ -268,6 +273,7 @@ Output [1]: [d_date_sk#33]
 (44) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 11]
@@ -290,6 +296,7 @@ Output [1]: [item_sk#18]
 (49) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_item_sk#35]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (50) Project [codegen id : 16]
@@ -329,6 +336,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (58) SortMergeJoin [codegen id : 22]
 Left keys [1]: [ws_bill_customer_sk#36]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (59) Project [codegen id : 22]
@@ -341,6 +349,7 @@ Output [1]: [d_date_sk#40]
 (61) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ws_sold_date_sk#39]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 22]
@@ -468,6 +477,7 @@ Output [1]: [c_customer_sk#56]
 (81) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#51]
 Right keys [1]: [c_customer_sk#56]
+Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 3]
@@ -480,6 +490,7 @@ Output [1]: [d_date_sk#57]
 (84) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#54]
 Right keys [1]: [d_date_sk#57]
+Join type: Inner
 Join condition: None
 
 (85) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b.sf100/explain.txt
@@ -174,6 +174,7 @@ Output [2]: [d_date_sk#10, d_date#11]
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -213,6 +214,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (19) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#7]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 8]
@@ -248,6 +250,7 @@ Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
 (26) SortMergeJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -313,6 +316,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (41) SortMergeJoin [codegen id : 15]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 15]
@@ -348,6 +352,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (48) SortMergeJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (49) ReusedExchange [Reuses operator id: 134]
@@ -356,6 +361,7 @@ Output [1]: [d_date_sk#33]
 (50) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
@@ -401,6 +407,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (61) SortMergeJoin [codegen id : 24]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 24]
@@ -436,11 +443,13 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (68) SortMergeJoin [codegen id : 25]
 Left keys [1]: [c_customer_sk#34]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (69) SortMergeJoin [codegen id : 26]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#34]
+Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 26]
@@ -505,6 +514,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (83) SortMergeJoin [codegen id : 35]
 Left keys [1]: [ss_item_sk#7]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (84) Project [codegen id : 35]
@@ -540,6 +550,7 @@ Arguments: [item_sk#18 ASC NULLS FIRST], false, 0
 (90) SortMergeJoin [codegen id : 36]
 Left keys [1]: [ws_item_sk#43]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (91) Project [codegen id : 36]
@@ -571,6 +582,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (98) SortMergeJoin [codegen id : 42]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 42]
@@ -606,6 +618,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (105) SortMergeJoin [codegen id : 44]
 Left keys [1]: [ws_bill_customer_sk#44]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (106) ReusedExchange [Reuses operator id: 134]
@@ -614,6 +627,7 @@ Output [1]: [d_date_sk#48]
 (107) BroadcastHashJoin [codegen id : 44]
 Left keys [1]: [ws_sold_date_sk#47]
 Right keys [1]: [d_date_sk#48]
+Join type: Inner
 Join condition: None
 
 (108) Project [codegen id : 44]
@@ -644,6 +658,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (115) SortMergeJoin [codegen id : 51]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 51]
@@ -679,11 +694,13 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (122) SortMergeJoin [codegen id : 52]
 Left keys [1]: [c_customer_sk#49]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (123) SortMergeJoin [codegen id : 53]
 Left keys [1]: [ws_bill_customer_sk#44]
 Right keys [1]: [c_customer_sk#49]
+Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 53]
@@ -817,6 +834,7 @@ Output [1]: [d_date_sk#66]
 (144) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#64]
 Right keys [1]: [d_date_sk#66]
+Join type: Inner
 Join condition: None
 
 (145) Project [codegen id : 2]
@@ -841,6 +859,7 @@ Arguments: [c_customer_sk#67 ASC NULLS FIRST], false, 0
 (150) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#61]
 Right keys [1]: [c_customer_sk#67]
+Join type: Inner
 Join condition: None
 
 (151) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q23b/explain.txt
@@ -124,6 +124,7 @@ Output [2]: [d_date_sk#10, d_date#11]
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -151,6 +152,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#7]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 3]
@@ -190,6 +192,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (23) Project [codegen id : 5]
@@ -243,6 +246,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#20]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -282,6 +286,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (42) SortMergeJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (43) Scan parquet spark_catalog.default.customer
@@ -331,6 +336,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (53) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#33]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (54) BroadcastExchange
@@ -340,6 +346,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#33]
+Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
@@ -352,6 +359,7 @@ Output [1]: [d_date_sk#36]
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#36]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -397,6 +405,7 @@ Output [1]: [item_sk#18]
 (67) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ws_item_sk#43]
 Right keys [1]: [item_sk#18]
+Join type: LeftSemi
 Join condition: None
 
 (68) Project [codegen id : 23]
@@ -436,6 +445,7 @@ Arguments: [c_customer_sk#24 ASC NULLS FIRST], false, 0
 (76) SortMergeJoin [codegen id : 35]
 Left keys [1]: [ws_bill_customer_sk#44]
 Right keys [1]: [c_customer_sk#24]
+Join type: LeftSemi
 Join condition: None
 
 (77) ReusedExchange [Reuses operator id: 54]
@@ -444,6 +454,7 @@ Output [3]: [c_customer_sk#48, c_first_name#49, c_last_name#50]
 (78) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ws_bill_customer_sk#44]
 Right keys [1]: [c_customer_sk#48]
+Join type: Inner
 Join condition: None
 
 (79) Project [codegen id : 35]
@@ -456,6 +467,7 @@ Output [1]: [d_date_sk#51]
 (81) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ws_sold_date_sk#47]
 Right keys [1]: [d_date_sk#51]
+Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 35]
@@ -587,6 +599,7 @@ Output [1]: [c_customer_sk#66]
 (102) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#61]
 Right keys [1]: [c_customer_sk#66]
+Join type: Inner
 Join condition: None
 
 (103) Project [codegen id : 3]
@@ -599,6 +612,7 @@ Output [1]: [d_date_sk#67]
 (105) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#64]
 Right keys [1]: [d_date_sk#67]
+Join type: Inner
 Join condition: None
 
 (106) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -89,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
@@ -128,6 +129,7 @@ Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
@@ -171,6 +173,7 @@ Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST],
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
@@ -216,6 +219,7 @@ Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [s_zip#24]
 Right keys [1]: [ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
@@ -229,6 +233,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, 
 (41) BroadcastHashJoin [codegen id : 12]
 Left keys [2]: [ss_store_sk#3, c_birth_country#16]
 Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
@@ -370,6 +375,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (59) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#20]
+Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
@@ -409,6 +415,7 @@ Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 (68) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
@@ -433,6 +440,7 @@ Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 (74) SortMergeJoin [codegen id : 10]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
@@ -457,6 +465,7 @@ Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST],
 (80) SortMergeJoin [codegen id : 14]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
@@ -496,6 +505,7 @@ Arguments: [upper(ca_country#27) ASC NULLS FIRST, ca_zip#26 ASC NULLS FIRST], fa
 (89) SortMergeJoin [codegen id : 18]
 Left keys [2]: [c_birth_country#16, s_zip#24]
 Right keys [2]: [upper(ca_country#27), ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a/explain.txt
@@ -102,6 +102,7 @@ Arguments: [sr_ticket_number#8 ASC NULLS FIRST, sr_item_sk#7 ASC NULLS FIRST], f
 (13) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#8, sr_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 9]
@@ -133,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 9]
@@ -160,6 +162,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -187,6 +190,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#21]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]
@@ -214,6 +218,7 @@ Arguments: HashedRelationBroadcastMode(List(upper(input[2, string, false]), inpu
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [c_birth_country#24, s_zip#14]
 Right keys [2]: [upper(ca_country#27), ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]
@@ -309,6 +314,7 @@ Arguments: [sr_ticket_number#8 ASC NULLS FIRST, sr_item_sk#7 ASC NULLS FIRST], f
 (51) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#8, sr_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 9]
@@ -321,6 +327,7 @@ Output [4]: [s_store_sk#10, s_store_name#11, s_state#13, s_zip#14]
 (54) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 9]
@@ -348,6 +355,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 9]
@@ -360,6 +368,7 @@ Output [4]: [c_customer_sk#21, c_first_name#22, c_last_name#23, c_birth_country#
 (63) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#21]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 9]
@@ -372,6 +381,7 @@ Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
 (66) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [c_birth_country#24, s_zip#14]
 Right keys [2]: [upper(ca_country#27), ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -89,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
@@ -128,6 +129,7 @@ Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 (18) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
@@ -171,6 +173,7 @@ Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST],
 (28) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 12]
@@ -216,6 +219,7 @@ Condition : (isnotnull(ca_country#27) AND isnotnull(ca_zip#26))
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [s_zip#24]
 Right keys [1]: [ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
@@ -229,6 +233,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, 
 (41) BroadcastHashJoin [codegen id : 12]
 Left keys [2]: [ss_store_sk#3, c_birth_country#16]
 Right keys [2]: [s_store_sk#20, upper(ca_country#27)]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 12]
@@ -370,6 +375,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (59) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#20]
+Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 2]
@@ -409,6 +415,7 @@ Arguments: [i_item_sk#7 ASC NULLS FIRST], false, 0
 (68) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 6]
@@ -433,6 +440,7 @@ Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 (74) SortMergeJoin [codegen id : 10]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 10]
@@ -457,6 +465,7 @@ Arguments: [sr_ticket_number#18 ASC NULLS FIRST, sr_item_sk#17 ASC NULLS FIRST],
 (80) SortMergeJoin [codegen id : 14]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#18, sr_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 14]
@@ -496,6 +505,7 @@ Arguments: [upper(ca_country#27) ASC NULLS FIRST, ca_zip#26 ASC NULLS FIRST], fa
 (89) SortMergeJoin [codegen id : 18]
 Left keys [2]: [c_birth_country#16, s_zip#24]
 Right keys [2]: [upper(ca_country#27), ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 18]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b/explain.txt
@@ -102,6 +102,7 @@ Arguments: [sr_ticket_number#8 ASC NULLS FIRST, sr_item_sk#7 ASC NULLS FIRST], f
 (13) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#8, sr_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 9]
@@ -133,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 9]
@@ -160,6 +162,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -187,6 +190,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#21]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]
@@ -214,6 +218,7 @@ Arguments: HashedRelationBroadcastMode(List(upper(input[2, string, false]), inpu
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [c_birth_country#24, s_zip#14]
 Right keys [2]: [upper(ca_country#27), ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]
@@ -309,6 +314,7 @@ Arguments: [sr_ticket_number#8 ASC NULLS FIRST, sr_item_sk#7 ASC NULLS FIRST], f
 (51) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#8, sr_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 9]
@@ -321,6 +327,7 @@ Output [4]: [s_store_sk#10, s_store_name#11, s_state#13, s_zip#14]
 (54) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 9]
@@ -348,6 +355,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 9]
@@ -360,6 +368,7 @@ Output [4]: [c_customer_sk#21, c_first_name#22, c_last_name#23, c_birth_country#
 (63) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#21]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 9]
@@ -372,6 +381,7 @@ Output [3]: [ca_state#25, ca_zip#26, ca_country#27]
 (66) BroadcastHashJoin [codegen id : 9]
 Left keys [2]: [c_birth_country#24, s_zip#14]
 Right keys [2]: [upper(ca_country#27), ca_zip#26]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -137,6 +139,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -172,6 +175,7 @@ Output [1]: [d_date_sk#21]
 (28) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [sr_returned_date_sk#19]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
@@ -189,6 +193,7 @@ Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST, sr
 (32) SortMergeJoin [codegen id : 12]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
 Right keys [3]: [sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 12]
@@ -224,6 +229,7 @@ Output [1]: [d_date_sk#26]
 (40) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_sold_date_sk#25]
 Right keys [1]: [d_date_sk#26]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 15]
@@ -241,6 +247,7 @@ Arguments: [cs_bill_customer_sk#22 ASC NULLS FIRST, cs_item_sk#23 ASC NULLS FIRS
 (44) SortMergeJoin [codegen id : 17]
 Left keys [2]: [sr_customer_sk#16, sr_item_sk#15]
 Right keys [2]: [cs_bill_customer_sk#22, cs_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25/explain.txt
@@ -78,6 +78,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, 
 (8) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
 Right keys [3]: [sr_customer_sk#9, sr_item_sk#8, sr_ticket_number#10]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 8]
@@ -106,6 +107,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false]
 (14) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [sr_customer_sk#9, sr_item_sk#8]
 Right keys [2]: [cs_bill_customer_sk#14, cs_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 8]
@@ -118,6 +120,7 @@ Output [1]: [d_date_sk#18]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -130,6 +133,7 @@ Output [1]: [d_date_sk#19]
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [sr_returned_date_sk#12]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
@@ -142,6 +146,7 @@ Output [1]: [d_date_sk#20]
 (23) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 8]
@@ -169,6 +174,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#21]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -196,6 +202,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#24]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_bill_cdemo_sk#1]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -102,6 +103,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_promo_sk#3]
 Right keys [1]: [p_promo_sk#14]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 5]
@@ -114,6 +116,7 @@ Output [1]: [d_date_sk#17]
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_sold_date_sk#8]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_bill_cdemo_sk#1]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -83,6 +84,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -110,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_promo_sk#3]
 Right keys [1]: [p_promo_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -83,6 +84,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -110,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -137,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -83,6 +84,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -110,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -137,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28.sf100/explain.txt
@@ -184,6 +184,7 @@ Input [3]: [B2_LP#28, B2_CNT#29, B2_CNTD#30]
 Arguments: IdentityBroadcastMode, [plan_id=5]
 
 (22) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (23) Scan parquet spark_catalog.default.store_sales
@@ -245,6 +246,7 @@ Input [3]: [B3_LP#43, B3_CNT#44, B3_CNTD#45]
 Arguments: IdentityBroadcastMode, [plan_id=8]
 
 (34) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (35) Scan parquet spark_catalog.default.store_sales
@@ -306,6 +308,7 @@ Input [3]: [B4_LP#58, B4_CNT#59, B4_CNTD#60]
 Arguments: IdentityBroadcastMode, [plan_id=11]
 
 (46) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (47) Scan parquet spark_catalog.default.store_sales
@@ -367,6 +370,7 @@ Input [3]: [B5_LP#73, B5_CNT#74, B5_CNTD#75]
 Arguments: IdentityBroadcastMode, [plan_id=14]
 
 (58) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (59) Scan parquet spark_catalog.default.store_sales
@@ -428,5 +432,6 @@ Input [3]: [B6_LP#88, B6_CNT#89, B6_CNTD#90]
 Arguments: IdentityBroadcastMode, [plan_id=17]
 
 (70) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q28/explain.txt
@@ -184,6 +184,7 @@ Input [3]: [B2_LP#28, B2_CNT#29, B2_CNTD#30]
 Arguments: IdentityBroadcastMode, [plan_id=5]
 
 (22) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (23) Scan parquet spark_catalog.default.store_sales
@@ -245,6 +246,7 @@ Input [3]: [B3_LP#43, B3_CNT#44, B3_CNTD#45]
 Arguments: IdentityBroadcastMode, [plan_id=8]
 
 (34) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (35) Scan parquet spark_catalog.default.store_sales
@@ -306,6 +308,7 @@ Input [3]: [B4_LP#58, B4_CNT#59, B4_CNTD#60]
 Arguments: IdentityBroadcastMode, [plan_id=11]
 
 (46) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (47) Scan parquet spark_catalog.default.store_sales
@@ -367,6 +370,7 @@ Input [3]: [B5_LP#73, B5_CNT#74, B5_CNTD#75]
 Arguments: IdentityBroadcastMode, [plan_id=14]
 
 (58) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 
 (59) Scan parquet spark_catalog.default.store_sales
@@ -428,5 +432,6 @@ Input [3]: [B6_LP#88, B6_CNT#89, B6_CNTD#90]
 Arguments: IdentityBroadcastMode, [plan_id=17]
 
 (70) BroadcastNestedLoopJoin [codegen id : 18]
+Join type: Inner
 Join condition: None
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -137,6 +139,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -172,6 +175,7 @@ Output [1]: [d_date_sk#21]
 (28) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [sr_returned_date_sk#19]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
@@ -189,6 +193,7 @@ Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST, sr
 (32) SortMergeJoin [codegen id : 12]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
 Right keys [3]: [sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 12]
@@ -224,6 +229,7 @@ Output [1]: [d_date_sk#27]
 (40) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_sold_date_sk#25]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 15]
@@ -241,6 +247,7 @@ Arguments: [cs_bill_customer_sk#22 ASC NULLS FIRST, cs_item_sk#23 ASC NULLS FIRS
 (44) SortMergeJoin [codegen id : 17]
 Left keys [2]: [sr_customer_sk#16, sr_item_sk#15]
 Right keys [2]: [cs_bill_customer_sk#22, cs_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29/explain.txt
@@ -78,6 +78,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, false], input[0, int, 
 (8) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
 Right keys [3]: [sr_customer_sk#9, sr_item_sk#8, sr_ticket_number#10]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 8]
@@ -106,6 +107,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, false]
 (14) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [sr_customer_sk#9, sr_item_sk#8]
 Right keys [2]: [cs_bill_customer_sk#14, cs_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 8]
@@ -118,6 +120,7 @@ Output [1]: [d_date_sk#19]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -130,6 +133,7 @@ Output [1]: [d_date_sk#20]
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [sr_returned_date_sk#12]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
@@ -142,6 +146,7 @@ Output [1]: [d_date_sk#21]
 (23) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 8]
@@ -169,6 +174,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#22]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -196,6 +202,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#25]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3.sf100/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Output [2]: [d_date_sk#9, d_year#10]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q3/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/explain.txt
@@ -95,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#15]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
@@ -126,6 +127,7 @@ Output [1]: [d_date_sk#22]
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [wr_returned_date_sk#20]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
@@ -165,6 +167,7 @@ Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
 (25) SortMergeJoin [codegen id : 8]
 Left keys [1]: [wr_returning_addr_sk#18]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 8]
@@ -196,6 +199,7 @@ Condition : isnotnull(ctr_total_return#30)
 (31) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ctr_customer_sk#28]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 17]
@@ -223,6 +227,7 @@ Output [1]: [d_date_sk#22]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [wr_returned_date_sk#20]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -247,6 +252,7 @@ Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
 (43) SortMergeJoin [codegen id : 14]
 Left keys [1]: [wr_returning_addr_sk#18]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 14]
@@ -300,6 +306,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [pla
 (53) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ctr_state#29]
 Right keys [1]: [ctr_state#29#39]
+Join type: Inner
 Join condition: (cast(ctr_total_return#30 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#38)
 
 (54) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [wr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [wr_returning_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -147,6 +149,7 @@ Output [1]: [d_date_sk#6]
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [wr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -159,6 +162,7 @@ Output [2]: [ca_address_sk#7, ca_state#8]
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [wr_returning_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -212,6 +216,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [pla
 (34) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_state#13]
 Right keys [1]: [ctr_state#13#23]
+Join type: Inner
 Join condition: (cast(ctr_total_return#14 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#22)
 
 (35) Project [codegen id : 11]
@@ -239,6 +244,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_customer_sk#12]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
@@ -270,6 +276,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (47) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#26]
 Right keys [1]: [ca_address_sk#38]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31.sf100/explain.txt
@@ -132,6 +132,7 @@ Output [3]: [d_date_sk#5, d_year#6, d_qoy#7]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -171,6 +172,7 @@ Arguments: [ca_address_sk#8 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_addr_sk#1]
 Right keys [1]: [ca_address_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -216,6 +218,7 @@ Output [3]: [d_date_sk#18, d_year#19, d_qoy#20]
 (23) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#16]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 8]
@@ -240,6 +243,7 @@ Arguments: [ca_address_sk#21 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_addr_sk#14]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 12]
@@ -271,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (35) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ca_county#9]
 Right keys [1]: [ca_county#22]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 42]
@@ -298,6 +303,7 @@ Output [3]: [d_date_sk#30, d_year#31, d_qoy#32]
 (41) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [ss_sold_date_sk#28]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 15]
@@ -322,6 +328,7 @@ Arguments: [ca_address_sk#33 ASC NULLS FIRST], false, 0
 (47) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_addr_sk#26]
 Right keys [1]: [ca_address_sk#33]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 19]
@@ -353,6 +360,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (53) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ca_county#9]
 Right keys [1]: [ca_county#34]
+Join type: Inner
 Join condition: None
 
 (54) Project [codegen id : 42]
@@ -380,6 +388,7 @@ Output [3]: [d_date_sk#41, d_year#42, d_qoy#43]
 (59) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ws_sold_date_sk#40]
 Right keys [1]: [d_date_sk#41]
+Join type: Inner
 Join condition: None
 
 (60) Project [codegen id : 22]
@@ -404,6 +413,7 @@ Arguments: [ca_address_sk#44 ASC NULLS FIRST], false, 0
 (65) SortMergeJoin [codegen id : 26]
 Left keys [1]: [ws_bill_addr_sk#38]
 Right keys [1]: [ca_address_sk#44]
+Join type: Inner
 Join condition: None
 
 (66) Project [codegen id : 26]
@@ -449,6 +459,7 @@ Output [3]: [d_date_sk#53, d_year#54, d_qoy#55]
 (74) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ws_sold_date_sk#52]
 Right keys [1]: [d_date_sk#53]
+Join type: Inner
 Join condition: None
 
 (75) Project [codegen id : 28]
@@ -473,6 +484,7 @@ Arguments: [ca_address_sk#56 ASC NULLS FIRST], false, 0
 (80) SortMergeJoin [codegen id : 32]
 Left keys [1]: [ws_bill_addr_sk#50]
 Right keys [1]: [ca_address_sk#56]
+Join type: Inner
 Join condition: None
 
 (81) Project [codegen id : 32]
@@ -504,6 +516,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (86) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ca_county#45]
 Right keys [1]: [ca_county#57]
+Join type: Inner
 Join condition: None
 
 (87) Project [codegen id : 41]
@@ -531,6 +544,7 @@ Output [3]: [d_date_sk#64, d_year#65, d_qoy#66]
 (92) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ws_sold_date_sk#63]
 Right keys [1]: [d_date_sk#64]
+Join type: Inner
 Join condition: None
 
 (93) Project [codegen id : 35]
@@ -555,6 +569,7 @@ Arguments: [ca_address_sk#67 ASC NULLS FIRST], false, 0
 (98) SortMergeJoin [codegen id : 39]
 Left keys [1]: [ws_bill_addr_sk#61]
 Right keys [1]: [ca_address_sk#67]
+Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 39]
@@ -586,6 +601,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (104) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ca_county#45]
 Right keys [1]: [ca_county#68]
+Join type: Inner
 Join condition: None
 
 (105) Project [codegen id : 41]
@@ -599,6 +615,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (107) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ca_county#34]
 Right keys [1]: [ca_county#45]
+Join type: Inner
 Join condition: ((CASE WHEN (web_sales#49 > 0.00) THEN (web_sales#60 / web_sales#49) END > CASE WHEN (store_sales#37 > 0.00) THEN (store_sales#13 / store_sales#37) END) AND (CASE WHEN (web_sales#60 > 0.00) THEN (web_sales#71 / web_sales#60) END > CASE WHEN (store_sales#13 > 0.00) THEN (store_sales#25 / store_sales#13) END))
 
 (108) Project [codegen id : 42]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q31/explain.txt
@@ -112,6 +112,7 @@ Output [3]: [d_date_sk#5, d_year#6, d_qoy#7]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -139,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_addr_sk#1]
 Right keys [1]: [ca_address_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -184,6 +186,7 @@ Output [3]: [d_date_sk#18, d_year#19, d_qoy#20]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#16]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -196,6 +199,7 @@ Output [2]: [ca_address_sk#21, ca_county#22]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_addr_sk#14]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -227,6 +231,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (29) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#9]
 Right keys [1]: [ca_county#22]
+Join type: Inner
 Join condition: None
 
 (30) Scan parquet spark_catalog.default.store_sales
@@ -250,6 +255,7 @@ Output [3]: [d_date_sk#30, d_year#31, d_qoy#32]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#28]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -262,6 +268,7 @@ Output [2]: [ca_address_sk#33, ca_county#34]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_addr_sk#26]
 Right keys [1]: [ca_address_sk#33]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -293,6 +300,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (43) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#22]
 Right keys [1]: [ca_county#34]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 24]
@@ -320,6 +328,7 @@ Output [3]: [d_date_sk#41, d_year#42, d_qoy#43]
 (49) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#40]
 Right keys [1]: [d_date_sk#41]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 14]
@@ -332,6 +341,7 @@ Output [2]: [ca_address_sk#44, ca_county#45]
 (52) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_bill_addr_sk#38]
 Right keys [1]: [ca_address_sk#44]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 14]
@@ -363,6 +373,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (58) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#9]
 Right keys [1]: [ca_county#45]
+Join type: Inner
 Join condition: None
 
 (59) Scan parquet spark_catalog.default.web_sales
@@ -386,6 +397,7 @@ Output [3]: [d_date_sk#53, d_year#54, d_qoy#55]
 (63) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ws_sold_date_sk#52]
 Right keys [1]: [d_date_sk#53]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 18]
@@ -398,6 +410,7 @@ Output [2]: [ca_address_sk#56, ca_county#57]
 (66) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ws_bill_addr_sk#50]
 Right keys [1]: [ca_address_sk#56]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 18]
@@ -429,6 +442,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (72) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#45]
 Right keys [1]: [ca_county#57]
+Join type: Inner
 Join condition: (CASE WHEN (web_sales#49 > 0.00) THEN (web_sales#60 / web_sales#49) END > CASE WHEN (store_sales#13 > 0.00) THEN (store_sales#25 / store_sales#13) END)
 
 (73) Project [codegen id : 24]
@@ -456,6 +470,7 @@ Output [3]: [d_date_sk#64, d_year#65, d_qoy#66]
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ws_sold_date_sk#63]
 Right keys [1]: [d_date_sk#64]
+Join type: Inner
 Join condition: None
 
 (79) Project [codegen id : 22]
@@ -468,6 +483,7 @@ Output [2]: [ca_address_sk#67, ca_county#68]
 (81) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ws_bill_addr_sk#61]
 Right keys [1]: [ca_address_sk#67]
+Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 22]
@@ -499,6 +515,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (87) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [ca_county#45]
 Right keys [1]: [ca_county#68]
+Join type: Inner
 Join condition: (CASE WHEN (web_sales#60 > 0.00) THEN (web_sales#71 / web_sales#60) END > CASE WHEN (store_sales#25 > 0.00) THEN (store_sales#37 / store_sales#25) END)
 
 (88) Project [codegen id : 24]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32.sf100/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#9]
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -102,6 +103,7 @@ Condition : isnotnull((1.3 * avg(cs_ext_discount_amt))#15)
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#3]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
@@ -130,6 +132,7 @@ Condition : (isnotnull(cs_item_sk#16) AND isnotnull(cs_ext_discount_amt#17))
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#16]
+Join type: Inner
 Join condition: (cast(cs_ext_discount_amt#17 as decimal(14,7)) > (1.3 * avg(cs_ext_discount_amt))#15)
 
 (23) Project [codegen id : 6]
@@ -142,6 +145,7 @@ Output [1]: [d_date_sk#19]
 (25) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q32/explain.txt
@@ -68,6 +68,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 6]
@@ -95,6 +96,7 @@ Output [1]: [d_date_sk#10]
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 3]
@@ -130,6 +132,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#5]
 Right keys [1]: [cs_item_sk#7]
+Join type: Inner
 Join condition: (cast(cs_ext_discount_amt#2 as decimal(14,7)) > (1.3 * avg(cs_ext_discount_amt))#16)
 
 (23) Project [codegen id : 6]
@@ -142,6 +145,7 @@ Output [1]: [d_date_sk#17]
 (25) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/explain.txt
@@ -85,6 +85,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -130,6 +131,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_manufact_id#8]
 Right keys [1]: [i_manufact_id#10]
+Join type: LeftSemi
 Join condition: None
 
 (16) BroadcastExchange
@@ -139,6 +141,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#11]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -215,6 +219,7 @@ Output [1]: [d_date_sk#21]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#20]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -227,6 +232,7 @@ Output [2]: [i_item_sk#22, i_manufact_id#23]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#22]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -239,6 +245,7 @@ Output [1]: [ca_address_sk#24]
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_bill_addr_sk#17]
 Right keys [1]: [ca_address_sk#24]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -284,6 +291,7 @@ Output [1]: [d_date_sk#33]
 (48) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#32]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 17]
@@ -296,6 +304,7 @@ Output [2]: [i_item_sk#34, i_manufact_id#35]
 (51) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#29]
 Right keys [1]: [i_item_sk#34]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 17]
@@ -308,6 +317,7 @@ Output [1]: [ca_address_sk#36]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_bill_addr_sk#30]
 Right keys [1]: [ca_address_sk#36]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33/explain.txt
@@ -85,6 +85,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_manufact_id#10]
 Right keys [1]: [i_manufact_id#12]
+Join type: LeftSemi
 Join condition: None
 
 (23) BroadcastExchange
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -215,6 +219,7 @@ Output [1]: [d_date_sk#21]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#20]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -227,6 +232,7 @@ Output [1]: [ca_address_sk#22]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_bill_addr_sk#17]
 Right keys [1]: [ca_address_sk#22]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -239,6 +245,7 @@ Output [2]: [i_item_sk#23, i_manufact_id#24]
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -284,6 +291,7 @@ Output [1]: [d_date_sk#33]
 (48) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#32]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 17]
@@ -296,6 +304,7 @@ Output [1]: [ca_address_sk#34]
 (51) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_bill_addr_sk#30]
 Right keys [1]: [ca_address_sk#34]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 17]
@@ -308,6 +317,7 @@ Output [2]: [i_item_sk#35, i_manufact_id#36]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#29]
 Right keys [1]: [i_item_sk#35]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35.sf100/explain.txt
@@ -92,6 +92,7 @@ Output [1]: [d_date_sk#9]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -109,6 +110,7 @@ Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
@@ -127,6 +129,7 @@ Output [1]: [d_date_sk#12]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -144,6 +147,7 @@ Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
 (21) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ws_bill_customer_sk#10]
+Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.catalog_sales
@@ -162,6 +166,7 @@ Output [1]: [d_date_sk#15]
 (25) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 12]
@@ -179,6 +184,7 @@ Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [cs_ship_customer_sk#13]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (30) Filter [codegen id : 14]
@@ -222,6 +228,7 @@ Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 18]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 18]
@@ -261,6 +268,7 @@ Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
 (48) SortMergeJoin [codegen id : 22]
 Left keys [1]: [c_current_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q35/explain.txt
@@ -73,6 +73,7 @@ Output [1]: [d_date_sk#9]
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 2]
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (11) Scan parquet spark_catalog.default.web_sales
@@ -104,6 +106,7 @@ Output [1]: [d_date_sk#12]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -117,6 +120,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ws_bill_customer_sk#10]
+Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.catalog_sales
@@ -135,6 +139,7 @@ Output [1]: [d_date_sk#15]
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -148,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [cs_ship_customer_sk#13]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (25) Filter [codegen id : 9]
@@ -179,6 +185,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (31) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 9]
@@ -206,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
@@ -50,6 +50,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -81,6 +82,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36/explain.txt
@@ -50,6 +50,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -77,6 +78,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -73,6 +73,7 @@ Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [inv_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -85,6 +86,7 @@ Output [1]: [d_date_sk#10]
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -128,6 +130,7 @@ Arguments: [cs_item_sk#11 ASC NULLS FIRST], false, 0
 (23) SortMergeJoin [codegen id : 7]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37/explain.txt
@@ -70,6 +70,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [inv_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -82,6 +83,7 @@ Output [1]: [d_date_sk#10]
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -113,6 +115,7 @@ Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38.sf100/explain.txt
@@ -82,6 +82,7 @@ Output [2]: [d_date_sk#4, d_date#5]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#2]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -121,6 +122,7 @@ Arguments: [c_customer_sk#6 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#6]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -174,6 +176,7 @@ Output [2]: [d_date_sk#11, d_date#12]
 (25) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 10]
@@ -198,6 +201,7 @@ Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 14]
 Left keys [1]: [cs_bill_customer_sk#9]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 14]
@@ -233,6 +237,7 @@ Arguments: [coalesce(c_last_name#15, ) ASC NULLS FIRST, isnull(c_last_name#15) A
 (38) SortMergeJoin [codegen id : 17]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12)]
+Join type: LeftSemi
 Join condition: None
 
 (39) Scan parquet spark_catalog.default.web_sales
@@ -256,6 +261,7 @@ Output [2]: [d_date_sk#18, d_date#19]
 (43) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 19]
@@ -280,6 +286,7 @@ Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 (49) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#16]
 Right keys [1]: [c_customer_sk#20]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 23]
@@ -315,6 +322,7 @@ Arguments: [coalesce(c_last_name#22, ) ASC NULLS FIRST, isnull(c_last_name#22) A
 (56) SortMergeJoin [codegen id : 26]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19)]
+Join type: LeftSemi
 Join condition: None
 
 (57) Project [codegen id : 26]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q38/explain.txt
@@ -69,6 +69,7 @@ Output [2]: [d_date_sk#4, d_date#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#2]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -141,6 +143,7 @@ Output [2]: [d_date_sk#11, d_date#12]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -153,6 +156,7 @@ Output [3]: [c_customer_sk#13, c_first_name#14, c_last_name#15]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_bill_customer_sk#9]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -184,6 +188,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), 
 (29) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12)]
+Join type: LeftSemi
 Join condition: None
 
 (30) Scan parquet spark_catalog.default.web_sales
@@ -207,6 +212,7 @@ Output [2]: [d_date_sk#18, d_date#19]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -219,6 +225,7 @@ Output [3]: [c_customer_sk#20, c_first_name#21, c_last_name#22]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_bill_customer_sk#16]
 Right keys [1]: [c_customer_sk#20]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -250,6 +257,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), 
 (43) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19)]
+Join type: LeftSemi
 Join condition: None
 
 (44) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a.sf100/explain.txt
@@ -69,6 +69,7 @@ Output [2]: [d_date_sk#6, d_moy#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#9]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -184,6 +187,7 @@ Output [2]: [d_date_sk#31, d_moy#32]
 (30) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_date_sk#29]
 Right keys [1]: [d_date_sk#31]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 10]
@@ -196,6 +200,7 @@ Output [1]: [i_item_sk#33]
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_item_sk#26]
 Right keys [1]: [i_item_sk#33]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 10]
@@ -208,6 +213,7 @@ Output [2]: [w_warehouse_sk#34, w_warehouse_name#35]
 (36) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_warehouse_sk#27]
 Right keys [1]: [w_warehouse_sk#34]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 10]
@@ -251,6 +257,7 @@ Arguments: [i_item_sk#33 ASC NULLS FIRST, w_warehouse_sk#34 ASC NULLS FIRST], fa
 (45) SortMergeJoin [codegen id : 13]
 Left keys [2]: [i_item_sk#8, w_warehouse_sk#9]
 Right keys [2]: [i_item_sk#33, w_warehouse_sk#34]
+Join type: Inner
 Join condition: None
 
 (46) Exchange

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39a/explain.txt
@@ -81,6 +81,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -108,6 +109,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#7]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -120,6 +122,7 @@ Output [2]: [d_date_sk#9, d_moy#10]
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -173,6 +176,7 @@ Output [1]: [i_item_sk#31]
 (28) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [inv_item_sk#26]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]
@@ -185,6 +189,7 @@ Output [2]: [w_warehouse_sk#32, w_warehouse_name#33]
 (31) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [inv_warehouse_sk#27]
 Right keys [1]: [w_warehouse_sk#32]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 8]
@@ -197,6 +202,7 @@ Output [2]: [d_date_sk#34, d_moy#35]
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [inv_date_sk#29]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -236,6 +242,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [i_item_sk#6, w_warehouse_sk#7]
 Right keys [2]: [i_item_sk#31, w_warehouse_sk#32]
+Join type: Inner
 Join condition: None
 
 (43) Exchange

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b.sf100/explain.txt
@@ -69,6 +69,7 @@ Output [2]: [d_date_sk#6, d_moy#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#9]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -184,6 +187,7 @@ Output [2]: [d_date_sk#31, d_moy#32]
 (30) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_date_sk#29]
 Right keys [1]: [d_date_sk#31]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 10]
@@ -196,6 +200,7 @@ Output [1]: [i_item_sk#33]
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_item_sk#26]
 Right keys [1]: [i_item_sk#33]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 10]
@@ -208,6 +213,7 @@ Output [2]: [w_warehouse_sk#34, w_warehouse_name#35]
 (36) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_warehouse_sk#27]
 Right keys [1]: [w_warehouse_sk#34]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 10]
@@ -251,6 +257,7 @@ Arguments: [i_item_sk#33 ASC NULLS FIRST, w_warehouse_sk#34 ASC NULLS FIRST], fa
 (45) SortMergeJoin [codegen id : 13]
 Left keys [2]: [i_item_sk#8, w_warehouse_sk#9]
 Right keys [2]: [i_item_sk#33, w_warehouse_sk#34]
+Join type: Inner
 Join condition: None
 
 (46) Exchange

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q39b/explain.txt
@@ -81,6 +81,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -108,6 +109,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#7]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -120,6 +122,7 @@ Output [2]: [d_date_sk#9, d_moy#10]
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -173,6 +176,7 @@ Output [1]: [i_item_sk#31]
 (28) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [inv_item_sk#26]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]
@@ -185,6 +189,7 @@ Output [2]: [w_warehouse_sk#32, w_warehouse_name#33]
 (31) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [inv_warehouse_sk#27]
 Right keys [1]: [w_warehouse_sk#32]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 8]
@@ -197,6 +202,7 @@ Output [2]: [d_date_sk#34, d_moy#35]
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [inv_date_sk#29]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -236,6 +242,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, true] 
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [i_item_sk#6, w_warehouse_sk#7]
 Right keys [2]: [i_item_sk#31, w_warehouse_sk#32]
+Join type: Inner
 Join condition: None
 
 (43) Exchange

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4.sf100/explain.txt
@@ -140,6 +140,7 @@ Output [2]: [d_date_sk#8, d_year#9]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -179,6 +180,7 @@ Arguments: [c_customer_sk#10 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#10]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -236,6 +238,7 @@ Output [2]: [d_date_sk#32, d_year#33]
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#30]
 Right keys [1]: [d_date_sk#32]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -260,6 +263,7 @@ Arguments: [c_customer_sk#34 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_customer_sk#25]
 Right keys [1]: [c_customer_sk#34]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 14]
@@ -295,6 +299,7 @@ Arguments: [customer_id#46 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 17]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#46]
+Join type: Inner
 Join condition: None
 
 (40) Scan parquet spark_catalog.default.catalog_sales
@@ -318,6 +323,7 @@ Output [2]: [d_date_sk#60, d_year#61]
 (44) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_sold_date_sk#59]
 Right keys [1]: [d_date_sk#60]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 19]
@@ -342,6 +348,7 @@ Arguments: [c_customer_sk#62 ASC NULLS FIRST], false, 0
 (50) SortMergeJoin [codegen id : 23]
 Left keys [1]: [cs_bill_customer_sk#54]
 Right keys [1]: [c_customer_sk#62]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 23]
@@ -381,6 +388,7 @@ Arguments: [customer_id#75 ASC NULLS FIRST], false, 0
 (58) SortMergeJoin [codegen id : 26]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#75]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 26]
@@ -408,6 +416,7 @@ Output [2]: [d_date_sk#83, d_year#84]
 (64) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_sold_date_sk#82]
 Right keys [1]: [d_date_sk#83]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 28]
@@ -432,6 +441,7 @@ Arguments: [c_customer_sk#85 ASC NULLS FIRST], false, 0
 (70) SortMergeJoin [codegen id : 32]
 Left keys [1]: [cs_bill_customer_sk#77]
 Right keys [1]: [c_customer_sk#85]
+Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 32]
@@ -467,6 +477,7 @@ Arguments: [customer_id#97 ASC NULLS FIRST], false, 0
 (77) SortMergeJoin [codegen id : 35]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#97]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#76 > 0.000000) THEN (year_total#98 / year_total#76) END > CASE WHEN (year_total#24 > 0.000000) THEN (year_total#53 / year_total#24) END)
 
 (78) Project [codegen id : 35]
@@ -494,6 +505,7 @@ Output [2]: [d_date_sk#105, d_year#106]
 (83) BroadcastHashJoin [codegen id : 37]
 Left keys [1]: [ws_sold_date_sk#104]
 Right keys [1]: [d_date_sk#105]
+Join type: Inner
 Join condition: None
 
 (84) Project [codegen id : 37]
@@ -518,6 +530,7 @@ Arguments: [c_customer_sk#107 ASC NULLS FIRST], false, 0
 (89) SortMergeJoin [codegen id : 41]
 Left keys [1]: [ws_bill_customer_sk#99]
 Right keys [1]: [c_customer_sk#107]
+Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 41]
@@ -557,6 +570,7 @@ Arguments: [customer_id#120 ASC NULLS FIRST], false, 0
 (97) SortMergeJoin [codegen id : 44]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#120]
+Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 44]
@@ -584,6 +598,7 @@ Output [2]: [d_date_sk#128, d_year#129]
 (103) BroadcastHashJoin [codegen id : 46]
 Left keys [1]: [ws_sold_date_sk#127]
 Right keys [1]: [d_date_sk#128]
+Join type: Inner
 Join condition: None
 
 (104) Project [codegen id : 46]
@@ -608,6 +623,7 @@ Arguments: [c_customer_sk#130 ASC NULLS FIRST], false, 0
 (109) SortMergeJoin [codegen id : 50]
 Left keys [1]: [ws_bill_customer_sk#122]
 Right keys [1]: [c_customer_sk#130]
+Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 50]
@@ -643,6 +659,7 @@ Arguments: [customer_id#142 ASC NULLS FIRST], false, 0
 (116) SortMergeJoin [codegen id : 53]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#142]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#76 > 0.000000) THEN (year_total#98 / year_total#76) END > CASE WHEN (year_total#121 > 0.000000) THEN (year_total#143 / year_total#121) END)
 
 (117) Project [codegen id : 53]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q4/explain.txt
@@ -145,6 +145,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -157,6 +158,7 @@ Output [2]: [d_date_sk#16, d_year#17]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -221,6 +223,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#25]
 Right keys [1]: [ss_customer_sk#33]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -233,6 +236,7 @@ Output [2]: [d_date_sk#40, d_year#41]
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#38]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -264,6 +268,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (33) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#46]
+Join type: Inner
 Join condition: None
 
 (34) Scan parquet spark_catalog.default.customer
@@ -302,6 +307,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (41) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#54]
 Right keys [1]: [cs_bill_customer_sk#62]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 10]
@@ -314,6 +320,7 @@ Output [2]: [d_date_sk#68, d_year#69]
 (44) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#67]
 Right keys [1]: [d_date_sk#68]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 10]
@@ -349,6 +356,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (51) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#75]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 24]
@@ -391,6 +399,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#77]
 Right keys [1]: [cs_bill_customer_sk#85]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 14]
@@ -403,6 +412,7 @@ Output [2]: [d_date_sk#91, d_year#92]
 (63) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [cs_sold_date_sk#90]
 Right keys [1]: [d_date_sk#91]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 14]
@@ -434,6 +444,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (69) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#97]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#76 > 0.000000) THEN (year_total#98 / year_total#76) END > CASE WHEN (year_total#24 > 0.000000) THEN (year_total#53 / year_total#24) END)
 
 (70) Project [codegen id : 24]
@@ -476,6 +487,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (78) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [c_customer_sk#99]
 Right keys [1]: [ws_bill_customer_sk#107]
+Join type: Inner
 Join condition: None
 
 (79) Project [codegen id : 18]
@@ -488,6 +500,7 @@ Output [2]: [d_date_sk#113, d_year#114]
 (81) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ws_sold_date_sk#112]
 Right keys [1]: [d_date_sk#113]
+Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 18]
@@ -523,6 +536,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (88) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#120]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 24]
@@ -565,6 +579,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (97) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [c_customer_sk#122]
 Right keys [1]: [ws_bill_customer_sk#130]
+Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 22]
@@ -577,6 +592,7 @@ Output [2]: [d_date_sk#136, d_year#137]
 (100) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ws_sold_date_sk#135]
 Right keys [1]: [d_date_sk#136]
+Join type: Inner
 Join condition: None
 
 (101) Project [codegen id : 22]
@@ -608,6 +624,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (106) BroadcastHashJoin [codegen id : 24]
 Left keys [1]: [customer_id#23]
 Right keys [1]: [customer_id#142]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#76 > 0.000000) THEN (year_total#98 / year_total#76) END > CASE WHEN (year_total#121 > 0.000000) THEN (year_total#143 / year_total#121) END)
 
 (107) Project [codegen id : 24]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
@@ -86,6 +86,7 @@ Arguments: [cr_order_number#10 ASC NULLS FIRST, cr_item_sk#9 ASC NULLS FIRST], f
 (12) SortMergeJoin [codegen id : 8]
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
 Right keys [2]: [cr_order_number#10, cr_item_sk#9]
+Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 8]
@@ -117,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 8]
@@ -129,6 +131,7 @@ Output [2]: [d_date_sk#16, d_date#17]
 (22) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 8]
@@ -156,6 +159,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_warehouse_sk#1]
 Right keys [1]: [w_warehouse_sk#18]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40/explain.txt
@@ -86,6 +86,7 @@ Arguments: [cr_order_number#8 ASC NULLS FIRST, cr_item_sk#7 ASC NULLS FIRST], fa
 (12) SortMergeJoin [codegen id : 8]
 Left keys [2]: [cs_order_number#3, cs_item_sk#2]
 Right keys [2]: [cr_order_number#8, cr_item_sk#7]
+Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 8]
@@ -113,6 +114,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_warehouse_sk#1]
 Right keys [1]: [w_warehouse_sk#11]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 8]
@@ -144,6 +146,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 8]
@@ -156,6 +159,7 @@ Output [2]: [d_date_sk#16, d_date#17]
 (28) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41.sf100/explain.txt
@@ -90,6 +90,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_manufact#2]
 Right keys [1]: [i_manufact#5]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q41/explain.txt
@@ -90,6 +90,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_manufact#2]
 Right keys [1]: [i_manufact#5]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Output [2]: [d_date_sk#9, d_year#10]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43.sf100/explain.txt
@@ -62,6 +62,7 @@ Condition : isnotnull(ss_store_sk#4)
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q43/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44.sf100/explain.txt
@@ -118,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [rnk#14]
 Right keys [1]: [rnk#17]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 10]
@@ -145,6 +146,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [item_sk#10]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -157,6 +159,7 @@ Output [2]: [i_item_sk#20, i_product_name#21]
 (29) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [item_sk#15]
 Right keys [1]: [i_item_sk#20]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q44/explain.txt
@@ -123,6 +123,7 @@ Arguments: [rnk#17 ASC NULLS FIRST], false, 0
 (21) SortMergeJoin [codegen id : 11]
 Left keys [1]: [rnk#14]
 Right keys [1]: [rnk#17]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 11]
@@ -150,6 +151,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (27) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [item_sk#10]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 11]
@@ -162,6 +164,7 @@ Output [2]: [i_item_sk#20, i_product_name#21]
 (30) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [item_sk#15]
 Right keys [1]: [i_item_sk#20]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45.sf100/explain.txt
@@ -64,6 +64,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -91,6 +92,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#2]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -152,6 +154,7 @@ Arguments: [ca_address_sk#12 ASC NULLS FIRST], false, 0
 (25) SortMergeJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#11]
 Right keys [1]: [ca_address_sk#12]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 9]
@@ -169,6 +172,7 @@ Arguments: [c_customer_sk#10 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ws_bill_customer_sk#3]
 Right keys [1]: [c_customer_sk#10]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 12]
@@ -200,6 +204,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (36) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [i_item_id#9]
 Right keys [1]: [i_item_id#16]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (37) Filter [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q45/explain.txt
@@ -73,6 +73,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_bill_customer_sk#3]
 Right keys [1]: [c_customer_sk#7]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 6]
@@ -100,6 +101,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#8]
 Right keys [1]: [ca_address_sk#9]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -112,6 +114,7 @@ Output [1]: [d_date_sk#12]
 (17) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#5]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 6]
@@ -139,6 +142,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#2]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -170,6 +174,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_id#14]
 Right keys [1]: [i_item_id#16]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (31) Filter [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
@@ -95,6 +95,7 @@ Arguments: [ca_address_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 5]
 Left keys [1]: [c_current_addr_sk#2]
 Right keys [1]: [ca_address_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -130,6 +131,7 @@ Output [1]: [d_date_sk#16]
 (19) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 10]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#10]
 Right keys [1]: [s_store_sk#17]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -192,6 +195,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_hdemo_sk#8]
 Right keys [1]: [hd_demo_sk#19]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 10]
@@ -216,6 +220,7 @@ Arguments: [ca_address_sk#22 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_addr_sk#9]
 Right keys [1]: [ca_address_sk#22]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 14]
@@ -247,6 +252,7 @@ Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 (45) SortMergeJoin [codegen id : 16]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#7]
+Join type: Inner
 Join condition: NOT (ca_city#6 = bought_city#30)
 
 (46) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46/explain.txt
@@ -61,6 +61,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#13]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -150,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -195,6 +199,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#27]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -207,6 +212,7 @@ Output [2]: [ca_address_sk#31, ca_city#32]
 (37) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#28]
 Right keys [1]: [ca_address_sk#31]
+Join type: Inner
 Join condition: NOT (ca_city#32 = bought_city#24)
 
 (38) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
@@ -74,6 +74,7 @@ Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -101,6 +102,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -140,6 +142,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -237,6 +240,7 @@ Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_n
 (42) SortMergeJoin [codegen id : 24]
 Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
 Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1)]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 24]
@@ -269,6 +273,7 @@ Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_n
 (50) SortMergeJoin [codegen id : 36]
 Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
 Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1)]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 36]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47/explain.txt
@@ -82,6 +82,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Output [3]: [d_date_sk#9, d_year#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#5]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -206,6 +209,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1)]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 22]
@@ -234,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1)]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48.sf100/explain.txt
@@ -65,6 +65,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#1]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: ((((((cd_marital_status#11 = M) AND (cd_education_status#12 = 4 yr Degree         )) AND (ss_sales_price#5 >= 100.00)) AND (ss_sales_price#5 <= 150.00)) OR ((((cd_marital_status#11 = D) AND (cd_education_status#12 = 2 yr Degree         )) AND (ss_sales_price#5 >= 50.00)) AND (ss_sales_price#5 <= 100.00))) OR ((((cd_marital_status#11 = S) AND (cd_education_status#12 = College             )) AND (ss_sales_price#5 >= 150.00)) AND (ss_sales_price#5 <= 200.00)))
 
 (15) Project [codegen id : 5]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#13]
+Join type: Inner
 Join condition: ((((ca_state#14 IN (CO,OH,TX) AND (ss_net_profit#6 >= 0.00)) AND (ss_net_profit#6 <= 2000.00)) OR ((ca_state#14 IN (OR,MN,KY) AND (ss_net_profit#6 >= 150.00)) AND (ss_net_profit#6 <= 3000.00))) OR ((ca_state#14 IN (VA,CA,MS) AND (ss_net_profit#6 >= 50.00)) AND (ss_net_profit#6 <= 25000.00)))
 
 (22) Project [codegen id : 5]
@@ -135,6 +138,7 @@ Output [1]: [d_date_sk#16]
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q48/explain.txt
@@ -65,6 +65,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#1]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: ((((((cd_marital_status#11 = M) AND (cd_education_status#12 = 4 yr Degree         )) AND (ss_sales_price#5 >= 100.00)) AND (ss_sales_price#5 <= 150.00)) OR ((((cd_marital_status#11 = D) AND (cd_education_status#12 = 2 yr Degree         )) AND (ss_sales_price#5 >= 50.00)) AND (ss_sales_price#5 <= 100.00))) OR ((((cd_marital_status#11 = S) AND (cd_education_status#12 = College             )) AND (ss_sales_price#5 >= 150.00)) AND (ss_sales_price#5 <= 200.00)))
 
 (15) Project [codegen id : 5]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#13]
+Join type: Inner
 Join condition: ((((ca_state#14 IN (CO,OH,TX) AND (ss_net_profit#6 >= 0.00)) AND (ss_net_profit#6 <= 2000.00)) OR ((ca_state#14 IN (OR,MN,KY) AND (ss_net_profit#6 >= 150.00)) AND (ss_net_profit#6 <= 3000.00))) OR ((ca_state#14 IN (VA,CA,MS) AND (ss_net_profit#6 >= 50.00)) AND (ss_net_profit#6 <= 25000.00)))
 
 (22) Project [codegen id : 5]
@@ -135,6 +138,7 @@ Output [1]: [d_date_sk#16]
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49.sf100/explain.txt
@@ -112,6 +112,7 @@ Output [1]: [d_date_sk#8]
 (6) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (7) Project [codegen id : 2]
@@ -155,6 +156,7 @@ Arguments: [wr_order_number#10 ASC NULLS FIRST, wr_item_sk#9 ASC NULLS FIRST], f
 (16) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ws_order_number#2, ws_item_sk#1]
 Right keys [2]: [wr_order_number#10, wr_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -232,6 +234,7 @@ Output [1]: [d_date_sk#42]
 (33) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#41]
 Right keys [1]: [d_date_sk#42]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 12]
@@ -275,6 +278,7 @@ Arguments: [cr_order_number#44 ASC NULLS FIRST, cr_item_sk#43 ASC NULLS FIRST], 
 (43) SortMergeJoin [codegen id : 16]
 Left keys [2]: [cs_order_number#37, cs_item_sk#36]
 Right keys [2]: [cr_order_number#44, cr_item_sk#43]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 16]
@@ -352,6 +356,7 @@ Output [1]: [d_date_sk#76]
 (60) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ss_sold_date_sk#75]
 Right keys [1]: [d_date_sk#76]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 22]
@@ -395,6 +400,7 @@ Arguments: [sr_ticket_number#78 ASC NULLS FIRST, sr_item_sk#77 ASC NULLS FIRST],
 (70) SortMergeJoin [codegen id : 26]
 Left keys [2]: [ss_ticket_number#71, ss_item_sk#70]
 Right keys [2]: [sr_ticket_number#78, sr_item_sk#77]
+Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 26]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q49/explain.txt
@@ -122,6 +122,7 @@ Input [5]: [wr_item_sk#8, wr_order_number#9, wr_return_quantity#10, wr_return_am
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [2]: [ws_order_number#2, ws_item_sk#1]
 Right keys [2]: [wr_order_number#9, wr_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -134,6 +135,7 @@ Output [1]: [d_date_sk#13]
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#6]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -230,6 +232,7 @@ Input [5]: [cr_item_sk#42, cr_order_number#43, cr_return_quantity#44, cr_return_
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [cs_order_number#37, cs_item_sk#36]
 Right keys [2]: [cr_order_number#43, cr_item_sk#42]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -242,6 +245,7 @@ Output [1]: [d_date_sk#47]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#41]
 Right keys [1]: [d_date_sk#47]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -338,6 +342,7 @@ Input [5]: [sr_item_sk#76, sr_ticket_number#77, sr_return_quantity#78, sr_return
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [2]: [ss_ticket_number#71, ss_item_sk#70]
 Right keys [2]: [sr_ticket_number#77, sr_item_sk#76]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -350,6 +355,7 @@ Output [1]: [d_date_sk#81]
 (61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#75]
 Right keys [1]: [d_date_sk#81]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5.sf100/explain.txt
@@ -139,6 +139,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#22]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 5]
@@ -151,6 +152,7 @@ Output [1]: [d_date_sk#24]
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
@@ -236,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#62]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 11]
@@ -248,6 +251,7 @@ Output [1]: [d_date_sk#64]
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#64]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
@@ -338,6 +342,7 @@ Arguments: [ws_item_sk#97 ASC NULLS FIRST, ws_order_number#99 ASC NULLS FIRST], 
 (57) SortMergeJoin [codegen id : 18]
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 18]
@@ -367,6 +372,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (64) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#107]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 21]
@@ -379,6 +385,7 @@ Output [1]: [d_date_sk#109]
 (67) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#109]
+Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 21]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q5/explain.txt
@@ -121,6 +121,7 @@ Output [1]: [d_date_sk#22]
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -148,6 +149,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#23]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
@@ -218,6 +220,7 @@ Output [1]: [d_date_sk#62]
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#62]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
@@ -245,6 +248,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#63]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
@@ -323,6 +327,7 @@ Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_s
 (54) BroadcastHashJoin [codegen id : 15]
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 15]
@@ -337,6 +342,7 @@ Output [1]: [d_date_sk#107]
 (58) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#107]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 18]
@@ -364,6 +370,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (64) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#108]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 18]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
@@ -53,6 +53,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -93,6 +94,7 @@ Arguments: [ss_ticket_number#10 ASC NULLS FIRST, ss_item_sk#7 ASC NULLS FIRST, s
 (14) SortMergeJoin [codegen id : 8]
 Left keys [3]: [sr_ticket_number#3, sr_item_sk#1, sr_customer_sk#2]
 Right keys [3]: [ss_ticket_number#10, ss_item_sk#7, ss_customer_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 8]
@@ -120,6 +122,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
@@ -147,6 +150,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (26) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#9]
 Right keys [1]: [s_store_sk#13]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50/explain.txt
@@ -66,6 +66,7 @@ Arguments: HashedRelationBroadcastMode(List(input[2, int, false], input[0, int, 
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [3]: [ss_ticket_number#4, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [sr_ticket_number#8, sr_item_sk#6, sr_customer_sk#7]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 5]
@@ -120,6 +122,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 5]
@@ -132,6 +135,7 @@ Output [1]: [d_date_sk#23]
 (23) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_returned_date_sk#9]
 Right keys [1]: [d_date_sk#23]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51.sf100/explain.txt
@@ -59,6 +59,7 @@ Output [2]: [d_date_sk#5, d_date#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -128,6 +129,7 @@ Output [2]: [d_date_sk#16, d_date#17]
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#15]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
@@ -179,6 +181,7 @@ Arguments: [item_sk#21 ASC NULLS FIRST, d_date#17 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 13]
 Left keys [2]: [item_sk#10, d_date#6]
 Right keys [2]: [item_sk#21, d_date#17]
+Join type: FullOuter
 Join condition: None
 
 (32) Project [codegen id : 13]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q51/explain.txt
@@ -59,6 +59,7 @@ Output [2]: [d_date_sk#5, d_date#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -128,6 +129,7 @@ Output [2]: [d_date_sk#16, d_date#17]
 (20) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#15]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 8]
@@ -179,6 +181,7 @@ Arguments: [item_sk#21 ASC NULLS FIRST, d_date#17 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 13]
 Left keys [2]: [item_sk#10, d_date#6]
 Right keys [2]: [item_sk#21, d_date#17]
+Join type: FullOuter
 Join condition: None
 
 (32) Project [codegen id : 13]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Output [2]: [d_date_sk#9, d_year#10]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/explain.txt
@@ -69,6 +69,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Output [2]: [d_date_sk#16, d_qoy#17]
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53/explain.txt
@@ -69,6 +69,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -81,6 +82,7 @@ Output [2]: [d_date_sk#15, d_qoy#16]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#17]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -95,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, st
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [2]: [ca_county#2, ca_state#3]
 Right keys [2]: [s_county#4, s_state#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -151,6 +152,7 @@ Output [1]: [d_date_sk#19]
 (21) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [sold_date_sk#10]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 7]
@@ -182,6 +184,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (28) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [item_sk#12]
 Right keys [1]: [i_item_sk#20]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 7]
@@ -221,6 +224,7 @@ Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
 (37) SortMergeJoin
 Left keys [1]: [customer_sk#11]
 Right keys [1]: [c_customer_sk#23]
+Join type: Inner
 Join condition: None
 
 (38) Project
@@ -244,6 +248,7 @@ Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
 (41) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#24]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 11]
@@ -275,6 +280,7 @@ Output [1]: [d_date_sk#29]
 (48) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#27]
 Right keys [1]: [d_date_sk#29]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 13]
@@ -292,6 +298,7 @@ Arguments: [ss_customer_sk#25 ASC NULLS FIRST], false, 0
 (52) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#23]
 Right keys [1]: [ss_customer_sk#25]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 15]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54/explain.txt
@@ -122,6 +122,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [item_sk#7]
 Right keys [1]: [i_item_sk#14]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 6]
@@ -134,6 +135,7 @@ Output [1]: [d_date_sk#17]
 (18) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sold_date_sk#5]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 6]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [customer_sk#6]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -207,6 +210,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_customer_sk#18]
 Right keys [1]: [ss_customer_sk#20]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -234,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#19]
 Right keys [1]: [ca_address_sk#24]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -261,6 +266,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, false], input[1, st
 (45) BroadcastHashJoin [codegen id : 11]
 Left keys [2]: [ca_county#25, ca_state#26]
 Right keys [2]: [s_county#27, s_state#28]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 11]
@@ -273,6 +279,7 @@ Output [1]: [d_date_sk#29]
 (48) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#22]
 Right keys [1]: [d_date_sk#29]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Output [1]: [d_date_sk#9]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55/explain.txt
@@ -62,6 +62,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -93,6 +94,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56.sf100/explain.txt
@@ -85,6 +85,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#10]
 Right keys [1]: [i_item_id#11]
+Join type: LeftSemi
 Join condition: None
 
 (23) BroadcastExchange
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -215,6 +219,7 @@ Output [1]: [d_date_sk#21]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#20]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -227,6 +232,7 @@ Output [1]: [ca_address_sk#22]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_bill_addr_sk#17]
 Right keys [1]: [ca_address_sk#22]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -239,6 +245,7 @@ Output [2]: [i_item_sk#23, i_item_id#24]
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -284,6 +291,7 @@ Output [1]: [d_date_sk#33]
 (48) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#32]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 17]
@@ -296,6 +304,7 @@ Output [1]: [ca_address_sk#34]
 (51) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_bill_addr_sk#30]
 Right keys [1]: [ca_address_sk#34]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 17]
@@ -308,6 +317,7 @@ Output [2]: [i_item_sk#35, i_item_id#36]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#29]
 Right keys [1]: [i_item_sk#35]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q56/explain.txt
@@ -85,6 +85,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#10]
 Right keys [1]: [i_item_id#11]
+Join type: LeftSemi
 Join condition: None
 
 (23) BroadcastExchange
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -215,6 +219,7 @@ Output [1]: [d_date_sk#21]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#20]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -227,6 +232,7 @@ Output [1]: [ca_address_sk#22]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_bill_addr_sk#17]
 Right keys [1]: [ca_address_sk#22]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -239,6 +245,7 @@ Output [2]: [i_item_sk#23, i_item_id#24]
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -284,6 +291,7 @@ Output [1]: [d_date_sk#33]
 (48) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#32]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 17]
@@ -296,6 +304,7 @@ Output [1]: [ca_address_sk#34]
 (51) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_bill_addr_sk#30]
 Right keys [1]: [ca_address_sk#34]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 17]
@@ -308,6 +317,7 @@ Output [2]: [i_item_sk#35, i_item_id#36]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#29]
 Right keys [1]: [i_item_sk#35]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57.sf100/explain.txt
@@ -74,6 +74,7 @@ Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -101,6 +102,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_call_center_sk#1]
 Right keys [1]: [cc_call_center_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -140,6 +142,7 @@ Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -237,6 +240,7 @@ Arguments: [i_category#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, cc_name#2
 (42) SortMergeJoin [codegen id : 24]
 Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
 Right keys [4]: [i_category#21, i_brand#22, cc_name#23, (rn#28 + 1)]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 24]
@@ -269,6 +273,7 @@ Arguments: [i_category#30 ASC NULLS FIRST, i_brand#31 ASC NULLS FIRST, cc_name#3
 (50) SortMergeJoin [codegen id : 36]
 Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
 Right keys [4]: [i_category#30, i_brand#31, cc_name#32, (rn#35 - 1)]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 36]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q57/explain.txt
@@ -82,6 +82,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Output [3]: [d_date_sk#9, d_year#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_call_center_sk#4]
 Right keys [1]: [cc_call_center_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -206,6 +209,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#13, rn#19]
 Right keys [4]: [i_category#21, i_brand#22, cc_name#23, (rn#28 + 1)]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 22]
@@ -234,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#13, rn#19]
 Right keys [4]: [i_category#30, i_brand#31, cc_name#32, (rn#35 - 1)]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -147,6 +149,7 @@ Output [1]: [d_date_sk#16]
 (21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#15]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 8]
@@ -159,6 +162,7 @@ Output [2]: [i_item_sk#17, i_item_id#18]
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#13]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
@@ -194,6 +198,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (31) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#22]
+Join type: Inner
 Join condition: ((((cast(ss_item_rev#12 as decimal(19,3)) >= (0.9 * cs_item_rev#23)) AND (cast(ss_item_rev#12 as decimal(20,3)) <= (1.1 * cs_item_rev#23))) AND (cast(cs_item_rev#23 as decimal(19,3)) >= (0.9 * ss_item_rev#12))) AND (cast(cs_item_rev#23 as decimal(20,3)) <= (1.1 * ss_item_rev#12)))
 
 (32) Project [codegen id : 15]
@@ -221,6 +226,7 @@ Output [1]: [d_date_sk#27]
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_sold_date_sk#26]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
@@ -233,6 +239,7 @@ Output [2]: [i_item_sk#28, i_item_id#29]
 (40) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_item_sk#24]
 Right keys [1]: [i_item_sk#28]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 13]
@@ -268,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (47) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#33]
+Join type: Inner
 Join condition: ((((((((cast(ss_item_rev#12 as decimal(19,3)) >= (0.9 * ws_item_rev#34)) AND (cast(ss_item_rev#12 as decimal(20,3)) <= (1.1 * ws_item_rev#34))) AND (cast(cs_item_rev#23 as decimal(19,3)) >= (0.9 * ws_item_rev#34))) AND (cast(cs_item_rev#23 as decimal(20,3)) <= (1.1 * ws_item_rev#34))) AND (cast(ws_item_rev#34 as decimal(19,3)) >= (0.9 * ss_item_rev#12))) AND (cast(ws_item_rev#34 as decimal(20,3)) <= (1.1 * ss_item_rev#12))) AND (cast(ws_item_rev#34 as decimal(19,3)) >= (0.9 * cs_item_rev#23))) AND (cast(ws_item_rev#34 as decimal(20,3)) <= (1.1 * cs_item_rev#23)))
 
 (48) Project [codegen id : 15]
@@ -333,6 +341,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_
 (58) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date#39]
 Right keys [1]: [d_date#40]
+Join type: LeftSemi
 Join condition: None
 
 (59) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58/explain.txt
@@ -86,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -98,6 +99,7 @@ Output [1]: [d_date_sk#7]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -147,6 +149,7 @@ Output [2]: [i_item_sk#16, i_item_id#17]
 (21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#13]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 8]
@@ -159,6 +162,7 @@ Output [1]: [d_date_sk#18]
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#15]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
@@ -194,6 +198,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (31) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#22]
+Join type: Inner
 Join condition: ((((cast(ss_item_rev#12 as decimal(19,3)) >= (0.9 * cs_item_rev#23)) AND (cast(ss_item_rev#12 as decimal(20,3)) <= (1.1 * cs_item_rev#23))) AND (cast(cs_item_rev#23 as decimal(19,3)) >= (0.9 * ss_item_rev#12))) AND (cast(cs_item_rev#23 as decimal(20,3)) <= (1.1 * ss_item_rev#12)))
 
 (32) Project [codegen id : 15]
@@ -221,6 +226,7 @@ Output [2]: [i_item_sk#27, i_item_id#28]
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_item_sk#24]
 Right keys [1]: [i_item_sk#27]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
@@ -233,6 +239,7 @@ Output [1]: [d_date_sk#29]
 (40) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_sold_date_sk#26]
 Right keys [1]: [d_date_sk#29]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 13]
@@ -268,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (47) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#33]
+Join type: Inner
 Join condition: ((((((((cast(ss_item_rev#12 as decimal(19,3)) >= (0.9 * ws_item_rev#34)) AND (cast(ss_item_rev#12 as decimal(20,3)) <= (1.1 * ws_item_rev#34))) AND (cast(cs_item_rev#23 as decimal(19,3)) >= (0.9 * ws_item_rev#34))) AND (cast(cs_item_rev#23 as decimal(20,3)) <= (1.1 * ws_item_rev#34))) AND (cast(ws_item_rev#34 as decimal(19,3)) >= (0.9 * ss_item_rev#12))) AND (cast(ws_item_rev#34 as decimal(20,3)) <= (1.1 * ss_item_rev#12))) AND (cast(ws_item_rev#34 as decimal(19,3)) >= (0.9 * cs_item_rev#23))) AND (cast(ws_item_rev#34 as decimal(20,3)) <= (1.1 * cs_item_rev#23)))
 
 (48) Project [codegen id : 15]
@@ -333,6 +341,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_
 (58) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_date#39]
 Right keys [1]: [d_date#40]
+Join type: LeftSemi
 Join condition: None
 
 (59) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
@@ -91,6 +91,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -136,6 +137,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#37]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 10]
@@ -167,6 +169,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#41]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 10]
@@ -209,6 +212,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (33) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 6]
@@ -254,6 +258,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (42) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#68]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 9]
@@ -285,6 +290,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (49) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#71]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 9]
@@ -298,6 +304,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, in
 (52) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#44, d_week_seq1#43]
 Right keys [2]: [s_store_id2#73, (d_week_seq2#72 - 52)]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59/explain.txt
@@ -81,6 +81,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -126,6 +127,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#35]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 10]
@@ -157,6 +159,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#39]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 10]
@@ -194,6 +197,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#57]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]
@@ -225,6 +229,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#60]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 9]
@@ -238,6 +243,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, in
 (42) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [s_store_id1#42, d_week_seq1#41]
 Right keys [2]: [s_store_id2#62, (d_week_seq2#61 - 52)]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60.sf100/explain.txt
@@ -85,6 +85,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#10]
 Right keys [1]: [i_item_id#11]
+Join type: LeftSemi
 Join condition: None
 
 (23) BroadcastExchange
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -215,6 +219,7 @@ Output [1]: [d_date_sk#21]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#20]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -227,6 +232,7 @@ Output [1]: [ca_address_sk#22]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_bill_addr_sk#17]
 Right keys [1]: [ca_address_sk#22]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -239,6 +245,7 @@ Output [2]: [i_item_sk#23, i_item_id#24]
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -284,6 +291,7 @@ Output [1]: [d_date_sk#33]
 (48) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#32]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 17]
@@ -296,6 +304,7 @@ Output [1]: [ca_address_sk#34]
 (51) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_bill_addr_sk#30]
 Right keys [1]: [ca_address_sk#34]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 17]
@@ -308,6 +317,7 @@ Output [2]: [i_item_sk#35, i_item_id#36]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#29]
 Right keys [1]: [i_item_sk#35]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q60/explain.txt
@@ -85,6 +85,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_id#10]
 Right keys [1]: [i_item_id#11]
+Join type: LeftSemi
 Join condition: None
 
 (23) BroadcastExchange
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -215,6 +219,7 @@ Output [1]: [d_date_sk#21]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#20]
 Right keys [1]: [d_date_sk#21]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -227,6 +232,7 @@ Output [1]: [ca_address_sk#22]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_bill_addr_sk#17]
 Right keys [1]: [ca_address_sk#22]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -239,6 +245,7 @@ Output [2]: [i_item_sk#23, i_item_id#24]
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#23]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -284,6 +291,7 @@ Output [1]: [d_date_sk#33]
 (48) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#32]
 Right keys [1]: [d_date_sk#33]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 17]
@@ -296,6 +304,7 @@ Output [1]: [ca_address_sk#34]
 (51) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_bill_addr_sk#30]
 Right keys [1]: [ca_address_sk#34]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 17]
@@ -308,6 +317,7 @@ Output [2]: [i_item_sk#35, i_item_id#36]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#29]
 Right keys [1]: [i_item_sk#35]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/explain.txt
@@ -86,6 +86,7 @@ Output [1]: [d_date_sk#8]
 (5) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 7]
@@ -117,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 7]
@@ -148,6 +150,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_promo_sk#4]
 Right keys [1]: [p_promo_sk#11]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 7]
@@ -179,6 +182,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (26) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 7]
@@ -224,6 +228,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (36) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_current_addr_sk#18]
 Right keys [1]: [ca_address_sk#19]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 6]
@@ -237,6 +242,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#17]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 7]
@@ -282,6 +288,7 @@ Output [1]: [d_date_sk#30]
 (48) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#29]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 13]
@@ -294,6 +301,7 @@ Output [1]: [i_item_sk#31]
 (51) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#25]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 13]
@@ -306,6 +314,7 @@ Output [1]: [s_store_sk#32]
 (54) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#27]
 Right keys [1]: [s_store_sk#32]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 13]
@@ -318,6 +327,7 @@ Output [1]: [c_customer_sk#33]
 (57) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_customer_sk#26]
 Right keys [1]: [c_customer_sk#33]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 13]
@@ -347,6 +357,7 @@ Input [1]: [total#37]
 Arguments: IdentityBroadcastMode, [plan_id=8]
 
 (63) BroadcastNestedLoopJoin [codegen id : 15]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 15]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61/explain.txt
@@ -108,6 +108,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 7]
@@ -139,6 +140,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_promo_sk#4]
 Right keys [1]: [p_promo_sk#10]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 7]
@@ -151,6 +153,7 @@ Output [1]: [d_date_sk#14]
 (19) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 7]
@@ -178,6 +181,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 7]
@@ -209,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#16]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 7]
@@ -240,6 +245,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#19]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 7]
@@ -285,6 +291,7 @@ Output [1]: [s_store_sk#30]
 (48) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#27]
 Right keys [1]: [s_store_sk#30]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 13]
@@ -297,6 +304,7 @@ Output [1]: [d_date_sk#31]
 (51) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#29]
 Right keys [1]: [d_date_sk#31]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 13]
@@ -309,6 +317,7 @@ Output [2]: [c_customer_sk#32, c_current_addr_sk#33]
 (54) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_customer_sk#26]
 Right keys [1]: [c_customer_sk#32]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 13]
@@ -321,6 +330,7 @@ Output [1]: [ca_address_sk#34]
 (57) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#33]
 Right keys [1]: [ca_address_sk#34]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 13]
@@ -333,6 +343,7 @@ Output [1]: [i_item_sk#35]
 (60) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#25]
 Right keys [1]: [i_item_sk#35]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 13]
@@ -362,6 +373,7 @@ Input [1]: [total#39]
 Arguments: IdentityBroadcastMode, [plan_id=8]
 
 (66) BroadcastNestedLoopJoin [codegen id : 15]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 15]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -99,6 +100,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_web_site_sk#2]
 Right keys [1]: [web_site_sk#8]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 5]
@@ -126,6 +128,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#3]
 Right keys [1]: [sm_ship_mode_sk#10]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 5]
@@ -153,6 +156,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#4]
 Right keys [1]: [w_warehouse_sk#12]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q62/explain.txt
@@ -68,6 +68,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#4]
 Right keys [1]: [w_warehouse_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -95,6 +96,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#3]
 Right keys [1]: [sm_ship_mode_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 5]
@@ -122,6 +124,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_web_site_sk#2]
 Right keys [1]: [web_site_sk#10]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 5]
@@ -153,6 +156,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/explain.txt
@@ -69,6 +69,7 @@ Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Output [2]: [d_date_sk#16, d_moy#17]
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63/explain.txt
@@ -69,6 +69,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -81,6 +82,7 @@ Output [2]: [d_date_sk#15, d_moy#16]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#13]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -108,6 +110,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#11]
 Right keys [1]: [s_store_sk#17]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
@@ -64,6 +64,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -113,6 +114,7 @@ Output [1]: [d_date_sk#15]
 (15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 4]
@@ -166,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [ss_store_sk#12]
+Join type: Inner
 Join condition: (cast(revenue#10 as decimal(23,7)) <= (0.1 * ave#25))
 
 (26) Project [codegen id : 8]
@@ -193,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (31) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#26]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 8]
@@ -232,6 +236,7 @@ Arguments: [i_item_sk#28 ASC NULLS FIRST], false, 0
 (40) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#28]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65/explain.txt
@@ -75,6 +75,7 @@ Output [1]: [d_date_sk#8]
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -110,6 +111,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [s_store_sk#1]
 Right keys [1]: [ss_store_sk#4]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 9]
@@ -137,6 +139,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#3]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 9]
@@ -164,6 +167,7 @@ Output [1]: [d_date_sk#22]
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#21]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -217,6 +221,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [ss_store_sk#19]
+Join type: Inner
 Join condition: (cast(revenue#12 as decimal(23,7)) <= (0.1 * ave#32))
 
 (38) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66.sf100/explain.txt
@@ -93,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#2]
 Right keys [1]: [sm_ship_mode_sk#9]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -124,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_time_sk#1]
 Right keys [1]: [t_time_sk#11]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 5]
@@ -136,6 +138,7 @@ Output [3]: [d_date_sk#13, d_year#14, d_moy#15]
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_date_sk#7]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -163,6 +166,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#3]
 Right keys [1]: [w_warehouse_sk#16]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -208,6 +212,7 @@ Output [1]: [sm_ship_mode_sk#176]
 (34) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_mode_sk#170]
 Right keys [1]: [sm_ship_mode_sk#176]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 11]
@@ -220,6 +225,7 @@ Output [1]: [t_time_sk#177]
 (37) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_time_sk#169]
 Right keys [1]: [t_time_sk#177]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 11]
@@ -232,6 +238,7 @@ Output [3]: [d_date_sk#178, d_year#179, d_moy#180]
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#175]
 Right keys [1]: [d_date_sk#178]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
@@ -244,6 +251,7 @@ Output [7]: [w_warehouse_sk#181, w_warehouse_name#182, w_warehouse_sq_ft#183, w_
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_warehouse_sk#171]
 Right keys [1]: [w_warehouse_sk#181]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q66/explain.txt
@@ -89,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_warehouse_sk#3]
 Right keys [1]: [w_warehouse_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -101,6 +102,7 @@ Output [3]: [d_date_sk#16, d_year#17, d_moy#18]
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_date_sk#7]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -132,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_time_sk#1]
 Right keys [1]: [t_time_sk#19]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -163,6 +166,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_ship_mode_sk#2]
 Right keys [1]: [sm_ship_mode_sk#21]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -208,6 +212,7 @@ Output [7]: [w_warehouse_sk#176, w_warehouse_name#177, w_warehouse_sq_ft#178, w_
 (34) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_warehouse_sk#171]
 Right keys [1]: [w_warehouse_sk#176]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 11]
@@ -220,6 +225,7 @@ Output [3]: [d_date_sk#183, d_year#184, d_moy#185]
 (37) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_date_sk#175]
 Right keys [1]: [d_date_sk#183]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 11]
@@ -232,6 +238,7 @@ Output [1]: [t_time_sk#186]
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_sold_time_sk#169]
 Right keys [1]: [t_time_sk#186]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
@@ -244,6 +251,7 @@ Output [1]: [sm_ship_mode_sk#187]
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [cs_ship_mode_sk#170]
 Right keys [1]: [sm_ship_mode_sk#187]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
@@ -52,6 +52,7 @@ Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -79,6 +80,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -118,6 +120,7 @@ Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67/explain.txt
@@ -49,6 +49,7 @@ Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -76,6 +77,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -103,6 +105,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
@@ -95,6 +95,7 @@ Arguments: [ca_address_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 5]
 Left keys [1]: [c_current_addr_sk#2]
 Right keys [1]: [ca_address_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -130,6 +131,7 @@ Output [1]: [d_date_sk#17]
 (19) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#15]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 10]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#10]
 Right keys [1]: [s_store_sk#18]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -192,6 +195,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (33) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_hdemo_sk#8]
 Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 10]
@@ -216,6 +220,7 @@ Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_addr_sk#9]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 14]
@@ -247,6 +252,7 @@ Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 (45) SortMergeJoin [codegen id : 16]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#7]
+Join type: Inner
 Join condition: NOT (ca_city#6 = bought_city#34)
 
 (46) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68/explain.txt
@@ -61,6 +61,7 @@ Output [1]: [d_date_sk#11]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#9]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -150,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]
@@ -195,6 +199,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#32]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -207,6 +212,7 @@ Output [2]: [ca_address_sk#36, ca_city#37]
 (37) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#33]
 Right keys [1]: [ca_address_sk#36]
+Join type: Inner
 Join condition: NOT (ca_city#37 = bought_city#28)
 
 (38) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
@@ -86,6 +86,7 @@ Output [1]: [d_date_sk#9]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -103,6 +104,7 @@ Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
@@ -121,6 +123,7 @@ Output [1]: [d_date_sk#12]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -138,6 +141,7 @@ Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
 (21) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ws_bill_customer_sk#10]
+Join type: LeftAnti
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.catalog_sales
@@ -156,6 +160,7 @@ Output [1]: [d_date_sk#15]
 (25) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 12]
@@ -173,6 +178,7 @@ Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 15]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [cs_ship_customer_sk#13]
+Join type: LeftAnti
 Join condition: None
 
 (30) Project [codegen id : 15]
@@ -204,6 +210,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (36) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 15]
@@ -231,6 +238,7 @@ Condition : isnotnull(cd_demo_sk#18)
 (42) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69/explain.txt
@@ -73,6 +73,7 @@ Output [1]: [d_date_sk#7]
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 2]
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#4]
+Join type: LeftSemi
 Join condition: None
 
 (11) Scan parquet spark_catalog.default.web_sales
@@ -104,6 +106,7 @@ Output [1]: [d_date_sk#10]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -117,6 +120,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ws_bill_customer_sk#8]
+Join type: LeftAnti
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.catalog_sales
@@ -135,6 +139,7 @@ Output [1]: [d_date_sk#13]
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#12]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -148,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [cs_ship_customer_sk#11]
+Join type: LeftAnti
 Join condition: None
 
 (25) Project [codegen id : 9]
@@ -179,6 +185,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (31) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#14]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 9]
@@ -206,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#16]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -102,6 +103,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#14]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 5]
@@ -114,6 +116,7 @@ Output [1]: [d_date_sk#17]
 (19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -83,6 +84,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -110,6 +112,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -141,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70.sf100/explain.txt
@@ -64,6 +64,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 8]
@@ -105,6 +106,7 @@ Output [1]: [d_date_sk#12]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -132,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
 Right keys [1]: [s_store_sk#13]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 4]
@@ -179,6 +182,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
 Right keys [1]: [s_state#14]
+Join type: LeftSemi
 Join condition: None
 
 (31) BroadcastExchange
@@ -188,6 +192,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#6]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q70/explain.txt
@@ -64,6 +64,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 8]
@@ -120,6 +121,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -132,6 +134,7 @@ Output [1]: [d_date_sk#14]
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 4]
@@ -179,6 +182,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
 Right keys [1]: [s_state#13]
+Join type: LeftSemi
 Join condition: None
 
 (31) BroadcastExchange
@@ -188,6 +192,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#6]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71.sf100/explain.txt
@@ -82,6 +82,7 @@ Output [1]: [d_date_sk#10]
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -109,6 +110,7 @@ Output [1]: [d_date_sk#18]
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 5]
@@ -136,6 +138,7 @@ Output [1]: [d_date_sk#26]
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#25]
 Right keys [1]: [d_date_sk#26]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -147,6 +150,7 @@ Input [5]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_da
 (25) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [sold_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 9]
@@ -178,6 +182,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [time_sk#13]
 Right keys [1]: [t_time_sk#30]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q71/explain.txt
@@ -82,6 +82,7 @@ Output [1]: [d_date_sk#10]
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -109,6 +110,7 @@ Output [1]: [d_date_sk#18]
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 5]
@@ -136,6 +138,7 @@ Output [1]: [d_date_sk#26]
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#25]
 Right keys [1]: [d_date_sk#26]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -147,6 +150,7 @@ Input [5]: [ss_sold_time_sk#22, ss_item_sk#23, ss_ext_sales_price#24, ss_sold_da
 (25) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [sold_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 9]
@@ -178,6 +182,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [time_sk#13]
 Right keys [1]: [t_time_sk#30]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
@@ -111,6 +111,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -142,6 +143,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#12]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
@@ -169,6 +171,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 4]
@@ -208,6 +211,7 @@ Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 10]
@@ -220,6 +224,7 @@ Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#8]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: (d_date#15 > date_add(d_date#19, 5))
 
 (35) Project [codegen id : 10]
@@ -270,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (45) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [inv_warehouse_sk#23]
 Right keys [1]: [w_warehouse_sk#26]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 13]
@@ -287,6 +293,7 @@ Arguments: [inv_item_sk#22 ASC NULLS FIRST, inv_date_sk#25 ASC NULLS FIRST], fal
 (49) SortMergeJoin [codegen id : 16]
 Left keys [2]: [cs_item_sk#4, d_date_sk#21]
 Right keys [2]: [inv_item_sk#22, inv_date_sk#25]
+Join type: Inner
 Join condition: (inv_quantity_on_hand#24 < cs_quantity#7)
 
 (50) Project [codegen id : 16]
@@ -314,6 +321,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (55) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [cs_promo_sk#5]
 Right keys [1]: [p_promo_sk#28]
+Join type: LeftOuter
 Join condition: None
 
 (56) Project [codegen id : 16]
@@ -357,6 +365,7 @@ Arguments: [cr_item_sk#29 ASC NULLS FIRST, cr_order_number#30 ASC NULLS FIRST], 
 (65) SortMergeJoin [codegen id : 20]
 Left keys [2]: [cs_item_sk#4, cs_order_number#6]
 Right keys [2]: [cr_item_sk#29, cr_order_number#30]
+Join type: LeftOuter
 Join condition: None
 
 (66) Project [codegen id : 20]
@@ -440,6 +449,7 @@ Condition : (isnotnull(d_week_seq#39) AND isnotnull(d_date_sk#21))
 (79) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_week_seq#20]
 Right keys [1]: [d_week_seq#39]
+Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72/explain.txt
@@ -108,6 +108,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
 Right keys [1]: [inv_item_sk#10]
+Join type: Inner
 Join condition: (inv_quantity_on_hand#12 < cs_quantity#7)
 
 (9) Project [codegen id : 10]
@@ -135,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_warehouse_sk#11]
 Right keys [1]: [w_warehouse_sk#14]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 10]
@@ -162,6 +164,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 10]
@@ -193,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (27) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 10]
@@ -224,6 +228,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -236,6 +241,7 @@ Output [3]: [d_date_sk#22, d_date#23, d_week_seq#24]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#8]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -263,6 +269,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false]
 (43) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [d_week_seq#24, inv_date_sk#13]
 Right keys [2]: [d_week_seq#26, d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 10]
@@ -290,6 +297,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: (d_date#28 > date_add(d_date#23, 5))
 
 (50) Project [codegen id : 10]
@@ -317,6 +325,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (55) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_promo_sk#5]
 Right keys [1]: [p_promo_sk#29]
+Join type: LeftOuter
 Join condition: None
 
 (56) Project [codegen id : 10]
@@ -360,6 +369,7 @@ Arguments: [cr_item_sk#30 ASC NULLS FIRST, cr_order_number#31 ASC NULLS FIRST], 
 (65) SortMergeJoin [codegen id : 14]
 Left keys [2]: [cs_item_sk#4, cs_order_number#6]
 Right keys [2]: [cr_item_sk#30, cr_order_number#31]
+Join type: LeftOuter
 Join condition: None
 
 (66) Project [codegen id : 14]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
@@ -57,6 +57,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -88,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -119,6 +121,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -180,6 +183,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73/explain.txt
@@ -54,6 +54,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -85,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -116,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -165,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
@@ -81,6 +81,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -108,6 +109,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 3]
@@ -150,6 +152,7 @@ Condition : isnotnull(d_date_sk#17)
 (23) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ws_sold_date_sk#16]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 5]
@@ -177,6 +180,7 @@ Condition : isnotnull(i_item_sk#20)
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#13]
 Right keys [1]: [i_item_sk#20]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 6]
@@ -204,6 +208,7 @@ Output [3]: [d_date_sk#29, d_year#30, d_qoy#31]
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_sold_date_sk#28]
 Right keys [1]: [d_date_sk#29]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
@@ -216,6 +221,7 @@ Output [2]: [i_item_sk#32, i_category#33]
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#26]
 Right keys [1]: [i_item_sk#32]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76/explain.txt
@@ -75,6 +75,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -102,6 +103,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 3]
@@ -129,6 +131,7 @@ Output [2]: [i_item_sk#17, i_category#18]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#13]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -141,6 +144,7 @@ Output [3]: [d_date_sk#19, d_year#20, d_qoy#21]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#16]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -168,6 +172,7 @@ Output [2]: [i_item_sk#29, i_category#30]
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_item_sk#26]
 Right keys [1]: [i_item_sk#29]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
@@ -180,6 +185,7 @@ Output [3]: [d_date_sk#31, d_year#32, d_qoy#33]
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_sold_date_sk#28]
 Right keys [1]: [d_date_sk#31]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/explain.txt
@@ -107,6 +107,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -134,6 +135,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -179,6 +181,7 @@ Output [1]: [d_date_sk#20]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_returned_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -191,6 +194,7 @@ Output [1]: [s_store_sk#21]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_store_sk#16]
 Right keys [1]: [s_store_sk#21]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -222,6 +226,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
 Right keys [1]: [s_store_sk#21]
+Join type: LeftOuter
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -244,6 +249,7 @@ Output [1]: [d_date_sk#38]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#37]
 Right keys [1]: [d_date_sk#38]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -284,6 +290,7 @@ Output [1]: [d_date_sk#50]
 (42) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cr_returned_date_sk#49]
 Right keys [1]: [d_date_sk#50]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 12]
@@ -313,6 +320,7 @@ Input [2]: [returns#57, profit_loss#58]
 Arguments: IdentityBroadcastMode, [plan_id=7]
 
 (48) BroadcastNestedLoopJoin [codegen id : 14]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 14]
@@ -340,6 +348,7 @@ Output [1]: [d_date_sk#66]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#65]
 Right keys [1]: [d_date_sk#66]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]
@@ -367,6 +376,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#62]
 Right keys [1]: [wp_web_page_sk#67]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 17]
@@ -412,6 +422,7 @@ Output [1]: [d_date_sk#80]
 (69) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_returned_date_sk#79]
 Right keys [1]: [d_date_sk#80]
+Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 20]
@@ -424,6 +435,7 @@ Output [1]: [wp_web_page_sk#81]
 (72) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_web_page_sk#76]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 20]
@@ -455,6 +467,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#67]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: LeftOuter
 Join condition: None
 
 (79) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77/explain.txt
@@ -107,6 +107,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -134,6 +135,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -179,6 +181,7 @@ Output [1]: [d_date_sk#20]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_returned_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -191,6 +194,7 @@ Output [1]: [s_store_sk#21]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_store_sk#16]
 Right keys [1]: [s_store_sk#21]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -222,6 +226,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
 Right keys [1]: [s_store_sk#21]
+Join type: LeftOuter
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -244,6 +249,7 @@ Output [1]: [d_date_sk#38]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#37]
 Right keys [1]: [d_date_sk#38]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -288,6 +294,7 @@ Output [1]: [d_date_sk#50]
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [cr_returned_date_sk#49]
 Right keys [1]: [d_date_sk#50]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
@@ -313,6 +320,7 @@ Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#47))#55, sum(Unsca
 Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#47))#55,17,2) AS returns#57, MakeDecimal(sum(UnscaledValue(cr_net_loss#48))#56,17,2) AS profit_loss#58]
 
 (48) BroadcastNestedLoopJoin [codegen id : 14]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 14]
@@ -340,6 +348,7 @@ Output [1]: [d_date_sk#66]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#65]
 Right keys [1]: [d_date_sk#66]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]
@@ -367,6 +376,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#62]
 Right keys [1]: [wp_web_page_sk#67]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 17]
@@ -412,6 +422,7 @@ Output [1]: [d_date_sk#80]
 (69) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_returned_date_sk#79]
 Right keys [1]: [d_date_sk#80]
+Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 20]
@@ -424,6 +435,7 @@ Output [1]: [wp_web_page_sk#81]
 (72) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_web_page_sk#76]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 20]
@@ -455,6 +467,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#67]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: LeftOuter
 Join condition: None
 
 (79) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79.sf100/explain.txt
@@ -55,6 +55,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -117,6 +119,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -174,6 +177,7 @@ Arguments: [c_customer_sk#25 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#25]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q79/explain.txt
@@ -52,6 +52,7 @@ Output [1]: [d_date_sk#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -83,6 +84,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -114,6 +116,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -159,6 +162,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#25]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8.sf100/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -176,6 +178,7 @@ Arguments: [c_current_addr_sk#12 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ca_address_sk#10]
 Right keys [1]: [c_current_addr_sk#12]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
@@ -215,6 +218,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), 
 (37) BroadcastHashJoin [codegen id : 11]
 Left keys [2]: [coalesce(substr(ca_zip#9, 1, 5), ), isnull(substr(ca_zip#9, 1, 5))]
 Right keys [2]: [coalesce(ca_zip#17, ), isnull(ca_zip#17)]
+Join type: LeftSemi
 Join condition: None
 
 (38) Project [codegen id : 11]
@@ -250,6 +254,7 @@ Arguments: [substr(ca_zip#19, 1, 2) ASC NULLS FIRST], false, 0
 (44) SortMergeJoin [codegen id : 14]
 Left keys [1]: [substr(s_zip#8, 1, 2)]
 Right keys [1]: [substr(ca_zip#19, 1, 2)]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 14]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q8/explain.txt
@@ -65,6 +65,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 8]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 8]
@@ -150,6 +152,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ca_address_sk#10]
 Right keys [1]: [c_current_addr_sk#12]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
@@ -189,6 +192,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), 
 (32) BroadcastHashJoin [codegen id : 6]
 Left keys [2]: [coalesce(substr(ca_zip#9, 1, 5), ), isnull(substr(ca_zip#9, 1, 5))]
 Right keys [2]: [coalesce(ca_zip#17, ), isnull(ca_zip#17)]
+Join type: LeftSemi
 Join condition: None
 
 (33) Project [codegen id : 6]
@@ -220,6 +224,7 @@ Arguments: HashedRelationBroadcastMode(List(substr(input[0, string, true], 1, 2)
 (38) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [substr(s_zip#8, 1, 2)]
 Right keys [1]: [substr(ca_zip#19, 1, 2)]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
@@ -160,6 +160,7 @@ Arguments: [sr_item_sk#13 ASC NULLS FIRST, sr_ticket_number#14 ASC NULLS FIRST],
 (12) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
 Right keys [2]: [sr_item_sk#13, sr_ticket_number#14]
+Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 9]
@@ -191,6 +192,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 9]
@@ -222,6 +224,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#20]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -234,6 +237,7 @@ Output [1]: [d_date_sk#22]
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
@@ -261,6 +265,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#23]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
@@ -337,6 +342,7 @@ Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], 
 (51) SortMergeJoin [codegen id : 19]
 Left keys [2]: [cs_item_sk#44, cs_order_number#46]
 Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+Join type: LeftOuter
 Join condition: None
 
 (52) Project [codegen id : 19]
@@ -349,6 +355,7 @@ Output [1]: [i_item_sk#55]
 (54) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_item_sk#44]
 Right keys [1]: [i_item_sk#55]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
@@ -361,6 +368,7 @@ Output [1]: [p_promo_sk#56]
 (57) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_promo_sk#45]
 Right keys [1]: [p_promo_sk#56]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 19]
@@ -373,6 +381,7 @@ Output [1]: [d_date_sk#57]
 (60) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_sold_date_sk#49]
 Right keys [1]: [d_date_sk#57]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 19]
@@ -400,6 +409,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (66) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#43]
 Right keys [1]: [cp_catalog_page_sk#58]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
@@ -476,6 +486,7 @@ Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], 
 (82) SortMergeJoin [codegen id : 29]
 Left keys [2]: [ws_item_sk#78, ws_order_number#81]
 Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+Join type: LeftOuter
 Join condition: None
 
 (83) Project [codegen id : 29]
@@ -488,6 +499,7 @@ Output [1]: [i_item_sk#90]
 (85) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_item_sk#78]
 Right keys [1]: [i_item_sk#90]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
@@ -500,6 +512,7 @@ Output [1]: [p_promo_sk#91]
 (88) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_promo_sk#80]
 Right keys [1]: [p_promo_sk#91]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 29]
@@ -512,6 +525,7 @@ Output [1]: [d_date_sk#92]
 (91) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_sold_date_sk#84]
 Right keys [1]: [d_date_sk#92]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 29]
@@ -539,6 +553,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (97) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#79]
 Right keys [1]: [web_site_sk#93]
+Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80/explain.txt
@@ -160,6 +160,7 @@ Arguments: [sr_item_sk#9 ASC NULLS FIRST, sr_ticket_number#10 ASC NULLS FIRST], 
 (12) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
 Right keys [2]: [sr_item_sk#9, sr_ticket_number#10]
+Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 9]
@@ -172,6 +173,7 @@ Output [1]: [d_date_sk#14]
 (15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 9]
@@ -199,6 +201,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 9]
@@ -230,6 +233,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (28) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 9]
@@ -261,6 +265,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#19]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
@@ -337,6 +342,7 @@ Arguments: [cr_item_sk#46 ASC NULLS FIRST, cr_order_number#47 ASC NULLS FIRST], 
 (51) SortMergeJoin [codegen id : 19]
 Left keys [2]: [cs_item_sk#40, cs_order_number#42]
 Right keys [2]: [cr_item_sk#46, cr_order_number#47]
+Join type: LeftOuter
 Join condition: None
 
 (52) Project [codegen id : 19]
@@ -349,6 +355,7 @@ Output [1]: [d_date_sk#51]
 (54) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_sold_date_sk#45]
 Right keys [1]: [d_date_sk#51]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
@@ -376,6 +383,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#39]
 Right keys [1]: [cp_catalog_page_sk#52]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 19]
@@ -388,6 +396,7 @@ Output [1]: [i_item_sk#54]
 (63) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_item_sk#40]
 Right keys [1]: [i_item_sk#54]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 19]
@@ -400,6 +409,7 @@ Output [1]: [p_promo_sk#55]
 (66) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_promo_sk#41]
 Right keys [1]: [p_promo_sk#55]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
@@ -476,6 +486,7 @@ Arguments: [wr_item_sk#81 ASC NULLS FIRST, wr_order_number#82 ASC NULLS FIRST], 
 (82) SortMergeJoin [codegen id : 29]
 Left keys [2]: [ws_item_sk#74, ws_order_number#77]
 Right keys [2]: [wr_item_sk#81, wr_order_number#82]
+Join type: LeftOuter
 Join condition: None
 
 (83) Project [codegen id : 29]
@@ -488,6 +499,7 @@ Output [1]: [d_date_sk#86]
 (85) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_sold_date_sk#80]
 Right keys [1]: [d_date_sk#86]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
@@ -515,6 +527,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (91) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#75]
 Right keys [1]: [web_site_sk#87]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 29]
@@ -527,6 +540,7 @@ Output [1]: [i_item_sk#89]
 (94) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#89]
+Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 29]
@@ -539,6 +553,7 @@ Output [1]: [p_promo_sk#90]
 (97) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_promo_sk#76]
 Right keys [1]: [p_promo_sk#90]
+Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/explain.txt
@@ -93,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -128,6 +129,7 @@ Output [1]: [d_date_sk#24]
 (16) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cr_returned_date_sk#22]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 5]
@@ -167,6 +169,7 @@ Arguments: [ca_address_sk#25 ASC NULLS FIRST], false, 0
 (25) SortMergeJoin [codegen id : 9]
 Left keys [1]: [cr_returning_addr_sk#20]
 Right keys [1]: [ca_address_sk#25]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 9]
@@ -206,6 +209,7 @@ Arguments: [ctr_customer_sk#30 ASC NULLS FIRST], false, 0
 (33) SortMergeJoin [codegen id : 20]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ctr_customer_sk#30]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 20]
@@ -233,6 +237,7 @@ Output [1]: [d_date_sk#24]
 (39) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [cr_returned_date_sk#22]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 13]
@@ -257,6 +262,7 @@ Arguments: [ca_address_sk#25 ASC NULLS FIRST], false, 0
 (45) SortMergeJoin [codegen id : 17]
 Left keys [1]: [cr_returning_addr_sk#20]
 Right keys [1]: [ca_address_sk#25]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 17]
@@ -310,6 +316,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [pla
 (55) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ctr_state#31]
 Right keys [1]: [ctr_state#31#41]
+Join type: Inner
 Join condition: (cast(ctr_total_return#32 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#40)
 
 (56) Project [codegen id : 20]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81/explain.txt
@@ -70,6 +70,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -97,6 +98,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cr_returning_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -146,6 +148,7 @@ Output [1]: [d_date_sk#6]
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cr_returned_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -158,6 +161,7 @@ Output [2]: [ca_address_sk#7, ca_state#8]
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cr_returning_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -211,6 +215,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [pla
 (34) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_state#13]
 Right keys [1]: [ctr_state#13#23]
+Join type: Inner
 Join condition: (cast(ctr_total_return#14 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#22)
 
 (35) Project [codegen id : 11]
@@ -238,6 +243,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ctr_customer_sk#12]
 Right keys [1]: [c_customer_sk#24]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
@@ -265,6 +271,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (46) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [c_current_addr_sk#26]
 Right keys [1]: [ca_address_sk#30]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -73,6 +73,7 @@ Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [inv_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -85,6 +86,7 @@ Output [1]: [d_date_sk#10]
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -128,6 +130,7 @@ Arguments: [ss_item_sk#11 ASC NULLS FIRST], false, 0
 (23) SortMergeJoin [codegen id : 7]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82/explain.txt
@@ -70,6 +70,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [inv_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -82,6 +83,7 @@ Output [1]: [d_date_sk#10]
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -113,6 +115,7 @@ Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100/explain.txt
@@ -68,6 +68,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_returned_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 5]
@@ -95,6 +96,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -140,6 +142,7 @@ Output [1]: [d_date_sk#16]
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cr_returned_date_sk#15]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 10]
@@ -152,6 +155,7 @@ Output [2]: [i_item_sk#17, i_item_id#18]
 (23) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cr_item_sk#13]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 10]
@@ -183,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (29) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#22]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 18]
@@ -210,6 +215,7 @@ Output [1]: [d_date_sk#27]
 (35) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [wr_returned_date_sk#26]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 16]
@@ -222,6 +228,7 @@ Output [2]: [i_item_sk#28, i_item_id#29]
 (38) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [wr_item_sk#24]
 Right keys [1]: [i_item_sk#28]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 16]
@@ -253,6 +260,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (44) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#33]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 18]
@@ -331,6 +339,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (57) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_week_seq#41]
 Right keys [1]: [d_week_seq#43]
+Join type: LeftSemi
 Join condition: None
 
 (58) Project [codegen id : 2]
@@ -344,6 +353,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_
 (60) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date#39]
 Right keys [1]: [d_date#40]
+Join type: LeftSemi
 Join condition: None
 
 (61) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83/explain.txt
@@ -83,6 +83,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -95,6 +96,7 @@ Output [1]: [d_date_sk#7]
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_returned_date_sk#3]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -140,6 +142,7 @@ Output [2]: [i_item_sk#16, i_item_id#17]
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cr_item_sk#13]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 10]
@@ -152,6 +155,7 @@ Output [1]: [d_date_sk#18]
 (23) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cr_returned_date_sk#15]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 10]
@@ -183,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (29) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#22]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 18]
@@ -210,6 +215,7 @@ Output [2]: [i_item_sk#27, i_item_id#28]
 (35) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [wr_item_sk#24]
 Right keys [1]: [i_item_sk#27]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 16]
@@ -222,6 +228,7 @@ Output [1]: [d_date_sk#29]
 (38) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [wr_returned_date_sk#26]
 Right keys [1]: [d_date_sk#29]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 16]
@@ -253,6 +260,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (44) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [item_id#11]
 Right keys [1]: [item_id#33]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 18]
@@ -331,6 +339,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (57) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_week_seq#41]
 Right keys [1]: [d_week_seq#43]
+Join type: LeftSemi
 Join condition: None
 
 (58) Project [codegen id : 2]
@@ -344,6 +353,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, date, true]),false), [plan_
 (60) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date#39]
 Right keys [1]: [d_date#40]
+Join type: LeftSemi
 Join condition: None
 
 (61) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/explain.txt
@@ -77,6 +77,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_addr_sk#4]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -122,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [hd_income_band_sk#10]
 Right keys [1]: [ib_income_band_sk#11]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 3]
@@ -135,6 +137,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#9]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 4]
@@ -162,6 +165,7 @@ Condition : isnotnull(cd_demo_sk#14)
 (28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#14]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 5]
@@ -193,6 +197,7 @@ Input [2]: [sr_cdemo_sk#15, sr_returned_date_sk#16]
 (35) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cd_demo_sk#14]
 Right keys [1]: [sr_cdemo_sk#15]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84/explain.txt
@@ -77,6 +77,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_addr_sk#4]
 Right keys [1]: [ca_address_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -104,6 +105,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#9]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 5]
@@ -131,6 +133,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [c_current_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 5]
@@ -162,6 +165,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [hd_income_band_sk#11]
 Right keys [1]: [ib_income_band_sk#12]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 5]
@@ -193,6 +197,7 @@ Input [2]: [sr_cdemo_sk#15, sr_returned_date_sk#16]
 (35) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cd_demo_sk#9]
 Right keys [1]: [sr_cdemo_sk#15]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
@@ -91,6 +91,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_web_page_sk#2]
 Right keys [1]: [wp_web_page_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 2]
@@ -134,6 +135,7 @@ Arguments: [wr_item_sk#10 ASC NULLS FIRST, wr_order_number#15 ASC NULLS FIRST], 
 (18) SortMergeJoin [codegen id : 7]
 Left keys [2]: [ws_item_sk#1, ws_order_number#3]
 Right keys [2]: [wr_item_sk#10, wr_order_number#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 7]
@@ -161,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [wr_refunded_cdemo_sk#11]
 Right keys [1]: [cd_demo_sk#23]
+Join type: Inner
 Join condition: ((((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#24 = S) AND (cd_education_status#25 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
 
 (25) Project [codegen id : 7]
@@ -200,6 +203,7 @@ Arguments: [cd_demo_sk#26 ASC NULLS FIRST, cd_marital_status#27 ASC NULLS FIRST,
 (33) SortMergeJoin [codegen id : 14]
 Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25]
 Right keys [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 14]
@@ -231,6 +235,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (40) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_refunded_addr_sk#12]
 Right keys [1]: [ca_address_sk#29]
+Join type: Inner
 Join condition: ((((ca_state#30 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#30 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#30 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
 
 (41) Project [codegen id : 14]
@@ -243,6 +248,7 @@ Output [1]: [d_date_sk#32]
 (43) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#7]
 Right keys [1]: [d_date_sk#32]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 14]
@@ -270,6 +276,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (49) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [wr_reason_sk#14]
 Right keys [1]: [r_reason_sk#33]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 14]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85/explain.txt
@@ -89,6 +89,7 @@ Input [9]: [wr_item_sk#9, wr_refunded_cdemo_sk#10, wr_refunded_addr_sk#11, wr_re
 (9) BroadcastHashJoin [codegen id : 8]
 Left keys [2]: [ws_item_sk#1, ws_order_number#3]
 Right keys [2]: [wr_item_sk#9, wr_order_number#14]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 8]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_web_page_sk#2]
 Right keys [1]: [wp_web_page_sk#18]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 8]
@@ -143,6 +145,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [wr_refunded_cdemo_sk#10]
 Right keys [1]: [cd_demo_sk#19]
+Join type: Inner
 Join condition: ((((((cd_marital_status#20 = M) AND (cd_education_status#21 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#20 = S) AND (cd_education_status#21 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#20 = W) AND (cd_education_status#21 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
 
 (22) Project [codegen id : 8]
@@ -170,6 +173,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, false], input[1, strin
 (27) BroadcastHashJoin [codegen id : 8]
 Left keys [3]: [wr_returning_cdemo_sk#12, cd_marital_status#20, cd_education_status#21]
 Right keys [3]: [cd_demo_sk#22, cd_marital_status#23, cd_education_status#24]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 8]
@@ -201,6 +205,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [wr_refunded_addr_sk#11]
 Right keys [1]: [ca_address_sk#25]
+Join type: Inner
 Join condition: ((((ca_state#26 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#26 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#26 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
 
 (35) Project [codegen id : 8]
@@ -213,6 +218,7 @@ Output [1]: [d_date_sk#28]
 (37) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#7]
 Right keys [1]: [d_date_sk#28]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 8]
@@ -240,6 +246,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (43) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [wr_reason_sk#13]
 Right keys [1]: [r_reason_sk#29]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86.sf100/explain.txt
@@ -43,6 +43,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q86/explain.txt
@@ -43,6 +43,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87.sf100/explain.txt
@@ -82,6 +82,7 @@ Output [2]: [d_date_sk#4, d_date#5]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#2]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -121,6 +122,7 @@ Arguments: [c_customer_sk#6 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#6]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -174,6 +176,7 @@ Output [2]: [d_date_sk#11, d_date#12]
 (25) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 10]
@@ -198,6 +201,7 @@ Arguments: [c_customer_sk#13 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 14]
 Left keys [1]: [cs_bill_customer_sk#9]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 14]
@@ -233,6 +237,7 @@ Arguments: [coalesce(c_last_name#15, ) ASC NULLS FIRST, isnull(c_last_name#15) A
 (38) SortMergeJoin [codegen id : 17]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12)]
+Join type: LeftAnti
 Join condition: None
 
 (39) Scan parquet spark_catalog.default.web_sales
@@ -256,6 +261,7 @@ Output [2]: [d_date_sk#18, d_date#19]
 (43) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 19]
@@ -280,6 +286,7 @@ Arguments: [c_customer_sk#20 ASC NULLS FIRST], false, 0
 (49) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#16]
 Right keys [1]: [c_customer_sk#20]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 23]
@@ -315,6 +322,7 @@ Arguments: [coalesce(c_last_name#22, ) ASC NULLS FIRST, isnull(c_last_name#22) A
 (56) SortMergeJoin [codegen id : 26]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19)]
+Join type: LeftAnti
 Join condition: None
 
 (57) Project [codegen id : 26]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q87/explain.txt
@@ -69,6 +69,7 @@ Output [2]: [d_date_sk#4, d_date#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#2]
 Right keys [1]: [d_date_sk#4]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -96,6 +97,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -141,6 +143,7 @@ Output [2]: [d_date_sk#11, d_date#12]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -153,6 +156,7 @@ Output [3]: [c_customer_sk#13, c_first_name#14, c_last_name#15]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_bill_customer_sk#9]
 Right keys [1]: [c_customer_sk#13]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -184,6 +188,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), 
 (29) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#15, ), isnull(c_last_name#15), coalesce(c_first_name#14, ), isnull(c_first_name#14), coalesce(d_date#12, 1970-01-01), isnull(d_date#12)]
+Join type: LeftAnti
 Join condition: None
 
 (30) Scan parquet spark_catalog.default.web_sales
@@ -207,6 +212,7 @@ Output [2]: [d_date_sk#18, d_date#19]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_sold_date_sk#17]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -219,6 +225,7 @@ Output [3]: [c_customer_sk#20, c_first_name#21, c_last_name#22]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_bill_customer_sk#16]
 Right keys [1]: [c_customer_sk#20]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -250,6 +257,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, string, true], ), 
 (43) BroadcastHashJoin [codegen id : 12]
 Left keys [6]: [coalesce(c_last_name#8, ), isnull(c_last_name#8), coalesce(c_first_name#7, ), isnull(c_first_name#7), coalesce(d_date#5, 1970-01-01), isnull(d_date#5)]
 Right keys [6]: [coalesce(c_last_name#22, ), isnull(c_last_name#22), coalesce(c_first_name#21, ), isnull(c_first_name#21), coalesce(d_date#19, 1970-01-01), isnull(d_date#19)]
+Join type: LeftAnti
 Join condition: None
 
 (44) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/explain.txt
@@ -226,6 +226,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
 Right keys [1]: [t_time_sk#5]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -257,6 +258,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -288,6 +290,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
@@ -355,6 +358,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (38) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_time_sk#17]
 Right keys [1]: [t_time_sk#21]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 8]
@@ -367,6 +371,7 @@ Output [1]: [s_store_sk#24]
 (41) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#19]
 Right keys [1]: [s_store_sk#24]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 8]
@@ -379,6 +384,7 @@ Output [1]: [hd_demo_sk#25]
 (44) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_hdemo_sk#18]
 Right keys [1]: [hd_demo_sk#25]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 8]
@@ -408,6 +414,7 @@ Input [1]: [h9_to_9_30#29]
 Arguments: IdentityBroadcastMode, [plan_id=7]
 
 (50) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (51) Scan parquet spark_catalog.default.store_sales
@@ -453,6 +460,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (60) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_time_sk#30]
 Right keys [1]: [t_time_sk#34]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 13]
@@ -465,6 +473,7 @@ Output [1]: [s_store_sk#37]
 (63) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#32]
 Right keys [1]: [s_store_sk#37]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 13]
@@ -477,6 +486,7 @@ Output [1]: [hd_demo_sk#38]
 (66) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_hdemo_sk#31]
 Right keys [1]: [hd_demo_sk#38]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 13]
@@ -506,6 +516,7 @@ Input [1]: [h9_30_to_10#42]
 Arguments: IdentityBroadcastMode, [plan_id=10]
 
 (72) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (73) Scan parquet spark_catalog.default.store_sales
@@ -551,6 +562,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (82) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_sold_time_sk#43]
 Right keys [1]: [t_time_sk#47]
+Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 18]
@@ -563,6 +575,7 @@ Output [1]: [s_store_sk#50]
 (85) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_store_sk#45]
 Right keys [1]: [s_store_sk#50]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 18]
@@ -575,6 +588,7 @@ Output [1]: [hd_demo_sk#51]
 (88) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_hdemo_sk#44]
 Right keys [1]: [hd_demo_sk#51]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 18]
@@ -604,6 +618,7 @@ Input [1]: [h10_to_10_30#55]
 Arguments: IdentityBroadcastMode, [plan_id=13]
 
 (94) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (95) Scan parquet spark_catalog.default.store_sales
@@ -649,6 +664,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (104) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_sold_time_sk#56]
 Right keys [1]: [t_time_sk#60]
+Join type: Inner
 Join condition: None
 
 (105) Project [codegen id : 23]
@@ -661,6 +677,7 @@ Output [1]: [s_store_sk#63]
 (107) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_store_sk#58]
 Right keys [1]: [s_store_sk#63]
+Join type: Inner
 Join condition: None
 
 (108) Project [codegen id : 23]
@@ -673,6 +690,7 @@ Output [1]: [hd_demo_sk#64]
 (110) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_hdemo_sk#57]
 Right keys [1]: [hd_demo_sk#64]
+Join type: Inner
 Join condition: None
 
 (111) Project [codegen id : 23]
@@ -702,6 +720,7 @@ Input [1]: [h10_30_to_11#68]
 Arguments: IdentityBroadcastMode, [plan_id=16]
 
 (116) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (117) Scan parquet spark_catalog.default.store_sales
@@ -747,6 +766,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (126) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_sold_time_sk#69]
 Right keys [1]: [t_time_sk#73]
+Join type: Inner
 Join condition: None
 
 (127) Project [codegen id : 28]
@@ -759,6 +779,7 @@ Output [1]: [s_store_sk#76]
 (129) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_store_sk#71]
 Right keys [1]: [s_store_sk#76]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 28]
@@ -771,6 +792,7 @@ Output [1]: [hd_demo_sk#77]
 (132) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_hdemo_sk#70]
 Right keys [1]: [hd_demo_sk#77]
+Join type: Inner
 Join condition: None
 
 (133) Project [codegen id : 28]
@@ -800,6 +822,7 @@ Input [1]: [h11_to_11_30#81]
 Arguments: IdentityBroadcastMode, [plan_id=19]
 
 (138) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (139) Scan parquet spark_catalog.default.store_sales
@@ -845,6 +868,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (148) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_sold_time_sk#82]
 Right keys [1]: [t_time_sk#86]
+Join type: Inner
 Join condition: None
 
 (149) Project [codegen id : 33]
@@ -857,6 +881,7 @@ Output [1]: [s_store_sk#89]
 (151) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_store_sk#84]
 Right keys [1]: [s_store_sk#89]
+Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 33]
@@ -869,6 +894,7 @@ Output [1]: [hd_demo_sk#90]
 (154) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_hdemo_sk#83]
 Right keys [1]: [hd_demo_sk#90]
+Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 33]
@@ -898,6 +924,7 @@ Input [1]: [h11_30_to_12#94]
 Arguments: IdentityBroadcastMode, [plan_id=22]
 
 (160) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (161) Scan parquet spark_catalog.default.store_sales
@@ -943,6 +970,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (170) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_sold_time_sk#95]
 Right keys [1]: [t_time_sk#99]
+Join type: Inner
 Join condition: None
 
 (171) Project [codegen id : 38]
@@ -955,6 +983,7 @@ Output [1]: [s_store_sk#102]
 (173) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_store_sk#97]
 Right keys [1]: [s_store_sk#102]
+Join type: Inner
 Join condition: None
 
 (174) Project [codegen id : 38]
@@ -967,6 +996,7 @@ Output [1]: [hd_demo_sk#103]
 (176) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_hdemo_sk#96]
 Right keys [1]: [hd_demo_sk#103]
+Join type: Inner
 Join condition: None
 
 (177) Project [codegen id : 38]
@@ -996,5 +1026,6 @@ Input [1]: [h12_to_12_30#107]
 Arguments: IdentityBroadcastMode, [plan_id=25]
 
 (182) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88/explain.txt
@@ -226,6 +226,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#5]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -257,6 +258,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
 Right keys [1]: [t_time_sk#8]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -288,6 +290,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
@@ -336,6 +339,7 @@ Output [1]: [hd_demo_sk#21]
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_hdemo_sk#18]
 Right keys [1]: [hd_demo_sk#21]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -367,6 +371,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (41) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_time_sk#17]
 Right keys [1]: [t_time_sk#22]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 8]
@@ -379,6 +384,7 @@ Output [1]: [s_store_sk#25]
 (44) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#19]
 Right keys [1]: [s_store_sk#25]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 8]
@@ -408,6 +414,7 @@ Input [1]: [h9_to_9_30#29]
 Arguments: IdentityBroadcastMode, [plan_id=7]
 
 (50) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (51) Scan parquet spark_catalog.default.store_sales
@@ -434,6 +441,7 @@ Output [1]: [hd_demo_sk#34]
 (56) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_hdemo_sk#31]
 Right keys [1]: [hd_demo_sk#34]
+Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 13]
@@ -465,6 +473,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (63) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_time_sk#30]
 Right keys [1]: [t_time_sk#35]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 13]
@@ -477,6 +486,7 @@ Output [1]: [s_store_sk#38]
 (66) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#32]
 Right keys [1]: [s_store_sk#38]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 13]
@@ -506,6 +516,7 @@ Input [1]: [h9_30_to_10#42]
 Arguments: IdentityBroadcastMode, [plan_id=10]
 
 (72) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (73) Scan parquet spark_catalog.default.store_sales
@@ -532,6 +543,7 @@ Output [1]: [hd_demo_sk#47]
 (78) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_hdemo_sk#44]
 Right keys [1]: [hd_demo_sk#47]
+Join type: Inner
 Join condition: None
 
 (79) Project [codegen id : 18]
@@ -563,6 +575,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (85) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_sold_time_sk#43]
 Right keys [1]: [t_time_sk#48]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 18]
@@ -575,6 +588,7 @@ Output [1]: [s_store_sk#51]
 (88) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [ss_store_sk#45]
 Right keys [1]: [s_store_sk#51]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 18]
@@ -604,6 +618,7 @@ Input [1]: [h10_to_10_30#55]
 Arguments: IdentityBroadcastMode, [plan_id=13]
 
 (94) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (95) Scan parquet spark_catalog.default.store_sales
@@ -630,6 +645,7 @@ Output [1]: [hd_demo_sk#60]
 (100) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_hdemo_sk#57]
 Right keys [1]: [hd_demo_sk#60]
+Join type: Inner
 Join condition: None
 
 (101) Project [codegen id : 23]
@@ -661,6 +677,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (107) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_sold_time_sk#56]
 Right keys [1]: [t_time_sk#61]
+Join type: Inner
 Join condition: None
 
 (108) Project [codegen id : 23]
@@ -673,6 +690,7 @@ Output [1]: [s_store_sk#64]
 (110) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [ss_store_sk#58]
 Right keys [1]: [s_store_sk#64]
+Join type: Inner
 Join condition: None
 
 (111) Project [codegen id : 23]
@@ -702,6 +720,7 @@ Input [1]: [h10_30_to_11#68]
 Arguments: IdentityBroadcastMode, [plan_id=16]
 
 (116) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (117) Scan parquet spark_catalog.default.store_sales
@@ -728,6 +747,7 @@ Output [1]: [hd_demo_sk#73]
 (122) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_hdemo_sk#70]
 Right keys [1]: [hd_demo_sk#73]
+Join type: Inner
 Join condition: None
 
 (123) Project [codegen id : 28]
@@ -759,6 +779,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (129) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_sold_time_sk#69]
 Right keys [1]: [t_time_sk#74]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 28]
@@ -771,6 +792,7 @@ Output [1]: [s_store_sk#77]
 (132) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ss_store_sk#71]
 Right keys [1]: [s_store_sk#77]
+Join type: Inner
 Join condition: None
 
 (133) Project [codegen id : 28]
@@ -800,6 +822,7 @@ Input [1]: [h11_to_11_30#81]
 Arguments: IdentityBroadcastMode, [plan_id=19]
 
 (138) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (139) Scan parquet spark_catalog.default.store_sales
@@ -826,6 +849,7 @@ Output [1]: [hd_demo_sk#86]
 (144) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_hdemo_sk#83]
 Right keys [1]: [hd_demo_sk#86]
+Join type: Inner
 Join condition: None
 
 (145) Project [codegen id : 33]
@@ -857,6 +881,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (151) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_sold_time_sk#82]
 Right keys [1]: [t_time_sk#87]
+Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 33]
@@ -869,6 +894,7 @@ Output [1]: [s_store_sk#90]
 (154) BroadcastHashJoin [codegen id : 33]
 Left keys [1]: [ss_store_sk#84]
 Right keys [1]: [s_store_sk#90]
+Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 33]
@@ -898,6 +924,7 @@ Input [1]: [h11_30_to_12#94]
 Arguments: IdentityBroadcastMode, [plan_id=22]
 
 (160) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 
 (161) Scan parquet spark_catalog.default.store_sales
@@ -924,6 +951,7 @@ Output [1]: [hd_demo_sk#99]
 (166) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_hdemo_sk#96]
 Right keys [1]: [hd_demo_sk#99]
+Join type: Inner
 Join condition: None
 
 (167) Project [codegen id : 38]
@@ -955,6 +983,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (173) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_sold_time_sk#95]
 Right keys [1]: [t_time_sk#100]
+Join type: Inner
 Join condition: None
 
 (174) Project [codegen id : 38]
@@ -967,6 +996,7 @@ Output [1]: [s_store_sk#103]
 (176) BroadcastHashJoin [codegen id : 38]
 Left keys [1]: [ss_store_sk#97]
 Right keys [1]: [s_store_sk#103]
+Join type: Inner
 Join condition: None
 
 (177) Project [codegen id : 38]
@@ -996,5 +1026,6 @@ Input [1]: [h12_to_12_30#107]
 Arguments: IdentityBroadcastMode, [plan_id=25]
 
 (182) BroadcastNestedLoopJoin [codegen id : 40]
+Join type: Inner
 Join condition: None
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
@@ -64,6 +64,7 @@ Condition : (isnotnull(ss_item_sk#5) AND isnotnull(ss_store_sk#6))
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -76,6 +77,7 @@ Output [2]: [d_date_sk#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -103,6 +105,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89/explain.txt
@@ -64,6 +64,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -76,6 +77,7 @@ Output [2]: [d_date_sk#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -103,6 +105,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90.sf100/explain.txt
@@ -95,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_web_page_sk#3]
 Right keys [1]: [wp_web_page_sk#5]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -126,6 +127,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_ship_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#7]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -157,6 +159,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_time_sk#1]
 Right keys [1]: [t_time_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
@@ -205,6 +208,7 @@ Output [1]: [wp_web_page_sk#19]
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_web_page_sk#17]
 Right keys [1]: [wp_web_page_sk#19]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -217,6 +221,7 @@ Output [1]: [hd_demo_sk#20]
 (37) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_ship_hdemo_sk#16]
 Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 8]
@@ -248,6 +253,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (44) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_time_sk#15]
 Right keys [1]: [t_time_sk#21]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 8]
@@ -277,6 +283,7 @@ Input [1]: [pmc#26]
 Arguments: IdentityBroadcastMode, [plan_id=7]
 
 (50) BroadcastNestedLoopJoin [codegen id : 10]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q90/explain.txt
@@ -95,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_ship_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#5]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -126,6 +127,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_time_sk#1]
 Right keys [1]: [t_time_sk#7]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -157,6 +159,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_web_page_sk#3]
 Right keys [1]: [wp_web_page_sk#9]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
@@ -205,6 +208,7 @@ Output [1]: [hd_demo_sk#19]
 (34) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_ship_hdemo_sk#16]
 Right keys [1]: [hd_demo_sk#19]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 8]
@@ -236,6 +240,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (41) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_time_sk#15]
 Right keys [1]: [t_time_sk#20]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 8]
@@ -248,6 +253,7 @@ Output [1]: [wp_web_page_sk#22]
 (44) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_web_page_sk#17]
 Right keys [1]: [wp_web_page_sk#22]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 8]
@@ -277,6 +283,7 @@ Input [1]: [pmc#26]
 Arguments: IdentityBroadcastMode, [plan_id=7]
 
 (50) BroadcastNestedLoopJoin [codegen id : 10]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/explain.txt
@@ -79,6 +79,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 7]
@@ -110,6 +111,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (15) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#8]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 7]
@@ -141,6 +143,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#4]
 Right keys [1]: [ca_address_sk#10]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -168,6 +171,7 @@ Output [1]: [d_date_sk#17]
 (28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cr_returned_date_sk#15]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 5]
@@ -181,6 +185,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (31) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [cr_returning_customer_sk#12]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 7]
@@ -208,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cr_call_center_sk#13]
 Right keys [1]: [cc_call_center_sk#18]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91/explain.txt
@@ -80,6 +80,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cc_call_center_sk#1]
 Right keys [1]: [cr_call_center_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 7]
@@ -92,6 +93,7 @@ Output [1]: [d_date_sk#10]
 (11) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cr_returned_date_sk#8]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 7]
@@ -119,6 +121,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cr_returning_customer_sk#5]
 Right keys [1]: [c_customer_sk#11]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 7]
@@ -150,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#14]
 Right keys [1]: [ca_address_sk#15]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 7]
@@ -177,6 +181,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#12]
 Right keys [1]: [cd_demo_sk#17]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 7]
@@ -208,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_hdemo_sk#13]
 Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92.sf100/explain.txt
@@ -73,6 +73,7 @@ Output [1]: [d_date_sk#9]
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#5]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -104,6 +105,7 @@ Condition : isnotnull((1.3 * avg(ws_ext_discount_amt))#15)
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ws_item_sk#3]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
@@ -132,6 +134,7 @@ Condition : (isnotnull(ws_item_sk#16) AND isnotnull(ws_ext_discount_amt#17))
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ws_item_sk#16]
+Join type: Inner
 Join condition: (cast(ws_ext_discount_amt#17 as decimal(14,7)) > (1.3 * avg(ws_ext_discount_amt))#15)
 
 (23) Project [codegen id : 6]
@@ -144,6 +147,7 @@ Output [1]: [d_date_sk#19]
 (25) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#18]
 Right keys [1]: [d_date_sk#19]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q92/explain.txt
@@ -70,6 +70,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 6]
@@ -97,6 +98,7 @@ Output [1]: [d_date_sk#10]
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 3]
@@ -132,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint))
 (22) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_item_sk#5]
 Right keys [1]: [ws_item_sk#7]
+Join type: Inner
 Join condition: (cast(ws_ext_discount_amt#2 as decimal(14,7)) > (1.3 * avg(ws_ext_discount_amt))#16)
 
 (23) Project [codegen id : 6]
@@ -144,6 +147,7 @@ Output [1]: [d_date_sk#17]
 (25) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#17]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93.sf100/explain.txt
@@ -68,6 +68,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [sr_reason_sk#2]
 Right keys [1]: [r_reason_sk#6]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 2]
@@ -106,6 +107,7 @@ Arguments: [ss_item_sk#8 ASC NULLS FIRST, ss_ticket_number#10 ASC NULLS FIRST], 
 (19) SortMergeJoin [codegen id : 6]
 Left keys [2]: [sr_item_sk#1, sr_ticket_number#3]
 Right keys [2]: [ss_item_sk#8, ss_ticket_number#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q93/explain.txt
@@ -75,6 +75,7 @@ Arguments: [sr_item_sk#7 ASC NULLS FIRST, sr_ticket_number#9 ASC NULLS FIRST], f
 (12) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#3]
 Right keys [2]: [sr_item_sk#7, sr_ticket_number#9]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 6]
@@ -106,6 +107,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_reason_sk#8]
 Right keys [1]: [r_reason_sk#12]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -96,6 +96,7 @@ Arguments: [ws_order_number#16 ASC NULLS FIRST], false, 0
 (12) SortMergeJoin [codegen id : 5]
 Left keys [1]: [ws_order_number#5]
 Right keys [1]: [ws_order_number#16]
+Join type: LeftSemi
 Join condition: NOT (ws_warehouse_sk#4 = ws_warehouse_sk#15)
 
 (13) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Arguments: [wr_order_number#18 ASC NULLS FIRST], false, 0
 (19) SortMergeJoin [codegen id : 11]
 Left keys [1]: [ws_order_number#5]
 Right keys [1]: [wr_order_number#18]
+Join type: LeftAnti
 Join condition: None
 
 (20) Scan parquet spark_catalog.default.customer_address
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#20]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 11]
@@ -184,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_web_site_sk#3]
 Right keys [1]: [web_site_sk#22]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
@@ -215,6 +219,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94/explain.txt
@@ -96,6 +96,7 @@ Arguments: [ws_order_number#10 ASC NULLS FIRST], false, 0
 (12) SortMergeJoin [codegen id : 5]
 Left keys [1]: [ws_order_number#5]
 Right keys [1]: [ws_order_number#10]
+Join type: LeftSemi
 Join condition: NOT (ws_warehouse_sk#4 = ws_warehouse_sk#9)
 
 (13) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Arguments: [wr_order_number#12 ASC NULLS FIRST], false, 0
 (19) SortMergeJoin [codegen id : 11]
 Left keys [1]: [ws_order_number#5]
 Right keys [1]: [wr_order_number#12]
+Join type: LeftAnti
 Join condition: None
 
 (20) Scan parquet spark_catalog.default.date_dim
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (25) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 11]
@@ -184,6 +187,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
@@ -215,6 +219,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (39) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ws_web_site_sk#3]
 Right keys [1]: [web_site_sk#18]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
@@ -120,6 +120,7 @@ Arguments: [ws_order_number#18 ASC NULLS FIRST], false, 0
 (15) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ws_order_number#15]
 Right keys [1]: [ws_order_number#18]
+Join type: Inner
 Join condition: NOT (ws_warehouse_sk#14 = ws_warehouse_sk#17)
 
 (16) Project [codegen id : 7]
@@ -129,6 +130,7 @@ Input [4]: [ws_warehouse_sk#14, ws_order_number#15, ws_warehouse_sk#17, ws_order
 (17) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [ws_order_number#15]
+Join type: LeftSemi
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.web_returns
@@ -167,6 +169,7 @@ Arguments: [ws_order_number#15 ASC NULLS FIRST], false, 0
 (26) SortMergeJoin [codegen id : 13]
 Left keys [1]: [wr_order_number#19]
 Right keys [1]: [ws_order_number#15]
+Join type: Inner
 Join condition: None
 
 (27) ReusedExchange [Reuses operator id: 11]
@@ -179,6 +182,7 @@ Arguments: [ws_order_number#18 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 16]
 Left keys [1]: [ws_order_number#15]
 Right keys [1]: [ws_order_number#18]
+Join type: Inner
 Join condition: NOT (ws_warehouse_sk#14 = ws_warehouse_sk#17)
 
 (30) Project [codegen id : 16]
@@ -188,6 +192,7 @@ Input [5]: [wr_order_number#19, ws_warehouse_sk#14, ws_order_number#15, ws_wareh
 (31) SortMergeJoin [codegen id : 20]
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [wr_order_number#19]
+Join type: LeftSemi
 Join condition: None
 
 (32) Scan parquet spark_catalog.default.customer_address
@@ -215,6 +220,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (37) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 20]
@@ -246,6 +252,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (44) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_web_site_sk#3]
 Right keys [1]: [web_site_sk#23]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 20]
@@ -277,6 +284,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (51) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 20]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95/explain.txt
@@ -121,6 +121,7 @@ Arguments: [ws_order_number#12 ASC NULLS FIRST], false, 0
 (15) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ws_order_number#9]
 Right keys [1]: [ws_order_number#12]
+Join type: Inner
 Join condition: NOT (ws_warehouse_sk#8 = ws_warehouse_sk#11)
 
 (16) Project [codegen id : 7]
@@ -130,6 +131,7 @@ Input [4]: [ws_warehouse_sk#8, ws_order_number#9, ws_warehouse_sk#11, ws_order_n
 (17) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [ws_order_number#9]
+Join type: LeftSemi
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.web_returns
@@ -175,6 +177,7 @@ Arguments: [ws_order_number#12 ASC NULLS FIRST], false, 0
 (28) SortMergeJoin [codegen id : 15]
 Left keys [1]: [ws_order_number#9]
 Right keys [1]: [ws_order_number#12]
+Join type: Inner
 Join condition: NOT (ws_warehouse_sk#8 = ws_warehouse_sk#11)
 
 (29) Project [codegen id : 15]
@@ -184,6 +187,7 @@ Input [4]: [ws_warehouse_sk#8, ws_order_number#9, ws_warehouse_sk#11, ws_order_n
 (30) SortMergeJoin [codegen id : 16]
 Left keys [1]: [wr_order_number#13]
 Right keys [1]: [ws_order_number#9]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 16]
@@ -193,6 +197,7 @@ Input [2]: [wr_order_number#13, ws_order_number#9]
 (32) SortMergeJoin [codegen id : 20]
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [wr_order_number#13]
+Join type: LeftSemi
 Join condition: None
 
 (33) Scan parquet spark_catalog.default.date_dim
@@ -220,6 +225,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (38) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 20]
@@ -251,6 +257,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (45) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#17]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 20]
@@ -282,6 +289,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (52) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [ws_web_site_sk#3]
 Right keys [1]: [web_site_sk#19]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 20]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
 Right keys [1]: [t_time_sk#5]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -103,6 +104,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -134,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96/explain.txt
@@ -72,6 +72,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#5]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 4]
@@ -103,6 +104,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_time_sk#1]
 Right keys [1]: [t_time_sk#7]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -134,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97.sf100/explain.txt
@@ -40,6 +40,7 @@ Output [1]: [d_date_sk#5]
 (4) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (5) Project [codegen id : 2]
@@ -84,6 +85,7 @@ Output [1]: [d_date_sk#11]
 (13) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 5]
@@ -115,6 +117,7 @@ Arguments: [customer_sk#12 ASC NULLS FIRST, item_sk#13 ASC NULLS FIRST], false, 
 (19) SortMergeJoin [codegen id : 7]
 Left keys [2]: [customer_sk#6, item_sk#7]
 Right keys [2]: [customer_sk#12, item_sk#13]
+Join type: FullOuter
 Join condition: None
 
 (20) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q97/explain.txt
@@ -40,6 +40,7 @@ Output [1]: [d_date_sk#5]
 (4) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (5) Project [codegen id : 2]
@@ -84,6 +85,7 @@ Output [1]: [d_date_sk#11]
 (13) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_sold_date_sk#10]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 5]
@@ -115,6 +117,7 @@ Arguments: [customer_sk#12 ASC NULLS FIRST, item_sk#13 ASC NULLS FIRST], false, 
 (19) SortMergeJoin [codegen id : 7]
 Left keys [2]: [customer_sk#6, item_sk#7]
 Right keys [2]: [customer_sk#12, item_sk#13]
+Join type: FullOuter
 Join condition: None
 
 (20) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98.sf100/explain.txt
@@ -74,6 +74,7 @@ Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
@@ -86,6 +87,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q98/explain.txt
@@ -59,6 +59,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -71,6 +72,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -99,6 +100,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (15) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_mode_sk#3]
 Right keys [1]: [sm_ship_mode_sk#8]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 5]
@@ -126,6 +128,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_call_center_sk#2]
 Right keys [1]: [cc_call_center_sk#10]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 5]
@@ -153,6 +156,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_warehouse_sk#4]
 Right keys [1]: [w_warehouse_sk#12]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q99/explain.txt
@@ -68,6 +68,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_warehouse_sk#4]
 Right keys [1]: [w_warehouse_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 5]
@@ -95,6 +96,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_mode_sk#3]
 Right keys [1]: [sm_ship_mode_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 5]
@@ -122,6 +124,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_call_center_sk#2]
 Right keys [1]: [cc_call_center_sk#10]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 5]
@@ -153,6 +156,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (27) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 5]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -84,6 +84,7 @@ Output [1]: [d_date_sk#9]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -101,6 +102,7 @@ Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
@@ -119,6 +121,7 @@ Output [1]: [d_date_sk#12]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -141,6 +144,7 @@ Output [1]: [d_date_sk#16]
 (22) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#15]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 10]
@@ -160,6 +164,7 @@ Arguments: [customer_sk#13 ASC NULLS FIRST], false, 0
 (27) SortMergeJoin [codegen id : 13]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#13]
+Join type: LeftSemi
 Join condition: None
 
 (28) Project [codegen id : 13]
@@ -191,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#18]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
@@ -218,6 +224,7 @@ Condition : isnotnull(cd_demo_sk#20)
 (40) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 14]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a/explain.txt
@@ -72,6 +72,7 @@ Output [1]: [d_date_sk#7]
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 2]
@@ -85,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#4]
+Join type: LeftSemi
 Join condition: None
 
 (11) Scan parquet spark_catalog.default.web_sales
@@ -103,6 +105,7 @@ Output [1]: [d_date_sk#10]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -125,6 +128,7 @@ Output [1]: [d_date_sk#14]
 (19) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 6]
@@ -140,6 +144,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (23) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customer_sk#11]
+Join type: LeftSemi
 Join condition: None
 
 (24) Project [codegen id : 9]
@@ -171,6 +176,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (30) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 9]
@@ -198,6 +204,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (36) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11.sf100/explain.txt
@@ -101,6 +101,7 @@ Output [2]: [d_date_sk#6, d_year#7]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -140,6 +141,7 @@ Arguments: [c_customer_sk#8 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -197,6 +199,7 @@ Output [2]: [d_date_sk#26, d_year#27]
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#24]
 Right keys [1]: [d_date_sk#26]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -221,6 +224,7 @@ Arguments: [c_customer_sk#28 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_customer_sk#21]
 Right keys [1]: [c_customer_sk#28]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 14]
@@ -256,6 +260,7 @@ Arguments: [customer_id#38 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 17]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#38]
+Join type: Inner
 Join condition: None
 
 (40) Scan parquet spark_catalog.default.web_sales
@@ -279,6 +284,7 @@ Output [2]: [d_date_sk#47, d_year#48]
 (44) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#46]
 Right keys [1]: [d_date_sk#47]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 19]
@@ -303,6 +309,7 @@ Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
 (50) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#43]
 Right keys [1]: [c_customer_sk#49]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 23]
@@ -342,6 +349,7 @@ Arguments: [customer_id#60 ASC NULLS FIRST], false, 0
 (58) SortMergeJoin [codegen id : 26]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#60]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 26]
@@ -369,6 +377,7 @@ Output [2]: [d_date_sk#66, d_year#67]
 (64) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ws_sold_date_sk#65]
 Right keys [1]: [d_date_sk#66]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 28]
@@ -393,6 +402,7 @@ Arguments: [c_customer_sk#68 ASC NULLS FIRST], false, 0
 (70) SortMergeJoin [codegen id : 32]
 Left keys [1]: [ws_bill_customer_sk#62]
 Right keys [1]: [c_customer_sk#68]
+Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 32]
@@ -428,6 +438,7 @@ Arguments: [customer_id#78 ASC NULLS FIRST], false, 0
 (77) SortMergeJoin [codegen id : 35]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#78]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#61 > 0.00) THEN (year_total#79 / year_total#61) ELSE 0E-20 END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#42 / year_total#20) ELSE 0E-20 END)
 
 (78) Project [codegen id : 35]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q11/explain.txt
@@ -108,6 +108,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#9]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -120,6 +121,7 @@ Output [2]: [d_date_sk#14, d_year#15]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#12]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -184,6 +186,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#21]
 Right keys [1]: [ss_customer_sk#29]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -196,6 +199,7 @@ Output [2]: [d_date_sk#34, d_year#35]
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#32]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -227,6 +231,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (33) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#38]
+Join type: Inner
 Join condition: None
 
 (34) Scan parquet spark_catalog.default.customer
@@ -265,6 +270,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (41) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#43]
 Right keys [1]: [ws_bill_customer_sk#51]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 10]
@@ -277,6 +283,7 @@ Output [2]: [d_date_sk#55, d_year#56]
 (44) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_sold_date_sk#54]
 Right keys [1]: [d_date_sk#55]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 10]
@@ -312,6 +319,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (51) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#60]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 16]
@@ -354,6 +362,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#62]
 Right keys [1]: [ws_bill_customer_sk#70]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 14]
@@ -366,6 +375,7 @@ Output [2]: [d_date_sk#74, d_year#75]
 (63) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#73]
 Right keys [1]: [d_date_sk#74]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 14]
@@ -397,6 +407,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (69) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#78]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#61 > 0.00) THEN (year_total#79 / year_total#61) ELSE 0E-20 END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#42 / year_total#20) ELSE 0E-20 END)
 
 (70) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
@@ -84,6 +85,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q12/explain.txt
@@ -57,6 +57,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -69,6 +70,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -158,6 +158,7 @@ Output [1]: [d_date_sk#13]
 (13) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 11]
@@ -207,6 +208,7 @@ Output [1]: [d_date_sk#20]
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
@@ -234,6 +236,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#21]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 8]
@@ -251,6 +254,7 @@ Arguments: [coalesce(i_brand_id#22, 0) ASC NULLS FIRST, isnull(i_brand_id#22) AS
 (34) SortMergeJoin [codegen id : 10]
 Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
 Right keys [6]: [coalesce(i_brand_id#22, 0), isnull(i_brand_id#22), coalesce(i_class_id#23, 0), isnull(i_class_id#23), coalesce(i_category_id#24, 0), isnull(i_category_id#24)]
+Join type: LeftSemi
 Join condition: None
 
 (35) BroadcastExchange
@@ -260,6 +264,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#14]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -313,6 +318,7 @@ Output [1]: [d_date_sk#30]
 (47) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 16]
@@ -325,6 +331,7 @@ Output [4]: [i_item_sk#31, i_brand_id#32, i_class_id#33, i_category_id#34]
 (50) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 16]
@@ -342,6 +349,7 @@ Arguments: [coalesce(i_brand_id#32, 0) ASC NULLS FIRST, isnull(i_brand_id#32) AS
 (54) SortMergeJoin [codegen id : 18]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#32, 0), isnull(i_brand_id#32), coalesce(i_class_id#33, 0), isnull(i_class_id#33), coalesce(i_category_id#34, 0), isnull(i_category_id#34)]
+Join type: LeftSemi
 Join condition: None
 
 (55) BroadcastExchange
@@ -351,6 +359,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 19]
@@ -368,6 +377,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (60) SortMergeJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (61) ReusedExchange [Reuses operator id: 123]
@@ -376,6 +386,7 @@ Output [1]: [d_date_sk#36]
 (62) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#36]
+Join type: Inner
 Join condition: None
 
 (63) Project [codegen id : 43]
@@ -414,6 +425,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (71) SortMergeJoin [codegen id : 42]
 Left keys [1]: [i_item_sk#37]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) BroadcastExchange
@@ -423,6 +435,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (73) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#37]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 43]
@@ -484,6 +497,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (86) SortMergeJoin [codegen id : 86]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (87) ReusedExchange [Reuses operator id: 137]
@@ -492,6 +506,7 @@ Output [1]: [d_date_sk#59]
 (88) BroadcastHashJoin [codegen id : 86]
 Left keys [1]: [ss_sold_date_sk#57]
 Right keys [1]: [d_date_sk#59]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 86]
@@ -504,6 +519,7 @@ Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 (91) BroadcastHashJoin [codegen id : 86]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [i_item_sk#60]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 86]
@@ -539,6 +555,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, t
 (98) BroadcastHashJoin [codegen id : 88]
 Left keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
 Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
+Join type: Inner
 Join condition: None
 
 (99) TakeOrderedAndProject
@@ -585,6 +602,7 @@ Output [1]: [d_date_sk#78]
 (103) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
+Join type: Inner
 Join condition: None
 
 (104) Project [codegen id : 2]
@@ -607,6 +625,7 @@ Output [1]: [d_date_sk#84]
 (108) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
+Join type: Inner
 Join condition: None
 
 (109) Project [codegen id : 4]
@@ -629,6 +648,7 @@ Output [1]: [d_date_sk#90]
 (113) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
+Join type: Inner
 Join condition: None
 
 (114) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14/explain.txt
@@ -179,6 +179,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
 Right keys [1]: [i_item_sk#19]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 3]
@@ -191,6 +192,7 @@ Output [1]: [d_date_sk#23]
 (23) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#23]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 3]
@@ -204,6 +206,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
 Right keys [6]: [coalesce(i_brand_id#20, 0), isnull(i_brand_id#20), coalesce(i_class_id#21, 0), isnull(i_class_id#21), coalesce(i_category_id#22, 0), isnull(i_category_id#22)]
+Join type: LeftSemi
 Join condition: None
 
 (27) BroadcastExchange
@@ -213,6 +216,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]
@@ -225,6 +229,7 @@ Output [1]: [d_date_sk#24]
 (31) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 6]
@@ -270,6 +275,7 @@ Output [4]: [i_item_sk#30, i_brand_id#31, i_class_id#32, i_category_id#33]
 (40) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#30]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 9]
@@ -282,6 +288,7 @@ Output [1]: [d_date_sk#34]
 (43) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 9]
@@ -295,6 +302,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#31, 0), isnull(i_brand_id#31), coalesce(i_class_id#32, 0), isnull(i_class_id#32), coalesce(i_category_id#33, 0), isnull(i_category_id#33)]
+Join type: LeftSemi
 Join condition: None
 
 (47) BroadcastExchange
@@ -304,6 +312,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (48) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 11]
@@ -317,6 +326,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (51) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (52) Scan parquet spark_catalog.default.item
@@ -339,6 +349,7 @@ Output [1]: [ss_item_sk#35]
 (56) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [i_item_sk#36]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (57) BroadcastExchange
@@ -348,6 +359,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#36]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 25]
@@ -360,6 +372,7 @@ Output [1]: [d_date_sk#40]
 (61) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 25]
@@ -409,6 +422,7 @@ Output [1]: [ss_item_sk#35]
 (71) BroadcastHashJoin [codegen id : 50]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) ReusedExchange [Reuses operator id: 57]
@@ -417,6 +431,7 @@ Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 (73) BroadcastHashJoin [codegen id : 50]
 Left keys [1]: [ss_item_sk#54]
 Right keys [1]: [i_item_sk#59]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 50]
@@ -429,6 +444,7 @@ Output [1]: [d_date_sk#63]
 (76) BroadcastHashJoin [codegen id : 50]
 Left keys [1]: [ss_sold_date_sk#57]
 Right keys [1]: [d_date_sk#63]
+Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 50]
@@ -464,6 +480,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, t
 (83) BroadcastHashJoin [codegen id : 52]
 Left keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
 Right keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
+Join type: Inner
 Join condition: None
 
 (84) TakeOrderedAndProject
@@ -510,6 +527,7 @@ Output [1]: [d_date_sk#78]
 (88) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 2]
@@ -532,6 +550,7 @@ Output [1]: [d_date_sk#84]
 (93) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#83]
 Right keys [1]: [d_date_sk#84]
+Join type: Inner
 Join condition: None
 
 (94) Project [codegen id : 4]
@@ -554,6 +573,7 @@ Output [1]: [d_date_sk#90]
 (98) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#89]
 Right keys [1]: [d_date_sk#90]
+Join type: Inner
 Join condition: None
 
 (99) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a.sf100/explain.txt
@@ -202,6 +202,7 @@ Output [1]: [d_date_sk#13]
 (13) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 11]
@@ -251,6 +252,7 @@ Output [1]: [d_date_sk#20]
 (24) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_sold_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
@@ -278,6 +280,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [cs_item_sk#18]
 Right keys [1]: [i_item_sk#21]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 8]
@@ -295,6 +298,7 @@ Arguments: [coalesce(i_brand_id#22, 0) ASC NULLS FIRST, isnull(i_brand_id#22) AS
 (34) SortMergeJoin [codegen id : 10]
 Left keys [6]: [coalesce(i_brand_id#15, 0), isnull(i_brand_id#15), coalesce(i_class_id#16, 0), isnull(i_class_id#16), coalesce(i_category_id#17, 0), isnull(i_category_id#17)]
 Right keys [6]: [coalesce(i_brand_id#22, 0), isnull(i_brand_id#22), coalesce(i_class_id#23, 0), isnull(i_class_id#23), coalesce(i_category_id#24, 0), isnull(i_category_id#24)]
+Join type: LeftSemi
 Join condition: None
 
 (35) BroadcastExchange
@@ -304,6 +308,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#14]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -357,6 +362,7 @@ Output [1]: [d_date_sk#30]
 (47) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#30]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 16]
@@ -369,6 +375,7 @@ Output [4]: [i_item_sk#31, i_brand_id#32, i_class_id#33, i_category_id#34]
 (50) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#31]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 16]
@@ -386,6 +393,7 @@ Arguments: [coalesce(i_brand_id#32, 0) ASC NULLS FIRST, isnull(i_brand_id#32) AS
 (54) SortMergeJoin [codegen id : 18]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#32, 0), isnull(i_brand_id#32), coalesce(i_class_id#33, 0), isnull(i_class_id#33), coalesce(i_category_id#34, 0), isnull(i_category_id#34)]
+Join type: LeftSemi
 Join condition: None
 
 (55) BroadcastExchange
@@ -395,6 +403,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (56) BroadcastHashJoin [codegen id : 19]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 19]
@@ -412,6 +421,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (60) SortMergeJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (61) ReusedExchange [Reuses operator id: 172]
@@ -420,6 +430,7 @@ Output [1]: [d_date_sk#36]
 (62) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#36]
+Join type: Inner
 Join condition: None
 
 (63) Project [codegen id : 43]
@@ -458,6 +469,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (71) SortMergeJoin [codegen id : 42]
 Left keys [1]: [i_item_sk#37]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) BroadcastExchange
@@ -467,6 +479,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (73) BroadcastHashJoin [codegen id : 43]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#37]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 43]
@@ -528,6 +541,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (86) SortMergeJoin [codegen id : 87]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (87) ReusedExchange [Reuses operator id: 172]
@@ -536,6 +550,7 @@ Output [1]: [d_date_sk#58]
 (88) BroadcastHashJoin [codegen id : 87]
 Left keys [1]: [cs_sold_date_sk#57]
 Right keys [1]: [d_date_sk#58]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 87]
@@ -548,6 +563,7 @@ Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
 (91) BroadcastHashJoin [codegen id : 87]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [i_item_sk#59]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 87]
@@ -609,6 +625,7 @@ Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 (104) SortMergeJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (105) ReusedExchange [Reuses operator id: 172]
@@ -617,6 +634,7 @@ Output [1]: [d_date_sk#78]
 (106) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_sold_date_sk#77]
 Right keys [1]: [d_date_sk#78]
+Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 131]
@@ -629,6 +647,7 @@ Output [4]: [i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
 (109) BroadcastHashJoin [codegen id : 131]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#79]
+Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 131]
@@ -853,6 +872,7 @@ Output [1]: [d_date_sk#157]
 (147) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#156]
 Right keys [1]: [d_date_sk#157]
+Join type: Inner
 Join condition: None
 
 (148) Project [codegen id : 2]
@@ -875,6 +895,7 @@ Output [1]: [d_date_sk#164]
 (152) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#162]
 Right keys [1]: [d_date_sk#164]
+Join type: Inner
 Join condition: None
 
 (153) Project [codegen id : 4]
@@ -897,6 +918,7 @@ Output [1]: [d_date_sk#170]
 (157) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#169]
 Right keys [1]: [d_date_sk#170]
+Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14a/explain.txt
@@ -220,6 +220,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#17]
 Right keys [1]: [i_item_sk#19]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 3]
@@ -232,6 +233,7 @@ Output [1]: [d_date_sk#23]
 (23) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#18]
 Right keys [1]: [d_date_sk#23]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 3]
@@ -245,6 +247,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (26) BroadcastHashJoin [codegen id : 4]
 Left keys [6]: [coalesce(i_brand_id#14, 0), isnull(i_brand_id#14), coalesce(i_class_id#15, 0), isnull(i_class_id#15), coalesce(i_category_id#16, 0), isnull(i_category_id#16)]
 Right keys [6]: [coalesce(i_brand_id#20, 0), isnull(i_brand_id#20), coalesce(i_class_id#21, 0), isnull(i_class_id#21), coalesce(i_category_id#22, 0), isnull(i_category_id#22)]
+Join type: LeftSemi
 Join condition: None
 
 (27) BroadcastExchange
@@ -254,6 +257,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#10]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 6]
@@ -266,6 +270,7 @@ Output [1]: [d_date_sk#24]
 (31) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 6]
@@ -311,6 +316,7 @@ Output [4]: [i_item_sk#30, i_brand_id#31, i_class_id#32, i_category_id#33]
 (40) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_item_sk#28]
 Right keys [1]: [i_item_sk#30]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 9]
@@ -323,6 +329,7 @@ Output [1]: [d_date_sk#34]
 (43) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ws_sold_date_sk#29]
 Right keys [1]: [d_date_sk#34]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 9]
@@ -336,6 +343,7 @@ Arguments: HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), is
 (46) BroadcastHashJoin [codegen id : 10]
 Left keys [6]: [coalesce(brand_id#25, 0), isnull(brand_id#25), coalesce(class_id#26, 0), isnull(class_id#26), coalesce(category_id#27, 0), isnull(category_id#27)]
 Right keys [6]: [coalesce(i_brand_id#31, 0), isnull(i_brand_id#31), coalesce(i_class_id#32, 0), isnull(i_class_id#32), coalesce(i_category_id#33, 0), isnull(i_category_id#33)]
+Join type: LeftSemi
 Join condition: None
 
 (47) BroadcastExchange
@@ -345,6 +353,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, true], input[1, int, t
 (48) BroadcastHashJoin [codegen id : 11]
 Left keys [3]: [i_brand_id#7, i_class_id#8, i_category_id#9]
 Right keys [3]: [brand_id#25, class_id#26, category_id#27]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 11]
@@ -358,6 +367,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (51) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (52) Scan parquet spark_catalog.default.item
@@ -380,6 +390,7 @@ Output [1]: [ss_item_sk#35]
 (56) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [i_item_sk#36]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (57) BroadcastExchange
@@ -389,6 +400,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#36]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 25]
@@ -401,6 +413,7 @@ Output [1]: [d_date_sk#40]
 (61) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#40]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 25]
@@ -450,6 +463,7 @@ Output [1]: [ss_item_sk#35]
 (71) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (72) ReusedExchange [Reuses operator id: 57]
@@ -458,6 +472,7 @@ Output [4]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61]
 (73) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [cs_item_sk#54]
 Right keys [1]: [i_item_sk#58]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 51]
@@ -470,6 +485,7 @@ Output [1]: [d_date_sk#62]
 (76) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [cs_sold_date_sk#57]
 Right keys [1]: [d_date_sk#62]
+Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 51]
@@ -519,6 +535,7 @@ Output [1]: [ss_item_sk#35]
 (86) BroadcastHashJoin [codegen id : 77]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [ss_item_sk#35]
+Join type: LeftSemi
 Join condition: None
 
 (87) ReusedExchange [Reuses operator id: 57]
@@ -527,6 +544,7 @@ Output [4]: [i_item_sk#78, i_brand_id#79, i_class_id#80, i_category_id#81]
 (88) BroadcastHashJoin [codegen id : 77]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#78]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 77]
@@ -539,6 +557,7 @@ Output [1]: [d_date_sk#82]
 (91) BroadcastHashJoin [codegen id : 77]
 Left keys [1]: [ws_sold_date_sk#77]
 Right keys [1]: [d_date_sk#82]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 77]
@@ -763,6 +782,7 @@ Output [1]: [d_date_sk#157]
 (129) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#156]
 Right keys [1]: [d_date_sk#157]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 2]
@@ -785,6 +805,7 @@ Output [1]: [d_date_sk#164]
 (134) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#162]
 Right keys [1]: [d_date_sk#164]
+Join type: Inner
 Join condition: None
 
 (135) Project [codegen id : 4]
@@ -807,6 +828,7 @@ Output [1]: [d_date_sk#170]
 (139) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_sold_date_sk#169]
 Right keys [1]: [d_date_sk#170]
+Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
@@ -197,6 +197,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -209,6 +210,7 @@ Output [1]: [d_date_sk#15]
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -236,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
@@ -289,6 +292,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#20]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 7]
@@ -328,6 +332,7 @@ Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 11]
 Left keys [1]: [c_current_cdemo_sk#19]
 Right keys [1]: [cd_demo_sk#27]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 11]
@@ -345,6 +350,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (43) SortMergeJoin [codegen id : 13]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
@@ -415,6 +421,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [c_current_addr_sk#20]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 21]
@@ -439,6 +446,7 @@ Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
 (64) SortMergeJoin [codegen id : 25]
 Left keys [1]: [c_current_cdemo_sk#19]
 Right keys [1]: [cd_demo_sk#27]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 25]
@@ -456,6 +464,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (68) SortMergeJoin [codegen id : 27]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 27]
@@ -530,6 +539,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (84) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [c_current_addr_sk#20]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (85) Project [codegen id : 35]
@@ -554,6 +564,7 @@ Arguments: [cd_demo_sk#27 ASC NULLS FIRST], false, 0
 (90) SortMergeJoin [codegen id : 39]
 Left keys [1]: [c_current_cdemo_sk#19]
 Right keys [1]: [cd_demo_sk#27]
+Join type: Inner
 Join condition: None
 
 (91) Project [codegen id : 39]
@@ -571,6 +582,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (94) SortMergeJoin [codegen id : 41]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 41]
@@ -616,6 +628,7 @@ Output [2]: [cd_demo_sk#11, cd_dep_count#14]
 (103) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (104) Project [codegen id : 49]
@@ -628,6 +641,7 @@ Output [1]: [d_date_sk#15]
 (106) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 49]
@@ -677,6 +691,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (117) BroadcastHashJoin [codegen id : 46]
 Left keys [1]: [c_current_addr_sk#20]
 Right keys [1]: [ca_address_sk#23]
+Join type: Inner
 Join condition: None
 
 (118) Project [codegen id : 46]
@@ -704,6 +719,7 @@ Condition : isnotnull(cd_demo_sk#27)
 (123) BroadcastHashJoin [codegen id : 47]
 Left keys [1]: [c_current_cdemo_sk#19]
 Right keys [1]: [cd_demo_sk#27]
+Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 47]
@@ -717,6 +733,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (126) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (127) Project [codegen id : 49]
@@ -729,6 +746,7 @@ Output [2]: [i_item_sk#16, i_item_id#17]
 (129) BroadcastHashJoin [codegen id : 49]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 49]
@@ -774,6 +792,7 @@ Output [2]: [cd_demo_sk#11, cd_dep_count#14]
 (138) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (139) Project [codegen id : 57]
@@ -786,6 +805,7 @@ Output [1]: [d_date_sk#15]
 (141) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (142) Project [codegen id : 57]
@@ -813,6 +833,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (147) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (148) Project [codegen id : 57]
@@ -825,6 +846,7 @@ Output [2]: [c_customer_sk#18, c_birth_year#22]
 (150) BroadcastHashJoin [codegen id : 57]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (151) Project [codegen id : 57]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a/explain.txt
@@ -194,6 +194,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 7]
@@ -225,6 +226,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 7]
@@ -252,6 +254,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (22) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_cdemo_sk#16]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -279,6 +282,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 7]
@@ -291,6 +295,7 @@ Output [1]: [d_date_sk#25]
 (31) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 7]
@@ -318,6 +323,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (37) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#26]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 7]
@@ -363,6 +369,7 @@ Output [2]: [cd_demo_sk#11, cd_dep_count#14]
 (46) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 15]
@@ -375,6 +382,7 @@ Output [4]: [c_customer_sk#15, c_current_cdemo_sk#16, c_current_addr_sk#17, c_bi
 (49) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (50) Project [codegen id : 15]
@@ -387,6 +395,7 @@ Output [1]: [cd_demo_sk#20]
 (52) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_cdemo_sk#16]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 15]
@@ -414,6 +423,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 15]
@@ -426,6 +436,7 @@ Output [1]: [d_date_sk#25]
 (61) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 15]
@@ -438,6 +449,7 @@ Output [2]: [i_item_sk#26, i_item_id#27]
 (64) BroadcastHashJoin [codegen id : 15]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#26]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 15]
@@ -483,6 +495,7 @@ Output [2]: [cd_demo_sk#11, cd_dep_count#14]
 (73) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (74) Project [codegen id : 23]
@@ -495,6 +508,7 @@ Output [4]: [c_customer_sk#15, c_current_cdemo_sk#16, c_current_addr_sk#17, c_bi
 (76) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 23]
@@ -507,6 +521,7 @@ Output [1]: [cd_demo_sk#20]
 (79) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [c_current_cdemo_sk#16]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 23]
@@ -538,6 +553,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (86) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (87) Project [codegen id : 23]
@@ -550,6 +566,7 @@ Output [1]: [d_date_sk#25]
 (89) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (90) Project [codegen id : 23]
@@ -562,6 +579,7 @@ Output [2]: [i_item_sk#26, i_item_id#27]
 (92) BroadcastHashJoin [codegen id : 23]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#26]
+Join type: Inner
 Join condition: None
 
 (93) Project [codegen id : 23]
@@ -607,6 +625,7 @@ Output [2]: [cd_demo_sk#11, cd_dep_count#14]
 (101) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (102) Project [codegen id : 31]
@@ -619,6 +638,7 @@ Output [4]: [c_customer_sk#15, c_current_cdemo_sk#16, c_current_addr_sk#17, c_bi
 (104) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (105) Project [codegen id : 31]
@@ -631,6 +651,7 @@ Output [1]: [cd_demo_sk#20]
 (107) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [c_current_cdemo_sk#16]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (108) Project [codegen id : 31]
@@ -662,6 +683,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (114) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (115) Project [codegen id : 31]
@@ -674,6 +696,7 @@ Output [1]: [d_date_sk#25]
 (117) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (118) Project [codegen id : 31]
@@ -686,6 +709,7 @@ Output [2]: [i_item_sk#26, i_item_id#27]
 (120) BroadcastHashJoin [codegen id : 31]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#26]
+Join type: Inner
 Join condition: None
 
 (121) Project [codegen id : 31]
@@ -731,6 +755,7 @@ Output [2]: [cd_demo_sk#11, cd_dep_count#14]
 (129) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 39]
@@ -743,6 +768,7 @@ Output [4]: [c_customer_sk#15, c_current_cdemo_sk#16, c_current_addr_sk#17, c_bi
 (132) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [cs_bill_customer_sk#1]
 Right keys [1]: [c_customer_sk#15]
+Join type: Inner
 Join condition: None
 
 (133) Project [codegen id : 39]
@@ -755,6 +781,7 @@ Output [1]: [cd_demo_sk#20]
 (135) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [c_current_cdemo_sk#16]
 Right keys [1]: [cd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (136) Project [codegen id : 39]
@@ -767,6 +794,7 @@ Output [1]: [ca_address_sk#21]
 (138) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#21]
+Join type: Inner
 Join condition: None
 
 (139) Project [codegen id : 39]
@@ -779,6 +807,7 @@ Output [1]: [d_date_sk#25]
 (141) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [cs_sold_date_sk#9]
 Right keys [1]: [d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (142) Project [codegen id : 39]
@@ -806,6 +835,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (147) BroadcastHashJoin [codegen id : 39]
 Left keys [1]: [cs_item_sk#3]
 Right keys [1]: [i_item_sk#26]
+Join type: Inner
 Join condition: None
 
 (148) Project [codegen id : 39]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20.sf100/explain.txt
@@ -72,6 +72,7 @@ Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
@@ -84,6 +85,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q20/explain.txt
@@ -57,6 +57,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -69,6 +70,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22.sf100/explain.txt
@@ -47,6 +47,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [inv_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -86,6 +87,7 @@ Arguments: [i_item_sk#6 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 7]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 7]
@@ -106,6 +108,7 @@ Input: []
 Arguments: IdentityBroadcastMode, [plan_id=3]
 
 (19) BroadcastNestedLoopJoin [codegen id : 7]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22/explain.txt
@@ -44,6 +44,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -71,6 +72,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -91,6 +93,7 @@ Input: []
 Arguments: IdentityBroadcastMode, [plan_id=2]
 
 (16) BroadcastNestedLoopJoin [codegen id : 4]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a.sf100/explain.txt
@@ -85,6 +85,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#6]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -97,6 +98,7 @@ Output [1]: [d_date_sk#7]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -136,6 +138,7 @@ Arguments: [i_item_sk#8 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q22a/explain.txt
@@ -67,6 +67,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
 Right keys [1]: [w_warehouse_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
@@ -88,6 +88,7 @@ Condition : ((isnotnull(ca_address_sk#6) AND isnotnull(ca_country#9)) AND isnotn
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [s_zip#5]
 Right keys [1]: [ca_zip#8]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
@@ -115,6 +116,7 @@ Condition : ((isnotnull(c_customer_sk#10) AND isnotnull(c_current_addr_sk#11)) A
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [2]: [ca_address_sk#6, upper(ca_country#9)]
 Right keys [2]: [c_current_addr_sk#11, c_birth_country#14]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 3]
@@ -146,6 +148,7 @@ Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#1
 (22) BroadcastHashJoin [codegen id : 5]
 Left keys [2]: [s_store_sk#1, c_customer_sk#10]
 Right keys [2]: [ss_store_sk#17, ss_customer_sk#16]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 5]
@@ -173,6 +176,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (28) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#15]
 Right keys [1]: [i_item_sk#21]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 5]
@@ -216,6 +220,7 @@ Arguments: [sr_ticket_number#28 ASC NULLS FIRST, sr_item_sk#27 ASC NULLS FIRST],
 (38) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#18, ss_item_sk#15]
 Right keys [2]: [sr_ticket_number#28, sr_item_sk#27]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]
@@ -327,6 +332,7 @@ Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#1
 (54) BroadcastHashJoin [codegen id : 4]
 Left keys [2]: [s_store_sk#1, c_customer_sk#10]
 Right keys [2]: [ss_store_sk#17, ss_customer_sk#16]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 4]
@@ -366,6 +372,7 @@ Arguments: [i_item_sk#21 ASC NULLS FIRST], false, 0
 (63) SortMergeJoin [codegen id : 8]
 Left keys [1]: [ss_item_sk#15]
 Right keys [1]: [i_item_sk#21]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 8]
@@ -390,6 +397,7 @@ Arguments: [sr_ticket_number#28 ASC NULLS FIRST, sr_item_sk#27 ASC NULLS FIRST],
 (69) SortMergeJoin [codegen id : 12]
 Left keys [2]: [ss_ticket_number#18, ss_item_sk#15]
 Right keys [2]: [sr_ticket_number#28, sr_item_sk#27]
+Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 12]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24/explain.txt
@@ -104,6 +104,7 @@ Arguments: [sr_ticket_number#8 ASC NULLS FIRST, sr_item_sk#7 ASC NULLS FIRST], f
 (13) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#8, sr_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 9]
@@ -135,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (20) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 9]
@@ -162,6 +164,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -189,6 +192,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#21]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]
@@ -216,6 +220,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, int, false], upper(input[3,
 (38) BroadcastHashJoin [codegen id : 9]
 Left keys [3]: [c_current_addr_sk#22, c_birth_country#25, s_zip#14]
 Right keys [3]: [ca_address_sk#26, upper(ca_country#29), ca_zip#28]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 9]
@@ -319,6 +324,7 @@ Arguments: [sr_ticket_number#8 ASC NULLS FIRST, sr_item_sk#7 ASC NULLS FIRST], f
 (53) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#8, sr_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (54) Project [codegen id : 9]
@@ -331,6 +337,7 @@ Output [4]: [s_store_sk#10, s_store_name#11, s_state#13, s_zip#14]
 (56) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#10]
+Join type: Inner
 Join condition: None
 
 (57) Project [codegen id : 9]
@@ -358,6 +365,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (62) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#15]
+Join type: Inner
 Join condition: None
 
 (63) Project [codegen id : 9]
@@ -370,6 +378,7 @@ Output [5]: [c_customer_sk#21, c_current_addr_sk#22, c_first_name#23, c_last_nam
 (65) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#21]
+Join type: Inner
 Join condition: None
 
 (66) Project [codegen id : 9]
@@ -382,6 +391,7 @@ Output [4]: [ca_address_sk#26, ca_state#27, ca_zip#28, ca_country#29]
 (68) BroadcastHashJoin [codegen id : 9]
 Left keys [3]: [c_current_addr_sk#22, c_birth_country#25, s_zip#14]
 Right keys [3]: [ca_address_sk#26, upper(ca_country#29), ca_zip#28]
+Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
@@ -114,6 +114,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -180,6 +183,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -225,6 +229,7 @@ Output [1]: [cd_demo_sk#10]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -256,6 +261,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (40) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
@@ -268,6 +274,7 @@ Output [1]: [d_date_sk#14]
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]
@@ -280,6 +287,7 @@ Output [2]: [i_item_sk#17, i_item_id#18]
 (46) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 11]
@@ -325,6 +333,7 @@ Output [1]: [cd_demo_sk#10]
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
@@ -337,6 +346,7 @@ Output [1]: [s_store_sk#15]
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -349,6 +359,7 @@ Output [1]: [d_date_sk#14]
 (61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]
@@ -376,6 +387,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a/explain.txt
@@ -114,6 +114,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 5]
@@ -126,6 +127,7 @@ Output [1]: [d_date_sk#14]
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
@@ -153,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -180,6 +183,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -225,6 +229,7 @@ Output [1]: [cd_demo_sk#10]
 (33) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 11]
@@ -237,6 +242,7 @@ Output [1]: [d_date_sk#14]
 (36) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 11]
@@ -268,6 +274,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (43) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]
@@ -280,6 +287,7 @@ Output [2]: [i_item_sk#17, i_item_id#18]
 (46) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 11]
@@ -325,6 +333,7 @@ Output [1]: [cd_demo_sk#10]
 (55) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
@@ -337,6 +346,7 @@ Output [1]: [d_date_sk#14]
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#8]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -349,6 +359,7 @@ Output [1]: [s_store_sk#15]
 (61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]
@@ -376,6 +387,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (67) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
@@ -57,6 +57,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -88,6 +89,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -119,6 +121,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -180,6 +183,7 @@ Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34/explain.txt
@@ -54,6 +54,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -85,6 +86,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -116,6 +118,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_hdemo_sk#2]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
@@ -165,6 +168,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35.sf100/explain.txt
@@ -92,6 +92,7 @@ Output [1]: [d_date_sk#9]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -109,6 +110,7 @@ Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
@@ -127,6 +129,7 @@ Output [1]: [d_date_sk#12]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -144,6 +147,7 @@ Arguments: [ws_bill_customer_sk#10 ASC NULLS FIRST], false, 0
 (21) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ws_bill_customer_sk#10]
+Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (22) Scan parquet spark_catalog.default.catalog_sales
@@ -162,6 +166,7 @@ Output [1]: [d_date_sk#15]
 (25) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 12]
@@ -179,6 +184,7 @@ Arguments: [cs_ship_customer_sk#13 ASC NULLS FIRST], false, 0
 (29) SortMergeJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [cs_ship_customer_sk#13]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (30) Filter [codegen id : 14]
@@ -222,6 +228,7 @@ Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 18]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 18]
@@ -261,6 +268,7 @@ Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
 (48) SortMergeJoin [codegen id : 22]
 Left keys [1]: [c_current_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35/explain.txt
@@ -73,6 +73,7 @@ Output [1]: [d_date_sk#9]
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 2]
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#6]
+Join type: LeftSemi
 Join condition: None
 
 (11) Scan parquet spark_catalog.default.web_sales
@@ -104,6 +106,7 @@ Output [1]: [d_date_sk#12]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -117,6 +120,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (17) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ws_bill_customer_sk#10]
+Join type: ExistenceJoin(exists#2)
 Join condition: None
 
 (18) Scan parquet spark_catalog.default.catalog_sales
@@ -135,6 +139,7 @@ Output [1]: [d_date_sk#15]
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#14]
 Right keys [1]: [d_date_sk#15]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -148,6 +153,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (24) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [cs_ship_customer_sk#13]
+Join type: ExistenceJoin(exists#1)
 Join condition: None
 
 (25) Filter [codegen id : 9]
@@ -179,6 +185,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (31) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 9]
@@ -206,6 +213,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (37) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a.sf100/explain.txt
@@ -89,6 +89,7 @@ Output [1]: [d_date_sk#7]
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -106,6 +107,7 @@ Arguments: [ss_customer_sk#4 ASC NULLS FIRST], false, 0
 (13) SortMergeJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#4]
+Join type: LeftSemi
 Join condition: None
 
 (14) Scan parquet spark_catalog.default.web_sales
@@ -124,6 +126,7 @@ Output [1]: [d_date_sk#10]
 (17) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 8]
@@ -146,6 +149,7 @@ Output [1]: [d_date_sk#14]
 (22) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 10]
@@ -165,6 +169,7 @@ Arguments: [customsk#11 ASC NULLS FIRST], false, 0
 (27) SortMergeJoin [codegen id : 12]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customsk#11]
+Join type: LeftSemi
 Join condition: None
 
 (28) Project [codegen id : 12]
@@ -204,6 +209,7 @@ Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 (36) SortMergeJoin [codegen id : 16]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 16]
@@ -243,6 +249,7 @@ Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
 (45) SortMergeJoin [codegen id : 20]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 20]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q35a/explain.txt
@@ -71,6 +71,7 @@ Output [1]: [d_date_sk#7]
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (8) Project [codegen id : 2]
@@ -84,6 +85,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (10) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#4]
+Join type: LeftSemi
 Join condition: None
 
 (11) Scan parquet spark_catalog.default.web_sales
@@ -102,6 +104,7 @@ Output [1]: [d_date_sk#10]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ws_sold_date_sk#9]
 Right keys [1]: [d_date_sk#10]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -124,6 +127,7 @@ Output [1]: [d_date_sk#14]
 (19) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [cs_sold_date_sk#13]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 6]
@@ -139,6 +143,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (23) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [customsk#11]
+Join type: LeftSemi
 Join condition: None
 
 (24) Project [codegen id : 9]
@@ -166,6 +171,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#3]
 Right keys [1]: [ca_address_sk#16]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
@@ -193,6 +199,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
@@ -63,6 +63,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (12) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#8]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a/explain.txt
@@ -63,6 +63,7 @@ Output [1]: [d_date_sk#7]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -90,6 +91,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
@@ -74,6 +74,7 @@ Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -101,6 +102,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -140,6 +142,7 @@ Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -237,6 +240,7 @@ Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_n
 (42) SortMergeJoin [codegen id : 24]
 Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
 Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1)]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 24]
@@ -269,6 +273,7 @@ Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_n
 (50) SortMergeJoin [codegen id : 36]
 Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
 Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1)]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 36]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47/explain.txt
@@ -82,6 +82,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Output [3]: [d_date_sk#9, d_year#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#5]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -206,6 +209,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#30 + 1)]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 22]
@@ -234,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [5]: [i_category#3, i_brand#2, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#38 - 1)]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49.sf100/explain.txt
@@ -112,6 +112,7 @@ Output [1]: [d_date_sk#8]
 (6) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
+Join type: Inner
 Join condition: None
 
 (7) Project [codegen id : 2]
@@ -155,6 +156,7 @@ Arguments: [wr_order_number#10 ASC NULLS FIRST, wr_item_sk#9 ASC NULLS FIRST], f
 (16) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ws_order_number#2, ws_item_sk#1]
 Right keys [2]: [wr_order_number#10, wr_item_sk#9]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -232,6 +234,7 @@ Output [1]: [d_date_sk#42]
 (33) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cs_sold_date_sk#41]
 Right keys [1]: [d_date_sk#42]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 12]
@@ -275,6 +278,7 @@ Arguments: [cr_order_number#44 ASC NULLS FIRST, cr_item_sk#43 ASC NULLS FIRST], 
 (43) SortMergeJoin [codegen id : 16]
 Left keys [2]: [cs_order_number#37, cs_item_sk#36]
 Right keys [2]: [cr_order_number#44, cr_item_sk#43]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 16]
@@ -352,6 +356,7 @@ Output [1]: [d_date_sk#76]
 (60) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [ss_sold_date_sk#75]
 Right keys [1]: [d_date_sk#76]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 22]
@@ -395,6 +400,7 @@ Arguments: [sr_ticket_number#78 ASC NULLS FIRST, sr_item_sk#77 ASC NULLS FIRST],
 (70) SortMergeJoin [codegen id : 26]
 Left keys [2]: [ss_ticket_number#71, ss_item_sk#70]
 Right keys [2]: [sr_ticket_number#78, sr_item_sk#77]
+Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 26]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q49/explain.txt
@@ -122,6 +122,7 @@ Input [5]: [wr_item_sk#8, wr_order_number#9, wr_return_quantity#10, wr_return_am
 (10) BroadcastHashJoin [codegen id : 3]
 Left keys [2]: [ws_order_number#2, ws_item_sk#1]
 Right keys [2]: [wr_order_number#9, wr_item_sk#8]
+Join type: Inner
 Join condition: None
 
 (11) Project [codegen id : 3]
@@ -134,6 +135,7 @@ Output [1]: [d_date_sk#13]
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#6]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]
@@ -230,6 +232,7 @@ Input [5]: [cr_item_sk#42, cr_order_number#43, cr_return_quantity#44, cr_return_
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [cs_order_number#37, cs_item_sk#36]
 Right keys [2]: [cr_order_number#43, cr_item_sk#42]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -242,6 +245,7 @@ Output [1]: [d_date_sk#47]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#41]
 Right keys [1]: [d_date_sk#47]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -338,6 +342,7 @@ Input [5]: [sr_item_sk#76, sr_ticket_number#77, sr_return_quantity#78, sr_return
 (58) BroadcastHashJoin [codegen id : 17]
 Left keys [2]: [ss_ticket_number#71, ss_item_sk#70]
 Right keys [2]: [sr_ticket_number#77, sr_item_sk#76]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
@@ -350,6 +355,7 @@ Output [1]: [d_date_sk#81]
 (61) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#75]
 Right keys [1]: [d_date_sk#81]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a.sf100/explain.txt
@@ -92,6 +92,7 @@ Output [2]: [d_date_sk#5, d_date#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -166,6 +167,7 @@ Arguments: [item_sk#16 ASC NULLS FIRST], false, 0
 (22) SortMergeJoin [codegen id : 13]
 Left keys [1]: [item_sk#10]
 Right keys [1]: [item_sk#16]
+Join type: Inner
 Join condition: (rk#12 >= rk#15)
 
 (23) Project [codegen id : 13]
@@ -215,6 +217,7 @@ Output [2]: [d_date_sk#27, d_date#28]
 (32) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [ss_sold_date_sk#26]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 16]
@@ -289,6 +292,7 @@ Arguments: [item_sk#38 ASC NULLS FIRST], false, 0
 (49) SortMergeJoin [codegen id : 27]
 Left keys [1]: [item_sk#32]
 Right keys [1]: [item_sk#38]
+Join type: Inner
 Join condition: (rk#34 >= rk#37)
 
 (50) Project [codegen id : 27]
@@ -320,6 +324,7 @@ Arguments: [item_sk#32 ASC NULLS FIRST, d_date#28 ASC NULLS FIRST], false, 0
 (55) SortMergeJoin [codegen id : 29]
 Left keys [2]: [item_sk#10, d_date#6]
 Right keys [2]: [item_sk#32, d_date#28]
+Join type: FullOuter
 Join condition: None
 
 (56) Filter [codegen id : 29]
@@ -360,6 +365,7 @@ Input [5]: [item_sk#46, d_date#47, web_sales#48, store_sales#49, rk#51]
 (65) SortMergeJoin [codegen id : 62]
 Left keys [1]: [item_sk#46]
 Right keys [1]: [item_sk#52]
+Join type: Inner
 Join condition: (rk#50 >= rk#51)
 
 (66) Project [codegen id : 62]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q51a/explain.txt
@@ -89,6 +89,7 @@ Output [2]: [d_date_sk#5, d_date#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -151,6 +152,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [item_sk#10]
 Right keys [1]: [item_sk#16]
+Join type: Inner
 Join condition: (rk#12 >= rk#15)
 
 (20) Project [codegen id : 10]
@@ -204,6 +206,7 @@ Output [2]: [d_date_sk#27, d_date#28]
 (30) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ss_sold_date_sk#26]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 14]
@@ -266,6 +269,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (44) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [item_sk#32]
 Right keys [1]: [item_sk#38]
+Join type: Inner
 Join condition: (rk#34 >= rk#37)
 
 (45) Project [codegen id : 22]
@@ -301,6 +305,7 @@ Arguments: [item_sk#32 ASC NULLS FIRST, d_date#28 ASC NULLS FIRST], false, 0
 (51) SortMergeJoin [codegen id : 25]
 Left keys [2]: [item_sk#10, d_date#6]
 Right keys [2]: [item_sk#32, d_date#28]
+Join type: FullOuter
 Join condition: None
 
 (52) Filter [codegen id : 25]
@@ -345,6 +350,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (62) BroadcastHashJoin [codegen id : 54]
 Left keys [1]: [item_sk#46]
 Right keys [1]: [item_sk#52]
+Join type: Inner
 Join condition: (rk#50 >= rk#51)
 
 (63) Project [codegen id : 54]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57.sf100/explain.txt
@@ -74,6 +74,7 @@ Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -101,6 +102,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_call_center_sk#1]
 Right keys [1]: [cc_call_center_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -140,6 +142,7 @@ Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#11]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
@@ -237,6 +240,7 @@ Arguments: [i_category#21 ASC NULLS FIRST, i_brand#22 ASC NULLS FIRST, cc_name#2
 (42) SortMergeJoin [codegen id : 24]
 Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
 Right keys [4]: [i_category#21, i_brand#22, cc_name#23, (rn#28 + 1)]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 24]
@@ -269,6 +273,7 @@ Arguments: [i_category#30 ASC NULLS FIRST, i_brand#31 ASC NULLS FIRST, cc_name#3
 (50) SortMergeJoin [codegen id : 36]
 Left keys [4]: [i_category#13, i_brand#12, cc_name#10, rn#19]
 Right keys [4]: [i_category#30, i_brand#31, cc_name#32, (rn#35 - 1)]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 36]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q57/explain.txt
@@ -82,6 +82,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [cs_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 4]
@@ -94,6 +95,7 @@ Output [3]: [d_date_sk#9, d_year#10, d_moy#11]
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -121,6 +123,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_call_center_sk#4]
 Right keys [1]: [cc_call_center_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -206,6 +209,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (36) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#13, rn#19]
 Right keys [4]: [i_category#21, i_brand#22, cc_name#23, (rn#28 + 1)]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 22]
@@ -234,6 +238,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true], input[1, str
 (43) BroadcastHashJoin [codegen id : 22]
 Left keys [4]: [i_category#3, i_brand#2, cc_name#13, rn#19]
 Right keys [4]: [i_category#30, i_brand#31, cc_name#32, (rn#35 - 1)]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a.sf100/explain.txt
@@ -152,6 +152,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#22]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 5]
@@ -164,6 +165,7 @@ Output [1]: [d_date_sk#24]
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
@@ -249,6 +251,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#62]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 11]
@@ -261,6 +264,7 @@ Output [1]: [d_date_sk#64]
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#64]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
@@ -351,6 +355,7 @@ Arguments: [ws_item_sk#97 ASC NULLS FIRST, ws_order_number#99 ASC NULLS FIRST], 
 (57) SortMergeJoin [codegen id : 18]
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 18]
@@ -380,6 +385,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (64) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#107]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 21]
@@ -392,6 +398,7 @@ Output [1]: [d_date_sk#109]
 (67) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#109]
+Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 21]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q5a/explain.txt
@@ -134,6 +134,7 @@ Output [1]: [d_date_sk#22]
 (11) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [date_sk#7]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
@@ -161,6 +162,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [store_sk#6]
 Right keys [1]: [s_store_sk#23]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 5]
@@ -231,6 +233,7 @@ Output [1]: [d_date_sk#62]
 (32) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [date_sk#47]
 Right keys [1]: [d_date_sk#62]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
@@ -258,6 +261,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (38) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [page_sk#46]
 Right keys [1]: [cp_catalog_page_sk#63]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 11]
@@ -336,6 +340,7 @@ Input [4]: [ws_item_sk#97, ws_web_site_sk#98, ws_order_number#99, ws_sold_date_s
 (54) BroadcastHashJoin [codegen id : 15]
 Left keys [2]: [wr_item_sk#92, wr_order_number#93]
 Right keys [2]: [ws_item_sk#97, ws_order_number#99]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 15]
@@ -350,6 +355,7 @@ Output [1]: [d_date_sk#107]
 (58) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [date_sk#87]
 Right keys [1]: [d_date_sk#107]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 18]
@@ -377,6 +383,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (64) BroadcastHashJoin [codegen id : 18]
 Left keys [1]: [wsr_web_site_sk#86]
 Right keys [1]: [web_site_sk#108]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 18]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
@@ -103,6 +103,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [pla
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [i_category#3]
 Right keys [1]: [i_category#5]
+Join type: Inner
 Join condition: (cast(i_current_price#2 as decimal(14,7)) > (1.2 * avg(i_current_price)#11))
 
 (13) Project [codegen id : 3]
@@ -131,6 +132,7 @@ Condition : (isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12))
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#12]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -143,6 +145,7 @@ Output [1]: [d_date_sk#16]
 (21) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#16]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 5]
@@ -204,6 +207,7 @@ Arguments: [c_current_addr_sk#20 ASC NULLS FIRST], false, 0
 (35) SortMergeJoin [codegen id : 11]
 Left keys [1]: [ca_address_sk#17]
 Right keys [1]: [c_current_addr_sk#20]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 11]
@@ -221,6 +225,7 @@ Arguments: [c_customer_sk#19 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 13]
 Left keys [1]: [ss_customer_sk#13]
 Right keys [1]: [c_customer_sk#19]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 13]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6/explain.txt
@@ -75,6 +75,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 7]
@@ -103,6 +104,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#6]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 7]
@@ -115,6 +117,7 @@ Output [1]: [d_date_sk#9]
 (17) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 7]
@@ -178,6 +181,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [pla
 (30) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [i_category#12]
 Right keys [1]: [i_category#14]
+Join type: Inner
 Join condition: (cast(i_current_price#11 as decimal(14,7)) > (1.2 * avg(i_current_price)#20))
 
 (31) Project [codegen id : 6]
@@ -191,6 +195,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (33) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#5]
 Right keys [1]: [i_item_sk#10]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64.sf100/explain.txt
@@ -262,6 +262,7 @@ Arguments: [sr_item_sk#16 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST],
 (12) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#8]
 Right keys [2]: [sr_item_sk#16, sr_ticket_number#17]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 13]
@@ -323,6 +324,7 @@ Arguments: [cr_item_sk#23 ASC NULLS FIRST, cr_order_number#24 ASC NULLS FIRST], 
 (26) SortMergeJoin [codegen id : 9]
 Left keys [2]: [cs_item_sk#19, cs_order_number#20]
 Right keys [2]: [cr_item_sk#23, cr_order_number#24]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -362,6 +364,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (34) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [cs_item_sk#19]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 13]
@@ -374,6 +377,7 @@ Output [2]: [d_date_sk#39, d_year#40]
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_sold_date_sk#12]
 Right keys [1]: [d_date_sk#39]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
@@ -401,6 +405,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#41]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
@@ -440,6 +445,7 @@ Arguments: [c_customer_sk#44 ASC NULLS FIRST], false, 0
 (52) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#44]
+Join type: Inner
 Join condition: None
 
 (53) Project [codegen id : 19]
@@ -467,6 +473,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (58) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [c_first_sales_date_sk#49]
 Right keys [1]: [d_date_sk#50]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 19]
@@ -479,6 +486,7 @@ Output [2]: [d_date_sk#52, d_year#53]
 (61) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [c_first_shipto_date_sk#48]
 Right keys [1]: [d_date_sk#52]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 19]
@@ -518,6 +526,7 @@ Arguments: [cd_demo_sk#54 ASC NULLS FIRST], false, 0
 (70) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ss_cdemo_sk#3]
 Right keys [1]: [cd_demo_sk#54]
+Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 23]
@@ -542,6 +551,7 @@ Arguments: [cd_demo_sk#56 ASC NULLS FIRST], false, 0
 (76) SortMergeJoin [codegen id : 30]
 Left keys [1]: [c_current_cdemo_sk#45]
 Right keys [1]: [cd_demo_sk#56]
+Join type: Inner
 Join condition: NOT (cd_marital_status#55 = cd_marital_status#57)
 
 (77) Project [codegen id : 30]
@@ -569,6 +579,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (82) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_promo_sk#7]
 Right keys [1]: [p_promo_sk#58]
+Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 30]
@@ -596,6 +607,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (88) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [ss_hdemo_sk#4]
 Right keys [1]: [hd_demo_sk#59]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 30]
@@ -608,6 +620,7 @@ Output [2]: [hd_demo_sk#61, hd_income_band_sk#62]
 (91) BroadcastHashJoin [codegen id : 30]
 Left keys [1]: [c_current_hdemo_sk#46]
 Right keys [1]: [hd_demo_sk#61]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 30]
@@ -647,6 +660,7 @@ Arguments: [ca_address_sk#63 ASC NULLS FIRST], false, 0
 (100) SortMergeJoin [codegen id : 34]
 Left keys [1]: [ss_addr_sk#5]
 Right keys [1]: [ca_address_sk#63]
+Join type: Inner
 Join condition: None
 
 (101) Project [codegen id : 34]
@@ -671,6 +685,7 @@ Arguments: [ca_address_sk#68 ASC NULLS FIRST], false, 0
 (106) SortMergeJoin [codegen id : 41]
 Left keys [1]: [c_current_addr_sk#47]
 Right keys [1]: [ca_address_sk#68]
+Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 41]
@@ -698,6 +713,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (112) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [hd_income_band_sk#60]
 Right keys [1]: [ib_income_band_sk#73]
+Join type: Inner
 Join condition: None
 
 (113) Project [codegen id : 41]
@@ -710,6 +726,7 @@ Output [1]: [ib_income_band_sk#74]
 (115) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [hd_income_band_sk#62]
 Right keys [1]: [ib_income_band_sk#74]
+Join type: Inner
 Join condition: None
 
 (116) Project [codegen id : 41]
@@ -741,6 +758,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (122) BroadcastHashJoin [codegen id : 41]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#75]
+Join type: Inner
 Join condition: None
 
 (123) Project [codegen id : 41]
@@ -806,6 +824,7 @@ Arguments: [sr_item_sk#121 ASC NULLS FIRST, sr_ticket_number#122 ASC NULLS FIRST
 (136) SortMergeJoin [codegen id : 56]
 Left keys [2]: [ss_item_sk#108, ss_ticket_number#115]
 Right keys [2]: [sr_item_sk#121, sr_ticket_number#122]
+Join type: Inner
 Join condition: None
 
 (137) Project [codegen id : 56]
@@ -818,6 +837,7 @@ Output [1]: [cs_item_sk#123]
 (139) BroadcastHashJoin [codegen id : 56]
 Left keys [1]: [ss_item_sk#108]
 Right keys [1]: [cs_item_sk#123]
+Join type: Inner
 Join condition: None
 
 (140) Project [codegen id : 56]
@@ -830,6 +850,7 @@ Output [2]: [d_date_sk#124, d_year#125]
 (142) BroadcastHashJoin [codegen id : 56]
 Left keys [1]: [ss_sold_date_sk#119]
 Right keys [1]: [d_date_sk#124]
+Join type: Inner
 Join condition: None
 
 (143) Project [codegen id : 56]
@@ -842,6 +863,7 @@ Output [3]: [s_store_sk#126, s_store_name#127, s_zip#128]
 (145) BroadcastHashJoin [codegen id : 56]
 Left keys [1]: [ss_store_sk#113]
 Right keys [1]: [s_store_sk#126]
+Join type: Inner
 Join condition: None
 
 (146) Project [codegen id : 56]
@@ -866,6 +888,7 @@ Arguments: [c_customer_sk#129 ASC NULLS FIRST], false, 0
 (151) SortMergeJoin [codegen id : 62]
 Left keys [1]: [ss_customer_sk#109]
 Right keys [1]: [c_customer_sk#129]
+Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 62]
@@ -878,6 +901,7 @@ Output [2]: [d_date_sk#135, d_year#136]
 (154) BroadcastHashJoin [codegen id : 62]
 Left keys [1]: [c_first_sales_date_sk#134]
 Right keys [1]: [d_date_sk#135]
+Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 62]
@@ -890,6 +914,7 @@ Output [2]: [d_date_sk#137, d_year#138]
 (157) BroadcastHashJoin [codegen id : 62]
 Left keys [1]: [c_first_shipto_date_sk#133]
 Right keys [1]: [d_date_sk#137]
+Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 62]
@@ -914,6 +939,7 @@ Arguments: [cd_demo_sk#139 ASC NULLS FIRST], false, 0
 (163) SortMergeJoin [codegen id : 66]
 Left keys [1]: [ss_cdemo_sk#110]
 Right keys [1]: [cd_demo_sk#139]
+Join type: Inner
 Join condition: None
 
 (164) Project [codegen id : 66]
@@ -938,6 +964,7 @@ Arguments: [cd_demo_sk#141 ASC NULLS FIRST], false, 0
 (169) SortMergeJoin [codegen id : 73]
 Left keys [1]: [c_current_cdemo_sk#130]
 Right keys [1]: [cd_demo_sk#141]
+Join type: Inner
 Join condition: NOT (cd_marital_status#140 = cd_marital_status#142)
 
 (170) Project [codegen id : 73]
@@ -950,6 +977,7 @@ Output [1]: [p_promo_sk#143]
 (172) BroadcastHashJoin [codegen id : 73]
 Left keys [1]: [ss_promo_sk#114]
 Right keys [1]: [p_promo_sk#143]
+Join type: Inner
 Join condition: None
 
 (173) Project [codegen id : 73]
@@ -962,6 +990,7 @@ Output [2]: [hd_demo_sk#144, hd_income_band_sk#145]
 (175) BroadcastHashJoin [codegen id : 73]
 Left keys [1]: [ss_hdemo_sk#111]
 Right keys [1]: [hd_demo_sk#144]
+Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 73]
@@ -974,6 +1003,7 @@ Output [2]: [hd_demo_sk#146, hd_income_band_sk#147]
 (178) BroadcastHashJoin [codegen id : 73]
 Left keys [1]: [c_current_hdemo_sk#131]
 Right keys [1]: [hd_demo_sk#146]
+Join type: Inner
 Join condition: None
 
 (179) Project [codegen id : 73]
@@ -998,6 +1028,7 @@ Arguments: [ca_address_sk#148 ASC NULLS FIRST], false, 0
 (184) SortMergeJoin [codegen id : 77]
 Left keys [1]: [ss_addr_sk#112]
 Right keys [1]: [ca_address_sk#148]
+Join type: Inner
 Join condition: None
 
 (185) Project [codegen id : 77]
@@ -1022,6 +1053,7 @@ Arguments: [ca_address_sk#153 ASC NULLS FIRST], false, 0
 (190) SortMergeJoin [codegen id : 84]
 Left keys [1]: [c_current_addr_sk#132]
 Right keys [1]: [ca_address_sk#153]
+Join type: Inner
 Join condition: None
 
 (191) Project [codegen id : 84]
@@ -1034,6 +1066,7 @@ Output [1]: [ib_income_band_sk#158]
 (193) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [hd_income_band_sk#145]
 Right keys [1]: [ib_income_band_sk#158]
+Join type: Inner
 Join condition: None
 
 (194) Project [codegen id : 84]
@@ -1046,6 +1079,7 @@ Output [1]: [ib_income_band_sk#159]
 (196) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [hd_income_band_sk#147]
 Right keys [1]: [ib_income_band_sk#159]
+Join type: Inner
 Join condition: None
 
 (197) Project [codegen id : 84]
@@ -1058,6 +1092,7 @@ Output [2]: [i_item_sk#160, i_product_name#161]
 (199) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [ss_item_sk#108]
 Right keys [1]: [i_item_sk#160]
+Join type: Inner
 Join condition: None
 
 (200) Project [codegen id : 84]
@@ -1093,6 +1128,7 @@ Arguments: [item_sk#168 ASC NULLS FIRST, store_name#169 ASC NULLS FIRST, store_z
 (206) SortMergeJoin [codegen id : 87]
 Left keys [3]: [item_sk#92, store_name#93, store_zip#94]
 Right keys [3]: [item_sk#168, store_name#169, store_zip#170]
+Join type: Inner
 Join condition: (cnt#172 <= cnt#104)
 
 (207) Project [codegen id : 87]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q64/explain.txt
@@ -224,6 +224,7 @@ Input [3]: [sr_item_sk#14, sr_ticket_number#15, sr_returned_date_sk#16]
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#8]
 Right keys [2]: [sr_item_sk#14, sr_ticket_number#15]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]
@@ -293,6 +294,7 @@ Arguments: [cr_item_sk#21 ASC NULLS FIRST, cr_order_number#22 ASC NULLS FIRST], 
 (25) SortMergeJoin [codegen id : 8]
 Left keys [2]: [cs_item_sk#17, cs_order_number#18]
 Right keys [2]: [cr_item_sk#21, cr_order_number#22]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 8]
@@ -332,6 +334,7 @@ Arguments: [cs_item_sk#17 ASC NULLS FIRST], false, 0
 (33) SortMergeJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [cs_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 25]
@@ -344,6 +347,7 @@ Output [2]: [d_date_sk#37, d_year#38]
 (36) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_sold_date_sk#12]
 Right keys [1]: [d_date_sk#37]
+Join type: Inner
 Join condition: None
 
 (37) Project [codegen id : 25]
@@ -371,6 +375,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (42) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_store_sk#6]
 Right keys [1]: [s_store_sk#39]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 25]
@@ -398,6 +403,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (48) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#42]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 25]
@@ -425,6 +431,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (54) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [c_first_sales_date_sk#47]
 Right keys [1]: [d_date_sk#48]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 25]
@@ -437,6 +444,7 @@ Output [2]: [d_date_sk#50, d_year#51]
 (57) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [c_first_shipto_date_sk#46]
 Right keys [1]: [d_date_sk#50]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 25]
@@ -464,6 +472,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (63) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_cdemo_sk#3]
 Right keys [1]: [cd_demo_sk#52]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 25]
@@ -476,6 +485,7 @@ Output [2]: [cd_demo_sk#54, cd_marital_status#55]
 (66) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [c_current_cdemo_sk#43]
 Right keys [1]: [cd_demo_sk#54]
+Join type: Inner
 Join condition: NOT (cd_marital_status#53 = cd_marital_status#55)
 
 (67) Project [codegen id : 25]
@@ -503,6 +513,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (72) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_promo_sk#7]
 Right keys [1]: [p_promo_sk#56]
+Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 25]
@@ -530,6 +541,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (78) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_hdemo_sk#4]
 Right keys [1]: [hd_demo_sk#57]
+Join type: Inner
 Join condition: None
 
 (79) Project [codegen id : 25]
@@ -542,6 +554,7 @@ Output [2]: [hd_demo_sk#59, hd_income_band_sk#60]
 (81) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [c_current_hdemo_sk#44]
 Right keys [1]: [hd_demo_sk#59]
+Join type: Inner
 Join condition: None
 
 (82) Project [codegen id : 25]
@@ -569,6 +582,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (87) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_addr_sk#5]
 Right keys [1]: [ca_address_sk#61]
+Join type: Inner
 Join condition: None
 
 (88) Project [codegen id : 25]
@@ -581,6 +595,7 @@ Output [5]: [ca_address_sk#66, ca_street_number#67, ca_street_name#68, ca_city#6
 (90) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [c_current_addr_sk#45]
 Right keys [1]: [ca_address_sk#66]
+Join type: Inner
 Join condition: None
 
 (91) Project [codegen id : 25]
@@ -608,6 +623,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (96) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [hd_income_band_sk#58]
 Right keys [1]: [ib_income_band_sk#71]
+Join type: Inner
 Join condition: None
 
 (97) Project [codegen id : 25]
@@ -620,6 +636,7 @@ Output [1]: [ib_income_band_sk#72]
 (99) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [hd_income_band_sk#60]
 Right keys [1]: [ib_income_band_sk#72]
+Join type: Inner
 Join condition: None
 
 (100) Project [codegen id : 25]
@@ -651,6 +668,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (106) BroadcastHashJoin [codegen id : 25]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#73]
+Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 25]
@@ -719,6 +737,7 @@ Input [3]: [sr_item_sk#119, sr_ticket_number#120, sr_returned_date_sk#121]
 (120) BroadcastHashJoin [codegen id : 28]
 Left keys [2]: [ss_item_sk#106, ss_ticket_number#113]
 Right keys [2]: [sr_item_sk#119, sr_ticket_number#120]
+Join type: Inner
 Join condition: None
 
 (121) Project [codegen id : 28]
@@ -758,6 +777,7 @@ Arguments: [cs_item_sk#122 ASC NULLS FIRST], false, 0
 (129) SortMergeJoin [codegen id : 51]
 Left keys [1]: [ss_item_sk#106]
 Right keys [1]: [cs_item_sk#122]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 51]
@@ -770,6 +790,7 @@ Output [2]: [d_date_sk#130, d_year#131]
 (132) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_sold_date_sk#117]
 Right keys [1]: [d_date_sk#130]
+Join type: Inner
 Join condition: None
 
 (133) Project [codegen id : 51]
@@ -782,6 +803,7 @@ Output [3]: [s_store_sk#132, s_store_name#133, s_zip#134]
 (135) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_store_sk#111]
 Right keys [1]: [s_store_sk#132]
+Join type: Inner
 Join condition: None
 
 (136) Project [codegen id : 51]
@@ -794,6 +816,7 @@ Output [6]: [c_customer_sk#135, c_current_cdemo_sk#136, c_current_hdemo_sk#137, 
 (138) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_customer_sk#107]
 Right keys [1]: [c_customer_sk#135]
+Join type: Inner
 Join condition: None
 
 (139) Project [codegen id : 51]
@@ -806,6 +829,7 @@ Output [2]: [d_date_sk#141, d_year#142]
 (141) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [c_first_sales_date_sk#140]
 Right keys [1]: [d_date_sk#141]
+Join type: Inner
 Join condition: None
 
 (142) Project [codegen id : 51]
@@ -818,6 +842,7 @@ Output [2]: [d_date_sk#143, d_year#144]
 (144) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [c_first_shipto_date_sk#139]
 Right keys [1]: [d_date_sk#143]
+Join type: Inner
 Join condition: None
 
 (145) Project [codegen id : 51]
@@ -830,6 +855,7 @@ Output [2]: [cd_demo_sk#145, cd_marital_status#146]
 (147) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_cdemo_sk#108]
 Right keys [1]: [cd_demo_sk#145]
+Join type: Inner
 Join condition: None
 
 (148) Project [codegen id : 51]
@@ -842,6 +868,7 @@ Output [2]: [cd_demo_sk#147, cd_marital_status#148]
 (150) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [c_current_cdemo_sk#136]
 Right keys [1]: [cd_demo_sk#147]
+Join type: Inner
 Join condition: NOT (cd_marital_status#146 = cd_marital_status#148)
 
 (151) Project [codegen id : 51]
@@ -854,6 +881,7 @@ Output [1]: [p_promo_sk#149]
 (153) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_promo_sk#112]
 Right keys [1]: [p_promo_sk#149]
+Join type: Inner
 Join condition: None
 
 (154) Project [codegen id : 51]
@@ -866,6 +894,7 @@ Output [2]: [hd_demo_sk#150, hd_income_band_sk#151]
 (156) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_hdemo_sk#109]
 Right keys [1]: [hd_demo_sk#150]
+Join type: Inner
 Join condition: None
 
 (157) Project [codegen id : 51]
@@ -878,6 +907,7 @@ Output [2]: [hd_demo_sk#152, hd_income_band_sk#153]
 (159) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [c_current_hdemo_sk#137]
 Right keys [1]: [hd_demo_sk#152]
+Join type: Inner
 Join condition: None
 
 (160) Project [codegen id : 51]
@@ -890,6 +920,7 @@ Output [5]: [ca_address_sk#154, ca_street_number#155, ca_street_name#156, ca_cit
 (162) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_addr_sk#110]
 Right keys [1]: [ca_address_sk#154]
+Join type: Inner
 Join condition: None
 
 (163) Project [codegen id : 51]
@@ -902,6 +933,7 @@ Output [5]: [ca_address_sk#159, ca_street_number#160, ca_street_name#161, ca_cit
 (165) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [c_current_addr_sk#138]
 Right keys [1]: [ca_address_sk#159]
+Join type: Inner
 Join condition: None
 
 (166) Project [codegen id : 51]
@@ -914,6 +946,7 @@ Output [1]: [ib_income_band_sk#164]
 (168) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [hd_income_band_sk#151]
 Right keys [1]: [ib_income_band_sk#164]
+Join type: Inner
 Join condition: None
 
 (169) Project [codegen id : 51]
@@ -926,6 +959,7 @@ Output [1]: [ib_income_band_sk#165]
 (171) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [hd_income_band_sk#153]
 Right keys [1]: [ib_income_band_sk#165]
+Join type: Inner
 Join condition: None
 
 (172) Project [codegen id : 51]
@@ -938,6 +972,7 @@ Output [2]: [i_item_sk#166, i_product_name#167]
 (174) BroadcastHashJoin [codegen id : 51]
 Left keys [1]: [ss_item_sk#106]
 Right keys [1]: [i_item_sk#166]
+Join type: Inner
 Join condition: None
 
 (175) Project [codegen id : 51]
@@ -969,6 +1004,7 @@ Arguments: [item_sk#174 ASC NULLS FIRST, store_name#175 ASC NULLS FIRST, store_z
 (180) SortMergeJoin [codegen id : 53]
 Left keys [3]: [item_sk#90, store_name#91, store_zip#92]
 Right keys [3]: [item_sk#174, store_name#175, store_zip#176]
+Join type: Inner
 Join condition: (cnt#178 <= cnt#102)
 
 (181) Project [codegen id : 53]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
@@ -92,6 +92,7 @@ Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -119,6 +120,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -158,6 +160,7 @@ Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
 (20) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a/explain.txt
@@ -89,6 +89,7 @@ Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 (5) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 4]
@@ -116,6 +117,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
@@ -143,6 +145,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#13]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a.sf100/explain.txt
@@ -77,6 +77,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 8]
@@ -118,6 +119,7 @@ Output [1]: [d_date_sk#12]
 (14) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 4]
@@ -145,6 +147,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
 Right keys [1]: [s_store_sk#13]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 4]
@@ -192,6 +195,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
 Right keys [1]: [s_state#14]
+Join type: LeftSemi
 Join condition: None
 
 (31) BroadcastExchange
@@ -201,6 +205,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#6]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q70a/explain.txt
@@ -77,6 +77,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 8]
@@ -133,6 +134,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (17) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#9]
 Right keys [1]: [s_store_sk#12]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
@@ -145,6 +147,7 @@ Output [1]: [d_date_sk#14]
 (20) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_sold_date_sk#11]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 4]
@@ -192,6 +195,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_state#8]
 Right keys [1]: [s_state#13]
+Join type: LeftSemi
 Join condition: None
 
 (31) BroadcastExchange
@@ -201,6 +205,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (32) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#6]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
@@ -111,6 +111,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#10]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -142,6 +143,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#12]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
@@ -169,6 +171,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 4]
@@ -208,6 +211,7 @@ Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
 (31) SortMergeJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 10]
@@ -220,6 +224,7 @@ Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#8]
 Right keys [1]: [d_date_sk#18]
+Join type: Inner
 Join condition: (d_date#15 > date_add(d_date#19, 5))
 
 (35) Project [codegen id : 10]
@@ -270,6 +275,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (45) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [inv_warehouse_sk#23]
 Right keys [1]: [w_warehouse_sk#26]
+Join type: Inner
 Join condition: None
 
 (46) Project [codegen id : 13]
@@ -287,6 +293,7 @@ Arguments: [inv_item_sk#22 ASC NULLS FIRST, inv_date_sk#25 ASC NULLS FIRST], fal
 (49) SortMergeJoin [codegen id : 16]
 Left keys [2]: [cs_item_sk#4, d_date_sk#21]
 Right keys [2]: [inv_item_sk#22, inv_date_sk#25]
+Join type: Inner
 Join condition: (inv_quantity_on_hand#24 < cs_quantity#7)
 
 (50) Project [codegen id : 16]
@@ -314,6 +321,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (55) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [cs_promo_sk#5]
 Right keys [1]: [p_promo_sk#28]
+Join type: LeftOuter
 Join condition: None
 
 (56) Project [codegen id : 16]
@@ -357,6 +365,7 @@ Arguments: [cr_item_sk#29 ASC NULLS FIRST, cr_order_number#30 ASC NULLS FIRST], 
 (65) SortMergeJoin [codegen id : 20]
 Left keys [2]: [cs_item_sk#4, cs_order_number#6]
 Right keys [2]: [cr_item_sk#29, cr_order_number#30]
+Join type: LeftOuter
 Join condition: None
 
 (66) Project [codegen id : 20]
@@ -440,6 +449,7 @@ Condition : (isnotnull(d_week_seq#39) AND isnotnull(d_date_sk#21))
 (79) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [d_week_seq#20]
 Right keys [1]: [d_week_seq#39]
+Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72/explain.txt
@@ -108,6 +108,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
 Right keys [1]: [inv_item_sk#10]
+Join type: Inner
 Join condition: (inv_quantity_on_hand#12 < cs_quantity#7)
 
 (9) Project [codegen id : 10]
@@ -135,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (14) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [inv_warehouse_sk#11]
 Right keys [1]: [w_warehouse_sk#14]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 10]
@@ -162,6 +164,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (20) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_item_sk#4]
 Right keys [1]: [i_item_sk#16]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 10]
@@ -193,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (27) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 10]
@@ -224,6 +228,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_bill_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -236,6 +241,7 @@ Output [3]: [d_date_sk#22, d_date#23, d_week_seq#24]
 (37) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#8]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 10]
@@ -263,6 +269,7 @@ Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[1, int, false]
 (43) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [d_week_seq#24, inv_date_sk#13]
 Right keys [2]: [d_week_seq#26, d_date_sk#25]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 10]
@@ -290,6 +297,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (49) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_ship_date_sk#1]
 Right keys [1]: [d_date_sk#27]
+Join type: Inner
 Join condition: (d_date#28 > date_add(d_date#23, 5))
 
 (50) Project [codegen id : 10]
@@ -317,6 +325,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (55) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_promo_sk#5]
 Right keys [1]: [p_promo_sk#29]
+Join type: LeftOuter
 Join condition: None
 
 (56) Project [codegen id : 10]
@@ -360,6 +369,7 @@ Arguments: [cr_item_sk#30 ASC NULLS FIRST, cr_order_number#31 ASC NULLS FIRST], 
 (65) SortMergeJoin [codegen id : 14]
 Left keys [2]: [cs_item_sk#4, cs_order_number#6]
 Right keys [2]: [cr_item_sk#30, cr_order_number#31]
+Join type: LeftOuter
 Join condition: None
 
 (66) Project [codegen id : 14]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74.sf100/explain.txt
@@ -101,6 +101,7 @@ Output [2]: [d_date_sk#5, d_year#6]
 (5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 2]
@@ -140,6 +141,7 @@ Arguments: [c_customer_sk#7 ASC NULLS FIRST], false, 0
 (14) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#7]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -197,6 +199,7 @@ Output [2]: [d_date_sk#20, d_year#21]
 (26) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#18]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
@@ -221,6 +224,7 @@ Arguments: [c_customer_sk#22 ASC NULLS FIRST], false, 0
 (32) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ss_customer_sk#16]
 Right keys [1]: [c_customer_sk#22]
+Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 14]
@@ -256,6 +260,7 @@ Arguments: [customer_id#28 ASC NULLS FIRST], false, 0
 (39) SortMergeJoin [codegen id : 17]
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#28]
+Join type: Inner
 Join condition: None
 
 (40) Scan parquet spark_catalog.default.web_sales
@@ -279,6 +284,7 @@ Output [2]: [d_date_sk#35, d_year#36]
 (44) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [ws_sold_date_sk#34]
 Right keys [1]: [d_date_sk#35]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 19]
@@ -303,6 +309,7 @@ Arguments: [c_customer_sk#37 ASC NULLS FIRST], false, 0
 (50) SortMergeJoin [codegen id : 23]
 Left keys [1]: [ws_bill_customer_sk#32]
 Right keys [1]: [c_customer_sk#37]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 23]
@@ -342,6 +349,7 @@ Arguments: [customer_id#44 ASC NULLS FIRST], false, 0
 (58) SortMergeJoin [codegen id : 26]
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#44]
+Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 26]
@@ -369,6 +377,7 @@ Output [2]: [d_date_sk#49, d_year#50]
 (64) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [ws_sold_date_sk#48]
 Right keys [1]: [d_date_sk#49]
+Join type: Inner
 Join condition: None
 
 (65) Project [codegen id : 28]
@@ -393,6 +402,7 @@ Arguments: [c_customer_sk#51 ASC NULLS FIRST], false, 0
 (70) SortMergeJoin [codegen id : 32]
 Left keys [1]: [ws_bill_customer_sk#46]
 Right keys [1]: [c_customer_sk#51]
+Join type: Inner
 Join condition: None
 
 (71) Project [codegen id : 32]
@@ -428,6 +438,7 @@ Arguments: [customer_id#57 ASC NULLS FIRST], false, 0
 (77) SortMergeJoin [codegen id : 35]
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#57]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#45 > 0.00) THEN (year_total#58 / year_total#45) END > CASE WHEN (year_total#15 > 0.00) THEN (year_total#31 / year_total#15) END)
 
 (78) Project [codegen id : 35]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q74/explain.txt
@@ -108,6 +108,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -120,6 +121,7 @@ Output [2]: [d_date_sk#9, d_year#10]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#9]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -184,6 +186,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (24) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_customer_sk#16]
 Right keys [1]: [ss_customer_sk#20]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 6]
@@ -196,6 +199,7 @@ Output [2]: [d_date_sk#24, d_year#25]
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#22]
 Right keys [1]: [d_date_sk#24]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -227,6 +231,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (33) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#28]
+Join type: Inner
 Join condition: None
 
 (34) Scan parquet spark_catalog.default.customer
@@ -265,6 +270,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (41) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#32]
 Right keys [1]: [ws_bill_customer_sk#36]
+Join type: Inner
 Join condition: None
 
 (42) Project [codegen id : 10]
@@ -277,6 +283,7 @@ Output [2]: [d_date_sk#39, d_year#40]
 (44) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ws_sold_date_sk#38]
 Right keys [1]: [d_date_sk#39]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 10]
@@ -312,6 +319,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (51) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#44]
+Join type: Inner
 Join condition: None
 
 (52) Project [codegen id : 16]
@@ -354,6 +362,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [c_customer_sk#46]
 Right keys [1]: [ws_bill_customer_sk#50]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 14]
@@ -366,6 +375,7 @@ Output [2]: [d_date_sk#53, d_year#54]
 (63) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ws_sold_date_sk#52]
 Right keys [1]: [d_date_sk#53]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 14]
@@ -397,6 +407,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, string, true]),false), [pla
 (69) BroadcastHashJoin [codegen id : 16]
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#57]
+Join type: Inner
 Join condition: (CASE WHEN (year_total#45 > 0.00) THEN (year_total#58 / year_total#45) END > CASE WHEN (year_total#15 > 0.00) THEN (year_total#31 / year_total#15) END)
 
 (70) Project [codegen id : 16]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
@@ -170,6 +170,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -182,6 +183,7 @@ Output [2]: [d_date_sk#13, d_year#14]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]
@@ -225,6 +227,7 @@ Arguments: [cr_order_number#16 ASC NULLS FIRST, cr_item_sk#15 ASC NULLS FIRST], 
 (22) SortMergeJoin [codegen id : 7]
 Left keys [2]: [cs_order_number#2, cs_item_sk#1]
 Right keys [2]: [cr_order_number#16, cr_item_sk#15]
+Join type: LeftOuter
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -252,6 +255,7 @@ Output [5]: [i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_man
 (28) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_item_sk#22]
 Right keys [1]: [i_item_sk#27]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
@@ -264,6 +268,7 @@ Output [2]: [d_date_sk#32, d_year#33]
 (31) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#26]
 Right keys [1]: [d_date_sk#32]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 10]
@@ -307,6 +312,7 @@ Arguments: [sr_ticket_number#35 ASC NULLS FIRST, sr_item_sk#34 ASC NULLS FIRST],
 (41) SortMergeJoin [codegen id : 14]
 Left keys [2]: [ss_ticket_number#23, ss_item_sk#22]
 Right keys [2]: [sr_ticket_number#35, sr_item_sk#34]
+Join type: LeftOuter
 Join condition: None
 
 (42) Project [codegen id : 14]
@@ -334,6 +340,7 @@ Output [5]: [i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_man
 (47) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#41]
 Right keys [1]: [i_item_sk#46]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 17]
@@ -346,6 +353,7 @@ Output [2]: [d_date_sk#51, d_year#52]
 (50) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#45]
 Right keys [1]: [d_date_sk#51]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
@@ -389,6 +397,7 @@ Arguments: [wr_order_number#54 ASC NULLS FIRST, wr_item_sk#53 ASC NULLS FIRST], 
 (60) SortMergeJoin [codegen id : 21]
 Left keys [2]: [ws_order_number#42, ws_item_sk#41]
 Right keys [2]: [wr_order_number#54, wr_item_sk#53]
+Join type: LeftOuter
 Join condition: None
 
 (61) Project [codegen id : 21]
@@ -466,6 +475,7 @@ Output [5]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_man
 (76) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_item_sk#68]
 Right keys [1]: [i_item_sk#74]
+Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 28]
@@ -478,6 +488,7 @@ Output [2]: [d_date_sk#79, d_year#80]
 (79) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_sold_date_sk#72]
 Right keys [1]: [d_date_sk#79]
+Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 28]
@@ -502,6 +513,7 @@ Arguments: [cr_order_number#82 ASC NULLS FIRST, cr_item_sk#81 ASC NULLS FIRST], 
 (85) SortMergeJoin [codegen id : 32]
 Left keys [2]: [cs_order_number#69, cs_item_sk#68]
 Right keys [2]: [cr_order_number#82, cr_item_sk#81]
+Join type: LeftOuter
 Join condition: None
 
 (86) Project [codegen id : 32]
@@ -529,6 +541,7 @@ Output [5]: [i_item_sk#90, i_brand_id#91, i_class_id#92, i_category_id#93, i_man
 (91) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_item_sk#85]
 Right keys [1]: [i_item_sk#90]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 35]
@@ -541,6 +554,7 @@ Output [2]: [d_date_sk#95, d_year#96]
 (94) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_sold_date_sk#89]
 Right keys [1]: [d_date_sk#95]
+Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 35]
@@ -565,6 +579,7 @@ Arguments: [sr_ticket_number#98 ASC NULLS FIRST, sr_item_sk#97 ASC NULLS FIRST],
 (100) SortMergeJoin [codegen id : 39]
 Left keys [2]: [ss_ticket_number#86, ss_item_sk#85]
 Right keys [2]: [sr_ticket_number#98, sr_item_sk#97]
+Join type: LeftOuter
 Join condition: None
 
 (101) Project [codegen id : 39]
@@ -592,6 +607,7 @@ Output [5]: [i_item_sk#106, i_brand_id#107, i_class_id#108, i_category_id#109, i
 (106) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ws_item_sk#101]
 Right keys [1]: [i_item_sk#106]
+Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 42]
@@ -604,6 +620,7 @@ Output [2]: [d_date_sk#111, d_year#112]
 (109) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ws_sold_date_sk#105]
 Right keys [1]: [d_date_sk#111]
+Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 42]
@@ -628,6 +645,7 @@ Arguments: [wr_order_number#114 ASC NULLS FIRST, wr_item_sk#113 ASC NULLS FIRST]
 (115) SortMergeJoin [codegen id : 46]
 Left keys [2]: [ws_order_number#102, ws_item_sk#101]
 Right keys [2]: [wr_order_number#114, wr_item_sk#113]
+Join type: LeftOuter
 Join condition: None
 
 (116) Project [codegen id : 46]
@@ -687,6 +705,7 @@ Arguments: [i_brand_id#75 ASC NULLS FIRST, i_class_id#76 ASC NULLS FIRST, i_cate
 (127) SortMergeJoin [codegen id : 51]
 Left keys [4]: [i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
 Right keys [4]: [i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Join type: Inner
 Join condition: ((cast(sales_cnt#66 as decimal(17,2)) / cast(sales_cnt#119 as decimal(17,2))) < 0.90000000000000000000)
 
 (128) Project [codegen id : 51]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75/explain.txt
@@ -170,6 +170,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_item_sk#1]
 Right keys [1]: [i_item_sk#7]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -182,6 +183,7 @@ Output [2]: [d_date_sk#13, d_year#14]
 (12) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_sold_date_sk#5]
 Right keys [1]: [d_date_sk#13]
+Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]
@@ -225,6 +227,7 @@ Arguments: [cr_order_number#16 ASC NULLS FIRST, cr_item_sk#15 ASC NULLS FIRST], 
 (22) SortMergeJoin [codegen id : 7]
 Left keys [2]: [cs_order_number#2, cs_item_sk#1]
 Right keys [2]: [cr_order_number#16, cr_item_sk#15]
+Join type: LeftOuter
 Join condition: None
 
 (23) Project [codegen id : 7]
@@ -252,6 +255,7 @@ Output [5]: [i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_man
 (28) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_item_sk#22]
 Right keys [1]: [i_item_sk#27]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
@@ -264,6 +268,7 @@ Output [2]: [d_date_sk#32, d_year#33]
 (31) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_sold_date_sk#26]
 Right keys [1]: [d_date_sk#32]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 10]
@@ -307,6 +312,7 @@ Arguments: [sr_ticket_number#35 ASC NULLS FIRST, sr_item_sk#34 ASC NULLS FIRST],
 (41) SortMergeJoin [codegen id : 14]
 Left keys [2]: [ss_ticket_number#23, ss_item_sk#22]
 Right keys [2]: [sr_ticket_number#35, sr_item_sk#34]
+Join type: LeftOuter
 Join condition: None
 
 (42) Project [codegen id : 14]
@@ -334,6 +340,7 @@ Output [5]: [i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_man
 (47) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_item_sk#41]
 Right keys [1]: [i_item_sk#46]
+Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 17]
@@ -346,6 +353,7 @@ Output [2]: [d_date_sk#51, d_year#52]
 (50) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#45]
 Right keys [1]: [d_date_sk#51]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
@@ -389,6 +397,7 @@ Arguments: [wr_order_number#54 ASC NULLS FIRST, wr_item_sk#53 ASC NULLS FIRST], 
 (60) SortMergeJoin [codegen id : 21]
 Left keys [2]: [ws_order_number#42, ws_item_sk#41]
 Right keys [2]: [wr_order_number#54, wr_item_sk#53]
+Join type: LeftOuter
 Join condition: None
 
 (61) Project [codegen id : 21]
@@ -466,6 +475,7 @@ Output [5]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_man
 (76) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_item_sk#68]
 Right keys [1]: [i_item_sk#74]
+Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 28]
@@ -478,6 +488,7 @@ Output [2]: [d_date_sk#79, d_year#80]
 (79) BroadcastHashJoin [codegen id : 28]
 Left keys [1]: [cs_sold_date_sk#72]
 Right keys [1]: [d_date_sk#79]
+Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 28]
@@ -502,6 +513,7 @@ Arguments: [cr_order_number#82 ASC NULLS FIRST, cr_item_sk#81 ASC NULLS FIRST], 
 (85) SortMergeJoin [codegen id : 32]
 Left keys [2]: [cs_order_number#69, cs_item_sk#68]
 Right keys [2]: [cr_order_number#82, cr_item_sk#81]
+Join type: LeftOuter
 Join condition: None
 
 (86) Project [codegen id : 32]
@@ -529,6 +541,7 @@ Output [5]: [i_item_sk#90, i_brand_id#91, i_class_id#92, i_category_id#93, i_man
 (91) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_item_sk#85]
 Right keys [1]: [i_item_sk#90]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 35]
@@ -541,6 +554,7 @@ Output [2]: [d_date_sk#95, d_year#96]
 (94) BroadcastHashJoin [codegen id : 35]
 Left keys [1]: [ss_sold_date_sk#89]
 Right keys [1]: [d_date_sk#95]
+Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 35]
@@ -565,6 +579,7 @@ Arguments: [sr_ticket_number#98 ASC NULLS FIRST, sr_item_sk#97 ASC NULLS FIRST],
 (100) SortMergeJoin [codegen id : 39]
 Left keys [2]: [ss_ticket_number#86, ss_item_sk#85]
 Right keys [2]: [sr_ticket_number#98, sr_item_sk#97]
+Join type: LeftOuter
 Join condition: None
 
 (101) Project [codegen id : 39]
@@ -592,6 +607,7 @@ Output [5]: [i_item_sk#106, i_brand_id#107, i_class_id#108, i_category_id#109, i
 (106) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ws_item_sk#101]
 Right keys [1]: [i_item_sk#106]
+Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 42]
@@ -604,6 +620,7 @@ Output [2]: [d_date_sk#111, d_year#112]
 (109) BroadcastHashJoin [codegen id : 42]
 Left keys [1]: [ws_sold_date_sk#105]
 Right keys [1]: [d_date_sk#111]
+Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 42]
@@ -628,6 +645,7 @@ Arguments: [wr_order_number#114 ASC NULLS FIRST, wr_item_sk#113 ASC NULLS FIRST]
 (115) SortMergeJoin [codegen id : 46]
 Left keys [2]: [ws_order_number#102, ws_item_sk#101]
 Right keys [2]: [wr_order_number#114, wr_item_sk#113]
+Join type: LeftOuter
 Join condition: None
 
 (116) Project [codegen id : 46]
@@ -687,6 +705,7 @@ Arguments: [i_brand_id#75 ASC NULLS FIRST, i_class_id#76 ASC NULLS FIRST, i_cate
 (127) SortMergeJoin [codegen id : 51]
 Left keys [4]: [i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
 Right keys [4]: [i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Join type: Inner
 Join condition: ((cast(sales_cnt#66 as decimal(17,2)) / cast(sales_cnt#119 as decimal(17,2))) < 0.90000000000000000000)
 
 (128) Project [codegen id : 51]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
@@ -120,6 +120,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -147,6 +148,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -192,6 +194,7 @@ Output [1]: [d_date_sk#20]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_returned_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -204,6 +207,7 @@ Output [1]: [s_store_sk#21]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_store_sk#16]
 Right keys [1]: [s_store_sk#21]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -235,6 +239,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
 Right keys [1]: [s_store_sk#21]
+Join type: LeftOuter
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -257,6 +262,7 @@ Output [1]: [d_date_sk#38]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#37]
 Right keys [1]: [d_date_sk#38]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -297,6 +303,7 @@ Output [1]: [d_date_sk#50]
 (42) BroadcastHashJoin [codegen id : 12]
 Left keys [1]: [cr_returned_date_sk#49]
 Right keys [1]: [d_date_sk#50]
+Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 12]
@@ -326,6 +333,7 @@ Input [2]: [returns#57, profit_loss#58]
 Arguments: IdentityBroadcastMode, [plan_id=7]
 
 (48) BroadcastNestedLoopJoin [codegen id : 14]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 14]
@@ -353,6 +361,7 @@ Output [1]: [d_date_sk#66]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#65]
 Right keys [1]: [d_date_sk#66]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]
@@ -380,6 +389,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#62]
 Right keys [1]: [wp_web_page_sk#67]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 17]
@@ -425,6 +435,7 @@ Output [1]: [d_date_sk#80]
 (69) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_returned_date_sk#79]
 Right keys [1]: [d_date_sk#80]
+Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 20]
@@ -437,6 +448,7 @@ Output [1]: [wp_web_page_sk#81]
 (72) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_web_page_sk#76]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 20]
@@ -468,6 +480,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#67]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: LeftOuter
 Join condition: None
 
 (79) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a/explain.txt
@@ -120,6 +120,7 @@ Output [1]: [d_date_sk#6]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -147,6 +148,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#7]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
@@ -192,6 +194,7 @@ Output [1]: [d_date_sk#20]
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_returned_date_sk#19]
 Right keys [1]: [d_date_sk#20]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -204,6 +207,7 @@ Output [1]: [s_store_sk#21]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [sr_store_sk#16]
 Right keys [1]: [s_store_sk#21]
+Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
@@ -235,6 +239,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_store_sk#7]
 Right keys [1]: [s_store_sk#21]
+Join type: LeftOuter
 Join condition: None
 
 (30) Project [codegen id : 8]
@@ -257,6 +262,7 @@ Output [1]: [d_date_sk#38]
 (34) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cs_sold_date_sk#37]
 Right keys [1]: [d_date_sk#38]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 10]
@@ -301,6 +307,7 @@ Output [1]: [d_date_sk#50]
 (43) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [cr_returned_date_sk#49]
 Right keys [1]: [d_date_sk#50]
+Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
@@ -326,6 +333,7 @@ Aggregate Attributes [2]: [sum(UnscaledValue(cr_return_amount#47))#55, sum(Unsca
 Results [2]: [MakeDecimal(sum(UnscaledValue(cr_return_amount#47))#55,17,2) AS returns#57, MakeDecimal(sum(UnscaledValue(cr_net_loss#48))#56,17,2) AS profit_loss#58]
 
 (48) BroadcastNestedLoopJoin [codegen id : 14]
+Join type: Inner
 Join condition: None
 
 (49) Project [codegen id : 14]
@@ -353,6 +361,7 @@ Output [1]: [d_date_sk#66]
 (54) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_sold_date_sk#65]
 Right keys [1]: [d_date_sk#66]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 17]
@@ -380,6 +389,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#62]
 Right keys [1]: [wp_web_page_sk#67]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 17]
@@ -425,6 +435,7 @@ Output [1]: [d_date_sk#80]
 (69) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_returned_date_sk#79]
 Right keys [1]: [d_date_sk#80]
+Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 20]
@@ -437,6 +448,7 @@ Output [1]: [wp_web_page_sk#81]
 (72) BroadcastHashJoin [codegen id : 20]
 Left keys [1]: [wr_web_page_sk#76]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 20]
@@ -468,6 +480,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (78) BroadcastHashJoin [codegen id : 22]
 Left keys [1]: [wp_web_page_sk#67]
 Right keys [1]: [wp_web_page_sk#81]
+Join type: LeftOuter
 Join condition: None
 
 (79) Project [codegen id : 22]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78.sf100/explain.txt
@@ -123,6 +123,7 @@ Arguments: [sr_ticket_number#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], 
 (12) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ss_ticket_number#3, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#10, sr_item_sk#9]
+Join type: LeftOuter
 Join condition: None
 
 (13) Filter [codegen id : 6]
@@ -139,6 +140,7 @@ Output [2]: [d_date_sk#12, d_year#13]
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -219,6 +221,7 @@ Arguments: [wr_order_number#35 ASC NULLS FIRST, wr_item_sk#34 ASC NULLS FIRST], 
 (33) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ws_order_number#29, ws_item_sk#27]
 Right keys [2]: [wr_order_number#35, wr_item_sk#34]
+Join type: LeftOuter
 Join condition: None
 
 (34) Filter [codegen id : 13]
@@ -235,6 +238,7 @@ Output [2]: [d_date_sk#37, d_year#38]
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_sold_date_sk#33]
 Right keys [1]: [d_date_sk#37]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
@@ -270,6 +274,7 @@ Arguments: [ws_sold_year#48 ASC NULLS FIRST, ws_item_sk#27 ASC NULLS FIRST, ws_c
 (44) SortMergeJoin [codegen id : 15]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 15]
@@ -328,6 +333,7 @@ Arguments: [cr_order_number#61 ASC NULLS FIRST, cr_item_sk#60 ASC NULLS FIRST], 
 (57) SortMergeJoin [codegen id : 21]
 Left keys [2]: [cs_order_number#55, cs_item_sk#54]
 Right keys [2]: [cr_order_number#61, cr_item_sk#60]
+Join type: LeftOuter
 Join condition: None
 
 (58) Filter [codegen id : 21]
@@ -344,6 +350,7 @@ Output [2]: [d_date_sk#63, d_year#64]
 (61) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_sold_date_sk#59]
 Right keys [1]: [d_date_sk#63]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 21]
@@ -379,6 +386,7 @@ Arguments: [cs_sold_year#74 ASC NULLS FIRST, cs_item_sk#54 ASC NULLS FIRST, cs_c
 (68) SortMergeJoin [codegen id : 23]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75]
+Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 23]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q78/explain.txt
@@ -123,6 +123,7 @@ Arguments: [sr_ticket_number#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], 
 (12) SortMergeJoin [codegen id : 6]
 Left keys [2]: [ss_ticket_number#3, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#10, sr_item_sk#9]
+Join type: LeftOuter
 Join condition: None
 
 (13) Filter [codegen id : 6]
@@ -139,6 +140,7 @@ Output [2]: [d_date_sk#12, d_year#13]
 (16) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#12]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 6]
@@ -219,6 +221,7 @@ Arguments: [wr_order_number#35 ASC NULLS FIRST, wr_item_sk#34 ASC NULLS FIRST], 
 (33) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ws_order_number#29, ws_item_sk#27]
 Right keys [2]: [wr_order_number#35, wr_item_sk#34]
+Join type: LeftOuter
 Join condition: None
 
 (34) Filter [codegen id : 13]
@@ -235,6 +238,7 @@ Output [2]: [d_date_sk#37, d_year#38]
 (37) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [ws_sold_date_sk#33]
 Right keys [1]: [d_date_sk#37]
+Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
@@ -270,6 +274,7 @@ Arguments: [ws_sold_year#48 ASC NULLS FIRST, ws_item_sk#27 ASC NULLS FIRST, ws_c
 (44) SortMergeJoin [codegen id : 15]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [ws_sold_year#48, ws_item_sk#27, ws_customer_sk#49]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 15]
@@ -328,6 +333,7 @@ Arguments: [cr_order_number#61 ASC NULLS FIRST, cr_item_sk#60 ASC NULLS FIRST], 
 (57) SortMergeJoin [codegen id : 21]
 Left keys [2]: [cs_order_number#55, cs_item_sk#54]
 Right keys [2]: [cr_order_number#61, cr_item_sk#60]
+Join type: LeftOuter
 Join condition: None
 
 (58) Filter [codegen id : 21]
@@ -344,6 +350,7 @@ Output [2]: [d_date_sk#63, d_year#64]
 (61) BroadcastHashJoin [codegen id : 21]
 Left keys [1]: [cs_sold_date_sk#59]
 Right keys [1]: [d_date_sk#63]
+Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 21]
@@ -379,6 +386,7 @@ Arguments: [cs_sold_year#74 ASC NULLS FIRST, cs_item_sk#54 ASC NULLS FIRST, cs_c
 (68) SortMergeJoin [codegen id : 23]
 Left keys [3]: [ss_sold_year#23, ss_item_sk#1, ss_customer_sk#2]
 Right keys [3]: [cs_sold_year#74, cs_item_sk#54, cs_customer_sk#75]
+Join type: Inner
 Join condition: None
 
 (69) Project [codegen id : 23]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -255,6 +255,7 @@ Arguments: [sr_item_sk#13 ASC NULLS FIRST, sr_ticket_number#14 ASC NULLS FIRST],
 (12) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
 Right keys [2]: [sr_item_sk#13, sr_ticket_number#14]
+Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 9]
@@ -286,6 +287,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (19) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 9]
@@ -317,6 +319,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (26) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#20]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 9]
@@ -329,6 +332,7 @@ Output [1]: [d_date_sk#22]
 (29) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (30) Project [codegen id : 9]
@@ -356,6 +360,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#23]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
@@ -432,6 +437,7 @@ Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], 
 (51) SortMergeJoin [codegen id : 19]
 Left keys [2]: [cs_item_sk#44, cs_order_number#46]
 Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+Join type: LeftOuter
 Join condition: None
 
 (52) Project [codegen id : 19]
@@ -444,6 +450,7 @@ Output [1]: [i_item_sk#55]
 (54) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_item_sk#44]
 Right keys [1]: [i_item_sk#55]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
@@ -456,6 +463,7 @@ Output [1]: [p_promo_sk#56]
 (57) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_promo_sk#45]
 Right keys [1]: [p_promo_sk#56]
+Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 19]
@@ -468,6 +476,7 @@ Output [1]: [d_date_sk#57]
 (60) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_sold_date_sk#49]
 Right keys [1]: [d_date_sk#57]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 19]
@@ -495,6 +504,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (66) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#43]
 Right keys [1]: [cp_catalog_page_sk#58]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
@@ -571,6 +581,7 @@ Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], 
 (82) SortMergeJoin [codegen id : 29]
 Left keys [2]: [ws_item_sk#78, ws_order_number#81]
 Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+Join type: LeftOuter
 Join condition: None
 
 (83) Project [codegen id : 29]
@@ -583,6 +594,7 @@ Output [1]: [i_item_sk#90]
 (85) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_item_sk#78]
 Right keys [1]: [i_item_sk#90]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
@@ -595,6 +607,7 @@ Output [1]: [p_promo_sk#91]
 (88) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_promo_sk#80]
 Right keys [1]: [p_promo_sk#91]
+Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 29]
@@ -607,6 +620,7 @@ Output [1]: [d_date_sk#92]
 (91) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_sold_date_sk#84]
 Right keys [1]: [d_date_sk#92]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 29]
@@ -634,6 +648,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (97) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#79]
 Right keys [1]: [web_site_sk#93]
+Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]
@@ -731,6 +746,7 @@ Arguments: [wr_item_sk#85 ASC NULLS FIRST, wr_order_number#86 ASC NULLS FIRST], 
 (117) SortMergeJoin [codegen id : 61]
 Left keys [2]: [ws_item_sk#78, ws_order_number#81]
 Right keys [2]: [wr_item_sk#85, wr_order_number#86]
+Join type: LeftOuter
 Join condition: None
 
 (118) Project [codegen id : 61]
@@ -743,6 +759,7 @@ Output [1]: [i_item_sk#90]
 (120) BroadcastHashJoin [codegen id : 61]
 Left keys [1]: [ws_item_sk#78]
 Right keys [1]: [i_item_sk#90]
+Join type: Inner
 Join condition: None
 
 (121) Project [codegen id : 61]
@@ -755,6 +772,7 @@ Output [1]: [p_promo_sk#91]
 (123) BroadcastHashJoin [codegen id : 61]
 Left keys [1]: [ws_promo_sk#80]
 Right keys [1]: [p_promo_sk#91]
+Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 61]
@@ -767,6 +785,7 @@ Output [1]: [d_date_sk#92]
 (126) BroadcastHashJoin [codegen id : 61]
 Left keys [1]: [ws_sold_date_sk#84]
 Right keys [1]: [d_date_sk#92]
+Join type: Inner
 Join condition: None
 
 (127) Project [codegen id : 61]
@@ -779,6 +798,7 @@ Output [2]: [web_site_sk#93, web_site_id#94]
 (129) BroadcastHashJoin [codegen id : 61]
 Left keys [1]: [ws_web_site_sk#79]
 Right keys [1]: [web_site_sk#93]
+Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 61]
@@ -874,6 +894,7 @@ Arguments: [sr_item_sk#13 ASC NULLS FIRST, sr_ticket_number#14 ASC NULLS FIRST],
 (148) SortMergeJoin [codegen id : 74]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
 Right keys [2]: [sr_item_sk#13, sr_ticket_number#14]
+Join type: LeftOuter
 Join condition: None
 
 (149) Project [codegen id : 74]
@@ -886,6 +907,7 @@ Output [1]: [i_item_sk#18]
 (151) BroadcastHashJoin [codegen id : 74]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#18]
+Join type: Inner
 Join condition: None
 
 (152) Project [codegen id : 74]
@@ -898,6 +920,7 @@ Output [1]: [p_promo_sk#20]
 (154) BroadcastHashJoin [codegen id : 74]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#20]
+Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 74]
@@ -910,6 +933,7 @@ Output [1]: [d_date_sk#22]
 (157) BroadcastHashJoin [codegen id : 74]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#22]
+Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 74]
@@ -922,6 +946,7 @@ Output [2]: [s_store_sk#23, s_store_id#24]
 (160) BroadcastHashJoin [codegen id : 74]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#23]
+Join type: Inner
 Join condition: None
 
 (161) Project [codegen id : 74]
@@ -979,6 +1004,7 @@ Arguments: [cr_item_sk#50 ASC NULLS FIRST, cr_order_number#51 ASC NULLS FIRST], 
 (172) SortMergeJoin [codegen id : 84]
 Left keys [2]: [cs_item_sk#44, cs_order_number#46]
 Right keys [2]: [cr_item_sk#50, cr_order_number#51]
+Join type: LeftOuter
 Join condition: None
 
 (173) Project [codegen id : 84]
@@ -991,6 +1017,7 @@ Output [1]: [i_item_sk#55]
 (175) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [cs_item_sk#44]
 Right keys [1]: [i_item_sk#55]
+Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 84]
@@ -1003,6 +1030,7 @@ Output [1]: [p_promo_sk#56]
 (178) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [cs_promo_sk#45]
 Right keys [1]: [p_promo_sk#56]
+Join type: Inner
 Join condition: None
 
 (179) Project [codegen id : 84]
@@ -1015,6 +1043,7 @@ Output [1]: [d_date_sk#57]
 (181) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [cs_sold_date_sk#49]
 Right keys [1]: [d_date_sk#57]
+Join type: Inner
 Join condition: None
 
 (182) Project [codegen id : 84]
@@ -1027,6 +1056,7 @@ Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
 (184) BroadcastHashJoin [codegen id : 84]
 Left keys [1]: [cs_catalog_page_sk#43]
 Right keys [1]: [cp_catalog_page_sk#58]
+Join type: Inner
 Join condition: None
 
 (185) Project [codegen id : 84]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a/explain.txt
@@ -173,6 +173,7 @@ Arguments: [sr_item_sk#9 ASC NULLS FIRST, sr_ticket_number#10 ASC NULLS FIRST], 
 (12) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ss_item_sk#1, ss_ticket_number#4]
 Right keys [2]: [sr_item_sk#9, sr_ticket_number#10]
+Join type: LeftOuter
 Join condition: None
 
 (13) Project [codegen id : 9]
@@ -185,6 +186,7 @@ Output [1]: [d_date_sk#14]
 (15) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_sold_date_sk#7]
 Right keys [1]: [d_date_sk#14]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 9]
@@ -212,6 +214,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (21) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#15]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 9]
@@ -243,6 +246,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (28) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#17]
+Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 9]
@@ -274,6 +278,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint))
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_promo_sk#3]
 Right keys [1]: [p_promo_sk#19]
+Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
@@ -350,6 +355,7 @@ Arguments: [cr_item_sk#46 ASC NULLS FIRST, cr_order_number#47 ASC NULLS FIRST], 
 (51) SortMergeJoin [codegen id : 19]
 Left keys [2]: [cs_item_sk#40, cs_order_number#42]
 Right keys [2]: [cr_item_sk#46, cr_order_number#47]
+Join type: LeftOuter
 Join condition: None
 
 (52) Project [codegen id : 19]
@@ -362,6 +368,7 @@ Output [1]: [d_date_sk#51]
 (54) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_sold_date_sk#45]
 Right keys [1]: [d_date_sk#51]
+Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
@@ -389,6 +396,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (60) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#39]
 Right keys [1]: [cp_catalog_page_sk#52]
+Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 19]
@@ -401,6 +409,7 @@ Output [1]: [i_item_sk#54]
 (63) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_item_sk#40]
 Right keys [1]: [i_item_sk#54]
+Join type: Inner
 Join condition: None
 
 (64) Project [codegen id : 19]
@@ -413,6 +422,7 @@ Output [1]: [p_promo_sk#55]
 (66) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_promo_sk#41]
 Right keys [1]: [p_promo_sk#55]
+Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
@@ -489,6 +499,7 @@ Arguments: [wr_item_sk#81 ASC NULLS FIRST, wr_order_number#82 ASC NULLS FIRST], 
 (82) SortMergeJoin [codegen id : 29]
 Left keys [2]: [ws_item_sk#74, ws_order_number#77]
 Right keys [2]: [wr_item_sk#81, wr_order_number#82]
+Join type: LeftOuter
 Join condition: None
 
 (83) Project [codegen id : 29]
@@ -501,6 +512,7 @@ Output [1]: [d_date_sk#86]
 (85) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_sold_date_sk#80]
 Right keys [1]: [d_date_sk#86]
+Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
@@ -528,6 +540,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (91) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#75]
 Right keys [1]: [web_site_sk#87]
+Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 29]
@@ -540,6 +553,7 @@ Output [1]: [i_item_sk#89]
 (94) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_item_sk#74]
 Right keys [1]: [i_item_sk#89]
+Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 29]
@@ -552,6 +566,7 @@ Output [1]: [p_promo_sk#90]
 (97) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_promo_sk#76]
 Right keys [1]: [p_promo_sk#90]
+Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a.sf100/explain.txt
@@ -56,6 +56,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -83,6 +84,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q86a/explain.txt
@@ -56,6 +56,7 @@ Output [1]: [d_date_sk#5]
 (5) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_sold_date_sk#3]
 Right keys [1]: [d_date_sk#5]
+Join type: Inner
 Join condition: None
 
 (6) Project [codegen id : 3]
@@ -83,6 +84,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ws_item_sk#1]
 Right keys [1]: [i_item_sk#6]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98.sf100/explain.txt
@@ -73,6 +73,7 @@ Arguments: [i_item_sk#5 ASC NULLS FIRST], false, 0
 (11) SortMergeJoin [codegen id : 6]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 6]
@@ -85,6 +86,7 @@ Output [1]: [d_date_sk#11]
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q98/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#1]
 Right keys [1]: [i_item_sk#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -70,6 +71,7 @@ Output [1]: [d_date_sk#11]
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_sold_date_sk#3]
 Right keys [1]: [d_date_sk#11]
+Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q10/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q10/explain.txt
@@ -67,6 +67,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [pla
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_custkey#1]
 Right keys [1]: [o_custkey#9]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (16) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [o_orderkey#8]
 Right keys [1]: [l_orderkey#11]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 4]
@@ -125,6 +127,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (22) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_nationkey#4]
 Right keys [1]: [n_nationkey#15]
+Join type: Inner
 Join condition: None
 
 (23) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpch-plan-stability/q11/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q11/explain.txt
@@ -58,6 +58,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_suppkey#2]
 Right keys [1]: [s_suppkey#5]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 3]
@@ -89,6 +90,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [s_nationkey#6]
 Right keys [1]: [n_nationkey#7]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 3]
@@ -162,6 +164,7 @@ Output [2]: [s_suppkey#20, s_nationkey#21]
 (27) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_suppkey#17]
 Right keys [1]: [s_suppkey#20]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 3]
@@ -174,6 +177,7 @@ Output [1]: [n_nationkey#22]
 (30) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [s_nationkey#21]
 Right keys [1]: [n_nationkey#22]
+Join type: Inner
 Join condition: None
 
 (31) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q12/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q12/explain.txt
@@ -55,6 +55,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [o_orderkey#1]
 Right keys [1]: [l_orderkey#3]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q13/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q13/explain.txt
@@ -52,6 +52,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [pla
 (8) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_custkey#1]
 Right keys [1]: [o_custkey#3]
+Join type: LeftOuter
 Join condition: None
 
 (9) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q14/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q14/explain.txt
@@ -53,6 +53,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [l_partkey#1]
 Right keys [1]: [p_partkey#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q15/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q15/explain.txt
@@ -78,6 +78,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (13) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [s_suppkey#1]
 Right keys [1]: [supplier_no#14]
+Join type: Inner
 Join condition: None
 
 (14) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q16/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q16/explain.txt
@@ -63,6 +63,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),true), [plan
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_suppkey#2]
 Right keys [1]: [s_suppkey#3]
+Join type: LeftAnti
 Join condition: None
 
 (10) Scan parquet spark_catalog.default.part
@@ -86,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (14) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ps_partkey#1]
 Right keys [1]: [p_partkey#5]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q17/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q17/explain.txt
@@ -63,6 +63,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [l_partkey#1]
 Right keys [1]: [p_partkey#4]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 4]
@@ -112,6 +113,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [pla
 (19) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [p_partkey#4]
 Right keys [1]: [l_partkey#8]
+Join type: Inner
 Join condition: (cast(l_quantity#2 as decimal(16,5)) < (0.2 * avg(l_quantity))#15)
 
 (20) Project [codegen id : 4]

--- a/sql/core/src/test/resources/tpch-plan-stability/q18/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q18/explain.txt
@@ -101,6 +101,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (15) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [o_orderkey#3]
 Right keys [1]: [l_orderkey#7]
+Join type: LeftSemi
 Join condition: None
 
 (16) BroadcastExchange
@@ -110,6 +111,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [pl
 (17) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [c_custkey#1]
 Right keys [1]: [o_custkey#4]
+Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 7]
@@ -136,6 +138,7 @@ Output [1]: [l_orderkey#7]
 (23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#16]
 Right keys [1]: [l_orderkey#7]
+Join type: LeftSemi
 Join condition: None
 
 (24) BroadcastExchange
@@ -145,6 +148,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [o_orderkey#3]
 Right keys [1]: [l_orderkey#16]
+Join type: Inner
 Join condition: None
 
 (26) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpch-plan-stability/q19/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q19/explain.txt
@@ -53,6 +53,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (9) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [l_partkey#1]
 Right keys [1]: [p_partkey#7]
+Join type: Inner
 Join condition: (((((((p_brand#8 = Brand#11) AND p_container#10 IN (SM CASE,SM BOX,SM PACK,SM PKG)) AND (l_quantity#2 >= 1)) AND (l_quantity#2 <= 11)) AND (p_size#9 <= 5)) OR (((((p_brand#8 = Brand#12) AND p_container#10 IN (MED BAG,MED BOX,MED PKG,MED PACK)) AND (l_quantity#2 >= 10)) AND (l_quantity#2 <= 20)) AND (p_size#9 <= 10))) OR (((((p_brand#8 = Brand#13) AND p_container#10 IN (LG CASE,LG BOX,LG PACK,LG PKG)) AND (l_quantity#2 >= 20)) AND (l_quantity#2 <= 30)) AND (p_size#9 <= 15)))
 
 (10) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q2/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q2/explain.txt
@@ -95,6 +95,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (9) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [p_partkey#1]
 Right keys [1]: [ps_partkey#5]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 10]
@@ -136,6 +137,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (18) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ps_suppkey#9]
 Right keys [1]: [s_suppkey#11]
+Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 5]
@@ -163,6 +165,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [s_nationkey#12]
 Right keys [1]: [n_nationkey#13]
+Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
@@ -194,6 +197,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (31) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [n_regionkey#14]
 Right keys [1]: [r_regionkey#15]
+Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 5]
@@ -229,6 +233,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, decimal(10,0), false], inpu
 (38) BroadcastHashJoin [codegen id : 10]
 Left keys [2]: [ps_supplycost#7, p_partkey#1]
 Right keys [2]: [min(ps_supplycost)#20, ps_partkey#8]
+Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 10]
@@ -256,6 +261,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (44) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ps_suppkey#6]
 Right keys [1]: [s_suppkey#21]
+Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 10]
@@ -283,6 +289,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (50) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [s_nationkey#24]
 Right keys [1]: [n_nationkey#28]
+Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 10]
@@ -295,6 +302,7 @@ Output [1]: [r_regionkey#31]
 (53) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [n_regionkey#30]
 Right keys [1]: [r_regionkey#31]
+Join type: Inner
 Join condition: None
 
 (54) Project [codegen id : 10]

--- a/sql/core/src/test/resources/tpch-plan-stability/q20/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q20/explain.txt
@@ -91,6 +91,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ps_partkey#5]
 Right keys [1]: [p_partkey#8]
+Join type: LeftSemi
 Join condition: None
 
 (13) Scan parquet spark_catalog.default.lineitem
@@ -117,6 +118,7 @@ Output [1]: [p_partkey#8]
 (18) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [l_partkey#10]
 Right keys [1]: [p_partkey#8]
+Join type: LeftSemi
 Join condition: None
 
 (19) HashAggregate [codegen id : 3]
@@ -148,6 +150,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true], input[2, big
 (24) BroadcastHashJoin [codegen id : 5]
 Left keys [2]: [ps_partkey#5, ps_suppkey#6]
 Right keys [2]: [l_partkey#10, l_suppkey#11]
+Join type: Inner
 Join condition: (cast(ps_availqty#7 as decimal(22,1)) > (0.5 * sum(l_quantity))#19)
 
 (25) Project [codegen id : 5]
@@ -161,6 +164,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (27) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_suppkey#1]
 Right keys [1]: [ps_suppkey#6]
+Join type: LeftSemi
 Join condition: None
 
 (28) Project [codegen id : 7]
@@ -192,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (34) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [s_nationkey#4]
 Right keys [1]: [n_nationkey#20]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 7]

--- a/sql/core/src/test/resources/tpch-plan-stability/q21/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q21/explain.txt
@@ -87,6 +87,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (11) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [l_orderkey#4]
 Right keys [1]: [l_orderkey#8]
+Join type: LeftSemi
 Join condition: NOT (l_suppkey#9 = l_suppkey#5)
 
 (12) Scan parquet spark_catalog.default.lineitem
@@ -114,6 +115,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (17) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [l_orderkey#4]
 Right keys [1]: [l_orderkey#10]
+Join type: LeftAnti
 Join condition: NOT (l_suppkey#11 = l_suppkey#5)
 
 (18) BroadcastExchange
@@ -123,6 +125,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [pla
 (19) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_suppkey#1]
 Right keys [1]: [l_suppkey#5]
+Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 6]
@@ -154,6 +157,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (26) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#4]
 Right keys [1]: [o_orderkey#14]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 6]
@@ -185,6 +189,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (33) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#3]
 Right keys [1]: [n_nationkey#16]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpch-plan-stability/q22/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q22/explain.txt
@@ -44,6 +44,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (7) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [c_custkey#1]
 Right keys [1]: [o_custkey#6]
+Join type: LeftAnti
 Join condition: None
 
 (8) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q3/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q3/explain.txt
@@ -61,6 +61,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [pl
 (9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [c_custkey#1]
 Right keys [1]: [o_custkey#4]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 3]
@@ -92,6 +93,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [o_orderkey#3]
 Right keys [1]: [l_orderkey#7]
+Join type: Inner
 Join condition: None
 
 (17) Project [codegen id : 3]

--- a/sql/core/src/test/resources/tpch-plan-stability/q4/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q4/explain.txt
@@ -60,6 +60,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (10) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [o_orderkey#1]
 Right keys [1]: [l_orderkey#4]
+Join type: LeftSemi
 Join condition: None
 
 (11) Project [codegen id : 2]

--- a/sql/core/src/test/resources/tpch-plan-stability/q5/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q5/explain.txt
@@ -80,6 +80,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, true]),false), [pla
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_custkey#1]
 Right keys [1]: [o_custkey#4]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 6]
@@ -107,6 +108,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [o_orderkey#3]
 Right keys [1]: [l_orderkey#6]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 6]
@@ -134,6 +136,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false], input[1, bi
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [2]: [l_suppkey#7, c_nationkey#2]
 Right keys [2]: [s_suppkey#10, s_nationkey#11]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -161,6 +164,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#11]
 Right keys [1]: [n_nationkey#12]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -192,6 +196,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (34) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [n_regionkey#14]
 Right keys [1]: [r_regionkey#15]
+Join type: Inner
 Join condition: None
 
 (35) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpch-plan-stability/q7/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q7/explain.txt
@@ -71,6 +71,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [pl
 (8) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_suppkey#1]
 Right keys [1]: [l_suppkey#4]
+Join type: Inner
 Join condition: None
 
 (9) Project [codegen id : 6]
@@ -98,6 +99,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (14) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#3]
 Right keys [1]: [o_orderkey#8]
+Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 6]
@@ -125,6 +127,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (20) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [o_custkey#9]
 Right keys [1]: [c_custkey#10]
+Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
@@ -152,6 +155,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (26) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#2]
 Right keys [1]: [n_nationkey#12]
+Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 6]
@@ -164,6 +168,7 @@ Output [2]: [n_nationkey#14, n_name#15]
 (29) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [c_nationkey#11]
 Right keys [1]: [n_nationkey#14]
+Join type: Inner
 Join condition: (((n_name#13 = FRANCE) AND (n_name#15 = GERMANY)) OR ((n_name#13 = GERMANY) AND (n_name#15 = FRANCE)))
 
 (30) Project [codegen id : 6]

--- a/sql/core/src/test/resources/tpch-plan-stability/q8/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q8/explain.txt
@@ -92,6 +92,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [pl
 (9) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [p_partkey#1]
 Right keys [1]: [l_partkey#4]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 8]
@@ -119,6 +120,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (15) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [l_suppkey#5]
 Right keys [1]: [s_suppkey#8]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 8]
@@ -146,6 +148,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (21) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [l_orderkey#3]
 Right keys [1]: [o_orderkey#10]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 8]
@@ -173,6 +176,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (27) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [o_custkey#11]
 Right keys [1]: [c_custkey#13]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 8]
@@ -200,6 +204,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (33) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_nationkey#14]
 Right keys [1]: [n_nationkey#15]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 8]
@@ -227,6 +232,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (39) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [s_nationkey#9]
 Right keys [1]: [n_nationkey#17]
+Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 8]
@@ -258,6 +264,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, true]),false), [pla
 (46) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [n_regionkey#16]
 Right keys [1]: [r_regionkey#19]
+Join type: Inner
 Join condition: None
 
 (47) Project [codegen id : 8]

--- a/sql/core/src/test/resources/tpch-plan-stability/q9/explain.txt
+++ b/sql/core/src/test/resources/tpch-plan-stability/q9/explain.txt
@@ -79,6 +79,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false]),false), [pl
 (9) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [p_partkey#1]
 Right keys [1]: [l_partkey#4]
+Join type: Inner
 Join condition: None
 
 (10) Project [codegen id : 6]
@@ -106,6 +107,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (15) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_suppkey#5]
 Right keys [1]: [s_suppkey#9]
+Join type: Inner
 Join condition: None
 
 (16) Project [codegen id : 6]
@@ -133,6 +135,7 @@ Arguments: HashedRelationBroadcastMode(List(input[1, bigint, false], input[0, bi
 (21) BroadcastHashJoin [codegen id : 6]
 Left keys [2]: [l_suppkey#5, l_partkey#4]
 Right keys [2]: [ps_suppkey#12, ps_partkey#11]
+Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 6]
@@ -160,6 +163,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (27) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [l_orderkey#3]
 Right keys [1]: [o_orderkey#14]
+Join type: Inner
 Join condition: None
 
 (28) Project [codegen id : 6]
@@ -187,6 +191,7 @@ Arguments: HashedRelationBroadcastMode(List(input[0, bigint, false]),false), [pl
 (33) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [s_nationkey#10]
 Right keys [1]: [n_nationkey#16]
+Join type: Inner
 Join condition: None
 
 (34) Project [codegen id : 6]

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -599,6 +599,7 @@ class ExplainSuiteAE extends ExplainSuiteHelper with EnableAdaptiveExecutionSuit
         |(16) BroadcastHashJoin
         |Left keys [1]: [k#x]
         |Right keys [1]: [k#x]
+        |Join type: Inner
         |Join condition: None
         |""".stripMargin,
       """


### PR DESCRIPTION

### What changes were proposed in this pull request?
The current verbose string of LogicalPlan didn't contain join type, we should add this
```
(10) BroadcastHashJoin [codegen id : 4]
Left keys [1]: [ws_sold_date_sk#7]
Right keys [1]: [d_date_sk#9]
Join type: Inner
Join condition: None
```



### Why are the changes needed?
Add missed join type in verbose plan


### Does this PR introduce _any_ user-facing change?
User can see join type in verbose plan string

### How was this patch tested?
Existed UT
