### PR TITLE
[SPARK-39784][SQL][FOLLOW-UP] Use BinaryComparison instead of Predicate (if) for type check

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -154,8 +154,8 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
       val r = generateExpression(b.right)
       if (l.isDefined && r.isDefined) {
         b match {
-          case _: Predicate if isBinaryComparisonOperator(b.sqlOperator) &&
-              l.get.isInstanceOf[LiteralValue[_]] && r.get.isInstanceOf[FieldReference] =>
+          case _: BinaryComparison if l.get.isInstanceOf[LiteralValue[_]] &&
+              r.get.isInstanceOf[FieldReference] =>
             Some(new V2Predicate(flipComparisonOperatorName(b.sqlOperator),
               Array[V2Expression](r.get, l.get)))
           case _: Predicate =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -269,13 +269,6 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
     case _ => None
   }
 
-  private def isBinaryComparisonOperator(operatorName: String): Boolean = {
-    operatorName match {
-      case ">" | "<" | ">=" | "<=" | "=" | "<=>" => true
-      case _ => false
-    }
-  }
-
   private def flipComparisonOperatorName(operatorName: String): String = {
     operatorName match {
       case ">" => "<"


### PR DESCRIPTION



### What changes were proposed in this pull request?
follow up this [comment](https://github.com/apache/spark/pull/37197#discussion_r928570992)


### Why are the changes needed?
code simplification


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing test
