### PR TITLE
[SPARK-40006][PYTHON][DOCS][FOLLOW-UP] Remove unused Spark context and duplicated Spark session initialization

### DIFF
--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -414,7 +414,6 @@ class GroupedData(PandasGroupedOpsMixin):
         Examples
         --------
         >>> from pyspark.sql import Row
-        >>> spark = SparkSession.builder.master("local[4]").appName("sql.group tests").getOrCreate()
         >>> df1 = spark.createDataFrame([
         ...     Row(course="dotNET", year=2012, earnings=10000),
         ...     Row(course="Java", year=2012, earnings=20000),
@@ -491,8 +490,6 @@ def _test() -> None:
 
     globs = pyspark.sql.group.__dict__.copy()
     spark = SparkSession.builder.master("local[4]").appName("sql.group tests").getOrCreate()
-    sc = spark.sparkContext
-    globs["sc"] = sc
     globs["spark"] = spark
 
     (failure_count, test_count) = doctest.testmod(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/37437 which missed to remove unused `sc` and duplicated Spark session initialization.

### Why are the changes needed?

To make the consistent example, and remove unused variables.

### Does this PR introduce _any_ user-facing change?

No. It's a documentation change. However, the previous PR is not released yet.

### How was this patch tested?

Ci in this PR should test it out.