### PR TITLE
[SPARK-40044][SQL] Fix the target interval type in cast overflow errors

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -790,10 +790,10 @@ case class Cast(
     case x: IntegralType =>
       if (x == LongType) {
         b => IntervalUtils.longToDayTimeInterval(
-          x.integral.asInstanceOf[Integral[Any]].toLong(b), it.endField)
+          x.integral.asInstanceOf[Integral[Any]].toLong(b), it.startField, it.endField)
       } else {
         b => IntervalUtils.intToDayTimeInterval(
-          x.integral.asInstanceOf[Integral[Any]].toInt(b), it.endField)
+          x.integral.asInstanceOf[Integral[Any]].toInt(b), it.startField, it.endField)
       }
   }
 
@@ -807,10 +807,10 @@ case class Cast(
     case x: IntegralType =>
       if (x == LongType) {
         b => IntervalUtils.longToYearMonthInterval(
-          x.integral.asInstanceOf[Integral[Any]].toLong(b), it.endField)
+          x.integral.asInstanceOf[Integral[Any]].toLong(b), it.startField, it.endField)
       } else {
         b => IntervalUtils.intToYearMonthInterval(
-          x.integral.asInstanceOf[Integral[Any]].toInt(b), it.endField)
+          x.integral.asInstanceOf[Integral[Any]].toInt(b), it.startField, it.endField)
       }
   }
 
@@ -1804,16 +1804,16 @@ case class Cast(
         """
     case x: IntegralType =>
       assert(it.startField == it.endField)
-      val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
+      val iu = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
       if (x == LongType) {
         (c, evPrim, _) =>
           code"""
-            $evPrim = $util.longToDayTimeInterval($c, (byte)${it.endField});
+            $evPrim = $iu.longToDayTimeInterval($c, (byte)${it.startField}, (byte)${it.endField});
           """
       } else {
         (c, evPrim, _) =>
           code"""
-            $evPrim = $util.intToDayTimeInterval($c, (byte)${it.endField});
+            $evPrim = $iu.intToDayTimeInterval($c, (byte)${it.startField}, (byte)${it.endField});
           """
       }
   }
@@ -1835,16 +1835,16 @@ case class Cast(
         """
     case x: IntegralType =>
       assert(it.startField == it.endField)
-      val util = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
+      val iu = IntervalUtils.getClass.getCanonicalName.stripSuffix("$")
       if (x == LongType) {
         (c, evPrim, _) =>
           code"""
-            $evPrim = $util.longToYearMonthInterval($c, (byte)${it.endField});
+            $evPrim = $iu.longToYearMonthInterval($c, (byte)${it.startField}, (byte)${it.endField});
           """
       } else {
         (c, evPrim, _) =>
           code"""
-            $evPrim = $util.intToYearMonthInterval($c, (byte)${it.endField});
+            $evPrim = $iu.intToYearMonthInterval($c, (byte)${it.startField}, (byte)${it.endField});
           """
       }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -1256,25 +1256,31 @@ object IntervalUtils {
     intervalString
   }
 
-  def intToYearMonthInterval(v: Int, endField: Byte): Int = {
+  def intToYearMonthInterval(v: Int, startField: Byte, endField: Byte): Int = {
     endField match {
       case YEAR =>
         try {
           Math.multiplyExact(v, MONTHS_PER_YEAR)
         } catch {
           case _: ArithmeticException =>
-            throw QueryExecutionErrors.castingCauseOverflowError(v, IntegerType, YM(endField))
+            throw QueryExecutionErrors.castingCauseOverflowError(
+              v,
+              IntegerType,
+              YearMonthIntervalType(startField, endField))
         }
       case MONTH => v
     }
   }
 
-  def longToYearMonthInterval(v: Long, endField: Byte): Int = {
+  def longToYearMonthInterval(v: Long, startField: Byte, endField: Byte): Int = {
     val vInt = v.toInt
     if (v != vInt) {
-      throw QueryExecutionErrors.castingCauseOverflowError(v, LongType, YM(endField))
+      throw QueryExecutionErrors.castingCauseOverflowError(
+        v,
+        LongType,
+        YearMonthIntervalType(startField, endField))
     }
-    intToYearMonthInterval(vInt, endField)
+    intToYearMonthInterval(vInt, startField, endField)
   }
 
   def yearMonthIntervalToInt(v: Int, startField: Byte, endField: Byte): Int = {
@@ -1308,14 +1314,17 @@ object IntervalUtils {
     vByte
   }
 
-  def intToDayTimeInterval(v: Int, endField: Byte): Long = {
+  def intToDayTimeInterval(v: Int, startField: Byte, endField: Byte): Long = {
     endField match {
       case DAY =>
         try {
           Math.multiplyExact(v, MICROS_PER_DAY)
         } catch {
           case _: ArithmeticException =>
-            throw QueryExecutionErrors.castingCauseOverflowError(v, IntegerType, DT(endField))
+            throw QueryExecutionErrors.castingCauseOverflowError(
+              v,
+              IntegerType,
+              DayTimeIntervalType(startField, endField))
         }
       case HOUR => v * MICROS_PER_HOUR
       case MINUTE => v * MICROS_PER_MINUTE
@@ -1323,7 +1332,7 @@ object IntervalUtils {
     }
   }
 
-  def longToDayTimeInterval(v: Long, endField: Byte): Long = {
+  def longToDayTimeInterval(v: Long, startField: Byte, endField: Byte): Long = {
     try {
       endField match {
         case DAY => Math.multiplyExact(v, MICROS_PER_DAY)
@@ -1333,7 +1342,10 @@ object IntervalUtils {
       }
     } catch {
       case _: ArithmeticException =>
-        throw QueryExecutionErrors.castingCauseOverflowError(v, LongType, DT(endField))
+        throw QueryExecutionErrors.castingCauseOverflowError(
+          v,
+          LongType,
+          DayTimeIntervalType(startField, endField))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -190,4 +190,20 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         "columnName" -> "`col`")
     )
   }
+
+  test("CAST_OVERFLOW: from long to ANSI intervals") {
+    Seq("INTERVAL YEAR TO MONTH", "INTERVAL HOUR TO MINUTE").foreach { it =>
+      checkError(
+        exception = intercept[SparkArithmeticException] {
+          sql(s"select CAST(9223372036854775807L AS $it)").collect()
+        },
+        errorClass = "CAST_OVERFLOW",
+        parameters = Map(
+          "value" -> "9223372036854775807L",
+          "sourceType" -> "\"BIGINT\"",
+          "targetType" -> s""""$it"""",
+          "ansiConfig" -> ansiConf),
+        sqlState = "22005")
+    }
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -190,20 +190,4 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         "columnName" -> "`col`")
     )
   }
-
-  test("CAST_OVERFLOW: from long to ANSI intervals") {
-    Seq("INTERVAL YEAR TO MONTH", "INTERVAL HOUR TO MINUTE").foreach { it =>
-      checkError(
-        exception = intercept[SparkArithmeticException] {
-          sql(s"select CAST(9223372036854775807L AS $it)").collect()
-        },
-        errorClass = "CAST_OVERFLOW",
-        parameters = Map(
-          "value" -> "9223372036854775807L",
-          "sourceType" -> "\"BIGINT\"",
-          "targetType" -> s""""$it"""",
-          "ansiConfig" -> ansiConf),
-        sqlState = "22005")
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -653,6 +653,22 @@ class QueryExecutionErrorsSuite
         "alternative" -> "",
         "config" -> SQLConf.ANSI_ENABLED.key))
   }
+
+  test("CAST_OVERFLOW: from long to ANSI intervals") {
+    Seq("INTERVAL YEAR TO MONTH", "INTERVAL HOUR TO MINUTE").foreach { it =>
+      checkError(
+        exception = intercept[SparkArithmeticException] {
+          sql(s"select CAST(9223372036854775807L AS $it)").collect()
+        },
+        errorClass = "CAST_OVERFLOW",
+        parameters = Map(
+          "value" -> "9223372036854775807L",
+          "sourceType" -> "\"BIGINT\"",
+          "targetType" -> s""""$it"""",
+          "ansiConfig" -> s""""${SQLConf.ANSI_ENABLED.key}""""),
+        sqlState = "22005")
+    }
+  }
 }
 
 class FakeFileSystemSetPermission extends LocalFileSystem {


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to fix the incorrect target type in the error message of the cast overflow. For example:
```sql
spark-sql> select CAST(9223372036854775807L AS INTERVAL YEAR TO MONTH);
org.apache.spark.SparkArithmeticException: [CAST_OVERFLOW] The value 9223372036854775807L of the type "BIGINT" cannot be cast to "INTERVAL MONTH" due to an overflow. 
```
The target type is **"INTERVAL MONTH"** instead of **"INTERVAL YEAR TO MONTH"**.

### Why are the changes needed?
To improve user experience with Spark SQL, and do not confuse users by incorrect error messages.


### Does this PR introduce _any_ user-facing change?
Yes, it changes user-facing error messages.

After the changes, for the example above:
```sql
spark-sql> select CAST(9223372036854775807L AS INTERVAL YEAR TO MONTH);
org.apache.spark.SparkArithmeticException: [CAST_OVERFLOW] The value 9223372036854775807L of the type "BIGINT" cannot be cast to "INTERVAL YEAR TO MONTH" due to an overflow.
```

### How was this patch tested?
By running new test:
```
$  build/sbt "test:testOnly *QueryExecutionErrorsSuite"
```