### PR TITLE
[SPARK-39814] Use AmazonKinesisClientBuilder.withCredentials instead of new AmazonKinesisClient(credentials)

### DIFF
--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisWordCountASL.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisWordCountASL.scala
@@ -23,7 +23,7 @@ import java.nio.ByteBuffer
 import scala.util.Random
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.kinesis.AmazonKinesisClient
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
 import com.amazonaws.services.kinesis.model.PutRecordRequest
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.core.config.Configurator
@@ -101,11 +101,12 @@ object KinesisWordCountASL extends Logging {
 
     // Determine the number of shards from the stream using the low-level Kinesis Client
     // from the AWS Java SDK.
-    val credentials = new DefaultAWSCredentialsProviderChain().getCredentials()
-    require(credentials != null,
+    val credentialsProvider = new DefaultAWSCredentialsProviderChain()
+    require(credentialsProvider.getCredentials != null,
       "No AWS credentials found. Please specify credentials using one of the methods specified " +
         "in http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/credentials.html")
-    val kinesisClient = new AmazonKinesisClient(credentials)
+    val kinesisClient = AmazonKinesisClientBuilder.standard().
+      withCredentials(credentialsProvider).build()
     kinesisClient.setEndpoint(endpointUrl)
     val numShards = kinesisClient.describeStream(streamName).getStreamDescription().getShards().size
 
@@ -221,7 +222,8 @@ object KinesisWordProducerASL {
     val totals = scala.collection.mutable.Map[String, Int]()
 
     // Create the low-level Kinesis Client from the AWS Java SDK.
-    val kinesisClient = new AmazonKinesisClient(new DefaultAWSCredentialsProviderChain())
+    val kinesisClient = AmazonKinesisClientBuilder.standard().
+      withCredentials(new DefaultAWSCredentialsProviderChain()).build()
     kinesisClient.setEndpoint(endpoint)
 
     println(s"Putting records onto stream $stream and endpoint $endpoint at a rate of" +

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala
@@ -23,8 +23,8 @@ import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.kinesis.AmazonKinesisClient
+import com.amazonaws.auth.{AWSCredentials, AWSStaticCredentialsProvider}
+import com.amazonaws.services.kinesis.{AmazonKinesisClientBuilder}
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model._
 
@@ -33,7 +33,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.{BlockRDD, BlockRDDPartition}
 import org.apache.spark.storage.BlockId
 import org.apache.spark.util.NextIterator
-
 
 /** Class representing a range of Kinesis sequence numbers. Both sequence numbers are inclusive. */
 private[kinesis]
@@ -139,7 +138,8 @@ class KinesisSequenceRangeIterator(
     range: SequenceNumberRange,
     kinesisReadConfigs: KinesisReadConfigurations) extends NextIterator[Record] with Logging {
 
-  private val client = new AmazonKinesisClient(credentials)
+  private val client = AmazonKinesisClientBuilder.standard().
+    withCredentials(new AWSStaticCredentialsProvider(credentials)).build()
   private val streamName = range.streamName
   private val shardId = range.shardId
   // AWS limits to maximum of 10k records per get call


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use AmazonKinesisClientBuilder.withCredentials instead of new AmazonKinesisClient(credentials) to cleanup following compilation warnings:
> [warn] /home/runner/work/spark/spark/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisWordCountASL.scala:108:25: [deprecation @ org.apache.spark.examples.streaming.KinesisWordCountASL.main.kinesisClient | origin=com.amazonaws.services.kinesis.AmazonKinesisClient.<init> | version=] constructor AmazonKinesisClient in class AmazonKinesisClient is deprecated

> [warn] /home/runner/work/spark/spark/connector/kinesis-asl/src/main/scala/org/apache/spark/examples/streaming/KinesisWordCountASL.scala:224:25: [deprecation @ org.apache.spark.examples.streaming.KinesisWordProducerASL.generate.kinesisClient | origin=com.amazonaws.services.kinesis.AmazonKinesisClient.<init> | version=] constructor AmazonKinesisClient in class AmazonKinesisClient is deprecated

> [warn] /home/runner/work/spark/spark/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisBackedBlockRDD.scala:142:24: [deprecation @ org.apache.spark.streaming.kinesis.KinesisSequenceRangeIterator.client | origin=com.amazonaws.services.kinesis.AmazonKinesisClient.<init> | version=] constructor AmazonKinesisClient in class AmazonKinesisClient is deprecated

> [warn] /home/runner/work/spark/spark/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala:58:18: [deprecation @ org.apache.spark.streaming.kinesis.KinesisTestUtils.kinesisClient.client | origin=com.amazonaws.services.kinesis.AmazonKinesisClient.<init> | version=] constructor AmazonKinesisClient in class AmazonKinesisClient is deprecated


### Why are the changes needed?
Cleanup deprecation api usage related to kinesis, include all case.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.