### PR TITLE
[SPARK-40054][SQL] Restore the error handling syntax of try_cast()

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1329,7 +1329,7 @@ case class Cast(
   protected[this] def castCode(ctx: CodegenContext, input: ExprValue, inputIsNull: ExprValue,
     result: ExprValue, resultIsNull: ExprValue, resultType: DataType, cast: CastFunction): Block = {
     val javaType = JavaCode.javaType(resultType)
-    val addTryCatchOnCastIfNeeded = if (!isTryCast) {
+    val castCodeWithTryCatchIfNeeded = if (!isTryCast) {
       s"${cast(input, result, resultIsNull)}"
     } else {
       s"""
@@ -1344,7 +1344,7 @@ case class Cast(
       boolean $resultIsNull = $inputIsNull;
       $javaType $result = ${CodeGenerator.defaultValue(resultType)};
       if (!$inputIsNull) {
-        $addTryCatchOnCastIfNeeded
+        $castCodeWithTryCatchIfNeeded
       }
     """
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -538,7 +538,10 @@ case class Cast(
   override def nullable: Boolean = if (!isTryCast) {
     child.nullable || Cast.forceNullable(child.dataType, dataType)
   } else {
-    true
+    (child.dataType, dataType) match {
+      case (StringType, BinaryType) => child.nullable
+      case _ => child.nullable || !Cast.canUpCast(child.dataType, dataType)
+    }
   }
 
   override def initQueryContext(): Option[SQLQueryContext] = if (ansiEnabled) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EvalMode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EvalMode.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.internal.SQLConf
+
+object EvalMode extends Enumeration {
+  val LEGACY, ANSI, TRY = Value
+
+  def fromSQLConf(conf: SQLConf): Value = if (conf.ansiEnabled) {
+    ANSI
+  } else {
+    LEGACY
+  }
+
+  def fromBoolean(ansiEnabled: Boolean): Value = if (ansiEnabled) {
+    ANSI
+  } else {
+    LEGACY
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EvalMode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/EvalMode.scala
@@ -18,6 +18,14 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.internal.SQLConf
 
+/**
+ * Expression evaluation modes.
+ *   - LEGACY: the default evaluation mode, which is compliant to Hive SQL.
+ *   - ANSI: a evaluation mode which is compliant to ANSI SQL standard.
+ *   - TRY: a evaluation mode for `try_*` functions. It is identical to ANSI evaluation mode
+ *          except for returning null result on errors.
+ */
+
 object EvalMode extends Enumeration {
   val LEGACY, ANSI, TRY = Value
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/TryEval.scala
@@ -18,12 +18,9 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
-import org.apache.spark.sql.catalyst.expressions.Cast.{forceNullable, resolvableNullability}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodeGenerator, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
-import org.apache.spark.sql.catalyst.trees.TreePattern.{RUNTIME_REPLACEABLE, TreePattern}
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
+import org.apache.spark.sql.types.DataType
 
 case class TryEval(child: Expression) extends UnaryExpression with NullIntolerant {
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -54,87 +51,6 @@ case class TryEval(child: Expression) extends UnaryExpression with NullIntoleran
 
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
-}
-
-/**
- * A special version of [[Cast]] with ansi mode on. It performs the same operation (i.e. converts a
- * value of one data type into another data type), but returns a NULL value instead of raising an
- * error when the conversion can not be performed.
- */
-@ExpressionDescription(
-  usage = """
-    _FUNC_(expr AS type) - Casts the value `expr` to the target data type `type`.
-      This expression is identical to CAST with configuration `spark.sql.ansi.enabled` as
-      true, except it returns NULL instead of raising an error. Note that the behavior of this
-      expression doesn't depend on configuration `spark.sql.ansi.enabled`.
-  """,
-  examples = """
-    Examples:
-      > SELECT _FUNC_('10' as int);
-       10
-      > SELECT _FUNC_(1234567890123L as int);
-       null
-  """,
-  since = "3.2.0",
-  group = "conversion_funcs")
-case class TryCast(child: Expression, toType: DataType, timeZoneId: Option[String] = None)
-  extends UnaryExpression with RuntimeReplaceable with TimeZoneAwareExpression {
-
-  override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression =
-    copy(timeZoneId = Option(timeZoneId))
-
-  override def nodePatternsInternal(): Seq[TreePattern] = Seq(RUNTIME_REPLACEABLE)
-
-  // When this cast involves TimeZone, it's only resolved if the timeZoneId is set;
-  // Otherwise behave like Expression.resolved.
-  override lazy val resolved: Boolean = childrenResolved && checkInputDataTypes().isSuccess &&
-    (!Cast.needsTimeZone(child.dataType, toType) || timeZoneId.isDefined)
-
-  override lazy val replacement = {
-    TryEval(Cast(child, toType, timeZoneId = timeZoneId, ansiEnabled = true))
-  }
-
-  // If the target data type is a complex type which can't have Null values, we should guarantee
-  // that the casting between the element types won't produce Null results.
-  private def canCast(from: DataType, to: DataType): Boolean = (from, to) match {
-    case (ArrayType(fromType, fn), ArrayType(toType, tn)) =>
-      canCast(fromType, toType) &&
-        resolvableNullability(fn || forceNullable(fromType, toType), tn)
-
-    case (MapType(fromKey, fromValue, fn), MapType(toKey, toValue, tn)) =>
-      canCast(fromKey, toKey) &&
-        (!forceNullable(fromKey, toKey)) &&
-        canCast(fromValue, toValue) &&
-        resolvableNullability(fn || forceNullable(fromValue, toValue), tn)
-
-    case (StructType(fromFields), StructType(toFields)) =>
-      fromFields.length == toFields.length &&
-        fromFields.zip(toFields).forall {
-          case (fromField, toField) =>
-            canCast(fromField.dataType, toField.dataType) &&
-              resolvableNullability(
-                fromField.nullable || forceNullable(fromField.dataType, toField.dataType),
-                toField.nullable)
-        }
-
-    case _ =>
-      Cast.canAnsiCast(from, to)
-  }
-
-  override def checkInputDataTypes(): TypeCheckResult = {
-    if (canCast(child.dataType, dataType)) {
-      TypeCheckResult.TypeCheckSuccess
-    } else {
-      TypeCheckResult.TypeCheckFailure(Cast.typeCheckFailureMessage(child.dataType, toType, None))
-    }
-  }
-
-  override def toString: String = s"try_cast($child as ${dataType.simpleString})"
-
-  override def sql: String = s"TRY_CAST(${child.sql} AS ${dataType.sql})"
-
-  override protected def withNewChildInternal(newChild: Expression): Expression =
-    this.copy(child = newChild)
 }
 
 // scalastyle:off line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -1795,9 +1795,9 @@ class AstBuilder extends SqlBaseParserBaseVisitor[AnyRef] with SQLConfHelper wit
         cast
 
       case SqlBaseParser.TRY_CAST =>
-        // `TryCast` can only be user-specified and we don't need to set the USER_SPECIFIED_CAST
-        // tag, which is only used by `Cast`
-        TryCast(expression(ctx.expression), dataType)
+        val cast = Cast(expression(ctx.expression), dataType, evalMode = EvalMode.TRY)
+        cast.setTagValue(Cast.USER_SPECIFIED_CAST, true)
+        cast
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -48,12 +48,12 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
 
-  protected def ansiEnabled: Boolean
+  protected def evalMode: EvalMode.Value
 
   protected def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): Cast = {
     v match {
-      case lit: Expression => Cast(lit, targetType, timeZoneId, ansiEnabled)
-      case _ => Cast(Literal(v), targetType, timeZoneId, ansiEnabled)
+      case lit: Expression => Cast(lit, targetType, timeZoneId, evalMode)
+      case _ => Cast(Literal(v), targetType, timeZoneId, evalMode)
     }
   }
 
@@ -76,7 +76,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       assert(message.contains(optionalExpectedMsg.get))
     } else {
       assert("cannot cast [a-zA-Z]+ to [a-zA-Z]+".r.findFirstIn(message).isDefined)
-      if (ansiEnabled) {
+      if (evalMode == EvalMode.ANSI) {
         assert(message.contains("with ANSI mode on"))
         assert(message.contains(s"set ${SQLConf.ANSI_ENABLED.key} as false"))
       }
@@ -986,10 +986,9 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
 
     Seq("INTERVAL '-106751991 04:00:54.775809' DAY TO SECOND",
       "INTERVAL '106751991 04:00:54.775808' DAY TO SECOND").foreach { interval =>
-      val e = intercept[ArithmeticException] {
-        cast(Literal.create(interval), DayTimeIntervalType()).eval()
-      }.getMessage
-      assert(e.contains("long overflow"))
+      checkExceptionInExpression[ArithmeticException](
+        cast(Literal.create(interval), DayTimeIntervalType()),
+        "long overflow")
     }
 
     Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Long.MaxValue, Long.MinValue + 1,
@@ -1030,10 +1029,9 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
 
     Seq("INTERVAL '-178956970-9' YEAR TO MONTH", "INTERVAL '178956970-8' YEAR TO MONTH")
       .foreach { interval =>
-        val e = intercept[IllegalArgumentException] {
-          cast(Literal.create(interval), YearMonthIntervalType()).eval()
-        }.getMessage
-        assert(e.contains("Error parsing interval year-month string: integer overflow"))
+        checkExceptionInExpression[IllegalArgumentException](
+          cast(Literal.create(interval), YearMonthIntervalType()),
+          "Error parsing interval year-month string: integer overflow")
       }
 
     Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Int.MinValue + 1, Int.MinValue)
@@ -1099,13 +1097,14 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
 
     Seq("INTERVAL '1-1' YEAR", "INTERVAL '1-1' MONTH").foreach { interval =>
       val dataType = YearMonthIntervalType()
-      val e = intercept[IllegalArgumentException] {
-        cast(Literal.create(interval), dataType).eval()
-      }.getMessage
-      assert(e.contains(s"Interval string does not match year-month format of " +
+      val expectedMsg = s"Interval string does not match year-month format of " +
         s"${IntervalUtils.supportedFormat((dataType.startField, dataType.endField))
           .map(format => s"`$format`").mkString(", ")} " +
-        s"when cast to ${dataType.typeName}: $interval"))
+        s"when cast to ${dataType.typeName}: $interval"
+      checkExceptionInExpression[IllegalArgumentException](
+        cast(Literal.create(interval), dataType),
+        expectedMsg
+      )
     }
     Seq(("1", YearMonthIntervalType(YEAR, MONTH)),
       ("1", YearMonthIntervalType(YEAR, MONTH)),
@@ -1118,13 +1117,13 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       ("INTERVAL '1' MONTH", YearMonthIntervalType(YEAR)),
       ("INTERVAL '1' MONTH", YearMonthIntervalType(YEAR, MONTH)))
       .foreach { case (interval, dataType) =>
-        val e = intercept[IllegalArgumentException] {
-          cast(Literal.create(interval), dataType).eval()
-        }.getMessage
-        assert(e.contains(s"Interval string does not match year-month format of " +
+        val expectedMsg = s"Interval string does not match year-month format of " +
           s"${IntervalUtils.supportedFormat((dataType.startField, dataType.endField))
             .map(format => s"`$format`").mkString(", ")} " +
-          s"when cast to ${dataType.typeName}: $interval"))
+          s"when cast to ${dataType.typeName}: $interval"
+        checkExceptionInExpression[IllegalArgumentException](
+          cast(Literal.create(interval), dataType),
+          expectedMsg)
       }
   }
 
@@ -1238,15 +1237,16 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       ("1.23", DayTimeIntervalType(MINUTE)),
       ("1.23", DayTimeIntervalType(MINUTE)))
       .foreach { case (interval, dataType) =>
-        val e = intercept[IllegalArgumentException] {
-          cast(Literal.create(interval), dataType).eval()
-        }.getMessage
-        assert(e.contains(s"Interval string does not match day-time format of " +
+        val expectedMsg = s"Interval string does not match day-time format of " +
           s"${IntervalUtils.supportedFormat((dataType.startField, dataType.endField))
             .map(format => s"`$format`").mkString(", ")} " +
           s"when cast to ${dataType.typeName}: $interval, " +
           s"set ${SQLConf.LEGACY_FROM_DAYTIME_STRING.key} to true " +
-          "to restore the behavior before Spark 3.0."))
+          "to restore the behavior before Spark 3.0."
+        checkExceptionInExpression[IllegalArgumentException](
+          cast(Literal.create(interval), dataType),
+          expectedMsg
+        )
       }
 
     // Check first field outof bound
@@ -1261,15 +1261,15 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       ("INTERVAL '1537228672801:54.7757' MINUTE TO SECOND", DayTimeIntervalType(MINUTE, SECOND)),
       ("INTERVAL '92233720368541.775807' SECOND", DayTimeIntervalType(SECOND)))
       .foreach { case (interval, dataType) =>
-        val e = intercept[IllegalArgumentException] {
-          cast(Literal.create(interval), dataType).eval()
-        }.getMessage
-        assert(e.contains(s"Interval string does not match day-time format of " +
+        val expectedMsg = "Interval string does not match day-time format of " +
           s"${IntervalUtils.supportedFormat((dataType.startField, dataType.endField))
             .map(format => s"`$format`").mkString(", ")} " +
           s"when cast to ${dataType.typeName}: $interval, " +
           s"set ${SQLConf.LEGACY_FROM_DAYTIME_STRING.key} to true " +
-          "to restore the behavior before Spark 3.0."))
+          "to restore the behavior before Spark 3.0."
+        checkExceptionInExpression[IllegalArgumentException](
+          cast(Literal.create(interval), dataType),
+          expectedMsg)
       }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -38,7 +38,7 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 class CastWithAnsiOffSuite extends CastSuiteBase {
 
-  override def ansiEnabled: Boolean = false
+  override def evalMode: EvalMode.Value = EvalMode.LEGACY
 
   test("null cast #2") {
     import DataTypeTestUtils._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -37,6 +37,8 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   override def evalMode: EvalMode.Value = EvalMode.ANSI
 
+  private def isTryCast = evalMode == EvalMode.TRY
+
   private def testIntMaxAndMin(dt: DataType): Unit = {
     assert(Seq(IntegerType, ShortType, ByteType).contains(dt))
     Seq(Int.MaxValue + 1L, Int.MinValue - 1L).foreach { value =>
@@ -334,22 +336,30 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
     }
 
     {
-      val ret = cast(array_notNull, ArrayType(BooleanType, containsNull = false))
+      val ret = cast(array_notNull, ArrayType(BooleanType, containsNull = evalMode == EvalMode.TRY))
       assert(ret.resolved)
-      checkExceptionInExpression[SparkRuntimeException](
-        ret, """cannot be cast to "BOOLEAN"""")
+      if (!isTryCast) {
+        checkExceptionInExpression[SparkRuntimeException](
+          ret, """cannot be cast to "BOOLEAN"""")
+      } else {
+        checkEvaluation(ret, Array(null, true, false))
+      }
     }
   }
 
   test("cast from array III") {
     val from: DataType = ArrayType(DoubleType, containsNull = false)
     val array = Literal.create(Seq(1.0, 2.0), from)
-    val to: DataType = ArrayType(IntegerType, containsNull = false)
+    val to: DataType = ArrayType(IntegerType, containsNull = isTryCast)
     val answer = Literal.create(Seq(1, 2), to).value
     checkEvaluation(cast(array, to), answer)
 
     val overflowArray = Literal.create(Seq(Int.MaxValue + 1.0D), from)
-    checkExceptionInExpression[ArithmeticException](cast(overflowArray, to), "overflow")
+    if (!isTryCast) {
+      checkExceptionInExpression[ArithmeticException](cast(overflowArray, to), "overflow")
+    } else {
+      checkEvaluation(cast(overflowArray, to), Array(null))
+    }
   }
 
   test("cast from map II") {
@@ -378,26 +388,38 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
     {
       val ret = cast(map, MapType(IntegerType, StringType, valueContainsNull = true))
-      assert(ret.resolved)
-      checkExceptionInExpression[NumberFormatException](
-        ret,
-        castErrMsg("a", IntegerType))
+      if (!isTryCast) {
+        assert(ret.resolved)
+        checkExceptionInExpression[NumberFormatException](
+          ret,
+          castErrMsg("a", IntegerType))
+      } else {
+        assert(!ret.resolved)
+      }
     }
 
     {
       val ret = cast(map_notNull, MapType(StringType, BooleanType, valueContainsNull = false))
-      assert(ret.resolved)
-      checkExceptionInExpression[SparkRuntimeException](
-        ret,
-        castErrMsg("123", BooleanType))
+      if (!isTryCast) {
+        assert(ret.resolved)
+        checkExceptionInExpression[SparkRuntimeException](
+          ret,
+          castErrMsg("123", BooleanType))
+      } else {
+        assert(!ret.resolved)
+      }
     }
 
     {
       val ret = cast(map_notNull, MapType(IntegerType, StringType, valueContainsNull = true))
-      assert(ret.resolved)
-      checkExceptionInExpression[NumberFormatException](
-        ret,
-        castErrMsg("a", IntegerType))
+      if (!isTryCast) {
+        assert(ret.resolved)
+        checkExceptionInExpression[NumberFormatException](
+          ret,
+          castErrMsg("a", IntegerType))
+      } else {
+        assert(!ret.resolved)
+      }
     }
   }
 
@@ -406,12 +428,14 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
     val map = Literal.create(Map(1.0 -> 2.0), from)
     val to: DataType = MapType(IntegerType, IntegerType, valueContainsNull = false)
     val answer = Literal.create(Map(1 -> 2), to).value
-    checkEvaluation(cast(map, to), answer)
+    if (!isTryCast) {
+      checkEvaluation(cast(map, to), answer)
 
-    Seq(
-      Literal.create(Map((Int.MaxValue + 1.0) -> 2.0), from),
-      Literal.create(Map(1.0 -> (Int.MinValue - 1.0)), from)).foreach { overflowMap =>
-      checkExceptionInExpression[ArithmeticException](cast(overflowMap, to), "overflow")
+      Seq(
+        Literal.create(Map((Int.MaxValue + 1.0) -> 2.0), from),
+        Literal.create(Map(1.0 -> (Int.MinValue - 1.0)), from)).foreach { overflowMap =>
+        checkExceptionInExpression[ArithmeticException](cast(overflowMap, to), "overflow")
+      }
     }
   }
 
@@ -471,22 +495,31 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
         StructField("a", BooleanType, nullable = true),
         StructField("b", BooleanType, nullable = true),
         StructField("c", BooleanType, nullable = false))))
-      assert(ret.resolved)
-      checkExceptionInExpression[SparkRuntimeException](
-        ret,
-        castErrMsg("123", BooleanType))
+      if (!isTryCast) {
+        assert(ret.resolved)
+        checkExceptionInExpression[SparkRuntimeException](
+          ret,
+          castErrMsg("123", BooleanType))
+      } else {
+        assert(!ret.resolved)
+      }
     }
   }
 
   test("cast from struct III") {
     val from: DataType = StructType(Seq(StructField("a", DoubleType, nullable = false)))
     val struct = Literal.create(InternalRow(1.0), from)
-    val to: DataType = StructType(Seq(StructField("a", IntegerType, nullable = false)))
+    val to: DataType = StructType(Seq(StructField("a", IntegerType, nullable = isTryCast)))
     val answer = Literal.create(InternalRow(1), to).value
     checkEvaluation(cast(struct, to), answer)
 
     val overflowStruct = Literal.create(InternalRow(Int.MaxValue + 1.0), from)
-    checkExceptionInExpression[ArithmeticException](cast(overflowStruct, to), "overflow")
+    val ret = cast(overflowStruct, to)
+    if (!isTryCast) {
+      checkExceptionInExpression[ArithmeticException](ret, "overflow")
+    } else {
+      checkEvaluation(ret, Row(null))
+    }
   }
 
   test("complex casting") {
@@ -513,10 +546,14 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
         StructType(Seq(
           StructField("l", LongType, nullable = true)))))))
 
-    assert(ret.resolved)
-    checkExceptionInExpression[NumberFormatException](
-      ret,
-      castErrMsg("true", IntegerType))
+    if (!isTryCast) {
+      assert(ret.resolved)
+      checkExceptionInExpression[NumberFormatException](
+        ret,
+        castErrMsg("true", IntegerType))
+    } else {
+      assert(!ret.resolved)
+    }
   }
 
   test("ANSI mode: cast string to timestamp with parse error") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
-  override def ansiEnabled: Boolean = true
+  override def evalMode: EvalMode.Value = EvalMode.ANSI
 
   private def testIntMaxAndMin(dt: DataType): Unit = {
     assert(Seq(IntegerType, ShortType, ByteType).contains(dt))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -26,16 +26,16 @@ import org.apache.spark.unsafe.types.UTF8String
 // A test suite to check analysis behaviors of `TryCast`.
 class TryCastSuite extends SparkFunSuite {
 
-  private def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): TryCast = {
+  private def cast(v: Any, targetType: DataType, timeZoneId: Option[String] = None): Cast = {
     v match {
-      case lit: Expression => TryCast(lit, targetType, timeZoneId)
-      case _ => TryCast(Literal(v), targetType, timeZoneId)
+      case lit: Expression => Cast(lit, targetType, timeZoneId, EvalMode.TRY)
+      case _ => Cast(Literal(v), targetType, timeZoneId, EvalMode.TRY)
     }
   }
 
   test("print string") {
-    assert(TryCast(Literal("1"), IntegerType).toString == "try_cast(1 as int)")
-    assert(TryCast(Literal("1"), IntegerType).sql == "TRY_CAST('1' AS INT)")
+    assert(cast(Literal("1"), IntegerType).toString == "try_cast(1 as int)")
+    assert(cast(Literal("1"), IntegerType).sql == "TRY_CAST('1' AS INT)")
   }
 
   test("nullability") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 // A test suite to check analysis behaviors of `TryCast`.
-class TryCastSuite extends CastSuiteBase {
+class TryCastSuite extends CastWithAnsiOnSuite {
 
   override def evalMode: EvalMode.Value = EvalMode.TRY
 
@@ -41,6 +41,15 @@ class TryCastSuite extends CastSuiteBase {
       inputRow: InternalRow,
       expectedErrMsg: String): Unit = {
     checkEvaluation(expression, null, inputRow)
+  }
+
+  override def checkCastToBooleanError(l: Literal, to: DataType, tryCastResult: Any): Unit = {
+    checkEvaluation(cast(l, to), tryCastResult, InternalRow(l.value))
+  }
+
+  override def checkCastToNumericError(l: Literal, to: DataType,
+      expectedDataTypeInErrorMsg: DataType, tryCastResult: Any): Unit = {
+    checkEvaluation(cast(l, to), tryCastResult, InternalRow(l.value))
   }
 
   test("print string") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -101,7 +101,7 @@ class TryCastSuite extends CastWithAnsiOnSuite {
 }
 
 class TryCastThrowExceptionSuite extends SparkFunSuite with ExpressionEvalHelper {
-  // The method checkExceptionInExpression is overridedn in TryCastSuite, so here we have a
+  // The method checkExceptionInExpression is overridden in TryCastSuite, so here we have a
   // new test suite for testing exceptions from the child of `try_cast()`.
   test("TryCast should not catch the exception from it's child") {
     val child = Divide(Literal(1.0), Literal(0.0), failOnError = true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TryCastSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.catalyst.expressions
 
 import scala.reflect.ClassTag
 
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils.UTC_OPT
 import org.apache.spark.sql.types._
@@ -96,5 +97,16 @@ class TryCastSuite extends CastWithAnsiOnSuite {
       .add("a", BooleanType, nullable = true)
       .add("b", BooleanType, nullable = false))
     assert(!c4.resolved)
+  }
+}
+
+class TryCastThrowExceptionSuite extends SparkFunSuite with ExpressionEvalHelper {
+  // The method checkExceptionInExpression is overridedn in TryCastSuite, so here we have a
+  // new test suite for testing exceptions from the child of `try_cast()`.
+  test("TryCast should not catch the exception from it's child") {
+    val child = Divide(Literal(1.0), Literal(0.0), failOnError = true)
+    checkExceptionInExpression[Exception](
+      Cast(child, StringType, None, EvalMode.TRY),
+      "Division by zero")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ConstantFoldingSuite.scala
@@ -146,7 +146,8 @@ class ConstantFoldingSuite extends PlanTest {
       testRelation
         .select(
           Cast(Literal("2"), IntegerType) + Literal(3) + $"a" as "c1",
-          Coalesce(Seq(TryCast(Literal("abc"), IntegerType).replacement, Literal(3))) as "c2")
+          Coalesce(Seq(
+            Cast(Literal("abc"), IntegerType, evalMode = EvalMode.TRY), Literal(3))) as "c2")
 
     val optimized = Optimize.execute(originalQuery.analyze)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -91,8 +91,8 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
       } else {
         None
       }
-    case Cast(child, dataType, _, ansiEnabled)
-        if ansiEnabled || Cast.canUpCast(child.dataType, dataType) =>
+    case Cast(child, dataType, _, evalMode)
+        if evalMode == EvalMode.ANSI || Cast.canUpCast(child.dataType, dataType) =>
       generateExpression(child).map(v => new V2Cast(v, dataType))
     case AggregateExpression(aggregateFunction, Complete, isDistinct, None, _) =>
       generateAggregateFunc(aggregateFunction, isDistinct)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/StatFunctions.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, Expression, GenericInternalRow, GetArrayItem, Literal, TryCast}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, EvalMode, Expression, GenericInternalRow, GetArrayItem, Literal}
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.catalyst.util.{GenericArrayData, QuantileSummaries}
@@ -247,7 +247,7 @@ object StatFunctions extends Logging {
     require(percentiles.forall(p => p >= 0 && p <= 1), "Percentiles must be in the range [0, 1]")
 
     def castAsDoubleIfNecessary(e: Expression): Expression = if (e.dataType == StringType) {
-      TryCast(e, DoubleType)
+      Cast(e, DoubleType, evalMode = EvalMode.TRY)
     } else {
       e
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.catalyst.{AliasIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{AnalysisContext, AnalysisTest, Analyzer, EmptyFunctionRegistry, NoSuchTableException, ResolvedFieldName, ResolvedIdentifier, ResolvedTable, ResolveSessionCatalog, UnresolvedAttribute, UnresolvedInlineTable, UnresolvedRelation, UnresolvedSubqueryColumnAliases, UnresolvedTable}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogStorageFormat, CatalogTable, CatalogTableType, InMemoryCatalog, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, EqualTo, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, EqualTo, EvalMode, Expression, InSubquery, IntegerLiteral, ListQuery, Literal, StringLiteral}
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.parser.{CatalystSqlParser, ParseException}
 import org.apache.spark.sql.catalyst.plans.logical.{AlterColumn, AnalysisOnlyCommand, AppendData, Assignment, CreateTable, CreateTableAsSelect, DeleteAction, DeleteFromTable, DescribeRelation, DropTable, InsertAction, InsertIntoStatement, LocalRelation, LogicalPlan, MergeIntoTable, OneRowRelation, Project, SetTableLocation, SetTableProperties, ShowTableProperties, SubqueryAlias, UnsetTableProperties, UpdateAction, UpdateTable}
@@ -1120,8 +1120,10 @@ class PlanResolutionSuite extends AnalysisTest {
             // Note that when resolving DEFAULT column references, the analyzer will insert literal
             // NULL values if the corresponding table does not define an explicit default value for
             // that column. This is intended.
-            Assignment(i: AttributeReference, cast1 @ Cast(Literal(null, _), IntegerType, _, true)),
-            Assignment(s: AttributeReference, cast2 @ Cast(Literal(null, _), StringType, _, true))),
+            Assignment(i: AttributeReference,
+              cast1 @ Cast(Literal(null, _), IntegerType, _, EvalMode.ANSI)),
+            Assignment(s: AttributeReference,
+              cast2 @ Cast(Literal(null, _), StringType, _, EvalMode.ANSI))),
           None) if cast1.getTagValue(Cast.BY_TABLE_INSERTION).isDefined &&
           cast2.getTagValue(Cast.BY_TABLE_INSERTION).isDefined =>
           assert(i.name == "i")
@@ -1151,7 +1153,8 @@ class PlanResolutionSuite extends AnalysisTest {
       parsed9 match {
         case UpdateTable(
         _,
-        Seq(Assignment(i: AttributeReference, cast @ Cast(Literal(null, _), StringType, _, true))),
+        Seq(Assignment(i: AttributeReference,
+          cast @ Cast(Literal(null, _), StringType, _, EvalMode.ANSI))),
         None) if cast.getTagValue(Cast.BY_TABLE_INSERTION).isDefined =>
           assert(i.name == "i")
 
@@ -1642,7 +1645,7 @@ class PlanResolutionSuite extends AnalysisTest {
               case UpdateAction(Some(EqualTo(_: AttributeReference, StringLiteral("update"))),
                 Seq(
                   Assignment(_: AttributeReference,
-                    cast @ Cast(Literal(null, _), StringType, _, true)),
+                    cast @ Cast(Literal(null, _), StringType, _, EvalMode.ANSI)),
                   Assignment(_: AttributeReference, _: AttributeReference)))
                 if cast.getTagValue(Cast.BY_TABLE_INSERTION).isDefined =>
               case other => fail("unexpected second matched action " + other)
@@ -1652,9 +1655,9 @@ class PlanResolutionSuite extends AnalysisTest {
             negative match {
               case InsertAction(Some(EqualTo(_: AttributeReference, StringLiteral("insert"))),
               Seq(Assignment(i: AttributeReference,
-                cast1 @ Cast(Literal(null, _), IntegerType, _, true)),
+                cast1 @ Cast(Literal(null, _), IntegerType, _, EvalMode.ANSI)),
               Assignment(s: AttributeReference,
-                cast2 @ Cast(Literal(null, _), StringType, _, true))))
+                cast2 @ Cast(Literal(null, _), StringType, _, EvalMode.ANSI))))
                 if cast1.getTagValue(Cast.BY_TABLE_INSERTION).isDefined &&
                   cast2.getTagValue(Cast.BY_TABLE_INSERTION).isDefined =>
                 assert(i.name == "i")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
For the following query
```
SET spark.sql.ansi.enabled=true;
SELECT try_cast(1/0 AS string); 
```
Spark 3.3 will throw an exception for the division by zero error. In the current master branch, it returns null after the refactoring PR https://github.com/apache/spark/pull/36703

This PR is to restore the previous error handling syntax.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. Restore the behavior of try_cast()
2. The previous syntax is more reasonable. Users can cleanly catch the exception from the child of `try_cast`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests