### PR TITLE
[SPARK-39826][BUILD] Bump scalatest-maven-plugin to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <commons.collections4.version>4.4</commons.collections4.version>
     <scala.version>2.12.16</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
+    <scalatest-maven-plugin.version>2.1.0</scalatest-maven-plugin.version>
     <!--
       This needs to be managed in different profiles to avoid
       errors building different Hadoop versions.


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade scalatest-maven-plugin to version 2.1.0.


### Why are the changes needed?
The last upgrade occurred 1 year ago. 
release note: 
> https://github.com/scalatest/scalatest-maven-plugin/releases/tag/release-2.1.0

v2.0.2 VS v2.1.0
> https://github.com/scalatest/scalatest-maven-plugin/compare/v2.0.2...release-2.1.0

compile with scala 2.12.16
https://github.com/scalatest/scalatest-maven-plugin/blob/master/pom.xml#L22~L24
https://github.com/scalatest/scalatest-maven-plugin/blob/master/pom.xml#L116~L121

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.