### PR TITLE
[SPARK-39871][CORE] Jmx http interface supported for SparkHistoryServer

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -32,6 +32,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.History
 import org.apache.spark.internal.config.UI._
+import org.apache.spark.jmx.JmxServletUtils
 import org.apache.spark.status.api.v1.{ApiRootResource, ApplicationInfo, UIRoot}
 import org.apache.spark.ui.{SparkUI, UIUtils, WebUI}
 import org.apache.spark.util.{ShutdownHookManager, SystemClock, Utils}
@@ -150,6 +151,7 @@ class HistoryServer(
     attachPage(new HistoryPage(this))
 
     attachHandler(ApiRootResource.getServletHandler(this))
+    attachHandler(JmxServletUtils.buildServlet("/jmx", "/*"))
 
     addStaticHandler(SparkUI.STATIC_RESOURCE_DIR)
 

--- a/core/src/main/scala/org/apache/spark/jmx/JMXJsonServlet.scala
+++ b/core/src/main/scala/org/apache/spark/jmx/JMXJsonServlet.scala
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.jmx
+
+import com.fasterxml.jackson.core.{JsonFactory, JsonGenerator}
+import java.io.Writer
+import java.lang.management.ManagementFactory
+import java.lang.reflect.Array
+import java.util.Locale
+import javax.management._
+import javax.management.openmbean.{CompositeData, TabularData}
+import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+import org.apache.spark.jmx.exception.{CheckAttributeException, CheckQryNameException}
+
+class JMXJsonServlet extends HttpServlet {
+
+  import JMXJsonServlet._
+
+
+  override def doGet(request: HttpServletRequest, response: HttpServletResponse): Unit = {
+    val generator = buildJsonGenerator(response.getWriter)
+    try {
+      // 1. match get parameter
+      // if match get, then process get parameter
+      // 2. match qry parameter
+      // match qry not empty, then query all parameter -> set qry '*:*'
+      val args: (String, ObjectName, String) = Option(
+        request.getParameter("get")
+      ) match {
+        case Some(x) => parseObjectNameAttribute("get", x)
+        case None => Option(request.getParameter("qry")) match {
+          case Some(x) => parseObjectNameAttribute(qryName = x)
+          case None => parseObjectNameAttribute(qryName = "*:*")
+        }
+      }
+      buildJmxResponse(generator, args)
+    } catch {
+      case _: CheckQryNameException =>
+        generator.writeStringField("result", "ERROR")
+        generator.writeStringField("message", "query format is not as expected.")
+        generator.close()
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST)
+      case e: CheckAttributeException =>
+        generator.writeStringField("result", "ERROR")
+        generator.writeStringField("message", "No attribute with name " + e.getAttribute
+          + " was found.")
+        // if we catch here, must has construct start {Object, Array}
+        generator.writeEndObject()
+        generator.writeEndArray()
+        generator.close()
+        response.setStatus(HttpServletResponse.SC_NOT_FOUND)
+    } finally {
+      Option(generator).foreach(_.close())
+    }
+  }
+
+}
+
+object JMXJsonServlet {
+  private[jmx] val ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods"
+  private[jmx] val ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin"
+
+  private[jmx] val qryNameMatcher = "^(.+):(.+)$".r
+
+  private val mBeanServer: MBeanServer = ManagementFactory.getPlatformMBeanServer
+  private val factory = new JsonFactory()
+
+  @transient private val log = LoggerFactory.getLogger(classOf[JMXJsonServlet])
+
+  /**
+   * @param generator json generator
+   * @param args (qry_name, qry_object_name, attribute)
+   */
+  @throws[CheckAttributeException]
+  private[jmx] def buildJmxResponse(
+    generator: JsonGenerator,
+    args: (String, ObjectName, String)
+  ): Unit = {
+    val (qryName, _, attribute) = args
+    generator.writeArrayFieldStart("beans")
+    val mBeanNames = mBeanServer.queryNames(new ObjectName(qryName), null)
+    for (mBeanName <- mBeanNames.asScala) {
+      // 1. get info from management
+      val mBeanInfo = Try(mBeanServer.getMBeanInfo(mBeanName)) match {
+        case Failure(e) =>
+          log.error(s"Problem while trying to process JMX query: $qryName " +
+            s"with MBean $mBeanName", e)
+          null
+        case Success(value) => value
+      }
+      // 2. if we cant get info, then skip for continue
+      if (mBeanInfo != null) {
+
+
+        // 4. get attributeType and modelerType
+        def processException(e: Exception): Unit = {
+          log.error("getting attribute " + attribute + " of " + mBeanName + " threw an exception",
+            e);
+        }
+
+        // 5. build { code, prs, attributeinfo}
+        var code = mBeanInfo.getClassName
+        var prs = ""
+        var attributeinfo: Object = null
+
+        try {
+          if ("org.apache.commons.modeler.BaseModelMBean".equals(code)) {
+            prs = "modelerType"
+            code = mBeanServer.getAttribute(mBeanName, prs).asInstanceOf[String]
+          }
+          if (attribute != null) {
+            prs = attribute;
+            attributeinfo = mBeanServer.getAttribute(mBeanName, prs)
+          }
+        } catch {
+          case e: AttributeNotFoundException => processException(e)
+          case e: MBeanException => processException(e)
+          case e: RuntimeException => processException(e)
+          case e: ReflectionException => processException(e)
+        }
+
+        // 6. write start object
+        generator.writeStartObject()
+        generator.writeStringField("name", mBeanName.toString)
+
+        // 7. write modelerType
+        generator.writeStringField("modelerType", code)
+
+        // 8. check
+        // when attribute exists, whether attributeinfo is null
+        if ((attribute != null) && (attributeinfo == null)) {
+          throw new CheckAttributeException(attribute)
+        }
+
+        // 9. write attribute
+        if (attribute != null) {
+          writeAttribute(generator, attribute, attributeinfo)
+        } else {
+          mBeanInfo.getAttributes.foreach { attr =>
+            writeAttribute(generator, mBeanName, attr)
+          }
+        }
+        generator.writeEndObject()
+      }
+    }
+    generator.writeEndArray()
+  }
+
+  /**
+   * @param generator json generator
+   * @param mBeanObjectName management bean of JMX
+   * @param attrInfo attribute info
+   */
+  private def writeAttribute(
+    generator: JsonGenerator,
+    mBeanObjectName: ObjectName,
+    attrInfo: MBeanAttributeInfo
+  ): Unit = {
+    // 1. check readable
+    if (!attrInfo.isReadable) return
+
+    def attributeContains(value: String*): Boolean = {
+      for (matchStr <- value) {
+        if (attrInfo.getName.contains(matchStr)) {
+          return true
+        }
+      }
+      false
+    }
+
+    // 2. check special character
+    if (attributeContains("=", ":", " ")) return
+    var value: Object = null
+    val attributeName = attrInfo.getName
+    try {
+      value = mBeanServer.getAttribute(mBeanObjectName, attributeName)
+    } catch {
+      case e: RuntimeMBeanException =>
+        if (e.getCause.isInstanceOf[UnsupportedOperationException]) {
+          log.debug("getting attribute " + attributeName + " of "
+            + mBeanObjectName + " threw an exception", e)
+        } else {
+          log.error("getting attribute " + attributeName + " of "
+            + mBeanObjectName + " threw an exception", e)
+        }
+        return
+      case e: RuntimeErrorException =>
+        log.debug("getting attribute " + attributeName + " of "
+          + mBeanObjectName + " threw an exception", e)
+        return
+      case _: AttributeNotFoundException =>
+        return
+      case e: MBeanException =>
+        log.error("getting attribute " + attributeName + " of "
+          + mBeanObjectName + " threw an exception", e)
+        return
+      case e: RuntimeException =>
+        log.error("getting attribute " + attributeName + " of "
+          + mBeanObjectName + " threw an exception", e)
+        return
+      case e: ReflectionException =>
+        log.error("getting attribute " + attributeName + " of "
+          + mBeanObjectName + " threw an exception", e)
+        return
+      case _: InstanceNotFoundException =>
+        return
+    }
+    writeAttribute(generator, attributeName, value)
+  }
+
+  private def writeAttribute(
+    generator: JsonGenerator,
+    attributeName: String,
+    value: Object
+  ): Unit = {
+    generator.writeFieldName(attributeName)
+    writeObject(generator, value)
+  }
+
+  /**
+   * @param jg    json generator
+   * @param value attribute object
+   */
+  private def writeObject(jg: JsonGenerator, value: Object): Unit = {
+    if (value == null) jg.writeNull()
+    else {
+      val c: Class[_] = value.getClass
+      if (c.isArray) {
+        jg.writeStartArray()
+        val len = Array.getLength(value)
+        for (j <- 0 until len) {
+          val item = Array.get(value, j)
+          writeObject(jg, item)
+        }
+        jg.writeEndArray()
+      } else value match {
+        case n: Number =>
+          jg.writeNumber(n.toString)
+        case b: java.lang.Boolean =>
+          jg.writeBoolean(b)
+        case cds: CompositeData =>
+          val comp = cds.getCompositeType
+          val keys = comp.keySet
+          jg.writeStartObject()
+          for (key <- keys.asScala) {
+            writeAttribute(jg, key, cds.get(key))
+          }
+          jg.writeEndObject()
+        case tds: TabularData =>
+          jg.writeStartArray()
+          for (entry <- tds.values.asScala) {
+            writeObject(jg, entry.asInstanceOf[Object])
+          }
+          jg.writeEndArray()
+        case _ => jg.writeString(value.toString)
+      }
+    }
+  }
+
+
+  /**
+   * @param response the basic response
+   */
+  private[jmx] def buildBasicResponse(response: HttpServletResponse): Unit = {
+    response.setContentType("application/json; charset=utf8")
+    response.setHeader(ACCESS_CONTROL_ALLOW_METHODS, "GET")
+    response.setHeader(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+  }
+
+  /**
+   * @param qryType GET | null
+   * @param qryName name key
+   * @return (ObjectName, Attribute)
+   */
+  @throws[CheckQryNameException]
+  private[jmx] def parseObjectNameAttribute(
+    qryType: String = "qry",
+    qryName: String):
+  (String, ObjectName, String) = {
+    if (!checkQryName(qryName)) {
+      throw new CheckQryNameException
+    }
+    qryType.toUpperCase(Locale.ROOT) match {
+      case "GET" =>
+        val splitName = qryName.split(":")
+        (qryName, new ObjectName(splitName(0)), splitName(1))
+      case _ =>
+        (qryName, new ObjectName(qryName), null)
+    }
+  }
+
+  /**
+   * @param qryName key:valye
+   * @return check result
+   */
+  private[jmx] def checkQryName(qryName: String): Boolean = {
+    if (qryNameMatcher.findAllIn(qryName).isEmpty) {
+      return false
+    }
+    true
+  }
+
+  /**
+   * @param writer java writer
+   * @return json generator
+   */
+  private[jmx] def buildJsonGenerator(writer: Writer) = {
+    val generator = factory.createGenerator(writer)
+    generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+    generator.useDefaultPrettyPrinter()
+    generator.writeStartObject()
+    generator
+  }
+}

--- a/core/src/main/scala/org/apache/spark/jmx/JmxServletUtils.java
+++ b/core/src/main/scala/org/apache/spark/jmx/JmxServletUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.jmx;
+
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+/**
+ * Avoid the effect of shade plugin, create a utils to build servlet
+ */
+public class JmxServletUtils {
+  public static ServletContextHandler buildServlet(String contextPath, String pathSpec) {
+    ServletContextHandler context = new ServletContextHandler(
+        ServletContextHandler.NO_SESSIONS);
+    context.setContextPath(contextPath);
+    context.addServlet(new ServletHolder(new JMXJsonServlet()), pathSpec);
+    return context;
+  }
+}

--- a/core/src/main/scala/org/apache/spark/jmx/exception/CheckAttributeException.java
+++ b/core/src/main/scala/org/apache/spark/jmx/exception/CheckAttributeException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.jmx.exception;
+
+/**
+ * A tag exception
+ */
+public class CheckAttributeException extends Exception {
+  private String attribute;
+  public CheckAttributeException(String attribute) {
+    this.attribute = attribute;
+  }
+
+  public String getAttribute() {
+    return attribute;
+  }
+}

--- a/core/src/main/scala/org/apache/spark/jmx/exception/CheckQryNameException.java
+++ b/core/src/main/scala/org/apache/spark/jmx/exception/CheckQryNameException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.jmx.exception;
+
+/**
+ * A tag exception
+ */
+public class CheckQryNameException extends Exception {
+}

--- a/core/src/test/scala/org/apache/spark/jmx/JMXJsonServletTest.scala
+++ b/core/src/test/scala/org/apache/spark/jmx/JMXJsonServletTest.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.jmx
+
+import java.io.{ByteArrayOutputStream, PrintWriter}
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import org.mockito.Mockito._
+import scala.collection.JavaConverters._
+
+import org.apache.spark.SparkFunSuite
+
+class JMXJsonServletTest extends SparkFunSuite {
+
+  import JMXJsonServlet._
+
+  private val servlet = new JMXJsonServlet
+
+  test("match qryName") {
+    // check true
+    assert(checkQryName("*:*"))
+    assert(checkQryName("key:value"))
+    // check false
+    assert(!checkQryName("single-key"))
+  }
+
+  test("test all attribute") {
+    val response = buildResponse()
+    val request = mock(classOf[HttpServletRequest])
+    val output = new ByteArrayOutputStream()
+    when(response.getWriter).thenReturn(new PrintWriter(output))
+    servlet.doGet(request, response)
+    assert(output.size() > 0)
+  }
+
+  test("test bad request") {
+    val response = buildResponse()
+    val request = mock(classOf[HttpServletRequest])
+    val output = new ByteArrayOutputStream()
+    when(response.getWriter).thenReturn(new PrintWriter(output))
+    when(request.getParameter("qry")).thenReturn("single-key")
+    // do get here
+    servlet.doGet(request, response)
+    // {
+    //  "result" : "ERROR",
+    //  "message" : "query format is not as expected."
+    // }
+    assert(output.toString().contains("ERROR"))
+  }
+
+  test("qry *:*") {
+    val response = buildResponse()
+    val request = mock(classOf[HttpServletRequest])
+    val output = new ByteArrayOutputStream()
+    when(response.getWriter).thenReturn(new PrintWriter(output))
+    servlet.doGet(request, response)
+    // scalastyle:off
+    println(output.toString())
+  }
+
+  private def buildResponse(): HttpServletResponse = {
+    val response = mock(classOf[HttpServletResponse])
+    buildBasicResponse(response)
+    when(response.getHeaderNames).thenReturn(List(
+      ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_ALLOW_METHODS
+    ).asJava)
+    response
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When i want to collect the details of SparkHistoryServer, such as GC, memory. But i cant find a way. I need to expose an interface for the other exporter to collect them.

I find hadoop just do it, but it conflict with spark. So i rewrite it in scala.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
this is a new API, i think JMX can help people better.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

1. start a historyserver firstly.
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/54064811/181139420-8b3eb81b-3cce-4f3c-86cb-5b630f5adff8.png">

2. get the content by http protocol
<img width="893" alt="image" src="https://user-images.githubusercontent.com/54064811/181139457-0b399513-09bd-45ad-9eea-e029d8682e5a.png">
