### PR TITLE
[SPARK-39997][SQL] Fix ParquetSchemaConverter fails match schema by id

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -340,7 +340,7 @@ class ParquetToSparkSchemaConverter(
 
         if (isElementType(repeatedType, field.getName)) {
           var converted = convertField(repeated, sparkReadElementType)
-          val convertedType = sparkReadElementType.getOrElse(converted.sparkType)
+          val convertedType = converted.sparkType
 
           // legacy format such as:
           //   optional group my_list (LIST) {
@@ -354,7 +354,7 @@ class ParquetToSparkSchemaConverter(
         } else {
           val element = repeated.asInstanceOf[GroupColumnIO].getChild(0)
           val converted = convertField(element, sparkReadElementType)
-          val convertedType = sparkReadElementType.getOrElse(converted.sparkType)
+          val convertedType = converted.sparkType
           val optional = element.getType.isRepetition(OPTIONAL)
           ParquetColumn(ArrayType(convertedType, containsNull = optional),
             groupColumn, Seq(converted))
@@ -384,8 +384,8 @@ class ParquetToSparkSchemaConverter(
         val sparkReadValueType = sparkReadType.map(_.asInstanceOf[MapType].valueType)
         val convertedKey = convertField(key, sparkReadKeyType)
         val convertedValue = convertField(value, sparkReadValueType)
-        val convertedKeyType = sparkReadKeyType.getOrElse(convertedKey.sparkType)
-        val convertedValueType = sparkReadValueType.getOrElse(convertedValue.sparkType)
+        val convertedKeyType = convertedKey.sparkType
+        val convertedValueType = convertedValue.sparkType
         val valueOptional = value.getType.isRepetition(OPTIONAL)
         ParquetColumn(
           MapType(convertedKeyType, convertedValueType,


### PR DESCRIPTION


currently, match parquet schema by id fails under certain case

no

new unit test added



### What changes were proposed in this pull request?

in this PR, fixed cases where ParquetSchemaConverter fails match schema by id
when converting parquet schema, SparkType is preferred instead of Converted parquet type, chances are SparkType has a name which will then fail the same type validation in later cases when running vectorized nested column read.



### Why are the changes needed?
when converting parquet schema, SparkType is preferred instead of Converted parquet type, chances are SparkType has a name which will then fail the same type validation in later cases when running vectorized nested column read.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added new ut
