### PR TITLE
[SPARK-39950][SQL] It's unnecessary to materialize BroadcastQueryStage firstly, because the BroadcastQueryStage does not timeout in AQE.

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -78,7 +78,6 @@ abstract class QueryStageExec extends LeafExecNode {
    * stage is ready.
    */
   final def materialize(): Future[Any] = {
-    logDebug(s"Materialize query stage ${this.getClass.getSimpleName}: $id")
     doMaterialize()
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the https://issues.apache.org/jira/browse/SPARK-33933, it materializes BroadcastQueryStage firstly to try to avoid broadcast timeout in AQE, but the BroadcastQueryStage does not timeout in AQE any more, so we should not materialize BroadcastQueryStage firstly.
### Why are the changes needed?
It's unnecessary to materialize BroadcastQueryStage firstly in AQE.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass CI.