### PR TITLE
[SPARK-39743][SQL] Unable to set zstd compression level while writing…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -922,6 +922,22 @@ object SQLConf {
     .checkValues(Set("none", "uncompressed", "snappy", "gzip", "lzo", "lz4", "brotli", "zstd"))
     .createWithDefault("snappy")
 
+  val PARQUET_COMPRESSION_ZSTD_LEVEL = buildConf("spark.sql.parquet.zstd.level")
+    .doc("Sets the zstd level when writing Parquet files and compression codec is `zstd`. " +
+      "The valid range is 1~22. Generally the higher compression level, the higher compression " +
+      "ratio can be achieved, but the writing time will be longer.")
+    .version("3.4.0")
+    .intConf
+    .createWithDefault(3)
+
+  val PARQUET_COMPRESSION_ZSTD_WORKERS = buildConf("spark.sql.parquet.zstd.workers")
+    .doc("Sets the zstd workers when writing Parquet files and compression codec is `zstd`. " +
+      "The number of threads will be spawned to compress in parallel. More workers improve " +
+      "speed, but also increase memory usage. When it is 0, it works as single-threaded mode.")
+    .version("3.4.0")
+    .intConf
+    .createWithDefault(0)
+
   val PARQUET_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.parquet.filterPushdown")
     .doc("Enables Parquet filter push-down optimization when set to true.")
     .version("1.2.0")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -34,6 +34,7 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GRO
 import org.apache.parquet.hadoop._
 import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel
 import org.apache.parquet.hadoop.codec.CodecConfig
+import org.apache.parquet.hadoop.codec.ZstandardCodec
 import org.apache.parquet.hadoop.util.ContextUtil
 
 import org.apache.spark.TaskContext
@@ -125,6 +126,15 @@ class ParquetFileFormat
 
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
+
+    // Sets Zstd level and Zstd workers, only effect when compression codec is `zstd`
+    conf.set(
+      ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL,
+      parquetOptions.zstdLevel)
+
+    conf.set(
+      ZstandardCodec.PARQUET_COMPRESS_ZSTD_WORKERS,
+      parquetOptions.zstdWorkers)
 
     // SPARK-15719: Disables writing Parquet summary files by default.
     if (conf.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL) == null

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetOptions.scala
@@ -83,6 +83,18 @@ class ParquetOptions(
   def int96RebaseModeInRead: String = parameters
     .get(INT96_REBASE_MODE)
     .getOrElse(sqlConf.getConf(SQLConf.PARQUET_INT96_REBASE_MODE_IN_READ))
+  /**
+   * The compression level for zstd.
+   */
+  def zstdLevel: String = parameters
+    .get(ZSTD_LEVEL)
+    .getOrElse(sqlConf.getConf(SQLConf.PARQUET_COMPRESSION_ZSTD_LEVEL).toString)
+  /**
+   * The compression workers for zstd.
+   */
+  def zstdWorkers: String = parameters
+    .get(ZSTD_WORKERS)
+    .getOrElse(sqlConf.getConf(SQLConf.PARQUET_COMPRESSION_ZSTD_WORKERS).toString)
 }
 
 
@@ -115,4 +127,13 @@ object ParquetOptions {
   // the SQL config `spark.sql.parquet.int96RebaseModeInRead`.
   // The valid option values are: `EXCEPTION`, `LEGACY` or `CORRECTED`.
   val INT96_REBASE_MODE = "int96RebaseMode"
+
+  // The option controls the compression level for zstd. The valid range is 1~22.
+  // In higher compression level, the higher compression ratio can be achieved,
+  // but the writing time will be longer.
+  val ZSTD_LEVEL = "zstdLevel"
+
+  // The option controls the compression workers for zstd.
+  // More workers improve speed, but also increase memory usage.
+  val ZSTD_WORKERS = "zstdWorkers"
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
@@ -20,7 +20,6 @@ import org.apache.hadoop.mapreduce.{Job, OutputCommitter, TaskAttemptContext}
 import org.apache.parquet.hadoop.{ParquetOutputCommitter, ParquetOutputFormat}
 import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel
 import org.apache.parquet.hadoop.codec.CodecConfig
-import org.apache.parquet.hadoop.codec.ZstandardCodec
 import org.apache.parquet.hadoop.util.ContextUtil
 
 import org.apache.spark.internal.Logging

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
@@ -89,15 +89,6 @@ case class ParquetWrite(
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
 
-    // Sets Zstd level and Zstd workers, only effect when compression codec is `zstd`
-    conf.set(
-      ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL,
-      parquetOptions.zstdLevel)
-
-    conf.set(
-      ZstandardCodec.PARQUET_COMPRESS_ZSTD_WORKERS,
-      parquetOptions.zstdWorkers)
-
     // SPARK-15719: Disables writing Parquet summary files by default.
     if (conf.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL) == null
       && conf.get(ParquetOutputFormat.ENABLE_JOB_SUMMARY) == null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/parquet/ParquetWrite.scala
@@ -20,6 +20,7 @@ import org.apache.hadoop.mapreduce.{Job, OutputCommitter, TaskAttemptContext}
 import org.apache.parquet.hadoop.{ParquetOutputCommitter, ParquetOutputFormat}
 import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel
 import org.apache.parquet.hadoop.codec.CodecConfig
+import org.apache.parquet.hadoop.codec.ZstandardCodec
 import org.apache.parquet.hadoop.util.ContextUtil
 
 import org.apache.spark.internal.Logging
@@ -87,6 +88,15 @@ case class ParquetWrite(
 
     // Sets compression scheme
     conf.set(ParquetOutputFormat.COMPRESSION, parquetOptions.compressionCodecClassName)
+
+    // Sets Zstd level and Zstd workers, only effect when compression codec is `zstd`
+    conf.set(
+      ZstandardCodec.PARQUET_COMPRESS_ZSTD_LEVEL,
+      parquetOptions.zstdLevel)
+
+    conf.set(
+      ZstandardCodec.PARQUET_COMPRESS_ZSTD_WORKERS,
+      parquetOptions.zstdWorkers)
 
     // SPARK-15719: Disables writing Parquet summary files by default.
     if (conf.get(ParquetOutputFormat.JOB_SUMMARY_LEVEL) == null

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodecPrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodecPrecedenceSuite.scala
@@ -130,7 +130,7 @@ class ParquetCompressionCodecPrecedenceSuite extends ParquetTest with SharedSpar
       assert(option.zstdLevel == "10")
       val parameters = Map("zstdLevel" -> "20")
       val optionWithPar = new ParquetOptions(parameters, spark.sessionState.conf)
-      assert(option.zstdLevel == "20")
+      assert(optionWithPar.zstdLevel == "20")
     }
   }
 
@@ -140,7 +140,7 @@ class ParquetCompressionCodecPrecedenceSuite extends ParquetTest with SharedSpar
       assert(option.zstdWorkers == "10")
       val parameters = Map("zstdWorkers" -> "20")
       val optionWithPar = new ParquetOptions(parameters, spark.sessionState.conf)
-      assert(option.zstdWorkers == "20")
+      assert(optionWithPar.zstdWorkers == "20")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodecPrecedenceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCompressionCodecPrecedenceSuite.scala
@@ -123,4 +123,24 @@ class ParquetCompressionCodecPrecedenceSuite extends ParquetTest with SharedSpar
       assert(exception.getMessage.contains("Codec [aa] is not available"))
     }
   }
+
+  test("[SPARK-39743] Test `spark.sql.parquet.zstd.level` config") {
+    withSQLConf(SQLConf.PARQUET_COMPRESSION_ZSTD_LEVEL.key -> "10") {
+      val option = new ParquetOptions(Map.empty[String, String], spark.sessionState.conf)
+      assert(option.zstdLevel == "10")
+      val parameters = Map("zstdLevel" -> "20")
+      val optionWithPar = new ParquetOptions(parameters, spark.sessionState.conf)
+      assert(option.zstdLevel == "20")
+    }
+  }
+
+  test("[SPARK-39743] Test `spark.sql.parquet.zstd.workers` config") {
+    withSQLConf(SQLConf.PARQUET_COMPRESSION_ZSTD_WORKERS.key -> "10") {
+      val option = new ParquetOptions(Map.empty[String, String], spark.sessionState.conf)
+      assert(option.zstdWorkers == "10")
+      val parameters = Map("zstdWorkers" -> "20")
+      val optionWithPar = new ParquetOptions(parameters, spark.sessionState.conf)
+      assert(option.zstdWorkers == "20")
+    }
+  }
 }


### PR DESCRIPTION
… parquet files

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Support zstd level and zstd workers when writing Parquet files and compression codec is `zstd`.

- spark.sql.parquet.zstd.level
- spark.sql.parquet.zstd.workers


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve write parquet file

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

using zstd to write parquet file with diffent `spark.sql.parquet.zstd.level` conf

```
    val spark = SparkSession.
      builder()
      .master("local[*]")
      .appName("AppName")
      .config("spark.sql.parquet.compression.codec", "zstd")
      .config("spark.sql.parquet.zstd.level", "10")  // set zstd level 10
      .getOrCreate() 
    val csvfile = spark.read.csv("file:///home/test_data/Reviews.csv")
    csvfile.coalesce(1).write.parquet("file:///home/test_data/nn_parq_10")
```
the file size :
> -rw-r--r-- 1 shezhiming shezhiming 15540603 7月  24 16:32 part-00000-4cbeda06-f694-4354-931e-23c3b9161f98-c000.zstd.parquet

```
    val spark = SparkSession.
      builder()
      .master("local[*]")
      .appName("AppName")
      .config("spark.sql.parquet.compression.codec", "zstd")
      .config("spark.sql.parquet.zstd.level", "5")  // set zstd level 5
      .getOrCreate()
    val csvfile = spark.read.csv("file:///home/test_data/Reviews.csv")
    csvfile.coalesce(1).write.parquet("file:///home/test_data/nn_parq_5")
```
the file size

> -rw-r--r-- 1 shezhiming shezhiming 16468894 7月  24 16:31 part-00000-2a0a3147-0884-4e46-9c51-b4ee3e80872a-c000.zstd.parquet

