### PR TITLE
[SPARK-39974][INFRA] Create separate static image tag for infra cache

### DIFF
--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           context: ./dev/infra/
           push: true
-          tags: ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}
+          tags: ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}-static
           cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}
           cache-to: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }},mode=max
       - name: Image digest


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create separate static image tag for infra static image


### Why are the changes needed?
Currently, we put the **static image** and **cache** together in same tag like [`ghcr.io/apache/spark/apache-spark-github-action-image-cache:master`](https://github.com/apache/spark/pkgs/container/spark%2Fapache-spark-github-action-image-cache/versions).

Cache and static image occupy separate different image hash and same image tags. this bring some problem in below cases:
- **Debug job with static docker images**, they have to find hash. If use cache directly, will raise something like:
```
yikun-x86:~# docker run -ti ghcr.io/yikun/apache-spark-github-action-image-cache:master
Unable to find image 'ghcr.io/yikun/apache-spark-github-action-image-cache:master' locally
master: Pulling from yikun/apache-spark-github-action-image-cache
docker: no matching manifest for linux/amd64 in the manifest list entries.
```

- **Use static image in CI**, such as for some reason we want to switch static image temporarily.
- **Easy to see history for last cache**, such as system deps/lib.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Local test: https://github.com/Yikun/spark/pull/144, and static image tag push [passed](https://github.com/Yikun/spark/runs/7664266955?check_suite_focus=true#step:6:212)
- Run static image:
```
root@yikun-x86:~# docker run -ti ghcr.io/yikun/apache-spark-github-action-image-cache:master-static
Unable to find image 'ghcr.io/yikun/apache-spark-github-action-image-cache:master-static' locally
master-static: Pulling from yikun/apache-spark-github-action-image-cache
Digest: sha256:5198fd8111c925b7c92d04427268bcb0e5574bb72cef09808076595f3372bf7b
Status: Downloaded newer image for ghcr.io/yikun/apache-spark-github-action-image-cache:master-static
root@3550e09e0e93:/# exit
```

