### PR TITLE
[SPARK-39877][PYTHON][FOLLOW-UP] Add DataFrame melt to PySpark docs

### DIFF
--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -73,6 +73,7 @@ DataFrame
     DataFrame.localCheckpoint
     DataFrame.mapInPandas
     DataFrame.mapInArrow
+    DataFrame.melt
     DataFrame.na
     DataFrame.observe
     DataFrame.orderBy

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2263,8 +2263,6 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         `IntegerType` and `LongType` are cast to `LongType`, while `IntegerType` and `StringType`
         do not have a common data type and `unpivot` fails.
 
-        :func:`groupby` is an alias for :func:`groupBy`.
-
         .. versionadded:: 3.4.0
 
         Parameters
@@ -2309,6 +2307,10 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         |  2|   int|12.0|
         |  2|double| 1.2|
         +---+------+----+
+
+        See Also
+        --------
+        DataFrame.melt
         """
 
         def to_jcols(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Same as #37354, but DataFrame.melt is missing from documentation.

Also removes erroneous alias from DataFrame.unpivot doc.

### Why are the changes needed?
Documenting new method.

### Does this PR introduce _any_ user-facing change?
Only documentation.

### How was this patch tested?
No.