### PR TITLE
[SPARK-40030][BUILD] Upgrade scala-maven-plugin to 4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,7 @@
       errors building different Hadoop versions.
       See: SPARK-36547, SPARK-38394.
        -->
-    <!--
-      SPARK-39502: Please don't upgrade the version to 4.6.2 due to
-      there is a compilation issue when run `mvn test` with Java 8
-      -->
-    <scala-maven-plugin.version>4.6.1</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.7.1</scala-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->
     <scalafmt.skip>true</scalafmt.skip>
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims upgrade scala-maven-plugin to 4.7.1


### Why are the changes needed?
This version brings some bug fix related to `Incremental compile` and upgrade zinc to 1.7.1

all changes as follows:

- https://github.com/davidB/scala-maven-plugin/compare/4.6.1...4.7.1


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass Github Actions
- Manually test the issue described in SPARK-39502

Run following command with Java 8/11/17:

```
mvn clean install -DskipTests -pl core -am
mvn test -pl core  -Dtest.exclude.tags=org.apache.spark.tags.ExtendedLevelDBTest 
```

All test passed and no errors described in SPARK-39502