### PR TITLE
[SPARK-39955][CORE] Improve LaunchTask process to avoid Stage failures caused by fail-to-send LaunchTask messages

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
@@ -93,6 +93,8 @@ class TaskInfo(
 
   var killed = false
 
+  var launching = true
+
   private[spark] def markGettingResult(time: Long): Unit = {
     gettingResultTime = time
   }
@@ -106,6 +108,10 @@ class TaskInfo(
     } else if (state == TaskState.KILLED) {
       killed = true
     }
+  }
+
+  private[spark] def launchSucceeded: Unit = {
+    launching = false
   }
 
   def gettingResult: Boolean = gettingResultTime != 0

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
@@ -110,7 +110,7 @@ class TaskInfo(
     }
   }
 
-  private[spark] def launchSucceeded: Unit = {
+  private[spark] def launchSucceeded(): Unit = {
     launching = false
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -826,7 +826,7 @@ private[spark] class TaskSchedulerImpl(
               }
             }
             if (state == TaskState.RUNNING) {
-              taskSet.taskInfos(tid).launchSucceeded
+              taskSet.taskInfos(tid).launchSucceeded()
             }
           case None =>
             logError(

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -825,6 +825,9 @@ private[spark] class TaskSchedulerImpl(
                 taskResultGetter.enqueueFailedTask(taskSet, tid, state, serializedData)
               }
             }
+            if (state == TaskState.RUNNING) {
+              taskSet.taskInfos(tid).launchSucceeded
+            }
           case None =>
             logError(
               ("Ignoring update with state %s for TID %s because its task set is gone (this is " +

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1067,11 +1067,14 @@ private[spark] class TaskSetManager(
       }
     }
     for ((tid, info) <- taskInfos if info.running && info.executorId == execId) {
+      // If the task is launching, this indicates that Driver has sent LaunchTask to Executor,
+      // but Executor has not sent StatusUpdate(TaskState.RUNNING) to Driver. Hence, we assume that
+      // the task is not running, and it is NetworkFailure rather than TaskFailure.
       val exitCausedByApp: Boolean = reason match {
-        case exited: ExecutorExited => exited.exitCausedByApp
+        case ExecutorExited(_, false, _) => false
         case ExecutorKilled | ExecutorDecommission(_) => false
         case ExecutorProcessLost(_, _, false) => false
-        case _ => true
+        case _ => !info.launching
       }
       handleFailedTask(tid, TaskState.FAILED, ExecutorLostFailure(info.executorId, exitCausedByApp,
         Some(reason.toString)))

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1067,13 +1067,13 @@ private[spark] class TaskSetManager(
       }
     }
     for ((tid, info) <- taskInfos if info.running && info.executorId == execId) {
-      // If the task is launching, this indicates that Driver has sent LaunchTask to Executor,
-      // but Executor has not sent StatusUpdate(TaskState.RUNNING) to Driver. Hence, we assume that
-      // the task is not running, and it is NetworkFailure rather than TaskFailure.
       val exitCausedByApp: Boolean = reason match {
         case ExecutorExited(_, false, _) => false
         case ExecutorKilled | ExecutorDecommission(_) => false
         case ExecutorProcessLost(_, _, false) => false
+        // If the task is launching, this indicates that Driver has sent LaunchTask to Executor,
+        // but Executor has not sent StatusUpdate(TaskState.RUNNING) to Driver. Hence, we assume
+        // that the task is not running, and it is NetworkFailure rather than TaskFailure.
         case _ => !info.launching
       }
       handleFailedTask(tid, TaskState.FAILED, ExecutorLostFailure(info.executorId, exitCausedByApp,

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -642,7 +642,7 @@ class TaskSetManagerSuite
 
     // Driver receives StatusUpdate(RUNNING) from Executors
     for ((tid, info) <- manager.taskInfos if info.running) {
-      manager.taskInfos(tid).launchSucceeded
+      manager.taskInfos(tid).launchSucceeded()
     }
     sched.removeExecutor("execC")
     manager.executorLost(

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2207,9 +2207,10 @@ class TaskSetManagerSuite
 
     val (taskId0, index0, exec0) = (task0.taskId, task0.index, task0.executorId)
     val (taskId1, index1, exec1) = (task1.taskId, task1.index, task1.executorId)
+
     // set up two running tasks
-    assert(manager.taskInfos(taskId0).running && manager.taskInfos(taskId0).launching)
-    assert(manager.taskInfos(taskId1).running && manager.taskInfos(taskId1).launching)
+    assert(manager.taskInfos(taskId0).running)
+    assert(manager.taskInfos(taskId1).running)
 
     val numFailures = PrivateMethod[Array[Int]](Symbol("numFailures"))
     // no task failures yet
@@ -2219,7 +2220,7 @@ class TaskSetManagerSuite
     sched.asInstanceOf[TaskSchedulerImpl]
       .statusUpdate(taskId1, TaskState.RUNNING, ByteBuffer.allocate(0))
     eventually(timeout(10.seconds), interval(100.milliseconds)) {
-      assert(manager.taskInfos(taskId0).running && manager.taskInfos(taskId0).launching)
+      assert(manager.taskInfos(taskId0).running)
       assert(manager.taskInfos(taskId1).running && !manager.taskInfos(taskId1).launching)
     }
     // let exec1 count task failures but exec0 doesn't

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -639,6 +639,11 @@ class TaskSetManagerSuite
       ExecutorExited(143, false, "Terminated for reason unrelated to running tasks"))
     assert(!sched.taskSetsFailed.contains(taskSet.id))
     assert(manager.resourceOffer("execC", "host2", ANY)._1.isDefined)
+
+    // Driver receives StatusUpdate(RUNNING) from Executors
+    for ((tid, info) <- manager.taskInfos if info.running) {
+      manager.taskInfos(tid).launchSucceeded
+    }
     sched.removeExecutor("execC")
     manager.executorLost(
       "execC", "host2", ExecutorExited(1, true, "Terminated due to issue with running tasks"))
@@ -2203,14 +2208,20 @@ class TaskSetManagerSuite
     val (taskId0, index0, exec0) = (task0.taskId, task0.index, task0.executorId)
     val (taskId1, index1, exec1) = (task1.taskId, task1.index, task1.executorId)
     // set up two running tasks
-    assert(manager.taskInfos(taskId0).running)
-    assert(manager.taskInfos(taskId1).running)
+    assert(manager.taskInfos(taskId0).running && manager.taskInfos(taskId0).launching)
+    assert(manager.taskInfos(taskId1).running && manager.taskInfos(taskId1).launching)
 
     val numFailures = PrivateMethod[Array[Int]](Symbol("numFailures"))
     // no task failures yet
     assert(manager.invokePrivate(numFailures())(index0) === 0)
     assert(manager.invokePrivate(numFailures())(index1) === 0)
 
+    sched.asInstanceOf[TaskSchedulerImpl]
+      .statusUpdate(taskId1, TaskState.RUNNING, ByteBuffer.allocate(0))
+    eventually(timeout(10.seconds), interval(100.milliseconds)) {
+      assert(manager.taskInfos(taskId0).running && manager.taskInfos(taskId0).launching)
+      assert(manager.taskInfos(taskId1).running && !manager.taskInfos(taskId1).launching)
+    }
     // let exec1 count task failures but exec0 doesn't
     backend.executorsPendingToRemove(exec0) = true
     backend.executorsPendingToRemove(exec1) = false


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
![milestone2](https://user-images.githubusercontent.com/20109646/182496148-8d19d885-2050-45fa-8653-682129123d44.png)
A. Non-Task Failure: Driver does not send any LaunchTask message to Executor, and thus there is no running task on Executor. It is impossible to be Task Failure.

B. Non-Task Failure: If a RPC failure happens before receiving the StatusUpdate message from Executor, it is Non-Task Failure because the task does not start to run in Executor.

C. Task Failure: If there is any running task in the Executor, we will recognize the RPC failure as Task Failure.

D. Non-Task Failure: There is no running task on the Executor when all tasks on the Executor are in finished states (FINISHED, FAILED, KILLED, LOST). Hence, the RPC failures in this phase are Non-Task Failure.
### Why are the changes needed?
There are two possible reasons, including Non-Task Failure and Task Failure, to make RPC failures.

(1) Task Failure: The network is good, but the task causes the executor's JVM crash. Hence, RPC fails.
(2) Non-Task Failure: The executor works well, but the network between Driver and Executor is broken. Hence, RPC fails.

We should handle these two different kinds of failure in different ways. First, if the failure is Task Failure, we should increment the variable `numFailures`. If the value of `numFailures` is larger than a threshold, Spark will label the job failed. Second, if the failure is Non-Task Failure, we will not increment the variable `numFailures`. We will just assign the task to a new executor. Hence, the job will not be recognized as failed due to Non-Task Failure.

However, currently, Spark recognizes every RPC failure as Task Failure. Hence, this PR aims to categorize RPC failures into two categories, Task Failure and Network Failure.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
build/sbt "core/testOnly *TaskSchedulerImplSuite -- -z SPARK-39955"
build/sbt "core/testOnly *TaskSetManagerSuite"
```
