### PR TITLE
[SPARK-39880][SQL] V2 SHOW FUNCTIONS command should print qualified function name like v1

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v1/ShowFunctionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.command.v1
 
-import java.util.Locale
+import test.org.apache.spark.sql.MyDoubleSum
 
 import org.apache.spark.sql.execution.command
 
@@ -26,30 +26,22 @@ import org.apache.spark.sql.execution.command
  * table catalogs. The tests that cannot run for all V1 catalogs are located in more
  * specific test suites:
  *
- *   - Temporary functions of V1 catalog:
- *     `org.apache.spark.sql.execution.command.v1.ShowTempFunctionsSuite`
- *   - Permanent functions of V1 catalog:
- *     `org.apache.spark.sql.hive.execution.command.ShowFunctionsSuite`
+ *   - V1 In-Memory catalog: `org.apache.spark.sql.execution.command.v1.ShowFunctionsSuite`
+ *   - V1 Hive External catalog: `org.apache.spark.sql.hive.execution.command.ShowFunctionsSuite`
  */
 trait ShowFunctionsSuiteBase extends command.ShowFunctionsSuiteBase
-  with command.TestsV1AndV2Commands
+  with command.TestsV1AndV2Commands {
+  override protected def createFunction(name: String): Unit = {
+    sql(s"CREATE FUNCTION $name AS '${classOf[MyDoubleSum].getName}'")
+  }
+  override protected def dropFunction(name: String): Unit = {
+    sql(s"DROP FUNCTION IF EXISTS $name")
+  }
+}
 
 /**
- * The class contains tests for the `SHOW FUNCTIONS` command to check temporary functions.
+ * The class contains tests for the `SHOW FUNCTIONS` command to check V1 In-Memory table catalog.
  */
-class ShowTempFunctionsSuite extends ShowFunctionsSuiteBase with CommandSuiteBase {
+class ShowFunctionsSuite extends ShowFunctionsSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[ShowFunctionsSuiteBase].commandVersion
-  override protected def isTempFunctions(): Boolean = true
-
-  override protected def createFunction(name: String): Unit = {
-    spark.udf.register(name, (arg1: Int, arg2: String) => arg2 + arg1)
-  }
-
-  override protected def dropFunction(name: String): Unit = {
-    spark.sessionState.catalog.dropTempFunction(name, false)
-  }
-
-  override protected def showFun(ns: String, name: String): String = {
-    s"$catalog.$ns.$name".toLowerCase(Locale.ROOT)
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/v2/ShowFunctionsSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.execution.command
  */
 class ShowFunctionsSuite extends command.ShowFunctionsSuiteBase with CommandSuiteBase {
   override protected def funCatalog: String = s"fun_$catalog"
-  override protected def showFun(ns: String, name: String): String = name
 
   private def getFunCatalog(): InMemoryCatalog = {
     spark.sessionState.catalogManager.catalog(funCatalog).asInstanceOf[InMemoryCatalog]

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowFunctionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/ShowFunctionsSuite.scala
@@ -19,22 +19,15 @@ package org.apache.spark.sql.hive.execution.command
 
 import java.util.Locale
 
-import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.execution.command.v1
-import org.apache.spark.sql.hive.execution.UDFToListInt
 
 /**
- * The class contains tests for the `SHOW FUNCTIONS` command to check permanent functions.
+ * The class contains tests for the `SHOW FUNCTIONS` command to check V1 Hive external catalog.
  */
 class ShowFunctionsSuite extends v1.ShowFunctionsSuiteBase with CommandSuiteBase {
   override def commandVersion: String = super[ShowFunctionsSuiteBase].commandVersion
-  override protected def showFun(ns: String, name: String): String =
-    s"$SESSION_CATALOG_NAME.$ns.$name".toLowerCase(Locale.ROOT)
-
-  override protected def createFunction(name: String): Unit = {
-    sql(s"CREATE FUNCTION $name AS '${classOf[UDFToListInt].getName}'")
-  }
-  override protected def dropFunction(name: String): Unit = {
-    sql(s"DROP FUNCTION IF EXISTS $name")
+  override def qualifiedFunName(ns: String, name: String): String = {
+    // Hive Metastore lower-cases all identifiers.
+    super.qualifiedFunName(ns, name).toLowerCase(Locale.ROOT)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes a mismatch between v1 and v2 SHOW FUNCTIONS command: v1 prints qualified function names such as `spark_catalog.db1.f1`, but v2 only prints the function name. V2 command should follow v1 behavior which makes more sense.

This PR also updates the SHOW FUNCTIONS test suites to match the new behavior.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
keep v1 and v2 commands consistent.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, v2 SHOW FUNCTIONS is new in Spark 3.4 (not released)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
updated tests