### PR TITLE
[SPARK-39810][SQL] Catalog.tableExists should handle nested namespace

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTable, LocalRelation, RecoverPartitions, ShowFunctions, ShowNamespaces, ShowTables, SubqueryAlias, TableSpec, View}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, Identifier, SupportsNamespaces, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{CatalogHelper, IdentifierHelper, MultipartIdentifierHelper, TransformHelper}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/CatalogImpl.scala
@@ -493,14 +493,10 @@ class CatalogImpl(sparkSession: SparkSession) extends Catalog {
    */
   override def tableExists(tableName: String): Boolean = {
     try {
-      val tableIdent = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
-      tableExists(tableIdent.database.orNull, tableIdent.table)
+      getTable(tableName)
+      true
     } catch {
-      case e: org.apache.spark.sql.catalyst.parser.ParseException =>
-        val ident = sparkSession.sessionState.sqlParser.parseMultipartIdentifier(tableName)
-        val catalog =
-          sparkSession.sessionState.catalogManager.catalog(ident(0)).asTableCatalog
-        catalog.tableExists(Identifier.of(Array(ident(1)), ident(2)))
+      case e: AnalysisException => false
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -767,6 +767,13 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       Map.empty[String, String], "")
 
     assert(spark.catalog.tableExists(Array(catalogName, dbName, tableName).mkString(".")))
+
+    val dbName2 = "my_db2.my_db3"
+    val tableName2 = "my_table2"
+    assert(!spark.catalog.tableExists(Array(catalogName, dbName2, tableName2).mkString(".")))
+    createTable(tableName2, dbName2, catalogName, classOf[FakeV2Provider].getName, tableSchema,
+      Map.empty[String, String], "")
+    assert(spark.catalog.tableExists(Array(catalogName, dbName2, tableName2).mkString(".")))
   }
 
   test("three layer namespace compatibility - database exists") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/CatalogSuite.scala
@@ -122,6 +122,7 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
   override def afterEach(): Unit = {
     try {
       sessionCatalog.reset()
+      spark.sessionState.catalogManager.reset()
     } finally {
       super.afterEach()
     }
@@ -767,13 +768,17 @@ class CatalogSuite extends SharedSparkSession with AnalysisTest with BeforeAndAf
       Map.empty[String, String], "")
 
     assert(spark.catalog.tableExists(Array(catalogName, dbName, tableName).mkString(".")))
+  }
 
-    val dbName2 = "my_db2.my_db3"
-    val tableName2 = "my_table2"
-    assert(!spark.catalog.tableExists(Array(catalogName, dbName2, tableName2).mkString(".")))
-    createTable(tableName2, dbName2, catalogName, classOf[FakeV2Provider].getName, tableSchema,
+  test("SPARK-39810: Catalog.tableExists should handle nested namespace") {
+    val tableSchema = new StructType().add("i", "int")
+    val catalogName = "testcat"
+    val dbName = "my_db2.my_db3"
+    val tableName = "my_table2"
+    assert(!spark.catalog.tableExists(Array(catalogName, dbName, tableName).mkString(".")))
+    createTable(tableName, dbName, catalogName, classOf[FakeV2Provider].getName, tableSchema,
       Map.empty[String, String], "")
-    assert(spark.catalog.tableExists(Array(catalogName, dbName2, tableName2).mkString(".")))
+    assert(spark.catalog.tableExists(Array(catalogName, dbName, tableName).mkString(".")))
   }
 
   test("three layer namespace compatibility - database exists") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Let CatalogImpl.tableExists to reuse CatalogImpl.getTable code.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Currently `tableExists` assume input is only have 3 name parts which is wrong assumption (namespace could be an array). The `getTable` implementation is correct. So we can re-use `getTable` code and if the getTable succeeds, then `tableExists` can return true.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT