### PR TITLE
[SPARK-38639][SQL]Ignore the corrupted rows that failed to deserialize in hive sequence table

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -552,6 +552,12 @@ object SQLConf {
     .checkValue(_ > 0, "The value of spark.sql.leafNodeDefaultParallelism must be positive.")
     .createOptional
 
+    val IGNORE_CORRUPT_ROWS = buildConf("spark.sql.hive.ignoreCorruptRows")
+    .doc("Whether to ignore corrupt rows. If true, the Spark jobs will continue to run when " +
+      "encountering corrupted row and the contents that have been read will be returned.")
+    .booleanConf
+    .createWithDefault(false)
+
   val SHUFFLE_PARTITIONS = buildConf("spark.sql.shuffle.partitions")
     .doc("The default number of partitions to use when shuffling data for joins or aggregations. " +
       "Note: For structured streaming, this configuration cannot be changed between query " +
@@ -4287,6 +4293,8 @@ class SQLConf extends Serializable with Logging {
 
   def advancedPartitionPredicatePushdownEnabled: Boolean =
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
+
+  def ignoreCorruptRows: Boolean = getConf(IGNORE_CORRUPT_ROWS)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Original pr: https://github.com/apache/spark/pull/35963

When reading the hive sequence table, you can switch whether to skip corrupt records that fail to be deserialized.
add new parameter: `spark.sql.hive.ignoreCorruptRows`, the default value is false

### Why are the changes needed?
If skipping the corrupt records does not supported,  when task read a file with corrupt records , the job will fail and other normal data files cannot also be read out.

The error stack information：
```
Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 30 in stage 8.0 failed 4 times, most recent failure: Lost task 30.3 in stage 8.0 (TID 5380) (zjy-hadoop-prc-st2338.bj executor 425): org.apache.hadoop.hive.serde2.SerDeException: org.apache.thrift.protocol.TProtocolException: don't know what type: 15
at org.apache.hadoop.hive.serde2.thrift.ThriftByteStreamTypedSerDe.deserialize(ThriftByteStreamTypedSerDe.java:80)
at org.apache.hadoop.hive.serde2.thrift.ThriftDeserializer.deserialize(ThriftDeserializer.java:74)
at org.apache.spark.sql.hive.HadoopTableReader$.$anonfun$fillObject$18(TableReader.scala:485)

Caused by: org.apache.thrift.protocol.TProtocolException: don't know what type: 15
at org.apache.thrift.protocol.TCompactProtocol.getTType(TCompactProtocol.java:898)
at org.apache.thrift.protocol.TCompactProtocol.readFieldBegin(TCompactProtocol.java:562)
at com.xiaomi.data.spec.log.misearch.AiMusicSearchLog.read(AiMusicSearchLog.java:2418)
at org.apache.hadoop.hive.serde2.thrift.ThriftByteStreamTypedSerDe.deserialize(ThriftByteStreamTypedSerDe.java:78)
```

### Does this PR introduce _any_ user-facing change?
add new parameter: spark.sql.hive.ignoreCorruptRows, the default value is false


### How was this patch tested?
manually test

