### PR TITLE
[SPARK-39821][PYTHON][PS] Fix error during using DatetimeIndex

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_datetime.py
+++ b/python/pyspark/pandas/tests/indexes/test_datetime.py
@@ -240,6 +240,11 @@ class DatetimeIndexTest(PandasOnSparkTestCase, TestUtils):
         mapper_pser = pd.Series([1, 2, 3], index=pidx)
         self.assert_eq(psidx.map(mapper_pser), pidx.map(mapper_pser))
 
+    def test_repr(self):
+        pidx_repr = pd.DatetimeIndex(['1970-01-01', '1970-02-01', '1970-03-01']).__repr__()
+        psidx_repr = ps.DatetimeIndex(['1970-01-01', '1970-02-01', '1970-03-01']).__repr__()
+        self.assert_eq(pidx_repr, psidx_repr)
+
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -87,7 +87,7 @@ class PandasConversionMixin:
 
         import numpy as np
         import pandas as pd
-        from pandas.core.dtypes.common import is_timedelta64_dtype
+        from pandas.core.dtypes.common import is_timedelta64_dtype, is_datetime64_dtype
 
         jconf = self.sparkSession._jconf
         timezone = jconf.sessionLocalTimeZone()
@@ -244,7 +244,10 @@ class PandasConversionMixin:
             # No need to cast for non-empty series for timedelta. The type is already correct.
             should_check_timedelta = is_timedelta64_dtype(t) and len(pdf) == 0
 
-            if (t is not None and not is_timedelta64_dtype(t)) or should_check_timedelta:
+            if (t is not None and
+                    not all([
+                        is_timedelta64_dtype(t),
+                        is_datetime64_dtype(t)])) or should_check_timedelta:
                 series = series.astype(t, copy=False)
 
             with catch_warnings():


### PR DESCRIPTION
Pandas disallow conversion between datetime/timedelta and
conversions for any datetimelike to float.

This will raise error in PYSPARK, during we simply call a DatetimeIndex.
So we need to avoid to call astype with datetime64.

BTW, PYSPARK PANDAS announces that won't support DatetimeTZD type.
So lets skip datetime64 type only in base __repr__ func in Index.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Skip datetime64 type during exec astype to convert by pandas in __repr__ func.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve the experience of spark python developers

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
Using Python version 3.8.13 (default, Jun 29 2022 11:50:19)
Spark context Web UI available at http://172.25.179.45:4042
Spark context available as 'sc' (master = local[*], app id = local-1658283215853).
SparkSession available as 'spark'.
>>> from pyspark import pandas as ps
WARNING:root:'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to set this environment variable to '1' in both driver and executor sides if you use pyarrow>=2.0.0. pandas-on-Spark will set it for you but it does not work if there is a Spark context already launched.
>>> ps.DatetimeIndex(['1970-01-01', '1970-01-01', '1970-01-01'])
/home/spark/spark/python/pyspark/pandas/internal.py:1573: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  fields = [
/home/spark/spark/python/pyspark/sql/pandas/conversion.py:486: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for column, series in pdf.iteritems():
/home/spark/.pyenv/versions/3.8.13/lib/python3.8/site-packages/_pydevd_bundle/pydevd_utils.py:601: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for item in s.iteritems():
/home/spark/.pyenv/versions/3.8.13/lib/python3.8/site-packages/_pydevd_bundle/pydevd_utils.py:601: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for item in s.iteritems():
/home/spark/.pyenv/versions/3.8.13/lib/python3.8/site-packages/_pydevd_bundle/pydevd_utils.py:601: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for item in s.iteritems():
/home/spark/.pyenv/versions/3.8.13/lib/python3.8/site-packages/_pydevd_bundle/pydevd_utils.py:601: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
  for item in s.iteritems():
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spark/spark/python/pyspark/pandas/indexes/base.py", line 2770, in __repr__
    pindex = self._psdf._get_or_create_repr_pandas_cache(max_display_count).index
  File "/home/spark/spark/python/pyspark/pandas/frame.py", line 12780, in _get_or_create_repr_pandas_cache
    self, "_repr_pandas_cache", {n: self.head(n + 1)._to_internal_pandas()}
  File "/home/spark/spark/python/pyspark/pandas/frame.py", line 12775, in _to_internal_pandas
    return self._internal.to_pandas_frame
  File "/home/spark/spark/python/pyspark/pandas/utils.py", line 589, in wrapped_lazy_property
    setattr(self, attr_name, fn(self))
  File "/home/spark/spark/python/pyspark/pandas/internal.py", line 1056, in to_pandas_frame
    pdf = sdf.toPandas()
  File "/home/spark/spark/python/pyspark/sql/pandas/conversion.py", line 248, in toPandas
    series = series.astype(t, copy=False)
  File "/home/spark/upstream/pandas/pandas/core/generic.py", line 6095, in astype
    new_data = self._mgr.astype(dtype=dtype, copy=copy, errors=errors)
  File "/home/spark/upstream/pandas/pandas/core/internals/managers.py", line 386, in astype
    return self.apply("astype", dtype=dtype, copy=copy, errors=errors)
  File "/home/spark/upstream/pandas/pandas/core/internals/managers.py", line 308, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/spark/upstream/pandas/pandas/core/internals/blocks.py", line 526, in astype
    new_values = astype_array_safe(values, dtype, copy=copy, errors=errors)
  File "/home/spark/upstream/pandas/pandas/core/dtypes/astype.py", line 299, in astype_array_safe
    new_values = astype_array(values, dtype, copy=copy)
  File "/home/spark/upstream/pandas/pandas/core/dtypes/astype.py", line 227, in astype_array
    values = values.astype(dtype, copy=copy)
  File "/home/spark/upstream/pandas/pandas/core/arrays/datetimes.py", line 631, in astype
    return dtl.DatetimeLikeArrayMixin.astype(self, dtype, copy)
  File "/home/spark/upstream/pandas/pandas/core/arrays/datetimelike.py", line 504, in astype
    raise TypeError(msg)
TypeError: Cannot cast DatetimeArray to dtype datetime64


```
