### PR TITLE
[DON'T MERGE] 

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 object JacksonUtils {
 
+  import com.fasterxml.jackson.module.scala.JavaTypeable
+
   private val mapper = {
     val ret = new ObjectMapper() with ClassTagExtensions
     ret.registerModule(DefaultScalaModule)
@@ -41,6 +43,8 @@ object JacksonUtils {
 
   def readValue[T](value: String, valueType: Class[T]): T =
     mapper.readValue(value, valueType)
+
+  def readValue[T: JavaTypeable](content: String): T = mapper.readValue[T](content)
 
   def readValue[T](reader: Reader, valueType: Class[T]): T =
     mapper.readValue(reader: Reader, valueType: Class[T])

--- a/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
@@ -33,6 +33,9 @@ object JacksonUtils {
     ret
   }
 
+  def writeValuePrettyAsString(o: Any): String =
+    mapper.writerWithDefaultPrettyPrinter().writeValueAsString(o)
+
   def writeValueAsString(o: Any): String = mapper.writeValueAsString(o)
 
   def writeValueAsBytes(o: Any): Array[Byte] = mapper.writeValueAsBytes(o)

--- a/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import java.io.{OutputStream, Reader, Writer}
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.ClassTagExtensions
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+object JacksonUtils {
+
+  private val mapper = {
+    val ret = new ObjectMapper() with ClassTagExtensions
+    ret.registerModule(DefaultScalaModule)
+    ret
+  }
+
+  def writeValueAsString(o: Any): String = mapper.writeValueAsString(o)
+
+  def writeValueAsBytes(o: Any): Array[Byte] = mapper.writeValueAsBytes(o)
+
+  def writeValue(out: OutputStream, o: Any): Unit = mapper.writeValue(out, o)
+
+  def writeValue(writer: Writer, o: Any): Unit = mapper.writeValue(writer, o)
+
+  def readValue[T](value: String, valueType: Class[T]): T =
+    mapper.readValue(value, valueType)
+
+  def readValue[T](reader: Reader, valueType: Class[T]): T =
+    mapper.readValue(reader: Reader, valueType: Class[T])
+
+}

--- a/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/JacksonUtils.scala
@@ -46,6 +46,8 @@ object JacksonUtils {
 
   def readValue[T: JavaTypeable](content: String): T = mapper.readValue[T](content)
 
+  def readValue[T: JavaTypeable](reader: Reader): T = mapper.readValue[T](reader)
+
   def readValue[T](reader: Reader, valueType: Class[T]): T =
     mapper.readValue(reader: Reader, valueType: Class[T])
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -22,8 +22,6 @@ import java.util.Locale
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.Path
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
 
 import org.apache.spark.SparkUpgradeException
 import org.apache.spark.sql.{SPARK_LEGACY_DATETIME_METADATA_KEY, SPARK_LEGACY_INT96_METADATA_KEY, SPARK_TIMEZONE_METADATA_KEY, SPARK_VERSION_METADATA_KEY}
@@ -38,6 +36,7 @@ import org.apache.spark.sql.internal.SQLConf.LegacyBehaviorPolicy
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.JacksonUtils
 import org.apache.spark.util.Utils
 
 
@@ -53,17 +52,12 @@ object DataSourceUtils extends PredicateHelper {
    */
   val PARTITION_OVERWRITE_MODE = "partitionOverwriteMode"
 
-  /**
-   * Utility methods for converting partitionBy columns to options and back.
-   */
-  private implicit val formats = Serialization.formats(NoTypeHints)
-
   def encodePartitioningColumns(columns: Seq[String]): String = {
-    Serialization.write(columns)
+    JacksonUtils.writeValueAsString(columns)
   }
 
   def decodePartitioningColumns(str: String): Seq[String] = {
-    Serialization.read[Seq[String]](str)
+    JacksonUtils.readValue(str, classOf[Seq[String]])
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CommitLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/CommitLog.scala
@@ -22,10 +22,8 @@ import java.nio.charset.StandardCharsets._
 
 import scala.io.{Source => IOSource}
 
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
-
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.util.JacksonUtils
 
 /**
  * Used to write log files that represent batch commit points in structured streaming.
@@ -78,11 +76,10 @@ object CommitLog {
 
 
 case class CommitMetadata(nextBatchWatermarkMs: Long = 0) {
-  def json: String = Serialization.write(this)(CommitMetadata.format)
+  def json: String = JacksonUtils.writeValueAsString(this)
 }
 
 object CommitMetadata {
-  implicit val format = Serialization.formats(NoTypeHints)
-
-  def apply(json: String): CommitMetadata = Serialization.read[CommitMetadata](json)
+  def apply(json: String): CommitMetadata =
+    JacksonUtils.readValue(json, classOf[CommitMetadata])
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSinkLog.scala
@@ -20,8 +20,6 @@ package org.apache.spark.sql.execution.streaming
 import java.net.URI
 
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.internal.SQLConf
@@ -84,8 +82,6 @@ class FileStreamSinkLog(
     path: String,
     _retentionMs: Option[Long] = None)
   extends CompactibleFileStreamLog[SinkFileStatus](metadataLogVersion, sparkSession, path) {
-
-  private implicit val formats = Serialization.formats(NoTypeHints)
 
   protected override val fileCleanupDelayMs = sparkSession.sessionState.conf.fileSinkLogCleanupDelay
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceLog.scala
@@ -22,9 +22,6 @@ import java.util.Map.Entry
 
 import scala.collection.mutable
 
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.FileStreamSource.FileEntry
 import org.apache.spark.sql.internal.SQLConf
@@ -50,8 +47,6 @@ class FileStreamSourceLog(
     sparkSession.sessionState.conf.fileSourceLogCleanupDelay
 
   protected override val isDeletingExpiredLog = sparkSession.sessionState.conf.fileSourceLogDeletion
-
-  private implicit val formats = Serialization.formats(NoTypeHints)
 
   // A fixed size log entry cache to cache the file entries belong to the compaction batch. It is
   // used to avoid scanning the compacted log file to retrieve it's own batch data.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FileStreamSourceOffset.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.execution.streaming
 
 import scala.util.control.Exception._
 
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
+import org.apache.spark.util.JacksonUtils
 
 /**
  * Offset for the [[FileStreamSource]].
@@ -29,12 +28,11 @@ import org.json4s.jackson.Serialization
  */
 case class FileStreamSourceOffset(logOffset: Long) extends Offset {
   override def json: String = {
-    Serialization.write(this)(FileStreamSourceOffset.format)
+    JacksonUtils.writeValueAsString(this)
   }
 }
 
 object FileStreamSourceOffset {
-  implicit val format = Serialization.formats(NoTypeHints)
 
   def apply(offset: Offset): FileStreamSourceOffset = {
     offset match {
@@ -43,7 +41,7 @@ object FileStreamSourceOffset {
         catching(classOf[NumberFormatException]).opt {
           FileStreamSourceOffset(str.toLong)
         }.getOrElse {
-          Serialization.read[FileStreamSourceOffset](str)
+          JacksonUtils.readValue(str, classOf[FileStreamSourceOffset])
         }
       case _ =>
         throw new IllegalArgumentException(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/RateStreamOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/RateStreamOffset.scala
@@ -17,16 +17,12 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import org.json4s.DefaultFormats
-import org.json4s.jackson.Serialization
-
 import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2}
+import org.apache.spark.util.JacksonUtils
 
 case class RateStreamOffset(partitionToValueAndRunTimeMs: Map[Int, ValueRunTimeMsPair])
   extends OffsetV2 {
-  implicit val defaultFormats: DefaultFormats = DefaultFormats
-  override val json = Serialization.write(partitionToValueAndRunTimeMs)
+  override val json = JacksonUtils.writeValueAsString(partitionToValueAndRunTimeMs)
 }
-
 
 case class ValueRunTimeMsPair(value: Long, runTimeMs: Long)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamMetadata.scala
@@ -25,12 +25,12 @@ import scala.util.control.NonFatal
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FSDataInputStream, Path}
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager.CancellableFSDataOutputStream
+import org.apache.spark.util.JacksonUtils
+import org.apache.spark.util.Utils
 
 /**
  * Contains metadata associated with a [[org.apache.spark.sql.streaming.StreamingQuery]].
@@ -41,11 +41,10 @@ import org.apache.spark.sql.execution.streaming.CheckpointFileManager.Cancellabl
  *            that needs to be persisted across restarts
  */
 case class StreamMetadata(id: String) {
-  def json: String = Serialization.write(this)(StreamMetadata.format)
+  def json: String = JacksonUtils.writeValueAsString(json)
 }
 
 object StreamMetadata extends Logging {
-  implicit val format = Serialization.formats(NoTypeHints)
 
   /** Read the metadata from file if it exists */
   def read(metadataFile: Path, hadoopConf: Configuration): Option[StreamMetadata] = {
@@ -55,8 +54,10 @@ object StreamMetadata extends Logging {
       var input: FSDataInputStream = null
       try {
         input = fileManager.open(metadataFile)
-        val reader = new InputStreamReader(input, StandardCharsets.UTF_8)
-        val metadata = Serialization.read[StreamMetadata](reader)
+        val metadata =
+          Utils.tryWithResource(new InputStreamReader(input, StandardCharsets.UTF_8)) { reader =>
+            JacksonUtils.readValue(reader, classOf[StreamMetadata])
+          }
         Some(metadata)
       } catch {
         case NonFatal(e) =>
@@ -78,7 +79,7 @@ object StreamMetadata extends Logging {
       val fileManager = CheckpointFileManager.create(metadataFile.getParent, hadoopConf)
       output = fileManager.createAtomic(metadataFile, overwriteIfPossible = false)
       val writer = new OutputStreamWriter(output)
-      Serialization.write(metadata, writer)
+      JacksonUtils.writeValue(writer, metadata)
       writer.close()
     } catch {
       case e: FileAlreadyExistsException =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamMetadata.scala
@@ -54,10 +54,8 @@ object StreamMetadata extends Logging {
       var input: FSDataInputStream = null
       try {
         input = fileManager.open(metadataFile)
-        val metadata =
-          Utils.tryWithResource(new InputStreamReader(input, StandardCharsets.UTF_8)) { reader =>
-            JacksonUtils.readValue(reader, classOf[StreamMetadata])
-          }
+        val reader = new InputStreamReader(input, StandardCharsets.UTF_8)
+        val metadata = JacksonUtils.readValue(reader, classOf[StreamMetadata])
         Some(metadata)
       } catch {
         case NonFatal(e) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamMetadata.scala
@@ -30,7 +30,6 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager.CancellableFSDataOutputStream
 import org.apache.spark.util.JacksonUtils
-import org.apache.spark.util.Utils
 
 /**
  * Contains metadata associated with a [[org.apache.spark.sql.streaming.StreamingQuery]].

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -17,20 +17,17 @@
 
 package org.apache.spark.sql.execution.streaming.continuous
 
-import org.json4s.DefaultFormats
-import org.json4s.jackson.Serialization
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.connector.read.streaming.{ContinuousPartitionReader, ContinuousPartitionReaderFactory, ContinuousStream, Offset, PartitionOffset}
 import org.apache.spark.sql.execution.streaming.{RateStreamOffset, ValueRunTimeMsPair}
+import org.apache.spark.util.JacksonUtils
 
 case class RateStreamPartitionOffset(
    partition: Int, currentValue: Long, currentTimeMs: Long) extends PartitionOffset
 
 class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extends ContinuousStream {
-  implicit val defaultFormats: DefaultFormats = DefaultFormats
 
   val creationTime = System.currentTimeMillis()
 
@@ -46,7 +43,7 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
   }
 
   override def deserializeOffset(json: String): Offset = {
-    RateStreamOffset(Serialization.read[Map[Int, ValueRunTimeMsPair]](json))
+    RateStreamOffset(JacksonUtils.readValue(json, classOf[Map[Int, ValueRunTimeMsPair]]))
   }
 
   override def initialOffset: Offset = createInitialOffset(numPartitions, creationTime)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousRateStreamSource.scala
@@ -43,7 +43,7 @@ class RateStreamContinuousStream(rowsPerSecond: Long, numPartitions: Int) extend
   }
 
   override def deserializeOffset(json: String): Offset = {
-    RateStreamOffset(JacksonUtils.readValue(json, classOf[Map[Int, ValueRunTimeMsPair]]))
+    RateStreamOffset(JacksonUtils.readValue[Map[Int, ValueRunTimeMsPair]](json))
   }
 
   override def initialOffset: Offset = createInitialOffset(numPartitions, creationTime)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/continuous/ContinuousTextSocketSource.scala
@@ -87,7 +87,7 @@ class TextSocketContinuousStream(
 
   override def deserializeOffset(json: String): Offset = {
     // need to define TypeRef?
-    TextSocketOffset(JacksonUtils.readValue(json, classOf[List[Int]]))
+    TextSocketOffset(JacksonUtils.readValue[List[Int]](json))
   }
 
   override def initialOffset(): Offset = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ContinuousMemoryStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ContinuousMemoryStream.scala
@@ -69,7 +69,7 @@ class ContinuousMemoryStream[A : Encoder](id: Int, sqlContext: SQLContext, numPa
 
   override def deserializeOffset(json: String): ContinuousMemoryStreamOffset = {
     // need to define TypeRef?
-    ContinuousMemoryStreamOffset(JacksonUtils.readValue(json, classOf[Map[Int, Int]]))
+    ContinuousMemoryStreamOffset(JacksonUtils.readValue[Map[Int, Int]](json))
   }
 
   override def mergeOffsets(offsets: Array[PartitionOffset]): ContinuousMemoryStreamOffset = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RatePerMicroBatchStream.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/RatePerMicroBatchStream.scala
@@ -17,15 +17,13 @@
 
 package org.apache.spark.sql.execution.streaming.sources
 
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.connector.read.streaming.{MicroBatchStream, Offset, ReadLimit, SupportsTriggerAvailableNow}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.JacksonUtils
 
 class RatePerMicroBatchStream(
     rowsPerBatch: Long,
@@ -125,15 +123,14 @@ class RatePerMicroBatchStream(
 
 case class RatePerMicroBatchStreamOffset(offset: Long, timestamp: Long) extends Offset {
   override def json(): String = {
-    Serialization.write(this)(RatePerMicroBatchStreamOffset.formats)
+    JacksonUtils.writeValueAsString(this)
   }
 }
 
 object RatePerMicroBatchStreamOffset {
-  implicit val formats = Serialization.formats(NoTypeHints)
-
-  def apply(json: String): RatePerMicroBatchStreamOffset =
-    Serialization.read[RatePerMicroBatchStreamOffset](json)
+  def apply(json: String): RatePerMicroBatchStreamOffset = {
+    JacksonUtils.readValue(json, classOf[RatePerMicroBatchStreamOffset])
+  }
 }
 
 case class RatePerMicroBatchStreamInputPartition(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -310,10 +310,7 @@ class RocksDB(
         "checkpoint" -> checkpointTimeMs,
         "fileSync" -> fileSyncTimeMs
       )
-      val start = System.nanoTime()
-      logWarning(s"Committed $newVersion, stats = ${metrics.json}")
-      val end = System.nanoTime()
-      logWarning(s"Time = ${end - start}")
+      logInfo(s"Committed $newVersion, stats = ${metrics.json}")
       loadedVersion
     } catch {
       case t: Throwable =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryStatus.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryStatus.scala
@@ -17,12 +17,10 @@
 
 package org.apache.spark.sql.streaming
 
-import org.json4s._
-import org.json4s.JsonAST.JValue
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods._
+import com.fasterxml.jackson.core.JsonGenerator
 
 import org.apache.spark.annotation.Evolving
+import org.apache.spark.util.JacksonUtils
 
 /**
  * Reports information about the instantaneous status of a streaming query.
@@ -43,10 +41,10 @@ class StreamingQueryStatus protected[sql](
     val isTriggerActive: Boolean) extends Serializable {
 
   /** The compact JSON representation of this status. */
-  def json: String = compact(render(jsonValue))
+  def json: String = JacksonUtils.toJsonString(jsonValue)
 
   /** The pretty (i.e. indented) JSON representation of this status. */
-  def prettyJson: String = pretty(render(jsonValue))
+  def prettyJson: String = JacksonUtils.toPrettyJsonString(jsonValue)
 
   override def toString: String = prettyJson
 
@@ -60,9 +58,11 @@ class StreamingQueryStatus protected[sql](
       isTriggerActive = isTriggerActive)
   }
 
-  private[sql] def jsonValue: JValue = {
-    ("message" -> JString(message)) ~
-    ("isDataAvailable" -> JBool(isDataAvailable)) ~
-    ("isTriggerActive" -> JBool(isTriggerActive))
+  private[sql] def jsonValue(generator: JsonGenerator): Unit = {
+    generator.writeStartObject()
+    generator.writeStringField("message", message)
+    generator.writeBooleanField("isDataAvailable", isDataAvailable)
+    generator.writeBooleanField("isTriggerActive", isTriggerActive)
+    generator.writeEndObject()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change to use Jackson instead of json4s to serialize `RocksDBMetrics`.


### Why are the changes needed?
Weaken the dependence on `json4s`.


### Does this PR introduce _any_ user-facing change?
No. In fact, `RocksDBMetrics.json` is only used to print logs now.


### How was this patch tested?

- Pass GitHub Actions
- Manually compare json results:

**Before**
```
13:22:48.839 INFO org.apache.spark.sql.execution.streaming.state.RocksDB [Thread-1]: Committed 1, stats = {"numCommittedKeys":1,"numUncommittedKeys":1,"totalMemUsageBytes":3976,"writeBatchMemUsageBytes":17,"totalSSTFilesBytes":1146,"nativeOpsHistograms":{"get":{"sum":11,"avg":5.5,"stddev":0.5,"median":5.0,"p95":5.9,"p99":5.98,"count":2},"put":{"sum":17932,"avg":17932.0,"stddev":0.0,"median":17932.0,"p95":17932.0,"p99":17932.0,"count":1},"compaction":{"sum":0,"avg":0.0,"stddev":0.0,"median":0.0,"p95":0.0,"p99":0.0,"count":0}},"lastCommitLatencyMs":{"fileSync":582,"writeBatch":18,"flush":58,"pause":0,"checkpoint":64,"compact":0},"filesCopied":1,"bytesCopied":1146,"filesReused":0,"zipFileBytesUncompressed":6973,"nativeOpsMetrics":{"writerStallDuration":0,"totalBytesReadThroughIterator":0,"readBlockCacheHitCount":0,"totalBytesWrittenByCompaction":0,"readBlockCacheMissCount":0,"totalBytesReadByCompaction":0,"totalBytesWritten":17,"totalBytesRead":0}}
```
**After**
```
13:18:45.210 INFO org.apache.spark.sql.execution.streaming.state.RocksDB [Thread-1]: Committed 1, stats = {"numCommittedKeys":1,"numUncommittedKeys":1,"totalMemUsageBytes":3976,"writeBatchMemUsageBytes":17,"totalSSTFilesBytes":1146,"nativeOpsHistograms":{"get":{"sum":7,"avg":3.5,"stddev":0.5,"median":3.0,"p95":3.9,"p99":3.98,"count":2},"put":{"sum":17927,"avg":17927.0,"stddev":0.0,"median":17927.0,"p95":17927.0,"p99":17927.0,"count":1},"compaction":{"sum":0,"avg":0.0,"stddev":0.0,"median":0.0,"p95":0.0,"p99":0.0,"count":0}},"lastCommitLatencyMs":{"fileSync":595,"writeBatch":17,"flush":60,"pause":0,"checkpoint":64,"compact":0},"filesCopied":1,"bytesCopied":1146,"filesReused":0,"zipFileBytesUncompressed":6973,"nativeOpsMetrics":{"writerStallDuration":0,"totalBytesReadThroughIterator":0,"readBlockCacheHitCount":0,"totalBytesWrittenByCompaction":0,"readBlockCacheMissCount":0,"totalBytesReadByCompaction":0,"totalBytesWritten":17,"totalBytesRead":0}}
```

seems no difference