### PR TITLE
[SPARK-38493][PS] Improve the test coverage for pandas API on Spark

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -7052,7 +7052,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         if on is None and not isinstance(self.index, DatetimeIndex):
             raise NotImplementedError("resample currently works only for DatetimeIndex")
         if on is not None and not isinstance(as_spark_type(on.dtype), TimestampType):
-            raise NotImplementedError("resample currently works only for TimestampType")
+            raise NotImplementedError("`on` currently works only for TimestampType")
 
         agg_columns: List[ps.Series] = []
         column_label = self._internal.column_labels[0]

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -126,11 +126,6 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         with self.assertRaisesRegex(AttributeError, expected_error_message):
             psidx.__getattr__(item)
 
-    def test_multi_index_basic(self):
-        # Creating MultiIndex without using other methods such as `from_arrays`, `from_tuples`.
-        pmidx = pd.MultiIndex()
-        psmidx = ps.MultiIndex()
-
     def test_to_series(self):
         pidx = self.pdf.index
         psidx = self.psdf.index

--- a/python/pyspark/pandas/tests/indexes/test_base.py
+++ b/python/pyspark/pandas/tests/indexes/test_base.py
@@ -61,6 +61,10 @@ class IndexesTest(ComparisonTestBase, TestUtils):
             self.assert_eq(psdf.index, pdf.index)
             self.assert_eq(type(psdf.index).__name__, type(pdf.index).__name__)
 
+        self.assert_eq(ps.Index([])._summary(), "Index: 0 entries")
+        with self.assertRaisesRegexp(ValueError, "The truth value of a Int64Index is ambiguous."):
+            bool(ps.Index([1]))
+
     def test_index_from_series(self):
         pser = pd.Series([1, 2, 3], name="a", index=[10, 20, 30])
         psser = ps.from_pandas(pser)
@@ -89,6 +93,7 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         self.assert_eq(ps.Index(psidx), pd.Index(pidx))
         self.assert_eq(ps.Index(psidx, dtype="float"), pd.Index(pidx, dtype="float"))
         self.assert_eq(ps.Index(psidx, name="x"), pd.Index(pidx, name="x"))
+        self.assert_eq(ps.Index(psidx, copy=True), pd.Index(pidx, copy=True))
 
         self.assert_eq(ps.Int64Index(psidx), pd.Int64Index(pidx))
         self.assert_eq(ps.Float64Index(psidx), pd.Float64Index(pidx))
@@ -120,6 +125,11 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         expected_error_message = "'MultiIndex' object has no attribute '{}'".format(item)
         with self.assertRaisesRegex(AttributeError, expected_error_message):
             psidx.__getattr__(item)
+
+    def test_multi_index_basic(self):
+        # Creating MultiIndex without using other methods such as `from_arrays`, `from_tuples`.
+        pmidx = pd.MultiIndex()
+        psmidx = ps.MultiIndex()
 
     def test_to_series(self):
         pidx = self.pdf.index
@@ -1512,6 +1522,9 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         self.assert_eq(psidx1.union(psidx2), pidx1.union(pidx2))
         self.assert_eq(psidx2.union(psidx1), pidx2.union(pidx1))
         self.assert_eq(psidx1.union(psidx3), pidx1.union(pidx3))
+        # Deprecated case, but adding to track if pandas stop supporting union
+        # as a set operation. It should work fine until stop supporting anyway.
+        self.assert_eq(pidx1 | pidx2, psidx1 | psidx2)
 
         self.assert_eq(psidx1.union([3, 4, 5, 6]), pidx1.union([3, 4, 5, 6]), almost=True)
         self.assert_eq(psidx2.union([1, 2, 3, 4]), pidx2.union([1, 2, 3, 4]), almost=True)
@@ -1827,6 +1840,9 @@ class IndexesTest(ComparisonTestBase, TestUtils):
         self.assert_eq(
             (pidx + 1).intersection(pidx_other), (psidx + 1).intersection(psidx_other).sort_values()
         )
+        # Deprecated case, but adding to track if pandas stop supporting intersection
+        # as a set operation. It should work fine until stop supporting anyway.
+        self.assert_eq(pidx & pidx_other, (psidx & psidx_other).sort_values())
 
         pidx_other_different_name = pd.Index([3, 4, 5, 6], name="Databricks")
         psidx_other_different_name = ps.from_pandas(pidx_other_different_name)

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -48,7 +48,7 @@ from pyspark.testing.pandasutils import (
     tabulate_requirement_message,
 )
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.pandas.utils import name_like_string
+from pyspark.pandas.utils import name_like_string, is_testing
 
 
 class DataFrameTest(ComparisonTestBase, SQLTestUtils):
@@ -95,6 +95,14 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         column_mask = pdf.columns.isin(["a", "b"])
         index_cols = pdf.columns[column_mask]
         self.assert_eq(psdf[index_cols], pdf[index_cols])
+
+        if is_testing():
+            err_msg = "pandas-on-Spark doesn't allow columns to be created via a new attribute name"
+            with self.assertRaisesRegex(AssertionError, err_msg):
+                psdf.X = [10, 20, 30, 40, 50, 60, 70, 80, 90]
+        else:
+            with self.assertWarns(UserWarning):
+                psdf.X = [10, 20, 30, 40, 50, 60, 70, 80, 90]
 
     def test_creation_index(self):
         err_msg = (
@@ -378,6 +386,10 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             self.assert_eq(ptuple, ktuple)
         for ptuple, ktuple in zip(pdf.itertuples(name=None), psdf.itertuples(name=None)):
             self.assert_eq(ptuple, ktuple)
+        for ptuple, ktuple in zip(
+            pdf.itertuples(index=False, name=None), psdf.itertuples(index=False, name=None)
+        ):
+            self.assert_eq(ptuple, ktuple)
 
         pdf.index = pd.MultiIndex.from_arrays(
             [[1, 2], ["black", "brown"]], names=("count", "color")
@@ -416,6 +428,15 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             },
             index=np.random.rand(3),
         )
+        psdf = ps.from_pandas(pdf)
+
+        for (pdf_k, pdf_v), (psdf_k, psdf_v) in zip(pdf.iterrows(), psdf.iterrows()):
+            self.assert_eq(pdf_k, psdf_k)
+            self.assert_eq(pdf_v, psdf_v)
+
+        # MultiIndex
+        pmidx = pd.Index([(1, 2), (3, 4), (5, 6)])
+        pdf.index = pmidx
         psdf = ps.from_pandas(pdf)
 
         for (pdf_k, pdf_v), (psdf_k, psdf_v) in zip(pdf.iterrows(), psdf.iterrows()):
@@ -879,6 +900,9 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         msg = r"level should be an integer between \[0, column_labels_level\)"
         with self.assertRaisesRegex(ValueError, msg):
             psdf2.rename(columns=str_lower, level=2)
+        msg = r"level should be an integer between \[0, 2\)"
+        with self.assertRaisesRegex(ValueError, msg):
+            psdf3.rename(index=str_lower, level=2)
 
     def test_rename_axis(self):
         index = pd.Index(["A", "B", "C"], name="index")
@@ -915,6 +939,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         self.assertRaises(ValueError, lambda: psdf.rename_axis(["index2", "index3"], axis=0))
         self.assertRaises(ValueError, lambda: psdf.rename_axis(["cols2", "cols3"], axis=1))
         self.assertRaises(TypeError, lambda: psdf.rename_axis(mapper=["index2"], index=["index3"]))
+        self.assertRaises(ValueError, lambda: psdf.rename_axis(ps))
 
         self.assert_eq(
             pdf.rename_axis(index={"index": "index2"}, columns={"cols": "cols2"}).sort_index(),
@@ -1354,7 +1379,6 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             },
             index=np.random.rand(6),
         )
-        psdf = ps.from_pandas(pdf)
 
         self._test_dropna(pdf, axis=0)
 
@@ -1362,6 +1386,14 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         pdf = pd.DataFrame(index=np.random.rand(6))
         psdf = ps.from_pandas(pdf)
 
+        self.assert_eq(psdf.dropna(), pdf.dropna())
+        self.assert_eq(psdf.dropna(how="all"), pdf.dropna(how="all"))
+        self.assert_eq(psdf.dropna(thresh=0), pdf.dropna(thresh=0))
+        self.assert_eq(psdf.dropna(thresh=1), pdf.dropna(thresh=1))
+
+        # Only NA value
+        pdf["a"] = [np.nan] * 6
+        psdf = ps.from_pandas(pdf)
         self.assert_eq(psdf.dropna(), pdf.dropna())
         self.assert_eq(psdf.dropna(how="all"), pdf.dropna(how="all"))
         self.assert_eq(psdf.dropna(thresh=0), pdf.dropna(thresh=0))
@@ -3668,6 +3700,17 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             psdf.reindex(index=kindex, fill_value=0.0).sort_index(),
         )
 
+        # Specifying the `labels` parameter
+        new_index = ["V", "W", "X", "Y", "Z"]
+        self.assert_eq(
+            pdf.reindex(labels=new_index, fill_value=0.0, axis=0).sort_index(),
+            psdf.reindex(labels=new_index, fill_value=0.0, axis=0).sort_index(),
+        )
+        self.assert_eq(
+            pdf.reindex(labels=new_index, fill_value=0.0, axis=1).sort_index(),
+            psdf.reindex(labels=new_index, fill_value=0.0, axis=1).sort_index(),
+        )
+
         self.assertRaises(TypeError, lambda: psdf.reindex(columns=["numbers", "2", "3"], axis=1))
         self.assertRaises(TypeError, lambda: psdf.reindex(columns=["numbers", "2", "3"], axis=2))
         self.assertRaises(TypeError, lambda: psdf.reindex(columns="numbers"))
@@ -4493,6 +4536,10 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         with self.assertRaisesRegex(AssertionError, "the first argument should be a callable"):
             psdf.transform(1)
+        with self.assertRaisesRegex(
+            NotImplementedError, 'axis should be either 0 or "index" currently.'
+        ):
+            psdf.transform(lambda x: x + 1, axis=1)
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("x", "a"), ("x", "b"), ("y", "c")])
@@ -4987,6 +5034,10 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         with self.assertRaisesRegex(TypeError, "type of cond must be a DataFrame or Series"):
             psdf.where(1)
+        with self.assertRaisesRegex(
+            NotImplementedError, 'axis should be either 0 or "index" currently.'
+        ):
+            psdf.where(psdf > 2, psdf.a + 10, axis=1)
 
     def test_mask(self):
         psdf = ps.from_pandas(self.pdf)
@@ -5578,11 +5629,17 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         self.assert_eq(np.abs(psdf), np.abs(pdf))
 
     def test_corrwith(self):
-        df1 = ps.DataFrame({"A": [1, np.nan, 7, 8], "X": [5, 8, np.nan, 3], "C": [10, 4, 9, 3]})
+        df1 = ps.DataFrame(
+            {"A": [1, np.nan, 7, 8], "B": [False, True, True, False], "C": [10, 4, 9, 3]}
+        )
         df2 = df1[["A", "C"]]
+        df3 = df1[["B", "C"]]
         self._test_corrwith(df1, df2)
+        self._test_corrwith(df1, df3)
         self._test_corrwith((df1 + 1), df2.A)
+        self._test_corrwith((df1 + 1), df3.B)
         self._test_corrwith((df1 + 1), (df2.C + 2))
+        self._test_corrwith((df1 + 1), (df3.B + 2))
 
         with self.assertRaisesRegex(
             NotImplementedError, "corrwith currently works only for method='pearson'"
@@ -6561,6 +6618,23 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         pdf = pd.DataFrame([("1", "2"), ("0", "3"), ("2", "0"), ("1", "1")], columns=["a", "b"])
         psdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.cov(), psdf.cov())
+
+    def test_style(self):
+        # Currently, the `style` function returns a pandas object `Styler` as it is,
+        # processing only the number of rows declared in `compute.max_rows`.
+        # So it's a bit vague to test, but we are doing minimal tests instead of not testing at all.
+        pdf = pd.DataFrame(np.random.randn(10, 4), columns=["A", "B", "C", "D"])
+        psdf = ps.from_pandas(pdf)
+
+        def style_negative(v, props=""):
+            return props if v < 0 else None
+
+        # If the value is negative, the text color will be displayed as red.
+        pdf_style = pdf.style.applymap(style_negative, props="color:red;")
+        psdf_style = psdf.style.applymap(style_negative, props="color:red;")
+
+        # Test whether the same shape as pandas table is created including the color.
+        self.assert_eq(pdf_style.to_latex(), psdf_style.to_latex())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -103,6 +103,9 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         else:
             with self.assertWarns(UserWarning):
                 psdf.X = [10, 20, 30, 40, 50, 60, 70, 80, 90]
+            # If a new column is created, the following test would fail.
+            # It means that the pandas have changed their behavior, so we'd better track just in case.
+            self.assert_eq(pdf, psdf)
 
     def test_creation_index(self):
         err_msg = (

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -104,7 +104,7 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             with self.assertWarns(UserWarning):
                 psdf.X = [10, 20, 30, 40, 50, 60, 70, 80, 90]
             # If a new column is created, the following test would fail.
-            # It means that the pandas have changed their behavior, so we'd better track just in case.
+            # It means that the pandas have changed their behavior, so we should follow.
             self.assert_eq(pdf, psdf)
 
     def test_creation_index(self):

--- a/python/pyspark/pandas/tests/test_dataframe_conversion.py
+++ b/python/pyspark/pandas/tests/test_dataframe_conversion.py
@@ -20,6 +20,7 @@ import shutil
 import string
 import tempfile
 import unittest
+import sys
 
 import numpy as np
 import pandas as pd
@@ -187,7 +188,10 @@ class DataFrameConversionTest(ComparisonTestBase, SQLTestUtils, TestUtils):
             output_path = "%s/%s/%s" % (self.tmp_dir, partition_path, output_paths[0])
             self.assertEqual("[%s]" % open(output_path).read().strip(), expected)
 
-    @unittest.skip("Pyperclip could not find a copy/paste mechanism for Linux.")
+    @unittest.skipIf(
+        sys.platform == "linux" or sys.platform == "linux2",
+        "Pyperclip could not find a copy/paste mechanism for Linux.",
+    )
     def test_to_clipboard(self):
         pdf = self.pdf
         psdf = self.psdf

--- a/python/pyspark/pandas/tests/test_dataframe_spark_io.py
+++ b/python/pyspark/pandas/tests/test_dataframe_spark_io.py
@@ -131,6 +131,28 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
                 expected.sort_values(by="f").to_spark().toPandas(),
             )
 
+            # Set `compression` with string
+            expected.to_parquet(tmp, mode="overwrite", partition_cols="i32", compression="none")
+            actual = ps.read_parquet(tmp)
+            self.assertFalse((actual.columns == self.test_column_order).all())
+            actual = actual[self.test_column_order]
+            self.assert_eq(
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
+            )
+
+            # Test `options` parameter
+            expected.to_parquet(
+                tmp, mode="overwrite", partition_cols="i32", options={"compression": "none"}
+            )
+            actual = ps.read_parquet(tmp)
+            self.assertFalse((actual.columns == self.test_column_order).all())
+            actual = actual[self.test_column_order]
+            self.assert_eq(
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
+            )
+
     def test_table(self):
         with self.table("test_table"):
             pdf = self.test_pdf
@@ -415,6 +437,20 @@ class DataFrameSparkIOTest(PandasOnSparkTestCase, TestUtils):
 
             # Write out partitioned by two columns
             expected.to_orc(tmp, mode="overwrite", partition_cols=["i32", "bhello"])
+            # Reset column order, as once the data is written out, Spark rearranges partition
+            # columns to appear first.
+            actual = ps.read_orc(tmp)
+            self.assertFalse((actual.columns == self.test_column_order).all())
+            actual = actual[self.test_column_order]
+            self.assert_eq(
+                actual.sort_values(by="f").to_spark().toPandas(),
+                expected.sort_values(by="f").to_spark().toPandas(),
+            )
+
+            # Test `options` parameter
+            expected.to_orc(
+                tmp, mode="overwrite", partition_cols="i32", options={"compression": "none"}
+            )
             # Reset column order, as once the data is written out, Spark rearranges partition
             # columns to appear first.
             actual = ps.read_orc(tmp)

--- a/python/pyspark/pandas/tests/test_generic_functions.py
+++ b/python/pyspark/pandas/tests/test_generic_functions.py
@@ -119,6 +119,18 @@ class GenericFunctionsTest(PandasOnSparkTestCase, TestUtils):
         )
         self._test_interpolate(pdf)
 
+        pdf = pd.DataFrame(
+            [
+                (0.0, np.nan, -1.0, False, np.nan),
+                (np.nan, 2.0, np.nan, True, np.nan),
+                (2.0, 3.0, np.nan, True, np.nan),
+                (np.nan, 4.0, -4.0, False, np.nan),
+                (np.nan, 1.0, np.nan, True, np.nan),
+            ],
+            columns=list("abcde"),
+        )
+        self._test_interpolate(pdf)
+
     def _test_stat_functions(self, stat_func):
         pdf = pd.DataFrame({"a": [np.nan, np.nan, np.nan], "b": [1, np.nan, 2], "c": [1, 2, 3]})
         psdf = ps.from_pandas(pdf)

--- a/python/pyspark/pandas/tests/test_generic_functions.py
+++ b/python/pyspark/pandas/tests/test_generic_functions.py
@@ -30,14 +30,28 @@ class GenericFunctionsTest(PandasOnSparkTestCase, TestUtils):
         ):
             psdf.interpolate(method="quadratic")
 
+        with self.assertRaisesRegex(
+            NotImplementedError, "interpolate currently works only for method='linear'"
+        ):
+            psdf.id.interpolate(method="quadratic")
+
         with self.assertRaisesRegex(ValueError, "limit must be > 0"):
             psdf.interpolate(limit=0)
+
+        with self.assertRaisesRegex(ValueError, "limit must be > 0"):
+            psdf.id.interpolate(limit=0)
 
         with self.assertRaisesRegex(ValueError, "invalid limit_direction"):
             psdf.interpolate(limit_direction="jump")
 
+        with self.assertRaisesRegex(ValueError, "invalid limit_direction"):
+            psdf.id.interpolate(limit_direction="jump")
+
         with self.assertRaisesRegex(ValueError, "invalid limit_area"):
             psdf.interpolate(limit_area="jump")
+
+        with self.assertRaisesRegex(ValueError, "invalid limit_area"):
+            psdf.id.interpolate(limit_area="jump")
 
     def _test_interpolate(self, pobj):
         psobj = ps.from_pandas(pobj)

--- a/python/pyspark/pandas/tests/test_numpy_compat.py
+++ b/python/pyspark/pandas/tests/test_numpy_compat.py
@@ -80,6 +80,11 @@ class NumPyCompatTest(ComparisonTestBase, SQLTestUtils):
         with self.assertRaisesRegex(NotImplementedError, "on-Spark.*not.*support.*sqrt.*"):
             np.sqrt(psdf, psdf)
 
+        psdf1 = ps.DataFrame({"A": [1, 2, 3]})
+        psdf2 = ps.DataFrame({("A", "B"): [4, 5, 6]})
+        with self.assertRaisesRegex(ValueError, "cannot join with no overlapping index names"):
+            np.left_shift(psdf1, psdf2)
+
     def test_np_spark_compat_series(self):
         # Use randomly generated dataFrame
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
+++ b/python/pyspark/pandas/tests/test_ops_on_diff_frames.py
@@ -1512,9 +1512,16 @@ class OpsOnDiffFramesEnabledTest(PandasOnSparkTestCase, SQLTestUtils):
         psser = ps.from_pandas(pser)
         pser_other = pd.Series([90, 91, 85], index=[0, 1, 3])
         psser_other = ps.from_pandas(pser_other)
+        pser_other2 = pd.Series([90, 91, 85, 100], index=[0, 1, 3, 5])
+        psser_other2 = ps.from_pandas(pser_other2)
 
         with self.assertRaisesRegex(ValueError, "matrices are not aligned"):
             psser.dot(psser_other)
+
+        with ps.option_context("compute.eager_check", False), self.assertRaisesRegex(
+            ValueError, "matrices are not aligned"
+        ):
+            psser.dot(psser_other2)
 
         with ps.option_context("compute.eager_check", True), self.assertRaisesRegex(
             ValueError, "matrices are not aligned"

--- a/python/pyspark/pandas/tests/test_resample.py
+++ b/python/pyspark/pandas/tests/test_resample.py
@@ -129,6 +129,11 @@ class ResampleTest(PandasOnSparkTestCase, TestUtils):
         ):
             psdf.resample("3Y").sum()
 
+        with self.assertRaisesRegex(
+            NotImplementedError, "resample currently works only for DatetimeIndex"
+        ):
+            psdf.id.resample("3Y").sum()
+
         dates = [
             datetime.datetime(2012, 1, 2),
             datetime.datetime(2012, 5, 3),
@@ -155,9 +160,17 @@ class ResampleTest(PandasOnSparkTestCase, TestUtils):
         ):
             psdf.A.resample("2D", on=psdf.A).sum()
 
+        with self.assertRaisesRegex(
+            NotImplementedError, "`on` currently works only for TimestampType"
+        ):
+            psdf[["A"]].resample("2D", on=psdf.A).sum()
+
         psdf["B"] = ["a", "b", "c", "d"]
         with self.assertRaisesRegex(ValueError, "No available aggregation columns!"):
             psdf.B.resample("2D").sum()
+
+        with self.assertRaisesRegex(ValueError, "No available aggregation columns!"):
+            psdf[[]].resample("2D").sum()
 
     def test_missing(self):
         pdf_r = self.psdf1.resample("3Y")

--- a/python/pyspark/pandas/tests/test_resample.py
+++ b/python/pyspark/pandas/tests/test_resample.py
@@ -150,6 +150,15 @@ class ResampleTest(PandasOnSparkTestCase, TestUtils):
         with self.assertRaisesRegex(ValueError, "invalid label: 'both'"):
             psdf.A.resample("3Y", label="both").sum()
 
+        with self.assertRaisesRegex(
+            NotImplementedError, "`on` currently works only for TimestampType"
+        ):
+            psdf.A.resample("2D", on=psdf.A).sum()
+
+        psdf["B"] = ["a", "b", "c", "d"]
+        with self.assertRaisesRegex(ValueError, "No available aggregation columns!"):
+            psdf.B.resample("2D").sum()
+
     def test_missing(self):
         pdf_r = self.psdf1.resample("3Y")
         pser_r = self.psdf1.A.resample("3Y")

--- a/python/pyspark/pandas/tests/test_series_conversion.py
+++ b/python/pyspark/pandas/tests/test_series_conversion.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+import sys
 
 import pandas as pd
 
@@ -33,7 +34,10 @@ class SeriesConversionTest(PandasOnSparkTestCase, SQLTestUtils):
     def psser(self):
         return ps.from_pandas(self.pser)
 
-    @unittest.skip("Pyperclip could not find a copy/paste mechanism for Linux.")
+    @unittest.skipIf(
+        sys.platform == "linux" or sys.platform == "linux2",
+        "Pyperclip could not find a copy/paste mechanism for Linux.",
+    )
     def test_to_clipboard(self):
         pser = self.pser
         psser = self.psser


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to improve the test coverage for pyspark/pandas module (pandas API on Spark) by addressing the existing source code/testes (e.g. adding missing tests or fixing inappropriate code)


### Why are the changes needed?

To improve the testability.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The added/addressed unit-tests and doc-tests should all b passed, and this would be virtually shown from https://codecov.io/gh/apache/spark/tree/master/python/pyspark/pandas as the number of test percentage improving.