### PR TITLE
[SPARK-40060][CORE] Add `numberDecommissioningExecutors` metric

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -1005,6 +1005,8 @@ private[spark] class ExecutorAllocationManagerSource(
   registerGauge("numberMaxNeededExecutors",
     executorAllocationManager.numExecutorsTargetPerResourceProfileId.keys
       .map(executorAllocationManager.maxNumExecutorsNeededPerResourceProfile(_)).sum, 0)
+  registerGauge("numberDecommissioningExecutors",
+    executorAllocationManager.executorMonitor.decommissioningCount, 0)
 }
 
 private object ExecutorAllocationManager {

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1212,6 +1212,7 @@ This is the component with the largest amount of instrumented metrics
   - executors.numberAllExecutors
   - executors.numberTargetExecutors
   - executors.numberMaxNeededExecutors
+  - executors.numberDecommissioningExecutors
   - executors.numberExecutorsGracefullyDecommissioned.count
   - executors.numberExecutorsDecommissionUnfinished.count
   - executors.numberExecutorsExitedUnexpectedly.count


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add numberDecommissioningExecutors metric in ExecutorAllocationManager

### Why are the changes needed?
This metric is helpful for understand decommission behavior

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested
