### PR TITLE
[SPARK-39960][BUILD] Upgrade mysql-connector-java to 8.0.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1218,7 +1218,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.29</version>
+        <version>8.0.30</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade mysql-connector-java from 8.0.29 to 8.0.30


### Why are the changes needed?
This version brings some bugs fixes, the release note as follows:
https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-30.html
Bugs Fixed, eg:
> Historically, MySQL Server has used utf8 as an alias for utf8mb3. Since release 8.0.29, utf8mb3 has become a recognized (though deprecated) character set on its own for MySQL Server and to make things consistent, in release 8.0.30, any collations prefixed with utf8_ are now prefixed with utf8mb3_ instead. To go with that change, Connector/J has updated its character set and collation mapping accordingly in this release, and users are encouraged to update to Connector/J 8.0.30 to avoid potential issues when working with MySQL Server 8.0.30 or later. (Bug #34090350)

> The description for the connection property rewriteBatchedStatements has been corrected, removing the limitation that server-sided prepared statements could not take advantage of the rewrite option. (Bug #34022110)

> DatabaseMetaData.getTypeInfo always returned false for AUTO_INCREMENT for all data types. With this fix, Connector/J returns the correct value for each data type. Also, the missing types DOUBLE UNSIGNED and DOUBLE PRECISION UNSIGNED have been added to the ResultSet. (Bug #106758, Bug #33973048)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.