### PR TITLE
[SPARK-39856][TESTS][INFRA] Skip q72 at TPC-DS build at GitHub Actions

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSBase.scala
@@ -36,9 +36,13 @@ trait TPCDSBase extends TPCBase with TPCDSSchema {
 
   // Since `tpcdsQueriesV2_7_0` has almost the same queries with these ones below,
   // we skip them in the TPCDS-related tests.
+  //
   // NOTE: q6" and "q75" can cause flaky test results, so we must exclude them.
   // For more details, see SPARK-35327.
-  private val excludedTpcdsQueries: Set[String] = Set("q6", "q34", "q64", "q74", "q75", "q78")
+  //
+  // Note: q72 requires too large memory, and GitHub Actions fails with out-of-memory.
+  // Should ideally fix this, see SPARK-39856.
+  private val excludedTpcdsQueries: Set[String] = Set("q6", "q34", "q64", "q72", "q74", "q75", "q78")
 
   val tpcdsQueries: Seq[String] = tpcdsAllQueries.filterNot(excludedTpcdsQueries.contains)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSBase.scala
@@ -36,13 +36,9 @@ trait TPCDSBase extends TPCBase with TPCDSSchema {
 
   // Since `tpcdsQueriesV2_7_0` has almost the same queries with these ones below,
   // we skip them in the TPCDS-related tests.
-  //
   // NOTE: q6" and "q75" can cause flaky test results, so we must exclude them.
   // For more details, see SPARK-35327.
-  //
-  // Note: q72 requires too large memory, and GitHub Actions fails with out-of-memory.
-  // Should ideally fix this, see SPARK-39856.
-  private val excludedTpcdsQueries: Set[String] = Set("q6", "q34", "q64", "q72", "q74", "q75", "q78")
+  private val excludedTpcdsQueries: Set[String] = Set("q6", "q34", "q64", "q74", "q75", "q78")
 
   val tpcdsQueries: Seq[String] = tpcdsAllQueries.filterNot(excludedTpcdsQueries.contains)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQuerySuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.tags.ExtendedSQLTest
 @ExtendedSQLTest
 class TPCDSQuerySuite extends BenchmarkQueryTest with TPCDSBase {
 
-  tpcdsQueries.foreach { name =>
+  // q72 is skipped due to GitHub Actions' memory limit.
+  tpcdsQueries.filterNot(sys.env.contains("GITHUB_ACTIONS") && _ == "q72").foreach { name =>
     val queryString = resourceToString(s"tpcds/$name.sql",
       classLoader = Thread.currentThread().getContextClassLoader)
     test(name) {
@@ -39,7 +40,8 @@ class TPCDSQuerySuite extends BenchmarkQueryTest with TPCDSBase {
     }
   }
 
-  tpcdsQueriesV2_7_0.foreach { name =>
+  // q72 is skipped due to GitHub Actions' memory limit.
+  tpcdsQueriesV2_7_0.filterNot(sys.env.contains("GITHUB_ACTIONS") && _ == "q72").foreach { name =>
     val queryString = resourceToString(s"tpcds-v2.7.0/$name.sql",
       classLoader = Thread.currentThread().getContextClassLoader)
     test(s"$name-v2.7") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
@@ -62,7 +62,7 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
 
   // To make output results deterministic
   override protected def sparkConf: SparkConf = super.sparkConf
-    .set(SQLConf.SHUFFLE_PARTITIONS.key, 4.toString)
+    .set(SQLConf.SHUFFLE_PARTITIONS.key, "1")
 
   protected override def createSparkSession: TestSparkSession = {
     new TestSparkSession(new SparkContext("local[1]", this.getClass.getSimpleName, sparkConf))
@@ -105,6 +105,7 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
       query: String,
       goldenFile: File,
       conf: Map[String, String]): Unit = {
+    val shouldSortResults = sortMergeJoinConf != conf  // Sort for other joins
     withSQLConf(conf.toSeq: _*) {
       try {
         val (schema, output) = handleExceptions(getNormalizedResult(spark, query))
@@ -142,15 +143,17 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
         assertResult(expectedSchema, s"Schema did not match\n$queryString") {
           schema
         }
-        // Truncate precisions because they can be vary per how the shuffle is performed.
-        val expectSorted = expectedOutput.split("\n").sorted.map(_.trim)
-          .mkString("\n").replaceAll("\\s+$", "")
-          .replaceAll("""([0-9]+.[0-9]{10})([0-9]*)""", "$1")
-        val outputSorted = output.sorted.map(_.trim).mkString("\n")
-          .replaceAll("\\s+$", "")
-          .replaceAll("""([0-9]+.[0-9]{10})([0-9]*)""", "$1")
-        assertResult(expectSorted, s"Result did not match\n$queryString") {
-          outputSorted
+        if (shouldSortResults) {
+          val expectSorted = expectedOutput.split("\n").sorted.map(_.trim)
+            .mkString("\n").replaceAll("\\s+$", "")
+          val outputSorted = output.sorted.map(_.trim).mkString("\n").replaceAll("\\s+$", "")
+          assertResult(expectSorted, s"Result did not match\n$queryString") {
+            outputSorted
+          }
+        } else {
+          assertResult(expectedOutput, s"Result did not match\n$queryString") {
+            outputString
+          }
         }
       } catch {
         case e: Throwable =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
@@ -62,7 +62,7 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
 
   // To make output results deterministic
   override protected def sparkConf: SparkConf = super.sparkConf
-    .set(SQLConf.SHUFFLE_PARTITIONS.key, 32.toString)
+    .set(SQLConf.SHUFFLE_PARTITIONS.key, 16.toString)
 
   protected override def createSparkSession: TestSparkSession = {
     new TestSparkSession(new SparkContext("local[1]", this.getClass.getSimpleName, sparkConf))

--- a/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/TPCDSQueryTestSuite.scala
@@ -62,7 +62,7 @@ class TPCDSQueryTestSuite extends QueryTest with TPCDSBase with SQLQueryTestHelp
 
   // To make output results deterministic
   override protected def sparkConf: SparkConf = super.sparkConf
-    .set(SQLConf.SHUFFLE_PARTITIONS.key, 16.toString)
+    .set(SQLConf.SHUFFLE_PARTITIONS.key, 4.toString)
 
   protected override def createSparkSession: TestSparkSession = {
     new TestSparkSession(new SparkContext("local[1]", this.getClass.getSimpleName, sparkConf))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reverts https://github.com/apache/spark/commit/7358253755762f9bfe6cedc1a50ec14616cfeace, https://github.com/apache/spark/commit/ae1f6a26ed39b297ace8d6c9420b72a3c01a3291 and https://github.com/apache/spark/commit/72b55ccf8327c00e173ab6130fdb428ad0d5aacc because they do not help fixing the TPC-DS build.

In addition, this PR skips the problematic query in GitHub Actions to avoid OOM.

### Why are the changes needed?

To make the build pass.

### Does this PR introduce _any_ user-facing change?

No, dev and test-only.

### How was this patch tested?

CI in this PR should test it out.