### PR TITLE
[SPARK-39968][K8S][DOCS] Update K8s doc to recommend K8s 1.22+

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.20 with access configured to it using
+* A running Kubernetes cluster at version >= 1.22 with access configured to it using
 [kubectl](https://kubernetes.io/docs/user-guide/prereqs/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s `Prerequisites` doc to recommend K8s 1.22+ for Apache Spark 3.4.0.

### Why are the changes needed?

SPARK-38597 added K8s integration test with the **latest** Minikube inside GitHub Action. As of today, we have K8s v1.24.3 test coverage on Minikube 1.26.1.

Apache Spark 3.4.0 is scheduled on February 2023 and a few K8s versions are going to be End-Of-Life before the Apache Spark 3.4.0 release like the following.

**End Of Support**
| K8s | AKS | GKE | EKS |
| - | ------ | ----|--------- |
| 1.20 | 2022-04 | 2022-08 | 2022-11 |
| 1.21 | 2022-07 | 2022-12 | 2023-02 |
| 1.22 | 2022-11 | 2023-03 | 2023-05 |

- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)
- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A