### PR TITLE
[SPARK-39984][CORE] Check workerLastHeartbeat with master before HeartbeatReceiver expires an executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -274,10 +274,8 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   }
 
   private def isStandalone(): Boolean = {
-    sc.schedulerBackend match {
-      case backend: StandaloneSchedulerBackend => true
-      case _ => false
-    }
+    sc.schedulerBackend.isInstanceOf[StandaloneSchedulerBackend]
+  }
   }
 
   private def removeExecutorFromExpiryCandidates(executorId: String): Unit = {

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -102,7 +102,12 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
 
   private val executorTimeoutMs = sc.conf.get(
     config.STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT
-  ).getOrElse(Utils.timeStringAsMs(s"${sc.conf.get(Network.NETWORK_EXECUTOR_TIMEOUT)}s"))
+  ).getOrElse(
+    sc.conf.get(Network.NETWORK_EXECUTOR_TIMEOUT) match {
+      case Some(executorTimeout) => Utils.timeStringAsMs(s"${executorTimeout}s")
+      case None => Utils.timeStringAsMs(s"${sc.conf.get(Network.NETWORK_TIMEOUT)}s")
+    }
+  )
 
   private val checkTimeoutIntervalMs = sc.conf.get(Network.NETWORK_TIMEOUT_INTERVAL)
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -104,7 +104,7 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
     config.STORAGE_BLOCKMANAGER_HEARTBEAT_TIMEOUT
   ).getOrElse(
     sc.conf.get(Network.NETWORK_EXECUTOR_TIMEOUT) match {
-      case Some(executorTimeout) => Utils.timeStringAsMs(s"${executorTimeout}s")
+      case Some(executorTimeout) => executorTimeout
       case None => Utils.timeStringAsMs(s"${sc.conf.get(Network.NETWORK_TIMEOUT)}s")
     }
   )

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -121,10 +121,8 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
    */
   private val checkWorkerLastHeartbeat = sc.conf.get(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT)
   private val expiryCandidatesTimeout = checkWorkerLastHeartbeat match {
-    case true =>
-      sc.conf.get(Network.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT)
-        .getOrElse(Utils.timeStringAsMs("30s"))
-    case false => Utils.timeStringAsMs("0s")
+    case true => sc.conf.get(Network.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT)
+    case false => 0
   }
 
   require(checkTimeoutIntervalMs <= executorTimeoutMs,

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -276,7 +276,6 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   private def isStandalone(): Boolean = {
     sc.schedulerBackend.isInstanceOf[StandaloneSchedulerBackend]
   }
-  }
 
   private def removeExecutorFromExpiryCandidates(executorId: String): Unit = {
     if (checkWorkerLastHeartbeat && isStandalone()) {

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -119,16 +119,15 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
    * `checkWorkerLastHeartbeat`: A flag to enable two-phase executor timeout.
    * `expiryCandidatesTimeout`: The timeout used for executorExpiryCandidates.
    */
-  private val checkWorkerLastHeartbeat = {
-    val isEnabled = sc.conf.get(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT)
-    if (isEnabled) logWarning(s"Keep `expiryCandidatesTimeout` larger than `HEARTBEAT_MILLIS` in" +
-      s"deploy/worker/Worker.scala to know whether master lost any heartbeat from the" +
-      s"worker or not.")
-    isEnabled
-  }
+  private val checkWorkerLastHeartbeat =
+    sc.conf.get(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT)
 
   private val expiryCandidatesTimeout = checkWorkerLastHeartbeat match {
-    case true => sc.conf.get(config.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT)
+    case true =>
+      logWarning(s"Worker heartbeat check is enabled. It only works normally when" +
+        s"${config.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT.key} is larger than worker's" +
+        s"heartbeat interval.")
+      sc.conf.get(config.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT)
     case false => 0
   }
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 
 import org.apache.spark.executor.ExecutorMetrics
 import org.apache.spark.internal.{config, Logging}
-import org.apache.spark.internal.config.{HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, Network}
+import org.apache.spark.internal.config.Network
 import org.apache.spark.rpc.{RpcCallContext, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, StandaloneSchedulerBackend}
@@ -119,9 +119,10 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
    * `checkWorkerLastHeartbeat`: A flag to enable two-phase executor timeout.
    * `expiryCandidatesTimeout`: The timeout used for executorExpiryCandidates.
    */
-  private val checkWorkerLastHeartbeat = sc.conf.get(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT)
+  private val checkWorkerLastHeartbeat = sc.conf
+    .get(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT)
   private val expiryCandidatesTimeout = checkWorkerLastHeartbeat match {
-    case true => sc.conf.get(Network.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT)
+    case true => sc.conf.get(config.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT)
     case false => 0
   }
 

--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -336,7 +336,7 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
             case Some(workerLastHeartbeats) =>
               for ((executorId, workerLastHeartbeat) <- buf zip workerLastHeartbeats) {
                 if (now - workerLastHeartbeat > expiryCandidatesTimeout) {
-                  val lastSeenMs = executorLastSeen.get(executorId).get
+                  val lastSeenMs = executorLastSeen(executorId)
                   killExecutor(executorId, now - lastSeenMs)
                   executorExpiryCandidates.remove(executorId)
                 } else {
@@ -346,7 +346,7 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
               }
             case None =>
               for (executorId <- buf) {
-                val lastSeenMs = executorLastSeen.get(executorId).get
+                val lastSeenMs = executorLastSeen(executorId)
                 killExecutor(executorId, now - lastSeenMs)
                 executorLastSeen.remove(executorId)
                 executorExpiryCandidates.remove(executorId)

--- a/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/DeployMessage.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy
 
 import scala.collection.immutable.List
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.deploy.ExecutorState.ExecutorState
 import org.apache.spark.deploy.master.{ApplicationInfo, DriverInfo, WorkerInfo}
@@ -137,6 +138,7 @@ private[deploy] object DeployMessages {
    */
   case class DecommissionWorkersOnHosts(hostnames: Seq[String])
 
+  case class WorkerLastHeartbeat(appId: String, executorFullIds: ArrayBuffer[String])
   // Master to Worker
 
   sealed trait RegisterWorkerResponse

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -64,7 +64,7 @@ private[spark] object Network {
         "[SPARK-39984] for more details")
       .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createOptional
+      .createWithDefaultString("30s")
 
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -54,8 +54,8 @@ private[spark] object Network {
   private[spark] val NETWORK_EXECUTOR_TIMEOUT =
     ConfigBuilder("spark.network.executorTimeout")
       .version("3.4.0")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("60s")
+      .timeConf(TimeUnit.SECONDS)
+      .createOptional
 
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -54,7 +54,7 @@ private[spark] object Network {
   private[spark] val NETWORK_EXECUTOR_TIMEOUT =
     ConfigBuilder("spark.network.executorTimeout")
       .version("3.4.0")
-      .timeConf(TimeUnit.SECONDS)
+      .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
   private[spark] val HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT =

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -53,7 +53,7 @@ private[spark] object Network {
 
   private[spark] val NETWORK_EXECUTOR_TIMEOUT =
     ConfigBuilder("spark.network.executorTimeout")
-      .version("1.3.0")
+      .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("60s")
 

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -57,15 +57,6 @@ private[spark] object Network {
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
 
-  private[spark] val HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT =
-    ConfigBuilder("spark.network.expiryCandidatesTimeout")
-      .doc("This config is a timeout used for heartbeat receiver `executorExpiryCandidates`. Be" +
-        "effective only when HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT is enabled. See" +
-        "[SPARK-39984] for more details")
-      .version("3.4.0")
-      .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("30s")
-
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")
       .version("1.4.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -57,11 +57,11 @@ private[spark] object Network {
       .timeConf(TimeUnit.SECONDS)
       .createOptional
 
-  private[spark] val HEARTBEAT_WAITINGLIST_TIMEOUT =
-    ConfigBuilder("spark.network.waitingListTimeout")
-      .doc("This config is a timeout used for heartbeat receiver waitingList. Be effective" +
-        "only when HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT is enabled. See [SPARK-39984]" +
-        "for more details")
+  private[spark] val HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT =
+    ConfigBuilder("spark.network.expiryCandidatesTimeout")
+      .doc("This config is a timeout used for heartbeat receiver `executorExpiryCandidates`. Be" +
+        "effective only when HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT is enabled. See" +
+        "[SPARK-39984] for more details")
       .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -49,7 +49,7 @@ private[spark] object Network {
     ConfigBuilder("spark.network.timeoutInterval")
       .version("1.3.2")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("15s")
+      .createWithDefaultString(STORAGE_BLOCKMANAGER_TIMEOUTINTERVAL.defaultValueString)
 
   private[spark] val NETWORK_EXECUTOR_TIMEOUT =
     ConfigBuilder("spark.network.executorTimeout")

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -57,6 +57,15 @@ private[spark] object Network {
       .timeConf(TimeUnit.SECONDS)
       .createOptional
 
+  private[spark] val HEARTBEAT_WAITINGLIST_TIMEOUT =
+    ConfigBuilder("spark.network.waitingListTimeout")
+      .doc("This config is a timeout used for heartbeat receiver waitingList. Be effective" +
+        "only when HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT is enabled. See [SPARK-39984]" +
+        "for more details")
+      .version("3.4.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createOptional
+
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")
       .version("1.4.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -49,13 +49,13 @@ private[spark] object Network {
     ConfigBuilder("spark.network.timeoutInterval")
       .version("1.3.2")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString(STORAGE_BLOCKMANAGER_TIMEOUTINTERVAL.defaultValueString)
+      .createWithDefaultString("15s")
 
   private[spark] val NETWORK_EXECUTOR_TIMEOUT =
     ConfigBuilder("spark.network.executorTimeout")
       .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createOptional
+      .createWithDefaultString("30s")
 
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")

--- a/core/src/main/scala/org/apache/spark/internal/config/Network.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Network.scala
@@ -49,7 +49,13 @@ private[spark] object Network {
     ConfigBuilder("spark.network.timeoutInterval")
       .version("1.3.2")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString(STORAGE_BLOCKMANAGER_TIMEOUTINTERVAL.defaultValueString)
+      .createWithDefaultString("15s")
+
+  private[spark] val NETWORK_EXECUTOR_TIMEOUT =
+    ConfigBuilder("spark.network.executorTimeout")
+      .version("1.3.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("60s")
 
   private[spark] val RPC_ASK_TIMEOUT =
     ConfigBuilder("spark.rpc.askTimeout")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2437,9 +2437,9 @@ package object config {
   private[spark] val HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT =
     ConfigBuilder("spark.driver.heartbeat.expiryCandidatesTimeout")
       .doc("This config is a timeout used for heartbeat receiver `executorExpiryCandidates`. Be" +
-        "effective only when HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT is enabled. See" +
-        "[SPARK-39984] for more details")
+        s"effective only when ${HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT.key} is enabled." +
+        "See [SPARK-39984] for more details")
       .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
-      .createWithDefaultString("30s")
+      .createWithDefaultString("90s")
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2425,6 +2425,10 @@ package object config {
 
   private[spark] val HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT =
     ConfigBuilder("spark.driver.heartbeat.checkWorkerLastHeartbeat")
+      .doc("If this config is set to true, heartbeat receiver will check worker's heartbeat when" +
+        "the receiver does not receive any heartbeat from an executor during a period. In" +
+        "addition, this config is only for standalone scheduler. See [SPARK-39984] for more" +
+        "details.")
       .internal()
       .version("3.4.0")
       .booleanConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2422,4 +2422,11 @@ package object config {
       .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
+
+  private[spark] val HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT =
+    ConfigBuilder("spark.driver.heartbeat.checkWorkerLastHeartbeat")
+      .internal()
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2428,5 +2428,5 @@ package object config {
       .internal()
       .version("3.4.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2429,4 +2429,13 @@ package object config {
       .version("3.4.0")
       .booleanConf
       .createWithDefault(false)
+
+  private[spark] val HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT =
+    ConfigBuilder("spark.driver.heartbeat.expiryCandidatesTimeout")
+      .doc("This config is a timeout used for heartbeat receiver `executorExpiryCandidates`. Be" +
+        "effective only when HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT is enabled. See" +
+        "[SPARK-39984] for more details")
+      .version("3.4.0")
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefaultString("30s")
 }

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -423,6 +423,7 @@ class HeartbeatReceiverSuite
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
       .set(Network.NETWORK_EXECUTOR_TIMEOUT.key, "50s")
+      .set(Network.NETWORK_TIMEOUT_INTERVAL.key, "15s")
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -32,7 +32,7 @@ import org.scalatest.concurrent.Eventually._
 import org.apache.spark.deploy.ApplicationDescription
 import org.apache.spark.deploy.client.{StandaloneAppClient, StandaloneAppClientListener}
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
-import org.apache.spark.internal.config.{DYN_ALLOCATION_TESTING, Network}
+import org.apache.spark.internal.config.{DYN_ALLOCATION_TESTING, HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, Network}
 import org.apache.spark.resource.{ResourceProfile, ResourceProfileManager}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler._
@@ -171,6 +171,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
+      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -230,6 +231,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
+      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -288,6 +290,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
+      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -351,6 +354,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
+      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)

--- a/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
+++ b/core/src/test/scala/org/apache/spark/HeartbeatReceiverSuite.scala
@@ -32,7 +32,8 @@ import org.scalatest.concurrent.Eventually._
 import org.apache.spark.deploy.ApplicationDescription
 import org.apache.spark.deploy.client.{StandaloneAppClient, StandaloneAppClientListener}
 import org.apache.spark.executor.{ExecutorMetrics, TaskMetrics}
-import org.apache.spark.internal.config.{DYN_ALLOCATION_TESTING, HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, Network}
+import org.apache.spark.internal.config
+import org.apache.spark.internal.config.{DYN_ALLOCATION_TESTING, Network}
 import org.apache.spark.resource.{ResourceProfile, ResourceProfileManager}
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpoint, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler._
@@ -174,7 +175,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
-      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
+      .set(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -235,7 +236,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
-      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
+      .set(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -295,7 +296,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
-      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
+      .set(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -365,7 +366,7 @@ class HeartbeatReceiverSuite
       .setMaster("local-cluster[1, 1, 1024]")
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
-      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
+      .set(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -420,7 +421,7 @@ class HeartbeatReceiverSuite
       .setAppName("test")
       .set(DYN_ALLOCATION_TESTING, true)
       .set(Network.NETWORK_TIMEOUT.key, "100s")
-      .set(Network.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT.key, "50s")
+      .set(config.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT.key, "50s")
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)
@@ -445,8 +446,8 @@ class HeartbeatReceiverSuite
       .set(DYN_ALLOCATION_TESTING, true)
       .set(Network.NETWORK_EXECUTOR_TIMEOUT.key, "50s")
       .set(Network.NETWORK_TIMEOUT_INTERVAL.key, "15s")
-      .set(Network.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT.key, "20s")
-      .set(HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
+      .set(config.HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT.key, "20s")
+      .set(config.HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT, true)
     sc = spy(new SparkContext(conf))
     scheduler = mock(classOf[TaskSchedulerImpl])
     when(sc.taskScheduler).thenReturn(scheduler)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to provide a method to lower the timeout. Our solution is to ask master for worker’s heartbeat when Driver does not receive heartbeat from executor for `TimeoutThreshold` seconds.

![Screen Shot 2022-08-01 at 6 10 56 PM](https://user-images.githubusercontent.com/20109646/182272331-2f972aa8-31c9-4c3e-8c88-b7cf2616fad8.png)

When Executor performs full GC, it cannot send any message during full GC. Next, Driver cannot receive heartbeat from Executor. Instead of removing the executor directly, driver will ask master for `workerLastHeartbeat`. Driver will determine whether it is network disconnection or other issues (e.g. GC) based on `workerLastHeartbeat`. If it is network disconnection, we will remove the executor. Otherwise, we will put the executor into `executorExpiryCandidates` rather than expiring it immediately.

[Note 1]
Worker will send heartbeats to Master every `(conf.get(WORKER_TIMEOUT) * 1000 / 4)` milliseconds. Check deploy/worker/Worker.scala for more details. It is good to keep `expiryCandidatesTimeout` larger than `(conf.get(WORKER_TIMEOUT) * 1000 / 4)` to know whether master lost any heartbeat from the worker or not.

[Note 2]
We can also use this method for other deployment methods, but not every deployment method schedules driver on master.

* Result
  * Milestone 4:
    * `HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT`: true 
    * `NETWORK_EXECUTOR_TIMEOUT` (TimeoutThreshold in the figures): 60s
    * `HEARTBEAT_EXPIRY_CANDIDATES_TIMEOUT`: 30s
    * `NETWORK_TIMEOUT_INTERVAL`: 15s
  * w/o Milestone 4 
    * `HEARTBEAT_RECEIVER_CHECK_WORKER_LAST_HEARTBEAT`: false 
    * `NETWORK_EXECUTOR_TIMEOUT` (TimeoutThreshold in the figures): 120s
    * `NETWORK_TIMEOUT_INTERVAL`: 60s
![Screen Shot 2022-08-01 at 6 54 51 PM](https://user-images.githubusercontent.com/20109646/182275086-474d7458-f2a8-473c-adb2-c13f5c942ea1.png)

### Why are the changes needed?
Currently, the driver’s HeartbeatReceiver will expire an executor if it does not receive any heartbeat from the executor for 120 seconds. However, 120 seconds is too long, but we will face other challenges when we try to lower the timeout threshold. To elaborate, when an executor is performing GC, it cannot reply any message.

![Screen Shot 2022-08-01 at 6 03 50 PM](https://user-images.githubusercontent.com/20109646/182269820-4802877d-a4e4-4d20-969d-6ece37ffdb55.png)

We will use the above figure to explain why we cannot lower `TimeoutThreshold` to 60 seconds directly. When Executor performs full GC, it cannot send any message, including heartbeat. Next, driver will remove the executor because driver cannot receive heartbeat from Executor for 60 seconds. In other words, we cannot distinguish between GC and network disconnection.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
```
build/sbt "core/testOnly *HeartbeatReceiverSuite"
build/sbt "core/testOnly *MasterSuite"
```
