### PR TITLE
[SPARK-39877][PYTHON] Add unpivot to PySpark DataFrame API

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -309,10 +309,7 @@ class SparkContext:
         if sys.version_info[:2] < (3, 8):
             with warnings.catch_warnings():
                 warnings.simplefilter("once")
-                warnings.warn(
-                    "Python 3.7 support is deprecated in Spark 3.4.",
-                    FutureWarning
-                )
+                warnings.warn("Python 3.7 support is deprecated in Spark 3.4.", FutureWarning)
 
         # Broadcast's __reduce__ method stores Broadcast instances here.
         # This allows other code to determine which Broadcast instances have

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -309,7 +309,10 @@ class SparkContext:
         if sys.version_info[:2] < (3, 8):
             with warnings.catch_warnings():
                 warnings.simplefilter("once")
-                warnings.warn("Python 3.7 support is deprecated in Spark 3.4.", FutureWarning)
+                warnings.warn(
+                    "Python 3.7 support is deprecated in Spark 3.4.",
+                    FutureWarning
+                )
 
         # Broadcast's __reduce__ method stores Broadcast instances here.
         # This allows other code to determine which Broadcast instances have

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2322,10 +2322,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         return DataFrame(
             self._jdf._unpivot(
-                self._jcols(ids),
-                self._jcols(values),
-                variableColumnName,
-                valueColumnName
+                self._jcols(ids), self._jcols(values), variableColumnName, valueColumnName
             ),
             self.sparkSession,
         )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2325,7 +2325,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
             return self._jcols(*lst)
 
         return DataFrame(
-            self._jdf._unpivot(
+            self._jdf.unpivotWithSeq(
                 to_jcols(ids), to_jcols(values), variableColumnName, valueColumnName
             ),
             self.sparkSession,

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2288,21 +2288,27 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         Examples
         --------
-        >>> df = ps.DataFrame({'id': {0: 1, 1: 2},
-        ...                    'int': {0: 11, 1: 21},
-        ...                    'double': {0: 1.2, 1: 2.2}},
-        ...                   columns=['id', 'int', 'double'])
-        >>> df
-           id  int  double
-        0  1    11     1.2
-        1  2    21     2.2
+        >>> df = spark.createDataFrame(
+        ...     [(1, 11, 1.1), (2, 12, 1.2)],
+        ...     ["id", "int", "double"],
+        ... )
+        >>> df.show()
+        +---+---+------+
+        | id|int|double|
+        +---+---+------+
+        |  1| 11|   1.1|
+        |  2| 12|   1.2|
+        +---+---+------+
 
-        >>> df.unpivot('id')
-          id variable value
-        0  1      int  11.0
-        1  1   double   1.2
-        2  2      int  21.0
-        3  2   double   2.2
+        >>> df.unpivot("id").show()
+        +---+--------+-----+
+        | id|variable|value|
+        +---+--------+-----+
+        |  1|     int| 11.0|
+        |  1|  double|  1.1|
+        |  2|     int| 12.0|
+        |  2|  double|  1.2|
+        +---+--------+-----+
         """
         if ids is None:
             id_list = []

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2300,25 +2300,29 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         |  2| 12|   1.2|
         +---+---+------+
 
-        >>> df.unpivot("id").show()
-        +---+--------+-----+
-        | id|variable|value|
-        +---+--------+-----+
-        |  1|     int| 11.0|
-        |  1|  double|  1.1|
-        |  2|     int| 12.0|
-        |  2|  double|  1.2|
-        +---+--------+-----+
+        >>> df.unpivot("id", ["int", "double"], "var", "val").show()
+        +---+------+----+
+        | id|   var| val|
+        +---+------+----+
+        |  1|   int|11.0|
+        |  1|double| 1.1|
+        |  2|   int|12.0|
+        |  2|double| 1.2|
+        +---+------+----+
         """
-        def to_jcols(cols) -> JavaObject:
-            l = cols
+
+        def to_jcols(
+            cols: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]]
+        ) -> JavaObject:
             if cols is None:
-                l = []
+                lst = []
             elif isinstance(cols, tuple):
-                l = list(cols)
-            elif not isinstance(cols, list):
-                l = [cols]
-            return self._jcols(*l)
+                lst = list(cols)
+            elif isinstance(cols, list):
+                lst = cols
+            else:
+                lst = [cols]
+            return self._jcols(*lst)
 
         return DataFrame(
             self._jdf._unpivot(

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2240,10 +2240,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     def unpivot(
         self,
-        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]] = None,
-        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]] = None,
-        variableColumnName: Optional[str] = None,
-        valueColumnName: Optional[str] = None,
+        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        variableColumnName: str,
+        valueColumnName: str,
     ) -> "DataFrame":
         """
         Unpivot a DataFrame from wide format to long format, optionally leaving
@@ -2271,15 +2271,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ----------
         ids : str, Column, tuple, list, optional
             Column(s) to use as identifiers. Can be a single column or column name,
-            or a list for multiple columns.
+            or a list or tuple for multiple columns.
         values : str, Column, tuple, list, optional
-            Column(s) to unpivot. Can be a single column or column name, or a list
+            Column(s) to unpivot. Can be a single column or column name, or a list or tuple
             for multiple columns. If not specified or empty, uses all columns that
             are not set as `ids`.
-        variableColumnName : scalar, default 'variable'
-            Name of the variable column. If None it uses 'variable'.
-        valueColumnName : scalar, default 'value'
-            Name of the value column. If None it uses 'value'.
+        variableColumnName : str
+            Name of the variable column.
+        valueColumnName : str
+            Name of the value column.
 
         Returns
         -------
@@ -2320,12 +2320,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                 l = [cols]
             return self._jcols(*l)
 
-        if variableColumnName is None:
-            variableColumnName = "variable"
-
-        if valueColumnName is None:
-            valueColumnName = "value"
-
         return DataFrame(
             self._jdf._unpivot(
                 to_jcols(ids), to_jcols(values), variableColumnName, valueColumnName
@@ -2335,10 +2329,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     def melt(
         self,
-        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName"]]] = None,
-        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName"]]] = None,
-        variableColumnName: Optional[str] = None,
-        valueColumnName: Optional[str] = None,
+        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]],
+        variableColumnName: str,
+        valueColumnName: str,
     ) -> "DataFrame":
         """
         Unpivot a DataFrame from wide format to long format, optionally leaving
@@ -2353,15 +2347,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ----------
         ids : str, Column, tuple, list, optional
             Column(s) to use as identifiers. Can be a single column or column name,
-            or a list for multiple columns.
+            or a list or tuple for multiple columns.
         values : str, Column, tuple, list, optional
-            Column(s) to unpivot. Can be a single column or column name, or a list
+            Column(s) to unpivot. Can be a single column or column name, or a list or tuple
             for multiple columns. If not specified or empty, uses all columns that
             are not set as `ids`.
-        variableColumnName : scalar, default 'variable'
-            Name of the variable column. If None it uses 'variable'.
-        valueColumnName : scalar, default 'value'
-            Name of the value column. If None it uses 'value'.
+        variableColumnName : str
+            Name of the variable column.
+        valueColumnName : str
+            Name of the value column.
 
         Returns
         -------

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2380,7 +2380,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         --------
         DataFrame.unpivot
         """
-        self.unpivot(ids, values, variableColumnName, valueColumnName)
+        return self.unpivot(ids, values, variableColumnName, valueColumnName)
 
     def agg(self, *exprs: Union[Column, Dict[str, str]]) -> "DataFrame":
         """Aggregate on the entire :class:`DataFrame` without groups

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2240,8 +2240,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
     def unpivot(
         self,
-        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName"]]] = None,
-        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName"]]] = None,
+        ids: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]] = None,
+        values: Optional[Union["ColumnOrName", List["ColumnOrName"], Tuple["ColumnOrName", ...]]] = None,
         variableColumnName: Optional[str] = None,
         valueColumnName: Optional[str] = None,
     ) -> "DataFrame":
@@ -2310,23 +2310,15 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         |  2|  double|  1.2|
         +---+--------+-----+
         """
-        if ids is None:
-            id_list = []
-        elif isinstance(ids, tuple):
-            id_list = list(ids)
-        elif isinstance(ids, list):
-            id_list = ids
-        else:
-            id_list = [ids]
-
-        if values is None:
-            value_list = []
-        elif isinstance(values, tuple):
-            value_list = list(values)
-        elif isinstance(values, list):
-            value_list = values
-        else:
-            value_list = [values]
+        def to_jcols(cols) -> JavaObject:
+            l = cols
+            if cols is None:
+                l = []
+            elif isinstance(cols, tuple):
+                l = list(cols)
+            elif not isinstance(cols, list):
+                l = [cols]
+            return self._jcols(*l)
 
         if variableColumnName is None:
             variableColumnName = "variable"
@@ -2336,7 +2328,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         return DataFrame(
             self._jdf._unpivot(
-                self._jcols(*id_list), self._jcols(*value_list), variableColumnName, valueColumnName
+                to_jcols(ids), to_jcols(values), variableColumnName, valueColumnName
             ),
             self.sparkSession,
         )

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2305,14 +2305,22 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         3  2   double   2.2
         """
         if ids is None:
-            ids = []
-        elif type(ids) == tuple:
-            ids = list(ids)
+            id_list = []
+        elif isinstance(ids, tuple):
+            id_list = list(ids)
+        elif isinstance(ids, list):
+            id_list = ids
+        else:
+            id_list = [ids]
 
         if values is None:
-            values = []
-        elif type(values) == tuple:
-            values = list(values)
+            value_list = []
+        elif isinstance(values, tuple):
+            value_list = list(values)
+        elif isinstance(values, list):
+            value_list = values
+        else:
+            value_list = [values]
 
         if variableColumnName is None:
             variableColumnName = "variable"
@@ -2322,7 +2330,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
 
         return DataFrame(
             self._jdf._unpivot(
-                self._jcols(ids), self._jcols(values), variableColumnName, valueColumnName
+                self._jcols(*id_list), self._jcols(*value_list), variableColumnName, valueColumnName
             ),
             self.sparkSession,
         )

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -669,6 +669,24 @@ class DataFrameTests(ReusedSQLTestCase):
             ):
                 df.unpivot("id", ["int", "str"])
 
+        with self.subTest(desc="with columns"):
+            for id in [df.id, [df.id], (df.id,)]:
+                for values in [[df.int, df.double], (df.int, df.double)]:
+                    with self.subTest(ids=id, values=values):
+                        self.assertEqual(
+                            df.unpivot(id, values).collect(),
+                            df.unpivot("id", ["int", "double"]).collect(),
+                        )
+
+        with self.subTest(desc="with column names and columns"):
+            for ids in [[df.id, "str"], (df.id, "str")]:
+                for values in [[df.int, "double"], (df.int, "double")]:
+                    with self.subTest(ids=ids, values=values):
+                        self.assertEqual(
+                            df.unpivot(ids, values).collect(),
+                            df.unpivot(["id", "str"], ["int", "double"]).collect(),
+                        )
+
         with self.subTest(desc="melt alias"):
             self.assertEqual(
                 df.unpivot("id", ["int", "double"]).collect(),

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -669,6 +669,12 @@ class DataFrameTests(ReusedSQLTestCase):
             ):
                 df.unpivot("id", ["int", "str"])
 
+        with self.subTest(desc="melt alias"):
+            self.assertEqual(
+                df.unpivot("id", ["int", "double"]).collect(),
+                df.melt("id", ["int", "double"]).collect(),
+            )
+
     def test_observe(self):
         # SPARK-36263: tests the DataFrame.observe(Observation, *Column) method
         from pyspark.sql import Observation

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -534,6 +534,143 @@ class DataFrameTests(ReusedSQLTestCase):
         self.assertEqual(1, logical_plan.toString().count("what"))
         self.assertEqual(3, logical_plan.toString().count("itworks"))
 
+    def test_unpivot(self):
+        # SPARK-39877: test the DataFrame.unpivot method
+        df = self.spark.createDataFrame(
+            [
+                (1, 10, 1.0, "one"),
+                (2, 20, 2.0, "two"),
+                (3, 30, 3.0, "three"),
+            ],
+            ["id", "int", "double", "str"],
+        )
+
+        with self.subTest(desc="with no identifier and no value columns"):
+            # select only columns that have common data type (double)
+            actual = df.select("id", "int", "double").unpivot()
+            self.assertEqual(actual.schema.simpleString(), "struct<variable:string,value:double>")
+            self.assertEqual(
+                actual.collect(),
+                [
+                    Row(variable="id", value=1.0),
+                    Row(variable="int", value=10.0),
+                    Row(variable="double", value=1.0),
+                    Row(variable="id", value=2.0),
+                    Row(variable="int", value=20.0),
+                    Row(variable="double", value=2.0),
+                    Row(variable="id", value=3.0),
+                    Row(variable="int", value=30.0),
+                    Row(variable="double", value=3.0),
+                ]
+            )
+
+        with self.subTest(desc="with no identifier column and multiple value columns"):
+            for id in [None, [], ()]:
+                for values in [["int", "double"], ("int", "double")]:
+                    with self.subTest(ids=id, values=values):
+                        actual = df.unpivot(id, values)
+                        self.assertEqual(
+                            actual.schema.simpleString(),
+                            "struct<variable:string,value:double>"
+                        )
+                        self.assertEqual(
+                            actual.collect(),
+                            [
+                                Row(variable="int", value=10.0),
+                                Row(variable="double", value=1.0),
+                                Row(variable="int", value=20.0),
+                                Row(variable="double", value=2.0),
+                                Row(variable="int", value=30.0),
+                                Row(variable="double", value=3.0),
+                            ]
+                        )
+
+        with self.subTest(desc="with single identifier column and multiple value columns"):
+            for id in ["id", ["id"], ("id",)]:
+                for values in [["int", "double"], ("int", "double")]:
+                    with self.subTest(ids=id, values=values):
+                        actual = df.unpivot(id, values)
+                        self.assertEqual(
+                            actual.schema.simpleString(),
+                            "struct<id:bigint,variable:string,value:double>"
+                        )
+                        self.assertEqual(
+                            actual.collect(),
+                            [
+                                Row(id=1, variable="int", value=10.0),
+                                Row(id=1, variable="double", value=1.0),
+                                Row(id=2, variable="int", value=20.0),
+                                Row(id=2, variable="double", value=2.0),
+                                Row(id=3, variable="int", value=30.0),
+                                Row(id=3, variable="double", value=3.0),
+                            ]
+                        )
+
+        with self.subTest(desc="with multiple identifier columns and single given value columns"):
+            for ids in [["id", "double"], ("id", "double")]:
+                for values in ["str", ["str"], ("str", )]:
+                    with self.subTest(ids=ids, values=values):
+                        actual = df.unpivot(ids, values)
+                        self.assertEqual(
+                            actual.schema.simpleString(),
+                            "struct<id:bigint,double:double,variable:string,value:string>"
+                        )
+                        self.assertEqual(
+                            actual.collect(),
+                            [
+                                Row(id=1, double=1.0, variable="str", value="one"),
+                                Row(id=2, double=2.0, variable="str", value="two"),
+                                Row(id=3, double=3.0, variable="str", value="three"),
+                            ]
+                        )
+
+        with self.subTest(desc="with multiple identifier columns but no given value columns"):
+            for ids in [["id", "str"], ("id", "str")]:
+                for values in [None, [], ()]:
+                    with self.subTest(ids=ids, values=values):
+                        actual = df.unpivot(ids, values)
+                        self.assertEqual(
+                            actual.schema.simpleString(),
+                            "struct<id:bigint,str:string,variable:string,value:double>"
+                        )
+                        self.assertEqual(
+                            actual.collect(),
+                            [
+                                Row(id=1, str="one", variable="int", value=10.0),
+                                Row(id=1, str="one", variable="double", value=1.0),
+                                Row(id=2, str="two", variable="int", value=20.0),
+                                Row(id=2, str="two", variable="double", value=2.0),
+                                Row(id=3, str="three", variable="int", value=30.0),
+                                Row(id=3, str="three", variable="double", value=3.0),
+                            ]
+                        )
+
+        with self.subTest(desc="with custom variable and value column names"):
+            actual = df.unpivot("id", ["int", "double"], "var", "val")
+            self.assertEqual(
+                actual.schema.simpleString(),
+                "struct<id:bigint,var:string,val:double>"
+            )
+            self.assertEqual(
+                actual.collect(),
+                [
+                    Row(id=1, var="int", val=10.0),
+                    Row(id=1, var="double", val=1.0),
+                    Row(id=2, var="int", val=20.0),
+                    Row(id=2, var="double", val=2.0),
+                    Row(id=3, var="int", val=30.0),
+                    Row(id=3, var="double", val=3.0),
+                ]
+            )
+
+        with self.subTest(desc="with value columns without common data type"):
+            with self.assertRaisesRegex(
+                AnalysisException,
+                r"\[UNPIVOT_VALUE_DATA_TYPE_MISMATCH\] Unpivot value columns must share "
+                r"a least common type, some types do not: .*"
+            ):
+                df.unpivot("id", ["int", "str"])
+
     def test_observe(self):
         # SPARK-36263: tests the DataFrame.observe(Observation, *Column) method
         from pyspark.sql import Observation

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -561,7 +561,7 @@ class DataFrameTests(ReusedSQLTestCase):
                     Row(variable="id", value=3.0),
                     Row(variable="int", value=30.0),
                     Row(variable="double", value=3.0),
-                ]
+                ],
             )
 
         with self.subTest(desc="with no identifier column and multiple value columns"):
@@ -570,8 +570,7 @@ class DataFrameTests(ReusedSQLTestCase):
                     with self.subTest(ids=id, values=values):
                         actual = df.unpivot(id, values)
                         self.assertEqual(
-                            actual.schema.simpleString(),
-                            "struct<variable:string,value:double>"
+                            actual.schema.simpleString(), "struct<variable:string,value:double>"
                         )
                         self.assertEqual(
                             actual.collect(),
@@ -582,7 +581,7 @@ class DataFrameTests(ReusedSQLTestCase):
                                 Row(variable="double", value=2.0),
                                 Row(variable="int", value=30.0),
                                 Row(variable="double", value=3.0),
-                            ]
+                            ],
                         )
 
         with self.subTest(desc="with single identifier column and multiple value columns"):
@@ -592,7 +591,7 @@ class DataFrameTests(ReusedSQLTestCase):
                         actual = df.unpivot(id, values)
                         self.assertEqual(
                             actual.schema.simpleString(),
-                            "struct<id:bigint,variable:string,value:double>"
+                            "struct<id:bigint,variable:string,value:double>",
                         )
                         self.assertEqual(
                             actual.collect(),
@@ -603,17 +602,17 @@ class DataFrameTests(ReusedSQLTestCase):
                                 Row(id=2, variable="double", value=2.0),
                                 Row(id=3, variable="int", value=30.0),
                                 Row(id=3, variable="double", value=3.0),
-                            ]
+                            ],
                         )
 
         with self.subTest(desc="with multiple identifier columns and single given value columns"):
             for ids in [["id", "double"], ("id", "double")]:
-                for values in ["str", ["str"], ("str", )]:
+                for values in ["str", ["str"], ("str",)]:
                     with self.subTest(ids=ids, values=values):
                         actual = df.unpivot(ids, values)
                         self.assertEqual(
                             actual.schema.simpleString(),
-                            "struct<id:bigint,double:double,variable:string,value:string>"
+                            "struct<id:bigint,double:double,variable:string,value:string>",
                         )
                         self.assertEqual(
                             actual.collect(),
@@ -621,7 +620,7 @@ class DataFrameTests(ReusedSQLTestCase):
                                 Row(id=1, double=1.0, variable="str", value="one"),
                                 Row(id=2, double=2.0, variable="str", value="two"),
                                 Row(id=3, double=3.0, variable="str", value="three"),
-                            ]
+                            ],
                         )
 
         with self.subTest(desc="with multiple identifier columns but no given value columns"):
@@ -631,7 +630,7 @@ class DataFrameTests(ReusedSQLTestCase):
                         actual = df.unpivot(ids, values)
                         self.assertEqual(
                             actual.schema.simpleString(),
-                            "struct<id:bigint,str:string,variable:string,value:double>"
+                            "struct<id:bigint,str:string,variable:string,value:double>",
                         )
                         self.assertEqual(
                             actual.collect(),
@@ -642,14 +641,13 @@ class DataFrameTests(ReusedSQLTestCase):
                                 Row(id=2, str="two", variable="double", value=2.0),
                                 Row(id=3, str="three", variable="int", value=30.0),
                                 Row(id=3, str="three", variable="double", value=3.0),
-                            ]
+                            ],
                         )
 
         with self.subTest(desc="with custom variable and value column names"):
             actual = df.unpivot("id", ["int", "double"], "var", "val")
             self.assertEqual(
-                actual.schema.simpleString(),
-                "struct<id:bigint,var:string,val:double>"
+                actual.schema.simpleString(), "struct<id:bigint,var:string,val:double>"
             )
             self.assertEqual(
                 actual.collect(),
@@ -660,14 +658,14 @@ class DataFrameTests(ReusedSQLTestCase):
                     Row(id=2, var="double", val=2.0),
                     Row(id=3, var="int", val=30.0),
                     Row(id=3, var="double", val=3.0),
-                ]
+                ],
             )
 
         with self.subTest(desc="with value columns without common data type"):
             with self.assertRaisesRegex(
                 AnalysisException,
                 r"\[UNPIVOT_VALUE_DATA_TYPE_MISMATCH\] Unpivot value columns must share "
-                r"a least common type, some types do not: .*"
+                r"a least common type, some types do not: .*",
             ):
                 df.unpivot("id", ["int", "str"])
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2109,6 +2109,7 @@ class Dataset[T] private[sql](
 
   /**
    * Called from Python as Seq[Column] are easier to create via py4j than Array[Column].
+   * We use Array[Column] for unpivot rather than Seq[Column] as those are Java-friendly.
    */
   private[sql] def _unpivot(ids: Seq[Column],
                             values: Seq[Column],

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2108,6 +2108,15 @@ class Dataset[T] private[sql](
     unpivot(ids, Array.empty, variableColumnName, valueColumnName)
 
   /**
+   * Called from Python as Seq[Column] are easier to create via py4j than Array[Column].
+   */
+  private[sql] def _unpivot(ids: Seq[Column],
+                            values: Seq[Column],
+                            variableColumnName: String,
+                            valueColumnName: String): DataFrame =
+    unpivot(ids.toArray, values.toArray, variableColumnName, valueColumnName)
+
+  /**
    * Unpivot a DataFrame from wide format to long format, optionally leaving identifier columns set.
    * This is the reverse to `groupBy(...).pivot(...).agg(...)`, except for the aggregation,
    * which cannot be reversed. This is an alias for `unpivot`.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2111,10 +2111,10 @@ class Dataset[T] private[sql](
    * Called from Python as Seq[Column] are easier to create via py4j than Array[Column].
    * We use Array[Column] for unpivot rather than Seq[Column] as those are Java-friendly.
    */
-  private[sql] def _unpivot(ids: Seq[Column],
-                            values: Seq[Column],
-                            variableColumnName: String,
-                            valueColumnName: String): DataFrame =
+  private[sql] def unpivotWithSeq(ids: Seq[Column],
+                                  values: Seq[Column],
+                                  variableColumnName: String,
+                                  valueColumnName: String): DataFrame =
     unpivot(ids.toArray, values.toArray, variableColumnName, valueColumnName)
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2111,10 +2111,11 @@ class Dataset[T] private[sql](
    * Called from Python as Seq[Column] are easier to create via py4j than Array[Column].
    * We use Array[Column] for unpivot rather than Seq[Column] as those are Java-friendly.
    */
-  private[sql] def unpivotWithSeq(ids: Seq[Column],
-                                  values: Seq[Column],
-                                  variableColumnName: String,
-                                  valueColumnName: String): DataFrame =
+  private[sql] def unpivotWithSeq(
+      ids: Seq[Column],
+      values: Seq[Column],
+      variableColumnName: String,
+      valueColumnName: String): DataFrame =
     unpivot(ids.toArray, values.toArray, variableColumnName, valueColumnName)
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds `unpivot` and its alias `melt` to the PySpark API. It calls into Scala `Dataset.unpivot` (#36150). Small difference to Scala method signature is that PySpark method has default values. This is similar to `melt` in Spark Pandas API.

### Why are the changes needed?
To support `unpivot` in Python.

### Does this PR introduce _any_ user-facing change?
Yes, adds `DataFrame.unpivot` and `DataFrame.melt` to PySpark API.

### How was this patch tested?
Added test to `test_dataframe.py`.