### PR TITLE
[SPARK-40043][PYTHON][SS][DOCS] Document DataStreamWriter.toTable and DataStreamReader.table

### DIFF
--- a/python/docs/source/reference/pyspark.ss/io.rst
+++ b/python/docs/source/reference/pyspark.ss/io.rst
@@ -34,6 +34,7 @@ Input/Output
     DataStreamReader.orc
     DataStreamReader.parquet
     DataStreamReader.schema
+    DataStreamReader.table
     DataStreamReader.text
     DataStreamWriter.foreach
     DataStreamWriter.foreachBatch
@@ -44,4 +45,5 @@ Input/Output
     DataStreamWriter.partitionBy
     DataStreamWriter.queryName
     DataStreamWriter.start
+    DataStreamWriter.toTable
     DataStreamWriter.trigger


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/30835 that adds `DataStreamWriter.toTable` and `DataStreamReader.table` into PySpark documentation.

### Why are the changes needed?

To document both features.

### Does this PR introduce _any_ user-facing change?

Yes, both API will be shown in PySpark reference documentation.

### How was this patch tested?

Manually built the documentation and checked.