### PR TITLE
[SPARK-39899][SQL] Fix passing of message parameters to `InvalidUDFClassException`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InvalidUDFClassException.scala
@@ -26,9 +26,14 @@ import org.apache.spark.sql.AnalysisException
  */
 class InvalidUDFClassException private[sql](
     message: String,
-    errorClass: Option[String] = None)
-  extends AnalysisException(message = message, errorClass = errorClass) {
+    errorClass: Option[String] = None,
+    messageParameters: Array[String] = Array.empty)
+  extends AnalysisException(
+    message = message, errorClass = errorClass, messageParameters = messageParameters) {
 
   def this(errorClass: String, messageParameters: Array[String]) =
-    this(SparkThrowableHelper.getMessage(errorClass, null, messageParameters), Some(errorClass))
+    this(
+      SparkThrowableHelper.getMessage(errorClass, null, messageParameters),
+      Some(errorClass),
+      messageParameters)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -208,11 +208,10 @@ class QueryCompilationErrorsSuite
       val e = intercept[AnalysisException] (
         sql(s"SELECT $functionName(123) as value")
       )
-      checkErrorClass(
+      checkError(
         exception = e,
         errorClass = "NO_HANDLER_FOR_UDAF",
-        msg = "No handler for UDAF 'org.apache.spark.sql.errors.MyCastToString'. " +
-          "Use sparkSession.udf.register(...) instead.; line 1 pos 7")
+        parameters = Map("functionName" -> "org.apache.spark.sql.errors.MyCastToString"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to pass `messageParameters` to `AnalysisException` from `InvalidUDFClassException`.

Also, I propose to replace `checkErrorClass` by `checkError` in the test "NO_HANDLER_FOR_UDAF: No handler for UDAF error" to check that the message parameters are passed correctly, and make the test independent from the message of the error class `NO_HANDLER_FOR_UDAF`.

### Why are the changes needed?
To fix a bug and provide actual message parameters to users.

### Does this PR introduce _any_ user-facing change?
Yes. After the changes, users receive non-empty message parameters.

### How was this patch tested?
By running the modified test suite:
```
$ build/sbt "sql/testOnly *QueryCompilationErrorsSuite"
```