### PR TITLE
[MINOR][PYTHON][DOC] Setting toggle-prompt button in docs to user-select:none

### DIFF
--- a/python/docs/source/_static/copybutton.js
+++ b/python/docs/source/_static/copybutton.js
@@ -22,7 +22,8 @@ $(document).ready(function() {
         'border-color': border_color, 'border-style': border_style,
         'border-width': border_width, 'color': border_color, 'text-size': '75%',
         'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
-        'border-radius': '0 3px 0 0'
+        'border-radius': '0 3px 0 0',
+        'user-select': 'none'
     }
 
     // create and add the button to all the code blocks that contain >>>


### PR DESCRIPTION

### What changes were proposed in this pull request?
Added a css tag for the button that toggles the python '>>>' interpreter prefix on and off.
This tag is called 'user-select' and was set to 'none'

### Why are the changes needed?
![image](https://user-images.githubusercontent.com/89562186/179639700-0d339544-0a46-42e1-8c84-c5affcc4cd33.png)

This prevents the user to highlight the button, a small enhancement to the user experience.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Building the docs on local.
