### PR TITLE
[SPARK-39854][SQL] withNewChildInternal in Generate Node should re-calculate 'unrequiredChildIndex'

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -269,7 +269,7 @@ case class Generate(
   override protected def withNewChildInternal(newChild: LogicalPlan): Generate = {
     // Generally speaking, using index to keep track of unrequired child nodes is not a good idea,
     //   should probably use exprId instead.
-    val unrequiredExprIdSet = unrequiredChildIndex.map(output).map(_.exprId).toSet
+    val unrequiredExprIdSet = unrequiredChildIndex.map(child.output).map(_.exprId).toSet
     val newUnrequiredChildIndices = newChild.output.indices.filter { idx =>
       val newAttr = newChild.output(idx)
       unrequiredExprIdSet.contains(newAttr.exprId)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -143,6 +143,47 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
       }
     }
   }
+
+  test("SPARK-39854: withNewChildInternal in Generate Node should re-calculate 'unrequiredChildIndex'") {
+    import org.apache.spark.sql.functions.{explode, struct}
+    import org.apache.spark.sql.SparkSession
+
+    val ss:SparkSession = spark
+    import ss.implicits._
+    val testJson =
+      """{
+        | "b": {
+        |  "id": "id00",
+        |  "data": [{
+        |   "b1": "vb1",
+        |   "b2": 101,
+        |   "ex2": [
+        |    { "fb1": false, "fb2": 11, "fb3": "t1" },
+        |    { "fb1": true, "fb2": 12, "fb3": "t2" }
+        |   ]}, {
+        |   "b1": "vb2",
+        |   "b2": 102,
+        |   "ex2": [
+        |    { "fb1": false, "fb2": 13, "fb3": "t3" },
+        |    { "fb1": true, "fb2": 14, "fb3": "t4" }
+        |   ]}
+        |  ],
+        |  "fa": "tes",
+        |  "v": "1.5"
+        | }
+        |}
+        |""".stripMargin
+    val df = spark.read.json((testJson :: Nil).toDS())
+      .withColumn("ex_b", explode($"b.data.ex2"))
+      .withColumn("ex_b2", explode($"ex_b"))
+    val df1 = df
+      .withColumn("rt", struct(
+        $"b.fa".alias("rt_fa"),
+        $"b.v".alias("rt_v")
+      ))
+      .drop("b", "ex_b")
+    df1.show(false)
+  }
 }
 
 case class ColumnarOp(child: SparkPlan) extends UnaryExecNode {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -149,7 +149,6 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
     import org.apache.spark.sql.SparkSession
     val ss: SparkSession = spark
     import ss.implicits._
-    
     val testJson =
       """{
         | "b": {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -144,10 +144,10 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SPARK-39854: withNewChildInternal in Generate Node should re-calculate 'unrequiredChildIndex'") {
+  test("SPARK-39854: withNewChildInternal in Generate should re-calculate unrequiredChildIndex") {
     import org.apache.spark.sql.functions.{explode, struct}
     import org.apache.spark.sql.SparkSession
-    val ss:SparkSession = spark
+    val ss: SparkSession = spark
     import ss.implicits._
     val testJson =
       """{

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -147,7 +147,6 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
   test("SPARK-39854: withNewChildInternal in Generate Node should re-calculate 'unrequiredChildIndex'") {
     import org.apache.spark.sql.functions.{explode, struct}
     import org.apache.spark.sql.SparkSession
-
     val ss:SparkSession = spark
     import ss.implicits._
     val testJson =

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SparkPlanSuite.scala
@@ -149,6 +149,7 @@ class SparkPlanSuite extends QueryTest with SharedSparkSession {
     import org.apache.spark.sql.SparkSession
     val ss: SparkSession = spark
     import ss.implicits._
+    
     val testJson =
       """{
         | "b": {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The current implementation of the `withNewChildInternal(newChild: LogicalPlan)` method in case class `Generate` simply replace with current child with the `newChild`, without updating the field `unrequiredChildIndex`. This means the  `unrequiredChildIndex` for the 'old' child will be applied to `newChild` as well, which can lead to error if the `newChild` has a different node set or it's just a re-ordering of the old child.
The proposed fix tries to use the `exprId` instead: it first collects the set of `exprId` from the curent child, it then finds all the indices in the `newChild` whose `exprId`s are found in the current set. After that a new `Geneate` node will be created with the `newChild` and the updated indices.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See the answer to the last question.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
A unit test is added to `SparkPlanSuite` (though I'm not quite sure where is the best place to put the test 😓)