### PR TITLE
[WIP][SPARK-39794][PYTHON] Introduce parametric singleton for DataType

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1075,6 +1075,22 @@ class TypesTests(ReusedSQLTestCase):
         with self.assertRaisesRegex(RuntimeError, "interval 0 to 321 is invalid"):
             DayTimeIntervalType(DayTimeIntervalType.DAY, 321)
 
+        d1 = DayTimeIntervalType(startField=1, endField=2)
+        d1_ = DayTimeIntervalType(startField=1, endField=2)
+        d2 = DayTimeIntervalType(1, 2)
+        d2_ = DayTimeIntervalType(1, 2)
+        d3 = DayTimeIntervalType(1, endField=2)
+        d3_ = DayTimeIntervalType(1, endField=2)
+        d4 = DayTimeIntervalType(endField=2, startField=1)
+        d4_ = DayTimeIntervalType(endField=2, startField=1)
+        self.assertTrue(d1 is d1_)
+        self.assertTrue(d2 is d2_)
+        self.assertTrue(d3 is d3_)
+        self.assertTrue(d4 is d4_)
+        self.assertTrue(d1 is not d2)
+        self.assertTrue(d1 is not d3)
+        self.assertTrue(d1 is not d4)
+
     def test_daytime_interval_type(self):
         # SPARK-37277: Support DayTimeIntervalType in createDataFrame
         timedetlas = [
@@ -1136,7 +1152,22 @@ class DataTypeTests(unittest.TestCase):
         self.assertTrue(t2 is not t1)
         self.assertNotEqual(t1, t2)
         t3 = DecimalType(8)
+        t3_ = DecimalType(8)
         self.assertNotEqual(t2, t3)
+        self.assertTrue(t3_ is t3)
+        t4 = DecimalType(scale=2, precision=10)
+        t4_ = DecimalType(scale=2, precision=10)
+        self.assertTrue(t2 is not t4)
+        self.assertTrue(t4_ is t4)
+        t5 = DecimalType(precision=10, scale=2)
+        t5_ = DecimalType(precision=10, scale=2)
+        self.assertTrue(t4 is not t5)
+        self.assertTrue(t2 is not t5)
+        self.assertTrue(t5_ is t5)
+        t6 = DecimalType(10, scale=2)
+        t6_ = DecimalType(10, scale=2)
+        self.assertTrue(t2 is not t6)
+        self.assertTrue(t6_ is t6)
 
     def test_varchar_type(self):
         v1 = VarcharType(10)
@@ -1145,7 +1176,7 @@ class DataTypeTests(unittest.TestCase):
         self.assertNotEqual(v1, v2)
         v3 = VarcharType(10)
         self.assertEqual(v1, v3)
-        self.assertFalse(v1 is v3)
+        self.assertTrue(v1 is v3)
 
     # regression test for SPARK-10392
     def test_datetype_equal_zero(self):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -138,12 +138,13 @@ class DataTypeSingleton(type):
 
     _instances: ClassVar[Dict[Type["DataTypeSingleton"], "DataTypeSingleton"]] = {}
 
-    def __call__(cls: Type[T]) -> T:  # type: ignore[override]
-        if cls not in cls._instances:  # type: ignore[attr-defined]
-            cls._instances[cls] = super(  # type: ignore[misc, attr-defined]
+    def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:  # type: ignore[override]
+        key = (cls, args, str(kwargs))
+        if key not in cls._instances:  # type: ignore[attr-defined]
+            cls._instances[key] = super(  # type: ignore[misc, attr-defined]
                 DataTypeSingleton, cls
-            ).__call__()
-        return cls._instances[cls]  # type: ignore[attr-defined]
+            ).__call__(*args, **kwargs)
+        return cls._instances[key]  # type: ignore[attr-defined]
 
 
 class NullType(DataType, metaclass=DataTypeSingleton):
@@ -182,7 +183,7 @@ class StringType(AtomicType, metaclass=DataTypeSingleton):
     pass
 
 
-class VarcharType(AtomicType):
+class VarcharType(AtomicType, metaclass=DataTypeSingleton):
     """Varchar data type
 
     Parameters
@@ -275,7 +276,7 @@ class TimestampNTZType(AtomicType, metaclass=DataTypeSingleton):
             )
 
 
-class DecimalType(FractionalType):
+class DecimalType(FractionalType, metaclass=DataTypeSingleton):
     """Decimal (decimal.Decimal) data type.
 
     The DecimalType must have fixed precision (the maximum total number of digits)
@@ -347,7 +348,7 @@ class LongType(IntegralType):
         return "bigint"
 
 
-class DayTimeIntervalType(AtomicType):
+class DayTimeIntervalType(AtomicType, metaclass=DataTypeSingleton):
     """DayTimeIntervalType (datetime.timedelta)."""
 
     DAY = 0

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -136,7 +136,7 @@ class DataType:
 class DataTypeSingleton(type):
     """Metaclass for DataType"""
 
-    _instances: ClassVar[Dict[Type["DataTypeSingleton"], "DataTypeSingleton"]] = {}
+    _instances: ClassVar[Dict[Tuple, "DataTypeSingleton"]] = {}
 
     def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:  # type: ignore[override]
         key = (cls, args, str(kwargs))

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -138,7 +138,7 @@ class DataTypeSingleton(type):
 
     _instances: ClassVar[Dict[Tuple, "DataTypeSingleton"]] = {}
 
-    def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:  # type: ignore[override]
+    def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:
         key = (cls, args, str(kwargs))
         if key not in cls._instances:  # type: ignore[attr-defined]
             cls._instances[key] = super(  # type: ignore[misc, attr-defined]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce parametric singleton for DataType.

### Why are the changes needed?
Otherwise, we will create a new DataType instance (with parameters in constructors, e.g. `Varchar`, `DecimalType`) every time it's called.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit test.