### PR TITLE
[SPARK-39844][SQL] Update SQLConf for DEFAULT column providers to allow/deny "ALTER TABLE ... ADD COLUMN" commands separately

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -115,6 +115,7 @@ object ResolveDefaultColumns {
               .defaultReferencesNotAllowedInDataSource(statementType, givenTableProvider)
           }
           if (addNewColumnToExistingTable &&
+            givenTableProvider.nonEmpty &&
             addColumnExistingTableBannedProviders.contains(givenTableProvider)) {
             throw QueryCompilationErrors
               .addNewDefaultColumnToExistingTableNotAllowed(statementType, givenTableProvider)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -115,7 +115,7 @@ object ResolveDefaultColumns {
               .defaultReferencesNotAllowedInDataSource(statementType, givenTableProvider)
           }
           if (addNewColumnToExistingTable &&
-            !addColumnExistingTableBannedProviders.contains(givenTableProvider)) {
+            addColumnExistingTableBannedProviders.contains(givenTableProvider)) {
             throw QueryCompilationErrors
               .addNewDefaultColumnToExistingTableNotAllowed(statementType, givenTableProvider)
           }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -90,22 +90,34 @@ object ResolveDefaultColumns {
    * @param tableSchema   represents the names and types of the columns of the statement to process.
    * @param tableProvider provider of the target table to store default values for, if any.
    * @param statementType name of the statement being processed, such as INSERT; useful for errors.
+   * @param addNewColumnToExistingTable true if the statement being processed adds a new column to
+   *                                    a table that already exists.
    * @return a copy of `tableSchema` with field metadata updated with the constant-folded values.
    */
   def constantFoldCurrentDefaultsToExistDefaults(
       tableSchema: StructType,
       tableProvider: Option[String],
-      statementType: String): StructType = {
+      statementType: String,
+      addNewColumnToExistingTable: Boolean): StructType = {
     if (SQLConf.get.enableDefaultColumns) {
       val allowedTableProviders: Array[String] =
         SQLConf.get.getConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS)
+          .toLowerCase().split(",").map(_.trim)
+      val addColumnExistingTableBannedProviders: Array[String] =
+        SQLConf.get.getConf(SQLConf.ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS)
           .toLowerCase().split(",").map(_.trim)
       val givenTableProvider: String = tableProvider.getOrElse("").toLowerCase()
       val newFields: Seq[StructField] = tableSchema.fields.map { field =>
         if (field.metadata.contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY)) {
           // Make sure that the target table has a provider that supports default column values.
           if (!allowedTableProviders.contains(givenTableProvider)) {
-            throw QueryCompilationErrors.defaultReferencesNotAllowedInDataSource(givenTableProvider)
+            throw QueryCompilationErrors
+              .defaultReferencesNotAllowedInDataSource(statementType, givenTableProvider)
+          }
+          if (addNewColumnToExistingTable &&
+            !addColumnExistingTableBannedProviders.contains(givenTableProvider)) {
+            throw QueryCompilationErrors
+              .addNewDefaultColumnToExistingTableNotAllowed(statementType, givenTableProvider)
           }
           val analyzed: Expression = analyze(field, statementType)
           val newMetadata: Metadata = new MetadataBuilder().withMetadata(field.metadata)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -104,7 +104,7 @@ object ResolveDefaultColumns {
         SQLConf.get.getConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS)
           .toLowerCase().split(",").map(_.trim)
       val allowedTableProviders: Array[String] =
-        keywords.filter(!_.endsWith("*"))
+        keywords.map(_.stripSuffix("*"))
       val addColumnExistingTableBannedProviders: Array[String] =
         keywords.filter(_.endsWith("*")).map(_.stripSuffix("*"))
       val givenTableProvider: String = tableProvider.getOrElse("").toLowerCase()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -100,12 +100,13 @@ object ResolveDefaultColumns {
       statementType: String,
       addNewColumnToExistingTable: Boolean): StructType = {
     if (SQLConf.get.enableDefaultColumns) {
-      val allowedTableProviders: Array[String] =
+      val keywords: Array[String] =
         SQLConf.get.getConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS)
           .toLowerCase().split(",").map(_.trim)
+      val allowedTableProviders: Array[String] =
+        keywords.filter(!_.endsWith("*"))
       val addColumnExistingTableBannedProviders: Array[String] =
-        SQLConf.get.getConf(SQLConf.ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS)
-          .toLowerCase().split(",").map(_.trim)
+        keywords.filter(_.endsWith("*")).map(_.stripSuffix("*"))
       val givenTableProvider: String = tableProvider.getOrElse("").toLowerCase()
       val newFields: Seq[StructField] = tableSchema.fields.map { field =>
         if (field.metadata.contains(CURRENT_DEFAULT_COLUMN_METADATA_KEY)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2511,6 +2511,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "adding new columns to previously existing target data source with table " +
         "provider: \"" + dataSource + "\"")
   }
+
   def defaultValuesMayNotContainSubQueryExpressions(): Throwable = {
     new AnalysisException(
       "Failed to execute command because subquery expressions are not allowed in DEFAULT values")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2497,12 +2497,20 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
         "literal value")
   }
 
-  def defaultReferencesNotAllowedInDataSource(dataSource: String): Throwable = {
+  def defaultReferencesNotAllowedInDataSource(
+      statementType: String, dataSource: String): Throwable = {
     new AnalysisException(
-      s"Failed to execute command because DEFAULT values are not supported for target data " +
-        "source with table provider: \"" + dataSource + "\"")
+      s"Failed to execute $statementType command because DEFAULT values are not supported for " +
+        "target data source with table provider: \"" + dataSource + "\"")
   }
 
+  def addNewDefaultColumnToExistingTableNotAllowed(
+      statementType: String, dataSource: String): Throwable = {
+    new AnalysisException(
+      s"Failed to execute $statementType command because DEFAULT values are not supported when " +
+        "adding new columns to previously existing target data source with table " +
+        "provider: \"" + dataSource + "\"")
+  }
   def defaultValuesMayNotContainSubQueryExpressions(): Throwable = {
     new AnalysisException(
       "Failed to execute command because subquery expressions are not allowed in DEFAULT values")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2914,21 +2914,13 @@ object SQLConf {
     buildConf("spark.sql.defaultColumn.allowedProviders")
       .internal()
       .doc("List of table providers wherein SQL commands are permitted to assign DEFAULT column " +
-        "values. Comma-separated list, whitespace ignored, case-insensitive.")
+        "values. Comma-separated list, whitespace ignored, case-insensitive. If an asterisk " +
+        "appears after any table provider in this list, any command may assign DEFAULT column " +
+        "except ALTER TABLE ... ADD COLUMN. Otherwise, if no asterisk appears, all commands are " +
+        "permitted.")
       .version("3.4.0")
       .stringConf
       .createWithDefault("csv,json,orc,parquet")
-
-  val ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS =
-    buildConf("spark.sql.defaultColumn.addColumnExistingTableBannedProviders")
-      .internal()
-      .doc("List of table providers wherein SQL commands are NOT permitted to assign DEFAULT " +
-        "values to new columns in existing tables, such as when using the ALTER TABLE ... " +
-        "ADD COLUMNS command in SQL. Comma-separated list, whitespace ignored, case-insensitive.")
-      .version("3.4.0")
-      .stringConf
-      .createWithDefault("")
-
 
   val USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES =
     buildConf("spark.sql.defaultColumn.useNullsForMissingDefaultValues")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2916,8 +2916,10 @@ object SQLConf {
       .doc("List of table providers wherein SQL commands are permitted to assign DEFAULT column " +
         "values. Comma-separated list, whitespace ignored, case-insensitive. If an asterisk " +
         "appears after any table provider in this list, any command may assign DEFAULT column " +
-        "except ALTER TABLE ... ADD COLUMN. Otherwise, if no asterisk appears, all commands are " +
-        "permitted.")
+        "except `ALTER TABLE ... ADD COLUMN`. Otherwise, if no asterisk appears, all commands " +
+        "are permitted. This is useful because in order for such `ALTER TABLE ... ADD COLUMN` " +
+        "commands to work, the target data source must include support for substituting in the " +
+        "provided values when the corresponding fields are not present in storage.")
       .version("3.4.0")
       .stringConf
       .createWithDefault("csv,json,orc,parquet")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2919,6 +2919,17 @@ object SQLConf {
       .stringConf
       .createWithDefault("csv,json,orc,parquet")
 
+  val ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS =
+    buildConf("spark.sql.defaultColumn.addColumnExistingTableBannedProviders")
+      .internal()
+      .doc("List of table providers wherein SQL commands are NOT permitted to assign DEFAULT " +
+        "values to new columns in existing tables, such as when using the ALTER TABLE ... " +
+        "ADD COLUMNS command in SQL. Comma-separated list, whitespace ignored, case-insensitive.")
+      .version("3.4.0")
+      .stringConf
+      .createWithDefault("")
+
+
   val USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES =
     buildConf("spark.sql.defaultColumn.useNullsForMissingDefaultValues")
       .internal()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -174,7 +174,7 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       // disabled.
       withSQLConf(SQLConf.ENABLE_DEFAULT_COLUMNS.key -> "false") {
         val result: StructType = ResolveDefaultColumns.constantFoldCurrentDefaultsToExistDefaults(
-          db1tbl3.schema, db1tbl3.provider, "CREATE TABLE")
+          db1tbl3.schema, db1tbl3.provider, "CREATE TABLE", false)
         val columnEWithFeatureDisabled: StructField = findField("e", result)
         // No constant-folding has taken place to the EXISTS_DEFAULT metadata.
         assert(!columnEWithFeatureDisabled.metadata.contains("EXISTS_DEFAULT"))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/tables.scala
@@ -290,7 +290,7 @@ case class AlterTableAddColumnsCommand(
     colsToAdd.map { col: StructField =>
       if (col.metadata.contains(ResolveDefaultColumns.CURRENT_DEFAULT_COLUMN_METADATA_KEY)) {
         val foldedStructType = ResolveDefaultColumns.constantFoldCurrentDefaultsToExistDefaults(
-          StructType(Seq(col)), tableProvider, "ALTER TABLE ADD COLUMNS")
+          StructType(Seq(col)), tableProvider, "ALTER TABLE ADD COLUMNS", true)
         foldedStructType.fields(0)
       } else {
         col

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -149,7 +149,7 @@ case class DataSourceAnalysis(analyzer: Analyzer) extends Rule[LogicalPlan] {
     case CreateTable(tableDesc, mode, None) if DDLUtils.isDatasourceTable(tableDesc) =>
       val newSchema: StructType =
         ResolveDefaultColumns.constantFoldCurrentDefaultsToExistDefaults(
-          tableDesc.schema, tableDesc.provider, "CREATE TABLE")
+          tableDesc.schema, tableDesc.provider, "CREATE TABLE", false)
       val newTableDesc = tableDesc.copy(schema = newSchema)
       CreateDataSourceTableCommand(newTableDesc, ignoreIfExists = mode == SaveMode.Ignore)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -173,7 +173,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
         tableSpec, ifNotExists) =>
       val newSchema: StructType =
         ResolveDefaultColumns.constantFoldCurrentDefaultsToExistDefaults(
-          schema, tableSpec.provider, "CREATE TABLE")
+          schema, tableSpec.provider, "CREATE TABLE", false)
       CreateTableExec(catalog.asTableCatalog, ident, newSchema,
         partitioning, qualifyLocInTableSpec(tableSpec), ifNotExists) :: Nil
 
@@ -195,7 +195,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
     case ReplaceTable(ResolvedIdentifier(catalog, ident), schema, parts, tableSpec, orCreate) =>
       val newSchema: StructType =
         ResolveDefaultColumns.constantFoldCurrentDefaultsToExistDefaults(
-          schema, tableSpec.provider, "CREATE TABLE")
+          schema, tableSpec.provider, "CREATE TABLE", false)
       catalog match {
         case staging: StagingTableCatalog =>
           AtomicReplaceTableExec(staging, ident, newSchema, parts,

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1838,20 +1838,37 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-39844 Restrict adding DEFAULT columns for existing tables to certain sources ") {
+  test("SPARK-39844 Restrict adding DEFAULT columns for existing tables to certain sources") {
     Seq("csv", "json", "orc", "parquet").foreach { provider =>
       withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> provider) {
-          withTable("t") {
-          sql(s"create table t(a int default 42) using $provider")
-          sql(s"alter table t add column (b string default 'abc')")
-          sql(s"insert into t values (42, default)")
-          checkAnswer(spark.table("t"), Row(42, "abc"))
+        withTable("t1") {
+          // It is OK to create a new table with a column DEFAULT value assigned if the table
+          // provider is in the allowlist.
+          sql(s"create table t1(a int default 42) using $provider")
+          // It is OK to add a new column to the table with a DEFAULT value to the existing table
+          // since this table provider is not yet present in the
+          // 'ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS' denylist.
+          sql(s"alter table t1 add column (b string default 'abc')")
+          // Insert a row into the table and check that the assigned DEFAULT value is correct.
+          sql(s"insert into t1 values (42, default)")
+          checkAnswer(spark.table("t1"), Row(42, "abc"))
+          // Now set the denylist of table providers to include the new table type.
           withSQLConf(SQLConf.ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS.key -> provider) {
             assert(intercept[AnalysisException] {
-              sql(s"alter table t add column (b string default 'abc')")
+              // Try to add another column to the existing table again. This fails because the table
+              // provider is now in the denylist.
+              sql(s"alter table t1 add column (b string default 'abc')")
             }.getMessage.contains(
               QueryCompilationErrors.addNewDefaultColumnToExistingTableNotAllowed(
                 "ALTER TABLE ADD COLUMNS", provider).getMessage))
+            withTable("t2") {
+              // It is still OK to create a new table with a column DEFAULT value assigned, even if
+              // the table provider is in the above denylist.
+              sql(s"create table t2(a int default 42) using $provider")
+              // Insert a row into the table and check that the assigned DEFAULT value is correct.
+              sql(s"insert into t2 values (default)")
+              checkAnswer(spark.table("t2"), Row(42))
+            }
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1841,7 +1841,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   test("SPARK-39844 Restrict adding DEFAULT columns for existing tables to certain sources ") {
     Seq("csv").foreach { provider =>
       withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> provider) {
-        withTable("t") {
+          withTable("t") {
           sql(s"create table t(a int default 42) using $provider")
           sql(s"alter table t add column (b string default 'abc')")
           sql(s"insert into t values (42, default)")
@@ -1850,7 +1850,8 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
             assert(intercept[AnalysisException] {
               sql(s"alter table t add column (b string default 'abc')")
             }.getMessage.contains(
-              QueryCompilationErrors.defaultValuesMayNotContainSubQueryExpressions().getMessage))
+              QueryCompilationErrors.addNewDefaultColumnToExistingTableNotAllowed(
+                "ALTER TABLE ADD COLUMNS", provider).getMessage))
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1839,7 +1839,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   }
 
   test("SPARK-39844 Restrict adding DEFAULT columns for existing tables to certain sources ") {
-    Seq("csv").foreach { provider =>
+    Seq("csv", "json", "orc", "parquet").foreach { provider =>
       withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> provider) {
           withTable("t") {
           sql(s"create table t(a int default 42) using $provider")

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1840,8 +1840,9 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
 
   test("SPARK-39844 Restrict adding DEFAULT columns for existing tables to certain sources") {
     Seq("csv", "json", "orc", "parquet").foreach { provider =>
-      withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> provider) {
-        withTable("t1") {
+      withTable("t1") {
+        // Set the allowlist of table providers to include the new table type for all SQL commands.
+        withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> provider) {
           // It is OK to create a new table with a column DEFAULT value assigned if the table
           // provider is in the allowlist.
           sql(s"create table t1(a int default 42) using $provider")
@@ -1852,23 +1853,24 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           // Insert a row into the table and check that the assigned DEFAULT value is correct.
           sql(s"insert into t1 values (42, default)")
           checkAnswer(spark.table("t1"), Row(42, "abc"))
-          // Now set the denylist of table providers to include the new table type.
-          withSQLConf(SQLConf.ADD_DEFAULT_COLUMN_EXISTING_TABLE_BANNED_PROVIDERS.key -> provider) {
-            assert(intercept[AnalysisException] {
-              // Try to add another column to the existing table again. This fails because the table
-              // provider is now in the denylist.
-              sql(s"alter table t1 add column (b string default 'abc')")
-            }.getMessage.contains(
-              QueryCompilationErrors.addNewDefaultColumnToExistingTableNotAllowed(
-                "ALTER TABLE ADD COLUMNS", provider).getMessage))
-            withTable("t2") {
-              // It is still OK to create a new table with a column DEFAULT value assigned, even if
-              // the table provider is in the above denylist.
-              sql(s"create table t2(a int default 42) using $provider")
-              // Insert a row into the table and check that the assigned DEFAULT value is correct.
-              sql(s"insert into t2 values (default)")
-              checkAnswer(spark.table("t2"), Row(42))
-            }
+        }
+        // Now update the allowlist of table providers to prohibit ALTER TABLE ADD COLUMN commands
+        // from assigning DEFAULT values.
+        withSQLConf(SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS.key -> s"$provider*") {
+          assert(intercept[AnalysisException] {
+            // Try to add another column to the existing table again. This fails because the table
+            // provider is now in the denylist.
+            sql(s"alter table t1 add column (b string default 'abc')")
+          }.getMessage.contains(
+            QueryCompilationErrors.addNewDefaultColumnToExistingTableNotAllowed(
+              "ALTER TABLE ADD COLUMNS", provider).getMessage))
+          withTable("t2") {
+            // It is still OK to create a new table with a column DEFAULT value assigned, even if
+            // the table provider is in the above denylist.
+            sql(s"create table t2(a int default 42) using $provider")
+            // Insert a row into the table and check that the assigned DEFAULT value is correct.
+            sql(s"insert into t2 values (default)")
+            checkAnswer(spark.table("t2"), Row(42))
           }
         }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Update `SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS` to allow/deny `ALTER TABLE ... ADD COLUMN` commands separately.

### Why are the changes needed?

When `ALTER TABLE ... ADD COLUMNS` commands assign column DEFAULT values, Spark constant-folds these values and stores the result in the `EXISTS_DEFAULT` column metadata. This allows the target data source to substitute this value for rows where the corresponding field is not present in storage. This responsibility is up to each data source.

In order to grant flexibility to certain data sources that are not yet ready to support this functionality, in this PR we update the `SQLConf.DEFAULT_COLUMN_ALLOWED_PROVIDERS` to support an optional asterisk after each table provider. When the asterisk is present, `ALTER TABLE ... ADD COLUMN` commands may not include DEFAULT values; when absent, they may include them.

### Does this PR introduce _any_ user-facing change?

Yes.

### How was this patch tested?

Existing column DEFAULT test coverage + new unit test coverage.