### PR TITLE
[SPARK-39849][SQL] Dataset.as(StructType) fills missing new columns with null value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -172,37 +172,53 @@ object Project {
     expected.map { f =>
       val matched = fields.filter(field => conf.resolver(field._1, f.name))
       if (matched.isEmpty) {
-        if (columnPath.isEmpty) {
-          throw QueryCompilationErrors.unresolvedColumnError(f.name, fields.map(_._1))
+        if (f.nullable) {
+          val columnExpr = Literal.create(null, f.dataType)
+          // Fill nullable missing new column with null value.
+          createNewColumn(columnExpr, f.name, f.metadata, Metadata.empty)
         } else {
-          throw QueryCompilationErrors.unresolvedFieldError(f.name, columnPath, fields.map(_._1))
+          if (columnPath.isEmpty) {
+            throw QueryCompilationErrors.unresolvedColumnError(f.name, fields.map(_._1))
+          } else {
+            throw QueryCompilationErrors.unresolvedFieldError(f.name, columnPath, fields.map(_._1))
+          }
         }
       } else if (matched.length > 1) {
         throw QueryCompilationErrors.ambiguousColumnOrFieldError(
           columnPath :+ f.name, matched.length)
-      }
+      } else {
+        val columnExpr = matched.head._2
+        val originalMetadata = columnExpr match {
+          case ne: NamedExpression => ne.metadata
+          case g: GetStructField => g.childSchema(g.ordinal).metadata
+          case _ => Metadata.empty
+        }
 
-      val columnExpr = matched.head._2
-      val originalMetadata = columnExpr match {
-        case ne: NamedExpression => ne.metadata
-        case g: GetStructField => g.childSchema(g.ordinal).metadata
-        case _ => Metadata.empty
+        val newColumnPath = columnPath :+ matched.head._1
+        val newColumnExpr = reconcileColumnType(columnExpr, newColumnPath, f.dataType, f.nullable, conf)
+        createNewColumn(newColumnExpr, f.name, f.metadata, originalMetadata)
       }
-      val newMetadata = new MetadataBuilder()
-        .withMetadata(originalMetadata)
-        .withMetadata(f.metadata)
-        .build()
+    }
+  }
 
-      val newColumnPath = columnPath :+ matched.head._1
-      reconcileColumnType(columnExpr, newColumnPath, f.dataType, f.nullable, conf) match {
-        case a: Attribute => a.withName(f.name).withMetadata(newMetadata)
-        case other =>
-          if (newMetadata == Metadata.empty) {
-            Alias(other, f.name)()
-          } else {
-            Alias(other, f.name)(explicitMetadata = Some(newMetadata))
-          }
-      }
+  private def createNewColumn(
+      col: Expression,
+      name: String,
+      newMetadata: Metadata,
+      originalMetadata: Metadata): NamedExpression = {
+    val metadata = new MetadataBuilder()
+      .withMetadata(originalMetadata)
+      .withMetadata(newMetadata)
+      .build()
+
+    col match {
+      case a: Attribute => a.withName(name).withMetadata(metadata)
+      case other =>
+        if (metadata == Metadata.empty) {
+          Alias(other, name)()
+        } else {
+          Alias(other, name)(explicitMetadata = Some(metadata))
+        }
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -195,7 +195,8 @@ object Project {
         }
 
         val newColumnPath = columnPath :+ matched.head._1
-        val newColumnExpr = reconcileColumnType(columnExpr, newColumnPath, f.dataType, f.nullable, conf)
+        val newColumnExpr = reconcileColumnType(
+          columnExpr, newColumnPath, f.dataType, f.nullable, conf)
         createNewColumn(newColumnExpr, f.name, f.metadata, originalMetadata)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As a followup of https://github.com/apache/spark/pull/37011#discussion_r917700960 , it would be great to fill missing new columns with null values, instead of failing out loud. Note it would only work for nullable columns.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better user experience when using `.as()` to cast with extra new columns, or new fields in existing struct type

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the exact described behavior change of the `.as()` API.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test in [DataFrameAsSchemaSuite.scala](https://github.com/apache/spark/compare/master...c21:spark:default-null?expand=1#diff-115433d6399124014f2600556a5f6ced9b79b64e4584c19d51997c3eff9e6f33)