### PR TITLE
[SPARK-39963][SQL] Simplify `SimplifyCasts.isWiderCast`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -1036,12 +1036,8 @@ object SimplifyCasts extends Rule[LogicalPlan] {
 
   // Returns whether the from DataType can be safely casted to the to DataType without losing
   // any precision or range.
-  private def isWiderCast(from: DataType, to: NumericType): Boolean = (from, to) match {
-    case (from: NumericType, to: DecimalType) if to.isWiderThan(from) => true
-    case (from: DecimalType, to: NumericType) if from.isTighterThan(to) => true
-    case (from: IntegralType, to: IntegralType) => Cast.canUpCast(from, to)
-    case _ => from == to
-  }
+  private def isWiderCast(from: DataType, to: NumericType): Boolean =
+    from.isInstanceOf[NumericType] && Cast.canUpCast(from, to)
 }
 
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyCastsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyCastsSuite.scala
@@ -95,6 +95,10 @@ class SimplifyCastsSuite extends PlanTest {
       Optimize.execute(
         input.select($"b".cast(DecimalType(10, 2)).cast(DecimalType(24, 2)).as("casted")).analyze),
       input.select($"b".cast(DecimalType(10, 2)).cast(DecimalType(24, 2)).as("casted")).analyze)
+    comparePlans(
+      Optimize.execute(
+        input.select($"c".cast(DecimalType(10, 2)).cast(DecimalType(24, 2)).as("casted")).analyze),
+      input.select($"c".cast(DecimalType(10, 2)).cast(DecimalType(24, 2)).as("casted")).analyze)
 
     comparePlans(
       Optimize.execute(


### PR DESCRIPTION
### What changes were proposed in this pull request?
`SimplifyCasts` is a optimize rule used to removes `Cast` that are unnecessary because the input is already the correct type.
Currently, the implementation of `SimplifyCasts` seems a little redundant. `Cast.canUpCast` can completely cover the function of `isWiderCast`.

On the other hand, `SimplifyCastsSuite` does't cover the case when `from` is non-numeric and `to` is numeric. This PR add a new test case for this case.


### Why are the changes needed?
Simplify the implementation of `SimplifyCasts`.


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.

### How was this patch tested?
N/A
