### PR TITLE
[SPARK-39921][SQL] SkewJoin--Stream side skew in BroadcastHashJoin

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeShuffleWithLocalRead.scala
@@ -122,7 +122,7 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
 
   object BroadcastJoinWithShuffleLeft {
     def unapply(plan: SparkPlan): Option[(SparkPlan, BuildSide)] = plan match {
-      case join: BroadcastHashJoinExec if canUseLocalShuffleRead(join.left) =>
+      case join: BroadcastHashJoinExec if !join.isSkewJoin && canUseLocalShuffleRead(join.left) =>
         Some((join.left, join.buildSide))
       case _ => None
     }
@@ -130,7 +130,7 @@ object OptimizeShuffleWithLocalRead extends AQEShuffleReadRule {
 
   object BroadcastJoinWithShuffleRight {
     def unapply(plan: SparkPlan): Option[(SparkPlan, BuildSide)] = plan match {
-      case join: BroadcastHashJoinExec if canUseLocalShuffleRead(join.right) =>
+      case join: BroadcastHashJoinExec if !join.isSkewJoin && canUseLocalShuffleRead(join.right) =>
         Some((join.right, join.buildSide))
       case _ => None
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewedJoin.scala
@@ -248,7 +248,7 @@ case class OptimizeSkewedJoin(ensureRequirements: EnsureRequirements)
     }
     logDebug(s"number of skewed partitions: stream $numSkewedChild")
     if (numSkewedChild > 0) {
-      Some(SkewJoinChildWrapper(AQEShuffleReadExec(child, childSidePartitions)))
+      Some(SkewJoinChildWrapper(AQEShuffleReadExec(child, childSidePartitions.toSeq)))
     } else {
       None
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/PlanAdaptiveDynamicPruningFilters.scala
@@ -49,9 +49,9 @@ case class PlanAdaptiveDynamicPruningFilters(
 
         val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           find(rootPlan) {
-            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _, _) =>
               left.sameResult(exchange)
-            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _, _) =>
               right.sameResult(exchange)
             case _ => false
           }.isDefined

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/simpleCosting.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.execution.adaptive
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
-import org.apache.spark.sql.execution.joins.ShuffledJoin
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledJoin}
 
 /**
  * A simple implementation of [[Cost]], which takes a number of [[Long]] as the cost value.
@@ -48,6 +48,7 @@ case class SimpleCostEvaluator(forceOptimizeSkewedJoin: Boolean) extends CostEva
     if (forceOptimizeSkewedJoin) {
       val numSkewJoins = plan.collect {
         case j: ShuffledJoin if j.isSkewJoin => j
+        case j: BroadcastHashJoinExec if j.isSkewJoin => j
       }.size
       // We put `-numSkewJoins` in the first 32 bits of the long value, so that it's compared first
       // when comparing the cost, and larger `numSkewJoins` means lower cost.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PlanDynamicPruningFilters.scala
@@ -58,9 +58,9 @@ case class PlanDynamicPruningFilters(sparkSession: SparkSession) extends Rule[Sp
         // the first to be applied (apart from `InsertAdaptiveSparkPlan`).
         val canReuseExchange = conf.exchangeReuseEnabled && buildKeys.nonEmpty &&
           plan.exists {
-            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildLeft, _, left, _, _, _) =>
               left.sameResult(sparkPlan)
-            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _) =>
+            case BroadcastHashJoinExec(_, _, _, BuildRight, _, _, right, _, _) =>
               right.sameResult(sparkPlan)
             case _ => false
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/BroadcastHashJoinExec.scala
@@ -45,7 +45,8 @@ case class BroadcastHashJoinExec(
     condition: Option[Expression],
     left: SparkPlan,
     right: SparkPlan,
-    isNullAwareAntiJoin: Boolean = false)
+    isNullAwareAntiJoin: Boolean = false,
+    isSkewJoin: Boolean = false)
   extends HashJoin {
 
   if (isNullAwareAntiJoin) {
@@ -55,6 +56,13 @@ case class BroadcastHashJoinExec(
     require(buildSide == BuildRight, "buildSide must be BuildRight.")
     require(condition.isEmpty, "null aware anti join optimize condition should be empty.")
   }
+
+  /**
+   * Returns the name of this type of TreeNode.  Defaults to the class name.
+   * Note that we remove the "Exec" suffix for physical operators here.
+   */
+  override def nodeName: String =
+    if (isSkewJoin) super.nodeName + "(skew=true)" else super.nodeName
 
   override lazy val metrics = Map(
     "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -345,7 +345,7 @@ abstract class DynamicPartitionPruningSuiteBase
        """.stripMargin)
 
       val found = df.queryExecution.executedPlan.exists {
-        case BroadcastHashJoinExec(_, _, p: ExistenceJoin, _, _, _, _, _) => true
+        case BroadcastHashJoinExec(_, _, p: ExistenceJoin, _, _, _, _, _, _) => true
         case _ => false
       }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -701,8 +701,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
       val distinctWithId = baseTable.distinct().withColumn("id", monotonically_increasing_id())
         .join(baseTable, "idx")
       assert(distinctWithId.queryExecution.executedPlan.exists {
-        case WholeStageCodegenExec(
-          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
+        case WholeStageCodegenExec(ProjectExec(_,
+        BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _, _))) => true
         case _ => false
       })
       checkAnswer(distinctWithId, Seq(Row(1, 0), Row(1, 0)))
@@ -713,8 +713,8 @@ class WholeStageCodegenSuite extends QueryTest with SharedSparkSession
         baseTable.groupBy("idx").sum().withColumn("id", monotonically_increasing_id())
         .join(baseTable, "idx")
       assert(groupByWithId.queryExecution.executedPlan.exists {
-        case WholeStageCodegenExec(
-          ProjectExec(_, BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _))) => true
+        case WholeStageCodegenExec(ProjectExec(_,
+        BroadcastHashJoinExec(_, _, _, _, _, _: HashAggregateExec, _, _, _))) => true
         case _ => false
       })
       checkAnswer(groupByWithId, Seq(Row(1, 2, 0), Row(1, 2, 0)))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2231,6 +2231,75 @@ class AdaptiveQueryExecSuite
     }
   }
 
+  test("SPARK-39921: Support optimize skew broadcast join even if introduce extra shuffle") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.ADAPTIVE_OPTIMIZE_SKEWS_IN_REBALANCE_PARTITIONS_ENABLED.key -> "false",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.ADAPTIVE_AUTO_BROADCASTJOIN_THRESHOLD.key -> "10M",
+      SQLConf.SKEW_JOIN_SKEWED_PARTITION_THRESHOLD.key -> "100",
+      SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key -> "100",
+      SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_NUM.key -> "1",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "10",
+      SQLConf.ADAPTIVE_FORCE_OPTIMIZE_SKEWED_JOIN.key -> "true") {
+      withTempView("skewData1", "skewData2") {
+        spark
+            .range(0, 1000, 1, 10)
+            .selectExpr("id % 3 as key1", "id as value1")
+            .createOrReplaceTempView("skewData1")
+        spark
+            .range(0, 1000, 1, 10)
+            .selectExpr("id % 1 as key2", "id as value2")
+            .createOrReplaceTempView("skewData2")
+
+        // check if optimized skewed join does not satisfy the required distribution
+        Seq(true, false).foreach { hasRequiredDistribution =>
+          Seq(true, false).foreach { hasPartitionNumber =>
+            val repartition = if (hasRequiredDistribution) {
+              s"/*+ repartition(${ if (hasPartitionNumber) "10," else ""}key1) */"
+            } else {
+              ""
+            }
+
+            // check required distribution and extra shuffle
+            val (_, adaptive1) =
+              runAdaptiveAndVerifyResult(s"SELECT $repartition key1 FROM skewData1 " +
+                  s"JOIN skewData2 ON key1 = key2 GROUP BY key1")
+            val shuffles1 = collect(adaptive1) {
+              case s: ShuffleExchangeExec => s
+            }
+            assert(shuffles1.size == 3)
+            // shuffles1.head is the top-level shuffle under the Aggregate operator
+            assert(shuffles1.head.shuffleOrigin == ENSURE_REQUIREMENTS)
+            val bhj1 = findTopLevelBroadcastHashJoin(adaptive1)
+            assert(bhj1.size == 1 && bhj1.head.isSkewJoin)
+
+            // only check required distribution
+            val (_, adaptive2) =
+              runAdaptiveAndVerifyResult(s"SELECT $repartition key1 FROM skewData1 " +
+                  s"JOIN skewData2 ON key1 = key2")
+            val shuffles2 = collect(adaptive2) {
+              case s: ShuffleExchangeExec => s
+            }
+            if (hasRequiredDistribution) {
+              assert(shuffles2.size == 3)
+              val finalShuffle = shuffles2.head
+              if (hasPartitionNumber) {
+                assert(finalShuffle.shuffleOrigin == REPARTITION_BY_NUM)
+              } else {
+                assert(finalShuffle.shuffleOrigin == REPARTITION_BY_COL)
+              }
+            } else {
+              assert(shuffles2.size == 2)
+            }
+            val bhj2 = findTopLevelBroadcastHashJoin(adaptive2)
+            assert(bhj2.size == 1 && bhj2.head.isSkewJoin)
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-35968: AQE coalescing should not produce too small partitions by default") {
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
       val (_, adaptive) =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Solve the data skew on the stream side in `BroadcastHashJoin`
- When data skew needs to introduce additional shuffle, support forcibly solve the data skew problem through `spark.sql.adaptive.forceOptimizeSkewedJoin`
- If data skew optimization is performed, `LocalShuffle` optimization will not be performed, otherwise the skew optimization will not take effect.

### Why are the changes needed?
In the actual production environment, data skew will slow down the task execution time
![1](https://user-images.githubusercontent.com/61445191/182834709-643a50f1-e600-4c7e-bebc-4266ce759c7c.png)
![2](https://user-images.githubusercontent.com/61445191/182834753-d82ebd80-3901-4269-92f4-d03753e38a58.png)
After solving the data skew
![4](https://user-images.githubusercontent.com/61445191/182834804-ea3353a5-41fe-4653-b108-b7f66987611a.png)
![3](https://user-images.githubusercontent.com/61445191/182834817-a2c28eab-d1ee-4521-aa61-f0f599c1b6f8.png)

### How was this patch tested?
UTs