### PR TITLE
[SPARK-39838][SQL] Preserve explicit empty column metadata

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -98,10 +98,15 @@ trait AliasHelper {
   protected def trimNonTopLevelAliases[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
-        val metadata = if (a.metadata == Metadata.empty) {
-          None
-        } else {
-          Some(a.metadata)
+        val metadata = a.explicitMetadata match {
+          // SPARK-39838 Preserve explicit metadata, even if it is empty
+          case Some(metadata) => Some(metadata)
+          case None =>
+            if (a.metadata == Metadata.empty) {
+              None
+            } else {
+              Some(a.metadata)
+            }
         }
         a.copy(child = trimAliases(a.child))(
           exprId = a.exprId,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/AliasHelper.scala
@@ -98,15 +98,10 @@ trait AliasHelper {
   protected def trimNonTopLevelAliases[T <: Expression](e: T): T = {
     val res = e match {
       case a: Alias =>
-        val metadata = a.explicitMetadata match {
-          // SPARK-39838 Preserve explicit metadata, even if it is empty
-          case Some(metadata) => Some(metadata)
-          case None =>
-            if (a.metadata == Metadata.empty) {
-              None
-            } else {
-              Some(a.metadata)
-            }
+        val metadata = if (a.metadata == Metadata.empty && a.explicitMetadata.isEmpty) {
+          None
+        } else {
+          Some(a.metadata)
         }
         a.copy(child = trimAliases(a.child))(
           exprId = a.exprId,


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the issue SPARK-39838 where an explicitly set empty Column Metadata object would be optimized away, making it impossible to reset column metadata.


### Why are the changes needed?
The behaviour changed from Spark 3.2.x to Spark 3.3. While  Spark 3.2.x would respect explicitly resetting a columns metadata to empty, Spark 3.3 inherits the metadata from child nodes. From my point of view, Spark 3.2.x behaviour is correct while Spark 3.3 is unexpected.

### Does this PR introduce _any_ user-facing change?
Not really, except that it restores the behaviour of Spark 3.2.x


### How was this patch tested?
A unittest was added
