### PR TITLE
[SPARK-39819][SQL] DS V2 aggregate push down can work with Top N or Paging (Sort with group column)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -433,7 +433,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         case _ => None
       }
 
-      val orderByGroupCols = order.flatMap(findGroupColForSortOrder)
+      lazy val orderByGroupCols = order.flatMap(findGroupColForSortOrder)
       if (sHolder.pushedAggregate.isDefined && orderByGroupCols.length != order.length) {
         return (s, false)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -424,7 +424,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
           CollapseProject.canCollapseExpressions(order, project, alwaysInline = true) =>
       val aliasMap = getAliasMap(project)
 
-      // TODO support push down ORDER BY expressions.
+      // TODO support push down Aggregate with ORDER BY expressions.
       def findGroupColForSortOrder(sortOrder: SortOrder): Option[SortOrder] = sortOrder match {
         case SortOrder(attr: AttributeReference, direction, nullOrdering, sameOrderExpressions) =>
           findGroupColumn(aliasMap(attr)).filter { groupCol =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, AttributeSet, Cast, Expression, IntegerLiteral, Literal, NamedExpression, PredicateHelper, ProjectionOverSchema, SortOrder, SubqueryExpression}
-import org.apache.spark.sql.catalyst.expressions.aggregate
+import org.apache.spark.sql.catalyst.expressions.{aggregate, Alias, And, Attribute, AttributeReference, AttributeSet, Cast, Expression, IntegerLiteral, Literal, NamedExpression, PredicateHelper, ProjectionOverSchema, SortOrder, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.optimizer.CollapseProject
 import org.apache.spark.sql.catalyst.planning.ScanOperation

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -428,8 +428,7 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
       def findGroupColForSortOrder(sortOrder: SortOrder): Option[SortOrder] = sortOrder match {
         case SortOrder(attr: AttributeReference, direction, nullOrdering, sameOrderExpressions) =>
           findGroupColumn(aliasMap(attr)).filter { groupCol =>
-            sHolder.relation.output.exists(out => out.name.equalsIgnoreCase(groupCol.name) &&
-              out.exprId == groupCol.exprId)
+            sHolder.relation.output.exists(out => out.semanticEquals(groupCol))
           }.map(SortOrder(_, direction, nullOrdering, sameOrderExpressions))
         case _ => None
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -433,12 +433,11 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
         case _ => None
       }
 
-      lazy val orderByGroupCols = order.flatMap(findGroupColForSortOrder)
-      if (sHolder.pushedAggregate.isDefined && orderByGroupCols.length != order.length) {
-        return (s, false)
-      }
-
       val newOrder = if (sHolder.pushedAggregate.isDefined) {
+        val orderByGroupCols = order.flatMap(findGroupColForSortOrder)
+        if (orderByGroupCols.length != order.length) {
+          return (s, false)
+        }
         orderByGroupCols
       } else {
         order.map(replaceAlias(_, aliasMap)).asInstanceOf[Seq[SortOrder]]

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -718,56 +718,45 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkAnswer(df5,
       Seq(Row(1, "cathy", 9000.00, 1200.0, false), Row(1, "amy", 10000.00, 1000.0, true)))
 
-    val df6 = spark.read
-      .table("h2.test.employee")
-      .groupBy("DEPT").sum("SALARY")
-      .orderBy("DEPT")
-      .limit(1)
-    checkSortRemoved(df6, false)
-    checkLimitRemoved(df6, false)
-    checkPushedInfo(df6, "PushedAggregates: [SUM(SALARY)]," +
-      " PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
-    checkAnswer(df6, Seq(Row(1, 19000.00)))
-
     val name = udf { (x: String) => x.matches("cat|dav|amy") }
     val sub = udf { (x: String) => x.substring(0, 3) }
-    val df7 = spark.read
+    val df6 = spark.read
       .table("h2.test.employee")
       .select($"SALARY", $"BONUS", sub($"NAME").as("shortName"))
       .filter(name($"shortName"))
       .sort($"SALARY".desc)
       .limit(1)
     // LIMIT is pushed down only if all the filters are pushed down
-    checkSortRemoved(df7, false)
-    checkLimitRemoved(df7, false)
-    checkPushedInfo(df7, "PushedFilters: [], ")
-    checkAnswer(df7, Seq(Row(10000.00, 1000.0, "amy")))
+    checkSortRemoved(df6, false)
+    checkLimitRemoved(df6, false)
+    checkPushedInfo(df6, "PushedFilters: [], ")
+    checkAnswer(df6, Seq(Row(10000.00, 1000.0, "amy")))
 
-    val df8 = spark.read
+    val df7 = spark.read
       .table("h2.test.employee")
       .sort(sub($"NAME"))
       .limit(1)
-    checkSortRemoved(df8, false)
-    checkLimitRemoved(df8, false)
-    checkPushedInfo(df8, "PushedFilters: [], ")
-    checkAnswer(df8, Seq(Row(2, "alex", 12000.00, 1200.0, false)))
+    checkSortRemoved(df7, false)
+    checkLimitRemoved(df7, false)
+    checkPushedInfo(df7, "PushedFilters: [], ")
+    checkAnswer(df7, Seq(Row(2, "alex", 12000.00, 1200.0, false)))
 
-    val df9 = spark.read
+    val df8 = spark.read
       .table("h2.test.employee")
       .select($"DEPT", $"name", $"SALARY",
         when(($"SALARY" > 8000).and($"SALARY" < 10000), $"salary").otherwise(0).as("key"))
       .sort("key", "dept", "SALARY")
       .limit(3)
-    checkSortRemoved(df9)
-    checkLimitRemoved(df9)
-    checkPushedInfo(df9, "PushedFilters: [], " +
+    checkSortRemoved(df8)
+    checkLimitRemoved(df8)
+    checkPushedInfo(df8, "PushedFilters: [], " +
       "PushedTopN: " +
       "ORDER BY [CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
       "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3,")
-    checkAnswer(df9,
+    checkAnswer(df8,
       Seq(Row(1, "amy", 10000, 0), Row(2, "david", 10000, 0), Row(2, "alex", 12000, 0)))
 
-    val df10 = spark.read
+    val df9 = spark.read
       .option("partitionColumn", "dept")
       .option("lowerBound", "0")
       .option("upperBound", "2")
@@ -777,13 +766,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         when(($"SALARY" > 8000).and($"SALARY" < 10000), $"salary").otherwise(0).as("key"))
       .orderBy($"key", $"dept", $"SALARY")
       .limit(3)
-    checkSortRemoved(df10, false)
-    checkLimitRemoved(df10, false)
-    checkPushedInfo(df10, "PushedFilters: [], " +
+    checkSortRemoved(df9, false)
+    checkLimitRemoved(df9, false)
+    checkPushedInfo(df9, "PushedFilters: [], " +
       "PushedTopN: " +
       "ORDER BY [CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
       "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3,")
-    checkAnswer(df10,
+    checkAnswer(df9,
       Seq(Row(1, "amy", 10000, 0), Row(2, "david", 10000, 0), Row(2, "alex", 12000, 0)))
   }
 
@@ -809,6 +798,64 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedFilters: [DEPT IS NOT NULL, DEPT > 1], " +
         "PushedTopN: ORDER BY [SALARY ASC NULLS FIRST] LIMIT 1, ")
     checkAnswer(df2, Seq(Row(2, "david", 10000.00)))
+  }
+
+  test("scan with aggregate push-down and top N push-down") {
+    val df1 = spark.read
+      .table("h2.test.employee")
+      .groupBy("DEPT").sum("SALARY")
+      .orderBy("DEPT")
+      .limit(1)
+    checkSortRemoved(df1)
+    checkLimitRemoved(df1)
+    checkPushedInfo(df1, "PushedAggregates: [SUM(SALARY)]," +
+      " PushedFilters: [], PushedGroupByExpressions: [DEPT], ")
+    checkAnswer(df1, Seq(Row(1, 19000.00)))
+
+    val df2 = sql(
+      """
+        |SELECT dept AS my_dept, SUM(SALARY) FROM h2.test.employee
+        |GROUP BY dept
+        |ORDER BY my_dept
+        |LIMIT 1
+        |""".stripMargin)
+    checkSortRemoved(df2)
+    checkLimitRemoved(df2)
+    checkPushedInfo(df2,
+      "PushedAggregates: [SUM(SALARY)]",
+      "PushedGroupByExpressions: [DEPT]",
+      "PushedFilters: []")
+    checkAnswer(df2, Seq(Row(1, 19000.00)))
+
+    val df4 = sql(
+      """
+        |SELECT dept, SUM(SALARY) FROM h2.test.employee
+        |GROUP BY dept
+        |ORDER BY SUM(SALARY)
+        |LIMIT 1
+        |""".stripMargin)
+    checkSortRemoved(df4, false)
+    checkLimitRemoved(df4, false)
+    checkPushedInfo(df4,
+      "PushedAggregates: [SUM(SALARY)]",
+      "PushedGroupByExpressions: [DEPT]",
+      "PushedFilters: []")
+    checkAnswer(df4, Seq(Row(6, 12000.00)))
+
+    val df5 = sql(
+      """
+        |SELECT dept, SUM(SALARY) AS total FROM h2.test.employee
+        |GROUP BY dept
+        |ORDER BY total
+        |LIMIT 1
+        |""".stripMargin)
+    checkSortRemoved(df5, false)
+    checkLimitRemoved(df5, false)
+    checkPushedInfo(df5,
+      "PushedAggregates: [SUM(SALARY)]",
+      "PushedGroupByExpressions: [DEPT]",
+      "PushedFilters: []")
+    checkAnswer(df5, Seq(Row(6, 12000.00)))
   }
 
   test("scan with filter push-down") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, DS V2 aggregate push-down cannot work with DS V2 Top N push-down (order by ... limit ...) or DS V2 Paging push-down (order by ... limit ... offset ...).
If we can push down aggregate with Top N or Paging, it will be better performance.

This PR only let aggregate pushed down with ORDER BY column which must be GROUP BY column.

The idea of this PR are:
1. If the `pushedAggregate` is defined, it tell me we may push down aggregate with Top N or Paging.
2. Confirm that all the columns of ORDER BY are column of GROUP BY. We need consider user have defined an alias for column of GROUP BY.
3. If all the columns of ORDER BY are column of GROUP BY, then we can push down aggregate with Top N or Paging.4. 


This PR have a key part which is how to get the original group by column name.
For lazily build the `Scan, the code show below give an expectation output of `ScanBuilderHolder`.
https://github.com/apache/spark/blob/55c3347c48f93a9c5c5c2fb00b30f838eb081b7f/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala#L198

Then the aggregate pushdown will construct an `Alias` for the group by columns show below.
https://github.com/apache/spark/blob/55c3347c48f93a9c5c5c2fb00b30f838eb081b7f/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala#L226
or
https://github.com/apache/spark/blob/55c3347c48f93a9c5c5c2fb00b30f838eb081b7f/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala#L279

So, if we want find out the original group by column, need two steps.
**First step**, use `findGroupColumn` to find out the `Alias` used for attribute starts with `group_col_`. As you know, the name of `Alias` may be the origin column name.
**Second step**, check the attribute looked from first step if it is the origin column by `sHolder.relation.output.exists(out => out.semanticEquals(groupCol)` .
**Third step**, recreate the `SortOrder` with the origin column.


### Why are the changes needed?
Let DS V2 aggregate push down can work with Top N or Paging (Sort with group column), then users can get the better performance.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New test cases.
