### PR TITLE
[SPARK-39856][SQL][TESTS][FOLLOW-UP] Increase the number of partitions in TPC-DS build to avoid out-of-memory

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
@@ -62,7 +62,7 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
 
   // To make output results deterministic
   override protected def sparkConf: SparkConf = super.sparkConf
-    .set(SQLConf.SHUFFLE_PARTITIONS.key, 16.toString)
+    .set(SQLConf.SHUFFLE_PARTITIONS.key, 32.toString)
 
   protected override def createSparkSession: TestSparkSession = {
     new TestSparkSession(new SparkContext("local[1]", this.getClass.getSimpleName, sparkConf))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR increases the number of partitions further more (see also https://github.com/apache/spark/pull/37270)

### Why are the changes needed?

To make the build pass.

At least, two builds (https://github.com/apache/spark/runs/7500542538?check_suite_focus=true and https://github.com/apache/spark/runs/7511748355?check_suite_focus=true) passed after https://github.com/apache/spark/pull/37273. I assume that the number of partitions helps, and this PR increases some more.

### Does this PR introduce _any_ user-facing change?
No, test and dev-only.

### How was this patch tested?

It's tested in https://github.com/LuciferYang/spark/runs/7497163716?check_suite_focus=true