### PR TITLE
add ignore for the recently added and failing mypy error 'type-var' SPARK-39811

### DIFF
--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -264,7 +264,7 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         return self._java_obj
 
     @staticmethod
-    def _from_java(java_stage: "JavaObject") -> "JP":
+    def _from_java(java_stage: "JavaObject") -> "JP":  # type: ignore[type-var]
         """
         Given a Java object, create and return a Python wrapper of it.
         Used for ML persistence.


### PR DESCRIPTION
A new error introduced to mypy is found in this repository. This PR adds comment to ignore that error.

> spark (https://github.com/apache/spark)
> + python/pyspark/ml/wrapper.py:267: error: A function returning TypeVar should receive at least one argument containing the same Typevar  [type-var]
> 

Reference:
https://github.com/python/mypy/pull/13166

Jira Issue:
https://issues.apache.org/jira/browse/SPARK-39811