### PR TITLE
[SPARK-37888][SQL][TESTS][FOLLOWUP] Don't check the `Created By` field in `DESCRIBE TABLE` tests

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -189,7 +189,7 @@ class DescribeTableSuite extends DescribeTableSuiteBase with CommandSuiteBase {
         ("data_type", StringType),
         ("comment", StringType)))
       QueryTest.checkAnswer(
-        descriptionDf.filter("col_name != 'Created Time'"),
+        descriptionDf.filter("!(col_name IN ('Created Time', 'Created By'))"),
         Seq(
           Row("data", "string", null),
           Row("id", "bigint", null),
@@ -202,7 +202,6 @@ class DescribeTableSuite extends DescribeTableSuiteBase with CommandSuiteBase {
           Row("Database", "ns", ""),
           Row("Table", "table", ""),
           Row("Last Access", "UNKNOWN", ""),
-          Row("Created By", "Spark 3.4.0-SNAPSHOT", ""),
           Row("Type", "EXTERNAL", ""),
           Row("Provider", getProvider(), ""),
           Row("Comment", "this is a test table", ""),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/DescribeTableSuite.scala
@@ -189,7 +189,7 @@ class DescribeTableSuite extends DescribeTableSuiteBase with CommandSuiteBase {
         ("data_type", StringType),
         ("comment", StringType)))
       QueryTest.checkAnswer(
-        descriptionDf.filter("!(col_name IN ('Created Time', 'Created By'))"),
+        descriptionDf.filter("!(col_name in ('Created Time', 'Created By'))"),
         Seq(
           Row("data", "string", null),
           Row("id", "bigint", null),

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeTableSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/DescribeTableSuite.scala
@@ -58,7 +58,7 @@ class DescribeTableSuite extends v1.DescribeTableSuiteBase with CommandSuiteBase
         ("comment", StringType)))
       QueryTest.checkAnswer(
         // Filter out 'Table Properties' to don't check `transient_lastDdlTime`
-        descriptionDf.filter("col_name != 'Created Time' and col_name != 'Table Properties'"),
+        descriptionDf.filter("!(col_name in ('Created Time', 'Table Properties', 'Created By'))"),
         Seq(
           Row("data", "string", null),
           Row("id", "bigint", null),
@@ -72,7 +72,6 @@ class DescribeTableSuite extends v1.DescribeTableSuiteBase with CommandSuiteBase
           Row("Table", "table", ""),
           Row(TableCatalog.PROP_OWNER.capitalize, Utils.getCurrentUserName(), ""),
           Row("Last Access", "UNKNOWN", ""),
-          Row("Created By", "Spark 3.4.0-SNAPSHOT", ""),
           Row("Type", "EXTERNAL", ""),
           Row("Provider", getProvider(), ""),
           Row("Comment", "this is a test table", ""),


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to do not check the field `Created By` in tests that check output of the `DESCRIBE TABLE` command.

### Why are the changes needed?
The field `Created By` depends on the current Spark version, for instance `Spark 3.4.0-SNAPSHOT`. Apparently, the tests that check the field depend on Spark version. The changes are needed to avoid dependency from Spark version, and to don't change the tests when bumping Spark version.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified tests:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *DescribeTableSuite"
```