### PR TITLE
[SPARK-40056][BUILD] Upgrade mvn-scalafmt from 1.0.4 to 1.1.1640084764.9f463a9

### DIFF
--- a/dev/scalafmt
+++ b/dev/scalafmt
@@ -18,5 +18,5 @@
 #
 
 VERSION="${@:-2.12}"
-./build/mvn -Pscala-$VERSION mvn-scalafmt_$VERSION:format -Dscalafmt.skip=false
+./build/mvn -Pscala-$VERSION scalafmt:format -Dscalafmt.skip=false
 

--- a/pom.xml
+++ b/pom.xml
@@ -3410,7 +3410,7 @@
       <plugin>
         <groupId>org.antipathy</groupId>
         <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
-        <version>1.0.4</version>
+        <version>1.1.1640084764.9f463a9</version>
         <configuration>
           <validateOnly>${scalafmt.skip}</validateOnly> <!-- (Optional) skip formatting -->
           <skipSources>${scalafmt.skip}</skipSources>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade mvn-scalafmt from 1.0.4 to 1.1.1640084764.9f463a9


### Why are the changes needed?
The last upgrade occurred 2 year ago.
<img width="810" alt="image" src="https://user-images.githubusercontent.com/15246973/184291798-b1960f0a-f5ab-4037-835a-c788fb9447fc.png">
maven repo version: https://mvnrepository.com/artifact/org.antipathy/mvn-scalafmt

The new version specifically update the following issues:
> 1.https://github.com/SimonJPegg/mvn_scalafmt/commit/6b9e0a4c4169c133729b087c587c1d542359ad75
> <img width="566" alt="image" src="https://user-images.githubusercontent.com/15246973/184291619-f77c3df3-0044-4f66-bc24-c60b8148e44b.png">

> 2.mvn_scalafmt_2.11(scala 2.11) be deprecated: https://github.com/SimonJPegg/mvn_scalafmt/commit/9f3d1095d1e4e944d1e375925fd8b9e3aad63894
> <img width="473" alt="image" src="https://user-images.githubusercontent.com/15246973/184292603-74f70241-05e7-4c4e-9ef7-60041c6d9e76.png">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA & Manual test
> 1.mvn -Pscala-2.12 scalafmt:format -Dscalafmt.skip=false
> 2.mvn -Pscala-2.13 scalafmt:format -Dscalafmt.skip=false