### PR TITLE
[SPARK-39841][SQL] simplify conflict binary comparison

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -941,6 +941,8 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
   }
 
   protected lazy val ordering: Ordering[Any] = TypeUtils.getInterpretedOrdering(left.dataType)
+
+  def flipExpression: BinaryComparison
 }
 
 
@@ -1001,6 +1003,8 @@ case class EqualTo(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): EqualTo = copy(left = newLeft, right = newRight)
+
+  override def flipExpression: BinaryComparison = this
 }
 
 // TODO: although map type is not orderable, technically map type should be able to be used
@@ -1066,6 +1070,8 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): EqualNullSafe =
     copy(left = newLeft, right = newRight)
+
+  override def flipExpression: BinaryComparison = this
 }
 
 @ExpressionDescription(
@@ -1139,6 +1145,8 @@ case class LessThan(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
+
+  override def flipExpression: BinaryComparison = GreaterThan(right, left)
 }
 
 @ExpressionDescription(
@@ -1174,6 +1182,8 @@ case class LessThanOrEqual(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
+
+  override def flipExpression: BinaryComparison = GreaterThanOrEqual(right, left)
 }
 
 @ExpressionDescription(
@@ -1209,6 +1219,8 @@ case class GreaterThan(left: Expression, right: Expression)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
+
+  override def flipExpression: BinaryComparison = LessThan(right, left)
 }
 
 @ExpressionDescription(
@@ -1245,6 +1257,8 @@ case class GreaterThanOrEqual(left: Expression, right: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): GreaterThanOrEqual =
     copy(left = newLeft, right = newRight)
+
+  override def flipExpression: BinaryComparison = LessThanOrEqual(right, left)
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -116,6 +116,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         SimplifyConditionals,
         PushFoldableIntoBranches,
         RemoveDispensableExpressions,
+        SimplifyConflictBinaryComparison,
         SimplifyBinaryComparison,
         ReplaceNullWithFalseInPredicate,
         SimplifyConditionalsInPredicate,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -27,7 +27,7 @@ case class RuleId(id: Int) {
   // Currently, there are more than 128 but less than 192 rules needing an id. However, the
   // requirement can be relaxed when we have more such rules. Note that increasing the max id can
   // result in increased memory consumption from every TreeNode.
-  require(id >= -1 && id < 192)
+  require(id >= -1 && id < 193)
 }
 
 // Unknown rule id which does not prune tree traversals. It is used as the default rule id for
@@ -152,6 +152,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.RewriteExceptAll" ::
       "org.apache.spark.sql.catalyst.optimizer.RewriteIntersectAll" ::
       "org.apache.spark.sql.catalyst.optimizer.RewriteAsOfJoin" ::
+      "org.apache.spark.sql.catalyst.optimizer.SimplifyConflictBinaryComparison" ::
       "org.apache.spark.sql.catalyst.optimizer.SimplifyBinaryComparison" ::
       "org.apache.spark.sql.catalyst.optimizer.SimplifyCaseConversionExpressions" ::
       "org.apache.spark.sql.catalyst.optimizer.SimplifyCasts" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1378,6 +1378,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException(s"Unsupported data type ${field.dataType.catalogString}")
   }
 
+  def cannotConvertTypeError(value: Any, t: String): Throwable = {
+    new AnalysisException(s"Can't convert $value to $t type")
+  }
+
   def incompatibleViewSchemaChange(
       viewName: String,
       colName: String,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConflictBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConflictBinaryComparisonSuite.scala
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.Literal.FalseLiteral
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class SimplifyConflictBinaryComparisonSuite extends PlanTest with PredicateHelper  {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+        Batch("Constant Folding", FixedPoint(50),
+          NullPropagation,
+          ConstantFolding,
+          BooleanSimplification,
+          SimplifyBinaryComparison,
+          SimplifyConflictBinaryComparison,
+          PruneFilters) :: Nil
+  }
+
+  val nonNullRelation: LocalRelation = LocalRelation($"a".int.withNullability(false))
+
+  test("EqualTo-related conjunction combinations") {
+    //  a = 1 and a = 2  =====> FalseLiteral
+    val plan1 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), EqualTo($"a", Literal.apply(2))))
+    val actual1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual1, correctAnswer1)
+
+    // a = 1 and a > 0  ====> a = 1
+    val plan2 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), GreaterThan($"a", Literal.apply(0))))
+    val actual2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual2, correctAnswer2)
+
+    // a = 1 and a > 2  ====> FalseLiteral
+    val plan3 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), GreaterThan($"a", Literal.apply(2))))
+    val actual3 = Optimize.execute(plan3.analyze)
+    val correctAnswer3 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual3, correctAnswer3)
+
+    // a = 1 and a < 0  ====> FalseLiteral
+    val plan4 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), LessThan($"a", Literal.apply(0))))
+    val actual4 = Optimize.execute(plan4.analyze)
+    val correctAnswer4 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual4, correctAnswer4)
+
+    // a = 1 and a < 3  ====> a = 1
+    val plan5 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), LessThan($"a", Literal.apply(3))))
+    val actual5 = Optimize.execute(plan5.analyze)
+    val correctAnswer5 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual5, correctAnswer5)
+
+    // a = 1 and a >= 3  ====> FalseLiteral
+    val plan6 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(3))))
+    val actual6 = Optimize.execute(plan6.analyze)
+    val correctAnswer6 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual6, correctAnswer6)
+
+    // a = 1 and a >= 0  ====> a = 1
+    val plan7 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(0))))
+    val actual7 = Optimize.execute(plan7.analyze)
+    val correctAnswer7 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual7, correctAnswer7)
+
+    // a = 1 and a >= 1  ====> a = 1
+    val plan8 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(1))))
+    val actual8 = Optimize.execute(plan8.analyze)
+    val correctAnswer8 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual8, correctAnswer8)
+
+    // a = 1 and a <= 0  ====> FalseLiteral
+    val plan9 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(0))))
+    val actual9 = Optimize.execute(plan9.analyze)
+    val correctAnswer9 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual9, correctAnswer9)
+
+    // a = 1 and a <= 3  ====> a = 1
+    val plan10 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(3))))
+    val actual10 = Optimize.execute(plan10.analyze)
+    val correctAnswer10 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual10, correctAnswer10)
+
+    // a = 1 and a <= 1  ====> FalseLiteral
+    val plan11 = nonNullRelation
+      .where(And(EqualTo($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(1))))
+    val actual11 = Optimize.execute(plan11.analyze)
+    val correctAnswer11 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual11, correctAnswer11)
+  }
+
+  test("GreaterThan-related conjunction combinations") {
+    //  a > 1 and a > 2  =====> a > 2
+    val plan1 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), GreaterThan($"a", Literal.apply(2))))
+    val actual1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(2))).analyze)
+    comparePlans(actual1, correctAnswer1)
+
+    // a > 1 and a > 0  ====> a > 1
+    val plan2 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), GreaterThan($"a", Literal.apply(0))))
+    val actual2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1))).analyze)
+    comparePlans(actual2, correctAnswer2)
+
+    // a > 1 and a = 0  ====> FalseLiteral
+    val plan3 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), EqualTo($"a", Literal.apply(0))))
+    val actual3 = Optimize.execute(plan3.analyze)
+    val correctAnswer3 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual3, correctAnswer3)
+
+    // a > 1 and a < 0  ====> FalseLiteral
+    val plan4 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), LessThan($"a", Literal.apply(0))))
+    val actual4 = Optimize.execute(plan4.analyze)
+    val correctAnswer4 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual4, correctAnswer4)
+
+    // a > 1 and a < 3  ====>  1 < a < 3
+    val plan5 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), LessThan($"a", Literal.apply(3))))
+    val actual5 = Optimize.execute(plan5.analyze)
+    val correctAnswer5 = Optimize.execute(nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), LessThan($"a", Literal.apply(3)))).analyze)
+    comparePlans(actual5, correctAnswer5)
+
+    // a > 1 and a >= 3  ====> a >= 3
+    val plan6 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(3))))
+    val actual6 = Optimize.execute(plan6.analyze)
+    val correctAnswer6 = Optimize.execute(nonNullRelation
+      .where(GreaterThanOrEqual($"a", Literal.apply(3))).analyze)
+    comparePlans(actual6, correctAnswer6)
+
+    // a > 1 and a >= 0  ====> a > 1
+    val plan7 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(0))))
+    val actual7 = Optimize.execute(plan7.analyze)
+    val correctAnswer7 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1))).analyze)
+    comparePlans(actual7, correctAnswer7)
+
+    // a > 1 and a >= 1  ====> a > 1
+    val plan8 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(1))))
+    val actual8 = Optimize.execute(plan8.analyze)
+    val correctAnswer8 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1))).analyze)
+    comparePlans(actual8, correctAnswer8)
+
+    // a > 1 and a <= 0  ====> FalseLiteral
+    val plan9 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(0))))
+    val actual9 = Optimize.execute(plan9.analyze)
+    val correctAnswer9 = Optimize.execute(nonNullRelation.where(FalseLiteral).analyze)
+    comparePlans(actual9, correctAnswer9)
+
+    // a > 1 and a <= 3  ====> a < a <= 3
+    val plan10 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(3))))
+    val actual10 = Optimize.execute(plan10.analyze)
+    val correctAnswer10 = Optimize.execute(nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)),
+        LessThanOrEqual($"a", Literal.apply(3)))).analyze)
+    comparePlans(actual10, correctAnswer10)
+
+    // a > 1 and a <= 1  ====> FalseLiteral
+    val plan11 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(1))))
+    val actual11 = Optimize.execute(plan11.analyze)
+    val correctAnswer11 = Optimize.execute(nonNullRelation
+      .where(FalseLiteral).analyze)
+    comparePlans(actual11, correctAnswer11)
+  }
+
+  test("LessThan-related conjunction combinations") {
+    //  a < 1 and a < 2  =====> a < 1
+    val plan1 = nonNullRelation
+      .where(And(LessThan($"a", Literal.apply(1)), LessThan($"a", Literal.apply(2))))
+    val actual1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = Optimize.execute(nonNullRelation
+      .where(LessThan($"a", Literal.apply(1))).analyze)
+    comparePlans(actual1, correctAnswer1)
+
+    // a < 1 and a >= 2  ====> FalseLiteral
+    val plan2 = nonNullRelation
+      .where(And(LessThan($"a", Literal.apply(1)), GreaterThanOrEqual($"a", Literal.apply(2))))
+    val actual2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = Optimize.execute(nonNullRelation
+      .where(FalseLiteral).analyze)
+    comparePlans(actual2, correctAnswer2)
+
+    // a < 1 and a <= 0  ====> a <= 0
+    val plan3 = nonNullRelation
+      .where(And(LessThan($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(0))))
+    val actual3 = Optimize.execute(plan3.analyze)
+    val correctAnswer3 = Optimize.execute(nonNullRelation
+      .where(LessThanOrEqual($"a", Literal.apply(0))).analyze)
+    comparePlans(actual3, correctAnswer3)
+
+    // a < 1 and a <= 1  ====> a < 1
+    val plan4 = nonNullRelation
+      .where(And(LessThan($"a", Literal.apply(1)), LessThanOrEqual($"a", Literal.apply(1))))
+    val actual4 = Optimize.execute(plan4.analyze)
+    val correctAnswer4 = Optimize.execute(nonNullRelation
+      .where(LessThan($"a", Literal.apply(1))).analyze)
+    comparePlans(actual4, correctAnswer4)
+  }
+
+  test("GreaterThanOrEqual-related conjunction combinations") {
+    //  a >= 1 and a >= 2  =====> a >= 2
+    val plan1 = nonNullRelation
+      .where(And(GreaterThanOrEqual($"a", Literal.apply(1)),
+        GreaterThanOrEqual($"a", Literal.apply(2))))
+    val actual1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = Optimize.execute(nonNullRelation
+      .where(GreaterThanOrEqual($"a", Literal.apply(2))).analyze)
+    comparePlans(actual1, correctAnswer1)
+
+    // a >= 1 and a <= 2  ====> 1 <= a <= 2
+    val plan2 = nonNullRelation
+      .where(And(GreaterThanOrEqual($"a", Literal.apply(1)),
+        LessThanOrEqual($"a", Literal.apply(2))))
+    val actual2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = Optimize.execute(nonNullRelation
+      .where(And(GreaterThanOrEqual($"a", Literal.apply(1)),
+        LessThanOrEqual($"a", Literal.apply(2)))).analyze)
+    comparePlans(actual2, correctAnswer2)
+
+    // a >= 1 and a <= 1  ====> a = 1
+    val plan3 = nonNullRelation
+      .where(And(GreaterThanOrEqual($"a", Literal.apply(1)),
+        LessThanOrEqual($"a", Literal.apply(1))))
+    val actual3 = Optimize.execute(plan3.analyze)
+    val correctAnswer3 = Optimize.execute(nonNullRelation
+      .where(EqualTo($"a", Literal.apply(1))).analyze)
+    comparePlans(actual3, correctAnswer3)
+  }
+
+  test("Attribute is left conjunction combinations") {
+    //  1 < a and 2 < a ===> a > 2
+    val plan1 = nonNullRelation
+      .where(And(LessThan(Literal.apply(1), $"a"),
+        LessThan(Literal.apply(2), $"a")))
+    val actual1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = Optimize.execute(nonNullRelation
+      .where(LessThan(Literal.apply(2), $"a")).analyze)
+    comparePlans(actual1, correctAnswer1)
+
+    // a < 0 and 3 < a  ===> a
+    val plan2 = nonNullRelation
+      .where(And(LessThan($"a", Literal.apply(0)),
+        GreaterThan($"a", Literal.apply(3))))
+    val actual2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = Optimize.execute(nonNullRelation
+      .where(FalseLiteral).analyze)
+    comparePlans(actual2, correctAnswer2)
+  }
+
+  test("Left and right types are inconsistent") {
+    // a > 1 and a > 0.5 => a > 1
+    val plan1 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)),
+        GreaterThan($"a", Literal.apply(0.5))))
+    val actual1 = Optimize.execute(plan1.analyze)
+    val correctAnswer1 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1))).analyze)
+    comparePlans(actual1, correctAnswer1)
+
+    // a > 1 and a > 1.5 => a > 1.5
+    val plan2 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1)),
+        GreaterThan($"a", Literal.apply(1.5))))
+    val actual2 = Optimize.execute(plan2.analyze)
+    val correctAnswer2 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1.5))).analyze)
+    comparePlans(actual2, correctAnswer2)
+
+    // a > 1.5 and a > 1 => a > 1.5
+    val plan3 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1.5)),
+        GreaterThan($"a", Literal.apply(1))))
+    val actual3 = Optimize.execute(plan3.analyze)
+    val correctAnswer3 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1.5))).analyze)
+    comparePlans(actual3, correctAnswer3)
+
+    // a > 1.5 and a > 0.5 => a > 1.5
+    val plan4 = nonNullRelation
+      .where(And(GreaterThan($"a", Literal.apply(1.5)),
+        GreaterThan($"a", Literal.apply(0.5))))
+    val actual4 = Optimize.execute(plan4.analyze)
+    val correctAnswer4 = Optimize.execute(nonNullRelation
+      .where(GreaterThan($"a", Literal.apply(1.5))).analyze)
+    comparePlans(actual4, correctAnswer4)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcFilterSuite.scala
@@ -380,11 +380,6 @@ class OrcFilterSuite extends OrcTest with SharedSparkSession {
         "leaf-0 = (LESS_THAN _1 2), leaf-1 = (LESS_THAN_EQUALS _1 3), " +
           "expr = (or leaf-0 (not leaf-1))"
       )
-      checkFilterPredicate(
-        $"_1" < 2 && $"_1" > 3,
-        "leaf-0 = (IS_NULL _1), leaf-1 = (LESS_THAN _1 2), leaf-2 = (LESS_THAN_EQUALS _1 3), " +
-          "expr = (and (not leaf-0) leaf-1 (not leaf-2))"
-      )
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Currently, We do not handle conflicting binary comparison expressions, Let's say have a query, it filter `a < 0 and a > 1`, this condition should be a `FalseLiteral`, we can fold ahead of time to avoid unnecessary calculations.

Have a idea, we can capture a and conjunction and both it's left and right are `BinaryComparisonExpression`, we optimize this predicate as following step:

- Normal and left and right comparison expression, to keep Attribute is left side and literal is right side.
- If both comparison expression left child is semantic equal and right child is foldable, we compute a range for column predicate comparison .
- Then update this column comparison predicate by this range.

Before this pr:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/51110188/180430599-fad13dbe-f8eb-4f13-9a04-77d920eba50b.png">

After this pr:
<img width="647" alt="image" src="https://user-images.githubusercontent.com/51110188/180435768-3e58435a-3e06-406b-971a-026961438882.png">



### Why are the changes needed?
Fold ahead to avoid unnecessary calculations & improve performance


### Does this PR introduce _any_ user-facing change?
No, improve only

### How was this patch tested?
Add new tests
