### PR TITLE
[SPARK-40008][SQL] Support casting of integrals to ANSI intervals

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -197,6 +197,7 @@ object Cast {
     case (_: DayTimeIntervalType, _: DayTimeIntervalType) => true
     case (_: YearMonthIntervalType, _: YearMonthIntervalType) => true
     case (_: AnsiIntervalType, _: IntegralType | _: DecimalType) => true
+    case (_: IntegralType, _: AnsiIntervalType) => true
 
     case (StringType, _: NumericType) => true
     case (BooleanType, _: NumericType) => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -112,6 +112,7 @@ object Cast {
     case (StringType, _: AnsiIntervalType) => true
 
     case (_: AnsiIntervalType, _: IntegralType | _: DecimalType) => true
+    case (_: IntegralType, _: AnsiIntervalType) => true
 
     case (_: DayTimeIntervalType, _: DayTimeIntervalType) => true
     case (_: YearMonthIntervalType, _: YearMonthIntervalType) => true
@@ -786,7 +787,6 @@ case class Cast(
     case _: DayTimeIntervalType => buildCast[Long](_, s =>
       IntervalUtils.durationToMicros(IntervalUtils.microsToDuration(s), it.endField))
     case x: IntegralType =>
-      assert(it.startField == it.endField)
       if (x == LongType) {
         b => IntervalUtils.longToDayTimeInterval(
           x.integral.asInstanceOf[Integral[Any]].toLong(b), it.endField)
@@ -804,7 +804,6 @@ case class Cast(
     case _: YearMonthIntervalType => buildCast[Int](_, s =>
       IntervalUtils.periodToMonths(IntervalUtils.monthsToPeriod(s), it.endField))
     case x: IntegralType =>
-      assert(it.startField == it.endField)
       if (x == LongType) {
         b => IntervalUtils.longToYearMonthInterval(
           x.integral.asInstanceOf[Integral[Any]].toLong(b), it.endField)

--- a/sql/core/src/test/resources/sql-tests/inputs/cast.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cast.sql
@@ -105,7 +105,7 @@ select cast('a' as timestamp_ntz);
 select cast(cast('inf' as double) as timestamp);
 select cast(cast('inf' as float) as timestamp);
 
--- cast ANSI intervals to numerics
+-- cast ANSI intervals to integrals
 select cast(interval '1' year as tinyint);
 select cast(interval '-10-2' year to month as smallint);
 select cast(interval '1000' month as int);
@@ -116,6 +116,18 @@ select cast(interval '10' day as bigint);
 
 select cast(interval '-1000' month as tinyint);
 select cast(interval '1000000' second as smallint);
+
+-- cast integrals to ANSI intervals
+select cast(1Y as interval year);
+select cast(-122S as interval year to month);
+select cast(1000 as interval month);
+select cast(-10L as interval second);
+select cast(100Y as interval hour to second);
+select cast(-1000S as interval day to second);
+select cast(10 as interval day);
+
+select cast(2147483647 as interval year);
+select cast(-9223372036854775808L as interval day);
 
 -- cast ANSI intervals to decimals
 select cast(interval '-1' year as decimal(10, 0));

--- a/sql/core/src/test/resources/sql-tests/results/ansi/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/cast.sql.out
@@ -841,6 +841,80 @@ org.apache.spark.SparkArithmeticException
 
 
 -- !query
+select cast(1Y as interval year)
+-- !query schema
+struct<CAST(1 AS INTERVAL YEAR):interval year>
+-- !query output
+1-0
+
+
+-- !query
+select cast(-122S as interval year to month)
+-- !query schema
+struct<CAST(-122 AS INTERVAL YEAR TO MONTH):interval year to month>
+-- !query output
+-10-2
+
+
+-- !query
+select cast(1000 as interval month)
+-- !query schema
+struct<CAST(1000 AS INTERVAL MONTH):interval month>
+-- !query output
+83-4
+
+
+-- !query
+select cast(-10L as interval second)
+-- !query schema
+struct<CAST(-10 AS INTERVAL SECOND):interval second>
+-- !query output
+-0 00:00:10.000000000
+
+
+-- !query
+select cast(100Y as interval hour to second)
+-- !query schema
+struct<CAST(100 AS INTERVAL HOUR TO SECOND):interval hour to second>
+-- !query output
+0 00:01:40.000000000
+
+
+-- !query
+select cast(-1000S as interval day to second)
+-- !query schema
+struct<CAST(-1000 AS INTERVAL DAY TO SECOND):interval day to second>
+-- !query output
+-0 00:16:40.000000000
+
+
+-- !query
+select cast(10 as interval day)
+-- !query schema
+struct<CAST(10 AS INTERVAL DAY):interval day>
+-- !query output
+10 00:00:00.000000000
+
+
+-- !query
+select cast(2147483647 as interval year)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+[CAST_OVERFLOW] The value 2147483647 of the type "INT" cannot be cast to "INTERVAL YEAR" due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
+
+
+-- !query
+select cast(-9223372036854775808L as interval day)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+[CAST_OVERFLOW] The value -9223372036854775808L of the type "BIGINT" cannot be cast to "INTERVAL DAY" due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
+
+
+-- !query
 select cast(interval '-1' year as decimal(10, 0))
 -- !query schema
 struct<CAST(INTERVAL '-1' YEAR AS DECIMAL(10,0)):decimal(10,0)>

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -679,10 +679,9 @@ struct<CAST(1 AS INTERVAL YEAR):interval year>
 -- !query
 select cast(-122S as interval year to month)
 -- !query schema
-struct<>
+struct<CAST(-122 AS INTERVAL YEAR TO MONTH):interval year to month>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'CAST(-122S AS INTERVAL YEAR TO MONTH)' due to data type mismatch: cannot cast smallint to interval year to month; line 1 pos 7
+-10-2
 
 
 -- !query
@@ -704,19 +703,17 @@ struct<CAST(-10 AS INTERVAL SECOND):interval second>
 -- !query
 select cast(100Y as interval hour to second)
 -- !query schema
-struct<>
+struct<CAST(100 AS INTERVAL HOUR TO SECOND):interval hour to second>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'CAST(100Y AS INTERVAL HOUR TO SECOND)' due to data type mismatch: cannot cast tinyint to interval hour to second; line 1 pos 7
+0 00:01:40.000000000
 
 
 -- !query
 select cast(-1000S as interval day to second)
 -- !query schema
-struct<>
+struct<CAST(-1000 AS INTERVAL DAY TO SECOND):interval day to second>
 -- !query output
-org.apache.spark.sql.AnalysisException
-cannot resolve 'CAST(-1000S AS INTERVAL DAY TO SECOND)' due to data type mismatch: cannot cast smallint to interval day to second; line 1 pos 7
+-0 00:16:40.000000000
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -669,6 +669,83 @@ org.apache.spark.SparkArithmeticException
 
 
 -- !query
+select cast(1Y as interval year)
+-- !query schema
+struct<CAST(1 AS INTERVAL YEAR):interval year>
+-- !query output
+1-0
+
+
+-- !query
+select cast(-122S as interval year to month)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+cannot resolve 'CAST(-122S AS INTERVAL YEAR TO MONTH)' due to data type mismatch: cannot cast smallint to interval year to month; line 1 pos 7
+
+
+-- !query
+select cast(1000 as interval month)
+-- !query schema
+struct<CAST(1000 AS INTERVAL MONTH):interval month>
+-- !query output
+83-4
+
+
+-- !query
+select cast(-10L as interval second)
+-- !query schema
+struct<CAST(-10 AS INTERVAL SECOND):interval second>
+-- !query output
+-0 00:00:10.000000000
+
+
+-- !query
+select cast(100Y as interval hour to second)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+cannot resolve 'CAST(100Y AS INTERVAL HOUR TO SECOND)' due to data type mismatch: cannot cast tinyint to interval hour to second; line 1 pos 7
+
+
+-- !query
+select cast(-1000S as interval day to second)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+cannot resolve 'CAST(-1000S AS INTERVAL DAY TO SECOND)' due to data type mismatch: cannot cast smallint to interval day to second; line 1 pos 7
+
+
+-- !query
+select cast(10 as interval day)
+-- !query schema
+struct<CAST(10 AS INTERVAL DAY):interval day>
+-- !query output
+10 00:00:00.000000000
+
+
+-- !query
+select cast(2147483647 as interval year)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+[CAST_OVERFLOW] The value 2147483647 of the type "INT" cannot be cast to "INTERVAL YEAR" due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
+
+
+-- !query
+select cast(-9223372036854775808L as interval day)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkArithmeticException
+[CAST_OVERFLOW] The value -9223372036854775808L of the type "BIGINT" cannot be cast to "INTERVAL DAY" due to an overflow. Use `try_cast` to tolerate overflow and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
+
+
+-- !query
 select cast(interval '-1' year as decimal(10, 0))
 -- !query schema
 struct<CAST(INTERVAL '-1' YEAR AS DECIMAL(10,0)):decimal(10,0)>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose
1. to support casting of the integral type: `TINYINT`, `SMALLINT`, `INT`, `BIGINT` to ANSI interval types.
2. and remove the restriction of casting only single unit intervals.

This PR is complement to https://github.com/apache/spark/pull/36811.

### Why are the changes needed?
To conform the SQL standard which allows such casting:
<img width="801" alt="173228149-17e1fbaa-c095-4eb7-bb3b-81a3f9c91928" src="https://user-images.githubusercontent.com/1580697/183467069-73b2b4e4-6c34-4395-beb8-f1d721483f43.png">


### Does this PR introduce _any_ user-facing change?
No, it extends existing behavior.

### How was this patch tested?
By running new tests:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z cast.sql"
```