### PR TITLE
[SPARK-40052][SQL] Handle direct byte buffers in VectorizedDeltaBinaryPackedReader

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
@@ -300,8 +300,12 @@ public class VectorizedDeltaBinaryPackedReader extends VectorizedReaderBase {
         bitWidths[currentMiniBlock]);
     for (int j = 0; j < miniBlockSizeInValues; j += 8) {
       ByteBuffer buffer = in.slice(packer.getBitWidth());
-      packer.unpack8Values(buffer.array(),
-        buffer.arrayOffset() + buffer.position(), unpackedValuesBuffer, j);
+      if (buffer.hasArray()) {
+        packer.unpack8Values(buffer.array(),
+          buffer.arrayOffset() + buffer.position(), unpackedValuesBuffer, j);
+      } else {
+        packer.unpack8Values(buffer, buffer.position(), unpackedValuesBuffer, j);
+      }
     }
     remainingInMiniBlock = miniBlockSizeInValues;
     currentMiniBlock++;

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaEncodingSuite.scala
@@ -246,7 +246,7 @@ abstract class ParquetDeltaEncodingSuite[T] extends ParquetCompatibilityTest
         ByteBuffer.allocate(page.length)
       }
       buf.put(page)
-      buf.rewind()
+      buf.flip()
 
       reader.initFromPage(100, ByteBufferInputStream.wrap(buf))
       readData(length, writableColumnVector, 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaEncodingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetDeltaEncodingSuite.scala
@@ -221,7 +221,6 @@ abstract class ParquetDeltaEncodingSuite[T] extends ParquetCompatibilityTest
         data(i) = getNextRandom
       }
       shouldReadAndWrite(data, size)
-      writer.reset()
     }
   }
 
@@ -231,19 +230,33 @@ abstract class ParquetDeltaEncodingSuite[T] extends ParquetCompatibilityTest
   }
 
   private def shouldReadAndWrite(data: Array[T], length: Int): Unit = {
-    writeData(data, length)
-    reader = new VectorizedDeltaBinaryPackedReader
-    val page = writer.getBytes.toByteArray
+    // SPARK-40052: Check that we can handle direct and non-direct byte buffers depending on the
+    // implementation of ByteBufferInputStream.
+    for (useDirect <- Seq(true, false)) {
+      writeData(data, length)
+      reader = new VectorizedDeltaBinaryPackedReader
+      val page = writer.getBytes.toByteArray
 
-    assert(estimatedSize(length) >= page.length)
-    writableColumnVector = new OnHeapColumnVector(data.length, getSparkSqlType)
-    reader.initFromPage(100, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)))
-    readData(length, writableColumnVector, 0)
-    for (i <- 0 until length) {
-      assert(data(i) == readDataFromVector(writableColumnVector, i))
+      assert(estimatedSize(length) >= page.length)
+      writableColumnVector = new OnHeapColumnVector(data.length, getSparkSqlType)
+
+      val buf = if (useDirect) {
+        ByteBuffer.allocateDirect(page.length)
+      } else {
+        ByteBuffer.allocate(page.length)
+      }
+      buf.put(page)
+      buf.rewind()
+
+      reader.initFromPage(100, ByteBufferInputStream.wrap(buf))
+      readData(length, writableColumnVector, 0)
+      for (i <- 0 until length) {
+        assert(data(i) == readDataFromVector(writableColumnVector, i))
+      }
+
+      writer.reset()
     }
   }
-
 }
 
 class ParquetDeltaEncodingInteger extends ParquetDeltaEncodingSuite[Int] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR is a follow-up for https://github.com/apache/spark/pull/37293. The patch proposes to use `hasArray()` API to check if a `ByteBuffer` has an underlying array that could be leveraged for direct access.

If the condition is not met, the code falls back to the original way of handling things using `ByteBuffer` API instead of an array.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fixes a potential issue of using direct byte buffers in Parquet-MR and makes the code forward-compatible.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. This is an internal change.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I have updated ParquetDeltaEncodingSuite to check both direct and non-direct byte buffers. I verified that the tests fail before the fix with ` java.lang.UnsupportedOperationException:` and pass with the fix.

I reran `DataSourceReadBenchmark` to ensure this `if-else` does not have a significant impact on performance.

The benchmark was rerun on the same machine for both cases sequentially (each of them used a different JVM process).

Benchmarks show that `if` statement does not have significant impact for on-heap `ByteBuffers` backed with an array so there should not be any performance regression for the use case being addressed by @LuciferYang.

### Before
```
OpenJDK 64-Bit Server VM 1.8.0_312-8u312-b07-0ubuntu1~18.04-b07 on Linux 5.4.0-1071-aws
Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
Parquet Reader Single INT Column Scan:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
---------------------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized: DataPageV1                   208            216           8         75.5          13.3       1.0X
ParquetReader Vectorized: DataPageV2                   315            323           6         50.0          20.0       0.7X
ParquetReader Vectorized -> Row: DataPageV1            233            236           3         67.6          14.8       0.9X
ParquetReader Vectorized -> Row: DataPageV2            339            341           4         46.4          21.5       0.6X

OpenJDK 64-Bit Server VM 1.8.0_312-8u312-b07-0ubuntu1~18.04-b07 on Linux 5.4.0-1071-aws
Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
Parquet Reader Single BIGINT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
---------------------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized: DataPageV1                   273            281           4         57.7          17.3       1.0X
ParquetReader Vectorized: DataPageV2                   443            446           2         35.5          28.1       0.6X
ParquetReader Vectorized -> Row: DataPageV1            286            293           6         55.0          18.2       1.0X
ParquetReader Vectorized -> Row: DataPageV2            452            458           7         34.8          28.7       0.6X
```


### After

```
OpenJDK 64-Bit Server VM 1.8.0_312-8u312-b07-0ubuntu1~18.04-b07 on Linux 5.4.0-1071-aws
Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
Parquet Reader Single INT Column Scan:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
---------------------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized: DataPageV1                   237            241           3         66.3          15.1       1.0X
ParquetReader Vectorized: DataPageV2                   347            356           9         45.4          22.0       0.7X
ParquetReader Vectorized -> Row: DataPageV1            233            237           4         67.5          14.8       1.0X
ParquetReader Vectorized -> Row: DataPageV2            338            342           6         46.5          21.5       0.7X

OpenJDK 64-Bit Server VM 1.8.0_312-8u312-b07-0ubuntu1~18.04-b07 on Linux 5.4.0-1071-aws
Intel(R) Xeon(R) Platinum 8259CL CPU @ 2.50GHz
Parquet Reader Single BIGINT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
---------------------------------------------------------------------------------------------------------------------------
ParquetReader Vectorized: DataPageV1                   267            296          52         58.9          17.0       1.0X
ParquetReader Vectorized: DataPageV2                   445            448           3         35.4          28.3       0.6X
ParquetReader Vectorized -> Row: DataPageV1            270            275           5         58.3          17.2       1.0X
ParquetReader Vectorized -> Row: DataPageV2            436            441           6         36.1          27.7       0.6X
```