### PR TITLE
[SPARK-38864][SQL][FOLLOW-UP] Make AnalysisException message deterministic

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -101,8 +101,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def unpivotValDataTypeMismatchError(values: Seq[NamedExpression]): Throwable = {
     val dataTypes = values
       .groupBy(_.dataType)
-      .mapValues(values => values.map(value => toSQLId(value.toString)))
+      .mapValues(values => values.map(value => toSQLId(value.toString)).sorted)
       .mapValues(values => if (values.length > 3) values.take(3) :+ "..." else values)
+      .toList.sortBy(_._1.sql)
       .map { case (dataType, values) => s"${toSQLType(dataType)} (${values.mkString(", ")})" }
 
     new AnalysisException(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetUnpivotSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetUnpivotSuite.scala
@@ -310,9 +310,9 @@ class DatasetUnpivotSuite extends QueryTest
       errorClass = "UNPIVOT_VALUE_DATA_TYPE_MISMATCH",
       parameters = Map(
         "types" ->
-          (""""STRING" \(`str1#\d+`\), """ +
+          (""""BIGINT" \(`long1#\d+L`, `long2#\d+L`\), """ +
            """"INT" \(`int1#\d+`, `int2#\d+`, `int3#\d+`, ...\), """ +
-           """"BIGINT" \(`long1#\d+L`, `long2#\d+L`\)""")),
+           """"STRING" \(`str1#\d+`\)""")),
       matchPVals = true)
   }
 
@@ -396,9 +396,9 @@ class DatasetUnpivotSuite extends QueryTest
       exception = e3,
       errorClass = "UNPIVOT_VALUE_DATA_TYPE_MISMATCH",
       parameters = Map("types" ->
-        (""""INT" \(`id#\d+`, `int1#\d+`\), """ +
-         """"STRING" \(`str1#\d+`, `str2#\d+`\), """ +
-         """"BIGINT" \(`long1#\d+L`\)""")),
+        (""""BIGINT" \(`long1#\d+L`\), """ +
+         """"INT" \(`id#\d+`, `int1#\d+`\), """ +
+         """"STRING" \(`str1#\d+`, `str2#\d+`\)""")),
       matchPVals = true)
 
     // unpivoting with star id columns so that no value columns are left
@@ -429,9 +429,9 @@ class DatasetUnpivotSuite extends QueryTest
       exception = e5,
       errorClass = "UNPIVOT_VALUE_DATA_TYPE_MISMATCH",
       parameters = Map("types" ->
-        (""""INT" \(`id#\d+`, `int1#\d+`\), """ +
-         """"STRING" \(`str1#\d+`, `str2#\d+`\), """ +
-         """"BIGINT" \(`long1#\d+L`\)""")),
+        (""""BIGINT" \(`long1#\d+L`\), """ +
+         """"INT" \(`id#\d+`, `int1#\d+`\), """ +
+         """"STRING" \(`str1#\d+`, `str2#\d+`\)""")),
       matchPVals = true)
 
     // unpivoting without giving values and no non-id columns


### PR DESCRIPTION
### What changes were proposed in this pull request?
Turns out the AnalysisException message is sensitive to the way Scala maps data types as used to generate the error message. This fix makes the error message deterministic.

https://github.com/apache/spark/pull/36150#discussion_r933962854

### Why are the changes needed?
This fixes tests.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test should not fail for Scala 2.13 anymore.