### PR TITLE
[SPARK-40036][CORE] Fix some API semantics of `Level/RocksDBIterator` after `db/iterator` is closed

### DIFF
--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -189,6 +189,7 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
     if (!closed) {
       it.close();
       closed = true;
+      next = null;
     }
   }
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/LevelDBIterator.java
@@ -159,6 +159,8 @@ class LevelDBIterator<T> implements KVStoreIterator<T> {
 
   @Override
   public boolean skip(long n) {
+    if (closed) return false;
+
     long skipped = 0;
     while (skipped < n) {
       if (next != null) {

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
@@ -183,6 +183,7 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
     if (!closed) {
       it.close();
       closed = true;
+      next = null;
     }
   }
 

--- a/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
+++ b/common/kvstore/src/main/java/org/apache/spark/util/kvstore/RocksDBIterator.java
@@ -150,6 +150,8 @@ class RocksDBIterator<T> implements KVStoreIterator<T> {
 
   @Override
   public boolean skip(long n) {
+    if(closed) return false;
+
     long skipped = 0;
     while (skipped < n) {
       if (next != null) {

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -305,6 +305,32 @@ public class LevelDBSuite {
     assertTrue(!dbPathForCloseTest.exists());
   }
 
+  @Test
+  public void testHasNextAfterIteratorClose() throws Exception {
+    String prefix = "test_db_hasNext.";
+    String suffix = ".ldb";
+    File path = File.createTempFile(prefix, suffix);
+    path.delete();
+    LevelDB db = new LevelDB(path);
+    // Write two records for test
+    db.write(createCustomType1(0));
+    db.write(createCustomType1(1));
+
+    KVStoreView<CustomType1> view = db.view(CustomType1.class);
+    KVStoreIterator<CustomType1> iter = view.closeableIterator();
+    assertEquals("key0", iter.next().key);
+    // iter should be true
+    assertTrue(iter.hasNext());
+    iter.close();
+    // iter should be false after iter close
+    assertFalse(iter.hasNext());
+
+    db.close();
+    assertTrue(path.exists());
+    FileUtils.deleteQuietly(path);
+    assertFalse(path.exists());
+  }
+
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -306,15 +306,8 @@ public class LevelDBSuite {
   }
 
   @Test
-  public void testHasNextAndNextAfterIteratorClose() throws Exception {
-    String prefix = "test_db_iter_close.";
-    String suffix = ".ldb";
-    File path = File.createTempFile(prefix, suffix);
-    path.delete();
-    LevelDB db = new LevelDB(path);
-    // Write one records for test
+  public void testHasNextAfterIteratorClose() throws Exception {
     db.write(createCustomType1(0));
-
     KVStoreIterator<CustomType1> iter =
       db.view(CustomType1.class).closeableIterator();
     // iter should be true
@@ -323,25 +316,11 @@ public class LevelDBSuite {
     iter.close();
     // iter.hasNext should be false after iter close
     assertFalse(iter.hasNext());
-    // iter.next should throw NoSuchElementException after iter close
-    assertThrows(NoSuchElementException.class, iter::next);
-
-    db.close();
-    assertTrue(path.exists());
-    FileUtils.deleteQuietly(path);
-    assertFalse(path.exists());
   }
 
   @Test
-  public void testHasNextAndNextAfterDBClose() throws Exception {
-    String prefix = "test_db_db_close.";
-    String suffix = ".ldb";
-    File path = File.createTempFile(prefix, suffix);
-    path.delete();
-    LevelDB db = new LevelDB(path);
-    // Write one record for test
+  public void testHasNextAfterDBClose() throws Exception {
     db.write(createCustomType1(0));
-
     KVStoreIterator<CustomType1> iter =
       db.view(CustomType1.class).closeableIterator();
     // iter should be true
@@ -350,12 +329,58 @@ public class LevelDBSuite {
     db.close();
     // iter.hasNext should be false after db close
     assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testNextAfterIteratorClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close iter
+    iter.close();
+    // iter.next should throw NoSuchElementException after iter close
+    assertThrows(NoSuchElementException.class, iter::next);
+  }
+
+  @Test
+  public void testNextAfterDBClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close db
+    iter.close();
     // iter.next should throw NoSuchElementException after db close
     assertThrows(NoSuchElementException.class, iter::next);
+  }
 
-    assertTrue(path.exists());
-    FileUtils.deleteQuietly(path);
-    assertFalse(path.exists());
+  @Test
+  public void testSkipAfterIteratorClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // close iter
+    iter.close();
+    // skip should always return false after iter close
+    assertFalse(iter.skip(0));
+    assertFalse(iter.skip(1));
+  }
+
+  @Test
+  public void testSkipAfterDBClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close db
+    db.close();
+    // skip should always return false after db close
+    assertFalse(iter.skip(0));
+    assertFalse(iter.skip(1));
   }
 
   private CustomType1 createCustomType1(int i) {

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/LevelDBSuite.java
@@ -306,26 +306,53 @@ public class LevelDBSuite {
   }
 
   @Test
-  public void testHasNextAfterIteratorClose() throws Exception {
-    String prefix = "test_db_hasNext.";
+  public void testHasNextAndNextAfterIteratorClose() throws Exception {
+    String prefix = "test_db_iter_close.";
     String suffix = ".ldb";
     File path = File.createTempFile(prefix, suffix);
     path.delete();
     LevelDB db = new LevelDB(path);
-    // Write two records for test
+    // Write one records for test
     db.write(createCustomType1(0));
-    db.write(createCustomType1(1));
 
-    KVStoreView<CustomType1> view = db.view(CustomType1.class);
-    KVStoreIterator<CustomType1> iter = view.closeableIterator();
-    assertEquals("key0", iter.next().key);
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
     // iter should be true
     assertTrue(iter.hasNext());
+    // close iter
     iter.close();
-    // iter should be false after iter close
+    // iter.hasNext should be false after iter close
     assertFalse(iter.hasNext());
+    // iter.next should throw NoSuchElementException after iter close
+    assertThrows(NoSuchElementException.class, iter::next);
 
     db.close();
+    assertTrue(path.exists());
+    FileUtils.deleteQuietly(path);
+    assertFalse(path.exists());
+  }
+
+  @Test
+  public void testHasNextAndNextAfterDBClose() throws Exception {
+    String prefix = "test_db_db_close.";
+    String suffix = ".ldb";
+    File path = File.createTempFile(prefix, suffix);
+    path.delete();
+    LevelDB db = new LevelDB(path);
+    // Write one record for test
+    db.write(createCustomType1(0));
+
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close db
+    db.close();
+    // iter.hasNext should be false after db close
+    assertFalse(iter.hasNext());
+    // iter.next should throw NoSuchElementException after db close
+    assertThrows(NoSuchElementException.class, iter::next);
+
     assertTrue(path.exists());
     FileUtils.deleteQuietly(path);
     assertFalse(path.exists());

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -303,6 +303,33 @@ public class RocksDBSuite {
     assertTrue(!dbPathForCloseTest.exists());
   }
 
+
+  @Test
+  public void testHasNextAfterIteratorClose() throws Exception {
+    String prefix = "test_db_hasNext.";
+    String suffix = ".rdb";
+    File path = File.createTempFile(prefix, suffix);
+    path.delete();
+    RocksDB db = new RocksDB(path);
+    // Write two records for test
+    db.write(createCustomType1(0));
+    db.write(createCustomType1(1));
+
+    KVStoreView<CustomType1> view = db.view(CustomType1.class);
+    KVStoreIterator<CustomType1> iter = view.closeableIterator();
+    assertEquals("key0", iter.next().key);
+    // iter should be true
+    assertTrue(iter.hasNext());
+    iter.close();
+    // iter should be false after iter close
+    assertFalse(iter.hasNext());
+
+    db.close();
+    assertTrue(path.exists());
+    FileUtils.deleteQuietly(path);
+    assertFalse(path.exists());
+  }
+
   private CustomType1 createCustomType1(int i) {
     CustomType1 t = new CustomType1();
     t.key = "key" + i;

--- a/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
+++ b/common/kvstore/src/test/java/org/apache/spark/util/kvstore/RocksDBSuite.java
@@ -304,15 +304,8 @@ public class RocksDBSuite {
   }
 
   @Test
-  public void testHasNextAndNextAfterIteratorClose() throws Exception {
-    String prefix = "test_db_iter_close.";
-    String suffix = ".rdb";
-    File path = File.createTempFile(prefix, suffix);
-    path.delete();
-    RocksDB db = new RocksDB(path);
-    // Write one records for test
+  public void testHasNextAfterIteratorClose() throws Exception {
     db.write(createCustomType1(0));
-
     KVStoreIterator<CustomType1> iter =
       db.view(CustomType1.class).closeableIterator();
     // iter should be true
@@ -321,25 +314,11 @@ public class RocksDBSuite {
     iter.close();
     // iter.hasNext should be false after iter close
     assertFalse(iter.hasNext());
-    // iter.next should throw NoSuchElementException after iter close
-    assertThrows(NoSuchElementException.class, iter::next);
-
-    db.close();
-    assertTrue(path.exists());
-    FileUtils.deleteQuietly(path);
-    assertFalse(path.exists());
   }
 
   @Test
-  public void testHasNextAndNextAfterDBClose() throws Exception {
-    String prefix = "test_db_db_close.";
-    String suffix = ".rdb";
-    File path = File.createTempFile(prefix, suffix);
-    path.delete();
-    RocksDB db = new RocksDB(path);
-    // Write one record for test
+  public void testHasNextAfterDBClose() throws Exception {
     db.write(createCustomType1(0));
-
     KVStoreIterator<CustomType1> iter =
       db.view(CustomType1.class).closeableIterator();
     // iter should be true
@@ -348,12 +327,58 @@ public class RocksDBSuite {
     db.close();
     // iter.hasNext should be false after db close
     assertFalse(iter.hasNext());
+  }
+
+  @Test
+  public void testNextAfterIteratorClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close iter
+    iter.close();
+    // iter.next should throw NoSuchElementException after iter close
+    assertThrows(NoSuchElementException.class, iter::next);
+  }
+
+  @Test
+  public void testNextAfterDBClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close db
+    iter.close();
     // iter.next should throw NoSuchElementException after db close
     assertThrows(NoSuchElementException.class, iter::next);
+  }
 
-    assertTrue(path.exists());
-    FileUtils.deleteQuietly(path);
-    assertFalse(path.exists());
+  @Test
+  public void testSkipAfterIteratorClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // close iter
+    iter.close();
+    // skip should always return false after iter close
+    assertFalse(iter.skip(0));
+    assertFalse(iter.skip(1));
+  }
+
+  @Test
+  public void testSkipAfterDBClose() throws Exception {
+    db.write(createCustomType1(0));
+    KVStoreIterator<CustomType1> iter =
+      db.view(CustomType1.class).closeableIterator();
+    // iter should be true
+    assertTrue(iter.hasNext());
+    // close db
+    db.close();
+    // skip should always return false after db close
+    assertFalse(iter.skip(0));
+    assertFalse(iter.skip(1));
   }
 
   private CustomType1 createCustomType1(int i) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR do the following changes to ensure that the semantics of `Level/RocksDBIterator`'s API are correct after `db/iterator` is closed

- Add `next = null` to `close()` method of `Level/RocksDBIterator` to ensure `hasNext()` always return `false` and `next()` always throw `NoSuchElementException` after `db/iterator` is closed

- Add `closed` to `skip(n)` method of `Level/RocksDBIterator` to ensure it always return `false` instead of throw `AssertionError` after `db/iterator` is closed


### Why are the changes needed?
Bug fix： fix API semantics of `Level/RocksDBIterator` after `db/iterator` is closed 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Add new test case