### PR TITLE
[SPARK-39981][SQL] Throw the exception QueryExecutionErrors.castingCauseOverflowErrorInTableInsert in Cast

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -2371,7 +2371,7 @@ case class CheckOverflowInTableInsert(child: Cast, columnName: String) extends U
     child.eval(input)
   } catch {
     case e: SparkArithmeticException =>
-      QueryExecutionErrors.castingCauseOverflowErrorInTableInsert(
+      throw QueryExecutionErrors.castingCauseOverflowErrorInTableInsert(
         child.child.dataType,
         child.dataType,
         columnName)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/37283. It missed `throw` keyword in the interpreted path.

### Why are the changes needed?

To throw an exception as intended instead of returning an exception itself.

### Does this PR introduce _any_ user-facing change?

Yes, it will throw an exception as expected in the interpreted path.

### How was this patch tested?

Haven't tested because it's too much straightforward.