### PR TITLE
[SPARK-39868][CORE][TESTS] StageFailed event should attach with the root cause

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala
@@ -160,7 +160,8 @@ private[spark] class OutputCommitCoordinator(
         if (stageState.authorizedCommitters(partition) == taskId) {
           sc.foreach(_.dagScheduler.stageFailed(stage, s"Authorized committer " +
             s"(attemptNumber=$attemptNumber, stage=$stage, partition=$partition) failed; " +
-            s"but task commit success, data duplication may happen."))
+            s"but task commit success, data duplication may happen. " +
+            s"reason=$reason"))
         }
     }
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/OutputCommitCoordinatorIntegrationSuite.scala
@@ -51,7 +51,8 @@ class OutputCommitCoordinatorIntegrationSuite
         sc.parallelize(1 to 4, 2).map(_.toString).saveAsTextFile(tempDir.getAbsolutePath + "/out")
       }
     }.getCause.getMessage
-    assert(e.endsWith("failed; but task commit success, data duplication may happen."))
+    assert(e.contains("failed; but task commit success, data duplication may happen.") &&
+      e.contains("Intentional exception"))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1202,15 +1202,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
         val m1 = intercept[SparkException] {
           spark.range(1).coalesce(1).write.options(extraOptions).parquet(dir.getCanonicalPath)
         }.getCause.getMessage
-        // SPARK-39622: The current case must handle the `TaskSetFailed` event before SPARK-39195
-        // due to `maxTaskFailures` is 1 when local mode. After SPARK-39195, it may handle to one
-        // of the `TaskSetFailed` event and `StageFailed` event, and the execution order of the
-        // two events is uncertain, so the assertion of `Authorized committer (attemptNumber=n,
-        // stage=s, partition=p) failed; but task commit success, data duplication may happen.`
-        // is added for workaround.
-        assert(m1.contains("Intentional exception for testing purposes") ||
-          (m1.contains("Authorized committer") &&
-            m1.contains("failed; but task commit success, data duplication may happen.")))
+        assert(m1.contains("Intentional exception for testing purposes"))
       }
 
       withTempPath { dir =>
@@ -1219,9 +1211,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
             .coalesce(1)
           df.write.partitionBy("a").options(extraOptions).parquet(dir.getCanonicalPath)
         }.getCause.getMessage
-        assert(m2.contains("Intentional exception for testing purposes") ||
-          (m2.contains("Authorized committer") &&
-            m2.contains("failed; but task commit success, data duplication may happen.")))
+        assert(m2.contains("Intentional exception for testing purposes"))
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr follow https://github.com/apache/spark/pull/37245
StageFailed event should attach with the root cause

### Why are the changes needed?
**It may be a good way for users to know the reason of failure.**

By carefully investigating the issue: https://issues.apache.org/jira/browse/SPARK-39622,
I found the root cause of test failure: StageFailed don't attach the failed reason from executor.
when OutputCommitCoordinator execute 'taskCompleted', the 'reason' is ignored.

Scenario 1: receive TaskSetFailed (Success)
> InsertIntoHadoopFsRelationCommand
> FileFormatWriter.write
> _**handleTaskSetFailed**_ (**attach root cause**)
> abortStage
> failJobAndIndependentStages
> SparkListenerJobEnd

Scenario 1: receive StageFailed (Fail)
> InsertIntoHadoopFsRelationCommand
> FileFormatWriter.write
> _**handleStageFailed**_ (**don't attach root cause**)
> abortStage
> failJobAndIndependentStages
> SparkListenerJobEnd

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manual run UT & Pass GitHub Actions
