### PR TITLE
[WIP][SPARK-40031][SQL] Remove unnecessary TryEval in TryCast

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Cast.{canUpCast, forceNullable,
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructType}
+import org.apache.spark.sql.types.{AnsiIntervalType, ArrayType, DataType, MapType, StringType, StructType}
 
 case class TryEval(child: Expression) extends UnaryExpression with NullIntolerant {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -100,7 +100,8 @@ case class TryCast(child: Expression, toType: DataType, timeZoneId: Option[Strin
 
   private def equivalentToNonAnsiCast: Boolean = {
     val fromType = child.dataType
-    canUpCast(fromType, toType) || fromType == StringType
+    canUpCast(fromType, toType) ||
+      (fromType == StringType && !toType.isInstanceOf[AnsiIntervalType])
   }
 
   // If the target data type is a complex type which can't have Null values, we should guarantee

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -39,8 +39,8 @@ class TryCastSuite extends SparkFunSuite {
   }
 
   test("nullability") {
-    assert(cast("abcdef", StringType).nullable)
-    assert(cast("abcdef", BinaryType).nullable)
+    assert(!cast("abcdef", StringType).nullable)
+    assert(!cast("abcdef", BinaryType).nullable)
   }
 
   test("only require timezone for datetime types") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -41,6 +41,12 @@ class TryCastSuite extends SparkFunSuite {
   test("nullability") {
     assert(!cast("abcdef", StringType).nullable)
     assert(!cast("abcdef", BinaryType).nullable)
+    DataTypeTestUtils.numericAndInterval.foreach { dt =>
+      assert(cast("abcdef", dt).nullable)
+    }
+    DataTypeTestUtils.atomicTypes.foreach { dt =>
+      assert(!cast(Literal.default(dt), StringType).nullable)
+    }
   }
 
   test("only require timezone for datetime types") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When the try_cast() syntax is equivalent to the non-ansi cast,  convert TryCast as Cast without wrapping with "TryEval" expression.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. For better performance. Taking `try_cast(string_col as int)` as example, Spark will have to contact error messages from [SparkThrowableHelper. getMessage ](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/ErrorInfo.scala#L86) for every invalid casting. This is actually not necessary in the try_cast function.
2. More accurate nullability. If the child of try_cast is non-nullable and the casting itself is up-cast, the result should be non-nullable too.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT + new UT for checking the nullability