### PR TITLE
[SPARK-39866][SQL] Memory leak when closing a session of Spark ThriftServer

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileStatusCache.scala
@@ -37,7 +37,7 @@ import org.apache.spark.util.SizeEstimator
 object FileStatusCache {
   private var sharedCache: SharedInMemoryCache = _
 
-  private[spark] val sessionToCache = new mutable.HashMap[String, FileStatusCache]
+  private[spark] val sessionToCache = new mutable.HashMap[String, Seq[FileStatusCache]]
 
   /**
    * @return a new FileStatusCache based on session configuration. Cache memory quota is
@@ -53,7 +53,10 @@ object FileStatusCache {
         )
       }
       val fileStatusCache = sharedCache.createForNewClient()
-      sessionToCache.put(session.sessionUUID, fileStatusCache)
+
+      sessionToCache.put(session.sessionUUID,
+        sessionToCache.getOrElse(session.sessionUUID, Seq.empty[FileStatusCache])
+          ++ Seq(fileStatusCache))
       fileStatusCache
     } else {
       NoopCache

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -371,7 +371,7 @@ abstract class BaseSessionStateBuilder(
       createClone,
       columnarRules,
       adaptiveRulesHolder,
-      Some(this))
+      session.sessionUUID)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/BaseSessionStateBuilder.scala
@@ -370,7 +370,8 @@ abstract class BaseSessionStateBuilder(
       createQueryExecution,
       createClone,
       columnarRules,
-      adaptiveRulesHolder)
+      adaptiveRulesHolder,
+      Some(this))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -127,7 +127,7 @@ private[sql] class SessionState(
     createQueryExecution(plan, mode)
 
   def closeState(): Unit = {
-    val cache = FileStatusCache.sessionToCache.get(sessionUUID)
+    val cache = FileStatusCache.sessionToCache.remove(sessionUUID)
     cache.foreach(_.invalidateAll())
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala
@@ -128,7 +128,7 @@ private[sql] class SessionState(
 
   def closeState(): Unit = {
     val cache = FileStatusCache.sessionToCache.remove(sessionUUID)
-    cache.foreach(_.invalidateAll())
+    cache.foreach(_.foreach(_.invalidateAll()))
   }
 }
 

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -88,6 +88,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
     HiveThriftServer2.eventManager.onSessionClosed(sessionHandle.getSessionId.toString)
     val ctx = sparkSqlOperationManager.sessionToContexts.getOrDefault(sessionHandle, sqlContext)
     ctx.sparkSession.sessionState.catalog.getTempViewNames().foreach(ctx.uncacheTable)
+    ctx.sparkSession.sessionState.closeSession()
     super.closeSession(sessionHandle)
     sparkSqlOperationManager.sessionToContexts.remove(sessionHandle)
   }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLSessionManager.scala
@@ -88,7 +88,7 @@ private[hive] class SparkSQLSessionManager(hiveServer: HiveServer2, sqlContext: 
     HiveThriftServer2.eventManager.onSessionClosed(sessionHandle.getSessionId.toString)
     val ctx = sparkSqlOperationManager.sessionToContexts.getOrDefault(sessionHandle, sqlContext)
     ctx.sparkSession.sessionState.catalog.getTempViewNames().foreach(ctx.uncacheTable)
-    ctx.sparkSession.sessionState.closeSession()
+    ctx.sparkSession.sessionState.closeState()
     super.closeSession(sessionHandle)
     sparkSqlOperationManager.sessionToContexts.remove(sessionHandle)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixed memory leak caused by not clearing the FileStatusCache created by calling FileStatusCache.getOrCreate when close a SparkSession of Spark Thrift Server.

### Why are the changes needed?
When create many sessions in Spark Thrift Server and do querys in each session, the fileStatus of files related will be cached.
But these filestatus will not be cleared when these sessions are closed, the memory leak causes Driver OOM.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested by the steps in SPARK-39866.