### PR TITLE
[SPARK-30628][SQL] Support Subquery partition pruning and DPP for V2 file source

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsRuntimeCatalystFilters.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/connector/SupportsRuntimeCatalystFilters.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.internal.connector
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.read.SupportsRuntimeV2Filtering
+
+/**
+ * A mix-in interface for {@link FileScan}. File sources can implement this interface to
+ * push down runtime filters to the file source. The runtime filters will be used for partition
+ * pruning.
+ */
+trait SupportsRuntimeCatalystFilters extends SupportsRuntimeV2Filtering {
+
+  /**
+   * Filters this scan using runtime expressions.
+   * <p>
+   * The provided expressions must be interpreted as a set of expressions that are ANDed together.
+   * Implementations may use the predicates to prune initially planned {@link InputPartition}s.
+   * <p>
+   * If the scan also implements {@link SupportsReportPartitioning}, it must preserve
+   * the originally reported partitioning during runtime filtering. While applying runtime
+   * predicates, the scan may detect that some {@link InputPartition}s have no matching data. It
+   * can omit such partitions entirely only if it does not report a specific partitioning.
+   * Otherwise, the scan can replace the initially planned {@link InputPartition}s that have no
+   * matching data with empty {@link InputPartition}s but must preserve the overall number of
+   * partitions.
+   * <p>
+   * Note that Spark will call {@link Scan#toBatch()} again after filtering the scan at runtime.
+   *
+   * @param filters expressions used to filter the scan at runtime
+   */
+  def filter(filters: Seq[Expression]): Unit
+
+  /**
+   * This should never be called, catalyst filters take precedence.
+   */
+  def filter(predicates: Array[Predicate]): Unit = {}
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceRDD.scala
@@ -36,7 +36,7 @@ class DataSourceRDDPartition(val index: Int, val inputPartitions: Seq[InputParti
 // columnar scan.
 class DataSourceRDD(
     sc: SparkContext,
-    @transient private val inputPartitions: Seq[Seq[InputPartition]],
+    @transient val inputPartitions: Seq[Seq[InputPartition]],
     partitionReaderFactory: PartitionReaderFactory,
     columnarReads: Boolean,
     customMetrics: Map[String, SQLMetric])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -1608,12 +1608,12 @@ class SubquerySuite extends QueryTest
           checkAnswer(df, Seq(Row(0, 0), Row(2, 0)))
           // need to execute the query before we can examine fs.inputRDDs()
           assert(stripAQEPlan(df.queryExecution.executedPlan) match {
-            case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(
-                bs @ BatchScanExec(_, _, runtimeFilters, _, _)))) =>
-              runtimeFilters.exists(ExecSubqueryExpression.hasSubquery)
+            case WholeStageCodegenExec(ColumnarToRowExec(InputAdapter(bs: BatchScanExec))) =>
+              bs.runtimeFilters.exists(ExecSubqueryExpression.hasSubquery) &&
                 bs.inputRDDs().forall(
                   _.asInstanceOf[DataSourceRDD].inputPartitions.flatten.forall(
-                    _.asInstanceOf[FilePartition].files.forall(_.filePath.contains("p=0"))))
+                    _.asInstanceOf[FilePartition].files.forall(
+                      _.filePath.toString.contains("p=0"))))
             case _ => false
           })
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add subquery partitioning pruning support to V2 file sources, and subsequently DPP as well because that mechanism is used for the subquery partition pruning. To do this, a new API is added, `SupportsRuntimeCatalystFilters`, similar to `SupportsPushDownCatalystFilters`. File sources implement this interface and return partition columns as runtime filterable attributes. This inherently adds support for DPP. BatchScanExec is updated to first check if a scan supports runtime catalyst filters and pushes those down before checking for runtime v2 filters.

Additionally, subquery filters on partition columns are wrapped in `DynamicPruningExpression` to automatically get used as runtime filters. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To support V1 file source features in the V2 implementation.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, adds subquery partitioning pruning and DPP to V2 file source.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
A new test was added for the subquery behavior, and the `DynamicPartitionPruningSuite` was updated with a new set of tests for V2 file source that use temporary views around `DataFrameReader.load` to get a SQL view on a V2 file table.