### PR TITLE
[SPARK-39894][SQL] Combine the similar binary comparison in boolean expression.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -304,6 +304,17 @@ trait PredicateHelper extends AliasHelper with Logging {
     case _: MultiLikeBase => true
     case _ => false
   }
+
+  /**
+   * Swaps the left and right sides of some binary comparisons. e.g., transform "a < b" to "b > a"
+   */
+  def swapComparison(comparison: BinaryComparison): BinaryComparison = comparison match {
+    case a LessThan b => GreaterThan(b, a)
+    case a LessThanOrEqual b => GreaterThanOrEqual(b, a)
+    case a GreaterThan b => LessThan(b, a)
+    case a GreaterThanOrEqual b => LessThanOrEqual(b, a)
+    case o => o
+  }
 }
 
 @ExpressionDescription(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -313,6 +313,7 @@ trait PredicateHelper extends AliasHelper with Logging {
     case a LessThanOrEqual b => GreaterThanOrEqual(b, a)
     case a GreaterThan b => LessThan(b, a)
     case a GreaterThanOrEqual b => LessThanOrEqual(b, a)
+    case a EqualTo b => EqualTo(b, a)
     case o => o
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -503,15 +503,15 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
       }
     case (LessThan(left0, literal0: Literal), LessThan(_, literal1: Literal)) =>
       if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(literal0.value, literal1.value)) {
-        Some(LessThan(left0, literal0))
-      } else {
         Some(LessThan(left0, literal1))
+      } else {
+        Some(LessThan(left0, literal0))
       }
     case (LessThanOrEqual(left0, literal0: Literal), LessThanOrEqual(_, literal1: Literal)) =>
       if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(literal0.value, literal1.value)) {
-        Some(LessThanOrEqual(left0, literal0))
-      } else {
         Some(LessThanOrEqual(left0, literal1))
+      } else {
+        Some(LessThanOrEqual(left0, literal0))
       }
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -354,6 +354,14 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
         if right0.semanticEquals(right1) =>
         combineComparison(swapComparison(op0), swapComparison(op1)).getOrElse(and)
       case and @ And(
+        op0 @ BinaryComparison(left0, _: Literal), op1 @ BinaryComparison(_: Literal, right1))
+        if left0.semanticEquals(right1) =>
+        combineComparison(op0, swapComparison(op1)).getOrElse(and)
+      case and @ And(
+        op0 @ BinaryComparison(_: Literal, right0), op1 @ BinaryComparison(left1, _: Literal))
+        if right0.semanticEquals(left1) =>
+        combineComparison(swapComparison(op0), op1).getOrElse(and)
+      case and @ And(
         op0 @ BinaryComparison(left0, _: Literal), op1 @ BinaryComparison(left1, _: Literal))
         if left0.semanticEquals(left1) =>
         combineComparison(op0, op1).getOrElse(and)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -513,6 +513,12 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
       } else {
         Some(LessThanOrEqual(left0, literal0))
       }
+    case (EqualTo(left0, literal0: Literal), EqualTo(_, literal1: Literal)) =>
+      if (TypeUtils.getInterpretedOrdering(left0.dataType).equiv(literal0.value, literal1.value)) {
+        Some(EqualTo(left0, literal0))
+      } else {
+        Some(FalseLiteral)
+      }
     case _ => None
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -486,8 +486,8 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
   }
 
   private def combineComparison(
-      leftC: BinaryComparison,
-      rightC: BinaryComparison): Option[Expression] = (leftC, rightC) match {
+      leftComp: BinaryComparison,
+      rightComp: BinaryComparison): Option[Expression] = (leftComp, rightComp) match {
     case (GreaterThan(left0, Literal(v0, _)), GreaterThan(_, Literal(v1, _))) =>
       if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(v0, v1)) {
         Some(GreaterThan(left0, Literal(v0)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -488,29 +488,30 @@ object BooleanSimplification extends Rule[LogicalPlan] with PredicateHelper {
   private def combineComparison(
       leftComp: BinaryComparison,
       rightComp: BinaryComparison): Option[Expression] = (leftComp, rightComp) match {
-    case (GreaterThan(left0, Literal(v0, _)), GreaterThan(_, Literal(v1, _))) =>
-      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(v0, v1)) {
-        Some(GreaterThan(left0, Literal(v0)))
+    case (GreaterThan(left0, literal0: Literal), GreaterThan(_, literal1: Literal)) =>
+      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(literal0.value, literal1.value)) {
+        Some(GreaterThan(left0, literal0))
       } else {
-        Some(GreaterThan(left0, Literal(v1)))
+        Some(GreaterThan(left0, literal1))
       }
-    case (GreaterThanOrEqual(left0, Literal(v0, _)), GreaterThanOrEqual(_, Literal(v1, _))) =>
-      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(v0, v1)) {
-        Some(GreaterThanOrEqual(left0, Literal(v0)))
+    case (GreaterThanOrEqual(left0, literal0: Literal),
+      GreaterThanOrEqual(_, literal1: Literal)) =>
+      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(literal0.value, literal1.value)) {
+        Some(GreaterThanOrEqual(left0, literal0))
       } else {
-        Some(GreaterThanOrEqual(left0, Literal(v1)))
+        Some(GreaterThanOrEqual(left0, literal1))
       }
-    case (LessThan(left0, Literal(v0, _)), LessThan(_, Literal(v1, _))) =>
-      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(v1, v0)) {
-        Some(LessThan(left0, Literal(v0)))
+    case (LessThan(left0, literal0: Literal), LessThan(_, literal1: Literal)) =>
+      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(literal0.value, literal1.value)) {
+        Some(LessThan(left0, literal0))
       } else {
-        Some(LessThan(left0, Literal(v1)))
+        Some(LessThan(left0, literal1))
       }
-    case (LessThanOrEqual(left0, Literal(v0, _)), LessThanOrEqual(_, Literal(v1, _))) =>
-      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(v1, v0)) {
-        Some(LessThanOrEqual(left0, Literal(v0)))
+    case (LessThanOrEqual(left0, literal0: Literal), LessThanOrEqual(_, literal1: Literal)) =>
+      if (TypeUtils.getInterpretedOrdering(left0.dataType).gteq(literal0.value, literal1.value)) {
+        Some(LessThanOrEqual(left0, literal0))
       } else {
-        Some(LessThanOrEqual(left0, Literal(v1)))
+        Some(LessThanOrEqual(left0, literal1))
       }
     case _ => None
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import scala.collection.immutable.HashSet
 import scala.collection.mutable.{ArrayBuffer, Stack}
 import scala.util.control.NonFatal
+
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.{MultiLikeBase, _}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -99,6 +99,7 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper {
     checkCondition(Literal(1) > $"a" && Literal(2) > $"a", $"a" < Literal(1))
     checkCondition($"a" <= Literal(1) && $"a" <= Literal(2), $"a" <= Literal(1))
     checkCondition(Literal(1) >= $"a" && Literal(2) >= $"a", $"a" <= Literal(1))
+    checkCondition($"a" === Literal(1) && $"a" === Literal(2), testRelation)
   }
 
   test("a || a => a") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -92,14 +92,25 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper {
 
   test("simplify binary comparisons") {
     checkCondition($"a" > Literal(1) && $"a" > Literal(2), $"a" > Literal(2))
+    checkCondition(Literal(1) < $"a" && $"a" > Literal(2), $"a" > Literal(2))
+    checkCondition($"a" > Literal(1) && Literal(2) < $"a", $"a" > Literal(2))
     checkCondition(Literal(1) < $"a" && Literal(2) < $"a", $"a" > Literal(2))
     checkCondition($"a" >= Literal(1) && $"a" >= Literal(2), $"a" >= Literal(2))
+    checkCondition(Literal(1) <= $"a" && $"a" >= Literal(2), $"a" >= Literal(2))
+    checkCondition($"a" >= Literal(1) && Literal(2) <= $"a", $"a" >= Literal(2))
     checkCondition(Literal(1) <= $"a" && Literal(2) <= $"a", $"a" >= Literal(2))
     checkCondition($"a" < Literal(1) && $"a" < Literal(2), $"a" < Literal(1))
+    checkCondition(Literal(1) > $"a" && $"a" < Literal(2), $"a" < Literal(1))
+    checkCondition($"a" < Literal(1) && Literal(2) > $"a", $"a" < Literal(1))
     checkCondition(Literal(1) > $"a" && Literal(2) > $"a", $"a" < Literal(1))
     checkCondition($"a" <= Literal(1) && $"a" <= Literal(2), $"a" <= Literal(1))
+    checkCondition(Literal(1) >= $"a" && $"a" <= Literal(2), $"a" <= Literal(1))
+    checkCondition($"a" <= Literal(1) && Literal(2) >= $"a", $"a" <= Literal(1))
     checkCondition(Literal(1) >= $"a" && Literal(2) >= $"a", $"a" <= Literal(1))
     checkCondition($"a" === Literal(1) && $"a" === Literal(2), testRelation)
+    checkCondition(Literal(1) === $"a" && $"a" === Literal(2), testRelation)
+    checkCondition($"a" === Literal(1) && Literal(2) === $"a", testRelation)
+    checkCondition(Literal(1) === $"a" && Literal(2) === $"a", testRelation)
   }
 
   test("a || a => a") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/BooleanSimplificationSuite.scala
@@ -90,6 +90,17 @@ class BooleanSimplificationSuite extends PlanTest with ExpressionEvalHelper {
     checkCondition(Literal(1) < $"a" && Literal(1) < $"a" && Literal(1) < $"a", Literal(1) < $"a")
   }
 
+  test("simplify binary comparisons") {
+    checkCondition($"a" > Literal(1) && $"a" > Literal(2), $"a" > Literal(2))
+    checkCondition(Literal(1) < $"a" && Literal(2) < $"a", $"a" > Literal(2))
+    checkCondition($"a" >= Literal(1) && $"a" >= Literal(2), $"a" >= Literal(2))
+    checkCondition(Literal(1) <= $"a" && Literal(2) <= $"a", $"a" >= Literal(2))
+    checkCondition($"a" < Literal(1) && $"a" < Literal(2), $"a" < Literal(1))
+    checkCondition(Literal(1) > $"a" && Literal(2) > $"a", $"a" < Literal(1))
+    checkCondition($"a" <= Literal(1) && $"a" <= Literal(2), $"a" <= Literal(1))
+    checkCondition(Literal(1) >= $"a" && Literal(2) >= $"a", $"a" <= Literal(1))
+  }
+
   test("a || a => a") {
     checkCondition(Literal(1) < $"a" || Literal(1) < $"a", Literal(1) < $"a")
     checkCondition(Literal(1) < $"a" || Literal(1) < $"a" || Literal(1) < $"a", Literal(1) < $"a")

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantPropagationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantPropagationSuite.scala
@@ -156,11 +156,11 @@ class ConstantPropagationSuite extends PlanTest {
     val query = testRelation
       .select(columnA)
       .where(
-        columnA === Literal(1) && columnA === Literal(2) && columnB === Add(columnA, Literal(3)))
+        columnC === Literal(1) && columnA === Literal(2) && columnB === Add(columnA, Literal(3)))
 
     val correctAnswer = testRelation
       .select(columnA)
-      .where(columnA === Literal(1) && columnA === Literal(2) && columnB === Literal(5)).analyze
+      .where(columnC === Literal(1) && columnA === Literal(2) && columnB === Literal(5)).analyze
 
     comparePlans(Optimize.execute(query.analyze), correctAnswer)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/FilterPushdownSuite.scala
@@ -223,12 +223,12 @@ class FilterPushdownSuite extends PlanTest {
     val originalQuery = testRelation
       .select($"a")
       .where($"a" === 1)
-      .where($"a" === 2)
+      .where($"b" === 2)
 
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .where($"a" === 1 && $"a" === 2)
+        .where($"a" === 1 && $"b" === 2)
         .select($"a").analyze
 
     comparePlans(optimized, correctAnswer)


### PR DESCRIPTION
### What changes were proposed in this pull request?
If boolean expression have two similar binary comparisons have the same symbol(e.g., >) and one side is literal and connected with `And`.
For example, `'a > 1 and 'a > 2`.
In fact, we can combine them as `'a > 2`.

The idea is compare literal value and combine them.

1. `'a > 1 and 'a > 2` combined to `'a > 2`
2. `1 < 'a and 2 < 'a` combined to `'a > 2`
3. `'a >= 1 and 'a >= 2` combined to `'a >= 2`
4. `1 <= 'a and 2 <= 'a` combined to `'a >= 2`
5. `'a < 1 and 'a < 2` combined to `'a < 1`
6. `1 > 'a and 2 > 'a` combined to `'a < 1`
7. `'a <= 1 and 'a <= 2` combined to `'a <= 1`
8. `1 >= 'a and 2 >= 'a` combined to `'a <= 1`
9. `'a === 1 and 'a === 1` combined to `'a === 1`
10. `1 === 'a and 1 === 'a` combined to `'a === 1`
11. `'a === 1 and 'a === 2` combined to `FalseLiteral`
12. `1 === 'a and 2 === 'a` combined to `FalseLiteral`

This PR also considers swap binary comparison if the literal on the left of `And`.
For example, `1 < 'a and 2 < 'a` will be combined as  `'a > 2` too.


### Why are the changes needed?
Simplify the binary comparisons in boolean expression.


### Does this PR introduce _any_ user-facing change?
'No'.
Just change the inner rule.


### How was this patch tested?
New test cases.
