### PR TITLE
[SPARK-39925][SQL] Add array_sort(column, comparator) overload to DataFrame operations

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3969,6 +3969,19 @@ object functions {
   def array_sort(e: Column): Column = withExpr { new ArraySort(e.expr) }
 
   /**
+   * Sorts the input array based on the given comparator function. The comparator will take two
+   * arguments representing two elements of the array. It returns a negative integer, 0, or a
+   * positive integer as the first element is less than, equal to, or greater than the second
+   * element. If the comparator function returns null, the function will fail and raise an error.
+   *
+   * @group collection_funcs
+   * @since 3.4.0
+   */
+  def array_sort(e: Column, comparator: (Column, Column) => Column): Column = withExpr {
+    new ArraySort(e.expr, createLambda(comparator))
+  }
+
+  /**
    * Remove all elements that equal to element from the given array.
    *
    * @group collection_funcs


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adding a new `array_sort` overload to `org.apache.spark.sql.functions` that matches the new overload defined in [SPARK-29020](https://issues.apache.org/jira/browse/SPARK-29020) and added via #25728.

### Why are the changes needed?
Adds access to the new overload for users of the DataFrame API so that they don't need to use the `expr` escape hatch.

### Does this PR introduce _any_ user-facing change?
Yes, now allows users to optionally provide a comparator function to the `array_sort`, which opens up the ability to sort descending as well as sort items that aren't naturally orderable.

#### Example:
Old:
```
df.selectExpr("array_sort(a, (x, y) -> cardinality(x) - cardinality(y))");
```

Added:
```
df.select(array_sort(col("a"), (x, y) => size(x) - size(y)));
```

### How was this patch tested?
Unit tests updated to validate that the overload matches the expression's behavior.