### PR TITLE
[SPARK-39988][CORE] Use `try-with-resource` to ensure `DBIterator` is close after use

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -457,18 +457,19 @@ public class ExternalShuffleBlockResolver {
       throws IOException {
     ConcurrentMap<AppExecId, ExecutorShuffleInfo> registeredExecutors = Maps.newConcurrentMap();
     if (db != null) {
-      DBIterator itr = db.iterator();
-      itr.seek(APP_KEY_PREFIX.getBytes(StandardCharsets.UTF_8));
-      while (itr.hasNext()) {
-        Map.Entry<byte[], byte[]> e = itr.next();
-        String key = new String(e.getKey(), StandardCharsets.UTF_8);
-        if (!key.startsWith(APP_KEY_PREFIX)) {
-          break;
+      try (DBIterator itr = db.iterator()) {
+        itr.seek(APP_KEY_PREFIX.getBytes(StandardCharsets.UTF_8));
+        while (itr.hasNext()) {
+          Map.Entry<byte[], byte[]> e = itr.next();
+          String key = new String(e.getKey(), StandardCharsets.UTF_8);
+          if (!key.startsWith(APP_KEY_PREFIX)) {
+            break;
+          }
+          AppExecId id = parseDbAppExecKey(key);
+          logger.info("Reloading registered executors: " +  id.toString());
+          ExecutorShuffleInfo shuffleInfo = mapper.readValue(e.getValue(), ExecutorShuffleInfo.class);
+          registeredExecutors.put(id, shuffleInfo);
         }
-        AppExecId id = parseDbAppExecKey(key);
-        logger.info("Reloading registered executors: " +  id.toString());
-        ExecutorShuffleInfo shuffleInfo = mapper.readValue(e.getValue(), ExecutorShuffleInfo.class);
-        registeredExecutors.put(id, shuffleInfo);
       }
     }
     return registeredExecutors;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalShuffleBlockResolver.java
@@ -467,7 +467,8 @@ public class ExternalShuffleBlockResolver {
           }
           AppExecId id = parseDbAppExecKey(key);
           logger.info("Reloading registered executors: " +  id.toString());
-          ExecutorShuffleInfo shuffleInfo = mapper.readValue(e.getValue(), ExecutorShuffleInfo.class);
+          ExecutorShuffleInfo shuffleInfo =
+            mapper.readValue(e.getValue(), ExecutorShuffleInfo.class);
           registeredExecutors.put(id, shuffleInfo);
         }
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -921,27 +921,27 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           AppPathsInfo appPathsInfo = mapper.readValue(entry.getValue(), AppPathsInfo.class);
           logger.debug("Reloading Application paths info for application {}", appAttemptId);
           appsShuffleInfo.compute(appAttemptId.appId,
-                  (appId, existingAppShuffleInfo) -> {
-                    if (existingAppShuffleInfo == null ||
-                            existingAppShuffleInfo.attemptId < appAttemptId.attemptId) {
-                      if (existingAppShuffleInfo != null) {
-                        AppAttemptId existingAppAttemptId = new AppAttemptId(
-                                existingAppShuffleInfo.appId, existingAppShuffleInfo.attemptId);
-                        try {
-                          // Add the former outdated DB key to deletion list
-                          dbKeysToBeRemoved.add(getDbAppAttemptPathsKey(existingAppAttemptId));
-                        } catch (IOException e) {
-                          logger.error("Failed to get the DB key for {}", existingAppAttemptId, e);
-                        }
-                      }
-                      return new AppShuffleInfo(
-                              appAttemptId.appId, appAttemptId.attemptId, appPathsInfo);
-                    } else {
-                      // Add the current DB key to deletion list as it is outdated
-                      dbKeysToBeRemoved.add(entry.getKey());
-                      return existingAppShuffleInfo;
+              (appId, existingAppShuffleInfo) -> {
+                if (existingAppShuffleInfo == null ||
+                    existingAppShuffleInfo.attemptId < appAttemptId.attemptId) {
+                  if (existingAppShuffleInfo != null) {
+                    AppAttemptId existingAppAttemptId = new AppAttemptId(
+                        existingAppShuffleInfo.appId, existingAppShuffleInfo.attemptId);
+                    try {
+                      // Add the former outdated DB key to deletion list
+                      dbKeysToBeRemoved.add(getDbAppAttemptPathsKey(existingAppAttemptId));
+                    } catch (IOException e) {
+                      logger.error("Failed to get the DB key for {}", existingAppAttemptId, e);
                     }
-                  });
+                  }
+                  return new AppShuffleInfo(
+                      appAttemptId.appId, appAttemptId.attemptId, appPathsInfo);
+                } else {
+                  // Add the current DB key to deletion list as it is outdated
+                  dbKeysToBeRemoved.add(entry.getKey());
+                  return existingAppShuffleInfo;
+                }
+          });
         }
       }
 
@@ -969,26 +969,26 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           AppShuffleInfo appShuffleInfo = appsShuffleInfo.get(partitionId.appId);
           if (appShuffleInfo != null && appShuffleInfo.attemptId == partitionId.attemptId) {
             appShuffleInfo.shuffles.compute(partitionId.shuffleId,
-                    (shuffleId, existingMergePartitionInfo) -> {
-                      if (existingMergePartitionInfo == null ||
-                              existingMergePartitionInfo.shuffleMergeId < partitionId.shuffleMergeId) {
-                        if (existingMergePartitionInfo != null) {
-                          AppAttemptShuffleMergeId appAttemptShuffleMergeId =
-                                  new AppAttemptShuffleMergeId(appShuffleInfo.appId, appShuffleInfo.attemptId,
-                                          shuffleId, existingMergePartitionInfo.shuffleMergeId);
-                          try{
-                            dbKeysToBeRemoved.add(
-                                    getDbAppAttemptShufflePartitionKey(appAttemptShuffleMergeId));
-                          } catch (Exception e) {
-                            logger.error("Error getting the DB key for {}", appAttemptShuffleMergeId, e);
-                          }
-                        }
-                        return new AppShuffleMergePartitionsInfo(partitionId.shuffleMergeId, true);
-                      } else {
-                        dbKeysToBeRemoved.add(entry.getKey());
-                        return existingMergePartitionInfo;
+                (shuffleId, existingMergePartitionInfo) -> {
+                  if (existingMergePartitionInfo == null ||
+                      existingMergePartitionInfo.shuffleMergeId < partitionId.shuffleMergeId) {
+                    if (existingMergePartitionInfo != null) {
+                      AppAttemptShuffleMergeId appAttemptShuffleMergeId =
+                          new AppAttemptShuffleMergeId(appShuffleInfo.appId, appShuffleInfo.attemptId,
+                              shuffleId, existingMergePartitionInfo.shuffleMergeId);
+                      try{
+                        dbKeysToBeRemoved.add(
+                            getDbAppAttemptShufflePartitionKey(appAttemptShuffleMergeId));
+                      } catch (Exception e) {
+                        logger.error("Error getting the DB key for {}", appAttemptShuffleMergeId, e);
                       }
-                    });
+                    }
+                    return new AppShuffleMergePartitionsInfo(partitionId.shuffleMergeId, true);
+                  } else {
+                    dbKeysToBeRemoved.add(entry.getKey());
+                    return existingMergePartitionInfo;
+                  }
+            });
           } else {
             dbKeysToBeRemoved.add(entry.getKey());
           }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -973,13 +973,15 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
                       existingMergePartitionInfo.shuffleMergeId < partitionId.shuffleMergeId) {
                     if (existingMergePartitionInfo != null) {
                       AppAttemptShuffleMergeId appAttemptShuffleMergeId =
-                          new AppAttemptShuffleMergeId(appShuffleInfo.appId, appShuffleInfo.attemptId,
+                          new AppAttemptShuffleMergeId(
+                              appShuffleInfo.appId, appShuffleInfo.attemptId,
                               shuffleId, existingMergePartitionInfo.shuffleMergeId);
                       try{
                         dbKeysToBeRemoved.add(
                             getDbAppAttemptShufflePartitionKey(appAttemptShuffleMergeId));
                       } catch (Exception e) {
-                        logger.error("Error getting the DB key for {}", appAttemptShuffleMergeId, e);
+                        logger.error("Error getting the DB key for {}",
+                            appAttemptShuffleMergeId, e);
                       }
                     }
                     return new AppShuffleMergePartitionsInfo(partitionId.shuffleMergeId, true);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -944,7 +944,6 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           });
         }
       }
-
     }
     return dbKeysToBeRemoved;
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -909,40 +909,42 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
   List<byte[]> reloadActiveAppAttemptsPathInfo(DB db) throws IOException {
     List<byte[]> dbKeysToBeRemoved = new ArrayList<>();
     if (db != null) {
-      DBIterator itr = db.iterator();
-      itr.seek(APP_ATTEMPT_PATH_KEY_PREFIX.getBytes(StandardCharsets.UTF_8));
-      while (itr.hasNext()) {
-        Map.Entry<byte[], byte[]> entry = itr.next();
-        String key = new String(entry.getKey(), StandardCharsets.UTF_8);
-        if (!key.startsWith(APP_ATTEMPT_PATH_KEY_PREFIX)) {
-          break;
+      try (DBIterator itr = db.iterator()) {
+        itr.seek(APP_ATTEMPT_PATH_KEY_PREFIX.getBytes(StandardCharsets.UTF_8));
+        while (itr.hasNext()) {
+          Map.Entry<byte[], byte[]> entry = itr.next();
+          String key = new String(entry.getKey(), StandardCharsets.UTF_8);
+          if (!key.startsWith(APP_ATTEMPT_PATH_KEY_PREFIX)) {
+            break;
+          }
+          AppAttemptId appAttemptId = parseDbAppAttemptPathsKey(key);
+          AppPathsInfo appPathsInfo = mapper.readValue(entry.getValue(), AppPathsInfo.class);
+          logger.debug("Reloading Application paths info for application {}", appAttemptId);
+          appsShuffleInfo.compute(appAttemptId.appId,
+                  (appId, existingAppShuffleInfo) -> {
+                    if (existingAppShuffleInfo == null ||
+                            existingAppShuffleInfo.attemptId < appAttemptId.attemptId) {
+                      if (existingAppShuffleInfo != null) {
+                        AppAttemptId existingAppAttemptId = new AppAttemptId(
+                                existingAppShuffleInfo.appId, existingAppShuffleInfo.attemptId);
+                        try {
+                          // Add the former outdated DB key to deletion list
+                          dbKeysToBeRemoved.add(getDbAppAttemptPathsKey(existingAppAttemptId));
+                        } catch (IOException e) {
+                          logger.error("Failed to get the DB key for {}", existingAppAttemptId, e);
+                        }
+                      }
+                      return new AppShuffleInfo(
+                              appAttemptId.appId, appAttemptId.attemptId, appPathsInfo);
+                    } else {
+                      // Add the current DB key to deletion list as it is outdated
+                      dbKeysToBeRemoved.add(entry.getKey());
+                      return existingAppShuffleInfo;
+                    }
+                  });
         }
-        AppAttemptId appAttemptId = parseDbAppAttemptPathsKey(key);
-        AppPathsInfo appPathsInfo = mapper.readValue(entry.getValue(), AppPathsInfo.class);
-        logger.debug("Reloading Application paths info for application {}", appAttemptId);
-        appsShuffleInfo.compute(appAttemptId.appId,
-            (appId, existingAppShuffleInfo) -> {
-              if (existingAppShuffleInfo == null ||
-                  existingAppShuffleInfo.attemptId < appAttemptId.attemptId) {
-                if (existingAppShuffleInfo != null) {
-                  AppAttemptId existingAppAttemptId = new AppAttemptId(
-                      existingAppShuffleInfo.appId, existingAppShuffleInfo.attemptId);
-                  try {
-                    // Add the former outdated DB key to deletion list
-                    dbKeysToBeRemoved.add(getDbAppAttemptPathsKey(existingAppAttemptId));
-                  } catch (IOException e) {
-                    logger.error("Failed to get the DB key for {}", existingAppAttemptId, e);
-                  }
-                }
-                return new AppShuffleInfo(
-                    appAttemptId.appId, appAttemptId.attemptId, appPathsInfo);
-              } else {
-                // Add the current DB key to deletion list as it is outdated
-                dbKeysToBeRemoved.add(entry.getKey());
-                return existingAppShuffleInfo;
-              }
-            });
       }
+
     }
     return dbKeysToBeRemoved;
   }
@@ -954,41 +956,42 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
   List<byte[]> reloadFinalizedAppAttemptsShuffleMergeInfo(DB db) throws IOException {
     List<byte[]> dbKeysToBeRemoved = new ArrayList<>();
     if (db != null) {
-      DBIterator itr = db.iterator();
-      itr.seek(APP_ATTEMPT_SHUFFLE_FINALIZE_STATUS_KEY_PREFIX.getBytes(StandardCharsets.UTF_8));
-      while (itr.hasNext()) {
-        Map.Entry<byte[], byte[]> entry = itr.next();
-        String key = new String(entry.getKey(), StandardCharsets.UTF_8);
-        if (!key.startsWith(APP_ATTEMPT_SHUFFLE_FINALIZE_STATUS_KEY_PREFIX)) {
-          break;
-        }
-        AppAttemptShuffleMergeId partitionId = parseDbAppAttemptShufflePartitionKey(key);
-        logger.debug("Reloading finalized shuffle info for partitionId {}", partitionId);
-        AppShuffleInfo appShuffleInfo = appsShuffleInfo.get(partitionId.appId);
-        if (appShuffleInfo != null && appShuffleInfo.attemptId == partitionId.attemptId) {
-          appShuffleInfo.shuffles.compute(partitionId.shuffleId,
-              (shuffleId, existingMergePartitionInfo) -> {
-                if (existingMergePartitionInfo == null ||
-                    existingMergePartitionInfo.shuffleMergeId < partitionId.shuffleMergeId) {
-                  if (existingMergePartitionInfo != null) {
-                    AppAttemptShuffleMergeId appAttemptShuffleMergeId =
-                        new AppAttemptShuffleMergeId(appShuffleInfo.appId, appShuffleInfo.attemptId,
-                            shuffleId, existingMergePartitionInfo.shuffleMergeId);
-                    try{
-                      dbKeysToBeRemoved.add(
-                          getDbAppAttemptShufflePartitionKey(appAttemptShuffleMergeId));
-                    } catch (Exception e) {
-                      logger.error("Error getting the DB key for {}", appAttemptShuffleMergeId, e);
-                    }
-                  }
-                  return new AppShuffleMergePartitionsInfo(partitionId.shuffleMergeId, true);
-                } else {
-                  dbKeysToBeRemoved.add(entry.getKey());
-                  return existingMergePartitionInfo;
-                }
-              });
-        } else {
-          dbKeysToBeRemoved.add(entry.getKey());
+      try (DBIterator itr = db.iterator()) {
+        itr.seek(APP_ATTEMPT_SHUFFLE_FINALIZE_STATUS_KEY_PREFIX.getBytes(StandardCharsets.UTF_8));
+        while (itr.hasNext()) {
+          Map.Entry<byte[], byte[]> entry = itr.next();
+          String key = new String(entry.getKey(), StandardCharsets.UTF_8);
+          if (!key.startsWith(APP_ATTEMPT_SHUFFLE_FINALIZE_STATUS_KEY_PREFIX)) {
+            break;
+          }
+          AppAttemptShuffleMergeId partitionId = parseDbAppAttemptShufflePartitionKey(key);
+          logger.debug("Reloading finalized shuffle info for partitionId {}", partitionId);
+          AppShuffleInfo appShuffleInfo = appsShuffleInfo.get(partitionId.appId);
+          if (appShuffleInfo != null && appShuffleInfo.attemptId == partitionId.attemptId) {
+            appShuffleInfo.shuffles.compute(partitionId.shuffleId,
+                    (shuffleId, existingMergePartitionInfo) -> {
+                      if (existingMergePartitionInfo == null ||
+                              existingMergePartitionInfo.shuffleMergeId < partitionId.shuffleMergeId) {
+                        if (existingMergePartitionInfo != null) {
+                          AppAttemptShuffleMergeId appAttemptShuffleMergeId =
+                                  new AppAttemptShuffleMergeId(appShuffleInfo.appId, appShuffleInfo.attemptId,
+                                          shuffleId, existingMergePartitionInfo.shuffleMergeId);
+                          try{
+                            dbKeysToBeRemoved.add(
+                                    getDbAppAttemptShufflePartitionKey(appAttemptShuffleMergeId));
+                          } catch (Exception e) {
+                            logger.error("Error getting the DB key for {}", appAttemptShuffleMergeId, e);
+                          }
+                        }
+                        return new AppShuffleMergePartitionsInfo(partitionId.shuffleMergeId, true);
+                      } else {
+                        dbKeysToBeRemoved.add(entry.getKey());
+                        return existingMergePartitionInfo;
+                      }
+                    });
+          } else {
+            dbKeysToBeRemoved.add(entry.getKey());
+          }
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `try-with-resource` to ensure `DBIterator` is close after use in `RemoteBlockPushResolver`, `YarnShuffleService` and `ExternalShuffleBlockResolver` to avoid resource leakage. 


### Why are the changes needed?
Avoid `DBIterator` resource leakage. 


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions
