### PR TITLE
[SPARK-39941][PYTHON][PS] window and min_periods should be integer in rolling func

### DIFF
--- a/python/pyspark/pandas/tests/test_rolling.py
+++ b/python/pyspark/pandas/tests/test_rolling.py
@@ -30,6 +30,10 @@ class RollingTest(PandasOnSparkTestCase, TestUtils):
             ps.range(10).rolling(window=-1)
         with self.assertRaisesRegex(ValueError, "min_periods must be >= 0"):
             ps.range(10).rolling(window=1, min_periods=-1)
+        with self.assertRaisesRegex(ValueError, "window must be an integer"):
+            ps.range(10).rolling(window=1.1)
+        with self.assertRaisesRegex(ValueError, "min_periods must be an integer"):
+            ps.range(10).rolling(window=1, min_periods=-1.1)
 
         with self.assertRaisesRegex(
             TypeError, "psdf_or_psser must be a series or dataframe; however, got:.*int"

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -144,10 +144,15 @@ class RollingLike(RollingAndExpanding[FrameLike]):
         window: int,
         min_periods: Optional[int] = None,
     ):
+        if type(window) is not int:
+            raise ValueError("window must be an integer")
         if window < 0:
             raise ValueError("window must be >= 0")
-        if (min_periods is not None) and (min_periods < 0):
-            raise ValueError("min_periods must be >= 0")
+        if min_periods is not None:
+            if type(min_periods) is not int:
+                raise ValueError("min_periods must be an integer")
+            if min_periods < 0:
+                raise ValueError("min_periods must be >= 0")
         if min_periods is None:
             # TODO: 'min_periods' is not equivalent in pandas because it does not count NA as
             #  a value.


### PR DESCRIPTION
window and min_periods parameters is not be validated in rolling function.

### What changes were proposed in this pull request?
Validate the said 2 parameters to be a integer only in rolling func, will raise ValueError if they are not Integer


### Why are the changes needed?
I guess we miss the validation towards those parameters.

PySpark will raise Error during using other type inputs
```
>>> s = ps.Series([4, 3, 5, 2, 6])
>>> s.rolling(1).sum()
0    4
1    3
2    5
3    2
4    6
dtype: int64
>>> s.rolling('STRING').sum()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spark/spark/python/pyspark/pandas/generic.py", line 2707, in rolling
    return Rolling(self, window=window, min_periods=min_periods)
  File "/home/spark/spark/python/pyspark/pandas/window.py", line 179, in __init__
    super().__init__(window, min_periods)
  File "/home/spark/spark/python/pyspark/pandas/window.py", line 147, in __init__
    if window < 0:
TypeError: '<' not supported between instances of 'str' and 'int'
>>> 
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Input other types of window and min_periods in rolling func will raise ValueError
