### PR TITLE
[SPARK-40064][SQL] Use V2 Filter in SupportsOverwrite

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCapability.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableCapability.java
@@ -76,7 +76,7 @@ public enum TableCapability {
    * Signals that the table can replace existing data that matches a filter with appended data in
    * a write operation.
    * <p>
-   * See {@link org.apache.spark.sql.connector.write.SupportsOverwrite}.
+   * See {@link org.apache.spark.sql.connector.write.SupportsOverwriteV2}.
    */
   OVERWRITE_BY_FILTER,
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsDynamicOverwrite.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/SupportsDynamicOverwrite.java
@@ -27,7 +27,7 @@ import org.apache.spark.annotation.Evolving;
  * write does not contain data will remain unchanged.
  * <p>
  * This is provided to implement SQL compatible with Hive table operations but is not recommended.
- * Instead, use the {@link SupportsOverwrite overwrite by filter API} to explicitly replace data.
+ * Instead, use the {@link SupportsOverwriteV2 overwrite by filter API} to explicitly replace data.
  *
  * @since 3.0.0
  */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -45,7 +45,7 @@ import org.apache.spark.unsafe.types.UTF8String
 /**
  * A simple in-memory table. Rows are stored as a buffered group produced by each output task.
  */
-class InMemoryBaseTable(
+abstract class InMemoryBaseTable(
     val name: String,
     val schema: StructType,
     override val partitioning: Array[Transform],
@@ -337,59 +337,39 @@ class InMemoryBaseTable(
     }
   }
 
-  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    InMemoryBaseTable.maybeSimulateFailedTableWrite(new CaseInsensitiveStringMap(properties))
-    InMemoryBaseTable.maybeSimulateFailedTableWrite(info.options)
+  abstract class InMemoryWriterBuilder() extends SupportsTruncate with SupportsDynamicOverwrite
+    with SupportsStreamingUpdateAsAppend {
 
-    new WriteBuilder with SupportsTruncate with SupportsOverwrite
-      with SupportsDynamicOverwrite with SupportsStreamingUpdateAsAppend {
+    protected var writer: BatchWrite = Append
+    protected var streamingWriter: StreamingWrite = StreamingAppend
 
-      private var writer: BatchWrite = Append
-      private var streamingWriter: StreamingWrite = StreamingAppend
+    override def overwriteDynamicPartitions(): WriteBuilder = {
+      assert(writer == Append)
+      writer = DynamicOverwrite
+      streamingWriter = new StreamingNotSupportedOperation("overwriteDynamicPartitions")
+      this
+    }
 
-      override def truncate(): WriteBuilder = {
-        assert(writer == Append)
-        writer = TruncateAndAppend
-        streamingWriter = StreamingTruncateAndAppend
-        this
+    override def build(): Write = new Write with RequiresDistributionAndOrdering {
+      override def requiredDistribution: Distribution = distribution
+
+      override def distributionStrictlyRequired: Boolean = isDistributionStrictlyRequired
+
+      override def requiredOrdering: Array[SortOrder] = ordering
+
+      override def requiredNumPartitions(): Int = {
+        numPartitions.getOrElse(0)
       }
 
-      override def overwrite(filters: Array[Filter]): WriteBuilder = {
-        assert(writer == Append)
-        writer = new Overwrite(filters)
-        streamingWriter = new StreamingNotSupportedOperation(
-          s"overwrite (${filters.mkString("filters(", ", ", ")")})")
-        this
+      override def toBatch: BatchWrite = writer
+
+      override def toStreaming: StreamingWrite = streamingWriter match {
+        case exc: StreamingNotSupportedOperation => exc.throwsException()
+        case s => s
       }
 
-      override def overwriteDynamicPartitions(): WriteBuilder = {
-        assert(writer == Append)
-        writer = DynamicOverwrite
-        streamingWriter = new StreamingNotSupportedOperation("overwriteDynamicPartitions")
-        this
-      }
-
-      override def build(): Write = new Write with RequiresDistributionAndOrdering {
-        override def requiredDistribution: Distribution = distribution
-
-        override def distributionStrictlyRequired: Boolean = isDistributionStrictlyRequired
-
-        override def requiredOrdering: Array[SortOrder] = ordering
-
-        override def requiredNumPartitions(): Int = {
-          numPartitions.getOrElse(0)
-        }
-
-        override def toBatch: BatchWrite = writer
-
-        override def toStreaming: StreamingWrite = streamingWriter match {
-          case exc: StreamingNotSupportedOperation => exc.throwsException()
-          case s => s
-        }
-
-        override def supportedCustomMetrics(): Array[CustomMetric] = {
-          Array(new InMemorySimpleCustomMetric)
-        }
+      override def supportedCustomMetrics(): Array[CustomMetric] = {
+        Array(new InMemorySimpleCustomMetric)
       }
     }
   }
@@ -402,7 +382,7 @@ class InMemoryBaseTable(
     override def abort(messages: Array[WriterCommitMessage]): Unit = {}
   }
 
-  private object Append extends TestBatchWrite {
+  protected object Append extends TestBatchWrite {
     override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
       withData(messages.map(_.asInstanceOf[BufferedRows]))
     }
@@ -416,24 +396,14 @@ class InMemoryBaseTable(
     }
   }
 
-  private class Overwrite(filters: Array[Filter]) extends TestBatchWrite {
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
-    override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
-      val deleteKeys = InMemoryBaseTable.filtersToKeys(
-        dataMap.keys, partCols.map(_.toSeq.quoted), filters)
-      dataMap --= deleteKeys
-      withData(messages.map(_.asInstanceOf[BufferedRows]))
-    }
-  }
-
-  private object TruncateAndAppend extends TestBatchWrite {
+  protected object TruncateAndAppend extends TestBatchWrite {
     override def commit(messages: Array[WriterCommitMessage]): Unit = dataMap.synchronized {
       dataMap.clear
       withData(messages.map(_.asInstanceOf[BufferedRows]))
     }
   }
 
-  private abstract class TestStreamingWrite extends StreamingWrite {
+  protected abstract class TestStreamingWrite extends StreamingWrite {
     def createStreamingWriterFactory(info: PhysicalWriteInfo): StreamingDataWriterFactory = {
       BufferedRowsWriterFactory
     }
@@ -441,7 +411,7 @@ class InMemoryBaseTable(
     def abort(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {}
   }
 
-  private class StreamingNotSupportedOperation(operation: String) extends TestStreamingWrite {
+  protected class StreamingNotSupportedOperation(operation: String) extends TestStreamingWrite {
     override def createStreamingWriterFactory(info: PhysicalWriteInfo): StreamingDataWriterFactory =
       throwsException()
 
@@ -463,7 +433,7 @@ class InMemoryBaseTable(
     }
   }
 
-  private object StreamingTruncateAndAppend extends TestStreamingWrite {
+  protected object StreamingTruncateAndAppend extends TestStreamingWrite {
     override def commit(epochId: Long, messages: Array[WriterCommitMessage]): Unit = {
       dataMap.synchronized {
         dataMap.clear
@@ -476,46 +446,7 @@ class InMemoryBaseTable(
 object InMemoryBaseTable {
   val SIMULATE_FAILED_WRITE_OPTION = "spark.sql.test.simulateFailedWrite"
 
-  def filtersToKeys(
-      keys: Iterable[Seq[Any]],
-      partitionNames: Seq[String],
-      filters: Array[Filter]): Iterable[Seq[Any]] = {
-    keys.filter { partValues =>
-      filters.flatMap(splitAnd).forall {
-        case EqualTo(attr, value) =>
-          value == extractValue(attr, partitionNames, partValues)
-        case EqualNullSafe(attr, value) =>
-          val attrVal = extractValue(attr, partitionNames, partValues)
-          if (attrVal == null && value === null) {
-            true
-          } else if (attrVal == null || value === null) {
-            false
-          } else {
-            value == attrVal
-          }
-        case IsNull(attr) =>
-          null == extractValue(attr, partitionNames, partValues)
-        case IsNotNull(attr) =>
-          null != extractValue(attr, partitionNames, partValues)
-        case AlwaysTrue() => true
-        case f =>
-          throw new IllegalArgumentException(s"Unsupported filter type: $f")
-      }
-    }
-  }
-
-  def supportsFilters(filters: Array[Filter]): Boolean = {
-    filters.flatMap(splitAnd).forall {
-      case _: EqualTo => true
-      case _: EqualNullSafe => true
-      case _: IsNull => true
-      case _: IsNotNull => true
-      case _: AlwaysTrue => true
-      case _ => false
-    }
-  }
-
-  private def extractValue(
+  def extractValue(
       attr: String,
       partFieldNames: Seq[String],
       partValues: Seq[Any]): Any = {
@@ -524,13 +455,6 @@ object InMemoryBaseTable {
         partValues(partIndex)
       case _ =>
         throw new IllegalArgumentException(s"Unknown filter attribute: $attr")
-    }
-  }
-
-  private def splitAnd(filter: Filter): Seq[Filter] = {
-    filter match {
-      case And(left, right) => splitAnd(left) ++ splitAnd(right)
-      case _ => filter :: Nil
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.internal.SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION
+import org.apache.spark.sql.sources.SimpleScanSource
+
+/**
+ * A collection of "DELETE" tests that can be run through the SQL APIs.
+ */
+trait DeleteFromTests extends DatasourceV2SQLBase {
+
+  protected val catalogAndNamespace: String
+
+  test("DeleteFrom with v2 filtering: basic - delete all") {
+    val t = s"${catalogAndNamespace}tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo PARTITIONED BY (id, p)")
+      sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+      sql(s"DELETE FROM $t")
+      checkAnswer(spark.table(t), Seq())
+    }
+  }
+
+  test("DeleteFrom with v2 filtering: basic - delete with where clause") {
+    val t = s"${catalogAndNamespace}tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo PARTITIONED BY (id, p)")
+      sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+      sql(s"DELETE FROM $t WHERE id = 2")
+      checkAnswer(spark.table(t), Seq(
+        Row(3, "c", 3)))
+    }
+  }
+
+  test("DeleteFrom with v2 filtering: delete from aliased target table") {
+    val t = s"${catalogAndNamespace}tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo PARTITIONED BY (id, p)")
+      sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+      sql(s"DELETE FROM $t AS tbl WHERE tbl.id = 2")
+      checkAnswer(spark.table(t), Seq(
+        Row(3, "c", 3)))
+    }
+  }
+
+  test("DeleteFrom with v2 filtering: normalize attribute names") {
+    val t = s"${catalogAndNamespace}tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo PARTITIONED BY (id, p)")
+      sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+      sql(s"DELETE FROM $t AS tbl WHERE tbl.ID = 2")
+      checkAnswer(spark.table(t), Seq(
+        Row(3, "c", 3)))
+    }
+  }
+
+  test("DeleteFrom with v2 filtering: fail if has subquery") {
+    val t = s"${catalogAndNamespace}tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo PARTITIONED BY (id, p)")
+      sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+      val exc = intercept[AnalysisException] {
+        sql(s"DELETE FROM $t WHERE id IN (SELECT id FROM $t)")
+      }
+
+      assert(spark.table(t).count === 3)
+      assert(exc.getMessage.contains("Delete by condition with subquery is not supported"))
+    }
+  }
+
+  test("DeleteFrom with v2 filtering: delete with unsupported predicates") {
+    val t = s"${catalogAndNamespace}tbl"
+    withTable(t) {
+      sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo")
+      sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+      val exc = intercept[AnalysisException] {
+        sql(s"DELETE FROM $t WHERE id > 3 AND p > 3")
+      }
+
+      assert(spark.table(t).count === 3)
+      assert(exc.getMessage.contains(s"Cannot delete from table $t"))
+    }
+  }
+
+  test("DeleteFrom: DELETE is only supported with v2 tables") {
+    // unset this config to use the default v2 session catalog.
+    spark.conf.unset(V2_SESSION_CATALOG_IMPLEMENTATION.key)
+    val v1Table = "tbl"
+    withTable(v1Table) {
+      sql(s"CREATE TABLE $v1Table" +
+        s" USING ${classOf[SimpleScanSource].getName} OPTIONS (from=0,to=1)")
+      val exc = intercept[AnalysisException] {
+        sql(s"DELETE FROM $v1Table WHERE i = 2")
+      }
+
+      assert(exc.getMessage.contains("DELETE is only supported with v2 tables"))
+    }
+  }
+
+  test("SPARK-33652: DeleteFrom should refresh caches referencing the table") {
+    val t = s"${catalogAndNamespace}tbl"
+    val view = "view"
+    withTable(t) {
+      withTempView(view) {
+        sql(s"CREATE TABLE $t (id bigint, data string, p int) USING foo PARTITIONED BY (id, p)")
+        sql(s"INSERT INTO $t VALUES (2L, 'a', 2), (2L, 'b', 3), (3L, 'c', 3)")
+        sql(s"CACHE TABLE view AS SELECT id FROM $t")
+        assert(spark.table(view).count() == 3)
+
+        sql(s"DELETE FROM $t WHERE id = 2")
+        assert(spark.table(view).count() == 1)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/V1WriteFallbackSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveM
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
-import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryBaseTable, SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.{Identifier, InMemoryTable, SupportsRead, SupportsWrite, Table, TableCapability}
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Transform}
 import org.apache.spark.sql.connector.read.{Scan, ScanBuilder, V1Scan}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, LogicalWriteInfoImpl, SupportsOverwrite, SupportsTruncate, V1Write, WriteBuilder}
@@ -359,7 +359,7 @@ class InMemoryTableWithV1Fallback(
     }
 
     override def overwrite(filters: Array[Filter]): WriteBuilder = {
-      val keys = InMemoryBaseTable.filtersToKeys(dataMap.keys, partFieldNames, filters)
+      val keys = InMemoryTable.filtersToKeys(dataMap.keys, partFieldNames, filters)
       dataMap --= keys
       mode = "overwrite"
       this


### PR DESCRIPTION

### What changes were proposed in this pull request?
Migrate `SupportsOverwrite` to use V2 Filter


### Why are the changes needed?
this is part of the V2Filter migration work


### Does this PR introduce _any_ user-facing change?
Yes
add `SupportsOverwriteV2`


### How was this patch tested?
new tests