### PR TITLE
[SPARK-39926][SQL] Fix bug in column DEFAULT support for non-vectorized Parquet scans

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetRowConverter.scala
@@ -234,7 +234,7 @@ private[parquet] class ParquetRowConverter(
           // Assume the schema for a Parquet file-based table contains N fields. Then if we later
           // run a command "ALTER TABLE t ADD COLUMN c DEFAULT <value>" on the Parquet table, this
           // adds one field to the Catalyst schema. Then if we query the old files with the new
-          // Catalyst schema, we should only apply the existence default value to all columns > N.
+          // Catalyst schema, we should only apply the existence default value to all columns >= N.
           if (i < parquetType.getFieldCount) {
             false
           } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1644,13 +1644,6 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     // Run the test several times using each configuration.
     Seq(
       TestCase(
-        dataSource = "parquet",
-        Seq(
-          Config(
-            Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false")),
-          Config(
-            None))),
-      TestCase(
         dataSource = "csv",
         Seq(
           Config(
@@ -1671,7 +1664,14 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           Config(
             None),
           Config(
-            Some(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false"))))
+            Some(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false")))),
+      TestCase(
+        dataSource = "parquet",
+        Seq(
+          Config(
+            Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false")),
+          Config(
+            None)))
     ).foreach { testCase: TestCase =>
       testCase.configs.foreach { config: Config =>
         // Run the test twice, once using SQL for the INSERT operations and again using DataFrames.

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1644,6 +1644,13 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
     // Run the test several times using each configuration.
     Seq(
       TestCase(
+        dataSource = "parquet",
+        Seq(
+          Config(
+            Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false")),
+          Config(
+            None))),
+      TestCase(
         dataSource = "csv",
         Seq(
           Config(
@@ -1664,15 +1671,7 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
           Config(
             None),
           Config(
-            Some(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false")))),
-      TestCase(
-        dataSource = "parquet",
-        Seq(
-          Config(
-            None),
-          Config(
-            Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false"),
-            insertNullsToStorage = false)))
+            Some(SQLConf.ORC_VECTORIZED_READER_ENABLED.key -> "false"))))
     ).foreach { testCase: TestCase =>
       testCase.configs.foreach { config: Config =>
         // Run the test twice, once using SQL for the INSERT operations and again using DataFrames.

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1669,9 +1669,9 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         dataSource = "parquet",
         Seq(
           Config(
-            Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false")),
-          Config(
-            None)))
+            None),
+        Config(
+        Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false"))))
     ).foreach { testCase: TestCase =>
       testCase.configs.foreach { config: Config =>
         // Run the test twice, once using SQL for the INSERT operations and again using DataFrames.

--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -1670,8 +1670,8 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         Seq(
           Config(
             None),
-        Config(
-        Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false"))))
+          Config(
+            Some(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "false"))))
     ).foreach { testCase: TestCase =>
       testCase.configs.foreach { config: Config =>
         // Run the test twice, once using SQL for the INSERT operations and again using DataFrames.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a bug in column DEFAULT support for non-vectorized Parquet scans, where inserting explicit NULL values to a column with a DEFAULT and then selecting the column back would sometimes erroneously return the default value. 

To exercise the behavior:

```
set spark.sql.parquet.enableVectorizedReader=false;
create table t(a int) using parquet;
insert into t values (42);
alter table t add column b int default 42;
insert into t values (43, null);
select * from t;
```

This should return two rows:

`(42, 42) and (43, NULL)`

But instead the scan missed the inserted NULL value, and returned the existence DEFAULT value of "42" instead:

`(42, 42) and (43, 42)`.

After this bug fix, Spark now returns the former correct result.

### Why are the changes needed?

This fixes the correctness of SQL queries using Spark.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The PR includes unit test coverage.