### PR TITLE
[SPARK-40008][SQL][FOLLOWUP] Fix codegen of casting integrals to ANSI intervals

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1803,7 +1803,6 @@ case class Cast(
           $evPrim = $util.durationToMicros($util.microsToDuration($c), (byte)${it.endField});
         """
     case x: IntegralType =>
-      assert(it.startField == it.endField)
       val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
       if (x == LongType) {
         (c, evPrim, _) =>
@@ -1834,7 +1833,6 @@ case class Cast(
           $evPrim = $util.periodToMonths($util.monthsToPeriod($c), (byte)${it.endField});
         """
     case x: IntegralType =>
-      assert(it.startField == it.endField)
       val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
       if (x == LongType) {
         (c, evPrim, _) =>

--- a/sql/core/src/test/resources/sql-tests/inputs/cast.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cast.sql
@@ -120,9 +120,11 @@ select cast(interval '1000000' second as smallint);
 -- cast integrals to ANSI intervals
 select cast(1Y as interval year);
 select cast(-122S as interval year to month);
+select cast(ym as interval year to month) from values(-122S) as t(ym);
 select cast(1000 as interval month);
 select cast(-10L as interval second);
 select cast(100Y as interval hour to second);
+select cast(dt as interval hour to second) from values(100Y) as t(dt);
 select cast(-1000S as interval day to second);
 select cast(10 as interval day);
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/cast.sql.out
@@ -857,6 +857,14 @@ struct<CAST(-122 AS INTERVAL YEAR TO MONTH):interval year to month>
 
 
 -- !query
+select cast(ym as interval year to month) from values(-122S) as t(ym)
+-- !query schema
+struct<ym:interval year to month>
+-- !query output
+-10-2
+
+
+-- !query
 select cast(1000 as interval month)
 -- !query schema
 struct<CAST(1000 AS INTERVAL MONTH):interval month>
@@ -876,6 +884,14 @@ struct<CAST(-10 AS INTERVAL SECOND):interval second>
 select cast(100Y as interval hour to second)
 -- !query schema
 struct<CAST(100 AS INTERVAL HOUR TO SECOND):interval hour to second>
+-- !query output
+0 00:01:40.000000000
+
+
+-- !query
+select cast(dt as interval hour to second) from values(100Y) as t(dt)
+-- !query schema
+struct<dt:interval hour to second>
 -- !query output
 0 00:01:40.000000000
 

--- a/sql/core/src/test/resources/sql-tests/results/cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cast.sql.out
@@ -685,6 +685,14 @@ struct<CAST(-122 AS INTERVAL YEAR TO MONTH):interval year to month>
 
 
 -- !query
+select cast(ym as interval year to month) from values(-122S) as t(ym)
+-- !query schema
+struct<ym:interval year to month>
+-- !query output
+-10-2
+
+
+-- !query
 select cast(1000 as interval month)
 -- !query schema
 struct<CAST(1000 AS INTERVAL MONTH):interval month>
@@ -704,6 +712,14 @@ struct<CAST(-10 AS INTERVAL SECOND):interval second>
 select cast(100Y as interval hour to second)
 -- !query schema
 struct<CAST(100 AS INTERVAL HOUR TO SECOND):interval hour to second>
+-- !query output
+0 00:01:40.000000000
+
+
+-- !query
+select cast(dt as interval hour to second) from values(100Y) as t(dt)
+-- !query schema
+struct<dt:interval hour to second>
 -- !query output
 0 00:01:40.000000000
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a follow up of https://github.com/apache/spark/pull/37442 that fixes the codegen of casting integrals to ANSI intervals w/ multi units. The PR removes the assert: 
```scala
assert(it.startField == it.endField)
```

### Why are the changes needed?
To make codegen consistent to interpreted code, and fix the assert.

### Does this PR introduce _any_ user-facing change?
Yes.

Before:
```sql
> select cast(dt as interval hour to second) from values(100Y) as t(dt);
java.lang.AssertionError
assertion failed
```

After:
```sql
> select cast(dt as interval hour to second) from values(100Y) as t(dt);
0 00:01:40.000000000
```

### How was this patch tested?
By running new tests:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z cast.sql"
```