### PR TITLE
[SPARK-39503][SQL][FOLLOWUP] InMemoryCatalog should keep the catalog field when renaming tables

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/InMemoryCatalog.scala
@@ -25,8 +25,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.CatalystIdentifier._
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils._
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -282,7 +280,7 @@ class InMemoryCatalog(
     requireTableExists(db, oldName)
     requireTableNotExists(db, newName)
     val oldDesc = catalog(db).tables(oldName)
-    oldDesc.table = oldDesc.table.copy(identifier = TableIdentifier(newName, Some(db)))
+    oldDesc.table = oldDesc.table.copy(identifier = oldDesc.table.identifier.copy(table = newName))
 
     if (oldDesc.table.tableType == CatalogTableType.MANAGED) {
       assert(oldDesc.table.storage.locationUri.isDefined,
@@ -344,8 +342,7 @@ class InMemoryCatalog(
 
   override def getTable(db: String, table: String): CatalogTable = synchronized {
     requireTableExists(db, table)
-    val catalogTable = catalog(db).tables(table).table
-    catalogTable.copy(identifier = attachSessionCatalog(catalogTable.identifier))
+    catalog(db).tables(table).table
   }
 
   override def getTablesByName(db: String, tables: Seq[String]): Seq[CatalogTable] = {
@@ -634,15 +631,15 @@ class InMemoryCatalog(
       newName: String): Unit = synchronized {
     requireFunctionExists(db, oldName)
     requireFunctionNotExists(db, newName)
-    val newFunc = getFunction(db, oldName).copy(identifier = FunctionIdentifier(newName, Some(db)))
+    val oldFunc = getFunction(db, oldName)
+    val newFunc = oldFunc.copy(identifier = oldFunc.identifier.copy(funcName = newName))
     catalog(db).functions.remove(oldName)
     catalog(db).functions.put(newName, newFunc)
   }
 
   override def getFunction(db: String, funcName: String): CatalogFunction = synchronized {
     requireFunctionExists(db, funcName)
-    val catalogFunction = catalog(db).functions(funcName)
-    catalogFunction.copy(identifier = attachSessionCatalog(catalogFunction.identifier))
+    catalog(db).functions(funcName)
   }
 
   override def functionExists(db: String, funcName: String): Boolean = synchronized {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -280,15 +280,13 @@ abstract class ExternalCatalogSuite extends SparkFunSuite {
   test("get tables by name") {
     val catalog = newBasicCatalog()
     val tables = catalog.getTablesByName("db2", Seq("tbl1", "tbl2"))
-    assert(tables.map(_.identifier.table) == Seq("tbl1", "tbl2"))
+    assert(tables.map(_.identifier.table).sorted == Seq("tbl1", "tbl2"))
     assert(tables.forall(_.identifier.catalog.isDefined))
 
     // After renaming a table, the identifier should still be qualified with catalog.
     catalog.renameTable("db2", "tbl1", "tblone")
-    // TODO: HMS seems to have a bug and the order of returned tables do not match the order of
-    //       table names. You can reproduce the bug by passing `Seq("tblone", "tbl2")` here.
     val tables2 = catalog.getTablesByName("db2", Seq("tbl2", "tblone"))
-    assert(tables2.map(_.identifier.table) == Seq("tbl2", "tblone"))
+    assert(tables2.map(_.identifier.table).sorted == Seq("tbl2", "tblone"))
     assert(tables2.forall(_.identifier.catalog.isDefined))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.{CatalystIdentifier, FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{FunctionAlreadyExistsException, NoSuchDatabaseException, NoSuchFunctionException, TableAlreadyExistsException}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions._
@@ -278,8 +278,16 @@ abstract class ExternalCatalogSuite extends SparkFunSuite {
   }
 
   test("get tables by name") {
-    assert(newBasicCatalog().getTablesByName("db2", Seq("tbl1", "tbl2"))
-      .map(_.identifier.table) == Seq("tbl1", "tbl2"))
+    val catalog = newBasicCatalog()
+    val tables = catalog.getTablesByName("db2", Seq("tbl1", "tbl2"))
+    assert(tables.map(_.identifier.table) == Seq("tbl1", "tbl2"))
+    assert(tables.forall(_.identifier.catalog.isDefined))
+
+    // After renaming a table, the identifier should still be qualified with catalog.
+    catalog.renameTable("db2", "tbl1", "tblone")
+    val tables2 = catalog.getTablesByName("db2", Seq("tblone", "tbl2"))
+    assert(tables2.map(_.identifier.table) == Seq("tblone", "tbl2"))
+    assert(tables2.forall(_.identifier.catalog.isDefined))
   }
 
   test("get tables by name when some tables do not exists") {
@@ -1029,7 +1037,7 @@ abstract class CatalogTestUtils {
       database: Option[String] = None,
       defaultColumns: Boolean = false): CatalogTable = {
     CatalogTable(
-      identifier = TableIdentifier(name, database),
+      identifier = CatalystIdentifier.attachSessionCatalog(TableIdentifier(name, database)),
       tableType = CatalogTableType.EXTERNAL,
       storage = storageFormat.copy(locationUri = Some(Utils.createTempDir().toURI)),
       schema = if (defaultColumns) {
@@ -1073,7 +1081,7 @@ abstract class CatalogTestUtils {
       name: String,
       props: Map[String, String]): CatalogTable = {
     CatalogTable(
-      identifier = TableIdentifier(name, Some(db)),
+      identifier = CatalystIdentifier.attachSessionCatalog(TableIdentifier(name, Some(db))),
       tableType = CatalogTableType.VIEW,
       storage = CatalogStorageFormat.empty,
       schema = new StructType()
@@ -1086,7 +1094,10 @@ abstract class CatalogTestUtils {
   }
 
   def newFunc(name: String, database: Option[String] = None): CatalogFunction = {
-    CatalogFunction(FunctionIdentifier(name, database), funcClass, Seq.empty[FunctionResource])
+    CatalogFunction(
+      CatalystIdentifier.attachSessionCatalog(FunctionIdentifier(name, database)),
+      funcClass,
+      Seq.empty[FunctionResource])
   }
 
   /**

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogSuite.scala
@@ -285,8 +285,10 @@ abstract class ExternalCatalogSuite extends SparkFunSuite {
 
     // After renaming a table, the identifier should still be qualified with catalog.
     catalog.renameTable("db2", "tbl1", "tblone")
-    val tables2 = catalog.getTablesByName("db2", Seq("tblone", "tbl2"))
-    assert(tables2.map(_.identifier.table) == Seq("tblone", "tbl2"))
+    // TODO: HMS seems to have a bug and the order of returned tables do not match the order of
+    //       table names. You can reproduce the bug by passing `Seq("tblone", "tbl2")` here.
+    val tables2 = catalog.getTablesByName("db2", Seq("tbl2", "tblone"))
+    assert(tables2.map(_.identifier.table) == Seq("tbl2", "tblone"))
     assert(tables2.forall(_.identifier.catalog.isDefined))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a followup of https://github.com/apache/spark/pull/37021 . The `renameTable` method should keep the catalog name in `TableIdentifier`. This is necessary as methods like `getTablesByName` won't qualifier the table identifiers again.

This PR also cleans up `InMemoryCatalog` a bit. The caller side `SessionCatalog` will create tables/functions using qualified identifiers with catalog name, and we don't need to attach catalog name again in places like `getTable`. We just need to make sure we don't drop the catalog field during table updating.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
make sure the v1 identifiers are always qualified with catalog name.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. `InMemoryCatalog` is test only

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
N/A