### PR TITLE
[SPARK-39985][SQL] Enable implicit DEFAULT column values in inserts from DataFrames

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDefaultColumns.scala
@@ -83,6 +83,9 @@ case class ResolveDefaultColumns(catalog: SessionCatalog) extends Rule[LogicalPl
       case u: UnresolvedInlineTable
         if u.rows.nonEmpty && u.rows.forall(_.size == u.rows(0).size) =>
         true
+      case r: LocalRelation
+        if r.data.nonEmpty && r.data.forall(_.numFields == r.data(0).numFields) =>
+        true
       case _ =>
         false
     }
@@ -99,14 +102,13 @@ case class ResolveDefaultColumns(catalog: SessionCatalog) extends Rule[LogicalPl
       children.append(node)
       node = node.children(0)
     }
-    val table = node.asInstanceOf[UnresolvedInlineTable]
     val insertTableSchemaWithoutPartitionColumns: Option[StructType] =
       getInsertTableSchemaWithoutPartitionColumns(i)
     insertTableSchemaWithoutPartitionColumns.map { schema: StructType =>
       val regenerated: InsertIntoStatement =
         regenerateUserSpecifiedCols(i, schema)
-      val expanded: UnresolvedInlineTable =
-        addMissingDefaultValuesForInsertFromInlineTable(table, schema)
+      val expanded: LogicalPlan =
+        addMissingDefaultValuesForInsertFromInlineTable(node, schema)
       val replaced: Option[LogicalPlan] =
         replaceExplicitDefaultValuesForInputOfInsertInto(schema, expanded)
       replaced.map { r: LogicalPlan =>
@@ -262,16 +264,35 @@ case class ResolveDefaultColumns(catalog: SessionCatalog) extends Rule[LogicalPl
    * Updates an inline table to generate missing default column values.
    */
   private def addMissingDefaultValuesForInsertFromInlineTable(
-      table: UnresolvedInlineTable,
-      insertTableSchemaWithoutPartitionColumns: StructType): UnresolvedInlineTable = {
-    val numQueryOutputs: Int = table.rows(0).size
+      node: LogicalPlan,
+      insertTableSchemaWithoutPartitionColumns: StructType): LogicalPlan = {
+    val numQueryOutputs: Int = node match {
+      case table: UnresolvedInlineTable => table.rows(0).size
+      case local: LocalRelation => local.data(0).numFields
+    }
     val schema = insertTableSchemaWithoutPartitionColumns
     val newDefaultExpressions: Seq[Expression] =
       getDefaultExpressionsForInsert(numQueryOutputs, schema)
     val newNames: Seq[String] = schema.fields.drop(numQueryOutputs).map { _.name }
-    table.copy(
-      names = table.names ++ newNames,
-      rows = table.rows.map { row => row ++ newDefaultExpressions })
+    node match {
+      case table: UnresolvedInlineTable =>
+        table.copy(
+          names = table.names ++ newNames,
+          rows = table.rows.map { row => row ++ newDefaultExpressions })
+      case local: LocalRelation if newDefaultExpressions.isEmpty =>
+        local
+      case local: LocalRelation =>
+        val colTypes = StructType(local.output.map(col => StructField(col.name, col.dataType)))
+        val newRows: Seq[Seq[Expression]] = local.data.map { row =>
+          row.toSeq(colTypes)
+            .map { v =>
+              Literal(v)
+            } ++ newDefaultExpressions
+        }
+        UnresolvedInlineTable(
+          local.output.map(_.name) ++ newNames,
+          newRows)
+    }
   }
 
   /**
@@ -338,6 +359,8 @@ case class ResolveDefaultColumns(catalog: SessionCatalog) extends Rule[LogicalPl
         replaceExplicitDefaultValuesForInlineTable(defaultExpressions, table)
       case project: Project =>
         replaceExplicitDefaultValuesForProject(defaultExpressions, project)
+      case local: LocalRelation =>
+        Some(local)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1872,7 +1872,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         }
         sql("alter table t alter column s drop default")
         if (config.useDataFrames) {
-          Seq((2)).toDF.write.insertInto("t")
+          Seq((2, null)).toDF.write.insertInto("t")
         } else {
           sql("insert into t select 2, default")
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -999,26 +999,44 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     // default column value references in the 'insert into' statements. Note these tests depend on
     // enabling the configuration to use NULLs for missing DEFAULT column values.
     withSQLConf(SQLConf.USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES.key -> "true") {
-      withTable("t1", "t2") {
-        sql("create table t1(j int, s bigint default 42, x bigint default 43) using parquet")
-        sql("insert into t1 values(1)")
-        sql("insert into t1 values(2, default)")
-        sql("insert into t1 values(3, default, default)")
-        sql("insert into t1 values(4, 44)")
-        sql("insert into t1 values(5, 44, 45)")
-        sql("create table t2(j int, s bigint default 42, x bigint default 43) using parquet")
-        sql("insert into t2 select j from t1 where j = 1")
-        sql("insert into t2 select j, default from t1 where j = 2")
-        sql("insert into t2 select j, default, default from t1 where j = 3")
-        sql("insert into t2 select j, s from t1 where j = 4")
-        sql("insert into t2 select j, s, default from t1 where j = 5")
-        checkAnswer(
-          spark.table("t2"),
-          Row(1, 42L, 43L) ::
-          Row(2, 42L, 43L) ::
-          Row(3, 42L, 43L) ::
-          Row(4, 44L, 43L) ::
-          Row(5, 44L, 43L) :: Nil)
+      for (useDataFrames <- Seq(false, true)) {
+        withTable("t1", "t2") {
+          sql("create table t1(j int, s bigint default 42, x bigint default 43) using parquet")
+          if (useDataFrames) {
+            Seq((1)).toDF.write.insertInto("t1")
+            Seq((2)).toDF.write.insertInto("t1")
+            Seq((3)).toDF.write.insertInto("t1")
+            Seq((4, 44)).toDF.write.insertInto("t1")
+            Seq((5, 44, 45)).toDF.write.insertInto("t1")
+          } else {
+            sql("insert into t1 values(1)")
+            sql("insert into t1 values(2, default)")
+            sql("insert into t1 values(3, default, default)")
+            sql("insert into t1 values(4, 44)")
+            sql("insert into t1 values(5, 44, 45)")
+          }
+          sql("create table t2(j int, s bigint default 42, x bigint default 43) using parquet")
+          if (useDataFrames) {
+            spark.table("t1").where("j = 1").select("j").write.insertInto("t2")
+            spark.table("t1").where("j = 2").select("j").write.insertInto("t2")
+            spark.table("t1").where("j = 3").select("j").write.insertInto("t2")
+            spark.table("t1").where("j = 4").select("j", "s").write.insertInto("t2")
+            spark.table("t1").where("j = 5").select("j", "s").write.insertInto("t2")
+          } else {
+            sql("insert into t2 select j from t1 where j = 1")
+            sql("insert into t2 select j, default from t1 where j = 2")
+            sql("insert into t2 select j, default, default from t1 where j = 3")
+            sql("insert into t2 select j, s from t1 where j = 4")
+            sql("insert into t2 select j, s, default from t1 where j = 5")
+          }
+          checkAnswer(
+            spark.table("t2"),
+            Row(1, 42L, 43L) ::
+            Row(2, 42L, 43L) ::
+            Row(3, 42L, 43L) ::
+            Row(4, 44L, 43L) ::
+            Row(5, 44L, 43L) :: Nil)
+        }
       }
     }
   }
@@ -1518,11 +1536,19 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
   test("INSERT rows, ALTER TABLE ADD COLUMNS with DEFAULTs, then SELECT them") {
     case class Config(
         sqlConf: Option[(String, String)],
-        insertNullsToStorage: Boolean = true)
+        insertNullsToStorage: Boolean = true,
+        useDataFrames: Boolean = false)
     def runTest(dataSource: String, config: Config): Unit = {
+      def insertIntoT(): Unit = {
+        if (config.useDataFrames) {
+          Seq(("xyz", 42)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t values('xyz', 42)")
+        }
+      }
       def withTableT(f: => Unit): Unit = {
         sql(s"create table t(a string, i int) using $dataSource")
-        sql("insert into t values('xyz', 42)")
+        insertIntoT
         withTable("t") { f }
       }
       // Positive tests:
@@ -1543,7 +1569,11 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
       // default values.
       withTableT {
         sql("alter table t add column (s string default concat('abc', 'def'))")
-        sql("insert into t values(null, null, null)")
+        if (config.useDataFrames) {
+          Seq((null, null, null)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t values(null, null, null)")
+        }
         sql("alter table t add column (x boolean default true)")
         // By default, INSERT commands into some tables (such as JSON) do not store NULL values.
         // Therefore, if such destination columns have DEFAULT values, SELECTing the same columns
@@ -1575,34 +1605,35 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           "u short default cast(42 as short), " +
           "v float default 0, " +
           "w double default 0, " +
-          "x date default date'0000', " +
-          "y timestamp default timestamp'0000', " +
-          "z timestamp_ntz default cast(timestamp'0000' as timestamp_ntz), " +
-          "a1 timestamp_ltz default cast(timestamp'0000' as timestamp_ltz), " +
+          "x date default cast('2021-01-02' as date), " +
+          "y timestamp default cast('2021-01-02 01:01:01' as timestamp), " +
+          "z timestamp_ntz default cast('2021-01-02 01:01:01' as timestamp_ntz), " +
+          "a1 timestamp_ltz default cast('2021-01-02 01:01:01' as timestamp_ltz), " +
           "a2 decimal(5, 2) default 123.45," +
           "a3 bigint default 43," +
           "a4 smallint default cast(5 as smallint)," +
           "a5 tinyint default cast(6 as tinyint))")
+        insertIntoT()
         // Manually inspect the result row values rather than using the 'checkAnswer' helper method
         // in order to ensure the values' correctness while avoiding minor type incompatibilities.
         val result: Array[Row] =
           sql("select s, t, u, v, w, x, y, z, a1, a2, a3, a4, a5 from t").collect()
-        assert(result.length == 1)
-        val row: Row = result(0)
-        assert(row.length == 13)
-        assert(row(0) == true)
-        assert(row(1) == null)
-        assert(row(2) == 42)
-        assert(row(3) == 0.0f)
-        assert(row(4) == 0.0d)
-        assert(row(5).toString == "0001-01-01")
-        assert(row(6).toString == "0001-01-01 00:00:00.0")
-        assert(row(7).toString == "0000-01-01T00:00")
-        assert(row(8).toString == "0001-01-01 00:00:00.0")
-        assert(row(9).toString == "123.45")
-        assert(row(10) == 43L)
-        assert(row(11) == 5)
-        assert(row(12) == 6)
+        for (row <- result) {
+          assert(row.length == 13)
+          assert(row(0) == true)
+          assert(row(1) == null)
+          assert(row(2) == 42)
+          assert(row(3) == 0.0f)
+          assert(row(4) == 0.0d)
+          assert(row(5).toString == "2021-01-02")
+          assert(row(6).toString == "2021-01-02 01:01:01.0")
+          assert(row(7).toString.startsWith("2021-01-02"))
+          assert(row(8).toString == "2021-01-02 01:01:01.0")
+          assert(row(9).toString == "123.45")
+          assert(row(10) == 43L)
+          assert(row(11) == 5)
+          assert(row(12) == 6)
+        }
       }
     }
 
@@ -1644,16 +1675,31 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
             insertNullsToStorage = false)))
     ).foreach { testCase: TestCase =>
       testCase.configs.foreach { config: Config =>
-        config.sqlConf.map { kv: (String, String) =>
-          withSQLConf(kv) {
-            // Run the test with the pair of custom SQLConf values.
-            runTest(testCase.dataSource, config)
+        // Run the test twice, once using SQL for the INSERT operations and again using DataFrames.
+        for (useDataFrames <- Seq(false, true)) {
+          config.sqlConf.map { kv: (String, String) =>
+            withSQLConf(kv) {
+              // Run the test with the pair of custom SQLConf values.
+              runTest(testCase.dataSource, config.copy(useDataFrames = useDataFrames))
+            }
+          }.getOrElse {
+            // Run the test with default settings.
+            runTest(testCase.dataSource, config.copy(useDataFrames = useDataFrames))
           }
-        }.getOrElse {
-          // Run the test with default settings.
-          runTest(testCase.dataSource, config)
         }
       }
+    }
+  }
+
+  test("SPARK-39985 Enable implicit DEFAULT column values in inserts from DataFrames") {
+    // Negative test: explicit column "default" references are not supported in write operations
+    // from DataFrames: since the operators are resolved one-by-one, any .select referring to
+    // "default" generates a "column not found" error before any following .insertInto.
+    withTable("t") {
+      sql(s"create table t(a string, i int default 42) using parquet")
+      assert(intercept[AnalysisException] {
+        Seq(("xyz")).toDF.select("value", "default").write.insertInto("t")
+      }.getMessage.contains("column or function parameter with name `default` cannot be resolved"))
     }
   }
 
@@ -1674,10 +1720,27 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
 
   test("SPARK-39557 INSERT INTO statements with tables with array defaults") {
     // Positive tests: array types are supported as default values.
-    Seq("parquet", "orc").foreach { dataSource =>
+    case class Config(
+        dataSource: String,
+        useDataFrames: Boolean = false)
+    Seq(
+      Config(
+        "parquet"),
+      Config(
+        "parquet",
+        useDataFrames = true),
+      Config(
+        "orc"),
+      Config(
+        "orc",
+        useDataFrames = true)).foreach { config =>
       withTable("t") {
-        sql(s"create table t(i boolean) using $dataSource")
-        sql("insert into t select false")
+        sql(s"create table t(i boolean) using ${config.dataSource}")
+        if (config.useDataFrames) {
+          Seq((false)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select false")
+        }
         sql("alter table t add column s array<int> default array(1, 2)")
         checkAnswer(spark.table("t"), Row(false, Seq(1, 2)))
       }
@@ -1687,45 +1750,102 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     val incompatibleDefault =
     "Failed to execute ALTER TABLE ADD COLUMNS command because the destination table column s " +
       "has a DEFAULT value with type"
-    withTable("t") {
-      sql("create table t(i boolean) using parquet")
-      sql("insert into t select false")
-      assert(intercept[AnalysisException] {
-        sql("alter table t add column s array<int> default array('abc', 'def')")
-      }.getMessage.contains(incompatibleDefault))
+    Seq(
+      Config(
+        "parquet"),
+      Config(
+        "parquet",
+        true)).foreach { config =>
+      withTable("t") {
+        sql(s"create table t(i boolean) using ${config.dataSource}")
+        if (config.useDataFrames) {
+          Seq((false)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select false")
+        }
+        assert(intercept[AnalysisException] {
+          sql("alter table t add column s array<int> default array('abc', 'def')")
+        }.getMessage.contains(incompatibleDefault))
+      }
     }
   }
 
   test("SPARK-39557 INSERT INTO statements with tables with struct defaults") {
     // Positive tests: struct types are supported as default values.
-    Seq("parquet", "orc").foreach { dataSource =>
+    case class Config(
+        dataSource: String,
+        useDataFrames: Boolean = false)
+    Seq(
+      Config(
+        "parquet"),
+      Config(
+        "parquet",
+        useDataFrames = true),
+      Config(
+        "orc"),
+      Config(
+        "orc",
+        useDataFrames = true)).foreach { config =>
       withTable("t") {
-        sql(s"create table t(i boolean) using $dataSource")
-        sql("insert into t select false")
+        sql(s"create table t(i boolean) using ${config.dataSource}")
+        if (config.useDataFrames) {
+          Seq((false)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select false")
+        }
         sql("alter table t add column s struct<x boolean, y string> default struct(true, 'abc')")
         checkAnswer(spark.table("t"), Row(false, Row(true, "abc")))
       }
     }
+
     // Negative tests: provided map element types must match their corresponding DEFAULT
     // declarations, if applicable.
     val incompatibleDefault =
     "Failed to execute ALTER TABLE ADD COLUMNS command because the destination table column s " +
       "has a DEFAULT value with type"
-    withTable("t") {
-      sql("create table t(i boolean) using parquet")
-      sql("insert into t select false")
-      assert(intercept[AnalysisException] {
-        sql("alter table t add column s struct<x boolean, y string> default struct(42, 56)")
-      }.getMessage.contains(incompatibleDefault))
+    Seq(
+      Config(
+        "parquet"),
+      Config(
+        "parquet",
+        true)).foreach { config =>
+      withTable("t") {
+        sql(s"create table t(i boolean) using ${config.dataSource}")
+        if (config.useDataFrames) {
+          Seq((false)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select false")
+        }
+        assert(intercept[AnalysisException] {
+          sql("alter table t add column s struct<x boolean, y string> default struct(42, 56)")
+        }.getMessage.contains(incompatibleDefault))
+      }
     }
   }
 
   test("SPARK-39557 INSERT INTO statements with tables with map defaults") {
     // Positive tests: map types are supported as default values.
-    Seq("parquet", "orc").foreach { dataSource =>
+    case class Config(
+        dataSource: String,
+        useDataFrames: Boolean = false)
+    Seq(
+      Config(
+        "parquet"),
+      Config(
+        "parquet",
+        useDataFrames = true),
+      Config(
+        "orc"),
+      Config(
+        "orc",
+        useDataFrames = true)).foreach { config =>
       withTable("t") {
-        sql(s"create table t(i boolean) using $dataSource")
-        sql("insert into t select false")
+        sql(s"create table t(i boolean) using ${config.dataSource}")
+        if (config.useDataFrames) {
+          Seq((false)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select false")
+        }
         sql("alter table t add column s map<boolean, string> default map(true, 'abc')")
         checkAnswer(spark.table("t"), Row(false, Map(true -> "abc")))
       }
@@ -1744,10 +1864,18 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
                   struct(1, 2)),
                 array(
                   map(false, 'def', true, 'jkl'))))
-              using $dataSource""")
-        sql("insert into t select 1, default")
+              using ${config.dataSource}""")
+        if (config.useDataFrames) {
+          Seq((1)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select 1, default")
+        }
         sql("alter table t alter column s drop default")
-        sql("insert into t select 2, default")
+        if (config.useDataFrames) {
+          Seq((2)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select 2, default")
+        }
         sql(
           """
             alter table t alter column s
@@ -1756,7 +1884,11 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
                 struct(3, 4)),
               array(
                 map(false, 'mno', true, 'pqr')))""")
-        sql("insert into t select 3, default")
+        if (config.useDataFrames) {
+          Seq((3)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select 3, default")
+        }
         sql(
           """
             alter table t
@@ -1764,7 +1896,11 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
               map<boolean, string>>
             default array(
               map(true, 'xyz'))""")
-        sql("insert into t select 4, default")
+        if (config.useDataFrames) {
+          Seq((4)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select 4, default")
+        }
         checkAnswer(spark.table("t"),
           Seq(
             Row(1,
@@ -1786,12 +1922,23 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     val incompatibleDefault =
     "Failed to execute ALTER TABLE ADD COLUMNS command because the destination table column s " +
       "has a DEFAULT value with type"
-    withTable("t") {
-      sql("create table t(i boolean) using parquet")
-      sql("insert into t select false")
-      assert(intercept[AnalysisException] {
-        sql("alter table t add column s map<boolean, string> default map(42, 56)")
-      }.getMessage.contains(incompatibleDefault))
+    Seq(
+      Config(
+        "parquet"),
+      Config(
+        "parquet",
+        true)).foreach { config =>
+      withTable("t") {
+        sql(s"create table t(i boolean) using ${config.dataSource}")
+        if (config.useDataFrames) {
+          Seq((false)).toDF.write.insertInto("t")
+        } else {
+          sql("insert into t select false")
+        }
+        assert(intercept[AnalysisException] {
+          sql("alter table t add column s map<boolean, string> default map(42, 56)")
+        }.getMessage.contains(incompatibleDefault))
+      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable implicit DEFAULT column values in inserts from DataFrames.

This mostly already worked since the DataFrame inserts already converted to LogicalPlans. I added testing and a small analysis change since the operators are resolved one-by-one instead of all at once.

Note that explicit column "default" references are not supported in write operations from DataFrames: since the operators are resolved one-by-one, any `.select` referring to "default" generates a "column not found" error before any following `.insertInto`.

### Why are the changes needed?

This makes inserts from DataFrames produce the same results as those from SQL commands, for consistency and correctness.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Extended the `InsertSuite` in this PR.