### PR TITLE
[SPARK-39922][COER][TESTS] Introduce `IteratorSizeBenchmark` for `Utils#getIteratorSize` method

### DIFF
--- a/core/benchmarks/IteratorSizeBenchmark-jdk11-results.txt
+++ b/core/benchmarks/IteratorSizeBenchmark-jdk11-results.txt
@@ -1,0 +1,105 @@
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Range iterator size 10:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        124.5           8.0       1.0X
+Use Utils.getIteratorSize                             1              1           0         99.0          10.1       0.8X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Range iterator size 100:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        112.3           8.9       1.0X
+Use Utils.getIteratorSize                             1              2           0         67.8          14.8       0.6X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Range iterator size 1000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        109.2           9.2       1.0X
+Use Utils.getIteratorSize                             7              7           0         14.1          70.9       0.1X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Range iterator size 10000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        109.8           9.1       1.0X
+Use Utils.getIteratorSize                            69             70           1          1.4         690.9       0.0X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Range iterator size 30000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        108.9           9.2       1.0X
+Use Utils.getIteratorSize                           201            201           0          0.5        2011.3       0.0X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Seq iterator size 10:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     2              2           0         45.6          21.9       1.0X
+Use Utils.getIteratorSize                             3              4           0         29.2          34.3       0.6X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Seq iterator size 100:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                    25             25           0          4.0         251.8       1.0X
+Use Utils.getIteratorSize                            29             29           0          3.5         289.5       0.9X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Seq iterator size 1000:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   260            260           0          0.4        2603.5       1.0X
+Use Utils.getIteratorSize                           292            293           0          0.3        2924.5       0.9X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Seq iterator size 10000:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  2608           2608           0          0.0       26080.9       1.0X
+Use Utils.getIteratorSize                          2992           2993           0          0.0       29923.9       0.9X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Seq iterator size 30000:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  7829           7829           1          0.0       78287.7       1.0X
+Use Utils.getIteratorSize                          8983           8983           0          0.0       89833.4       0.9X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Array iterator size 10:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0         95.2          10.5       1.0X
+Use Utils.getIteratorSize                             2              2           0         51.7          19.3       0.5X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Array iterator size 100:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              2           3         84.1          11.9       1.0X
+Use Utils.getIteratorSize                             2              3           0         40.6          24.6       0.5X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Array iterator size 1000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   396            402           8          0.3        3960.7       1.0X
+Use Utils.getIteratorSize                             8              8           0         12.6          79.2      50.0X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Array iterator size 10000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  4256           4268          17          0.0       42558.4       1.0X
+Use Utils.getIteratorSize                            70             70           0          1.4         698.8      60.9X
+
+OpenJDK 64-Bit Server VM 11.0.16+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
+Test Array iterator size 30000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                 12836          12841           7          0.0      128357.4       1.0X
+Use Utils.getIteratorSize                           202            203           0          0.5        2023.6      63.4X
+

--- a/core/benchmarks/IteratorSizeBenchmark-jdk17-results.txt
+++ b/core/benchmarks/IteratorSizeBenchmark-jdk17-results.txt
@@ -1,0 +1,105 @@
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Range iterator size 10:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        134.8           7.4       1.0X
+Use Utils.getIteratorSize                             8             11           1         12.0          83.2       0.1X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Range iterator size 100:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                    68             75           4          1.5         683.2       1.0X
+Use Utils.getIteratorSize                            88             94           3          1.1         876.0       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Range iterator size 1000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   819            832          11          0.1        8194.9       1.0X
+Use Utils.getIteratorSize                           980            993          15          0.1        9802.4       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Range iterator size 10000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  8206           8232          37          0.0       82060.2       1.0X
+Use Utils.getIteratorSize                          9792           9933         200          0.0       97915.9       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Range iterator size 30000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                 24750          24824         104          0.0      247500.1       1.0X
+Use Utils.getIteratorSize                         29710          29710           0          0.0      297095.3       0.8X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Seq iterator size 10:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                    11             13           1          9.2         108.9       1.0X
+Use Utils.getIteratorSize                             4              5           1         27.6          36.2       3.0X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Seq iterator size 100:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                    97            104           5          1.0         969.4       1.0X
+Use Utils.getIteratorSize                            26             29           2          3.8         263.4       3.7X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Seq iterator size 1000:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   969            987          18          0.1        9690.7       1.0X
+Use Utils.getIteratorSize                           267            283           9          0.4        2668.9       3.6X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Seq iterator size 10000:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  9982           9989          10          0.0       99819.7       1.0X
+Use Utils.getIteratorSize                          2921           2975          76          0.0       29212.7       3.4X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Seq iterator size 30000:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                 30354          30783         607          0.0      303535.8       1.0X
+Use Utils.getIteratorSize                          8768           8954         263          0.0       87676.4       3.5X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Array iterator size 10:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              2           0         87.2          11.5       1.0X
+Use Utils.getIteratorSize                             2              2           1         51.5          19.4       0.6X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Array iterator size 100:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              2           0         81.1          12.3       1.0X
+Use Utils.getIteratorSize                             3              3           0         38.9          25.7       0.5X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Array iterator size 1000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        113.0           8.8       1.0X
+Use Utils.getIteratorSize                             7              9           1         13.8          72.2       0.1X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Array iterator size 10000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        104.5           9.6       1.0X
+Use Utils.getIteratorSize                            51             55           3          2.0         506.8       0.0X
+
+OpenJDK 64-Bit Server VM 17.0.4+8-LTS on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+Test Array iterator size 30000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     1              1           0        104.4           9.6       1.0X
+Use Utils.getIteratorSize                           145            153           6          0.7        1453.9       0.0X
+

--- a/core/benchmarks/IteratorSizeBenchmark-results.txt
+++ b/core/benchmarks/IteratorSizeBenchmark-results.txt
@@ -1,0 +1,105 @@
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Range iterator size 10:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     9              9           0         11.6          86.2       1.0X
+Use Utils.getIteratorSize                             4              4           0         25.5          39.2       2.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Range iterator size 100:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                    73             73           0          1.4         727.0       1.0X
+Use Utils.getIteratorSize                            32             32           0          3.1         321.4       2.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Range iterator size 1000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   800            804           3          0.1        8002.4       1.0X
+Use Utils.getIteratorSize                           651            653           2          0.2        6511.5       1.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Range iterator size 10000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  8035           8083          68          0.0       80348.0       1.0X
+Use Utils.getIteratorSize                          7052           7056           6          0.0       70515.6       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Range iterator size 30000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                 24083          24127          62          0.0      240828.9       1.0X
+Use Utils.getIteratorSize                         21241          21244           4          0.0      212411.9       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Seq iterator size 10:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     9              9           0         11.8          85.1       1.0X
+Use Utils.getIteratorSize                             2              2           0         46.5          21.5       4.0X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Seq iterator size 100:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                    70             70           0          1.4         702.3       1.0X
+Use Utils.getIteratorSize                            23             23           0          4.4         227.3       3.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Seq iterator size 1000:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   674            674           0          0.1        6737.0       1.0X
+Use Utils.getIteratorSize                           276            276           0          0.4        2761.4       2.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Seq iterator size 10000:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  6701           6702           1          0.0       67012.5       1.0X
+Use Utils.getIteratorSize                          2817           2818           1          0.0       28172.5       2.4X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Seq iterator size 30000:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                 20156          20163          11          0.0      201557.8       1.0X
+Use Utils.getIteratorSize                          8718           8720           3          0.0       87183.1       2.3X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Array iterator size 10:              Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     2              2           0         62.4          16.0       1.0X
+Use Utils.getIteratorSize                             2              2           0         65.9          15.2       1.1X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Array iterator size 100:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                     2              2           0         58.8          17.0       1.0X
+Use Utils.getIteratorSize                             2              2           0         43.3          23.1       0.7X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Array iterator size 1000:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                   912            914           2          0.1        9120.2       1.0X
+Use Utils.getIteratorSize                             8              8           0         12.9          77.5     117.6X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Array iterator size 10000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                  9236           9237           1          0.0       92360.0       1.0X
+Use Utils.getIteratorSize                            45             46           0          2.2         454.6     203.2X
+
+OpenJDK 64-Bit Server VM 1.8.0_342-b07 on Linux 5.15.0-1014-azure
+Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+Test Array iterator size 30000:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+Use Iterator.size                                 27738          27743           8          0.0      277377.3       1.0X
+Use Utils.getIteratorSize                           129            129           0          0.8        1292.2     214.7X
+

--- a/core/src/test/scala/org/apache/spark/util/IteratorSizeBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/util/IteratorSizeBenchmark.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+
+/**
+ * Benchmark for Utils.getIteratorSize vs Iterator.size.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class> <spark core test jar>
+ *   2. build/sbt "core/Test/runMain <this class>"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "core/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/IteratorSizeBenchmark-results.txt".
+ * }}}
+ */
+object IteratorSizeBenchmark extends BenchmarkBase {
+
+  private def testRangeIteratorSize(valuesPerIteration: Int, range: Range): Unit = {
+
+    val benchmark = new Benchmark(s"Test Range iterator size ${range.size}",
+      valuesPerIteration,
+      output = output)
+
+    benchmark.addCase("Use Iterator.size") { _: Int =>
+      for (_ <- 0L until valuesPerIteration) {
+        range.iterator.size
+      }
+    }
+
+    benchmark.addCase("Use Utils.getIteratorSize") { _: Int =>
+      for (_ <- 0L until valuesPerIteration) {
+        Utils.getIteratorSize(range.iterator)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  private def testSeqIteratorSize(valuesPerIteration: Int, seq: Seq[Int]): Unit = {
+
+    val benchmark = new Benchmark(s"Test Seq iterator size ${seq.size}",
+      valuesPerIteration,
+      output = output)
+
+    benchmark.addCase("Use Iterator.size") { _: Int =>
+      for (_ <- 0L until valuesPerIteration) {
+        seq.iterator.size
+      }
+    }
+
+    benchmark.addCase("Use Utils.getIteratorSize") { _: Int =>
+      for (_ <- 0L until valuesPerIteration) {
+        Utils.getIteratorSize(seq.iterator)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  private def testArrayIteratorSize(valuesPerIteration: Int, array: Array[Int]): Unit = {
+
+    val benchmark = new Benchmark(s"Test Array iterator size ${array.length}",
+      valuesPerIteration,
+      output = output)
+
+    benchmark.addCase("Use Iterator.size") { _: Int =>
+      for (_ <- 0L until valuesPerIteration) {
+        array.iterator.size
+      }
+    }
+
+    benchmark.addCase("Use Utils.getIteratorSize") { _: Int =>
+      for (_ <- 0L until valuesPerIteration) {
+        Utils.getIteratorSize(array.iterator)
+      }
+    }
+
+    benchmark.run()
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+
+    val valuesPerIteration = 100000
+
+    // Test Range
+    testRangeIteratorSize(valuesPerIteration, Range(0, 10))
+    testRangeIteratorSize(valuesPerIteration, Range(0, 100))
+    testRangeIteratorSize(valuesPerIteration, Range(0, 1000))
+    testRangeIteratorSize(valuesPerIteration, Range(0, 10000))
+    testRangeIteratorSize(valuesPerIteration, Range(0, 30000))
+
+    // Test Seq
+    testSeqIteratorSize(valuesPerIteration, Seq.range(0, 10))
+    testSeqIteratorSize(valuesPerIteration, Seq.range(0, 100))
+    testSeqIteratorSize(valuesPerIteration, Seq.range(0, 1000))
+    testSeqIteratorSize(valuesPerIteration, Seq.range(0, 10000))
+    testSeqIteratorSize(valuesPerIteration, Seq.range(0, 30000))
+
+    // Test Array
+    testArrayIteratorSize(valuesPerIteration, Array.range(0, 10))
+    testArrayIteratorSize(valuesPerIteration, Array.range(0, 100))
+    testArrayIteratorSize(valuesPerIteration, Array.range(0, 1000))
+    testArrayIteratorSize(valuesPerIteration, Array.range(0, 10000))
+    testArrayIteratorSize(valuesPerIteration, Array.range(0, 30000))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr add a micro-benchmark for `o.a.spark.util.Utils#getIteratorSize` method.


### Why are the changes needed?

https://github.com/apache/spark/blob/82cd993244656153551c9bb122247789d2a5b6b4/core/src/main/scala/org/apache/spark/util/Utils.scala#L1910-L1915

From the method comments, `Utils#getIteratorSize` method was added due to `scala.collection.Iterator#size` uses a for loop and it is slightly slower in the current version of Scala.

  When adding this method, Spark uses Scala 2.10. Currently, Spark use Scala 2.12. this pr add introduce `IteratorSizeBenchmark` to ensure that the conclusion is still correct when upgrading the major version of Scala, otherwise we should use `Iterator#size` directly.


### Does this PR introduce _any_ user-facing change?
No, just for test 


### How was this patch tested?
Pass GitHub Actions.