### PR TITLE
[SPARK-40076] [SQL] Support number-only column names in ORC data sources when orc impl is hive

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -236,6 +236,183 @@ abstract class OrcSuite
     assert(exception.getCause.getMessage.contains("Could not read footer for file"))
   }
 
+  protected def testHandleOnlyNumbersColumnName(): Unit = {
+    withSQLConf(SQLConf.ORC_IMPLEMENTATION.key -> orcImp) {
+      withTempPath { dir =>
+        val path = dir.getAbsolutePath
+        spark.sql("SELECT 'a' as `1`, 'b' as `2`, 'c' as `3`").write.orc(path)
+        val df = spark.read.orc(path)
+        checkAnswer(df, Row("a", "b", "c"))
+        assert(df.schema.toArray ===
+          Array(
+            StructField("1", StringType),
+            StructField("2", StringType),
+            StructField("3", StringType)))
+      }
+
+      // test for struct in struct
+      withTempPath { dir =>
+        val path = dir.getAbsolutePath
+        spark.sql(
+          "SELECT 'a' as `10`, named_struct('20', 'b', '30', named_struct('40', 'c')) as `50`")
+          .write.orc(path)
+        val df = spark.read.orc(path)
+        checkAnswer(df, Row("a", Row("b", Row("c"))))
+        assert(df.schema.toArray === Array(
+          StructField("10", StringType),
+          StructField("50",
+            StructType(
+              StructField("20", StringType) ::
+                StructField("30",
+                  StructType(
+                    StructField("40", StringType) :: Nil)) :: Nil))))
+      }
+
+      // test for struct in array
+      withTempPath { dir =>
+        val path = dir.getAbsolutePath
+        spark.sql("SELECT array(array(named_struct('123', 'a'), " +
+          "named_struct('123', 'b'))) as `789`").write.orc(path)
+        val df = spark.read.orc(path)
+        checkAnswer(df, Row(Seq(Seq(Row("a"), Row("b")))))
+        assert(df.schema.toArray === Array(
+          StructField("789",
+            ArrayType(
+              ArrayType(
+                StructType(
+                  StructField("123", StringType) :: Nil))))))
+      }
+
+      // test for struct in map
+      withTempPath { dir =>
+        val path = dir.getAbsolutePath
+        spark.sql(
+          """
+            |SELECT
+            |  map(
+            |    named_struct('123', 'a'),
+            |    map(
+            |      named_struct('456', 'b'),
+            |      named_struct('789', 'c'))) as `012`""".stripMargin).write.orc(path)
+        val df = spark.read.orc(path)
+        checkAnswer(df, Row(Map(Row("a") -> Map(Row("b") -> Row("c")))))
+        assert(df.schema.toArray === Array(
+          StructField("012",
+            MapType(
+              StructType(
+                StructField("123", StringType) :: Nil),
+              MapType(
+                StructType(
+                  StructField("456", StringType) :: Nil),
+                StructType(
+                  StructField("789", StringType) :: Nil))))))
+      }
+
+      // test for deeply nested struct with complex types
+      withTempPath { dir =>
+        val path = dir.getAbsolutePath
+        spark.sql(
+          """
+            |SELECT
+            |  named_struct('123',
+            |    array(
+            |      map(
+            |        named_struct('456', 'a'),
+            |        named_struct('789', 'b')))) as `1000`,
+            |  named_struct('123',
+            |    map(
+            |      array(named_struct('456', 'a')),
+            |      array(named_struct('789', 'b')))) as `2000`,
+            |  array(
+            |    named_struct('123',
+            |      map(
+            |        named_struct('456', 'a'),
+            |        named_struct('789', 'b')))) as `3000`,
+            |  array(
+            |    map(
+            |      named_struct('123', 'a'),
+            |      named_struct('456', 'b'))) as `4000`,
+            |  map(
+            |    named_struct('123',
+            |      array(
+            |        named_struct('456', 'a'))),
+            |    named_struct('789',
+            |      array(
+            |        named_struct('012', 'b')))) as `5000`,
+            |  map(
+            |    array(
+            |      named_struct('123', 'a')),
+            |    array(
+            |      named_struct('456', 'b'))) as `6000`
+        """.stripMargin).write.orc(path)
+        val df = spark.read.orc(path)
+        checkAnswer(df, Row(
+          Row(Seq(Map(Row("a") -> Row("b")))),
+          Row(Map(Seq(Row("a")) -> Seq(Row("b")))),
+          Seq(Row(Map(Row("a") -> Row("b")))),
+          Seq(Map(Row("a") -> Row("b"))),
+          Map(Row(Seq(Row("a"))) -> Row(Seq(Row("b")))),
+          Map(Seq(Row("a")) -> Seq(Row("b")))))
+        assert(df.schema.toArray === Array(
+          StructField("1000",
+            StructType(
+              StructField("123",
+                ArrayType(
+                  MapType(
+                    StructType(
+                      StructField("456", StringType) :: Nil),
+                    StructType(
+                      StructField("789", StringType) :: Nil)))) :: Nil)),
+          StructField("2000",
+            StructType(
+              StructField("123",
+                MapType(
+                  ArrayType(
+                    StructType(
+                      StructField("456", StringType) :: Nil)),
+                  ArrayType(
+                    StructType(
+                      StructField("789", StringType) :: Nil)))) :: Nil)),
+          StructField("3000",
+            ArrayType(
+              StructType(
+                StructField("123",
+                  MapType(
+                    StructType(
+                      StructField("456", StringType) :: Nil),
+                    StructType(
+                      StructField("789", StringType) :: Nil))) :: Nil))),
+          StructField("4000",
+            ArrayType(
+              MapType(
+                StructType(
+                  StructField("123", StringType) :: Nil),
+                StructType(
+                  StructField("456", StringType) :: Nil)))),
+          StructField("5000",
+            MapType(
+              StructType(
+                StructField("123",
+                  ArrayType(
+                    StructType(
+                      StructField("456", StringType) :: Nil))) :: Nil),
+              StructType(
+                StructField("789",
+                  ArrayType(
+                    StructType(
+                      StructField("012", StringType) :: Nil))) :: Nil))),
+          StructField("6000",
+            MapType(
+              ArrayType(
+                StructType(
+                  StructField("123", StringType) :: Nil)),
+              ArrayType(
+                StructType(
+                  StructField("456", StringType) :: Nil))))))
+      }
+    }
+  }
+
   test("create temporary orc table") {
     checkAnswer(sql("SELECT COUNT(*) FROM normal_orc_source"), Row(10))
 
@@ -654,178 +831,7 @@ abstract class OrcSourceSuite extends OrcSuite with SharedSparkSession {
 
   test("SPARK-36663: OrcUtils.toCatalystSchema should correctly handle " +
     "a column name which consists of only numbers") {
-    withTempPath { dir =>
-      val path = dir.getAbsolutePath
-      spark.sql("SELECT 'a' as `1`, 'b' as `2`, 'c' as `3`").write.orc(path)
-      val df = spark.read.orc(path)
-      checkAnswer(df, Row("a", "b", "c"))
-      assert(df.schema.toArray ===
-        Array(
-          StructField("1", StringType),
-          StructField("2", StringType),
-          StructField("3", StringType)))
-    }
-
-    // test for struct in struct
-    withTempPath { dir =>
-      val path = dir.getAbsolutePath
-      spark.sql(
-        "SELECT 'a' as `10`, named_struct('20', 'b', '30', named_struct('40', 'c')) as `50`")
-        .write.orc(path)
-      val df = spark.read.orc(path)
-      checkAnswer(df, Row("a", Row("b", Row("c"))))
-      assert(df.schema.toArray === Array(
-        StructField("10", StringType),
-        StructField("50",
-          StructType(
-            StructField("20", StringType) ::
-            StructField("30",
-              StructType(
-                StructField("40", StringType) :: Nil)) :: Nil))))
-    }
-
-    // test for struct in array
-    withTempPath { dir =>
-      val path = dir.getAbsolutePath
-      spark.sql("SELECT array(array(named_struct('123', 'a'), named_struct('123', 'b'))) as `789`")
-        .write.orc(path)
-      val df = spark.read.orc(path)
-      checkAnswer(df, Row(Seq(Seq(Row("a"), Row("b")))))
-      assert(df.schema.toArray === Array(
-        StructField("789",
-          ArrayType(
-            ArrayType(
-              StructType(
-                StructField("123", StringType) :: Nil))))))
-    }
-
-    // test for struct in map
-    withTempPath { dir =>
-      val path = dir.getAbsolutePath
-      spark.sql(
-        """
-          |SELECT
-          |  map(
-          |    named_struct('123', 'a'),
-          |    map(
-          |      named_struct('456', 'b'),
-          |      named_struct('789', 'c'))) as `012`""".stripMargin).write.orc(path)
-      val df = spark.read.orc(path)
-      checkAnswer(df, Row(Map(Row("a") -> Map(Row("b") -> Row("c")))))
-      assert(df.schema.toArray === Array(
-        StructField("012",
-          MapType(
-            StructType(
-              StructField("123", StringType) :: Nil),
-            MapType(
-              StructType(
-                StructField("456", StringType) :: Nil),
-              StructType(
-                StructField("789", StringType) :: Nil))))))
-    }
-
-    // test for deeply nested struct with complex types
-    withTempPath { dir =>
-      val path = dir.getAbsolutePath
-      spark.sql(
-        """
-          |SELECT
-          |  named_struct('123',
-          |    array(
-          |      map(
-          |        named_struct('456', 'a'),
-          |        named_struct('789', 'b')))) as `1000`,
-          |  named_struct('123',
-          |    map(
-          |      array(named_struct('456', 'a')),
-          |      array(named_struct('789', 'b')))) as `2000`,
-          |  array(
-          |    named_struct('123',
-          |      map(
-          |        named_struct('456', 'a'),
-          |        named_struct('789', 'b')))) as `3000`,
-          |  array(
-          |    map(
-          |      named_struct('123', 'a'),
-          |      named_struct('456', 'b'))) as `4000`,
-          |  map(
-          |    named_struct('123',
-          |      array(
-          |        named_struct('456', 'a'))),
-          |    named_struct('789',
-          |      array(
-          |        named_struct('012', 'b')))) as `5000`,
-          |  map(
-          |    array(
-          |      named_struct('123', 'a')),
-          |    array(
-          |      named_struct('456', 'b'))) as `6000`
-        """.stripMargin).write.orc(path)
-      val df = spark.read.orc(path)
-      checkAnswer(df, Row(
-        Row(Seq(Map(Row("a") -> Row("b")))),
-        Row(Map(Seq(Row("a")) -> Seq(Row("b")))),
-        Seq(Row(Map(Row("a") -> Row("b")))),
-        Seq(Map(Row("a") -> Row("b"))),
-        Map(Row(Seq(Row("a"))) -> Row(Seq(Row("b")))),
-        Map(Seq(Row("a")) -> Seq(Row("b")))))
-      assert(df.schema.toArray === Array(
-        StructField("1000",
-          StructType(
-            StructField("123",
-              ArrayType(
-                MapType(
-                  StructType(
-                    StructField("456", StringType) :: Nil),
-                  StructType(
-                    StructField("789", StringType) :: Nil)))) :: Nil)),
-        StructField("2000",
-          StructType(
-            StructField("123",
-              MapType(
-                ArrayType(
-                  StructType(
-                    StructField("456", StringType) :: Nil)),
-                ArrayType(
-                  StructType(
-                    StructField("789", StringType) :: Nil)))) :: Nil)),
-        StructField("3000",
-          ArrayType(
-            StructType(
-              StructField("123",
-                MapType(
-                  StructType(
-                    StructField("456", StringType) :: Nil),
-                  StructType(
-                    StructField("789", StringType) :: Nil))) :: Nil))),
-        StructField("4000",
-          ArrayType(
-            MapType(
-              StructType(
-                StructField("123", StringType) :: Nil),
-              StructType(
-                StructField("456", StringType) :: Nil)))),
-        StructField("5000",
-          MapType(
-            StructType(
-              StructField("123",
-                ArrayType(
-                  StructType(
-                    StructField("456", StringType) :: Nil))) :: Nil),
-            StructType(
-              StructField("789",
-                ArrayType(
-                  StructType(
-                    StructField("012", StringType) :: Nil))) :: Nil))),
-        StructField("6000",
-          MapType(
-            ArrayType(
-              StructType(
-                StructField("123", StringType) :: Nil)),
-            ArrayType(
-              StructType(
-                StructField("456", StringType) :: Nil))))))
-    }
+    testHandleOnlyNumbersColumnName()
   }
 
   withAllNativeOrcReaders {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
@@ -154,7 +154,7 @@ private[hive] object OrcFileOperator extends Logging {
         val readerInspector = reader.getObjectInspector.asInstanceOf[StructObjectInspector]
         val schema = readerInspector.getTypeName
         logDebug(s"Reading schema from file $file., got Hive schema string: $schema")
-        CatalystSqlParser.parseDataType(schema).asInstanceOf[StructType]
+        toCatalystSchema(readerInspector)
       })
     }.flatten
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/orc/HiveOrcSourceSuite.scala
@@ -321,4 +321,8 @@ class HiveOrcSourceSuite extends OrcSuite with TestHiveSingleton {
     val df = readResourceOrcFile("test-data/TestStringDictionary.testRowIndex.orc")
     assert(df.where("str < 'row 001000'").count() === 1000)
   }
+
+  test("SPARK-36663: Support number-only column names in ORC data sources") {
+    testHandleOnlyNumbersColumnName()
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to support number-only column names in ORC data sources when orc impl is hive.
In the current master, with ORC datasource, we can write a DataFrame which contains such columns into ORC files.
```scala
spark.sql("SELECT 'a' as `1`, 'b' as `2`, 'c' as `3`").write.orc(path)
```
But reading the ORC files will fail.
```tex
val df = spark.read.orc(path)
...
== SQL ==
struct<1:string,2:string,3:string>
-------^^^

	at org.apache.spark.sql.catalyst.parser.ParseException.withCommand(ParseDriver.scala:265)
	at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parse(ParseDriver.scala:126)
	at org.apache.spark.sql.catalyst.parser.AbstractSqlParser.parseDataType(ParseDriver.scala:40)
	at org.apache.spark.sql.hive.orc.OrcFileOperator$$anonfun$readSchema$2.applyOrElse(OrcFileOperator.scala:101)
```
The cause of this is `CatalystSqlParser.parseDataType` fails to parse if a column name (and nested field) consists of only numbers.


### Why are the changes needed?
For better usability.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit Tests.
