### PR TITLE
[SPARK-39848][BUILD] Upgrade Kafka to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.2.0</kafka.version>
+    <kafka.version>3.2.1</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Kafka to 3.2.1.

### Why are the changes needed?

Apache Kafka 3.2.1 is released.
- https://lists.apache.org/thread/b6nonzos2qjhc9tpolld9qxrcxqcg011

Apache Kafka 3.2.1 has the following patches.
- https://home.apache.org/~davidarthur/kafka-3.2.1-rc3/RELEASE_NOTES.html

[KAFKA-14013](https://issues.apache.org/jira/browse/KAFKA-14013) Limit the length of the `reason` field sent on the wire Bug
[KAFKA-13474](https://issues.apache.org/jira/browse/KAFKA-13474) Regression in dynamic update of broker certificate
[KAFKA-13572](https://issues.apache.org/jira/browse/KAFKA-13572) Negative value for 'Preferred Replica Imbalance' metric
[KAFKA-13773](https://issues.apache.org/jira/browse/KAFKA-13773) Data loss after recovery from crash due to full hard disk
[KAFKA-13861](https://issues.apache.org/jira/browse/KAFKA-13861) validateOnly request field does not work for CreatePartition requests in Kraft mode.
[KAFKA-13899](https://issues.apache.org/jira/browse/KAFKA-13899) Inconsistent error codes returned from AlterConfig APIs
[KAFKA-13998](https://issues.apache.org/jira/browse/KAFKA-13998) JoinGroupRequestData 'reason' can be too large
[KAFKA-14010](https://issues.apache.org/jira/browse/KAFKA-14010) alterISR request won't retry when receiving retriable error
[KAFKA-14024](https://issues.apache.org/jira/browse/KAFKA-14024) Consumer stuck during cooperative rebalance for Commit offset in onJoinPrepare
[KAFKA-14035](https://issues.apache.org/jira/browse/KAFKA-14035) QuorumController handleRenounce throws NPE
[KAFKA-14055](https://issues.apache.org/jira/browse/KAFKA-14055) Transaction markers may be lost during cleaning if data keys conflict with marker keys
[KAFKA-14062](https://issues.apache.org/jira/browse/KAFKA-14062) OAuth client token refresh fails with SASL extensions
[KAFKA-14079](https://issues.apache.org/jira/browse/KAFKA-14079) Source task will not commit offsets and develops memory leak if "error.tolerance" is set to "all"


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs