### PR TITLE
[SPARK-39820][SQL] Add the Support for Custom Authentication for Thrift Server using Http Servlet Request

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/CustomAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/CustomAuthenticationProviderImpl.java
@@ -17,6 +17,7 @@
 package org.apache.hive.service.auth;
 
 import javax.security.sasl.AuthenticationException;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -46,4 +47,9 @@ public class CustomAuthenticationProviderImpl implements PasswdAuthenticationPro
     customProvider.Authenticate(user, password);
   }
 
+  @Override
+  public void AuthenticateRequest(HttpServletRequest request)
+          throws AuthenticationException {
+    customProvider.AuthenticateRequest(request);
+  }
 }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/PasswdAuthenticationProvider.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/PasswdAuthenticationProvider.java
@@ -17,6 +17,7 @@
 package org.apache.hive.service.auth;
 
 import javax.security.sasl.AuthenticationException;
+import javax.servlet.http.HttpServletRequest;
 
 public interface PasswdAuthenticationProvider {
 
@@ -35,4 +36,16 @@ public interface PasswdAuthenticationProvider {
    *                                 invalid by the implementation
    */
   void Authenticate(String user, String password) throws AuthenticationException;
+
+  /**
+   * Add the support of Custom Authentication using Http request
+   * @param request - The http request is used for deriving the information
+   *                  and used in Custom Authentication
+   * @throws AuthenticationException
+   */
+  default void AuthenticateRequest(HttpServletRequest request)
+          throws AuthenticationException {
+     // User can add their own implementation for deriving the
+    // custom params from the http request that can be used Authentication
+  }
 }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/thrift/ThriftHttpServlet.java
@@ -333,6 +333,9 @@ public class ThriftHttpServlet extends TServlet {
         PasswdAuthenticationProvider provider =
             AuthenticationProviderFactory.getAuthenticationProvider(authMethod);
         provider.Authenticate(userName, getPassword(request, authType));
+        if (authMethod == AuthMethods.CUSTOM) {
+          provider.AuthenticateRequest(request);
+        }
 
       } catch (Exception e) {
         throw new HttpAuthenticationException(e);


### PR DESCRIPTION
### What changes were proposed in this pull request?
As per the CustomAuthentication(hive.server2.transport.mode=HTTP) in Thrift Server only String username and String password is supported in the authenticate method of PasswdAuthenticationProvider(https://github.com/apache/spark/blob/master/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/PasswdAuthenticationProvider.java#L37). There is no support for the getting Header param of Request, input param of request, request URI, getMethod if these param is required by the Custom Authentication Service(third party sdk, In House Authentication Service).

In order to support CustomAuthentication for Custom Authentication Service(third party Authentication sdk, In House Authentication Service) there is need to add the code change in Spark Code , then only user can add the Custom Authentication.


### Why are the changes needed?
There is need to support void AuthenticateRequest(HttpServletRequest request) in the Spark Code base, to integrate the custom Authentication in apache spark
For eg
```
public class SampleAuthenticator implements PasswdAuthenticationProvider {
  static Logger logger = Logger.getLogger(SampleAuthenticator.class.getName());

  public SampleAuthenticator() {
    logger.log(Level.INFO, "initialize SampleAuthenticator");
  }
  @Override
  public void Authenticate(String user, String  password)
      throws AuthenticationException {
  }

 @Override
  public void AuthenticateRequest(HttpServletRequest request)
      throws AuthenticationException {
        Map<String, List<String>> requestHeaders = new HashMap(); 
        // derrive the request headerValue from the HttpServletRequest request
        logger.log(Level.INFO, "SampleAuthenticator AuthenticateRequest");
        dummyAuthenticate(request.getMethod(), requestHeaders, request.getRequestURI());
      }
  
public void dummyAuthenticate(String httpMethod, Map<String, List<String>> requestHeaders, String uri) {
     // Code added for custom Authentication
  }    
}
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually tested the patch by using above code .