### PR TITLE
[SPARK-39873][SQL] Remove `OptimizeLimitZero` and merge it into `EliminateLimits`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1963,8 +1963,6 @@ object EliminateLimits extends Rule[LogicalPlan] {
     case GlobalLimit(l, child) if canEliminate(l, child) =>
       child
 
-    case Limit(IntegerLiteral(0), child) =>
-      LocalRelation(child.output, data = Seq.empty, isStreaming = child.isStreaming)
     case LocalLimit(IntegerLiteral(0), child) =>
       LocalRelation(child.output, data = Seq.empty, isStreaming = child.isStreaming)
     case GlobalLimit(IntegerLiteral(0), child) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1946,7 +1946,7 @@ object PushPredicateThroughJoin extends Rule[LogicalPlan] with PredicateHelper {
 /**
  * This rule is applied by both normal and AQE Optimizer, and optimizes Limit operators by:
  * 1. Eliminate [[Limit]]/[[GlobalLimit]] operators if it's child max row <= limit.
- * 2. Replace [[Limit]]/[[LocalLimit]]/[[GlobalLimit]] operators to empty [[LocalRelation]]
+ * 2. Replace [[Limit]]/[[LocalLimit]]/[[GlobalLimit]] operators with empty [[LocalRelation]]
  *    if the limit value is zero (0).
  * 3. Combines two adjacent [[Limit]] operators into one, merging the
  *    expressions into one single expression.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -166,8 +166,6 @@ abstract class Optimizer(catalogManager: CatalogManager)
       RemoveNoopOperators,
       CombineUnions,
       RemoveNoopUnion) ::
-    Batch("OptimizeLimitZero", Once,
-      OptimizeLimitZero) ::
     // Run this once earlier. This might simplify the plan and reduce cost of optimizer.
     // For example, a query such as Filter(LocalRelation) would go through all the heavy
     // optimizer rules that are triggered when there is a filter

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -111,7 +111,7 @@ class CombiningLimitsSuite extends PlanTest {
     comparePlans(optimized1, expected1)
 
     // test child max row > limit.
-    val query2 = testRelation.select().groupBy()(count(1)).limit(0).analyze
+    val query2 = testRelation2.select($"x").groupBy($"x")(count(1)).limit(1).analyze
     val optimized2 = Optimize.execute(query2)
     comparePlans(optimized2, query2)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeLimitZeroSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeLimitZeroSuite.scala
@@ -32,7 +32,7 @@ class OptimizeLimitZeroSuite extends PlanTest {
     val batches =
       Batch("OptimizeLimitZero", Once,
         ReplaceIntersectWithSemiJoin,
-        OptimizeLimitZero,
+        EliminateLimits,
         PropagateEmptyRelation) :: Nil
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Spark `Optimizer` have two rule: `OptimizeLimitZero` and `EliminateLimits`.
In fact, `OptimizeLimitZero` is one case of eliminate limits.

This PR also follows `EliminateOffsets` which eliminate `Offset` with empty `LocalRelation` too.

After this PR, `EliminateLimits` and `EliminateOffsets` will on the same way.


### Why are the changes needed?
Improve the rule of `Optimizer`.


### Does this PR introduce _any_ user-facing change?
No.
Just update inner implementation.


### How was this patch tested?
Test cases has been adjusted.
