### PR TITLE
[SPARK-39892][SQL] Use ArrowType.Decimal(precision, scale, bitWidth) instead of ArrowType.Decimal(precision, scale)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -45,7 +45,7 @@ private[sql] object ArrowUtils {
     case DoubleType => new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
     case StringType => ArrowType.Utf8.INSTANCE
     case BinaryType => ArrowType.Binary.INSTANCE
-    case DecimalType.Fixed(precision, scale) => new ArrowType.Decimal(precision, scale)
+    case DecimalType.Fixed(precision, scale) => new ArrowType.Decimal(precision, scale, 128)
     case DateType => new ArrowType.Date(DateUnit.DAY)
     case TimestampType if timeZoneId == null =>
       throw new IllegalStateException("Missing timezoneId where it is mandatory.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use ArrowType.Decimal(precision, scale, bitWidth) instead of ArrowType.Decimal(precision, scale) to cleanup following compilation warnings:

> [warn] /home/runner/work/spark/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala:48:49: [deprecation @ org.apache.spark.sql.util.ArrowUtils.toArrowType | origin=org.apache.arrow.vector.types.pojo.ArrowType.Decimal.<init> | version=] constructor Decimal in class Decimal is deprecated

<img width="852" alt="image" src="https://user-images.githubusercontent.com/15246973/181190335-6e8582fc-fbf1-4b92-adbc-0216debb172c.png">


### Why are the changes needed?
Cleanup deprecation api usage related to Arrow.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.