### PR TITLE
[SPARK-40004][CORE] Remove redundant `LevelDB.get` in `RemoteBlockPushResolver`

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -417,9 +417,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     if (db != null) {
       try {
         byte[] key = getDbAppAttemptPathsKey(appAttemptId);
-        if (db.get(key) != null) {
-          db.delete(key);
-        }
+        db.delete(key);
       } catch (Exception e) {
         logger.error("Failed to remove the application attempt {} local path in DB",
             appAttemptId, e);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just remove redundant `LevelDB.get(key)` in `RemoteBlockPushResolver`.


### Why are the changes needed?
This is no need to check `db.get(key) != null` before `db.delete(key)`. LevelDB will handle this scene.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GitHub Actions