### PR TITLE
[MINOR][SQL] Improve the comments about null tracking for UnsafeRow

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -48,8 +48,7 @@ import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
  *
  * Each tuple has three parts: [null-tracking bit set] [values] [variable length portion]
  *
- * The null-tracking bit set is aligned to 8-byte word boundaries.
- * It stores one bit per field.
+ * The null-tracking bit set is aligned to 8-byte word boundaries. It stores one bit per field.
  *
  * In the `values` region, we store one 8-byte word per field. For fields that hold fixed-length
  * primitive types, such as long, double, or int, we store the value directly in the word. For

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -46,9 +46,9 @@ import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
 /**
  * An Unsafe implementation of Row which is backed by raw memory instead of Java objects.
  *
- * Each tuple has three parts: [null tracking portion] [values] [variable length portion]
+ * Each tuple has three parts: [null-tracking portion] [values] [variable length portion]
  *
- * The null tracking portion is used for null tracking and is aligned to 8-byte word boundaries.
+ * The null-tracking portion is used for null tracking and is aligned to 8-byte word boundaries.
  * It stores one bit per field.
  *
  * In the `values` region, we store one 8-byte word per field. For fields that hold fixed-length

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -46,7 +46,7 @@ import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
 /**
  * An Unsafe implementation of Row which is backed by raw memory instead of Java objects.
  *
- * Each tuple has three parts: [null-tracking portion] [values] [variable length portion]
+ * Each tuple has three parts: [null-tracking bit set] [values] [variable length portion]
  *
  * The null-tracking portion is used for null tracking and is aligned to 8-byte word boundaries.
  * It stores one bit per field.

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -48,7 +48,7 @@ import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
  *
  * Each tuple has three parts: [null-tracking bit set] [values] [variable length portion]
  *
- * The null-tracking portion is used for null tracking and is aligned to 8-byte word boundaries.
+ * The null-tracking bit set is used for null tracking and is aligned to 8-byte word boundaries.
  * It stores one bit per field.
  *
  * In the `values` region, we store one 8-byte word per field. For fields that hold fixed-length

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -48,7 +48,7 @@ import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
  *
  * Each tuple has three parts: [null-tracking bit set] [values] [variable length portion]
  *
- * The null-tracking bit set is used for null tracking and is aligned to 8-byte word boundaries.
+ * The null-tracking bit set is aligned to 8-byte word boundaries.
  * It stores one bit per field.
  *
  * In the `values` region, we store one 8-byte word per field. For fields that hold fixed-length

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeRow.java
@@ -46,10 +46,10 @@ import static org.apache.spark.unsafe.Platform.BYTE_ARRAY_OFFSET;
 /**
  * An Unsafe implementation of Row which is backed by raw memory instead of Java objects.
  *
- * Each tuple has three parts: [null bit set] [values] [variable length portion]
+ * Each tuple has three parts: [null tracking portion] [values] [variable length portion]
  *
- * The bit set is used for null tracking and is aligned to 8-byte word boundaries.  It stores
- * one bit per field.
+ * The null tracking portion is used for null tracking and is aligned to 8-byte word boundaries.
+ * It stores one bit per field.
  *
  * In the `values` region, we store one 8-byte word per field. For fields that hold fixed-length
  * primitive types, such as long, double, or int, we store the value directly in the word. For


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR expect to improve the comments about null tracking for `UnsafeRow`.
The old comment of `UnsafeRow` have confused text `[null bit set]`.
In fact, the portion is a lot of bit or bit array which does't always be null.
On the other hand, it tell users nothing. we need the information more clear.


### Why are the changes needed?
Improve the comments about null tracking for `UnsafeRow`.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update comments.


### How was this patch tested?
N/A
