### PR TITLE
[SPARK-39884][K8S] `KubernetesExecutorBackend` should handle `IPv6` hostname

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -158,7 +158,8 @@ private[spark] object KubernetesExecutorBackend extends Logging {
           bindAddress = value
           argv = tail
         case ("--hostname") :: value :: tail =>
-          hostname = value
+          // entrypoint.sh sets SPARK_EXECUTOR_POD_IP without '[]'
+          hostname = Utils.addBracketsIfNeeded(value)
           argv = tail
         case ("--cores") :: value :: tail =>
           cores = value.toInt


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `KubernetesExecutorBackend` to handle IPv6 hostname.

### Why are the changes needed?

`entrypoint.sh` uses `SPARK_EXECUTOR_POD_IP` for `--hostname`.

https://github.com/apache/spark/blob/e9eb28e27d10497c8b36774609823f4bbd2c8500/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh#L97

However, IPv6 `status.podIP` has no `[]`. We need to handle both IPv6 cases (`[]` or no `[]`).
```yaml
    - name: SPARK_EXECUTOR_POD_IP
          fieldPath: status.podIP
      value: -Djava.net.preferIPv6Addresses=true
  podIP: 2600:1f14:552:fb00:4c14::3
```

### Does this PR introduce _any_ user-facing change?

No, previously, it fails immediately.
```
22/07/26 19:20:46 INFO Executor: Starting executor ID 5 on host 2600:1f14:552:fb02:2dc2::1
22/07/26 19:20:46 ERROR CoarseGrainedExecutorBackend: Executor self-exiting due to : Unable to create executor due to assertion failed: Expected hostname or IPv6 IP enclosed in [] but got 2600:1f14:552:fb02:2dc2::1
```

### How was this patch tested?

Pass the CIs.