### PR TITLE
[SPARK-39887][SQL][3.3] RemoveRedundantAliases should keep aliases that make the output of projection nodes unique

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -513,9 +513,11 @@ object RemoveRedundantAliases extends Rule[LogicalPlan] {
   }
 
   /**
-   * Remove redundant alias expression from a LogicalPlan and its subtree. A set of excludes is used
-   * to prevent the removal of seemingly redundant aliases used to deduplicate the input for a
-   * (self) join or to prevent the removal of top-level subquery attributes.
+   * Remove redundant alias expression from a LogicalPlan and its subtree.
+   * A set of excludes is used to prevent the removal of:
+   * - seemingly redundant aliases used to deduplicate the input for a (self) join,
+   * - top-level subquery attributes and
+   * - attributes of a Union's first child
    */
   private def removeRedundantAliases(plan: LogicalPlan, excluded: AttributeSet): LogicalPlan = {
     if (!plan.containsPattern(ALIAS)) {
@@ -542,6 +544,21 @@ object RemoveRedundantAliases extends Rule[LogicalPlan] {
         })
         Join(newLeft, newRight, joinType, newCondition, hint)
 
+      case _: Union =>
+        var first = true
+        plan.mapChildren { child =>
+          if (first) {
+            first = false
+            // `Union` inherits its first child's outputs. We don't remove those aliases from the
+            // first child's tree that prevent aliased attributes to appear multiple times in the
+            // `Union`'s output. A parent projection node on the top of an `Union` with non-unique
+            // output attributes could return incorrect result.
+            removeRedundantAliases(child, excluded ++ child.outputSet)
+          } else {
+            removeRedundantAliases(child, excluded)
+          }
+        }
+
       case _ =>
         // Remove redundant aliases in the subtree(s).
         val currentNextAttrPairs = mutable.Buffer.empty[(Attribute, Attribute)]
@@ -551,9 +568,6 @@ object RemoveRedundantAliases extends Rule[LogicalPlan] {
           newChild
         }
 
-        // Create the attribute mapping. Note that the currentNextAttrPairs can contain duplicate
-        // keys in case of Union (this is caused by the PushProjectionThroughUnion rule); in this
-        // case we use the first mapping (which should be provided by the first child).
         val mapping = AttributeMap(currentNextAttrPairs.toSeq)
 
         // Create a an expression cleaning function for nodes that can actually produce redundant

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAliasAndProjectSuite.scala
@@ -97,7 +97,7 @@ class RemoveRedundantAliasAndProjectSuite extends PlanTest with PredicateHelper 
     val r2 = LocalRelation('b.int)
     val query = r1.select('a as 'a).union(r2.select('b as 'b)).select('a).analyze
     val optimized = Optimize.execute(query)
-    val expected = r1.union(r2)
+    val expected = r1.select($"a" as "a").union(r2).analyze
     comparePlans(optimized, expected)
   }
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a.sf100/explain.txt
@@ -476,31 +476,31 @@ Input [5]: [i_brand_id#38, i_class_id#39, i_category_id#40, sales#49, number_sal
 Condition : (isnotnull(sales#49) AND (cast(sales#49 as decimal(32,6)) > cast(Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
 (79) Project [codegen id : 44]
-Output [6]: [sales#49, number_sales#50, store AS channel#53, i_brand_id#38, i_class_id#39, i_category_id#40]
+Output [6]: [sales#49, number_sales#50, store AS channel#53, i_brand_id#38 AS i_brand_id#54, i_class_id#39 AS i_class_id#55, i_category_id#40 AS i_category_id#56]
 Input [5]: [i_brand_id#38, i_class_id#39, i_category_id#40, sales#49, number_sales#50]
 
 (80) Scan parquet default.catalog_sales
-Output [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Output [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#57), dynamicpruningexpression(cs_sold_date_sk#57 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#60), dynamicpruningexpression(cs_sold_date_sk#60 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (81) ColumnarToRow [codegen id : 45]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
 
 (82) Filter [codegen id : 45]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
-Condition : isnotnull(cs_item_sk#54)
+Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Condition : isnotnull(cs_item_sk#57)
 
 (83) Exchange
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
-Arguments: hashpartitioning(cs_item_sk#54, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Arguments: hashpartitioning(cs_item_sk#57, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (84) Sort [codegen id : 46]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
-Arguments: [cs_item_sk#54 ASC NULLS FIRST], false, 0
+Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Arguments: [cs_item_sk#57 ASC NULLS FIRST], false, 0
 
 (85) ReusedExchange [Reuses operator id: 58]
 Output [1]: [ss_item_sk#35]
@@ -510,82 +510,82 @@ Input [1]: [ss_item_sk#35]
 Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 
 (87) SortMergeJoin [codegen id : 87]
-Left keys [1]: [cs_item_sk#54]
+Left keys [1]: [cs_item_sk#57]
 Right keys [1]: [ss_item_sk#35]
 Join condition: None
 
 (88) ReusedExchange [Reuses operator id: 147]
-Output [1]: [d_date_sk#58]
+Output [1]: [d_date_sk#61]
 
 (89) BroadcastHashJoin [codegen id : 87]
-Left keys [1]: [cs_sold_date_sk#57]
-Right keys [1]: [d_date_sk#58]
+Left keys [1]: [cs_sold_date_sk#60]
+Right keys [1]: [d_date_sk#61]
 Join condition: None
 
 (90) Project [codegen id : 87]
-Output [3]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56]
-Input [5]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, d_date_sk#58]
+Output [3]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59]
+Input [5]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, d_date_sk#61]
 
 (91) ReusedExchange [Reuses operator id: 72]
-Output [4]: [i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Output [4]: [i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
 
 (92) BroadcastHashJoin [codegen id : 87]
-Left keys [1]: [cs_item_sk#54]
-Right keys [1]: [i_item_sk#59]
+Left keys [1]: [cs_item_sk#57]
+Right keys [1]: [i_item_sk#62]
 Join condition: None
 
 (93) Project [codegen id : 87]
-Output [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#60, i_class_id#61, i_category_id#62]
-Input [7]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, i_item_sk#59, i_brand_id#60, i_class_id#61, i_category_id#62]
+Output [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#63, i_class_id#64, i_category_id#65]
+Input [7]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, i_item_sk#62, i_brand_id#63, i_class_id#64, i_category_id#65]
 
 (94) HashAggregate [codegen id : 87]
-Input [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#60, i_class_id#61, i_category_id#62]
-Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
-Aggregate Attributes [3]: [sum#63, isEmpty#64, count#65]
-Results [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
+Input [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#63, i_class_id#64, i_category_id#65]
+Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
+Aggregate Attributes [3]: [sum#66, isEmpty#67, count#68]
+Results [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
 
 (95) Exchange
-Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
-Arguments: hashpartitioning(i_brand_id#60, i_class_id#61, i_category_id#62, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
+Arguments: hashpartitioning(i_brand_id#63, i_class_id#64, i_category_id#65, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (96) HashAggregate [codegen id : 88]
-Input [6]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum#66, isEmpty#67, count#68]
-Keys [3]: [i_brand_id#60, i_class_id#61, i_category_id#62]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2))), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2)))#69, count(1)#70]
-Results [5]: [i_brand_id#60, i_class_id#61, i_category_id#62, sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2)))#69 AS sales#71, count(1)#70 AS number_sales#72]
+Input [6]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum#69, isEmpty#70, count#71]
+Keys [3]: [i_brand_id#63, i_class_id#64, i_category_id#65]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2))), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2)))#72, count(1)#73]
+Results [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2)))#72 AS sales#74, count(1)#73 AS number_sales#75]
 
 (97) Filter [codegen id : 88]
-Input [5]: [i_brand_id#60, i_class_id#61, i_category_id#62, sales#71, number_sales#72]
-Condition : (isnotnull(sales#71) AND (cast(sales#71 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#74, number_sales#75]
+Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
 (98) Project [codegen id : 88]
-Output [6]: [sales#71, number_sales#72, catalog AS channel#73, i_brand_id#60, i_class_id#61, i_category_id#62]
-Input [5]: [i_brand_id#60, i_class_id#61, i_category_id#62, sales#71, number_sales#72]
+Output [6]: [sales#74, number_sales#75, catalog AS channel#76, i_brand_id#63, i_class_id#64, i_category_id#65]
+Input [5]: [i_brand_id#63, i_class_id#64, i_category_id#65, sales#74, number_sales#75]
 
 (99) Scan parquet default.web_sales
-Output [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
+Output [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#77), dynamicpruningexpression(ws_sold_date_sk#77 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#80), dynamicpruningexpression(ws_sold_date_sk#80 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (100) ColumnarToRow [codegen id : 89]
-Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 
 (101) Filter [codegen id : 89]
-Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
-Condition : isnotnull(ws_item_sk#74)
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
+Condition : isnotnull(ws_item_sk#77)
 
 (102) Exchange
-Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
-Arguments: hashpartitioning(ws_item_sk#74, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
+Arguments: hashpartitioning(ws_item_sk#77, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (103) Sort [codegen id : 90]
-Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
-Arguments: [ws_item_sk#74 ASC NULLS FIRST], false, 0
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
+Arguments: [ws_item_sk#77 ASC NULLS FIRST], false, 0
 
 (104) ReusedExchange [Reuses operator id: 58]
 Output [1]: [ss_item_sk#35]
@@ -595,87 +595,87 @@ Input [1]: [ss_item_sk#35]
 Arguments: [ss_item_sk#35 ASC NULLS FIRST], false, 0
 
 (106) SortMergeJoin [codegen id : 131]
-Left keys [1]: [ws_item_sk#74]
+Left keys [1]: [ws_item_sk#77]
 Right keys [1]: [ss_item_sk#35]
 Join condition: None
 
 (107) ReusedExchange [Reuses operator id: 147]
-Output [1]: [d_date_sk#78]
+Output [1]: [d_date_sk#81]
 
 (108) BroadcastHashJoin [codegen id : 131]
-Left keys [1]: [ws_sold_date_sk#77]
-Right keys [1]: [d_date_sk#78]
+Left keys [1]: [ws_sold_date_sk#80]
+Right keys [1]: [d_date_sk#81]
 Join condition: None
 
 (109) Project [codegen id : 131]
-Output [3]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76]
-Input [5]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, d_date_sk#78]
+Output [3]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79]
+Input [5]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, d_date_sk#81]
 
 (110) ReusedExchange [Reuses operator id: 72]
-Output [4]: [i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
+Output [4]: [i_item_sk#82, i_brand_id#83, i_class_id#84, i_category_id#85]
 
 (111) BroadcastHashJoin [codegen id : 131]
-Left keys [1]: [ws_item_sk#74]
-Right keys [1]: [i_item_sk#79]
+Left keys [1]: [ws_item_sk#77]
+Right keys [1]: [i_item_sk#82]
 Join condition: None
 
 (112) Project [codegen id : 131]
-Output [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#80, i_class_id#81, i_category_id#82]
-Input [7]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, i_item_sk#79, i_brand_id#80, i_class_id#81, i_category_id#82]
+Output [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#83, i_class_id#84, i_category_id#85]
+Input [7]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, i_item_sk#82, i_brand_id#83, i_class_id#84, i_category_id#85]
 
 (113) HashAggregate [codegen id : 131]
-Input [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#80, i_class_id#81, i_category_id#82]
-Keys [3]: [i_brand_id#80, i_class_id#81, i_category_id#82]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
-Aggregate Attributes [3]: [sum#83, isEmpty#84, count#85]
-Results [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#86, isEmpty#87, count#88]
+Input [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#83, i_class_id#84, i_category_id#85]
+Keys [3]: [i_brand_id#83, i_class_id#84, i_category_id#85]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
+Aggregate Attributes [3]: [sum#86, isEmpty#87, count#88]
+Results [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#89, isEmpty#90, count#91]
 
 (114) Exchange
-Input [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#86, isEmpty#87, count#88]
-Arguments: hashpartitioning(i_brand_id#80, i_class_id#81, i_category_id#82, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#89, isEmpty#90, count#91]
+Arguments: hashpartitioning(i_brand_id#83, i_class_id#84, i_category_id#85, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (115) HashAggregate [codegen id : 132]
-Input [6]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum#86, isEmpty#87, count#88]
-Keys [3]: [i_brand_id#80, i_class_id#81, i_category_id#82]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2))), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2)))#89, count(1)#90]
-Results [5]: [i_brand_id#80, i_class_id#81, i_category_id#82, sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2)))#89 AS sales#91, count(1)#90 AS number_sales#92]
+Input [6]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum#89, isEmpty#90, count#91]
+Keys [3]: [i_brand_id#83, i_class_id#84, i_category_id#85]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2))), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2)))#92, count(1)#93]
+Results [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2)))#92 AS sales#94, count(1)#93 AS number_sales#95]
 
 (116) Filter [codegen id : 132]
-Input [5]: [i_brand_id#80, i_class_id#81, i_category_id#82, sales#91, number_sales#92]
-Condition : (isnotnull(sales#91) AND (cast(sales#91 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sales#94, number_sales#95]
+Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
 (117) Project [codegen id : 132]
-Output [6]: [sales#91, number_sales#92, web AS channel#93, i_brand_id#80, i_class_id#81, i_category_id#82]
-Input [5]: [i_brand_id#80, i_class_id#81, i_category_id#82, sales#91, number_sales#92]
+Output [6]: [sales#94, number_sales#95, web AS channel#96, i_brand_id#83, i_class_id#84, i_category_id#85]
+Input [5]: [i_brand_id#83, i_class_id#84, i_category_id#85, sales#94, number_sales#95]
 
 (118) Union
 
 (119) Expand [codegen id : 133]
-Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#38, i_class_id#39, i_category_id#40]
-Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#38, i_class_id#39, i_category_id#40, 0], [sales#49, number_sales#50, channel#53, i_brand_id#38, i_class_id#39, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#38, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
+Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56]
+Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56, 0], [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#54, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 
 (120) HashAggregate [codegen id : 133]
-Input [7]: [sales#49, number_sales#50, channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
-Keys [5]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
+Input [7]: [sales#49, number_sales#50, channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
+Keys [5]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Functions [2]: [partial_sum(sales#49), partial_sum(number_sales#50)]
-Aggregate Attributes [3]: [sum#99, isEmpty#100, sum#101]
-Results [8]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, sum#102, isEmpty#103, sum#104]
+Aggregate Attributes [3]: [sum#102, isEmpty#103, sum#104]
+Results [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
 
 (121) Exchange
-Input [8]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, sum#102, isEmpty#103, sum#104]
-Arguments: hashpartitioning(channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, 5), ENSURE_REQUIREMENTS, [plan_id=18]
+Input [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
+Arguments: hashpartitioning(channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
 (122) HashAggregate [codegen id : 134]
-Input [8]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, sum#102, isEmpty#103, sum#104]
-Keys [5]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
+Input [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
+Keys [5]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Functions [2]: [sum(sales#49), sum(number_sales#50)]
-Aggregate Attributes [2]: [sum(sales#49)#105, sum(number_sales#50)#106]
-Results [6]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, sum(sales#49)#105 AS sum(sales)#107, sum(number_sales#50)#106 AS sum(number_sales)#108]
+Aggregate Attributes [2]: [sum(sales#49)#108, sum(number_sales#50)#109]
+Results [6]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales#49)#108 AS sum(sales)#110, sum(number_sales#50)#109 AS sum(number_sales)#111]
 
 (123) TakeOrderedAndProject
-Input [6]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, sum(sales)#107, sum(number_sales)#108]
-Arguments: 100, [channel#94 ASC NULLS FIRST, i_brand_id#95 ASC NULLS FIRST, i_class_id#96 ASC NULLS FIRST, i_category_id#97 ASC NULLS FIRST], [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, sum(sales)#107, sum(number_sales)#108]
+Input [6]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales)#110, sum(number_sales)#111]
+Arguments: 100, [channel#97 ASC NULLS FIRST, i_brand_id#98 ASC NULLS FIRST, i_class_id#99 ASC NULLS FIRST, i_category_id#100 ASC NULLS FIRST], [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales)#110, sum(number_sales)#111]
 
 ===== Subqueries =====
 
@@ -702,96 +702,96 @@ Subquery:1 Hosting operator id = 78 Hosting Expression = Subquery scalar-subquer
 
 
 (124) Scan parquet default.store_sales
-Output [3]: [ss_quantity#109, ss_list_price#110, ss_sold_date_sk#111]
+Output [3]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#111), dynamicpruningexpression(ss_sold_date_sk#111 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#114), dynamicpruningexpression(ss_sold_date_sk#114 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (125) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#109, ss_list_price#110, ss_sold_date_sk#111]
+Input [3]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114]
 
 (126) ReusedExchange [Reuses operator id: 152]
-Output [1]: [d_date_sk#112]
+Output [1]: [d_date_sk#115]
 
 (127) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#111]
-Right keys [1]: [d_date_sk#112]
+Left keys [1]: [ss_sold_date_sk#114]
+Right keys [1]: [d_date_sk#115]
 Join condition: None
 
 (128) Project [codegen id : 2]
-Output [2]: [ss_quantity#109 AS quantity#113, ss_list_price#110 AS list_price#114]
-Input [4]: [ss_quantity#109, ss_list_price#110, ss_sold_date_sk#111, d_date_sk#112]
+Output [2]: [ss_quantity#112 AS quantity#116, ss_list_price#113 AS list_price#117]
+Input [4]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114, d_date_sk#115]
 
 (129) Scan parquet default.catalog_sales
-Output [3]: [cs_quantity#115, cs_list_price#116, cs_sold_date_sk#117]
+Output [3]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#117), dynamicpruningexpression(cs_sold_date_sk#117 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#120), dynamicpruningexpression(cs_sold_date_sk#120 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (130) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#115, cs_list_price#116, cs_sold_date_sk#117]
+Input [3]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120]
 
 (131) ReusedExchange [Reuses operator id: 152]
-Output [1]: [d_date_sk#118]
+Output [1]: [d_date_sk#121]
 
 (132) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#117]
-Right keys [1]: [d_date_sk#118]
+Left keys [1]: [cs_sold_date_sk#120]
+Right keys [1]: [d_date_sk#121]
 Join condition: None
 
 (133) Project [codegen id : 4]
-Output [2]: [cs_quantity#115 AS quantity#119, cs_list_price#116 AS list_price#120]
-Input [4]: [cs_quantity#115, cs_list_price#116, cs_sold_date_sk#117, d_date_sk#118]
+Output [2]: [cs_quantity#118 AS quantity#122, cs_list_price#119 AS list_price#123]
+Input [4]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120, d_date_sk#121]
 
 (134) Scan parquet default.web_sales
-Output [3]: [ws_quantity#121, ws_list_price#122, ws_sold_date_sk#123]
+Output [3]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#123), dynamicpruningexpression(ws_sold_date_sk#123 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#126), dynamicpruningexpression(ws_sold_date_sk#126 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (135) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#121, ws_list_price#122, ws_sold_date_sk#123]
+Input [3]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126]
 
 (136) ReusedExchange [Reuses operator id: 152]
-Output [1]: [d_date_sk#124]
+Output [1]: [d_date_sk#127]
 
 (137) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#123]
-Right keys [1]: [d_date_sk#124]
+Left keys [1]: [ws_sold_date_sk#126]
+Right keys [1]: [d_date_sk#127]
 Join condition: None
 
 (138) Project [codegen id : 6]
-Output [2]: [ws_quantity#121 AS quantity#125, ws_list_price#122 AS list_price#126]
-Input [4]: [ws_quantity#121, ws_list_price#122, ws_sold_date_sk#123, d_date_sk#124]
+Output [2]: [ws_quantity#124 AS quantity#128, ws_list_price#125 AS list_price#129]
+Input [4]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126, d_date_sk#127]
 
 (139) Union
 
 (140) HashAggregate [codegen id : 7]
-Input [2]: [quantity#113, list_price#114]
+Input [2]: [quantity#116, list_price#117]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))]
-Aggregate Attributes [2]: [sum#127, count#128]
-Results [2]: [sum#129, count#130]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))]
+Aggregate Attributes [2]: [sum#130, count#131]
+Results [2]: [sum#132, count#133]
 
 (141) Exchange
-Input [2]: [sum#129, count#130]
+Input [2]: [sum#132, count#133]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
 
 (142) HashAggregate [codegen id : 8]
-Input [2]: [sum#129, count#130]
+Input [2]: [sum#132, count#133]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))#131]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))#131 AS average_sales#132]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))#134]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))#134 AS average_sales#135]
 
-Subquery:2 Hosting operator id = 124 Hosting Expression = ss_sold_date_sk#111 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 124 Hosting Expression = ss_sold_date_sk#114 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 129 Hosting Expression = cs_sold_date_sk#117 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 129 Hosting Expression = cs_sold_date_sk#120 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 134 Hosting Expression = ws_sold_date_sk#123 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 134 Hosting Expression = ws_sold_date_sk#126 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (147)
@@ -802,22 +802,22 @@ BroadcastExchange (147)
 
 
 (143) Scan parquet default.date_dim
-Output [3]: [d_date_sk#36, d_year#133, d_moy#134]
+Output [3]: [d_date_sk#36, d_year#136, d_moy#137]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (144) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#133, d_moy#134]
+Input [3]: [d_date_sk#36, d_year#136, d_moy#137]
 
 (145) Filter [codegen id : 1]
-Input [3]: [d_date_sk#36, d_year#133, d_moy#134]
-Condition : ((((isnotnull(d_year#133) AND isnotnull(d_moy#134)) AND (d_year#133 = 2001)) AND (d_moy#134 = 11)) AND isnotnull(d_date_sk#36))
+Input [3]: [d_date_sk#36, d_year#136, d_moy#137]
+Condition : ((((isnotnull(d_year#136) AND isnotnull(d_moy#137)) AND (d_year#136 = 2001)) AND (d_moy#137 = 11)) AND isnotnull(d_date_sk#36))
 
 (146) Project [codegen id : 1]
 Output [1]: [d_date_sk#36]
-Input [3]: [d_date_sk#36, d_year#133, d_moy#134]
+Input [3]: [d_date_sk#36, d_year#136, d_moy#137]
 
 (147) BroadcastExchange
 Input [1]: [d_date_sk#36]
@@ -832,22 +832,22 @@ BroadcastExchange (152)
 
 
 (148) Scan parquet default.date_dim
-Output [2]: [d_date_sk#13, d_year#135]
+Output [2]: [d_date_sk#13, d_year#138]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (149) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#135]
+Input [2]: [d_date_sk#13, d_year#138]
 
 (150) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#135]
-Condition : (((isnotnull(d_year#135) AND (d_year#135 >= 1999)) AND (d_year#135 <= 2001)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#13, d_year#138]
+Condition : (((isnotnull(d_year#138) AND (d_year#138 >= 1999)) AND (d_year#138 <= 2001)) AND isnotnull(d_date_sk#13))
 
 (151) Project [codegen id : 1]
 Output [1]: [d_date_sk#13]
-Input [2]: [d_date_sk#13, d_year#135]
+Input [2]: [d_date_sk#13, d_year#138]
 
 (152) BroadcastExchange
 Input [1]: [d_date_sk#13]
@@ -859,10 +859,10 @@ Subquery:8 Hosting operator id = 43 Hosting Expression = ws_sold_date_sk#29 IN d
 
 Subquery:9 Hosting operator id = 97 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
 
-Subquery:10 Hosting operator id = 80 Hosting Expression = cs_sold_date_sk#57 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 80 Hosting Expression = cs_sold_date_sk#60 IN dynamicpruning#5
 
 Subquery:11 Hosting operator id = 116 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
 
-Subquery:12 Hosting operator id = 99 Hosting Expression = ws_sold_date_sk#77 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 99 Hosting Expression = ws_sold_date_sk#80 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14a/explain.txt
@@ -410,182 +410,182 @@ Input [5]: [i_brand_id#37, i_class_id#38, i_category_id#39, sales#49, number_sal
 Condition : (isnotnull(sales#49) AND (cast(sales#49 as decimal(32,6)) > cast(Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
 (67) Project [codegen id : 26]
-Output [6]: [sales#49, number_sales#50, store AS channel#53, i_brand_id#37, i_class_id#38, i_category_id#39]
+Output [6]: [sales#49, number_sales#50, store AS channel#53, i_brand_id#37 AS i_brand_id#54, i_class_id#38 AS i_class_id#55, i_category_id#39 AS i_category_id#56]
 Input [5]: [i_brand_id#37, i_class_id#38, i_category_id#39, sales#49, number_sales#50]
 
 (68) Scan parquet default.catalog_sales
-Output [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Output [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#57), dynamicpruningexpression(cs_sold_date_sk#57 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#60), dynamicpruningexpression(cs_sold_date_sk#60 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (69) ColumnarToRow [codegen id : 51]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
+Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
 
 (70) Filter [codegen id : 51]
-Input [4]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57]
-Condition : isnotnull(cs_item_sk#54)
+Input [4]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60]
+Condition : isnotnull(cs_item_sk#57)
 
 (71) ReusedExchange [Reuses operator id: 50]
 Output [1]: [ss_item_sk#35]
 
 (72) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_item_sk#54]
+Left keys [1]: [cs_item_sk#57]
 Right keys [1]: [ss_item_sk#35]
 Join condition: None
 
 (73) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61]
+Output [4]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
 
 (74) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_item_sk#54]
-Right keys [1]: [i_item_sk#58]
+Left keys [1]: [cs_item_sk#57]
+Right keys [1]: [i_item_sk#61]
 Join condition: None
 
 (75) Project [codegen id : 51]
-Output [6]: [cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, i_brand_id#59, i_class_id#60, i_category_id#61]
-Input [8]: [cs_item_sk#54, cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, i_item_sk#58, i_brand_id#59, i_class_id#60, i_category_id#61]
+Output [6]: [cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [8]: [cs_item_sk#57, cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
 
 (76) ReusedExchange [Reuses operator id: 129]
-Output [1]: [d_date_sk#62]
+Output [1]: [d_date_sk#65]
 
 (77) BroadcastHashJoin [codegen id : 51]
-Left keys [1]: [cs_sold_date_sk#57]
-Right keys [1]: [d_date_sk#62]
+Left keys [1]: [cs_sold_date_sk#60]
+Right keys [1]: [d_date_sk#65]
 Join condition: None
 
 (78) Project [codegen id : 51]
-Output [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#59, i_class_id#60, i_category_id#61]
-Input [7]: [cs_quantity#55, cs_list_price#56, cs_sold_date_sk#57, i_brand_id#59, i_class_id#60, i_category_id#61, d_date_sk#62]
+Output [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [7]: [cs_quantity#58, cs_list_price#59, cs_sold_date_sk#60, i_brand_id#62, i_class_id#63, i_category_id#64, d_date_sk#65]
 
 (79) HashAggregate [codegen id : 51]
-Input [5]: [cs_quantity#55, cs_list_price#56, i_brand_id#59, i_class_id#60, i_category_id#61]
-Keys [3]: [i_brand_id#59, i_class_id#60, i_category_id#61]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
-Aggregate Attributes [3]: [sum#63, isEmpty#64, count#65]
-Results [6]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum#66, isEmpty#67, count#68]
+Input [5]: [cs_quantity#58, cs_list_price#59, i_brand_id#62, i_class_id#63, i_category_id#64]
+Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
+Aggregate Attributes [3]: [sum#66, isEmpty#67, count#68]
+Results [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#69, isEmpty#70, count#71]
 
 (80) Exchange
-Input [6]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum#66, isEmpty#67, count#68]
-Arguments: hashpartitioning(i_brand_id#59, i_class_id#60, i_category_id#61, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#69, isEmpty#70, count#71]
+Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (81) HashAggregate [codegen id : 52]
-Input [6]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum#66, isEmpty#67, count#68]
-Keys [3]: [i_brand_id#59, i_class_id#60, i_category_id#61]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2))), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2)))#69, count(1)#70]
-Results [5]: [i_brand_id#59, i_class_id#60, i_category_id#61, sum(CheckOverflow((promote_precision(cast(cs_quantity#55 as decimal(12,2))) * promote_precision(cast(cs_list_price#56 as decimal(12,2)))), DecimalType(18,2)))#69 AS sales#71, count(1)#70 AS number_sales#72]
+Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#69, isEmpty#70, count#71]
+Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2))), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2)))#72, count(1)#73]
+Results [5]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum(CheckOverflow((promote_precision(cast(cs_quantity#58 as decimal(12,2))) * promote_precision(cast(cs_list_price#59 as decimal(12,2)))), DecimalType(18,2)))#72 AS sales#74, count(1)#73 AS number_sales#75]
 
 (82) Filter [codegen id : 52]
-Input [5]: [i_brand_id#59, i_class_id#60, i_category_id#61, sales#71, number_sales#72]
-Condition : (isnotnull(sales#71) AND (cast(sales#71 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
 (83) Project [codegen id : 52]
-Output [6]: [sales#71, number_sales#72, catalog AS channel#73, i_brand_id#59, i_class_id#60, i_category_id#61]
-Input [5]: [i_brand_id#59, i_class_id#60, i_category_id#61, sales#71, number_sales#72]
+Output [6]: [sales#74, number_sales#75, catalog AS channel#76, i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [5]: [i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
 
 (84) Scan parquet default.web_sales
-Output [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
+Output [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#77), dynamicpruningexpression(ws_sold_date_sk#77 IN dynamicpruning#5)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#80), dynamicpruningexpression(ws_sold_date_sk#80 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (85) ColumnarToRow [codegen id : 77]
-Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
 
 (86) Filter [codegen id : 77]
-Input [4]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77]
-Condition : isnotnull(ws_item_sk#74)
+Input [4]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80]
+Condition : isnotnull(ws_item_sk#77)
 
 (87) ReusedExchange [Reuses operator id: 50]
 Output [1]: [ss_item_sk#35]
 
 (88) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#74]
+Left keys [1]: [ws_item_sk#77]
 Right keys [1]: [ss_item_sk#35]
 Join condition: None
 
 (89) ReusedExchange [Reuses operator id: 57]
-Output [4]: [i_item_sk#78, i_brand_id#79, i_class_id#80, i_category_id#81]
+Output [4]: [i_item_sk#81, i_brand_id#82, i_class_id#83, i_category_id#84]
 
 (90) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_item_sk#74]
-Right keys [1]: [i_item_sk#78]
+Left keys [1]: [ws_item_sk#77]
+Right keys [1]: [i_item_sk#81]
 Join condition: None
 
 (91) Project [codegen id : 77]
-Output [6]: [ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, i_brand_id#79, i_class_id#80, i_category_id#81]
-Input [8]: [ws_item_sk#74, ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, i_item_sk#78, i_brand_id#79, i_class_id#80, i_category_id#81]
+Output [6]: [ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, i_brand_id#82, i_class_id#83, i_category_id#84]
+Input [8]: [ws_item_sk#77, ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, i_item_sk#81, i_brand_id#82, i_class_id#83, i_category_id#84]
 
 (92) ReusedExchange [Reuses operator id: 129]
-Output [1]: [d_date_sk#82]
+Output [1]: [d_date_sk#85]
 
 (93) BroadcastHashJoin [codegen id : 77]
-Left keys [1]: [ws_sold_date_sk#77]
-Right keys [1]: [d_date_sk#82]
+Left keys [1]: [ws_sold_date_sk#80]
+Right keys [1]: [d_date_sk#85]
 Join condition: None
 
 (94) Project [codegen id : 77]
-Output [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#79, i_class_id#80, i_category_id#81]
-Input [7]: [ws_quantity#75, ws_list_price#76, ws_sold_date_sk#77, i_brand_id#79, i_class_id#80, i_category_id#81, d_date_sk#82]
+Output [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#82, i_class_id#83, i_category_id#84]
+Input [7]: [ws_quantity#78, ws_list_price#79, ws_sold_date_sk#80, i_brand_id#82, i_class_id#83, i_category_id#84, d_date_sk#85]
 
 (95) HashAggregate [codegen id : 77]
-Input [5]: [ws_quantity#75, ws_list_price#76, i_brand_id#79, i_class_id#80, i_category_id#81]
-Keys [3]: [i_brand_id#79, i_class_id#80, i_category_id#81]
-Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
-Aggregate Attributes [3]: [sum#83, isEmpty#84, count#85]
-Results [6]: [i_brand_id#79, i_class_id#80, i_category_id#81, sum#86, isEmpty#87, count#88]
+Input [5]: [ws_quantity#78, ws_list_price#79, i_brand_id#82, i_class_id#83, i_category_id#84]
+Keys [3]: [i_brand_id#82, i_class_id#83, i_category_id#84]
+Functions [2]: [partial_sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2))), partial_count(1)]
+Aggregate Attributes [3]: [sum#86, isEmpty#87, count#88]
+Results [6]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum#89, isEmpty#90, count#91]
 
 (96) Exchange
-Input [6]: [i_brand_id#79, i_class_id#80, i_category_id#81, sum#86, isEmpty#87, count#88]
-Arguments: hashpartitioning(i_brand_id#79, i_class_id#80, i_category_id#81, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [6]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum#89, isEmpty#90, count#91]
+Arguments: hashpartitioning(i_brand_id#82, i_class_id#83, i_category_id#84, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (97) HashAggregate [codegen id : 78]
-Input [6]: [i_brand_id#79, i_class_id#80, i_category_id#81, sum#86, isEmpty#87, count#88]
-Keys [3]: [i_brand_id#79, i_class_id#80, i_category_id#81]
-Functions [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2))), count(1)]
-Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2)))#89, count(1)#90]
-Results [5]: [i_brand_id#79, i_class_id#80, i_category_id#81, sum(CheckOverflow((promote_precision(cast(ws_quantity#75 as decimal(12,2))) * promote_precision(cast(ws_list_price#76 as decimal(12,2)))), DecimalType(18,2)))#89 AS sales#91, count(1)#90 AS number_sales#92]
+Input [6]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum#89, isEmpty#90, count#91]
+Keys [3]: [i_brand_id#82, i_class_id#83, i_category_id#84]
+Functions [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2))), count(1)]
+Aggregate Attributes [2]: [sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2)))#92, count(1)#93]
+Results [5]: [i_brand_id#82, i_class_id#83, i_category_id#84, sum(CheckOverflow((promote_precision(cast(ws_quantity#78 as decimal(12,2))) * promote_precision(cast(ws_list_price#79 as decimal(12,2)))), DecimalType(18,2)))#92 AS sales#94, count(1)#93 AS number_sales#95]
 
 (98) Filter [codegen id : 78]
-Input [5]: [i_brand_id#79, i_class_id#80, i_category_id#81, sales#91, number_sales#92]
-Condition : (isnotnull(sales#91) AND (cast(sales#91 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
+Input [5]: [i_brand_id#82, i_class_id#83, i_category_id#84, sales#94, number_sales#95]
+Condition : (isnotnull(sales#94) AND (cast(sales#94 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#51, [id=#52] as decimal(32,6))))
 
 (99) Project [codegen id : 78]
-Output [6]: [sales#91, number_sales#92, web AS channel#93, i_brand_id#79, i_class_id#80, i_category_id#81]
-Input [5]: [i_brand_id#79, i_class_id#80, i_category_id#81, sales#91, number_sales#92]
+Output [6]: [sales#94, number_sales#95, web AS channel#96, i_brand_id#82, i_class_id#83, i_category_id#84]
+Input [5]: [i_brand_id#82, i_class_id#83, i_category_id#84, sales#94, number_sales#95]
 
 (100) Union
 
 (101) Expand [codegen id : 79]
-Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#37, i_class_id#38, i_category_id#39]
-Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#37, i_class_id#38, i_category_id#39, 0], [sales#49, number_sales#50, channel#53, i_brand_id#37, i_class_id#38, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#37, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
+Input [6]: [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56]
+Arguments: [[sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, i_category_id#56, 0], [sales#49, number_sales#50, channel#53, i_brand_id#54, i_class_id#55, null, 1], [sales#49, number_sales#50, channel#53, i_brand_id#54, null, null, 3], [sales#49, number_sales#50, channel#53, null, null, null, 7], [sales#49, number_sales#50, null, null, null, null, 15]], [sales#49, number_sales#50, channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 
 (102) HashAggregate [codegen id : 79]
-Input [7]: [sales#49, number_sales#50, channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
-Keys [5]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
+Input [7]: [sales#49, number_sales#50, channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
+Keys [5]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Functions [2]: [partial_sum(sales#49), partial_sum(number_sales#50)]
-Aggregate Attributes [3]: [sum#99, isEmpty#100, sum#101]
-Results [8]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, sum#102, isEmpty#103, sum#104]
+Aggregate Attributes [3]: [sum#102, isEmpty#103, sum#104]
+Results [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
 
 (103) Exchange
-Input [8]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, sum#102, isEmpty#103, sum#104]
-Arguments: hashpartitioning(channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
+Arguments: hashpartitioning(channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (104) HashAggregate [codegen id : 80]
-Input [8]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98, sum#102, isEmpty#103, sum#104]
-Keys [5]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, spark_grouping_id#98]
+Input [8]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101, sum#105, isEmpty#106, sum#107]
+Keys [5]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, spark_grouping_id#101]
 Functions [2]: [sum(sales#49), sum(number_sales#50)]
-Aggregate Attributes [2]: [sum(sales#49)#105, sum(number_sales#50)#106]
-Results [6]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, sum(sales#49)#105 AS sum(sales)#107, sum(number_sales#50)#106 AS sum(number_sales)#108]
+Aggregate Attributes [2]: [sum(sales#49)#108, sum(number_sales#50)#109]
+Results [6]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales#49)#108 AS sum(sales)#110, sum(number_sales#50)#109 AS sum(number_sales)#111]
 
 (105) TakeOrderedAndProject
-Input [6]: [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, sum(sales)#107, sum(number_sales)#108]
-Arguments: 100, [channel#94 ASC NULLS FIRST, i_brand_id#95 ASC NULLS FIRST, i_class_id#96 ASC NULLS FIRST, i_category_id#97 ASC NULLS FIRST], [channel#94, i_brand_id#95, i_class_id#96, i_category_id#97, sum(sales)#107, sum(number_sales)#108]
+Input [6]: [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales)#110, sum(number_sales)#111]
+Arguments: 100, [channel#97 ASC NULLS FIRST, i_brand_id#98 ASC NULLS FIRST, i_class_id#99 ASC NULLS FIRST, i_category_id#100 ASC NULLS FIRST], [channel#97, i_brand_id#98, i_class_id#99, i_category_id#100, sum(sales)#110, sum(number_sales)#111]
 
 ===== Subqueries =====
 
@@ -612,96 +612,96 @@ Subquery:1 Hosting operator id = 66 Hosting Expression = Subquery scalar-subquer
 
 
 (106) Scan parquet default.store_sales
-Output [3]: [ss_quantity#109, ss_list_price#110, ss_sold_date_sk#111]
+Output [3]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#111), dynamicpruningexpression(ss_sold_date_sk#111 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#114), dynamicpruningexpression(ss_sold_date_sk#114 IN dynamicpruning#12)]
 ReadSchema: struct<ss_quantity:int,ss_list_price:decimal(7,2)>
 
 (107) ColumnarToRow [codegen id : 2]
-Input [3]: [ss_quantity#109, ss_list_price#110, ss_sold_date_sk#111]
+Input [3]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114]
 
 (108) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#112]
+Output [1]: [d_date_sk#115]
 
 (109) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_sold_date_sk#111]
-Right keys [1]: [d_date_sk#112]
+Left keys [1]: [ss_sold_date_sk#114]
+Right keys [1]: [d_date_sk#115]
 Join condition: None
 
 (110) Project [codegen id : 2]
-Output [2]: [ss_quantity#109 AS quantity#113, ss_list_price#110 AS list_price#114]
-Input [4]: [ss_quantity#109, ss_list_price#110, ss_sold_date_sk#111, d_date_sk#112]
+Output [2]: [ss_quantity#112 AS quantity#116, ss_list_price#113 AS list_price#117]
+Input [4]: [ss_quantity#112, ss_list_price#113, ss_sold_date_sk#114, d_date_sk#115]
 
 (111) Scan parquet default.catalog_sales
-Output [3]: [cs_quantity#115, cs_list_price#116, cs_sold_date_sk#117]
+Output [3]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#117), dynamicpruningexpression(cs_sold_date_sk#117 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#120), dynamicpruningexpression(cs_sold_date_sk#120 IN dynamicpruning#12)]
 ReadSchema: struct<cs_quantity:int,cs_list_price:decimal(7,2)>
 
 (112) ColumnarToRow [codegen id : 4]
-Input [3]: [cs_quantity#115, cs_list_price#116, cs_sold_date_sk#117]
+Input [3]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120]
 
 (113) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#118]
+Output [1]: [d_date_sk#121]
 
 (114) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#117]
-Right keys [1]: [d_date_sk#118]
+Left keys [1]: [cs_sold_date_sk#120]
+Right keys [1]: [d_date_sk#121]
 Join condition: None
 
 (115) Project [codegen id : 4]
-Output [2]: [cs_quantity#115 AS quantity#119, cs_list_price#116 AS list_price#120]
-Input [4]: [cs_quantity#115, cs_list_price#116, cs_sold_date_sk#117, d_date_sk#118]
+Output [2]: [cs_quantity#118 AS quantity#122, cs_list_price#119 AS list_price#123]
+Input [4]: [cs_quantity#118, cs_list_price#119, cs_sold_date_sk#120, d_date_sk#121]
 
 (116) Scan parquet default.web_sales
-Output [3]: [ws_quantity#121, ws_list_price#122, ws_sold_date_sk#123]
+Output [3]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ws_sold_date_sk#123), dynamicpruningexpression(ws_sold_date_sk#123 IN dynamicpruning#12)]
+PartitionFilters: [isnotnull(ws_sold_date_sk#126), dynamicpruningexpression(ws_sold_date_sk#126 IN dynamicpruning#12)]
 ReadSchema: struct<ws_quantity:int,ws_list_price:decimal(7,2)>
 
 (117) ColumnarToRow [codegen id : 6]
-Input [3]: [ws_quantity#121, ws_list_price#122, ws_sold_date_sk#123]
+Input [3]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126]
 
 (118) ReusedExchange [Reuses operator id: 134]
-Output [1]: [d_date_sk#124]
+Output [1]: [d_date_sk#127]
 
 (119) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ws_sold_date_sk#123]
-Right keys [1]: [d_date_sk#124]
+Left keys [1]: [ws_sold_date_sk#126]
+Right keys [1]: [d_date_sk#127]
 Join condition: None
 
 (120) Project [codegen id : 6]
-Output [2]: [ws_quantity#121 AS quantity#125, ws_list_price#122 AS list_price#126]
-Input [4]: [ws_quantity#121, ws_list_price#122, ws_sold_date_sk#123, d_date_sk#124]
+Output [2]: [ws_quantity#124 AS quantity#128, ws_list_price#125 AS list_price#129]
+Input [4]: [ws_quantity#124, ws_list_price#125, ws_sold_date_sk#126, d_date_sk#127]
 
 (121) Union
 
 (122) HashAggregate [codegen id : 7]
-Input [2]: [quantity#113, list_price#114]
+Input [2]: [quantity#116, list_price#117]
 Keys: []
-Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))]
-Aggregate Attributes [2]: [sum#127, count#128]
-Results [2]: [sum#129, count#130]
+Functions [1]: [partial_avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))]
+Aggregate Attributes [2]: [sum#130, count#131]
+Results [2]: [sum#132, count#133]
 
 (123) Exchange
-Input [2]: [sum#129, count#130]
+Input [2]: [sum#132, count#133]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=13]
 
 (124) HashAggregate [codegen id : 8]
-Input [2]: [sum#129, count#130]
+Input [2]: [sum#132, count#133]
 Keys: []
-Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))]
-Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))#131]
-Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#113 as decimal(12,2))) * promote_precision(cast(list_price#114 as decimal(12,2)))), DecimalType(18,2)))#131 AS average_sales#132]
+Functions [1]: [avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))]
+Aggregate Attributes [1]: [avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))#134]
+Results [1]: [avg(CheckOverflow((promote_precision(cast(quantity#116 as decimal(12,2))) * promote_precision(cast(list_price#117 as decimal(12,2)))), DecimalType(18,2)))#134 AS average_sales#135]
 
-Subquery:2 Hosting operator id = 106 Hosting Expression = ss_sold_date_sk#111 IN dynamicpruning#12
+Subquery:2 Hosting operator id = 106 Hosting Expression = ss_sold_date_sk#114 IN dynamicpruning#12
 
-Subquery:3 Hosting operator id = 111 Hosting Expression = cs_sold_date_sk#117 IN dynamicpruning#12
+Subquery:3 Hosting operator id = 111 Hosting Expression = cs_sold_date_sk#120 IN dynamicpruning#12
 
-Subquery:4 Hosting operator id = 116 Hosting Expression = ws_sold_date_sk#123 IN dynamicpruning#12
+Subquery:4 Hosting operator id = 116 Hosting Expression = ws_sold_date_sk#126 IN dynamicpruning#12
 
 Subquery:5 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (129)
@@ -712,22 +712,22 @@ BroadcastExchange (129)
 
 
 (125) Scan parquet default.date_dim
-Output [3]: [d_date_sk#40, d_year#133, d_moy#134]
+Output [3]: [d_date_sk#40, d_year#136, d_moy#137]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (126) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#40, d_year#133, d_moy#134]
+Input [3]: [d_date_sk#40, d_year#136, d_moy#137]
 
 (127) Filter [codegen id : 1]
-Input [3]: [d_date_sk#40, d_year#133, d_moy#134]
-Condition : ((((isnotnull(d_year#133) AND isnotnull(d_moy#134)) AND (d_year#133 = 2001)) AND (d_moy#134 = 11)) AND isnotnull(d_date_sk#40))
+Input [3]: [d_date_sk#40, d_year#136, d_moy#137]
+Condition : ((((isnotnull(d_year#136) AND isnotnull(d_moy#137)) AND (d_year#136 = 2001)) AND (d_moy#137 = 11)) AND isnotnull(d_date_sk#40))
 
 (128) Project [codegen id : 1]
 Output [1]: [d_date_sk#40]
-Input [3]: [d_date_sk#40, d_year#133, d_moy#134]
+Input [3]: [d_date_sk#40, d_year#136, d_moy#137]
 
 (129) BroadcastExchange
 Input [1]: [d_date_sk#40]
@@ -742,22 +742,22 @@ BroadcastExchange (134)
 
 
 (130) Scan parquet default.date_dim
-Output [2]: [d_date_sk#24, d_year#135]
+Output [2]: [d_date_sk#24, d_year#138]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), GreaterThanOrEqual(d_year,1999), LessThanOrEqual(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#135]
+Input [2]: [d_date_sk#24, d_year#138]
 
 (132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#135]
-Condition : (((isnotnull(d_year#135) AND (d_year#135 >= 1999)) AND (d_year#135 <= 2001)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#24, d_year#138]
+Condition : (((isnotnull(d_year#138) AND (d_year#138 >= 1999)) AND (d_year#138 <= 2001)) AND isnotnull(d_date_sk#24))
 
 (133) Project [codegen id : 1]
 Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_year#135]
+Input [2]: [d_date_sk#24, d_year#138]
 
 (134) BroadcastExchange
 Input [1]: [d_date_sk#24]
@@ -769,10 +769,10 @@ Subquery:8 Hosting operator id = 36 Hosting Expression = ws_sold_date_sk#29 IN d
 
 Subquery:9 Hosting operator id = 82 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
 
-Subquery:10 Hosting operator id = 68 Hosting Expression = cs_sold_date_sk#57 IN dynamicpruning#5
+Subquery:10 Hosting operator id = 68 Hosting Expression = cs_sold_date_sk#60 IN dynamicpruning#5
 
 Subquery:11 Hosting operator id = 98 Hosting Expression = ReusedSubquery Subquery scalar-subquery#51, [id=#52]
 
-Subquery:12 Hosting operator id = 84 Hosting Expression = ws_sold_date_sk#77 IN dynamicpruning#5
+Subquery:12 Hosting operator id = 84 Hosting Expression = ws_sold_date_sk#80 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -3220,6 +3220,67 @@ class DataFrameSuite extends QueryTest
     val d1 = Seq("a").toDF
     assert(d1.exceptAll(d1).count() === 0)
   }
+
+  test("SPARK-39887: RemoveRedundantAliases should keep attributes of a Union's first child") {
+    val df = sql(
+      """
+        |SELECT a, b AS a FROM (
+        |  SELECT a, a AS b FROM (SELECT a FROM VALUES (1) AS t(a))
+        |  UNION ALL
+        |  SELECT a, b FROM (SELECT a, b FROM VALUES (1, 2) AS t(a, b))
+        |)
+        |""".stripMargin)
+    val stringCols = df.logicalPlan.output.map(Column(_).cast(StringType))
+    val castedDf = df.select(stringCols: _*)
+    checkAnswer(castedDf, Row("1", "1") :: Row("1", "2") :: Nil)
+  }
+
+  test("SPARK-39887: RemoveRedundantAliases should keep attributes of a Union's first child 2") {
+    val df = sql(
+      """
+        |SELECT
+        |  to_date(a) a,
+        |  to_date(b) b
+        |FROM
+        |  (
+        |    SELECT
+        |      a,
+        |      a AS b
+        |    FROM
+        |      (
+        |        SELECT
+        |          to_date(a) a
+        |        FROM
+        |        VALUES
+        |          ('2020-02-01') AS t1(a)
+        |        GROUP BY
+        |          to_date(a)
+        |      ) t3
+        |    UNION ALL
+        |    SELECT
+        |      a,
+        |      b
+        |    FROM
+        |      (
+        |        SELECT
+        |          to_date(a) a,
+        |          to_date(b) b
+        |        FROM
+        |        VALUES
+        |          ('2020-01-01', '2020-01-02') AS t1(a, b)
+        |        GROUP BY
+        |          to_date(a),
+        |          to_date(b)
+        |      ) t4
+        |  ) t5
+        |GROUP BY
+        |  to_date(a),
+        |  to_date(b);
+        |""".stripMargin)
+    checkAnswer(df,
+      Row(java.sql.Date.valueOf("2020-02-01"), java.sql.Date.valueOf("2020-02-01")) ::
+        Row(java.sql.Date.valueOf("2020-01-01"), java.sql.Date.valueOf("2020-01-02")) :: Nil)
+  }
 }
 
 case class GroupByKey(a: Int, b: Int)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -639,8 +639,9 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
       val union = view.union(view)
       testSparkPlanMetrics(union, 1, Map(
         0L -> ("Union" -> Map()),
-        1L -> ("LocalTableScan" -> Map("number of output rows" -> 2L)),
-        2L -> ("LocalTableScan" -> Map("number of output rows" -> 2L))))
+        1L -> ("Project" -> Map()),
+        2L -> ("LocalTableScan" -> Map("number of output rows" -> 2L)),
+        3L -> ("LocalTableScan" -> Map("number of output rows" -> 2L))))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Keep the output attributes of a `Union` node's first child in the `RemoveRedundantAliases` rule to avoid correctness issues.

### Why are the changes needed?
To fix the result of the following query:
```
SELECT a, b AS a FROM (
  SELECT a, a AS b FROM (SELECT a FROM VALUES (1) AS t(a))
  UNION ALL
  SELECT a, b FROM (SELECT a, b FROM VALUES (1, 2) AS t(a, b))
)
```
Before this PR the query returns the incorrect result: 
```
+---+---+
|  a|  a|
+---+---+
|  1|  1|
|  2|  2|
+---+---+
```
After this PR it returns the expected result:
```
+---+---+
|  a|  a|
+---+---+
|  1|  1|
|  1|  2|
+---+---+
```

### Does this PR introduce _any_ user-facing change?
Yes, fixes a correctness issue.

### How was this patch tested?
Added new UTs.