### PR TITLE
[MINOR][DOCS] Rename Global to Glob

### DIFF
--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -71,9 +71,8 @@ the contents that have been read will still be returned.
 
 ### Path Glob Filter
 
-`pathGlobFilter` is used to only include files with file names matching the pattern.
-The syntax follows <code>org.apache.hadoop.fs.GlobFilter</code>.
-It does not change the behavior of partition discovery.
+`pathGlobFilter` is used to only include files with file names matching the pattern. The syntax follows
+<code>org.apache.hadoop.fs.GlobFilter</code>. It does not change the behavior of partition discovery.
 
 To load files with paths matching a given glob pattern while keeping the behavior of partition discovery,
 you can use:

--- a/docs/sql-data-sources-generic-options.md
+++ b/docs/sql-data-sources-generic-options.md
@@ -69,7 +69,7 @@ from files. Here, missing file really means the deleted file under directory aft
 `DataFrame`. When set to true, the Spark jobs will continue to run when encountering missing files and
 the contents that have been read will still be returned.
 
-### Path Global Filter
+### Path Glob Filter
 
 `pathGlobFilter` is used to only include files with file names matching the pattern.
 The syntax follows <code>org.apache.hadoop.fs.GlobFilter</code>.


### PR DESCRIPTION
This section is about the path **glob** filter. The word **global** seems to be a mistake.

### What changes were proposed in this pull request?
Just a typo fix.

### Why are the changes needed?
To be less confusing in what the section is about.

### Does this PR introduce _any_ user-facing change?
Apart from docs, no.

### How was this patch tested?
No testing needed.