### PR TITLE
[SPARK-39972][PYTHON][SQL][TESTS] Revert the test case of SPARK-39962 in branch-3.2 and branch-3.1

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -71,17 +71,4 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
         pythonTestUDF(count(pythonTestUDF(base("a") + 1))))
     checkAnswer(df1, df2)
   }
-
-  test("SPARK-39962: Global aggregation of Pandas UDF should respect the column order") {
-    assume(shouldTestGroupedAggPandasUDFs)
-    val df = Seq[(java.lang.Integer, java.lang.Integer)]((1, null)).toDF("a", "b")
-
-    val pandasTestUDF = TestGroupedAggPandasUDF(name = "pandas_udf")
-    val reorderedDf = df.select("b", "a")
-    val actual = reorderedDf.agg(
-      pandasTestUDF(reorderedDf("a")), pandasTestUDF(reorderedDf("b")))
-    val expected = df.agg(pandasTestUDF(df("a")), pandasTestUDF(df("b")))
-
-    checkAnswer(actual, expected)
-  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR reverts the test in https://github.com/apache/spark/pull/37390 in branch-3.2 and branch-3.1 because testing util does not exist in branch-3.2 and branch-3.1.

### Why are the changes needed?

See https://github.com/apache/spark/pull/37390#issuecomment-1204658808

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Logically clean revert.