### PR TITLE
[SPARK-39942][PYTHON][PS] Need to verify the input nums is integer in nsmallest func

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -7766,6 +7766,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         a  1
         d  2
         """
+        assert type(n) is int
         by_scols = self._prepare_sort_by_scols(columns)
         return self._sort(by=by_scols, ascending=True, na_position="last", keep=keep).head(n=n)
 

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -3574,6 +3574,7 @@ class SeriesGroupBy(GroupBy[Series]):
         3  6    3
         Name: b, dtype: int64
         """
+        assert type(n) is int
         if self._psser._internal.index_level > 1:
             raise ValueError("nsmallest do not support multi-index now")
 

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -3417,6 +3417,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    3.0
         dtype: float64
         """
+        assert type(n) is int
         return self.sort_values(ascending=True).head(n)
 
     def nlargest(self, n: int = 5) -> "Series":

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -1907,6 +1907,10 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         msg = 'keep must be either "first", "last" or "all".'
         with self.assertRaisesRegex(ValueError, msg):
             psdf.nlargest(5, columns=["c"], keep="xx")
+        with self.assertRaises(AssertionError):
+            psdf.nsmallest("test", columns=["c"], keep="last")
+        with self.assertRaises(AssertionError):
+            psdf.nsmallest(0.1, columns=["c"], keep="last")
 
     def test_xs(self):
         d = {

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1765,6 +1765,10 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
         )
         with self.assertRaisesRegex(ValueError, "nsmallest do not support multi-index now"):
             psdf.set_index(["a", "b"]).groupby(["c"])["d"].nsmallest(1)
+        with self.assertRaises(AssertionError):
+            psdf.groupby(["a"])["b"].nsmallest(0.1).sort_index()
+        with self.assertRaises(AssertionError):
+            psdf.groupby(["a"])["b"].nsmallest(False).sort_index()
 
     def test_nlargest(self):
         pdf = pd.DataFrame(

--- a/python/pyspark/pandas/tests/test_series.py
+++ b/python/pyspark/pandas/tests/test_series.py
@@ -877,6 +877,11 @@ class SeriesTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.nsmallest(), pser.nsmallest())
         self.assert_eq((psser + 1).nsmallest(), (pser + 1).nsmallest())
 
+        with self.assertRaises(AssertionError):
+            psser.nsmallest("String")
+        with self.assertRaises(AssertionError):
+            psser.nsmallest(0.1)
+
     def test_nlargest(self):
         sample_lst = [1, 2, 3, 4, np.nan, 6]
         pser = pd.Series(sample_lst, name="x")


### PR DESCRIPTION
The input parameter of nsmallest should be validated as Integer. So I think we might miss this validation.

And PySpark will raise Error when we input the strange types into nsmallest func.


### What changes were proposed in this pull request?
validate the input num is integer type only.


### Why are the changes needed?
PySpark will raise Error if we not limit the type.

```
>>> df = ps.DataFrame({'A': [1, 2, 3, 4], 'B': [3, 4, 5, 6]}, columns=['A', 'B'])
>>> df.groupby(['A'])['B']
<pyspark.pandas.groupby.SeriesGroupBy object at 0x7fda5a171fa0>
>>> df.groupby(['A'])['B'].nsmallest(True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/spark/spark/python/pyspark/pandas/groupby.py", line 3598, in nsmallest
    sdf.withColumn(temp_rank_column, F.row_number().over(window))
  File "/home/spark/spark/python/pyspark/sql/dataframe.py", line 2129, in filter
    jdf = self._jdf.filter(condition._jc)
  File "/home/spark/.pyenv/versions/3.8.13/lib/python3.8/site-packages/py4j/java_gateway.py", line 1321, in __call__
    return_value = get_return_value(
  File "/home/spark/spark/python/pyspark/sql/utils.py", line 196, in deco
    raise converted from None
pyspark.sql.utils.AnalysisException: cannot resolve '(__rank__ <= true)' due to data type mismatch: differing types in '(__rank__ <= true)' (int and boolean).;
'Filter (__rank__#4995 <= true)
+- Project [__index_level_0__#4988L, __index_level_1__#4989L, B#4979L, __natural_order__#4983L, __rank__#4995]
   +- Project [__index_level_0__#4988L, __index_level_1__#4989L, B#4979L, __natural_order__#4983L, __rank__#4995, __rank__#4995]
      +- Window [row_number() windowspecdefinition(__index_level_0__#4988L, B#4979L ASC NULLS FIRST, __natural_order__#4983L ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS __rank__#4995], [__index_level_0__#4988L], [B#4979L ASC NULLS FIRST, __natural_order__#4983L ASC NULLS FIRST]
         +- Project [__index_level_0__#4988L, __index_level_1__#4989L, B#4979L, __natural_order__#4983L]
            +- Project [A#4978L AS __index_level_0__#4988L, __index_level_0__#4977L AS __index_level_1__#4989L, B#4979L, __natural_order__#4983L]
               +- Project [__index_level_0__#4977L, A#4978L, B#4979L, monotonically_increasing_id() AS __natural_order__#4983L]
                  +- LogicalRDD [__index_level_0__#4977L, A#4978L, B#4979L], false

```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
input non-Integer type will raise AssersionError during calling nsmallest func
