### PR TITLE
[SPARK-39992][BUILD] Upgrade `slf4j` to 1.7.36

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -135,7 +135,7 @@ javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/1.7.32//jcl-over-slf4j-1.7.32.jar
+jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jersey-client/2.36//jersey-client-2.36.jar
 jersey-common/2.36//jersey-common-2.36.jar
@@ -159,7 +159,7 @@ json4s-scalap_2.12/3.7.0-M11//json4s-scalap_2.12-3.7.0-M11.jar
 jsp-api/2.1//jsp-api-2.1.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/1.7.32//jul-to-slf4j-1.7.32.jar
+jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client/5.12.3//kubernetes-client-5.12.3.jar
 kubernetes-model-admissionregistration/5.12.3//kubernetes-model-admissionregistration-5.12.3.jar
@@ -242,7 +242,7 @@ scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shims/0.9.30//shims-0.9.30.jar
-slf4j-api/1.7.32//slf4j-api-1.7.32.jar
+slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.30//snakeyaml-1.30.jar
 snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -122,7 +122,7 @@ javax.jdo/3.2.0-m3//javax.jdo-3.2.0-m3.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/1.7.32//jcl-over-slf4j-1.7.32.jar
+jcl-over-slf4j/1.7.36//jcl-over-slf4j-1.7.36.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6//jdom2-2.0.6.jar
 jersey-client/2.36//jersey-client-2.36.jar
@@ -145,7 +145,7 @@ json4s-jackson_2.12/3.7.0-M11//json4s-jackson_2.12-3.7.0-M11.jar
 json4s-scalap_2.12/3.7.0-M11//json4s-scalap_2.12-3.7.0-M11.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/1.7.32//jul-to-slf4j-1.7.32.jar
+jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client/5.12.3//kubernetes-client-5.12.3.jar
 kubernetes-model-admissionregistration/5.12.3//kubernetes-model-admissionregistration-5.12.3.jar
@@ -231,7 +231,7 @@ scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
 scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shims/0.9.30//shims-0.9.30.jar
-slf4j-api/1.7.32//slf4j-api-1.7.32.jar
+slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.30//snakeyaml-1.30.jar
 snappy-java/1.1.8.4//snappy-java-1.1.8.4.jar
 spire-macros_2.12/0.17.0//spire-macros_2.12-0.17.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <maven.version>3.8.6</maven.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.18.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.3</hadoop.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade `slf4j` from 1.7.32 to 1.7.36

### Why are the changes needed?
Snyk have [open up a PR at my branch](https://github.com/bjornjorgensen/spark/pull/19) , where they want to upgrade [ slf4j ](https://www.slf4j.org)

The recommended version is 4 versions ahead of your current version. 
The recommended version was released 6 months ago, on 2022-02-08.

[Release log](https://www.slf4j.org/news.html)  


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.