### PR TITLE
[SPARK-39309][PYTHON][INFRA] Change xmlrunner to unittest-xml-reporting

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -242,7 +242,7 @@ jobs:
     - name: Install Python packages (Python 3.8)
       if: (contains(matrix.modules, 'sql') && !contains(matrix.modules, 'sql-'))
       run: |
-        python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy xmlrunner
+        python3.8 -m pip install 'numpy>=1.20.0' pyarrow pandas scipy unittest-xml-reporting
         python3.8 -m pip list
     # Run the tests.
     - name: Run tests

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -32,7 +32,7 @@ RUN $APT_INSTALL software-properties-common git libxml2-dev pkg-config curl wget
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
-RUN python3.9 -m pip install numpy pyarrow 'pandas<1.4.0' scipy xmlrunner plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
+RUN python3.9 -m pip install numpy pyarrow 'pandas<1.4.0' scipy unittest-xml-reporting plotly>=4.8 sklearn 'mlflow>=1.0' coverage matplotlib
 
 RUN add-apt-repository ppa:pypy/ppa
 RUN apt update

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -12,7 +12,7 @@ sklearn
 matplotlib<3.3.0
 
 # PySpark test dependencies
-xmlrunner
+unittest-xml-reporting
 
 # PySpark test dependencies (optional)
 coverage


### PR DESCRIPTION
### What changes were proposed in this pull request?
The xmlrunner had been moved to https://github.com/xmlrunner/unittest-xml-reporting


### Why are the changes needed?
As metioned in SPARK-39309, I encountered a issue like: `AttributeError: '_SubTest' object has no attribute 'elapsed_time'`, according to https://github.com/xmlrunner/unittest-xml-reporting/issues/218#issuecomment-665088941 , I found that xmlrunner has been switch to `unittest-xml-reporting`.

We'd better to upgrade xmlrunner to avoid these kind of legacy issues.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Test on my local env
- CI passed