### PR TITLE
[SPARK-39962][PYTHON][SQL] Apply projection when group attributes are empty

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AggregateInPandasExec.scala
@@ -131,12 +131,13 @@ case class AggregateInPandasExec(
       val newIter: Iterator[InternalRow] = mayAppendUpdatingSessionIterator(iter)
       val prunedProj = UnsafeProjection.create(allInputs.toSeq, child.output)
 
-      val grouped = if (groupingExpressions.isEmpty) {
+      val groupedItr = if (groupingExpressions.isEmpty) {
         // Use an empty unsafe row as a place holder for the grouping key
         Iterator((new UnsafeRow(), newIter))
       } else {
         GroupedIterator(newIter, groupingExpressions, child.output)
-      }.map { case (key, rows) =>
+      }
+      val grouped = groupedItr.map { case (key, rows) =>
         (key, rows.map(prunedProj))
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to apply the projection to respect the reordered columns in its child when group attributes are empty.

### Why are the changes needed?

To respect the column order in the child.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes a bug as below:

```python
import pandas as pd 
from pyspark.sql import functions as f 

@f.pandas_udf("double") 
def AVG(x: pd.Series) -> float: 
    return x.mean() 


abc = spark.createDataFrame([(1.0, 5.0, 17.0)], schema=["a", "b", "c"]) 
abc.agg(AVG("a"), AVG("c")).show()
abc.select("c", "a").agg(AVG("a"), AVG("c")).show()
```

**Before**

```
+------+------+
|AVG(a)|AVG(c)|
+------+------+
|  17.0|   1.0|
+------+------+
```

**After**

```
+------+------+
|AVG(a)|AVG(c)|
+------+------+
|   1.0|  17.0|
+------+------+
```

### How was this patch tested?

Manually tested, and added an unittest.