### PR TITLE
[SPARK-37194][SQL] Avoid unnecessary sort in v1 write if it's not dynamic partition

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -109,9 +109,9 @@ object FileFormatWriter extends Logging {
       bucketSpec: Option[BucketSpec],
       statsTrackers: Seq[WriteJobStatsTracker],
       options: Map[String, String],
-      numStaticPartitions: Int = 0)
+      numStaticPartitionCols: Int = 0)
     : Set[String] = {
-    assert(partitionColumns.size >= numStaticPartitions)
+    require(partitionColumns.size >= numStaticPartitionCols)
 
     val job = Job.getInstance(hadoopConf)
     job.setOutputKeyClass(classOf[Void])
@@ -165,7 +165,7 @@ object FileFormatWriter extends Logging {
 
     // We should first sort by dynamic partition columns, then bucket id, and finally sorting
     // columns.
-    val requiredOrdering = partitionColumns.drop(numStaticPartitions) ++
+    val requiredOrdering = partitionColumns.drop(numStaticPartitionCols) ++
         writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
     // the sort order doesn't matter
     val actualOrdering = empty2NullPlan.outputOrdering.map(_.child)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -83,6 +83,7 @@ object FileFormatWriter extends Logging {
    */
   private[sql] var outputOrderingMatched: Boolean = false
 
+  // scalastyle:off argcount
   /**
    * Basic work flow of this command is:
    * 1. Driver side setup, including output committer initialization and data source specific
@@ -107,8 +108,10 @@ object FileFormatWriter extends Logging {
       partitionColumns: Seq[Attribute],
       bucketSpec: Option[BucketSpec],
       statsTrackers: Seq[WriteJobStatsTracker],
-      options: Map[String, String])
+      options: Map[String, String],
+      numStaticPartitions: Int = 0)
     : Set[String] = {
+    assert(partitionColumns.size >= numStaticPartitions)
 
     val job = Job.getInstance(hadoopConf)
     job.setOutputKeyClass(classOf[Void])
@@ -160,9 +163,10 @@ object FileFormatWriter extends Logging {
       statsTrackers = statsTrackers
     )
 
-    // We should first sort by partition columns, then bucket id, and finally sorting columns.
-    val requiredOrdering =
-      partitionColumns ++ writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
+    // We should first sort by dynamic partition columns, then bucket id, and finally sorting
+    // columns.
+    val requiredOrdering = partitionColumns.drop(numStaticPartitions) ++
+        writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns
     // the sort order doesn't matter
     val actualOrdering = empty2NullPlan.outputOrdering.map(_.child)
     val orderingMatched = if (requiredOrdering.length > actualOrdering.length) {
@@ -264,6 +268,7 @@ object FileFormatWriter extends Logging {
       throw QueryExecutionErrors.jobAbortedError(cause)
     }
   }
+  // scalastyle:on argcount
 
   /** Writes data out in a single Spark task. */
   private def executeTask(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -188,7 +188,7 @@ case class InsertIntoHadoopFsRelationCommand(
           bucketSpec = bucketSpec,
           statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
           options = options,
-          numStaticPartitions = staticPartitions.size)
+          numStaticPartitionCols = staticPartitions.size)
 
 
       // update metastore partition metadata

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -75,7 +75,8 @@ case class InsertIntoHadoopFsRelationCommand(
   }
 
   override def requiredOrdering: Seq[SortOrder] =
-    V1WritesUtils.getSortOrder(outputColumns, partitionColumns, bucketSpec, options)
+    V1WritesUtils.getSortOrder(outputColumns, partitionColumns, bucketSpec, options,
+      staticPartitions.size)
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {
     // Most formats don't do well with duplicate columns, so lets not allow that
@@ -186,7 +187,8 @@ case class InsertIntoHadoopFsRelationCommand(
           partitionColumns = partitionColumns,
           bucketSpec = bucketSpec,
           statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
-          options = options)
+          options = options,
+          numStaticPartitions = staticPartitions.size)
 
 
       // update metastore partition metadata

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -118,15 +118,15 @@ object V1WritesUtils {
       partitionColumns: Seq[Attribute],
       bucketSpec: Option[BucketSpec],
       options: Map[String, String],
-      numStaticPartitions: Int = 0): Seq[SortOrder] = {
-    assert(partitionColumns.size >= numStaticPartitions)
+      numStaticPartitionCols: Int = 0): Seq[SortOrder] = {
+    require(partitionColumns.size >= numStaticPartitionCols)
 
     val partitionSet = AttributeSet(partitionColumns)
     val dataColumns = outputColumns.filterNot(partitionSet.contains)
     val writerBucketSpec = V1WritesUtils.getWriterBucketSpec(bucketSpec, dataColumns, options)
     val sortColumns = V1WritesUtils.getBucketSortColumns(bucketSpec, dataColumns)
     // Static partition must to be ahead of dynamic partition
-    val dynamicPartitionColumns = partitionColumns.drop(numStaticPartitions)
+    val dynamicPartitionColumns = partitionColumns.drop(numStaticPartitionCols)
 
     if (SQLConf.get.maxConcurrentOutputFileWriters > 0 && sortColumns.isEmpty) {
       // Do not insert logical sort when concurrent output writers are enabled.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -117,20 +117,26 @@ object V1WritesUtils {
       outputColumns: Seq[Attribute],
       partitionColumns: Seq[Attribute],
       bucketSpec: Option[BucketSpec],
-      options: Map[String, String]): Seq[SortOrder] = {
+      options: Map[String, String],
+      numStaticPartitions: Int = 0): Seq[SortOrder] = {
+    assert(partitionColumns.size >= numStaticPartitions)
+
     val partitionSet = AttributeSet(partitionColumns)
     val dataColumns = outputColumns.filterNot(partitionSet.contains)
     val writerBucketSpec = V1WritesUtils.getWriterBucketSpec(bucketSpec, dataColumns, options)
     val sortColumns = V1WritesUtils.getBucketSortColumns(bucketSpec, dataColumns)
+    // Static partition must to be ahead of dynamic partition
+    val dynamicPartitionColumns = partitionColumns.drop(numStaticPartitions)
 
     if (SQLConf.get.maxConcurrentOutputFileWriters > 0 && sortColumns.isEmpty) {
       // Do not insert logical sort when concurrent output writers are enabled.
       Seq.empty
     } else {
-      // We should first sort by partition columns, then bucket id, and finally sorting columns.
+      // We should first sort by dynamic partition columns, then bucket id, and finally sorting
+      // columns.
       // Note we do not need to convert empty string partition columns to null when sorting the
       // columns since null and empty string values will be next to each other.
-      (partitionColumns ++writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns)
+      (dynamicPartitionColumns ++ writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns)
         .map(SortOrder(_, Ascending))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -20,13 +20,11 @@ package org.apache.spark.sql.execution.datasources
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Sort}
 import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.util.QueryExecutionListener
 
-abstract class V1WriteCommandSuiteBase
-  extends QueryTest with SQLTestUtils with AdaptiveSparkPlanHelper {
+abstract class V1WriteCommandSuiteBase extends QueryTest with SQLTestUtils {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -243,6 +243,15 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
               |SELECT key, value, value FROM testData
               |""".stripMargin)
         }
+
+        // partition columns are dynamic
+        executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+          sql(
+            """
+              |INSERT INTO t PARTITION(p1, p2)
+              |SELECT key, value, key, value FROM testData
+              |""".stripMargin)
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a rework for https://github.com/apache/spark/pull/34468, since we pull out v1write required ordering.

This prs add a new parameter numStaticPartitions to v1write and FileFormatWriter so we can skip unnecessary local sort for static partition write.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The v1 write requires ordering for dynamic partition, bucket expression and sort column during writing. The reason is the `DynamicPartitionDataSingleWriter` and `DynamicPartitionDataConcurrentWriter` assume the partition and bucket columns are continuous. Then if partition column is static, it's unnecessary to do the local sort.

For  v1 write, `InsertIntoHadoopFsRelationCommand` is the only case which adds a local sort even if the partition column is static.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no, only improve performance

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test