### PR TITLE
[SPARK-39785][CORE] Use `setBufferedIo` instead of `withBufferedIo` to cleanup log4j2 deprecated api usage

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala
@@ -66,7 +66,7 @@ private[spark] class DriverLogger(conf: SparkConf) extends Logging {
       // `AbstractFilterable.Builder.asBuilder()` method will return `Any` in Scala.
       val builder: Log4jFileAppender.Builder[_] = Log4jFileAppender.newBuilder()
       builder.withAppend(false)
-      builder.withBufferedIo(false)
+      builder.setBufferedIo(false)
       builder.setConfiguration(config)
       builder.withFileName(localLogFile)
       builder.setIgnoreExceptions(false)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just fix the following log4j2 compilation warning:

```
 [WARNING] /basedir/spark-source/core/src/main/scala/org/apache/spark/util/logging/DriverLogger.scala:69: [deprecation @ org.apache.spark.util.logging.DriverLogger.addLogAppender.log4jFileAppender | origin=org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.Builder.withBufferedIo | version=] method withBufferedIo in class Builder is deprecated
```

### Why are the changes needed?
Cleanup log4j2 deprecated api usage


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions