### PR TITLE
[SPARK-40017][SQL] Adaptive adjustment `spark.sql.adaptive.advisoryPartitionSizeInBytes`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -599,8 +599,9 @@ object SQLConf {
 
   val ADVISORY_PARTITION_SIZE_IN_BYTES =
     buildConf("spark.sql.adaptive.advisoryPartitionSizeInBytes")
-      .doc("The advisory size in bytes of the shuffle partition during adaptive optimization " +
-        s"(when ${ADAPTIVE_EXECUTION_ENABLED.key} is true). It takes effect when Spark " +
+      .doc("The initial advisory size in bytes of the shuffle partition during adaptive " +
+        s"optimization (when ${ADAPTIVE_EXECUTION_ENABLED.key} is true). It will be adaptively " +
+        "adjusted according to the operators that follows. It takes effect when Spark " +
         "coalesces small shuffle partitions or splits skewed shuffle partition.")
       .version("3.0.0")
       .fallbackConf(SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances `CoalesceShufflePartitions` to adaptive adjustment `spark.sql.adaptive.advisoryPartitionSizeInBytes` according to the `ExpandExec` operator that follows. For example:
```sql
SELECT                                          
  item.i_brand_id brand_id,                     
  item.i_brand brand,                           
  count(distinct ss_ext_sales_price),          
  count(distinct ss_addr_sk)                   
FROM store_sales, item                          
WHERE store_sales.ss_item_sk = item.i_item_sk
GROUP BY item.i_brand, item.i_brand_id          
```
 Before | After
-- | --
![image](https://user-images.githubusercontent.com/5399861/183652776-ed7802da-a431-4462-9596-4d90c9a1c491.png) |![image](https://user-images.githubusercontent.com/5399861/183652873-2f313c39-449f-4a2a-91f3-b1fa68e30506.png)


### Why are the changes needed?

Improve parallelism.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.