### PR TITLE
[SPARK-25342][CORE][SQL]Support rolling back a result stage and rerunning all result tasks when writing files

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2775,6 +2775,13 @@ object SparkContext extends Logging {
   private[spark] val RDD_SCOPE_KEY = "spark.rdd.scope"
   private[spark] val RDD_SCOPE_NO_OVERRIDE_KEY = "spark.rdd.scope.noOverride"
 
+  // just used to record the temporary output directory of HDFS or HIVE
+  private[spark] val MAPREDUCE_OUTPUT_FILEOUTPUTFORMAT_OUTPUTDIR =
+    "mapreduce.output.fileoutputformat.outputdir"
+  private[spark] val MAPREDUCE_JOB_APPLICATION_ATTEMPT_ID =
+    "mapreduce.job.application.attempt.id"
+
+
   /**
    * Executor id for the driver.  In earlier versions of Spark, this was `<driver>`, but this was
    * changed to `driver` because the angle brackets caused escaping issues in URLs and XML (see

--- a/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
+++ b/core/src/main/scala/org/apache/spark/internal/io/SparkHadoopWriter.scala
@@ -31,6 +31,7 @@ TaskAttemptContext => NewTaskAttemptContext, TaskAttemptID => NewTaskAttemptID, 
 import org.apache.hadoop.mapreduce.task.{TaskAttemptContextImpl => NewTaskAttemptContextImpl}
 
 import org.apache.spark.{SerializableWritable, SparkConf, SparkException, TaskContext}
+import org.apache.spark.SparkContext.{MAPREDUCE_JOB_APPLICATION_ATTEMPT_ID, MAPREDUCE_OUTPUT_FILEOUTPUTFORMAT_OUTPUTDIR}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
@@ -77,6 +78,13 @@ object SparkHadoopWriter extends Logging {
 
     val committer = config.createCommitter(commitJobId)
     committer.setupJob(jobContext)
+
+    rdd.context.setLocalProperty(MAPREDUCE_OUTPUT_FILEOUTPUTFORMAT_OUTPUTDIR,
+      jobContext.getConfiguration().get(MAPREDUCE_OUTPUT_FILEOUTPUTFORMAT_OUTPUTDIR))
+    rdd.context.setLocalProperty(MAPREDUCE_JOB_APPLICATION_ATTEMPT_ID,
+      jobContext.getConfiguration().getInt(MAPREDUCE_JOB_APPLICATION_ATTEMPT_ID, 0).toString)
+
+    rdd.setResultStageAllowToRetry(true)
 
     // Try to write all RDD partitions as a Hadoop OutputFormat.
     try {

--- a/core/src/main/scala/org/apache/spark/partial/ApproximateActionListener.scala
+++ b/core/src/main/scala/org/apache/spark/partial/ApproximateActionListener.scala
@@ -56,6 +56,10 @@ private[spark] class ApproximateActionListener[T, U, R](
     }
   }
 
+  override def stageFailed(): Unit = {
+    finishedTasks = 0
+  }
+
   override def jobFailed(exception: Exception): Unit = {
     synchronized {
       failure = Some(exception)

--- a/core/src/main/scala/org/apache/spark/scheduler/JobListener.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobListener.scala
@@ -24,5 +24,6 @@ package org.apache.spark.scheduler
  */
 private[spark] trait JobListener {
   def taskSucceeded(index: Int, result: Any): Unit
+  def stageFailed(): Unit
   def jobFailed(exception: Exception): Unit
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
@@ -53,13 +53,6 @@ private[spark] class JobWaiter[T](
     dagScheduler.cancelJob(jobId, None)
   }
 
-  /**
-   * reset the finishedTasks to the initial state
-   */
-  def reset(): Unit = {
-    finishedTasks.getAndSet(0)
-  }
-
   override def taskSucceeded(index: Int, result: Any): Unit = {
     // resultHandler call must be synchronized in case resultHandler itself is not thread safe.
     synchronized {
@@ -68,6 +61,10 @@ private[spark] class JobWaiter[T](
     if (finishedTasks.incrementAndGet() == totalTasks) {
       jobPromise.success(())
     }
+  }
+
+  override def stageFailed(): Unit = {
+    finishedTasks.getAndSet(0)
   }
 
   override def jobFailed(exception: Exception): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/JobWaiter.scala
@@ -53,6 +53,13 @@ private[spark] class JobWaiter[T](
     dagScheduler.cancelJob(jobId, None)
   }
 
+  /**
+   * reset the finishedTasks to the initial state
+   */
+  def reset(): Unit = {
+    finishedTasks.getAndSet(0)
+  }
+
   override def taskSucceeded(index: Int, result: Any): Unit = {
     // resultHandler call must be synchronized in case resultHandler itself is not thread safe.
     synchronized {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.{CustomMetrics, SQLMetric, SQLMetrics}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.util.{LongAccumulator, Utils}
+import org.apache.spark.util.Utils
 
 /**
  * Deprecated logical plan for writing data into data source v2. This is being replaced by more
@@ -365,7 +365,7 @@ trait V2TableWriteExec extends V2CommandExec with UnaryExecNode {
       PhysicalWriteInfoImpl(rdd.getNumPartitions))
     val useCommitCoordinator = batchWrite.useCommitCoordinator
     val messages = new Array[WriterCommitMessage](rdd.partitions.length)
-    val totalNumRowsAccumulator = Some(new LongAccumulator())
+    val totalNumRowsAccumulator = Some(sparkContext.longAccumulator)
 
     logInfo(s"Start processing data source write support: $batchWrite. " +
       s"The input RDD has ${messages.length} partitions.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
From this pr:https://github.com/apache/spark/pull/22112, we learn that currently we can't rollback and rerun a result stage, and just fail.

And this new pr is designed to solve some scenarios of this problem. When the analysis result from the result stage of a job will be output to a storage system, it can be written to a file system or database system.

1. If the result was written to a file system, it was stored in a temporary directory until the result stage run successfully. If the result stage whose map stage is  indeterminate failed but had committed output for some partitions, we can delete these temporary files and roll back the result stage.
2. If the result was written to a database system,  it will be written directly to the database and therefore if the result stage whose map stage is  indeterminate failed but some result tasks were successful, the result has been written successfully can not be rolled back
3. Therefore, the main purpose of this new pr is to support Result Stage rollback in the scenarios of writing to any file system.
4. I added a new identifier `isResultStageRetryAllowed` in RDD class to indicate whether its corresponding Result stage supports retries. 
It is a Boolean variable and the default value is false，indicating that result stage rollback is not supported  and corresponds to the scenario of writing to the database.
And in the case of writing to the file system, the result stage supports retries, and `isResultStageRetryAllowed` will be changed to true.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new tests and manually test

write to hive
![image](https://user-images.githubusercontent.com/94670132/183622089-2cce21d1-c729-427f-af4a-f58779adcda3.png)

write to iceberg
![image](https://user-images.githubusercontent.com/94670132/183622123-e73fb0f6-650c-4b4b-81d2-1cce4f5c01b2.png)

write to hdfs
![image](https://user-images.githubusercontent.com/94670132/183622149-9d38058e-9524-47d4-9882-a7b92939c70f.png)

write to mysql
![image](https://user-images.githubusercontent.com/94670132/183622162-ac7ff57c-f3a8-4e43-ac93-d749578843b9.png)
