### PR TITLE
[SPARK-40029][PYTHON][DOC] Make pyspark.sql.types examples self-contained

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -450,7 +450,7 @@ class ArrayType(DataType):
     --------
     >>> from pyspark.sql.types import ArrayType, StringType, StructField, StructType
 
-    The below example demonstrates how to create ArrayType:
+    The below example demonstrates how to create class:`ArrayType`:
 
     >>> arr = ArrayType(StringType())
 
@@ -521,11 +521,11 @@ class MapType(DataType):
     --------
     >>> from pyspark.sql.types import IntegerType, FloatType, MapType, StringType
 
-    The below example demonstrates how to create MapType:
+    The below example demonstrates how to create class:`MapType`:
 
     >>> map_type = MapType(StringType(), IntegerType())
 
-    The values of the map can contain null (None) values by default:
+    The values of the map can contain null (``None``) values by default:
 
     >>> (MapType(StringType(), IntegerType())
     ...        == MapType(StringType(), IntegerType(), True))
@@ -703,8 +703,8 @@ class StructType(DataType):
     >>> struct1 == struct2
     False
 
-    The below example demonstrates how to create a struct using StructType & StructField on
-    DataFrame:
+    The below example demonstrates how to create a struct using class:`StructType`
+    and class:`StructField` on DataFrame:
 
     >>> data = [("Alice", ["Java", "Scala"]), ("Bob", ["Python", "Scala"])]
     >>> schema = StructType([
@@ -717,7 +717,6 @@ class StructType(DataType):
      |-- name: string (nullable = true)
      |-- languagesSkills: array (nullable = true)
      |    |-- element: string (containsNull = true)
-    <BLANKLINE>
     >>> df.show()
     +-----+---------------+
     | name|languagesSkills|
@@ -725,7 +724,6 @@ class StructType(DataType):
     |Alice|  [Java, Scala]|
     |  Bob|[Python, Scala]|
     +-----+---------------+
-    <BLANKLINE>
     """
 
     def __init__(self, fields: Optional[List[StructField]] = None):
@@ -1080,7 +1078,6 @@ def _parse_datatype_string(s: str) -> DataType:
 
     Examples
     --------
-    >>> from pyspark.sql.types import _parse_datatype_string
     >>> _parse_datatype_string("int ")
     IntegerType()
     >>> _parse_datatype_string("INT ")
@@ -1153,8 +1150,6 @@ def _parse_datatype_json_string(json_string: str) -> DataType:
 
     Examples
     --------
-    >>> from pyspark.sql.types import *
-    >>> from pyspark.sql.types import _all_atomic_types, _parse_datatype_json_string
     >>> import pickle
     >>> def check_datatype(datatype):
     ...     pickled = pickle.loads(pickle.dumps(datatype))
@@ -1696,8 +1691,6 @@ def _make_type_verifier(
 
     Examples
     --------
-    >>> from pyspark.sql.types import *
-    >>> from pyspark.sql.types import _make_type_verifier
     >>> _make_type_verifier(StructType([]))(None)
     >>> _make_type_verifier(StringType())("")
     >>> _make_type_verifier(LongType())(0)
@@ -2188,7 +2181,9 @@ def _test() -> None:
     sc = SparkContext("local[4]", "PythonTest")
     globs["sc"] = sc
     globs["spark"] = SparkSession.builder.getOrCreate()
-    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    (failure_count, test_count) = doctest.testmod(
+        globs=globs, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+    )
     globs["sc"].stop()
     if failure_count:
         sys.exit(-1)

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -703,8 +703,8 @@ class StructType(DataType):
     >>> struct1 == struct2
     False
 
-    The below example demonstrates how to create a struct using class:`StructType`
-    and class:`StructField` on DataFrame:
+    The below example demonstrates how to create a DataFrame based on a struct created
+    using class:`StructType` and class:`StructField`:
 
     >>> data = [("Alice", ["Java", "Scala"]), ("Bob", ["Python", "Scala"])]
     >>> schema = StructType([

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2174,17 +2174,13 @@ register_input_converter(DayTimeIntervalTypeConverter())
 
 def _test() -> None:
     import doctest
-    from pyspark.context import SparkContext
     from pyspark.sql import SparkSession
 
     globs = globals()
-    sc = SparkContext("local[4]", "PythonTest")
-    globs["sc"] = sc
     globs["spark"] = SparkSession.builder.getOrCreate()
     (failure_count, test_count) = doctest.testmod(
         globs=globs, optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
     )
-    globs["sc"].stop()
     if failure_count:
         sys.exit(-1)
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -448,6 +448,7 @@ class ArrayType(DataType):
 
     Examples
     --------
+    >>> from pyspark.sql.types import ArrayType, StringType
     >>> ArrayType(StringType()) == ArrayType(StringType(), True)
     True
     >>> ArrayType(StringType(), False) == ArrayType(StringType())
@@ -511,6 +512,7 @@ class MapType(DataType):
 
     Examples
     --------
+    >>> from pyspark.sql.types import IntegerType, FloatType, MapType, StringType
     >>> (MapType(StringType(), IntegerType())
     ...        == MapType(StringType(), IntegerType(), True))
     True
@@ -588,6 +590,7 @@ class StructField(DataType):
 
     Examples
     --------
+    >>> from pyspark.sql.types import StringType, StructField
     >>> (StructField("f1", StringType(), True)
     ...      == StructField("f1", StringType(), True))
     True
@@ -661,6 +664,7 @@ class StructType(DataType):
 
     Examples
     --------
+    >>> from pyspark.sql.types import CharType, IntegerType, StringType, StructField, StructType, VarcharType
     >>> struct1 = StructType([StructField("f1", StringType(), True)])
     >>> struct1["f1"]
     StructField('f1', StringType(), True)
@@ -747,8 +751,9 @@ class StructType(DataType):
 
         Examples
         --------
+        >>> from pyspark.sql.types import IntegerType, StringType, StructField, StructType
         >>> struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)
-        >>> struct2 = StructType([StructField("f1", StringType(), True), \\
+        >>> struct2 = StructType([StructField("f1", StringType(), True),
         ...     StructField("f2", StringType(), True, None)])
         >>> struct1 == struct2
         True
@@ -823,6 +828,7 @@ class StructType(DataType):
 
         Examples
         --------
+        >>> from pyspark.sql.types import StringType, StructField, StructType
         >>> struct = StructType([StructField("f1", StringType(), True)])
         >>> struct.fieldNames()
         ['f1']
@@ -1036,6 +1042,7 @@ def _parse_datatype_string(s: str) -> DataType:
 
     Examples
     --------
+    >>> from pyspark.sql.types import _parse_datatype_string
     >>> _parse_datatype_string("int ")
     IntegerType()
     >>> _parse_datatype_string("INT ")
@@ -1108,6 +1115,18 @@ def _parse_datatype_json_string(json_string: str) -> DataType:
 
     Examples
     --------
+    >>> from pyspark.sql.types import (
+            ArrayType,
+            BinaryType,
+            BooleanType,
+            CharType,
+            DecimalType,
+            LongType,
+            MapType,
+            StringType,
+            StructType,
+            VarcharType,
+        )
     >>> import pickle
     >>> def check_datatype(datatype):
     ...     pickled = pickle.loads(pickle.dumps(datatype))
@@ -1649,6 +1668,19 @@ def _make_type_verifier(
 
     Examples
     --------
+    >>> from pyspark.sql.types import (
+    ...     ArrayType,
+    ...     BooleanType,
+    ...     ByteType,
+    ...     DecimalType,
+    ...     IntegerType,
+    ...     LongType,
+    ...     MapType,
+    ...     ShortType,
+    ...     StringType,
+    ...     StructType,
+    ...     _make_type_verifier
+    ... )
     >>> _make_type_verifier(StructType([]))(None)
     >>> _make_type_verifier(StringType())("")
     >>> _make_type_verifier(LongType())(0)
@@ -1899,6 +1931,7 @@ class Row(tuple):
 
     Examples
     --------
+    >>> from pyspark.sql import Row
     >>> row = Row(name="Alice", age=11)
     >>> row
     Row(name='Alice', age=11)
@@ -1972,6 +2005,7 @@ class Row(tuple):
 
         Examples
         --------
+        >>> from pyspark.sql import Row
         >>> Row(name="Alice", age=11).asDict() == {'name': 'Alice', 'age': 11}
         True
         >>> row = Row(key=1, value=Row(name='a', age=2))

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -448,7 +448,14 @@ class ArrayType(DataType):
 
     Examples
     --------
-    >>> from pyspark.sql.types import ArrayType, StringType
+    >>> from pyspark.sql.types import ArrayType, StringType, StructField, StructType
+
+    The below example demonstrates how to create ArrayType:
+
+    >>> arr = ArrayType(StringType())
+
+    The array can contain null (None) values by default:
+
     >>> ArrayType(StringType()) == ArrayType(StringType(), True)
     True
     >>> ArrayType(StringType(), False) == ArrayType(StringType())
@@ -513,6 +520,13 @@ class MapType(DataType):
     Examples
     --------
     >>> from pyspark.sql.types import IntegerType, FloatType, MapType, StringType
+
+    The below example demonstrates how to create MapType:
+
+    >>> map_type = MapType(StringType(), IntegerType())
+
+    The values of the map can contain null (None) values by default:
+
     >>> (MapType(StringType(), IntegerType())
     ...        == MapType(StringType(), IntegerType(), True))
     True
@@ -664,7 +678,7 @@ class StructType(DataType):
 
     Examples
     --------
-    >>> from pyspark.sql.types import CharType, IntegerType, StringType, StructField, StructType, VarcharType
+    >>> from pyspark.sql.types import *
     >>> struct1 = StructType([StructField("f1", StringType(), True)])
     >>> struct1["f1"]
     StructField('f1', StringType(), True)
@@ -688,6 +702,30 @@ class StructType(DataType):
     ...     StructField("f2", IntegerType(), False)])
     >>> struct1 == struct2
     False
+
+    The below example demonstrates how to create a struct using StructType & StructField on
+    DataFrame:
+
+    >>> data = [("Alice", ["Java", "Scala"]), ("Bob", ["Python", "Scala"])]
+    >>> schema = StructType([
+    ...     StructField("name", StringType()),
+    ...     StructField("languagesSkills", ArrayType(StringType())),
+    ... ])
+    >>> df = spark.createDataFrame(data=data, schema=schema)
+    >>> df.printSchema()
+    root
+     |-- name: string (nullable = true)
+     |-- languagesSkills: array (nullable = true)
+     |    |-- element: string (containsNull = true)
+    <BLANKLINE>
+    >>> df.show()
+    +-----+---------------+
+    | name|languagesSkills|
+    +-----+---------------+
+    |Alice|  [Java, Scala]|
+    |  Bob|[Python, Scala]|
+    +-----+---------------+
+    <BLANKLINE>
     """
 
     def __init__(self, fields: Optional[List[StructField]] = None):
@@ -1115,18 +1153,8 @@ def _parse_datatype_json_string(json_string: str) -> DataType:
 
     Examples
     --------
-    >>> from pyspark.sql.types import (
-            ArrayType,
-            BinaryType,
-            BooleanType,
-            CharType,
-            DecimalType,
-            LongType,
-            MapType,
-            StringType,
-            StructType,
-            VarcharType,
-        )
+    >>> from pyspark.sql.types import *
+    >>> from pyspark.sql.types import _all_atomic_types, _parse_datatype_json_string
     >>> import pickle
     >>> def check_datatype(datatype):
     ...     pickled = pickle.loads(pickle.dumps(datatype))
@@ -1668,19 +1696,8 @@ def _make_type_verifier(
 
     Examples
     --------
-    >>> from pyspark.sql.types import (
-    ...     ArrayType,
-    ...     BooleanType,
-    ...     ByteType,
-    ...     DecimalType,
-    ...     IntegerType,
-    ...     LongType,
-    ...     MapType,
-    ...     ShortType,
-    ...     StringType,
-    ...     StructType,
-    ...     _make_type_verifier
-    ... )
+    >>> from pyspark.sql.types import *
+    >>> from pyspark.sql.types import _make_type_verifier
     >>> _make_type_verifier(StructType([]))(None)
     >>> _make_type_verifier(StringType())("")
     >>> _make_type_verifier(LongType())(0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to improve the examples in `pyspark.sql.types` by making each example self-contained with a brief explanation and a bit more realistic example.

### Why are the changes needed?
To make the documentation more readable and able to copy and paste directly in PySpark shell.


### Does this PR introduce _any_ user-facing change?
Yes, doc


### How was this patch tested?
Ran each test
