### PR TITLE
[SPARK-39788][SQL] Rename `catalogName` to `dialectName` for `JdbcUtils`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -1114,10 +1114,10 @@ object JdbcUtils extends Logging with SQLConfHelper {
    */
   def processIndexProperties(
       properties: util.Map[String, String],
-      catalogName: String): (String, Array[String]) = {
+      dialectName: String): (String, Array[String]) = {
     var indexType = ""
     val indexPropertyList: ArrayBuffer[String] = ArrayBuffer[String]()
-    val supportedIndexTypeList = getSupportedIndexTypeList(catalogName)
+    val supportedIndexTypeList = getSupportedIndexTypeList(dialectName)
 
     if (!properties.isEmpty) {
       properties.asScala.foreach { case (k, v) =>
@@ -1147,8 +1147,8 @@ object JdbcUtils extends Logging with SQLConfHelper {
     false
   }
 
-  def getSupportedIndexTypeList(catalogName: String): Array[String] = {
-    catalogName match {
+  def getSupportedIndexTypeList(dialectName: String): Array[String] = {
+    dialectName match {
       case "mysql" => Array("BTREE", "HASH")
       case "postgresql" => Array("BTREE", "HASH", "BRIN")
       case _ => Array.empty


### PR DESCRIPTION
### What changes were proposed in this pull request?
Recently, I read the the implement of DS V2 index. I find an issue let me confused.
Currently, `processIndexProperties` and `getSupportedIndexTypeList` in `JdbcUtils` have one parameter named `catalogName`.
In fact, the parameter means the JDBC dialect.


### Why are the changes needed?
Improve the API readability.


### Does this PR introduce _any_ user-facing change?
'No'.
Just change the inner implement.


### How was this patch tested?
N/A
