### PR TITLE
[SPARK-39823][SQL][PYTHON] Rename Dataset.as as Dataset.to and add DataFrame.to in PySpark

### DIFF
--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -29,7 +29,6 @@ DataFrame
     DataFrame.alias
     DataFrame.approxQuantile
     DataFrame.cache
-    DataFrame.cast
     DataFrame.checkpoint
     DataFrame.coalesce
     DataFrame.colRegex
@@ -103,6 +102,7 @@ DataFrame
     DataFrame.summary
     DataFrame.tail
     DataFrame.take
+    DataFrame.to
     DataFrame.toDF
     DataFrame.toJSON
     DataFrame.toLocalIterator

--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -28,8 +28,8 @@ DataFrame
     DataFrame.agg
     DataFrame.alias
     DataFrame.approxQuantile
-    DataFrame.asSchema
     DataFrame.cache
+    DataFrame.cast
     DataFrame.checkpoint
     DataFrame.coalesce
     DataFrame.colRegex

--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -28,6 +28,7 @@ DataFrame
     DataFrame.agg
     DataFrame.alias
     DataFrame.approxQuantile
+    DataFrame.asSchema
     DataFrame.cache
     DataFrame.checkpoint
     DataFrame.coalesce

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1427,8 +1427,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         Returns a new :class:`DataFrame` where each row is reconciled to match the specified
         schema.
 
-        Spark will:
-
+        Notes
+        -----
         1, Reorder columns and/or inner fields by name to match the specified schema.
 
         2, Project away columns and/or inner fields that are not needed by the specified schema.
@@ -1469,12 +1469,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         +---+---+
         """
         assert schema is not None
-        sc = self.sparkSession._sc
-        assert sc is not None and sc._jvm is not None
-        _struct_type = getattr(
-            getattr(sc._jvm.org.apache.spark.sql.types, "StructType$"), "MODULE$"
-        )
-        jschema = _struct_type.fromString(schema.json())
+        jschema = self._jdf.sparkSession().parseDataType(schema.json())
         return DataFrame(self._jdf.to(jschema), self.sparkSession)
 
     def alias(self, alias: str) -> "DataFrame":

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1475,7 +1475,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             getattr(sc._jvm.org.apache.spark.sql.types, "StructType$"), "MODULE$"
         )
         jschema = _struct_type.fromString(schema.json())
-        return DataFrame(getattr(self._jdf, "as")(jschema), self.sparkSession)
+        return DataFrame(self._jdf.to(jschema), self.sparkSession)
 
     def alias(self, alias: str) -> "DataFrame":
         """Returns a new :class:`DataFrame` with an alias set.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1422,7 +1422,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jc = self._jdf.colRegex(colName)
         return Column(jc)
 
-    def asSchema(self, schema: StructType) -> "DataFrame":
+    def cast(self, schema: StructType) -> "DataFrame":
         """
         Returns a new :class:`DataFrame` where each row is reconciled to match the specified
         schema.
@@ -1458,7 +1458,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df.schema
         StructType([StructField('i', StringType(), True), StructField('j', LongType(), True)])
         >>> schema = StructType([StructField("j", StringType()), StructField("i", StringType())])
-        >>> df2 = df.asSchema(schema)
+        >>> df2 = df.cast(schema)
         >>> df2.schema
         StructType([StructField('j', StringType(), True), StructField('i', StringType(), True)])
         >>> df2.show()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1422,6 +1422,52 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jc = self._jdf.colRegex(colName)
         return Column(jc)
 
+    def convert(self, schema: StructType) -> "DataFrame":
+        """
+        Returns a new DataFrame where each row is reconciled to match the specified schema.
+        Spark will:
+        1, Reorder columns and/or inner fields by name to match the specified schema.
+        2, Project away columns and/or inner fields that are not needed by the specified schema.
+        Missing columns and/or inner fields (present in the specified schema but not input
+        DataFrame) lead to failures.
+        3, Cast the columns and/or inner fields to match the data types in the specified schema,
+        if the types are compatible, e.g., numeric to numeric (error if overflows), but not string
+        to int.
+        4, Carry over the metadata from the specified schema, while the columns and/or inner fields
+        still keep their own metadata if not overwritten by the specified schema.
+        5, Fail if the nullability are not compatible. For example, the column and/or inner field
+        is nullable but the specified schema requires them to be not nullable.
+
+        .. versionadded:: 3.4.0
+
+        Parameters
+        ----------
+        schema : StructType
+            specified schema.
+
+        Examples
+        --------
+        >>> df = spark.createDataFrame([("a", 1)], ["i", "j"])
+        >>> df.schema
+        StructType([StructField('i', StringType(), True), StructField('j', LongType(), True)])
+        >>> schema = StructType([StructField("j", StringType()), StructField("i", StringType())])
+        >>> df2 = df.convert(schema)
+        >>> df2.schema
+        StructType([StructField('j', StringType(), True), StructField('i', StringType(), True)])
+        >>> df2.show()
+        +---+---+
+        |  j|  i|
+        +---+---+
+        |  1|  a|
+        +---+---+
+        """
+        assert schema is not None
+        sc = self.sparkSession._sc
+        jschema = sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseStructTypeFromJson(
+            schema.json()
+        )
+        return DataFrame(getattr(self._jdf, "as")(jschema), self.sparkSession)
+
     def alias(self, alias: str) -> "DataFrame":
         """Returns a new :class:`DataFrame` with an alias set.
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1442,7 +1442,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         4, Carry over the metadata from the specified schema, while the columns and/or inner fields
         still keep their own metadata if not overwritten by the specified schema.
 
-        5, Fail if the nullability are not compatible. For example, the column and/or inner field
+        5, Fail if the nullability is not compatible. For example, the column and/or inner field
         is nullable but the specified schema requires them to be not nullable.
 
         .. versionadded:: 3.4.0

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1424,19 +1424,24 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     def asSchema(self, schema: StructType) -> "DataFrame":
         """
-        Returns a new DataFrame where each row is reconciled to match the specified schema.
+        Returns a new :class:`DataFrame` where each row is reconciled to match the specified
+        schema.
 
         Spark will:
 
         1, Reorder columns and/or inner fields by name to match the specified schema.
+
         2, Project away columns and/or inner fields that are not needed by the specified schema.
         Missing columns and/or inner fields (present in the specified schema but not input
         DataFrame) lead to failures.
+
         3, Cast the columns and/or inner fields to match the data types in the specified schema,
         if the types are compatible, e.g., numeric to numeric (error if overflows), but not string
         to int.
+
         4, Carry over the metadata from the specified schema, while the columns and/or inner fields
         still keep their own metadata if not overwritten by the specified schema.
+
         5, Fail if the nullability are not compatible. For example, the column and/or inner field
         is nullable but the specified schema requires them to be not nullable.
 
@@ -1444,8 +1449,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Parameters
         ----------
-        schema : class:`StructType`
-            specified schema.
+        schema : :class:`StructType`
+            Specified schema.
 
         Examples
         --------

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1422,10 +1422,12 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jc = self._jdf.colRegex(colName)
         return Column(jc)
 
-    def convert(self, schema: StructType) -> "DataFrame":
+    def asSchema(self, schema: StructType) -> "DataFrame":
         """
         Returns a new DataFrame where each row is reconciled to match the specified schema.
+
         Spark will:
+
         1, Reorder columns and/or inner fields by name to match the specified schema.
         2, Project away columns and/or inner fields that are not needed by the specified schema.
         Missing columns and/or inner fields (present in the specified schema but not input
@@ -1442,7 +1444,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Parameters
         ----------
-        schema : StructType
+        schema : class:`StructType`
             specified schema.
 
         Examples
@@ -1451,7 +1453,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df.schema
         StructType([StructField('i', StringType(), True), StructField('j', LongType(), True)])
         >>> schema = StructType([StructField("j", StringType()), StructField("i", StringType())])
-        >>> df2 = df.convert(schema)
+        >>> df2 = df.asSchema(schema)
         >>> df2.schema
         StructType([StructField('j', StringType(), True), StructField('i', StringType(), True)])
         >>> df2.show()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1463,6 +1463,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         """
         assert schema is not None
         sc = self.sparkSession._sc
+        assert sc is not None and sc._jvm is not None
         jschema = sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseStructTypeFromJson(
             schema.json()
         )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1422,7 +1422,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jc = self._jdf.colRegex(colName)
         return Column(jc)
 
-    def cast(self, schema: StructType) -> "DataFrame":
+    def to(self, schema: StructType) -> "DataFrame":
         """
         Returns a new :class:`DataFrame` where each row is reconciled to match the specified
         schema.
@@ -1458,7 +1458,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df.schema
         StructType([StructField('i', StringType(), True), StructField('j', LongType(), True)])
         >>> schema = StructType([StructField("j", StringType()), StructField("i", StringType())])
-        >>> df2 = df.cast(schema)
+        >>> df2 = df.to(schema)
         >>> df2.schema
         StructType([StructField('j', StringType(), True), StructField('i', StringType(), True)])
         >>> df2.show()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1466,9 +1466,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         assert schema is not None
         sc = self.sparkSession._sc
         assert sc is not None and sc._jvm is not None
-        jschema = sc._jvm.org.apache.spark.sql.api.python.PythonSQLUtils.parseStructTypeFromJson(
-            schema.json()
+        _struct_type = getattr(
+            getattr(sc._jvm.org.apache.spark.sql.types, "StructType$"), "MODULE$"
         )
+        jschema = _struct_type.fromString(schema.json())
         return DataFrame(getattr(self._jdf, "as")(jschema), self.sparkSession)
 
     def alias(self, alias: str) -> "DataFrame":

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1201,37 +1201,37 @@ class DataFrameTests(ReusedSQLTestCase):
             [Row(value=None)],
         )
 
-    def test_cast(self):
+    def test_to(self):
         schema = StructType(
             [StructField("i", StringType(), True), StructField("j", IntegerType(), True)]
         )
         df = self.spark.createDataFrame([("a", 1)], schema)
 
         schema1 = StructType([StructField("j", StringType()), StructField("i", StringType())])
-        df1 = df.cast(schema1)
+        df1 = df.to(schema1)
         self.assertEqual(schema1, df1.schema)
         self.assertEqual(df.count(), df1.count())
 
         schema2 = StructType([StructField("j", LongType())])
-        df2 = df.cast(schema2)
+        df2 = df.to(schema2)
         self.assertEqual(schema2, df2.schema)
         self.assertEqual(df.count(), df2.count())
 
         schema3 = StructType([StructField("struct", schema1, False)])
-        df3 = df.select(struct("i", "j").alias("struct")).cast(schema3)
+        df3 = df.select(struct("i", "j").alias("struct")).to(schema3)
         self.assertEqual(schema3, df3.schema)
         self.assertEqual(df.count(), df3.count())
 
         # incompatible field nullability
         schema4 = StructType([StructField("j", LongType(), False)])
         self.assertRaisesRegex(
-            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.cast(schema4)
+            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.to(schema4)
         )
 
         # field cannot upcast
         schema5 = StructType([StructField("i", LongType())])
         self.assertRaisesRegex(
-            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.cast(schema5)
+            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.to(schema5)
         )
 
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -25,11 +25,12 @@ import unittest
 from typing import cast
 
 from pyspark.sql import SparkSession, Row
-from pyspark.sql.functions import col, lit, count, sum, mean
+from pyspark.sql.functions import col, lit, count, sum, mean, struct
 from pyspark.sql.types import (
     StringType,
     IntegerType,
     DoubleType,
+    LongType,
     StructType,
     StructField,
     BooleanType,
@@ -1198,6 +1199,39 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertEqual(
             self.spark.createDataFrame(data=[Decimal("NaN")], schema="decimal").collect(),
             [Row(value=None)],
+        )
+
+    def test_convert(self):
+        schema = StructType(
+            [StructField("i", StringType(), True), StructField("j", IntegerType(), True)]
+        )
+        df = self.spark.createDataFrame([("a", 1)], schema)
+
+        schema1 = StructType([StructField("j", StringType()), StructField("i", StringType())])
+        df1 = df.convert(schema1)
+        self.assertEqual(schema1, df1.schema)
+        self.assertEqual(df.count(), df1.count())
+
+        schema2 = StructType([StructField("j", LongType())])
+        df2 = df.convert(schema2)
+        self.assertEqual(schema2, df2.schema)
+        self.assertEqual(df.count(), df2.count())
+
+        schema3 = StructType([StructField("struct", schema1, False)])
+        df3 = df.select(struct("i", "j").alias("struct")).convert(schema3)
+        self.assertEqual(schema3, df3.schema)
+        self.assertEqual(df.count(), df3.count())
+
+        # incompatible field nullability
+        schema4 = StructType([StructField("j", LongType(), False)])
+        self.assertRaisesRegex(
+            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.convert(schema4)
+        )
+
+        # field cannot upcast
+        schema5 = StructType([StructField("i", LongType())])
+        self.assertRaisesRegex(
+            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.convert(schema5)
         )
 
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1201,37 +1201,37 @@ class DataFrameTests(ReusedSQLTestCase):
             [Row(value=None)],
         )
 
-    def test_convert(self):
+    def test_as_schema(self):
         schema = StructType(
             [StructField("i", StringType(), True), StructField("j", IntegerType(), True)]
         )
         df = self.spark.createDataFrame([("a", 1)], schema)
 
         schema1 = StructType([StructField("j", StringType()), StructField("i", StringType())])
-        df1 = df.convert(schema1)
+        df1 = df.asSchema(schema1)
         self.assertEqual(schema1, df1.schema)
         self.assertEqual(df.count(), df1.count())
 
         schema2 = StructType([StructField("j", LongType())])
-        df2 = df.convert(schema2)
+        df2 = df.asSchema(schema2)
         self.assertEqual(schema2, df2.schema)
         self.assertEqual(df.count(), df2.count())
 
         schema3 = StructType([StructField("struct", schema1, False)])
-        df3 = df.select(struct("i", "j").alias("struct")).convert(schema3)
+        df3 = df.select(struct("i", "j").alias("struct")).asSchema(schema3)
         self.assertEqual(schema3, df3.schema)
         self.assertEqual(df.count(), df3.count())
 
         # incompatible field nullability
         schema4 = StructType([StructField("j", LongType(), False)])
         self.assertRaisesRegex(
-            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.convert(schema4)
+            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.asSchema(schema4)
         )
 
         # field cannot upcast
         schema5 = StructType([StructField("i", LongType())])
         self.assertRaisesRegex(
-            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.convert(schema5)
+            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.asSchema(schema5)
         )
 
 

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1201,37 +1201,37 @@ class DataFrameTests(ReusedSQLTestCase):
             [Row(value=None)],
         )
 
-    def test_as_schema(self):
+    def test_cast(self):
         schema = StructType(
             [StructField("i", StringType(), True), StructField("j", IntegerType(), True)]
         )
         df = self.spark.createDataFrame([("a", 1)], schema)
 
         schema1 = StructType([StructField("j", StringType()), StructField("i", StringType())])
-        df1 = df.asSchema(schema1)
+        df1 = df.cast(schema1)
         self.assertEqual(schema1, df1.schema)
         self.assertEqual(df.count(), df1.count())
 
         schema2 = StructType([StructField("j", LongType())])
-        df2 = df.asSchema(schema2)
+        df2 = df.cast(schema2)
         self.assertEqual(schema2, df2.schema)
         self.assertEqual(df.count(), df2.count())
 
         schema3 = StructType([StructField("struct", schema1, False)])
-        df3 = df.select(struct("i", "j").alias("struct")).asSchema(schema3)
+        df3 = df.select(struct("i", "j").alias("struct")).cast(schema3)
         self.assertEqual(schema3, df3.schema)
         self.assertEqual(df.count(), df3.count())
 
         # incompatible field nullability
         schema4 = StructType([StructField("j", LongType(), False)])
         self.assertRaisesRegex(
-            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.asSchema(schema4)
+            AnalysisException, "NULLABLE_COLUMN_OR_FIELD", lambda: df.cast(schema4)
         )
 
         # field cannot upcast
         schema5 = StructType([StructField("i", LongType())])
         self.assertRaisesRegex(
-            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.asSchema(schema5)
+            AnalysisException, "INVALID_COLUMN_OR_FIELD_DATA_TYPE", lambda: df.cast(schema5)
         )
 
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -483,7 +483,7 @@ class Dataset[T] private[sql](
    * @group basic
    * @since 3.4.0
    */
-  def as(schema: StructType): DataFrame = withPlan {
+  def to(schema: StructType): DataFrame = withPlan {
     Project.matchSchema(logicalPlan, schema, sparkSession.sessionState.conf)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -476,7 +476,7 @@ class Dataset[T] private[sql](
    *   int.</li>
    *   <li>Carry over the metadata from the specified schema, while the columns and/or inner fields
    *   still keep their own metadata if not overwritten by the specified schema.</li>
-   *   <li>Fail if the nullability are not compatible. For example, the column and/or inner field is
+   *   <li>Fail if the nullability is not compatible. For example, the column and/or inner field is
    *   nullable but the specified schema requires them to be not nullable.</li>
    * </ul>
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.{ExplainMode, QueryExecution}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.{DataType, StructType}
 
 private[sql] object PythonSQLUtils extends Logging {
   private lazy val internalRowPickler = {
@@ -46,6 +46,8 @@ private[sql] object PythonSQLUtils extends Logging {
   }
 
   def parseDataType(typeText: String): DataType = CatalystSqlParser.parseDataType(typeText)
+
+  def parseStructTypeFromJson(jsonText: String): StructType = StructType.fromString(jsonText)
 
   // This is needed when generating SQL documentation for built-in functions.
   def listBuiltinFunctionInfos(): Array[ExpressionInfo] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.{ExplainMode, QueryExecution}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
 import org.apache.spark.sql.execution.python.EvaluatePython
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.types.DataType
 
 private[sql] object PythonSQLUtils extends Logging {
   private lazy val internalRowPickler = {
@@ -46,8 +46,6 @@ private[sql] object PythonSQLUtils extends Logging {
   }
 
   def parseDataType(typeText: String): DataType = CatalystSqlParser.parseDataType(typeText)
-
-  def parseStructTypeFromJson(jsonText: String): StructType = StructType.fromString(jsonText)
 
   // This is needed when generating SQL documentation for built-in functions.
   def listBuiltinFunctionInfos(): Array[ExpressionInfo] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameToSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameToSchemaSuite.scala
@@ -22,33 +22,33 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
+class DataFrameToSchemaSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 
   test("reorder columns by name") {
     val schema = new StructType().add("j", StringType).add("i", StringType)
-    val df = Seq("a" -> "b").toDF("i", "j").as(schema)
+    val df = Seq("a" -> "b").toDF("i", "j").to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row("b", "a"))
   }
 
   test("case insensitive: reorder columns by name") {
     val schema = new StructType().add("J", StringType).add("I", StringType)
-    val df = Seq("a" -> "b").toDF("i", "j").as(schema)
+    val df = Seq("a" -> "b").toDF("i", "j").to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row("b", "a"))
   }
 
   test("select part of the columns") {
     val schema = new StructType().add("j", StringType)
-    val df = Seq("a" -> "b").toDF("i", "j").as(schema)
+    val df = Seq("a" -> "b").toDF("i", "j").to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row("b"))
   }
 
   test("negative: column not found") {
     val schema = new StructType().add("non_exist", StringType)
-    val e = intercept[SparkThrowable](Seq("a" -> "b").toDF("i", "j").as(schema))
+    val e = intercept[SparkThrowable](Seq("a" -> "b").toDF("i", "j").to(schema))
     checkError(
       exception = e,
       errorClass = "UNRESOLVED_COLUMN",
@@ -59,7 +59,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
 
   test("negative: ambiguous column") {
     val schema = new StructType().add("i", StringType)
-    val e = intercept[SparkThrowable](Seq("a" -> "b").toDF("i", "I").as(schema))
+    val e = intercept[SparkThrowable](Seq("a" -> "b").toDF("i", "I").to(schema))
     checkError(
       exception = e,
       errorClass = "AMBIGUOUS_COLUMN_OR_FIELD",
@@ -72,7 +72,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("j", IntegerType)
     val data = Seq("a" -> 1).toDF("i", "j")
     assert(!data.schema.fields(1).nullable)
-    val df = data.as(schema)
+    val df = data.to(schema)
     val finalSchema = new StructType().add("j", IntegerType, nullable = false)
     assert(df.schema == finalSchema)
     checkAnswer(df, Row(1))
@@ -82,7 +82,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("i", IntegerType, nullable = false)
     val data = sql("SELECT i FROM VALUES 1, NULL as t(i)")
     assert(data.schema.fields(0).nullable)
-    val e = intercept[SparkThrowable](data.as(schema))
+    val e = intercept[SparkThrowable](data.to(schema))
     checkError(
       exception = e,
       errorClass = "NULLABLE_COLUMN_OR_FIELD",
@@ -91,14 +91,14 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
 
   test("upcast the original column") {
     val schema = new StructType().add("j", LongType, nullable = false)
-    val df = Seq("a" -> 1).toDF("i", "j").as(schema)
+    val df = Seq("a" -> 1).toDF("i", "j").to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(1L))
   }
 
   test("negative: column cannot upcast") {
     val schema = new StructType().add("i", IntegerType)
-    val e = intercept[SparkThrowable](Seq("a" -> 1).toDF("i", "j").as(schema))
+    val e = intercept[SparkThrowable](Seq("a" -> 1).toDF("i", "j").to(schema))
     checkError(
       exception = e,
       errorClass = "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
@@ -113,7 +113,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val metadata1 = new MetadataBuilder().putString("a", "1").putString("b", "2").build()
     val metadata2 = new MetadataBuilder().putString("b", "3").putString("c", "4").build()
     val schema = new StructType().add("i", IntegerType, nullable = true, metadata = metadata2)
-    val df = Seq((1)).toDF("i").select($"i".as("i", metadata1)).as(schema)
+    val df = Seq((1)).toDF("i").select($"i".as("i", metadata1)).to(schema)
     // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
     val resultMetadata = new MetadataBuilder()
       .putString("a", "1").putString("b", "3").putString("c", "4").build()
@@ -124,7 +124,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
   test("reorder inner fields by name") {
     val innerFields = new StructType().add("j", StringType).add("i", StringType)
     val schema = new StructType().add("struct", innerFields, nullable = false)
-    val df = Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    val df = Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Row("b", "a")))
   }
@@ -132,7 +132,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
   test("case insensitive: reorder inner fields by name") {
     val innerFields = new StructType().add("J", StringType).add("I", StringType)
     val schema = new StructType().add("struct", innerFields, nullable = false)
-    val df = Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    val df = Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Row("b", "a")))
   }
@@ -141,7 +141,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val innerFields = new StructType().add("non_exist", StringType)
     val schema = new StructType().add("struct", innerFields, nullable = false)
     val e = intercept[SparkThrowable] {
-      Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+      Seq("a" -> "b").toDF("i", "j").select(struct($"i", $"j").as("struct")).to(schema)
     }
     checkError(
       exception = e,
@@ -158,7 +158,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val data = Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct"))
     assert(!data.schema.fields(0).nullable)
     assert(!data.schema.fields(0).dataType.asInstanceOf[StructType].fields(1).nullable)
-    val df = data.as(schema)
+    val df = data.to(schema)
     val finalFields = new StructType().add("j", IntegerType, nullable = false)
     val finalSchema = new StructType().add("struct", finalFields, nullable = false)
     assert(df.schema == finalSchema)
@@ -171,7 +171,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val data = sql("SELECT i FROM VALUES 1, NULL as t(i)").select(struct($"i").as("struct"))
     assert(!data.schema.fields(0).nullable)
     assert(data.schema.fields(0).dataType.asInstanceOf[StructType].fields(0).nullable)
-    val e = intercept[SparkThrowable](data.as(schema))
+    val e = intercept[SparkThrowable](data.to(schema))
     checkError(
       exception = e,
       errorClass = "NULLABLE_COLUMN_OR_FIELD",
@@ -181,7 +181,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
   test("upcast the original field") {
     val innerFields = new StructType().add("j", LongType, nullable = false)
     val schema = new StructType().add("struct", innerFields, nullable = false)
-    val df = Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+    val df = Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct")).to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Row(1L)))
   }
@@ -190,7 +190,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val innerFields = new StructType().add("i", IntegerType)
     val schema = new StructType().add("struct", innerFields, nullable = false)
     val e = intercept[SparkThrowable] {
-      Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct")).as(schema)
+      Seq("a" -> 1).toDF("i", "j").select(struct($"i", $"j").as("struct")).to(schema)
     }
     checkError(
       exception = e,
@@ -210,7 +210,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val df = Seq((1)).toDF("i")
       .select($"i".as("i", metadata1))
       .select(struct($"i").as("struct"))
-      .as(schema)
+      .to(schema)
     // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
     val resultMetadata = new MetadataBuilder()
       .putString("a", "1").putString("b", "3").putString("c", "4").build()
@@ -223,7 +223,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("arr", arr, nullable = false)
     val df = Seq("a" -> "b").toDF("i", "j")
       .select(array(struct($"i", $"j")).as("arr"))
-      .as(schema)
+      .to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Seq(Row("b", "a"))))
   }
@@ -234,7 +234,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("arr", arr, nullable = false)
     val df = Seq("a" -> 1).toDF("i", "j")
       .select(array(struct($"i", $"j")).as("arr"))
-      .as(schema)
+      .to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Seq(Row(1L))))
   }
@@ -244,7 +244,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("arr", arr)
     val data = sql("SELECT i FROM VALUES 1, NULL as t(i)").select(array($"i").as("arr"))
     assert(data.schema.fields(0).dataType.asInstanceOf[ArrayType].containsNull)
-    val e = intercept[SparkThrowable](data.as(schema))
+    val e = intercept[SparkThrowable](data.to(schema))
     checkError(
       exception = e,
       errorClass = "NULLABLE_ARRAY_OR_MAP_ELEMENT",
@@ -260,7 +260,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val df = Seq((1)).toDF("i")
       .select($"i")
       .select(array(struct($"i")).as("arr", metadata1))
-      .as(schema)
+      .to(schema)
     // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
     val resultMetadata = new MetadataBuilder()
       .putString("a", "1").putString("b", "3").putString("c", "4").build()
@@ -276,7 +276,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val df = Seq((1)).toDF("i")
       .select($"i".as("i", metadata1))
       .select(array(struct($"i")).as("arr"))
-      .as(schema)
+      .to(schema)
     // Metadata "a" remains, "b" gets overwritten by the specified schema, "c" is newly added.
     val resultMetadata = new MetadataBuilder()
       .putString("a", "1").putString("b", "3").putString("c", "4").build()
@@ -290,7 +290,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("map", m, nullable = false)
     val df = Seq("a" -> "b").toDF("i", "j")
       .select(map(struct($"i", $"j"), $"i").as("map"))
-      .as(schema)
+      .to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Map(Row("b", "a") -> "a")))
   }
@@ -301,7 +301,7 @@ class DataFrameAsSchemaSuite extends QueryTest with SharedSparkSession {
     val schema = new StructType().add("map", m, nullable = false)
     val df = Seq("a" -> "b").toDF("i", "j")
       .select(map($"i", struct($"i", $"j")).as("map"))
-      .as(schema)
+      .to(schema)
     assert(df.schema == schema)
     checkAnswer(df, Row(Map("a" -> Row("b", "a"))))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1, rename `Dataset.as(StructType)` to `Dataset.to(StructType)`, since `as` is a keyword in python, we dont want to use a different name;
2, Add `DataFrame.to(StructType)` in Python


### Why are the changes needed?
for function parity


### Does this PR introduce _any_ user-facing change?
yes, new api


### How was this patch tested?
added UT
