### PR TITLE
[SPARK-39319][FOLLOW-UP][SQL] Make TreeNode.context as lazy val

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/SQLQueryContext.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/SQLQueryContext.scala
@@ -42,9 +42,7 @@ case class SQLQueryContext(
    */
   lazy val summary: String = {
     // If the query context is missing or incorrect, simply return an empty string.
-    if (sqlText.isEmpty || originStartIndex.isEmpty || originStopIndex.isEmpty ||
-      originStartIndex.get < 0 || originStopIndex.get >= sqlText.get.length ||
-      originStartIndex.get > originStopIndex.get) {
+    if (!isValid) {
       ""
     } else {
       val positionContext = if (line.isDefined && startPosition.isDefined) {
@@ -119,12 +117,17 @@ case class SQLQueryContext(
 
   /** Gets the textual fragment of a SQL query. */
   override lazy val fragment: String = {
-    if (sqlText.isEmpty || originStartIndex.isEmpty || originStopIndex.isEmpty ||
-      originStartIndex.get < 0 || originStopIndex.get >= sqlText.get.length ||
-      originStartIndex.get > originStopIndex.get) {
+    if (!isValid) {
       ""
     } else {
       sqlText.get.substring(originStartIndex.get, originStopIndex.get)
     }
+  }
+
+  private def isValid: Boolean = {
+    sqlText.isDefined && originStartIndex.isDefined && originStopIndex.isDefined &&
+      originStartIndex.get >= 0 && originStopIndex.get < sqlText.get.length &&
+      originStartIndex.get <= originStopIndex.get
+
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -66,7 +66,7 @@ case class Origin(
     objectType: Option[String] = None,
     objectName: Option[String] = None) {
 
-  val context: SQLQueryContext = SQLQueryContext(
+  lazy val context: SQLQueryContext = SQLQueryContext(
     line, startPosition, startIndex, stopIndex, sqlText, objectType, objectName)
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Make TreeNode.context as lazy val
- Code clean up in SQLQueryContext

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Making TreeNode.context as lazy val can save the memory usage, which is only called on certain expressions under ANSI SQL mode.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT