### PR TITLE
[SPARK-39906][INFRA] Eliminate build warnings - 'sbt 0.13 shell syntax is deprecated; use slash syntax instead'

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -707,7 +707,7 @@ jobs:
     - name: Build with SBT
       run: |
         ./dev/change-scala-version.sh 2.13
-        ./build/sbt -Pyarn -Pmesos -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 compile test:compile
+        ./build/sbt -Pyarn -Pmesos -Pkubernetes -Pvolcano -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pdocker-integration-tests -Pkubernetes-integration-tests -Pspark-ganglia-lgpl -Pscala-2.13 compile Test/compile
 
   # Any TPC-DS related updates on this job need to be applied to tpcds-1g-gen job of benchmark.yml as well
   tpcds-1g:

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -249,7 +249,7 @@ def build_spark_sbt(extra_profiles):
     # Enable all of the profiles for the build:
     build_profiles = extra_profiles + modules.root.build_profile_flags
     sbt_goals = [
-        "test:package",  # Build test jars as some tests depend on them
+        "Test/package",  # Build test jars as some tests depend on them
         "streaming-kinesis-asl-assembly/assembly",
     ]
     profiles_and_goals = build_profiles + sbt_goals


### PR DESCRIPTION
### What changes were proposed in this pull request?
**The following warnings are displayed in github action log:**
> 1../2_Run  Build modules catalyst, hive-thriftserver.txt:2022-07-27T01:23:12.1294533Z [warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: examples / Test / package, avro / Test / package, network-shuffle / Test / package, sketch / Test / package, unsafe / Test / package, launcher / Test / package, network-yarn / Test / package, streaming / Test / package, catalyst / Test / package, hive-thriftserver / Test / package, kvstore / Test / package, core / Test / package, ganglia-lgpl / Test / package, hadoop-cloud / Test / package, streaming-kinesis-asl-assembly / Test / package, assembly / Test / package, network-common / Test / package, sql / Test / package, streaming-kafka-0-10-assembly / Test / package, mllib / Test / package, streaming-kinesis-asl / Test / package, docker-integration-tests / Test / package, kubernetes / Test / package, yarn / Test / package, tags / Test / package, graphx / Test / package, token-provider-kafka-0-10 / Test / package, mesos / Test / package, streaming-kafka-0-10 / Test / package, hive / Test / package, tools / Test / package, mllib-local / Test / package, repl / Test / package, sql-kafka-0-10 / Test / package, Test / package

> 2../Run  Scala 2.13 build with SBT/7_Build with SBT.txt:2022-07-27T01:30:27.0571032Z [warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: examples / Test / compile, avro / Test / compile, network-shuffle / Test / compile, sketch / Test / compile, unsafe / Test / compile, launcher / Test / compile, kubernetes-integration-tests / Test / compile, network-yarn / Test / compile, streaming / Test / compile, catalyst / Test / compile, hive-thriftserver / Test / compile, kvstore / Test / compile, core / Test / compile, ganglia-lgpl / Test / compile, hadoop-cloud / Test / compile, streaming-kinesis-asl-assembly / Test / compile, assembly / Test / compile, network-common / Test / compile, sql / Test / compile, streaming-kafka-0-10-assembly / Test / compile, mllib / Test / compile, streaming-kinesis-asl / Test / compile, docker-integration-tests / Test / compile, kubernetes / Test / compile, yarn / Test / compile, tags / Test / compile, graphx / Test / compile, token-provider-kafka-0-10 / Test / compile, mesos / Test / compile, streaming-kafka-0-10 / Test / compile, hive / Test / compile, tools / Test / compile, mllib-local / Test / compile, repl / Test / compile, sql-kafka-0-10 / Test / compile, Test / compile


### Why are the changes needed?
Use the recommended sbt syntax to eliminate build warnings: _sbt 0.13 shell syntax is deprecated; use slash syntax instead_

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.