### PR TITLE
[SPARK-39559][CORE][FOLLOWUP] Use INADDR_ANY and IN6ADDR_ANY in WebUI

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/WebUI.scala
+++ b/core/src/main/scala/org/apache/spark/ui/WebUI.scala
@@ -140,7 +140,8 @@ private[spark] abstract class WebUI(
   def initialize(): Unit
 
   def initServer(): ServerInfo = {
-    val hostName = Utils.localHostNameForURI()
+    val hostName = Option(conf.getenv("SPARK_LOCAL_IP"))
+        .getOrElse(if (Utils.preferIPv6) "[::]" else "0.0.0.0")
     val server = startJettyServer(hostName, port, sslOptions, conf, name, poolSize)
     server
   }
@@ -152,7 +153,9 @@ private[spark] abstract class WebUI(
       val server = initServer()
       handlers.foreach(server.addHandler(_, securityManager))
       serverInfo = Some(server)
-      logInfo(s"Bound $className to ${Utils.localHostNameForURI()}, and started at $webUrl")
+      val hostName = Option(conf.getenv("SPARK_LOCAL_IP"))
+          .getOrElse(if (Utils.preferIPv6) "[::]" else "0.0.0.0")
+      logInfo(s"Bound $className to $hostName, and started at $webUrl")
     } catch {
       case e: Exception =>
         logError(s"Failed to bind $className", e)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a partial revert of SPARK-39559 which used `localHostNameForURI` to get `hostName`.
This PR aims to use INADDR_ANY back on IPv4 and IN6ADDR_ANY on IPv6.

### Why are the changes needed?

Although `localHostNameForURI` works for both IPv4 and IPv6, K8s `port-forward` assumes local loop back address like `127.0.0.1` or `[::1]` instead of PodIP.
```
$ k port-forward pi 4040
Forwarding from 127.0.0.1:4040 -> 4040
Forwarding from [::1]:4040 -> 4040
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.