### PR TITLE
[SPARK-39930][SQL] Introduce Cache Hints

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -536,6 +536,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException(s"$hintName Hint expects a partition number as a parameter")
   }
 
+  def invalidCacheHintParameterError(hintName: String, invalidParams: Seq[Any]): Throwable = {
+    new AnalysisException(s"$hintName Hint does not accept any parameter, but " +
+      s"${invalidParams.mkString(", ")} found")
+  }
+
   def attributeNameSyntaxError(name: String): Throwable = {
     new AnalysisException(s"syntax error in attribute name: $name")
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/ResolveCacheHints.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/analysis/ResolveCacheHints.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.analysis
+
+import java.util.Locale
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnresolvedHint}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.catalyst.trees.TreePattern.UNRESOLVED_HINT
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.analysis.ResolveCacheHints.NO_RESULT_CACHE_TAG
+
+case class ResolveCacheHints(session: SparkSession) extends Rule[LogicalPlan] {
+  private lazy val cacheManager = session.sharedState.cacheManager
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan.resolveOperatorsWithPruning(_.containsPattern(UNRESOLVED_HINT)) {
+      case hint @ UnresolvedHint(hintName, parameters, child) =>
+        hintName.toUpperCase(Locale.ROOT) match {
+          case "RESULT_CACHE" =>
+            if (parameters.nonEmpty) {
+              throw QueryCompilationErrors.invalidCacheHintParameterError(hintName, parameters)
+            }
+            if (cacheManager.lookupCachedData(child).isEmpty) {
+              cacheManager.cacheQuery(session, child, None)
+            }
+            child.unsetTagValue(NO_RESULT_CACHE_TAG)
+            child
+          case "NO_RESULT_CACHE" =>
+            if (parameters.nonEmpty) {
+              throw QueryCompilationErrors.invalidCacheHintParameterError(hintName, parameters)
+            }
+            child.setTagValue(NO_RESULT_CACHE_TAG, true)
+            child
+          case "RESULT_UNCACHE" =>
+            if (parameters.nonEmpty) {
+              throw QueryCompilationErrors.invalidCacheHintParameterError(hintName, parameters)
+            }
+            if (cacheManager.lookupCachedData(child).nonEmpty) {
+              cacheManager.uncacheQuery(session, child, cascade = false, blocking = true)
+            }
+            child
+          case _ => hint
+        }
+    }
+  }
+}
+
+object ResolveCacheHints {
+  /**
+   * A tag for telling the `CacheManager` to skip the cached plan when true.
+   */
+  val NO_RESULT_CACHE_TAG: TreeNodeTag[Boolean] = TreeNodeTag[Boolean]("NO_RESULT_CACHE")
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.{ColumnarRule, CommandExecutionMode, QueryExecution, SparkOptimizer, SparkPlanner, SparkSqlParser}
 import org.apache.spark.sql.execution.adaptive.AdaptiveRulesHolder
 import org.apache.spark.sql.execution.aggregate.{ResolveEncodersInScalaAgg, ScalaUDAF}
-import org.apache.spark.sql.execution.analysis.DetectAmbiguousSelfJoin
+import org.apache.spark.sql.execution.analysis.{DetectAmbiguousSelfJoin, ResolveCacheHints}
 import org.apache.spark.sql.execution.command.CommandCheck
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.{TableCapabilityCheck, V2SessionCatalog}
@@ -197,6 +197,7 @@ abstract class BaseSessionStateBuilder(
         PreprocessTableInsertion +:
         DataSourceAnalysis(this) +:
         ReplaceCharWithVarchar +:
+        ResolveCacheHints(session) +:
         customPostHocResolutionRules
 
     override val extendedCheckRules: Seq[LogicalPlan => Unit] =

--- a/sql/core/src/test/scala/org/apache/spark/sql/CacheHintsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CacheHintsSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.execution.CachedData
+import org.apache.spark.sql.execution.analysis.ResolveCacheHints.NO_RESULT_CACHE_TAG
+import org.apache.spark.sql.test.SharedSparkSession
+
+class CacheHintsSuite extends PlanTest with SharedSparkSession {
+  private def lookupCachedData(df: DataFrame): Option[CachedData] = {
+    spark.sharedState.cacheManager.lookupCachedData(df)
+  }
+
+  test("RESULT_CACHE Hint") {
+    val e = intercept[AnalysisException](
+      sql("SELECT /*+ RESULT_CACHE(abc) */ id from range(0, 1)").collect())
+    assert(e.getMessage.contains("RESULT_CACHE Hint does not accept any parameter"))
+    val df = sql("SELECT /*+ RESULT_CACHE */ id from range(0, 1)")
+    assert(lookupCachedData(df).nonEmpty)
+    sql("SELECT * FROM range(2, 3) WHERE EXISTS (SELECT /*+ RESULT_CACHE */ id from range(1, 2))")
+    assert(lookupCachedData(sql("SELECT id from range(1, 2)")).nonEmpty)
+  }
+
+  test("RESULT_UNCACHE Hint") {
+    val e = intercept[AnalysisException](
+      sql("SELECT /*+ RESULT_UNCACHE(abc) */ id from range(0, 1)").collect())
+    assert(e.getMessage.contains("RESULT_UNCACHE Hint does not accept any parameter"))
+    sql("SELECT /*+ RESULT_CACHE */ id from range(0, 1)")
+    assert(lookupCachedData(sql("SELECT id from range(0, 1)")).nonEmpty)
+    sql("SELECT /*+ RESULT_UNCACHE */ id from range(0, 1)")
+    assert(lookupCachedData(sql("SELECT id from range(0, 1)")).isEmpty)
+
+    sql("CACHE TABLE abc AS SELECT id from range(1, 2)")
+    sql("SELECT /*+ RESULT_UNCACHE */ id from range(1, 2)")
+    assert(!spark.catalog.isCached("abc"))
+  }
+
+  test("NO_RESULT_CACHE Hint") {
+    val e = intercept[AnalysisException](
+      sql("SELECT /*+ NO_RESULT_CACHE(abc) */ id from range(0, 1)").collect())
+    assert(e.getMessage.contains("NO_RESULT_CACHE Hint does not accept any parameter"))
+    val resultCache = sql("SELECT /*+ RESULT_CACHE */ id from range(0, 1)").logicalPlan
+    assert(resultCache.getTagValue(NO_RESULT_CACHE_TAG).isEmpty)
+    val noResultCache = sql("SELECT /*+ NO_RESULT_CACHE */ id from range(0, 1)").logicalPlan
+    assert(noResultCache.getTagValue(NO_RESULT_CACHE_TAG).contains(true))
+  }
+
+  test("Unrecognized hints for ResolveCacheHints rule") {
+    val logAppender = new LogAppender("RESULT_CACHE_UNKNOWN")
+
+    withLogAppender(logAppender) {
+      val analyzed =
+        sql("SELECT /*+ RESULT_CACHE_UNKNOWN */ id from range(0, 1)").queryExecution.analyzed
+    }
+    assert(logAppender.loggingEvents.exists(
+      _.getMessage.toString.contains("Unrecognized hint: RESULT_CACHE_UNKNOWN()")))
+
+  }
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperationListener.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperationListener.scala
@@ -1,0 +1,5 @@
+package org.apache.spark.sql.hive.thriftserver
+
+class SparkOperationListener {
+
+}

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperationListener.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkOperationListener.scala
@@ -1,5 +1,0 @@
-package org.apache.spark.sql.hive.thriftserver
-
-class SparkOperationListener {
-
-}

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveSessionStateBuilder.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlanner
 import org.apache.spark.sql.execution.aggregate.ResolveEncodersInScalaAgg
-import org.apache.spark.sql.execution.analysis.DetectAmbiguousSelfJoin
+import org.apache.spark.sql.execution.analysis.{DetectAmbiguousSelfJoin, ResolveCacheHints}
 import org.apache.spark.sql.execution.command.CommandCheck
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.v2.TableCapabilityCheck
@@ -103,6 +103,7 @@ class HiveSessionStateBuilder(
         DataSourceAnalysis(this) +:
         HiveAnalysis +:
         ReplaceCharWithVarchar +:
+        ResolveCacheHints(session) +:
         customPostHocResolutionRules
 
     override val extendedCheckRules: Seq[LogicalPlan => Unit] =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


This ticket intends to add query hints for cache behaviors, users can perform actions like the use/skip/cache/uncache, etc on the cached results by the following hints.

 
- RESULT_CACHE: spark will use cache by default, this hint keeps this behavior but will cache the child plan if uncached yet.

- NO_RESULT_CACHE:with this hint, we can skip the default behavior to bypass the cached data if it is cached

- RESULT_UNCACHE: with this hint, we can remove the cached data.

RESULT_CACHE and NO_RESULT_CACHE are borrowed from oracle, FYI,[https://docs.oracle.com/database/121/TGDBA/tune_result_cache.htm#TGDBA647.](https://docs.oracle.com/database/121/TGDBA/tune_result_cache.htm#TGDBA647), while RESULT_UNCACHE's added accordingly via the naming rule.
Similar ideas can also be found in MySQL, FYI https://dev.mysql.com/doc/refman/5.7/en/query-cache-in-select.html

Maybe we can add more cache hints like RESULT_RECACHE to refresh the cached data, or maybe some cache behaviors that relate to metadata.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As a supplement for CACHE/UNCACHE commands, pure SQL users can operate the cache in their queries directly without extra definitions. Also, cache skipping is supported by hints.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, this PR brings some new hints

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

- new tests for ut

- test dist by hand

<img width="1670" alt="image" src="https://user-images.githubusercontent.com/8326978/182107570-38cdb9ca-08e1-4157-8bdd-72a6e361e1f4.png">

