### PR TITLE
[MINOR][SQL] Simplify the description of built-in function.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
@@ -139,7 +139,8 @@ case class TryCast(child: Expression, toType: DataType, timeZoneId: Option[Strin
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(expr1, expr2) - Returns the sum of `expr1`and `expr2` and the result is null on overflow. The acceptable input types are the same with the `+` operator.",
+  usage = "_FUNC_(expr1, expr2) - Returns the sum of `expr1`and `expr2` and the result is null on overflow. " +
+    "The acceptable input types are the same with the `+` operator.",
   examples = """
     Examples:
       > SELECT _FUNC_(1, 2);
@@ -173,7 +174,8 @@ case class TryAdd(left: Expression, right: Expression, replacement: Expression)
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(dividend, divisor) - Returns `dividend`/`divisor`. It always performs floating point division. Its result is always null if `expr2` is 0. `dividend` must be a numeric or an interval. `divisor` must be a numeric.",
+  usage = "_FUNC_(dividend, divisor) - Returns `dividend`/`divisor`. It always performs floating point division. Its result is always null if `expr2` is 0. " +
+    "`dividend` must be a numeric or an interval. `divisor` must be a numeric.",
   examples = """
     Examples:
       > SELECT _FUNC_(3, 2);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
@@ -139,8 +139,7 @@ case class TryCast(child: Expression, toType: DataType, timeZoneId: Option[Strin
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(expr1, expr2) - Returns the sum of `expr1`and `expr2` and the result is null on overflow. " +
-    "The acceptable input types are the same with the `+` operator.",
+  usage = "_FUNC_(expr1, expr2) - Returns the sum of `expr1`and `expr2` and the result is null on overflow. The acceptable input types are the same with the `+` operator.",
   examples = """
     Examples:
       > SELECT _FUNC_(1, 2);
@@ -174,8 +173,7 @@ case class TryAdd(left: Expression, right: Expression, replacement: Expression)
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = "_FUNC_(dividend, divisor) - Returns `dividend`/`divisor`. It always performs floating point division. Its result is always null if `expr2` is 0. " +
-    "`dividend` must be a numeric or an interval. `divisor` must be a numeric.",
+  usage = "_FUNC_(dividend, divisor) - Returns `dividend`/`divisor`. It always performs floating point division. Its result is always null if `expr2` is 0. `dividend` must be a numeric or an interval. `divisor` must be a numeric.",
   examples = """
     Examples:
       > SELECT _FUNC_(3, 2);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/AnyValue.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/AnyValue.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """
     _FUNC_(expr[, isIgnoreNull]) - Returns some value of `expr` for a group of rows.
-      If `isIgnoreNull` is true, returns only non-null values.""",
+      If `isIgnoreNull` is true, returns only non-null values.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(col) FROM VALUES (10), (5), (20) AS tab(col);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CountIf.scala
@@ -22,9 +22,7 @@ import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.types.{AbstractDataType, BooleanType}
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the number of `TRUE` values for the expression.
-  """,
+  usage = "_FUNC_(expr) - Returns the number of `TRUE` values for the expression.",
   examples = """
     Examples:
       > SELECT _FUNC_(col % 2 = 0) FROM VALUES (NULL), (0), (1), (2), (3) AS tab(col);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala
@@ -48,7 +48,8 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """
     _FUNC_(expr[, relativeSD]) - Returns the estimated cardinality by HyperLogLog++.
-      `relativeSD` defines the maximum relative standard deviation allowed.""",
+      `relativeSD` defines the maximum relative standard deviation allowed.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(col1) FROM VALUES (1), (1), (2), (2), (3) tab(col1);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Last.scala
@@ -34,7 +34,8 @@ import org.apache.spark.sql.types._
 @ExpressionDescription(
   usage = """
     _FUNC_(expr[, isIgnoreNull]) - Returns the last value of `expr` for a group of rows.
-      If `isIgnoreNull` is true, returns only non-null values""",
+      If `isIgnoreNull` is true, returns only non-null values
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(col) FROM VALUES (10), (5), (20) AS tab(col);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1917,7 +1917,8 @@ case class ArrayMin(child: Expression)
 @ExpressionDescription(
   usage = """
     _FUNC_(array) - Returns the maximum value in the array. NaN is greater than
-    any non-NaN elements for double/float type. NULL elements are skipped.""",
+    any non-NaN elements for double/float type. NULL elements are skipped.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(array(1, 20, null, 3));

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -175,10 +175,8 @@ case class Pi() extends LeafMathExpression(math.Pi, "PI")
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the inverse cosine (a.k.a. arc cosine) of `expr`, as if computed by
-      `java.lang.Math._FUNC_`.
-  """,
+  usage = "_FUNC_(expr) - Returns the inverse cosine (a.k.a. arc cosine) of `expr`, as if " +
+    "computed by `java.lang.Math._FUNC_`.",
   examples = """
     Examples:
       > SELECT _FUNC_(1);
@@ -193,10 +191,8 @@ case class Acos(child: Expression) extends UnaryMathExpression(math.acos, "ACOS"
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the inverse sine (a.k.a. arc sine) the arc sin of `expr`,
-      as if computed by `java.lang.Math._FUNC_`.
-  """,
+  usage = "_FUNC_(expr) - Returns the inverse sine (a.k.a. arc sine) the arc sin of `expr`, " +
+    "as if computed by `java.lang.Math._FUNC_`.",
   examples = """
     Examples:
       > SELECT _FUNC_(0);
@@ -211,10 +207,8 @@ case class Asin(child: Expression) extends UnaryMathExpression(math.asin, "ASIN"
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the inverse tangent (a.k.a. arc tangent) of `expr`, as if computed by
-      `java.lang.Math._FUNC_`
-  """,
+  usage = "_FUNC_(expr) - Returns the inverse tangent (a.k.a. arc tangent) of `expr`, as if " +
+    "computed by `java.lang.Math._FUNC_`",
   examples = """
     Examples:
       > SELECT _FUNC_(0);
@@ -329,10 +323,8 @@ case class RoundCeil(child: Expression, scale: Expression)
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the cosine of `expr`, as if computed by
-      `java.lang.Math._FUNC_`.
-  """,
+  usage = "_FUNC_(expr) - Returns the cosine of `expr`, as if computed by " +
+    "`java.lang.Math._FUNC_`.",
   arguments = """
     Arguments:
       * expr - angle in radians
@@ -349,9 +341,7 @@ case class Cos(child: Expression) extends UnaryMathExpression(math.cos, "COS") {
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the secant of `expr`, as if computed by `1/java.lang.Math.cos`.
-  """,
+  usage = "_FUNC_(expr) - Returns the secant of `expr`, as if computed by `1/java.lang.Math.cos`.",
   arguments = """
     Arguments:
       * expr - angle in radians
@@ -372,10 +362,8 @@ case class Sec(child: Expression)
 }
 
 @ExpressionDescription(
-  usage = """
-      _FUNC_(expr) - Returns the hyperbolic cosine of `expr`, as if computed by
-        `java.lang.Math._FUNC_`.
-  """,
+  usage = "_FUNC_(expr) - Returns the hyperbolic cosine of `expr`, as if computed by " +
+    "`java.lang.Math._FUNC_`.",
   arguments = """
     Arguments:
       * expr - hyperbolic angle
@@ -876,10 +864,8 @@ case class Cot(child: Expression)
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns the hyperbolic tangent of `expr`, as if computed by
-      `java.lang.Math._FUNC_`.
-  """,
+  usage = "_FUNC_(expr) - Returns the hyperbolic tangent of `expr`, as if computed by " +
+    "`java.lang.Math._FUNC_`.",
   arguments = """
     Arguments:
       * expr - hyperbolic angle
@@ -1146,11 +1132,9 @@ case class Unhex(child: Expression)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(exprY, exprX) - Returns the angle in radians between the positive x-axis of a plane
-      and the point given by the coordinates (`exprX`, `exprY`), as if computed by
-      `java.lang.Math._FUNC_`.
-  """,
+  usage = "_FUNC_(exprY, exprX) - Returns the angle in radians between the positive x-axis of " +
+    "a plane and the point given by the coordinates (`exprX`, `exprY`), as if computed by " +
+    "`java.lang.Math._FUNC_`.",
   arguments = """
     Arguments:
       * exprY - coordinate on y-axis
@@ -1703,11 +1687,9 @@ object WidthBucket {
  * @param numBucket is the number of buckets
  */
 @ExpressionDescription(
-  usage = """
-    _FUNC_(value, min_value, max_value, num_bucket) - Returns the bucket number to which
-      `value` would be assigned in an equiwidth histogram with `num_bucket` buckets,
-      in the range `min_value` to `max_value`."
-  """,
+  usage = "_FUNC_(value, min_value, max_value, num_bucket) - Returns the bucket number to " +
+    "which `value` would be assigned in an equiwidth histogram with `num_bucket` buckets, in the " +
+    "range `min_value` to `max_value`.",
   examples = """
     Examples:
       > SELECT _FUNC_(5.3, 0.2, 10.6, 5);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1133,8 +1133,8 @@ case class Unhex(child: Expression)
 
 @ExpressionDescription(
   usage = "_FUNC_(exprY, exprX) - Returns the angle in radians between the positive x-axis of " +
-    "a plane and the point given by the coordinates (`exprX`, `exprY`), as if computed by " +
-    "`java.lang.Math._FUNC_`.",
+    """a plane and the point given by the coordinates (`exprX`, `exprY`), as if computed by """ +
+    """`java.lang.Math._FUNC_`.""",
   arguments = """
     Arguments:
       * exprY - coordinate on y-axis
@@ -1688,8 +1688,8 @@ object WidthBucket {
  */
 @ExpressionDescription(
   usage = "_FUNC_(value, min_value, max_value, num_bucket) - Returns the bucket number to " +
-    "which `value` would be assigned in an equiwidth histogram with `num_bucket` buckets, in the " +
-    "range `min_value` to `max_value`.",
+    """which `value` would be assigned in an equiwidth histogram with `num_bucket` buckets, """ +
+    """in the range `min_value` to `max_value`.""",
   examples = """
     Examples:
       > SELECT _FUNC_(5.3, 0.2, 10.6, 5);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -175,8 +175,10 @@ case class Pi() extends LeafMathExpression(math.Pi, "PI")
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the inverse cosine (a.k.a. arc cosine) of `expr`, as if " +
-    "computed by `java.lang.Math._FUNC_`.",
+  usage = """
+    _FUNC_(expr) - Returns the inverse cosine (a.k.a. arc cosine) of `expr`, as if computed by
+      `java.lang.Math._FUNC_`.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(1);
@@ -191,8 +193,10 @@ case class Acos(child: Expression) extends UnaryMathExpression(math.acos, "ACOS"
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the inverse sine (a.k.a. arc sine) the arc sin of `expr`, " +
-    "as if computed by `java.lang.Math._FUNC_`.",
+  usage = """
+    _FUNC_(expr) - Returns the inverse sine (a.k.a. arc sine) the arc sin of `expr`,
+      as if computed by `java.lang.Math._FUNC_`.
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(0);
@@ -207,8 +211,10 @@ case class Asin(child: Expression) extends UnaryMathExpression(math.asin, "ASIN"
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the inverse tangent (a.k.a. arc tangent) of `expr`, as if " +
-    "computed by `java.lang.Math._FUNC_`",
+  usage = """
+    _FUNC_(expr) - Returns the inverse tangent (a.k.a. arc tangent) of `expr`, as if computed by
+      `java.lang.Math._FUNC_`
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(0);
@@ -323,8 +329,10 @@ case class RoundCeil(child: Expression, scale: Expression)
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the cosine of `expr`, as if computed by " +
-    "`java.lang.Math._FUNC_`.",
+  usage = """
+    _FUNC_(expr) - Returns the cosine of `expr`, as if computed by
+      `java.lang.Math._FUNC_`.
+  """,
   arguments = """
     Arguments:
       * expr - angle in radians
@@ -362,8 +370,10 @@ case class Sec(child: Expression)
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the hyperbolic cosine of `expr`, as if computed by " +
-    "`java.lang.Math._FUNC_`.",
+  usage = """
+    _FUNC_(expr) - Returns the hyperbolic cosine of `expr`, as if computed by
+      `java.lang.Math._FUNC_`.
+  """,
   arguments = """
     Arguments:
       * expr - hyperbolic angle
@@ -864,8 +874,10 @@ case class Cot(child: Expression)
 }
 
 @ExpressionDescription(
-  usage = "_FUNC_(expr) - Returns the hyperbolic tangent of `expr`, as if computed by " +
-    "`java.lang.Math._FUNC_`.",
+  usage = """
+    _FUNC_(expr) - Returns the hyperbolic tangent of `expr`, as if computed by
+      `java.lang.Math._FUNC_`.
+  """,
   arguments = """
     Arguments:
       * expr - hyperbolic angle

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1132,9 +1132,11 @@ case class Unhex(child: Expression)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @ExpressionDescription(
-  usage = "_FUNC_(exprY, exprX) - Returns the angle in radians between the positive x-axis of " +
-    """a plane and the point given by the coordinates (`exprX`, `exprY`), as if computed by """ +
-    """`java.lang.Math._FUNC_`.""",
+  usage = """
+    _FUNC_(exprY, exprX) - Returns the angle in radians between the positive x-axis of a plane
+      and the point given by the coordinates (`exprX`, `exprY`), as if computed by
+      `java.lang.Math._FUNC_`.
+  """,
   arguments = """
     Arguments:
       * exprY - coordinate on y-axis
@@ -1687,9 +1689,11 @@ object WidthBucket {
  * @param numBucket is the number of buckets
  */
 @ExpressionDescription(
-  usage = "_FUNC_(value, min_value, max_value, num_bucket) - Returns the bucket number to " +
-    """which `value` would be assigned in an equiwidth histogram with `num_bucket` buckets, """ +
-    """in the range `min_value` to `max_value`.""",
+  usage = """
+    _FUNC_(value, min_value, max_value, num_bucket) - Returns the bucket number to which
+      `value` would be assigned in an equiwidth histogram with `num_bucket` buckets,
+      in the range `min_value` to `max_value`."
+  """,
   examples = """
     Examples:
       > SELECT _FUNC_(5.3, 0.2, 10.6, 5);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -392,9 +392,7 @@ case class Cosh(child: Expression) extends UnaryMathExpression(math.cosh, "COSH"
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns inverse hyperbolic cosine of `expr`.
-  """,
+  usage = "_FUNC_(expr) - Returns inverse hyperbolic cosine of `expr`.",
   examples = """
     Examples:
       > SELECT _FUNC_(1);
@@ -529,7 +527,7 @@ case class Floor(child: Expression) extends UnaryMathExpression(math.floor, "FLO
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = " _FUNC_(expr[, scale]) - Returns the largest number after rounding down that is not greater than `expr`. An optional `scale` parameter can be specified to control the rounding behavior.",
+  usage = "_FUNC_(expr[, scale]) - Returns the largest number after rounding down that is not greater than `expr`. An optional `scale` parameter can be specified to control the rounding behavior.",
   examples = """
     Examples:
       > SELECT _FUNC_(-0.1);
@@ -802,9 +800,7 @@ case class Sinh(child: Expression) extends UnaryMathExpression(math.sinh, "SINH"
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns inverse hyperbolic sine of `expr`.
-  """,
+  usage = "_FUNC_(expr) - Returns inverse hyperbolic sine of `expr`.",
   examples = """
     Examples:
       > SELECT _FUNC_(0);
@@ -900,9 +896,7 @@ case class Tanh(child: Expression) extends UnaryMathExpression(math.tanh, "TANH"
 }
 
 @ExpressionDescription(
-  usage = """
-    _FUNC_(expr) - Returns inverse hyperbolic tangent of `expr`.
-  """,
+  usage = "_FUNC_(expr) - Returns inverse hyperbolic tangent of `expr`.",
   examples = """
     Examples:
       > SELECT _FUNC_(0);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -189,15 +189,13 @@ case class CurrentCatalog() extends LeafExpression with Unevaluable {
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_() - Returns an universally unique identifier (UUID) string. The value is returned as a canonical UUID 36-character string.""",
+  usage = "_FUNC_() - Returns an universally unique identifier (UUID) string. The value is returned as a canonical UUID 36-character string.",
   examples = """
     Examples:
       > SELECT _FUNC_();
        46707d92-02f4-4817-8116-a4c3b23e6266
   """,
-  note = """
-    The function is non-deterministic.
-  """,
+  note = "The function is non-deterministic.",
   since = "2.3.0",
   group = "misc_funcs")
 // scalastyle:on line.size.limit
@@ -241,7 +239,7 @@ case class Uuid(randomSeed: Option[Long] = None) extends LeafExpression with Sta
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release version and the second being a git revision.""",
+  usage = "_FUNC_() - Returns the Spark version. The string contains 2 fields, the first being a release version and the second being a git revision.",
   examples = """
     Examples:
       > SELECT _FUNC_();
@@ -261,7 +259,7 @@ case class SparkVersion() extends LeafExpression with CodegenFallback {
 }
 
 @ExpressionDescription(
-  usage = """_FUNC_(expr) - Return DDL-formatted type string for the data type of the input.""",
+  usage = "_FUNC_(expr) - Return DDL-formatted type string for the data type of the input.",
   examples = """
     Examples:
       > SELECT _FUNC_(1);
@@ -286,7 +284,7 @@ case class TypeOf(child: Expression) extends UnaryExpression {
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_() - user name of current execution context.""",
+  usage = "_FUNC_() - user name of current execution context.",
   examples = """
     Examples:
       > SELECT _FUNC_();

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -195,7 +195,9 @@ case class CurrentCatalog() extends LeafExpression with Unevaluable {
       > SELECT _FUNC_();
        46707d92-02f4-4817-8116-a4c3b23e6266
   """,
-  note = "The function is non-deterministic.",
+  note = """
+    The function is non-deterministic.
+  """,
   since = "2.3.0",
   group = "misc_funcs")
 // scalastyle:on line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -82,9 +82,7 @@ trait ExpressionWithRandomSeed extends Expression {
       > SELECT _FUNC_(null);
        0.7604953758285915
   """,
-  note = """
-    The function is non-deterministic in general case.
-  """,
+  note = "The function is non-deterministic in general case.",
   since = "1.5.0",
   group = "math_funcs")
 // scalastyle:on line.size.limit
@@ -125,7 +123,7 @@ object Rand {
 /** Generate a random column with i.i.d. values drawn from the standard normal distribution. */
 // scalastyle:off line.size.limit
 @ExpressionDescription(
-  usage = """_FUNC_([seed]) - Returns a random value with independent and identically distributed (i.i.d.) values drawn from the standard normal distribution.""",
+  usage = "_FUNC_([seed]) - Returns a random value with independent and identically distributed (i.i.d.) values drawn from the standard normal distribution.",
   examples = """
     Examples:
       > SELECT _FUNC_();
@@ -135,9 +133,7 @@ object Rand {
       > SELECT _FUNC_(null);
        1.6034991609278433
   """,
-  note = """
-    The function is non-deterministic in general case.
-  """,
+  note = "The function is non-deterministic in general case.",
   since = "1.5.0",
   group = "math_funcs")
 // scalastyle:on line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/randomExpressions.scala
@@ -82,7 +82,9 @@ trait ExpressionWithRandomSeed extends Expression {
       > SELECT _FUNC_(null);
        0.7604953758285915
   """,
-  note = "The function is non-deterministic in general case.",
+  note = """
+    The function is non-deterministic in general case.
+  """,
   since = "1.5.0",
   group = "math_funcs")
 // scalastyle:on line.size.limit
@@ -133,7 +135,9 @@ object Rand {
       > SELECT _FUNC_(null);
        1.6034991609278433
   """,
-  note = "The function is non-deterministic in general case.",
+  note = """
+    The function is non-deterministic in general case.
+  """,
   since = "1.5.0",
   group = "math_funcs")
 // scalastyle:on line.size.limit


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR used to simplify the description of built-in function.

This PR have a lot of simplified cases.
**Case one:**
```
  usage = """
     _FUNC_(expr[, isIgnoreNull]) - Returns some value of `expr` for a group of rows.
       If `isIgnoreNull` is true, returns only non-null values.""",
```
This PR change it to:
```
  usage = """
     _FUNC_(expr[, isIgnoreNull]) - Returns some value of `expr` for a group of rows.
       If `isIgnoreNull` is true, returns only non-null values.
   """,
```
This case will not affect `DESCRIBE FUNCTION`.

**Case two:**
```
  usage = """
    _FUNC_(expr) - Returns the number of `TRUE` values for the expression.
  """,
```
This PR change it to:
`usage = "_FUNC_(expr) - Returns the number of `TRUE` values for the expression.",`

This case will affect `DESCRIBE FUNCTION`.
The output of `DESCRIBE FUNCTION` before this change show below.
```
Class: org.apache.spark.sql.catalyst.expressions.aggregate.CountIf
Function: count_if
Usage: 
    count_if(expr) - Returns the number of `TRUE` values for the expression.
```
The output of `DESCRIBE FUNCTION` after this change show below.
```
Class: org.apache.spark.sql.catalyst.expressions.aggregate.CountIf
Function: count_if
Usage: count_if(expr) - Returns the number of `TRUE` values for the expression.
```

**Case three:**
`usage = """_FUNC_() - Returns an universally unique identifier (UUID) string. The value is returned as a canonical UUID 36-character string.""",`

This PR change it to:

`usage = "_FUNC_() - Returns an universally unique identifier (UUID) string. The value is returned as a canonical UUID 36-character string.",`

This case will not affect `DESCRIBE FUNCTION`.

### Why are the changes needed?
Simplify the description of built-in function.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update comments.


### How was this patch tested?
N/A
