### PR TITLE
[SPARK-40049][SQL][TESTS] Add ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
@@ -17,29 +17,24 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.{CaseWhen, If, Literal}
 import org.apache.spark.sql.execution.LocalTableScanExec
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.adaptive.{
+  AdaptiveSparkPlanHelper,
+  DisableAdaptiveExecutionSuite,
+  EnableAdaptiveExecutionSuite
+}
 import org.apache.spark.sql.functions.{lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.BooleanType
 
 class ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite extends
-  ReplaceNullWithFalseInPredicateEndToEndSuite {
-  override protected def sparkConf: SparkConf = {
-    super.sparkConf.set("spark.sql.adaptive.forceApply", "true")
-  }
-}
+  ReplaceNullWithFalseInPredicateEndToEndSuite with EnableAdaptiveExecutionSuite
 
 class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with SharedSparkSession with
-  AdaptiveSparkPlanHelper {
+  AdaptiveSparkPlanHelper with DisableAdaptiveExecutionSuite {
   import testImplicits._
-
-  override protected def sparkConf: SparkConf = {
-    super.sparkConf.set("spark.sql.adaptive.forceApply", "false")
-  }
 
   private def checkPlanIsEmptyLocalScan(df: DataFrame): Unit =
     stripAQEPlan(df.queryExecution.executedPlan) match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
@@ -19,18 +19,11 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.{CaseWhen, If, Literal}
 import org.apache.spark.sql.execution.LocalTableScanExec
-import org.apache.spark.sql.execution.adaptive.{
-  AdaptiveSparkPlanHelper,
-  DisableAdaptiveExecutionSuite,
-  EnableAdaptiveExecutionSuite
-}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.functions.{lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.BooleanType
-
-class ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite extends
-  ReplaceNullWithFalseInPredicateEndToEndSuite with EnableAdaptiveExecutionSuite
 
 class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with SharedSparkSession with
   AdaptiveSparkPlanHelper with DisableAdaptiveExecutionSuite {
@@ -133,3 +126,6 @@ class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with Shared
     }
   }
 }
+
+class ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite extends
+  ReplaceNullWithFalseInPredicateEndToEndSuite with EnableAdaptiveExecutionSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to add `ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite ` i.e. test cases of `ReplaceNullWithFalseInPredicateEndToEndSuite` with AQE (Adaptive Query Execution) turned on.


### Why are the changes needed?
Currently `ReplaceNullWithFalseInPredicateEndToEndSuite` assumes that AQE is always turned off. We should also test with AQE turned on


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added an AQE version tests along with the non AQE version
