### PR TITLE
[SPARK-39850][YARN]Print applicationId once applied from yarn rm

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -200,6 +200,7 @@ private[spark] class Client(
       val newApp = yarnClient.createApplication()
       val newAppResponse = newApp.getNewApplicationResponse()
       this.appId = newAppResponse.getApplicationId()
+      logInfo(s"Got application $appId from  ResourceManager")
 
       // The app staging dir based on the STAGING_DIR configuration if configured
       // otherwise based on the users home directory.


### PR DESCRIPTION

### What changes were proposed in this pull request?
Print the application id after getting application from yarn.


### Why are the changes needed?
it's useful for users to find out the failed  application id before submit to yarn.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
it's not necessary.
