### PR TITLE
[SPARK-39980][INFRA] Change infra image to static tag: `ubuntu:focal-20220801`

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -16,7 +16,8 @@
 #
 
 # Image for building and testing Spark branches. Based on Ubuntu 20.04.
-FROM ubuntu:20.04
+# See also in https://hub.docker.com/_/ubuntu
+FROM ubuntu:focal-20220801
 
 ENV FULL_REFRESH_DATE 20220706
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change infra image to static tag: ubuntu:focal-20220801 (current latest 20.04). This patch don't bring any real change on image because ubuntu:20.04 and ubuntu:focal-20220801 are point to same hash at current time.

```shell
$ docker run -ti ubuntu:focal-20220801 bash
Digest: sha256:af5efa9c28de78b754777af9b4d850112cad01899a5d37d2617bb94dc63a49aa
Status: Downloaded newer image for ubuntu:focal-20220801

$ docker run -ti ubuntu:20.04 bash
Digest: sha256:af5efa9c28de78b754777af9b4d850112cad01899a5d37d2617bb94dc63a49aa
Status: Downloaded newer image for ubuntu:20.04
```

### Why are the changes needed?
- The `ubuntu:20.04` is not a static tag, it is for ubuntu latest 20.04 version, Ubuntu upgrades the version [every 1-2 months](https://github.com/docker-library/official-images/commits/master/library/ubuntu).
- If we don't pin the ubuntu version to specific static tag, once the ubuntu upgrade the version, the image cache will be outdate. Then the infra image of CI job will do full refresh, it makes CI unstable just like SPARK-39831 .

So, we need a planned upgrade of Ubuntu in infra to aovid unstable.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
