### PR TITLE
[SPARK-39775][CORE][AVRO] Disable validate default values when parsing Avro schemas

### DIFF
--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDataToCatalyst.scala
@@ -53,7 +53,8 @@ private[avro] case class AvroDataToCatalyst(
 
   private lazy val avroOptions = AvroOptions(options)
 
-  @transient private lazy val actualSchema = new Schema.Parser().parse(jsonFormatSchema)
+  @transient private lazy val actualSchema =
+    new Schema.Parser().setValidateDefaults(false).parse(jsonFormatSchema)
 
   @transient private lazy val expectedSchema = avroOptions.schema.getOrElse(actualSchema)
 

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -54,13 +54,13 @@ private[sql] class AvroOptions(
    * instead of "string" type in the default converted schema.
    */
   val schema: Option[Schema] = {
-    parameters.get("avroSchema").map(new Schema.Parser().parse).orElse({
+    parameters.get("avroSchema").map(new Schema.Parser().setValidateDefaults(false).parse).orElse({
       val avroUrlSchema = parameters.get("avroSchemaUrl").map(url => {
         log.debug("loading avro schema from url: " + url)
         val fs = FileSystem.get(new URI(url), conf)
         val in = fs.open(new Path(url))
         try {
-          new Schema.Parser().parse(in)
+          new Schema.Parser().setValidateDefaults(false).parse(in)
         } finally {
           in.close()
         }

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
@@ -36,8 +36,7 @@ private[sql] class AvroOutputWriterFactory(
     avroSchemaAsJsonString: String,
     positionalFieldMatching: Boolean) extends OutputWriterFactory {
 
-  private lazy val avroSchema =
-    new Schema.Parser().setValidateDefaults(false).parse(avroSchemaAsJsonString)
+  private lazy val avroSchema = new Schema.Parser().parse(avroSchemaAsJsonString)
 
   override def getFileExtension(context: TaskAttemptContext): String = ".avro"
 

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroOutputWriterFactory.scala
@@ -36,7 +36,8 @@ private[sql] class AvroOutputWriterFactory(
     avroSchemaAsJsonString: String,
     positionalFieldMatching: Boolean) extends OutputWriterFactory {
 
-  private lazy val avroSchema = new Schema.Parser().parse(avroSchemaAsJsonString)
+  private lazy val avroSchema =
+    new Schema.Parser().setValidateDefaults(false).parse(avroSchemaAsJsonString)
 
   override def getFileExtension(context: TaskAttemptContext): String = ".avro"
 

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/CatalystDataToAvro.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/CatalystDataToAvro.scala
@@ -35,7 +35,7 @@ private[avro] case class CatalystDataToAvro(
 
   @transient private lazy val avroType =
     jsonFormatSchema
-      .map(new Schema.Parser().parse)
+      .map(new Schema.Parser().setValidateDefaults(false).parse)
       .getOrElse(SchemaConverters.toAvroType(child.dataType, child.nullable))
 
   @transient private lazy val serializer =

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -261,6 +261,13 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
     withTempPath { dir =>
       df.write.format("avro").save(dir.getCanonicalPath)
       checkAnswer(spark.read.schema(sparkSchema).format("avro").load(dir.getCanonicalPath), df)
+
+      val msg = intercept[SparkException] {
+        spark.read.option("avroSchema", avroTypeStruct).format("avro")
+          .load(dir.getCanonicalPath)
+          .collect()
+      }.getCause.getMessage
+      assert(msg.contains("Invalid default for field id: null not a \"long\""))
     }
   }
 }

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroFunctionsSuite.scala
@@ -253,8 +253,8 @@ class AvroFunctionsSuite extends QueryTest with SharedSparkSession {
     val avroSchema = AvroOptions(Map("avroSchema" -> avroTypeStruct)).schema.get
     val sparkSchema = SchemaConverters.toSqlType(avroSchema).dataType.asInstanceOf[StructType]
 
-    val df = spark.range(5).select('id)
-    val structDf = df.select(struct('id).as("struct"))
+    val df = spark.range(5).select($"id")
+    val structDf = df.select(struct($"id").as("struct"))
     val avroStructDF = structDf.select(functions.to_avro('struct, avroTypeStruct).as("avro"))
     checkAnswer(avroStructDF.select(functions.from_avro('avro, avroTypeStruct)), structDf)
 

--- a/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/GenericAvroSerializer.scala
@@ -97,7 +97,7 @@ private[serializer] class GenericAvroSerializer[D <: GenericContainer]
     } {
       in.close()
     }
-    new Schema.Parser().parse(new String(bytes, StandardCharsets.UTF_8))
+    new Schema.Parser().setValidateDefaults(false).parse(new String(bytes, StandardCharsets.UTF_8))
   })
 
   /**
@@ -137,7 +137,7 @@ private[serializer] class GenericAvroSerializer[D <: GenericContainer]
         val fingerprint = input.readLong()
         schemaCache.getOrElseUpdate(fingerprint, {
           schemas.get(fingerprint) match {
-            case Some(s) => new Schema.Parser().parse(s)
+            case Some(s) => new Schema.Parser().setValidateDefaults(false).parse(s)
             case None =>
               throw new SparkException(
                 "Error reading attempting to read avro data -- encountered an unknown " +

--- a/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/serializer/GenericAvroSerializerSuite.scala
@@ -110,4 +110,20 @@ class GenericAvroSerializerSuite extends SparkFunSuite with SharedSparkContext {
       assert(rdd.collect() sameElements Array.fill(10)(datum))
     }
   }
+
+  test("SPARK-39775: Disable validate default values when parsing Avro schemas") {
+    val avroTypeStruct = s"""
+      |{
+      |  "type": "record",
+      |  "name": "struct",
+      |  "fields": [
+      |    {"name": "id", "type": "long", "default": null}
+      |  ]
+      |}
+    """.stripMargin
+    val schema = new Schema.Parser().setValidateDefaults(false).parse(avroTypeStruct)
+
+    val genericSer = new GenericAvroSerializer(conf.getAvroSchema)
+    assert(schema === genericSer.decompress(ByteBuffer.wrap(genericSer.compress(schema))))
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR disables validate default values when parsing Avro schemas.

### Why are the changes needed?

Spark will throw exception if upgrade to Spark 3.2. We have fixed the Hive serde tables before: SPARK-34512.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.