### PR TITLE
[SPARK-40047][TEST] Exclude unused `xalan` transitive dependency from `htmlunit`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -712,6 +712,12 @@
         <groupId>net.sourceforge.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
         <version>${htmlunit.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+          </exclusion>
+        </exclusions>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr exclude `xalan` from `htmlunit` to clean warning of CVE-2022-34169:

```
Provides transitive vulnerable dependency xalan:xalan:2.7.2
CVE-2022-34169 7.5 Integer Coercion Error vulnerability with medium severity found
Results powered by Checkmarx(c)
```
`xalan:xalan:2.7.2` is the latest version, the code base has not been updated for 5 years, so can't solve by upgrading `xalan`.


### Why are the changes needed?
The vulnerability is described is [CVE-2022-34169](https://github.com/advisories/GHSA-9339-86wc-4qgf), better to exclude it although it's just test dependency for Spark.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?

- Pass GitHub Actions
- Manual test:

run `mvn dependency:tree -Phadoop-3 -Phadoop-cloud -Pmesos -Pyarn -Pkinesis-asl -Phive-thriftserver -Pspark-ganglia-lgpl -Pkubernetes -Phive | grep xalan` to check that `xalan` is not matched after this pr
