### PR TITLE
[SPARK-39938][PYTHON][PS] Accept all inputs of prefix/suffix which implement __str__ in add_predix/add_suffix

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -9012,9 +9012,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2      3      5
         3      4      6
         """
-        assert isinstance(prefix, str)
+        f = partial("{prefix}{}".format, prefix=prefix)
         return self._apply_series_op(
-            lambda psser: psser.rename(tuple([prefix + i for i in psser._column_label]))
+            lambda psser: psser.rename(tuple([f(i) for i in psser._column_label]))
         )
 
     def add_suffix(self, suffix: str) -> "DataFrame":
@@ -9057,9 +9057,9 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2      3      5
         3      4      6
         """
-        assert isinstance(suffix, str)
+        f = partial("{}{suffix}".format, suffix=suffix)
         return self._apply_series_op(
-            lambda psser: psser.rename(tuple([i + suffix for i in psser._column_label]))
+            lambda psser: psser.rename(tuple([f(i) for i in psser._column_label]))
         )
 
     # TODO: include, and exclude should be implemented.

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3170,11 +3170,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         item_3    4
         dtype: int64
         """
-        assert isinstance(prefix, str)
         internal = self._internal.resolved_copy
         sdf = internal.spark_frame.select(
             [
-                F.concat(SF.lit(prefix), index_spark_column).alias(index_spark_column_name)
+                F.concat(SF.lit(str(prefix)), index_spark_column).alias(index_spark_column_name)
                 for index_spark_column, index_spark_column_name in zip(
                     internal.index_spark_columns, internal.index_spark_column_names
                 )
@@ -3225,11 +3224,10 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         3_item    4
         dtype: int64
         """
-        assert isinstance(suffix, str)
         internal = self._internal.resolved_copy
         sdf = internal.spark_frame.select(
             [
-                F.concat(index_spark_column, SF.lit(suffix)).alias(index_spark_column_name)
+                F.concat(index_spark_column, SF.lit(str(suffix))).alias(index_spark_column_name)
                 for index_spark_column, index_spark_column_name in zip(
                     internal.index_spark_columns, internal.index_spark_column_names
                 )

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -2701,6 +2701,8 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         pdf = pd.DataFrame({"A": [1, 2, 3, 4], "B": [3, 4, 5, 6]}, index=np.random.rand(4))
         psdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.add_prefix("col_"), psdf.add_prefix("col_"))
+        self.assert_eq(pdf.add_prefix(1.1), psdf.add_prefix(1.1))
+        self.assert_eq(pdf.add_prefix(True), psdf.add_prefix(True))
 
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B")])
         pdf.columns = columns
@@ -2711,6 +2713,8 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         pdf = pd.DataFrame({"A": [1, 2, 3, 4], "B": [3, 4, 5, 6]}, index=np.random.rand(4))
         psdf = ps.from_pandas(pdf)
         self.assert_eq(pdf.add_suffix("first_series"), psdf.add_suffix("first_series"))
+        self.assert_eq(pdf.add_suffix(1.1), psdf.add_suffix(1.1))
+        self.assert_eq(pdf.add_suffix(True), psdf.add_suffix(True))
 
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B")])
         pdf.columns = columns

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -1293,6 +1293,8 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser = pd.Series([1, 2, 3, 4], name="0")
         psser = ps.from_pandas(pser)
         self.assert_eq(pser.add_prefix("item_"), psser.add_prefix("item_"))
+        self.assert_eq(pser.add_prefix(1.1), psser.add_prefix(1.1))
+        self.assert_eq(pser.add_prefix(False), psser.add_prefix(False))
 
         pser = pd.Series(
             [1, 2, 3],
@@ -1306,6 +1308,8 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         pser = pd.Series([1, 2, 3, 4], name="0")
         psser = ps.from_pandas(pser)
         self.assert_eq(pser.add_suffix("_item"), psser.add_suffix("_item"))
+        self.assert_eq(pser.add_suffix(1.1), psser.add_suffix(1.1))
+        self.assert_eq(pser.add_suffix(False), psser.add_suffix(False))
 
         pser = pd.Series(
             [1, 2, 3],


### PR DESCRIPTION
We need to follow the pandas behavior of prefix/suffix parameter validation in add_prefix/add_suffix.

Now, we force to validate it as a String type. But pandas looks all values which can be formated as String(implement __str__ func). So it's different here.

### What changes were proposed in this pull request?
We support all kind inputs which can be formated as string.

### Why are the changes needed?
As pandas behavior is different with PySpark when we input other types into add_prefix/add_suffix funcs.
PySpark
```
>>> from pyspark import pandas as ps
>>> df = ps.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]}, columns=['A', 'B'])
>>> df.add_suffix(666)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spark/spark/python/pyspark/pandas/frame.py", line 9060, in add_suffix
    assert isinstance(suffix, str)
AssertionError
>>> df.add_suffix(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spark/spark/python/pyspark/pandas/frame.py", line 9060, in add_suffix
    assert isinstance(suffix, str)
AssertionError
```

Pandas: 1.3.X/1.4.X
```
>>> pdf.add_suffix(0.1)
   A0.1  B0.1
0     1     3
1     2     4
2     3     5
3     4     6
>>> pdf.add_suffix(True)
   ATrue  BTrue
0      1      3
1      2      4
2      3      5
3      4      6
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Input any can be stringable input into add_prefix/add_suffix funcs.
