### PR TITLE
[MINOR][PYTHON][DOCS] Fix broken Example section in col/column functions

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -140,7 +140,7 @@ def lit(col: Any) -> Column:
 @since(1.3)
 def col(col: str) -> Column:
     """
-    Returns a :class:`~pyspark.sql.Column` based on the given column name.'
+    Returns a :class:`~pyspark.sql.Column` based on the given column name.
 
     Examples
     --------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a bug in the documentation. Trailing `'` breaks Example section in Python reference documentation. This PR removes it.

### Why are the changes needed?

To render the documentation as intended in NumPy documentation style.

### Does this PR introduce _any_ user-facing change?

Yes, the documentation is updated.

**Before**

<img width="789" alt="Screen Shot 2022-07-19 at 12 20 55 PM" src="https://user-images.githubusercontent.com/6477701/179661216-715dec96-bff2-474f-ab48-41577bf4c15c.png">

**After**

<img width="633" alt="Screen Shot 2022-07-19 at 12 48 04 PM" src="https://user-images.githubusercontent.com/6477701/179661245-72d15184-aeed-43c2-b9c9-5f3cab1ae28d.png">


### How was this patch tested?

Manually built the documentation and tested.
