### PR TITLE
[SPARK-39803][SQL] Use `LevenshteinDistance` instead of `StringUtils.getLevenshteinDistance`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala
@@ -21,7 +21,7 @@ import java.util.regex.{Pattern, PatternSyntaxException}
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.commons.lang3.{ StringUtils => ACLStringUtils }
+import org.apache.commons.text.similarity.LevenshteinDistance
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.errors.QueryCompilationErrors
@@ -76,7 +76,7 @@ object StringUtils extends Logging {
   private[spark] def orderStringsBySimilarity(
       baseString: String,
       testStrings: Seq[String]): Seq[String] = {
-    testStrings.sortBy(ACLStringUtils.getLevenshteinDistance(_, baseString))
+    testStrings.sortBy(LevenshteinDistance.getDefaultInstance.apply(_, baseString))
   }
 
   // scalastyle:off caselocale


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just use `LevenshteinDistance` in `commons-text` instead of `StringUtils.getLevenshteinDistance` in `commons-lang3` to cleanup following compilation warnings:

```
[WARNING] /basedir/spark-source/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/StringUtils.scala:79: [deprecation @ org.apache.spark.sql.catalyst.util.StringUtils.orderStringsBySimilarity.$anonfun | origin=org.apache.commons.lang3.StringUtils.getLevenshteinDistance | version=] method getLevenshteinDistance in class StringUtils is deprecated
```


### Why are the changes needed?
Cleanup deprecation api usage related  to `commons-lang3`, only this one case.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions