### PR TITLE
[SPARK-39644][SQL] Add RangePartitioning reporting for V2 DataSources

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -513,7 +513,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
 
   private def checkAggregatePushed(df: DataFrame, funcName: String): Unit = {
     df.queryExecution.optimizedPlan.collect {
-      case DataSourceV2ScanRelation(_, scan, _, _, _) =>
+      case DataSourceV2ScanRelation(_, scan, _, _, _, _) =>
         assert(scan.isInstanceOf[V1ScanWrapper])
         val wrapper = scan.asInstanceOf[V1ScanWrapper]
         assert(wrapper.pushedDownOperators.aggregation.isDefined)

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/Partitioning.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/Partitioning.java
@@ -28,6 +28,7 @@ import org.apache.spark.sql.connector.read.SupportsReportPartitioning;
  * use one of the following subclasses:
  * <ul>
  * <li>{@link KeyGroupedPartitioning}</li>
+ * <li>{@link RangePartitioning}</li>
  * <li>{@link UnknownPartitioning}</li>
  * </ul>
  *

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/RangePartitioning.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/partitioning/RangePartitioning.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read.partitioning;
+
+import java.util.Arrays;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.SortOrder;
+
+/**
+ * Represents a partitioning where rows are ordered based on order expressions
+ * returned by {@link RangePartitioning#order} and split across partitions at
+ * certain value boundaries. This is similar to {@link KeyGroupedPartitioning}
+ * with `SortOrder::expression` being the keys and keys ordered and split according
+ * to {@link RangePartitioning#order}.
+ * <p>
+ * Note: Data source implementations should make sure for a single partition, all of its rows
+ * must be evaluated to the same partition value after being applied by
+ * {@link RangePartitioning#keys()} expressions. Different partitions can share the same
+ * partition value: Spark will group these into a single logical partition during planning phase.
+ *
+ * @since 3.4.0
+ */
+@Evolving
+public class RangePartitioning extends KeyGroupedPartitioning {
+    private final SortOrder[] order;
+
+    private static Expression[] orderExpressions(SortOrder[] order) {
+        return Arrays.stream(order)
+                .map(SortOrder::expression)
+                .toArray(Expression[]::new);
+    }
+
+    public RangePartitioning(SortOrder[] order, int numPartitions) {
+        super(orderExpressions(order), numPartitions);
+        this.order = order;
+    }
+
+    /**
+     * Returns the partition order expressions for this partitioning.
+     */
+    public SortOrder[] order() {
+        return order;
+    }
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -116,13 +116,16 @@ case class DataSourceV2Relation(
  * @param output the output attributes of this relation
  * @param keyGroupedPartitioning if set, the partitioning expressions that are used to split the
  *                               rows in the scan across different partitions
- * @param ordering if set, the ordering provided by the scan
+ * @param rangePartitioning if set, the range partitioning expressions that are used to split the
+ *                               rows in the scan across different partitions
+ * @param ordering if set, the in-partition ordering provided by the scan
  */
 case class DataSourceV2ScanRelation(
     relation: DataSourceV2Relation,
     scan: Scan,
     output: Seq[AttributeReference],
     keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    rangePartitioning: Option[Seq[SortOrder]] = None,
     ordering: Option[Seq[SortOrder]] = None) extends LeafNode with NamedRelation {
 
   override def name: String = relation.table.name()

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -3930,7 +3930,7 @@ class Dataset[T] private[sql](
       case r: HiveTableRelation =>
         r.tableMeta.storage.locationUri.map(_.toString).toArray
       case DataSourceV2ScanRelation(DataSourceV2Relation(table: FileTable, _, _, _, _),
-          _, _, _, _) =>
+          _, _, _, _, _) =>
         table.fileIndex.inputFiles
     }.flatten
     files.toSet.toArray

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -38,6 +38,7 @@ case class BatchScanExec(
     @transient scan: Scan,
     runtimeFilters: Seq[Expression],
     keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    rangePartitioning: Option[Seq[SortOrder]] = None,
     ordering: Option[Seq[SortOrder]] = None,
     @transient table: Table,
     commonPartitionValues: Option[Seq[(InternalRow, Int)]] = None,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ContinuousScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ContinuousScanExec.scala
@@ -33,6 +33,7 @@ case class ContinuousScanExec(
     @transient stream: ContinuousStream,
     @transient start: Offset,
     keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    rangePartitioning: Option[Seq[SortOrder]] = None,
     ordering: Option[Seq[SortOrder]] = None) extends DataSourceV2ScanExecBase {
 
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MicroBatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MicroBatchScanExec.scala
@@ -33,6 +33,7 @@ case class MicroBatchScanExec(
     @transient start: Offset,
     @transient end: Offset,
     keyGroupedPartitioning: Option[Seq[Expression]] = None,
+    rangePartitioning: Option[Seq[SortOrder]] = None,
     ordering: Option[Seq[SortOrder]] = None) extends DataSourceV2ScanExecBase {
 
   // TODO: unify the equal/hashCode implementation for all data source v2 query plans.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelOperationRuntimeGroupFiltering.scala
@@ -45,7 +45,7 @@ class RowLevelOperationRuntimeGroupFiltering(optimizeSubqueries: Rule[LogicalPla
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     // apply special dynamic filtering only for group-based row-level operations
     case GroupBasedRowLevelOperation(replaceData, cond,
-        DataSourceV2ScanRelation(_, scan: SupportsRuntimeV2Filtering, _, _, _))
+        DataSourceV2ScanRelation(_, scan: SupportsRuntimeV2Filtering, _, _, _, _))
         if conf.runtimeRowLevelOperationGroupFilterEnabled && cond != TrueLiteral =>
 
       // use reference equality on scan to find required scan relations

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaKeyGroupedPartitioningAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaKeyGroupedPartitioningAwareDataSource.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.apache.spark.sql.connector;
+
+import java.io.IOException;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.TestingV2Source;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.read.*;
+import org.apache.spark.sql.connector.read.partitioning.Partitioning;
+import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+public class JavaKeyGroupedPartitioningAwareDataSource implements TestingV2Source {
+
+  static class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportPartitioning {
+
+    @Override
+    public InputPartition[] planInputPartitions() {
+      InputPartition[] partitions = new InputPartition[2];
+      partitions[0] = new SpecificInputPartition(new int[]{1, 1, 3}, new int[]{4, 4, 6});
+      partitions[1] = new SpecificInputPartition(new int[]{2, 4, 4}, new int[]{6, 2, 2});
+      return partitions;
+    }
+
+    @Override
+    public PartitionReaderFactory createReaderFactory() {
+      return new SpecificReaderFactory();
+    }
+
+    @Override
+    public Partitioning outputPartitioning() {
+      Expression[] clustering = new Transform[] { Expressions.identity("i") };
+      return new KeyGroupedPartitioning(clustering, 2);
+    }
+  }
+
+  @Override
+  public Table getTable(CaseInsensitiveStringMap options) {
+    return new JavaSimpleBatchTable() {
+      @Override
+      public Transform[] partitioning() {
+        return new Transform[] { Expressions.identity("i") };
+      }
+
+      @Override
+      public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+        return new MyScanBuilder();
+      }
+    };
+  }
+
+  static class SpecificInputPartition implements InputPartition, HasPartitionKey {
+    int[] i;
+    int[] j;
+
+    SpecificInputPartition(int[] i, int[] j) {
+      assert i.length == j.length;
+      this.i = i;
+      this.j = j;
+    }
+
+    @Override
+    public InternalRow partitionKey() {
+      return new GenericInternalRow(new Object[] {i[0]});
+    }
+  }
+
+  static class SpecificReaderFactory implements PartitionReaderFactory {
+
+    @Override
+    public PartitionReader<InternalRow> createReader(InputPartition partition) {
+      SpecificInputPartition p = (SpecificInputPartition) partition;
+      return new PartitionReader<InternalRow>() {
+        private int current = -1;
+
+        @Override
+        public boolean next() throws IOException {
+          current += 1;
+          return current < p.i.length;
+        }
+
+        @Override
+        public InternalRow get() {
+          return new GenericInternalRow(new Object[] {p.i[current], p.j[current]});
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+      };
+    }
+  }
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndKeyGroupedPartitioningAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaOrderAndKeyGroupedPartitioningAwareDataSource.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.org.apache.spark.sql.connector;
+
+import java.util.Arrays;
+
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.expressions.*;
+import org.apache.spark.sql.connector.read.*;
+import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
+import org.apache.spark.sql.connector.read.partitioning.Partitioning;
+import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+public class JavaOrderAndKeyGroupedPartitioningAwareDataSource
+        extends JavaKeyGroupedPartitioningAwareDataSource {
+
+  static class MyScanBuilder extends JavaKeyGroupedPartitioningAwareDataSource.MyScanBuilder
+    implements SupportsReportOrdering {
+
+    private final Partitioning partitioning;
+    private final SortOrder[] ordering;
+
+    MyScanBuilder(String partitionKeys, String orderKeys) {
+      if (partitionKeys != null) {
+        String[] keys = partitionKeys.split(",");
+        Expression[] clustering = new Transform[keys.length];
+        for (int i = 0; i < keys.length; i++) {
+          clustering[i] = Expressions.identity(keys[i]);
+        }
+        this.partitioning = new KeyGroupedPartitioning(clustering, 2);
+      } else {
+        this.partitioning = new UnknownPartitioning(2);
+      }
+
+      if (orderKeys != null) {
+        String[] keys = orderKeys.split(",");
+        this.ordering = new SortOrder[keys.length];
+        for (int i = 0; i < keys.length; i++) {
+          this.ordering[i] = new MySortOrder(keys[i]);
+        }
+      } else {
+        this.ordering = new SortOrder[0];
+      }
+    }
+
+    @Override
+    public InputPartition[] planInputPartitions() {
+      InputPartition[] partitions = new InputPartition[2];
+      partitions[0] = new SpecificInputPartition(new int[]{1, 1, 3}, new int[]{4, 5, 5});
+      partitions[1] = new SpecificInputPartition(new int[]{2, 4, 4}, new int[]{6, 1, 2});
+      return partitions;
+    }
+
+    @Override
+    public Partitioning outputPartitioning() {
+      return this.partitioning;
+    }
+
+    @Override
+    public SortOrder[] outputOrdering() {
+      return this.ordering;
+    }
+  }
+
+  @Override
+  public Table getTable(CaseInsensitiveStringMap options) {
+    return new JavaSimpleBatchTable() {
+      @Override
+      public Transform[] partitioning() {
+        String partitionKeys = options.get("partitionKeys");
+        if (partitionKeys == null) {
+          return new Transform[0];
+        } else {
+          return (Transform[]) Arrays.stream(partitionKeys.split(","))
+            .map(Expressions::identity).toArray();
+        }
+      }
+
+      @Override
+      public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+        return new MyScanBuilder(options.get("partitionKeys"), options.get("orderKeys"));
+      }
+    };
+  }
+
+  static class MySortOrder implements SortOrder {
+    private final Expression expression;
+
+    MySortOrder(String columnName) {
+      this.expression = new MyIdentityTransform(new MyNamedReference(columnName));
+    }
+
+    @Override
+    public Expression expression() {
+      return expression;
+    }
+
+    @Override
+    public SortDirection direction() {
+      return SortDirection.ASCENDING;
+    }
+
+    @Override
+    public NullOrdering nullOrdering() {
+      return NullOrdering.NULLS_FIRST;
+    }
+  }
+
+  static class MyNamedReference implements NamedReference {
+    private final String[] parts;
+
+    MyNamedReference(String part) {
+      this.parts = new String[] { part };
+    }
+
+    @Override
+    public String[] fieldNames() {
+      return this.parts;
+    }
+  }
+
+  static class MyIdentityTransform implements Transform {
+    private final Expression[] args;
+
+    MyIdentityTransform(NamedReference namedReference) {
+      this.args = new Expression[] { namedReference };
+    }
+
+    @Override
+    public String name() {
+      return "identity";
+    }
+
+    @Override
+    public NamedReference[] references() {
+      return new NamedReference[0];
+    }
+
+    @Override
+    public Expression[] arguments() {
+      return this.args;
+    }
+  }
+
+}

--- a/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaRangePartitioningAwareDataSource.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/connector/JavaRangePartitioningAwareDataSource.java
@@ -17,29 +17,27 @@
 
 package test.org.apache.spark.sql.connector;
 
-import java.io.IOException;
-
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.TestingV2Source;
 import org.apache.spark.sql.connector.catalog.Table;
-import org.apache.spark.sql.connector.expressions.Expression;
-import org.apache.spark.sql.connector.expressions.Expressions;
-import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.expressions.*;
 import org.apache.spark.sql.connector.read.*;
+import org.apache.spark.sql.connector.read.partitioning.RangePartitioning;
 import org.apache.spark.sql.connector.read.partitioning.Partitioning;
-import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-public class JavaPartitionAwareDataSource implements TestingV2Source {
+import java.io.IOException;
+
+public class JavaRangePartitioningAwareDataSource implements TestingV2Source {
 
   static class MyScanBuilder extends JavaSimpleScanBuilder implements SupportsReportPartitioning {
 
     @Override
     public InputPartition[] planInputPartitions() {
       InputPartition[] partitions = new InputPartition[2];
-      partitions[0] = new SpecificInputPartition(new int[]{1, 1, 3}, new int[]{4, 4, 6});
-      partitions[1] = new SpecificInputPartition(new int[]{2, 4, 4}, new int[]{6, 2, 2});
+      partitions[0] = new SpecificInputPartition(new int[]{2, 1, 3}, new int[]{3, 1, 4});
+      partitions[1] = new SpecificInputPartition(new int[]{4, 5, 4}, new int[]{2, 4, 3});
       return partitions;
     }
 
@@ -50,8 +48,8 @@ public class JavaPartitionAwareDataSource implements TestingV2Source {
 
     @Override
     public Partitioning outputPartitioning() {
-      Expression[] clustering = new Transform[] { Expressions.identity("i") };
-      return new KeyGroupedPartitioning(clustering, 2);
+      SortOrder[] order = new MySortOrder[] { new MySortOrder("i") };
+      return new RangePartitioning(order, 2);
     }
   }
 
@@ -68,6 +66,65 @@ public class JavaPartitionAwareDataSource implements TestingV2Source {
         return new MyScanBuilder();
       }
     };
+  }
+
+  static class MySortOrder implements SortOrder {
+    private final Expression expression;
+
+    MySortOrder(String columnName) {
+      this.expression = new MyIdentityTransform(new MyNamedReference(columnName));
+    }
+
+    @Override
+    public Expression expression() {
+      return expression;
+    }
+
+    @Override
+    public SortDirection direction() {
+      return SortDirection.ASCENDING;
+    }
+
+    @Override
+    public NullOrdering nullOrdering() {
+      return NullOrdering.NULLS_FIRST;
+    }
+  }
+
+  static class MyNamedReference implements NamedReference {
+    private final String[] parts;
+
+    MyNamedReference(String part) {
+      this.parts = new String[] { part };
+    }
+
+    @Override
+    public String[] fieldNames() {
+      return this.parts;
+    }
+  }
+
+  static class MyIdentityTransform implements Transform {
+    private final Expression[] args;
+
+    MyIdentityTransform(NamedReference namedReference) {
+      this.args = new Expression[] { namedReference };
+    }
+
+    @Override
+    public String name() {
+      return "identity";
+    }
+
+    @Override
+    public NamedReference[] references() {
+      return new NamedReference[0];
+    }
+
+    @Override
+    public Expression[] arguments() {
+      return this.args;
+    }
   }
 
   static class SpecificInputPartition implements InputPartition, HasPartitionKey {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -61,7 +61,7 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
       .where(Column(predicate))
 
     query.queryExecution.optimizedPlan match {
-      case PhysicalOperation(_, filters, DataSourceV2ScanRelation(_, o: OrcScan, _, _, _)) =>
+      case PhysicalOperation(_, filters, DataSourceV2ScanRelation(_, o: OrcScan, _, _, _, _)) =>
         assert(filters.nonEmpty, "No filter is analyzed from the given query")
         assert(o.pushedFilters.nonEmpty, "No filter is pushed down")
         val maybeFilter = OrcFilters.createFilter(query.schema, o.pushedFilters)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcTest.scala
@@ -120,7 +120,7 @@ trait OrcTest extends QueryTest with FileBasedDataSourceTest with BeforeAndAfter
       .where(Column(predicate))
 
     query.queryExecution.optimizedPlan match {
-      case PhysicalOperation(_, filters, DataSourceV2ScanRelation(_, o: OrcScan, _, _, _)) =>
+      case PhysicalOperation(_, filters, DataSourceV2ScanRelation(_, o: OrcScan, _, _, _, _)) =>
         assert(filters.nonEmpty, "No filter is analyzed from the given query")
         if (noneSupported) {
           assert(o.pushedFilters.isEmpty, "Unsupported filters should not show in pushed filters")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFilterSuite.scala
@@ -2248,7 +2248,7 @@ class ParquetV2FilterSuite extends ParquetFilterSuite {
 
       query.queryExecution.optimizedPlan.collectFirst {
         case PhysicalOperation(_, filters,
-            DataSourceV2ScanRelation(_, scan: ParquetScan, _, _, _)) =>
+            DataSourceV2ScanRelation(_, scan: ParquetScan, _, _, _, _)) =>
           assert(filters.nonEmpty, "No filter is analyzed from the given query")
           val sourceFilters = filters.flatMap(DataSourceStrategy.translateFilter(_, true)).toArray
           val pushedFilters = scan.pushedFilters


### PR DESCRIPTION
### What changes were proposed in this pull request?
DataSourceV2 allows data sources to report existing partitioning of read data (`org.apache.spark.sql.connector.read.partitioning`). Currently, there is only `KeyGroupedPartitioning` and `UnknownPartitioning`. Data sources should be able to report global ordered data so that downstream operations can exploit this.

The following is required for this to work:
- Define `RangePartitioning` as a new implementation of `Partitioning`
- Add Catalyst rules that handle this partitioning
- Add a test source that reports ordering to proof that subsequent operations requiring order do not invoke sorting data

### Why are the changes needed?
Transformations that require certain order or partitioning should not shuffle or sort data when that is redundant.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tests in `DataSourceV2Suite`.