### PR TITLE
[MINOR][SQL][DOCS] Fix description of days width in datetime patterns

### DIFF
--- a/docs/sql-ref-datetime-pattern.md
+++ b/docs/sql-ref-datetime-pattern.md
@@ -34,7 +34,7 @@ Spark uses pattern letters in the following table for date and timestamp parsing
 |**y**|year|year|2020; 20|
 |**D**|day-of-year|number(3)|189|
 |**M/L**|month-of-year|month|7; 07; Jul; July|
-|**d**|day-of-month|number(3)|28|
+|**d**|day-of-month|number(2)|28|
 |**Q/q**|quarter-of-year|number/text|3; 03; Q3; 3rd quarter|
 |**E**|day-of-week|text|Tue; Tuesday|
 |**F**|aligned day of week in month|number(1)|3|
@@ -61,7 +61,9 @@ The count of pattern letters determines the format.
 
 - Text: The text style is determined based on the number of pattern letters used. Less than 4 pattern letters will use the short text form, typically an abbreviation, e.g. day-of-week Monday might output "Mon". Exactly 4 pattern letters will use the full text form, typically the full description, e.g, day-of-week Monday might output "Monday". 5 or more letters will fail.
 
-- Number(n): The n here represents the maximum count of letters this type of datetime pattern can be used. If the count of letters is one, then the value is output using the minimum number of digits and without padding. Otherwise, the count of digits is used as the width of the output field, with the value zero-padded as necessary.
+- Number(n): The n here represents the maximum count of letters this type of datetime pattern can be used.
+  - In formatting, if the count of letters is one, then the value is output using the minimum number of digits and without padding otherwise, the count of digits is used as the width of the output field, with the value zero-padded as necessary.
+  - In parsing, the exact count of digits is expected in the input field.
 
 - Number/Text: If the count of pattern letters is 3 or greater, use the Text rules above. Otherwise use the Number rules above.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to fix the width of the day-of-month field to the maximum value 2:
<img width="573" alt="Screenshot 2022-07-21 at 21 11 11" src="https://user-images.githubusercontent.com/1580697/180284361-ac0d11f2-5fb2-4fa9-b950-8d5cf5e7b16f.png">

and clarify the behavior of parsing numbers:

<img width="751" alt="Screenshot 2022-07-21 at 21 11 23" src="https://user-images.githubusercontent.com/1580697/180284644-7af789af-5ebb-4e7e-a041-a00dea8c7b5b.png">


### Why are the changes needed?
To not confuse users and improve user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By building docs and manually checking the changes.