### PR TITLE
[SPARK-39933][SQL][TESTS] Check query context by `checkError()`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -295,7 +295,8 @@ abstract class SparkFunSuite
       errorSubClass: Option[String] = None,
       sqlState: Option[String] = None,
       parameters: Map[String, String] = Map.empty,
-      matchPVals: Boolean = false): Unit = {
+      matchPVals: Boolean = false,
+      queryContext: Array[QueryContext] = Array.empty): Unit = {
     assert(exception.getErrorClass === errorClass)
     if (exception.getErrorSubClass != null) {
       assert(errorSubClass.isDefined)
@@ -318,6 +319,15 @@ abstract class SparkFunSuite
     } else {
       assert(expectedParameters === parameters)
     }
+    val actualQueryContext = exception.getQueryContext()
+    assert(actualQueryContext.length === queryContext.length, "Invalid length of the query context")
+    actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
+      assert(actual.objectType() === expected.objectType(), "Invalid objectType of a query context")
+      assert(actual.objectName() === expected.objectName(), "Invalid objectName of a query context")
+      assert(actual.startIndex() === expected.startIndex(), "Invalid startIndex of a query context")
+      assert(actual.stopIndex() === expected.stopIndex(), "Invalid stopIndex of a query context")
+      assert(actual.fragment() === expected.fragment(), "Invalid fragment of a query context")
+    }
   }
 
   protected def checkError(
@@ -334,6 +344,21 @@ abstract class SparkFunSuite
       sqlState: String,
       parameters: Map[String, String]): Unit =
     checkError(exception, errorClass, None, Some(sqlState), parameters)
+
+  protected def checkError(
+      exception: SparkThrowable,
+      errorClass: String,
+      sqlState: String,
+      parameters: Map[String, String],
+      context: QueryContext): Unit =
+    checkError(exception, errorClass, None, Some(sqlState), parameters, false, Array(context))
+
+  protected def checkError(
+      exception: SparkThrowable,
+      errorClass: String,
+      parameters: Map[String, String],
+      context: QueryContext): Unit =
+    checkError(exception, errorClass, None, None, parameters, false, Array(context))
 
   class LogAppender(msg: String = "", maxEvents: Int = 1000)
       extends AbstractAppender("logAppender", null, null, true, Property.EMPTY_ARRAY) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.SparkThrowable
+import org.apache.spark.{QueryContext, SparkThrowable}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -50,5 +50,18 @@ trait QueryErrorsSuiteBase extends SharedSparkSession {
     assert(exception.getErrorSubClass === errorSubClass.orNull)
     assert(exception.getSqlState === sqlState)
     assert(exception.getMessage === s"""\n[$fullErrorClass] """ + message)
+  }
+
+  case class ExpectedContext(
+      objectType: String,
+      objectName: String,
+      startIndex: Int,
+      stopIndex: Int,
+      fragment: String) extends QueryContext
+
+  object ExpectedContext {
+    def apply(fragment: String, start: Int, stop: Int): ExpectedContext = {
+      ExpectedContext("", "", start, stop, fragment)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -46,7 +46,8 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
       },
       errorClass = "DIVIDE_BY_ZERO",
       sqlState = "22012",
-      parameters = Map("config" -> ansiConf))
+      parameters = Map("config" -> ansiConf),
+      context = ExpectedContext(fragment = "6/", start = 7, stop = 9))
   }
 
   test("INTERVAL_DIVIDED_BY_ZERO: interval divided by zero") {
@@ -55,8 +56,9 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         sql("select interval 1 day / 0").collect()
       },
       errorClass = "INTERVAL_DIVIDED_BY_ZERO",
-      parameters = Map.empty
-    )
+      sqlState = "22012",
+      parameters = Map.empty[String, String],
+      context = ExpectedContext(fragment = "interval 1 day / ", start = 7, stop = 24))
   }
 
   test("INVALID_FRACTION_OF_SECOND: in the function make_timestamp") {
@@ -80,7 +82,11 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         "value" -> "Decimal(expanded, 66666666666666.666, 17, 3)",
         "precision" -> "8",
         "scale" -> "1",
-        "config" -> ansiConf))
+        "config" -> ansiConf),
+      context = ExpectedContext(
+        fragment = "CAST('66666666666666.666' AS DECIMAL(8, 1)",
+        start = 7,
+        stop = 49))
   }
 
   test("INVALID_ARRAY_INDEX: get element from array") {
@@ -89,8 +95,8 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         sql("select array(1, 2, 3, 4, 5)[8]").collect()
       },
       errorClass = "INVALID_ARRAY_INDEX",
-      parameters = Map("indexValue" -> "8", "arraySize" -> "5", "ansiConfig" -> ansiConf)
-    )
+      parameters = Map("indexValue" -> "8", "arraySize" -> "5", "ansiConfig" -> ansiConf),
+      context = ExpectedContext(fragment = "array(1, 2, 3, 4, 5)[8", start = 7, stop = 29))
   }
 
   test("INVALID_ARRAY_INDEX_IN_ELEMENT_AT: element_at from array") {
@@ -99,8 +105,11 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         sql("select element_at(array(1, 2, 3, 4, 5), 8)").collect()
       },
       errorClass = "INVALID_ARRAY_INDEX_IN_ELEMENT_AT",
-      parameters = Map("indexValue" -> "8", "arraySize" -> "5", "ansiConfig" -> ansiConf)
-    )
+      parameters = Map("indexValue" -> "8", "arraySize" -> "5", "ansiConfig" -> ansiConf),
+      context = ExpectedContext(
+        fragment = "element_at(array(1, 2, 3, 4, 5), 8",
+        start = 7,
+        stop = 41))
   }
 
   test("MAP_KEY_DOES_NOT_EXIST: key does not exist in element_at") {
@@ -111,7 +120,11 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
       errorClass = "MAP_KEY_DOES_NOT_EXIST",
       parameters = Map(
         "keyValue" -> "3",
-        "config" -> ansiConf))
+        "config" -> ansiConf),
+      context = ExpectedContext(
+        fragment = "element_at(map(1, 'a', 2, 'b'), 3",
+        start = 7,
+        stop = 40))
   }
 
   test("CAST_INVALID_INPUT: cast string to double") {
@@ -124,7 +137,11 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         "expression" -> "'111111111111xe23'",
         "sourceType" -> "\"STRING\"",
         "targetType" -> "\"DOUBLE\"",
-        "ansiConfig" -> ansiConf))
+        "ansiConfig" -> ansiConf),
+      context = ExpectedContext(
+        fragment = "CAST('111111111111xe23' AS DOUBLE",
+        start = 7,
+        stop = 40))
   }
 
   test("CANNOT_PARSE_TIMESTAMP: parse string to timestamp") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to check the query context by `checkError()`.

### Why are the changes needed?
To extend test coverage.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt "test:testOnly *QueryExecutionAnsiErrorsSuite"
```