### PR TITLE
[SPARK-39896][SQL] UnwrapCastInBinaryComparison should work when the literal of In/InSet downcast failed

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -171,7 +171,7 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         case _ => throw new IllegalStateException("Illegal value found in in.list.")
       }
 
-      // return original expression when in.list contains only null values.
+      // return None when in.list contains only null values.
       if (canCastList.isEmpty && cannotCastList.isEmpty) {
         None
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -162,11 +162,10 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
             //     CAST(boundreference() AS DECIMAL(10,4)) = 123456.1234BD
             // Due to `cast(lit, fromExp.dataType) == null` we simply return
             // `falseIfNotNull(fromExp)`.
-            case None =>
+            case None | Some(And(IsNull(_), Literal(null, BooleanType))) =>
               cannotCastList += falseIfNotNull(fromExp)
             case Some(EqualTo(_, unwrapLit: Literal)) =>
               canCastList += unwrapLit
-            case Some(e @ And(IsNull(_), Literal(null, BooleanType))) => cannotCastList += e
             case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
           }
         case _ => throw new IllegalStateException("Illegal value found in in.list.")
@@ -210,11 +209,10 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
             unwrapCast(EqualTo(inSet.child, lit)) match {
               // The same with `In`, when the lit cast to from.dataType failed, we simply return
               // `falseIfNotNull(fromExp)`.
-              case None =>
+              case None | Some(And(IsNull(_), Literal(null, BooleanType))) =>
                 cannotCastSet += falseIfNotNull(fromExp)
               case Some(EqualTo(_, unwrapLit: Literal)) =>
                 canCastSet += unwrapLit.value
-              case Some(e @ And(IsNull(_), Literal(null, BooleanType))) => cannotCastSet += e
               case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
             }
           case _ => throw new IllegalStateException("Illegal value found in hset.")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparison.scala
@@ -157,15 +157,17 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
         case lit @ NonNullLiteral(_, _) =>
           val originalEqualTo = EqualTo(in.value, lit)
           unwrapCast(originalEqualTo) match {
-            // the function `unwrapCast` may returns original expression when the literal can not
-            // cast to fromType, for instance: (the boundreference is of type DECIMAL(5,2))
-            //     CAST(boundreference() AS DECIMAL(10,4)) = 123456.1234BD
-            // Due to `cast(lit, fromExp.dataType) == null` we simply return
-            // `falseIfNotNull(fromExp)`.
-            case equalTo: EqualTo if equalTo == originalEqualTo &&
-              Cast(lit, fromExp.dataType).eval() == null =>
-              cannotCastList += falseIfNotNull(fromExp)
-            case EqualTo(_, unwrapLit: Literal) => canCastList += unwrapLit
+            case equalTo @ EqualTo(_, unwrapLit: Literal) =>
+              // the function `unwrapCast` may returns original expression when the literal can not
+              // cast to fromType, for instance: (the boundreference is of type DECIMAL(5,2))
+              //     CAST(boundreference() AS DECIMAL(10,4)) = 123456.1234BD
+              // Due to `cast(lit, fromExp.dataType) == null` we simply return
+              // `falseIfNotNull(fromExp)`.
+              if (equalTo == originalEqualTo && Cast(lit, fromExp.dataType).eval() == null) {
+                cannotCastList += falseIfNotNull(fromExp)
+              } else {
+                canCastList += unwrapLit
+              }
             case e @ And(IsNull(_), Literal(null, BooleanType)) => cannotCastList += e
             case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
           }
@@ -209,12 +211,14 @@ object UnwrapCastInBinaryComparison extends Rule[LogicalPlan] {
           case lit @ NonNullLiteral(_, _) =>
             val originalEqualTo = EqualTo(inSet.child, lit)
             unwrapCast(originalEqualTo) match {
-              // The same with `In`, when the lit cast to from.dataType failed, we simply return
-              // `falseIfNotNull(fromExp)`.
-              case equalTo: EqualTo if equalTo == originalEqualTo &&
-                Cast(lit, fromExp.dataType).eval() == null =>
-                cannotCastSet += falseIfNotNull(fromExp)
-              case EqualTo(_, unwrapLit: Literal) => canCastSet += unwrapLit.value
+              case equalTo @ EqualTo(_, unwrapLit: Literal) =>
+                // The same with `In`, when the lit cast to from.dataType failed, we simply return
+                // `falseIfNotNull(fromExp)`.
+                if (equalTo == originalEqualTo && Cast(lit, fromExp.dataType).eval() == null) {
+                  cannotCastSet += falseIfNotNull(fromExp)
+                } else {
+                  canCastSet += unwrapLit.value
+                }
               case e @ And(IsNull(_), Literal(null, BooleanType)) => cannotCastSet += e
               case _ => throw new IllegalStateException("Illegal unwrap cast result found.")
             }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -287,6 +287,28 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
       Or(falseIfNotNull(f3), f3.in(decimal(decimalValue2))))
   }
 
+  test("SPARK-39896: unwrap cast when the literal of In/Inset has round up or down") {
+
+    val doubleValue = 1.0
+    val doubleValue1 = 100.6
+    checkInAndInSet(
+      In(castDouble(f), Seq(doubleValue1, doubleValue)),
+      Or(falseIfNotNull(f), f.in(doubleValue.toShort)))
+
+    // Cases for rounding up: 3.14 will be rounded to 3.14000010... after casting to float
+    val doubleValue2 = 3.14
+    checkInAndInSet(
+      In(castDouble(f2), Seq(doubleValue2, doubleValue)),
+      Or(falseIfNotNull(f2), f2.in(doubleValue.toFloat)))
+
+    // Another case: 400.5678 is rounded up to 400.57
+    val decimalValue1 = decimal2(400.5678)
+    val decimalValue2 = decimal2(1.0)
+    checkInAndInSet(
+      In(castDecimal2(f3), Seq(decimalValue1, decimalValue2)),
+      Or(falseIfNotNull(f3), f3.in(decimal(decimalValue2))))
+  }
+
   test("SPARK-36130: unwrap In should skip when in.list contains an expression that " +
     "is not literal") {
     val add = Cast(f2, DoubleType) + 1.0d


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR aims to fix the case

```scala
sql("create table t1(a decimal(3, 0)) using parquet")
sql("insert into t1 values(100), (10), (1)")
sql("select * from t1 where a in(100000, 1.00)").show
```

```
java.lang.RuntimeException: After applying rule org.apache.spark.sql.catalyst.optimizer.UnwrapCastInBinaryComparison in batch Operator Optimization before Inferring Filters, the structural integrity of the plan is broken.
	at org.apache.spark.sql.errors.QueryExecutionErrors$.structuralIntegrityIsBrokenAfterApplyingRuleError(QueryExecutionErrors.scala:1325)
```

1. the rule `UnwrapCastInBinaryComparison` transforms the expression `In` to Equals

```
CAST(a as decimal(12,2)) IN (100000.00,1.00)


OR(
   CAST(a as decimal(12,2)) = 100000.00,
   CAST(a as decimal(12,2)) = 1.00
)
```


2. using `UnwrapCastInBinaryComparison.unwrapCast()` to optimize each `EqualTo`

```
// Expression1
CAST(a as decimal(12,2)) = 100000.00 => CAST(a as decimal(12,2)) = 100000.00

// Expression2
CAST(a as decimal(12,2)) = 1.00      => a = 1
```

3. return the new unwrapped cast expression `In`

```
a IN (100000.00, 1.00)
```


Before this PR:

the method `UnwrapCastInBinaryComparison.unwrapCast()` returns the original expression when downcasting to a decimal type fails (the `Expression1`),returns the original expression if the downcast to the decimal type succeeds (the `Expression2`), the two expressions have different data type which would break the structural integrity

```
a IN (100000.00, 1.00)
       |           |
    decimal(12, 2) |
               decimal(3, 0)
```


After this PR:

the PR transform the downcasting failed expression to `falseIfNotNull(fromExp)`
```

((isnull(a) AND null) OR a IN (1.00)
```



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, only bug fix.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test.
