### PR TITLE
[SPARK-39891][BUILD] Bump h2 to 2.1.214

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -153,7 +153,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.1.210</version>
+      <version>2.1.214</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade H2 from 2.1.210 to 2.1.214.


### Why are the changes needed?
This version brings some important bugs and regression fixes, the release note as follows:
https://github.com/h2database/h2database/releases


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.