### PR TITLE
[SPARK-39999][BUILD] Replace `postgresql` 42.3.3 with 42.2.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1230,7 +1230,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.3</version>
+        <version>42.2.26</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace `postgresql` 42.3.3 with 42.2.26


### Why are the changes needed?
postgresql >= 42.3.0, < 42.4.1 is affected by [CVE-2022-31197](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-r38f-c4h4-hqq2) 

Upgrade postgresql to [42.4.1 won't pass Github actions tests. ](https://github.com/bjornjorgensen/spark/runs/7705423158?check_suite_focus=true)

[42.2.26](https://github.com/pgjdbc/pgjdbc/commits/release/42.2) is a backport to fix this CVE

### Does this PR introduce _any_ user-facing change?
No.



### How was this patch tested?
Pass GA.