### PR TITLE
[SPARK-39982][DOC] Add doc string to StructType.fromJson

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -821,9 +821,9 @@ class StructType(DataType):
         Parameters
         ----------
         json : dict or a dict-like object e.g. json object
-             This "dict" must have "fields" key that returns an array of fields each of which must have
-             specific keys (name, type, nullable, metadata). Below is a json schema it must
-             adhere to:
+             This "dict" must have "fields" key that returns an array of fields
+             each of which must have specific keys (name, type, nullable, metadata).
+             Below is a json schema it must adhere to:
              {
                "title":"StructType",
                "description":"Schema of StructType in json format",
@@ -840,8 +840,8 @@ class StructType(DataType):
                                "type":"string"
                             },
                             "type":{
-                               "description":
-                               "Type of the field. Can be either another nested StructType or a primitive type",
+                               "description": "Type of the field. Can either be
+                                               another nested StructType or primitive type",
                                "type":"object/string"
                             },
                             "nullable":{
@@ -904,7 +904,6 @@ class StructType(DataType):
         >>> scheme = StructType.fromJson(json.loads(json_str))
         >>> scheme.simpleString()
         'struct<Person:struct<name:string,surname:string>>'
-
         """
         return StructType([StructField.fromJson(f) for f in json["fields"]])
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -829,7 +829,7 @@ class StructType(DataType):
         Examples
         --------
         >>> json_str = '''
-        >>>  {
+        ...  {
         ...      "fields": [
         ...          {
         ...              "metadata": {},
@@ -857,11 +857,10 @@ class StructType(DataType):
         ...      "type": "struct"
         ...  }
         ...  '''
-
         >>> import json
         >>> scheme = StructType.fromJson(json.loads(json_str))
-        >>> print(scheme.simpleString())
-        struct<Person:struct<name:string,surname:string>>
+        >>> scheme.simpleString()
+        'struct<Person:struct<name:string,surname:string>>'
 
         """
         return StructType([StructField.fromJson(f) for f in json["fields"]])

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -815,6 +815,55 @@ class StructType(DataType):
 
     @classmethod
     def fromJson(cls, json: Dict[str, Any]) -> "StructType":
+        """
+        Constructs StructType from a scheme defined in json format
+
+        Parameters
+        ----------
+        json : Dict of str/any or a dict like object e.g. json object
+
+        Returns
+        -------
+        :class:`StructType`
+
+        Examples
+        --------
+        >>> json_str = """
+        >>>  {
+        >>>      "fields": [
+        >>>          {
+        >>>              "metadata": {},
+        >>>              "name": "Person",
+        >>>              "nullable": true,
+        >>>              "type": {
+        >>>                  "fields": [
+        >>>                      {
+        >>>                          "metadata": {},
+        >>>                          "name": "name",
+        >>>                          "nullable": false,
+        >>>                          "type": "string"
+        >>>                      },
+        >>>                      {
+        >>>                          "metadata": {},
+        >>>                          "name": "surname",
+        >>>                          "nullable": false,
+        >>>                          "type": "string"
+        >>>                      }
+        >>>                  ],
+        >>>                  "type": "struct"
+        >>>              }
+        >>>          }
+        >>>      ],
+        >>>      "type": "struct"
+        >>>  }
+        >>>  """
+
+        >>> import json
+        >>> scheme = StructType.fromJson(json.loads(json_str))
+        >>> print(scheme.simpleString())
+        struct<Person:struct<name:string,surname:string>>
+
+        """
         return StructType([StructField.fromJson(f) for f in json["fields"]])
 
     def fieldNames(self) -> List[str]:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -828,35 +828,35 @@ class StructType(DataType):
 
         Examples
         --------
-        >>> json_str = """
+        >>> json_str = '''
         >>>  {
-        >>>      "fields": [
-        >>>          {
-        >>>              "metadata": {},
-        >>>              "name": "Person",
-        >>>              "nullable": true,
-        >>>              "type": {
-        >>>                  "fields": [
-        >>>                      {
-        >>>                          "metadata": {},
-        >>>                          "name": "name",
-        >>>                          "nullable": false,
-        >>>                          "type": "string"
-        >>>                      },
-        >>>                      {
-        >>>                          "metadata": {},
-        >>>                          "name": "surname",
-        >>>                          "nullable": false,
-        >>>                          "type": "string"
-        >>>                      }
-        >>>                  ],
-        >>>                  "type": "struct"
-        >>>              }
-        >>>          }
-        >>>      ],
-        >>>      "type": "struct"
-        >>>  }
-        >>>  """
+        ...      "fields": [
+        ...          {
+        ...              "metadata": {},
+        ...              "name": "Person",
+        ...              "nullable": true,
+        ...              "type": {
+        ...                  "fields": [
+        ...                      {
+        ...                          "metadata": {},
+        ...                          "name": "name",
+        ...                          "nullable": false,
+        ...                          "type": "string"
+        ...                      },
+        ...                      {
+        ...                          "metadata": {},
+        ...                          "name": "surname",
+        ...                          "nullable": false,
+        ...                          "type": "string"
+        ...                      }
+        ...                  ],
+        ...                  "type": "struct"
+        ...              }
+        ...          }
+        ...      ],
+        ...      "type": "struct"
+        ...  }
+        ...  '''
 
         >>> import json
         >>> scheme = StructType.fromJson(json.loads(json_str))

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -816,7 +816,7 @@ class StructType(DataType):
     @classmethod
     def fromJson(cls, json: Dict[str, Any]) -> "StructType":
         """
-        Constructs :class`StructType` from a schema defined in JSON format.
+        Constructs :class:`StructType` from a schema defined in JSON format.
 
         Below is a JSON schema it must adhere to::
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -816,54 +816,55 @@ class StructType(DataType):
     @classmethod
     def fromJson(cls, json: Dict[str, Any]) -> "StructType":
         """
-        Constructs :class`StructType` from a schema defined in JSON format
+        Constructs :class`StructType` from a schema defined in JSON format.
+
+        Below is a JSON schema it must adhere to::
+
+            {
+              "title":"StructType",
+              "description":"Schema of StructType in json format",
+              "type":"object",
+              "properties":{
+                 "fields":{
+                    "description":"Array of struct fields",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "properties":{
+                           "name":{
+                              "description":"Name of the field",
+                              "type":"string"
+                           },
+                           "type":{
+                              "description": "Type of the field. Can either be
+                                              another nested StructType or primitive type",
+                              "type":"object/string"
+                           },
+                           "nullable":{
+                              "description":"If nulls are allowed",
+                              "type":"boolean"
+                           },
+                           "metadata":{
+                              "description":"Additional metadata to supply",
+                              "type":"object"
+                           },
+                           "required":[
+                              "name",
+                              "type",
+                              "nullable",
+                              "metadata"
+                           ]
+                        }
+                   }
+                }
+             }
+           }
 
         Parameters
         ----------
         json : dict or a dict-like object e.g. JSON object
-             This "dict" must have "fields" key that returns an array of fields
-             each of which must have specific keys (name, type, nullable, metadata).
-             Below is a JSON schema it must adhere to:
-             {
-               "title":"StructType",
-               "description":"Schema of StructType in json format",
-               "type":"object",
-               "properties":{
-                  "fields":{
-                     "description":"Array of struct fields",
-                     "type":"array",
-                     "items":{
-                         "type":"object",
-                         "properties":{
-                            "name":{
-                               "description":"Name of the field",
-                               "type":"string"
-                            },
-                            "type":{
-                               "description": "Type of the field. Can either be
-                                               another nested StructType or primitive type",
-                               "type":"object/string"
-                            },
-                            "nullable":{
-                               "description":"If nulls are allowed",
-                               "type":"boolean"
-                            },
-                            "metadata":{
-                               "description":"Additional metadata to supply",
-                               "type":"object"
-                            },
-                            "required":[
-                               "name",
-                               "type",
-                               "nullable",
-                               "metadata"
-                            ]
-                         }
-                    }
-                 }
-              }
-            }
-
+            This "dict" must have "fields" key that returns an array of fields
+            each of which must have specific keys (name, type, nullable, metadata).
 
         Returns
         -------

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -816,14 +816,14 @@ class StructType(DataType):
     @classmethod
     def fromJson(cls, json: Dict[str, Any]) -> "StructType":
         """
-        Constructs :class`StructType` from a schema defined in json format
+        Constructs :class`StructType` from a schema defined in JSON format
 
         Parameters
         ----------
-        json : dict or a dict-like object e.g. json object
+        json : dict or a dict-like object e.g. JSON object
              This "dict" must have "fields" key that returns an array of fields
              each of which must have specific keys (name, type, nullable, metadata).
-             Below is a json schema it must adhere to:
+             Below is a JSON schema it must adhere to:
              {
                "title":"StructType",
                "description":"Schema of StructType in json format",

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -816,11 +816,54 @@ class StructType(DataType):
     @classmethod
     def fromJson(cls, json: Dict[str, Any]) -> "StructType":
         """
-        Constructs StructType from a scheme defined in json format
+        Constructs :class`StructType` from a schema defined in json format
 
         Parameters
         ----------
-        json : Dict of str/any or a dict like object e.g. json object
+        json : dict or a dict-like object e.g. json object
+             This "dict" must have "fields" key that returns an array of fields each of which must have
+             specific keys (name, type, nullable, metadata). Below is a json schema it must
+             adhere to:
+             {
+               "title":"StructType",
+               "description":"Schema of StructType in json format",
+               "type":"object",
+               "properties":{
+                  "fields":{
+                     "description":"Array of struct fields",
+                     "type":"array",
+                     "items":{
+                         "type":"object",
+                         "properties":{
+                            "name":{
+                               "description":"Name of the field",
+                               "type":"string"
+                            },
+                            "type":{
+                               "description":
+                               "Type of the field. Can be either another nested StructType or a primitive type",
+                               "type":"object/string"
+                            },
+                            "nullable":{
+                               "description":"If nulls are allowed",
+                               "type":"boolean"
+                            },
+                            "metadata":{
+                               "description":"Additional metadata to supply",
+                               "type":"object"
+                            },
+                            "required":[
+                               "name",
+                               "type",
+                               "nullable",
+                               "metadata"
+                            ]
+                         }
+                    }
+                 }
+              }
+            }
+
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?

Documentation provided for StructType.fromJson method


### Why are the changes needed?

To make it easy for a user to understand this method and use it. It was inspired by [this SO question](https://stackoverflow.com/questions/73233593/pyspark-typeerror-col-should-be-column/73235143)


### Does this PR introduce _any_ user-facing change?
Yes, adding missing documentation

### How was this patch tested?
Unit tests