### PR TITLE
[SPARK-39819][SQL] DS V2 aggregate push down can work with Top N or Paging (Sort with expressions)

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Cast.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/Cast.java
@@ -42,4 +42,9 @@ public class Cast implements Expression, Serializable {
 
   @Override
   public Expression[] children() { return new Expression[]{ expression() }; }
+
+  @Override
+  public String toString() {
+    return "CAST(" + expression.describe() + " AS " + dataType.typeName() + ")";
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanRelationPushDown.scala
@@ -413,8 +413,8 @@ object V2ScanRelationPushDown extends Rule[LogicalPlan] with PredicateHelper {
     case s @ Sort(order, _, operation @ PhysicalOperation(project, Nil, sHolder: ScanBuilderHolder))
         // Without building the Scan, we do not know the resulting column names after aggregate
         // push-down, and thus can't push down Top-N which needs to know the ordering column names.
-        // TODO: we can support simple cases like GROUP BY columns directly and ORDER BY the same
-        //       columns, which we know the resulting column names: the original table columns.
+        // In particular, we push down the simple cases like GROUP BY expressions directly and
+        // ORDER BY the same expressions, which we know the original table columns.
         if CollapseProject.canCollapseExpressions(order, project, alwaysInline = true) =>
       val aliasMap = getAliasMap(project)
       def findGroupExprForSortOrder(sortOrder: SortOrder): SortOrder = sortOrder match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -913,7 +913,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       val df4 = spark.read
         .table("h2.test.employee")
         .groupBy("dept").sum("SALARY")
-        .orderBy($"dept" + 1)
+        .orderBy($"dept" + 100)
         .limit(1)
       checkSortRemoved(df4)
       checkLimitRemoved(df4)
@@ -921,7 +921,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         "PushedAggregates: [SUM(SALARY)]",
         "PushedGroupByExpressions: [DEPT]",
         "PushedFilters: []",
-        "PushedTopN: ORDER BY [DEPT + 1 ASC NULLS FIRST] LIMIT 1")
+        "PushedTopN: ORDER BY [DEPT + 100 ASC NULLS FIRST] LIMIT 1")
       checkAnswer(df4, Seq(Row(1, 19000.00)))
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -873,13 +873,12 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedTopN: ORDER BY [DEPT ASC NULLS FIRST] LIMIT 1")
     checkAnswer(df1, Seq(Row(1, 19000.00)))
 
-    val df2 = sql(
-      """
-        |SELECT dept AS my_dept, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY dept
-        |ORDER BY my_dept
-        |LIMIT 1
-        |""".stripMargin)
+    val df2 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT".as("my_dept"), $"SALARY")
+      .groupBy("my_dept").sum("SALARY")
+      .orderBy("my_dept")
+      .limit(1)
     checkSortRemoved(df2)
     checkLimitRemoved(df2)
     checkPushedInfo(df2,
@@ -922,13 +921,12 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedTopN: ORDER BY [DEPT ASC NULLS FIRST, IS_MANAGER ASC NULLS FIRST] LIMIT 1")
     checkAnswer(df4, Seq(Row(1, false, 9000.00)))
 
-    val df5 = sql(
-      """
-        |SELECT dept AS my_dept, is_manager AS my_manager, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY dept, my_manager
-        |ORDER BY my_dept, my_manager
-        |LIMIT 1
-        |""".stripMargin)
+    val df5 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT".as("my_dept"), $"IS_MANAGER".as("my_manager"), $"SALARY")
+      .groupBy("my_dept", "my_manager").sum("SALARY")
+      .orderBy("my_dept", "my_manager")
+      .limit(1)
     checkSortRemoved(df5)
     checkLimitRemoved(df5)
     checkPushedInfo(df5,
@@ -958,13 +956,12 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         "ASC NULLS FIRST, IS_MANAGER ASC NULLS FIRST] LIMIT 1")
     checkAnswer(df6, Seq(Row(0.00, false, 12000.00)))
 
-    val df7 = sql(
-      """
-        |SELECT dept, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY dept
-        |ORDER BY SUM(SALARY)
-        |LIMIT 1
-        |""".stripMargin)
+    val df7 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT", $"SALARY")
+      .groupBy("dept").agg(sum("SALARY"))
+      .orderBy(sum("SALARY"))
+      .limit(1)
     checkSortRemoved(df7, false)
     checkLimitRemoved(df7, false)
     checkPushedInfo(df7,
@@ -973,13 +970,12 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedFilters: []")
     checkAnswer(df7, Seq(Row(6, 12000.00)))
 
-    val df8 = sql(
-      """
-        |SELECT dept, SUM(SALARY) AS total FROM h2.test.employee
-        |GROUP BY dept
-        |ORDER BY total
-        |LIMIT 1
-        |""".stripMargin)
+    val df8 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT", $"SALARY")
+      .groupBy("dept").agg(sum("SALARY").as("total"))
+      .orderBy("total")
+      .limit(1)
     checkSortRemoved(df8, false)
     checkLimitRemoved(df8, false)
     checkPushedInfo(df8,
@@ -1006,14 +1002,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedTopN: ORDER BY [DEPT ASC NULLS FIRST] LIMIT 2")
     checkAnswer(df1, Seq(Row(2, 22000.00)))
 
-    val df2 = sql(
-      """
-        |SELECT dept AS my_dept, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY my_dept
-        |ORDER BY my_dept
-        |LIMIT 1
-        |OFFSET 1
-        |""".stripMargin)
+    val df2 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT".as("my_dept"), $"SALARY")
+      .groupBy("my_dept").sum("SALARY")
+      .orderBy("my_dept")
+      .offset(1)
+      .limit(1)
     checkSortRemoved(df2)
     checkLimitRemoved(df2)
     checkPushedInfo(df2,
@@ -1045,14 +1040,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         "ASC NULLS FIRST] LIMIT 2")
     checkAnswer(df3, Seq(Row(9000, 9000.00)))
 
-    val df4 = sql(
-      """
-        |SELECT dept AS my_dept, is_manager, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY my_dept, is_manager
-        |ORDER BY my_dept, is_manager
-        |LIMIT 1
-        |OFFSET 1
-        |""".stripMargin)
+    val df4 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT".as("my_dept"), $"IS_MANAGER", $"SALARY")
+      .groupBy("my_dept", "is_manager").sum("SALARY")
+      .orderBy("my_dept", "is_manager")
+      .offset(1)
+      .limit(1)
     checkSortRemoved(df4)
     checkLimitRemoved(df4)
     checkPushedInfo(df4,
@@ -1063,14 +1057,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedTopN: ORDER BY [DEPT ASC NULLS FIRST, IS_MANAGER ASC NULLS FIRST] LIMIT 2")
     checkAnswer(df4, Seq(Row(1, true, 10000.00)))
 
-    val df5 = sql(
-      """
-        |SELECT dept, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY dept
-        |ORDER BY SUM(SALARY)
-        |LIMIT 1
-        |OFFSET 1
-        |""".stripMargin)
+    val df5 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT", $"SALARY")
+      .groupBy("dept").agg(sum("SALARY"))
+      .orderBy(sum("SALARY"))
+      .offset(1)
+      .limit(1)
     checkSortRemoved(df5, false)
     checkLimitRemoved(df5, false)
     checkPushedInfo(df5,
@@ -1079,14 +1072,13 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedFilters: []")
     checkAnswer(df5, Seq(Row(1, 19000.00)))
 
-    val df6 = sql(
-      """
-        |SELECT dept, SUM(SALARY) AS total FROM h2.test.employee
-        |GROUP BY dept
-        |ORDER BY total
-        |LIMIT 1
-        |OFFSET 1
-        |""".stripMargin)
+    val df6 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT", $"SALARY")
+      .groupBy("dept").agg(sum("SALARY").as("total"))
+      .orderBy("total")
+      .offset(1)
+      .limit(1)
     checkSortRemoved(df6, false)
     checkLimitRemoved(df6, false)
     checkPushedInfo(df6,
@@ -1094,6 +1086,24 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedGroupByExpressions: [DEPT]",
       "PushedFilters: []")
     checkAnswer(df6, Seq(Row(1, 19000.00)))
+
+    val df7 = spark.read
+      .table("h2.test.employee")
+      .select($"DEPT", $"IS_MANAGER", $"SALARY")
+      .groupBy("dept", "is_manager").sum("SALARY")
+      .orderBy(when($"is_manager", $"dept").otherwise(0))
+      .offset(1)
+      .limit(1)
+    checkSortRemoved(df7)
+    checkLimitRemoved(df7)
+    checkPushedInfo(df7,
+      "PushedAggregates: [SUM(SALARY)]",
+      "PushedGroupByExpressions: [DEPT, IS_MANAGER]",
+      "PushedFilters: []",
+      "PushedOffset: OFFSET 1",
+      "PushedTopN: " +
+        "ORDER BY [CASE WHEN IS_MANAGER = true THEN DEPT ELSE 0 END ASC NULLS FIRST] LIMIT 2")
+    checkAnswer(df7, Seq(Row(1, false, 9000.00)))
   }
 
   test("scan with filter push-down") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -786,7 +786,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     // LIMIT is pushed down only if all the filters are pushed down
     checkSortRemoved(df6, false)
     checkLimitRemoved(df6, false)
-    checkPushedInfo(df6, "PushedFilters: [], ")
+    checkPushedInfo(df6, "PushedFilters: []")
     checkAnswer(df6, Seq(Row(10000.00, 1000.0, "amy")))
 
     val df7 = spark.read
@@ -795,7 +795,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limit(1)
     checkSortRemoved(df7, false)
     checkLimitRemoved(df7, false)
-    checkPushedInfo(df7, "PushedFilters: [], ")
+    checkPushedInfo(df7, "PushedFilters: []")
     checkAnswer(df7, Seq(Row(2, "alex", 12000.00, 1200.0, false)))
 
     val df8 = spark.read
@@ -806,10 +806,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limit(3)
     checkSortRemoved(df8)
     checkLimitRemoved(df8)
-    checkPushedInfo(df8, "PushedFilters: [], " +
-      "PushedTopN: " +
-      "ORDER BY [CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
-      "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3,")
+    checkPushedInfo(df8,
+      "PushedFilters: []",
+      "PushedTopN: ORDER BY " +
+        "[CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END" +
+        " ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3")
     checkAnswer(df8,
       Seq(Row(1, "amy", 10000, 0), Row(2, "david", 10000, 0), Row(2, "alex", 12000, 0)))
 
@@ -825,10 +826,11 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       .limit(3)
     checkSortRemoved(df9, false)
     checkLimitRemoved(df9, false)
-    checkPushedInfo(df9, "PushedFilters: [], " +
-      "PushedTopN: " +
-      "ORDER BY [CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
-      "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3,")
+    checkPushedInfo(df9,
+      "PushedFilters: []",
+      "PushedTopN: ORDER BY " +
+        "[CASE WHEN (SALARY > 8000.00) AND (SALARY < 10000.00) THEN SALARY ELSE 0.00 END " +
+        "ASC NULLS FIRST, DEPT ASC NULLS FIRST, SALARY ASC NULLS FIRST] LIMIT 3")
     checkAnswer(df9,
       Seq(Row(1, "amy", 10000, 0), Row(2, "david", 10000, 0), Row(2, "alex", 12000, 0)))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -909,21 +909,19 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         "ASC NULLS FIRST] LIMIT 1")
     checkAnswer(df3, Seq(Row(0, 44000.00)))
 
-    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
-      val df4 = spark.read
-        .table("h2.test.employee")
-        .groupBy("dept").sum("SALARY")
-        .orderBy($"dept" + 100)
-        .limit(1)
-      checkSortRemoved(df4)
-      checkLimitRemoved(df4)
-      checkPushedInfo(df4,
-        "PushedAggregates: [SUM(SALARY)]",
-        "PushedGroupByExpressions: [DEPT]",
-        "PushedFilters: []",
-        "PushedTopN: ORDER BY [DEPT + 100 ASC NULLS FIRST] LIMIT 1")
-      checkAnswer(df4, Seq(Row(1, 19000.00)))
-    }
+    val df4 = spark.read
+      .table("h2.test.employee")
+      .groupBy("dept").sum("SALARY")
+      .orderBy($"dept".gt(1))
+      .limit(1)
+    checkSortRemoved(df4)
+    checkLimitRemoved(df4)
+    checkPushedInfo(df4,
+      "PushedAggregates: [SUM(SALARY)]",
+      "PushedGroupByExpressions: [DEPT]",
+      "PushedFilters: []",
+      "PushedTopN: ORDER BY [DEPT > 1 ASC NULLS FIRST] LIMIT 1")
+    checkAnswer(df4, Seq(Row(1, 19000.00)))
 
     val df5 = spark.read
       .table("h2.test.employee")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1009,7 +1009,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     val df2 = sql(
       """
         |SELECT dept AS my_dept, SUM(SALARY) FROM h2.test.employee
-        |GROUP BY dept
+        |GROUP BY my_dept
         |ORDER BY my_dept
         |LIMIT 1
         |OFFSET 1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, DS V2 aggregate push-down cannot work with DS V2 Top N push-down (`ORDER BY col LIMIT m`) or DS V2 Paging push-down (`ORDER BY col LIMIT m OFFSET n`).
If we can push down aggregate with Top N or Paging, it will be better performance.

This PR only let aggregate pushed down with ORDER BY expressions which must be GROUP BY expressions.

The idea of this PR are:
1. When we give an expectation outputs of `ScanBuilderHolder`, holding the map from expectation outputs to origin expressions (contains origin columns).
2. When we try to push down Top N or Paging, we need restore the origin expressions for `SortOrder`.


### Why are the changes needed?
Let DS V2 aggregate push down can work with Top N or Paging (Sort with group expressions), then users can get the better performance.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
New test cases.
