### PR TITLE
[SPARK-40077][PYTHON][DOCS] Make pyspark.context examples self-contained

### DIFF
--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -121,10 +121,10 @@ class SparkContext:
         The serializer for RDDs.
     conf : :class:`SparkConf`, optional
         An object setting Spark properties.
-    gateway : :py:class:`py4j.java_gateway.JavaGateway`,  optional
+    gateway : class:`py4j.java_gateway.JavaGateway`,  optional
         Use an existing gateway and JVM, otherwise a new JVM
         will be instantiated. This is only used internally.
-    jsc : :py:class:`py4j.java_gateway.JavaObject`, optional
+    jsc : class:`py4j.java_gateway.JavaObject`, optional
         The JavaSparkContext instance. This is only used internally.
     profiler_cls : type, optional, default :class:`BasicProfiler`
         A class of custom Profiler used to do profiling
@@ -574,6 +574,11 @@ class SparkContext:
         """Return the URL of the SparkUI instance started by this :class:`SparkContext`
 
         .. versionadded:: 2.1.0
+
+        Examples
+        --------
+        >>> sc.uiWebUrl
+        'http://...'
         """
         return self._jsc.sc().uiWebUrl().get()
 
@@ -813,7 +818,7 @@ class SparkContext:
         --------
         data
             object to be serialized
-        serializer : :py:class:`pyspark.serializers.Serializer`
+        serializer : class:`pyspark.serializers.Serializer`
         reader_func : function
             A function which takes a filename and reads in the data in the jvm and
             returns a JavaRDD. Only used when encryption is disabled.
@@ -1261,7 +1266,7 @@ class SparkContext:
         """
         Read a 'new API' Hadoop InputFormat with arbitrary key and value class from HDFS,
         a local file system (available on all nodes), or any Hadoop-supported file system URI.
-        The mechanism is the same as for :py:meth:`SparkContext.sequenceFile`.
+        The mechanism is the same as for meth:`SparkContext.sequenceFile`.
 
         A Hadoop configuration can be passed in as a Python dict. This will be converted into a
         Configuration in Java
@@ -1361,7 +1366,7 @@ class SparkContext:
         Read a 'new API' Hadoop InputFormat with arbitrary key and value class, from an arbitrary
         Hadoop configuration, which is passed in as a Python dict.
         This will be converted into a Configuration in Java.
-        The mechanism is the same as for :py:meth:`SparkContext.sequenceFile`.
+        The mechanism is the same as for meth:`SparkContext.sequenceFile`.
 
         .. versionadded:: 1.1.0
 
@@ -1464,7 +1469,7 @@ class SparkContext:
         """
         Read an 'old' Hadoop InputFormat with arbitrary key and value class from HDFS,
         a local file system (available on all nodes), or any Hadoop-supported file system URI.
-        The mechanism is the same as for :py:meth:`SparkContext.sequenceFile`.
+        The mechanism is the same as for meth:`SparkContext.sequenceFile`.
 
         .. versionadded:: 1.1.0
 
@@ -1560,7 +1565,7 @@ class SparkContext:
         Read an 'old' Hadoop InputFormat with arbitrary key and value class, from an arbitrary
         Hadoop configuration, which is passed in as a Python dict.
         This will be converted into a Configuration in Java.
-        The mechanism is the same as for :py:meth:`SparkContext.sequenceFile`.
+        The mechanism is the same as for meth:`SparkContext.sequenceFile`.
 
         .. versionadded:: 1.1.0
 
@@ -2361,9 +2366,11 @@ class SparkContext:
 
 def _test() -> None:
     import doctest
+    from pyspark import SparkConf
 
     globs = globals().copy()
-    globs["sc"] = SparkContext("local[4]", "context tests")
+    conf = SparkConf().set("spark.ui.enabled", True)
+    globs["sc"] = SparkContext("local[4]", "context tests", conf=conf)
     (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
     globs["sc"].stop()
     if failure_count:

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -2369,7 +2369,7 @@ def _test() -> None:
     from pyspark import SparkConf
 
     globs = globals().copy()
-    conf = SparkConf().set("spark.ui.enabled", True)
+    conf = SparkConf().set("spark.ui.enabled", "True")
     globs["sc"] = SparkContext("local[4]", "context tests", conf=conf)
     (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
     globs["sc"].stop()

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -569,11 +569,6 @@ class SparkContext:
         """Return the URL of the SparkUI instance started by this `SparkContext`
 
         .. versionadded:: 2.1.0
-
-        Examples
-        --------
-        >>> sc.uiWebUrl
-        'http://...'
         """
         return self._jsc.sc().uiWebUrl().get()
 
@@ -862,15 +857,14 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
-        >>> with TemporaryDirectory() as d:
-        ...     path1 = os.path.join(d.name, "pickled1")
-        ...     path2 = os.path.join(d.name, "pickled2")
-        ...
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
         ...     # Write a temporary pickled file
+        ...     path1 = os.path.join(d, "pickled1")
         ...     sc.parallelize(range(10)).saveAsPickleFile(path1, 3)
         ...
         ...     # Write another temporary pickled file
+        ...     path2 = os.path.join(d, "pickled2")
         ...     sc.parallelize(range(-10, -5)).saveAsPickleFile(path2, 3)
         ...
         ...     # Load picked file
@@ -921,10 +915,10 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
-        >>> with TemporaryDirectory() as d:
-        ...     path1 = os.path.join(d.name, "text1")
-        ...     path2 = os.path.join(d.name, "text2")
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path1 = os.path.join(d, "text1")
+        ...     path2 = os.path.join(d, "text2")
         ...
         ...     # Write a temporary text file
         ...     sc.parallelize(["x", "y", "z"]).saveAsTextFile(path1)
@@ -932,11 +926,11 @@ class SparkContext:
         ...     # Write another temporary text file
         ...     sc.parallelize(["aa", "bb", "cc"]).saveAsTextFile(path2)
         ...
-        ...     # Load picked file
+        ...     # Load text file
         ...     collected1 = sorted(sc.textFile(path1, 3).collect())
         ...     collected2 = sorted(sc.textFile(path2, 4).collect())
         ...
-        ...     # Load two picked files together
+        ...     # Load two text files together
         ...     collected3 = sorted(sc.textFile('{},{}'.format(path1, path2), 5).collect())
 
         >>> collected1
@@ -1006,17 +1000,17 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
-        >>> with TemporaryDirectory() as d:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
         ...     # Write a temporary text file
-        ...     with open(os.path.join(d.name, "1.txt"), "w") as f:
+        ...     with open(os.path.join(d, "1.txt"), "w") as f:
         ...         _ = f.write("123")
         ...
         ...     # Write another temporary text file
-        ...     with open(os.path.join(d.name, "2.txt"), "w") as f:
+        ...     with open(os.path.join(d, "2.txt"), "w") as f:
         ...         _ = f.write("xyz")
         ...
-        ...     collected = sorted(sc.wholeTextFiles(d.name).collect())
+        ...     collected = sorted(sc.wholeTextFiles(d).collect())
 
         >>> collected
         [('.../1.txt', '123'), ('.../2.txt', 'xyz')]
@@ -1058,17 +1052,17 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
-        >>> with TemporaryDirectory() as d:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
         ...     # Write a temporary binary file
-        ...     with open(os.path.join(d.name, "1.bin"), "wb") as f1:
+        ...     with open(os.path.join(d, "1.bin"), "wb") as f1:
         ...         _ = f1.write(b"binary data I")
         ...
         ...     # Write another temporary binary file
-        ...     with open(os.path.join(d.name, "2.bin"), "wb") as f2:
+        ...     with open(os.path.join(d, "2.bin"), "wb") as f2:
         ...         _ = f2.write(b"binary data II")
         ...
-        ...     collected = sorted(sc.binaryFiles(d.name).collect())
+        ...     collected = sorted(sc.binaryFiles(d).collect())
 
         >>> collected
         [('.../1.bin', b'binary data I'), ('.../2.bin', b'binary data II')]
@@ -1103,19 +1097,19 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
-        >>> with TemporaryDirectory() as d:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
         ...     # Write a temporary file
-        ...     with open(os.path.join(d.name, "1.bin"), "w") as f:
+        ...     with open(os.path.join(d, "1.bin"), "w") as f:
         ...         for i in range(3):
         ...             _ = f.write("%04d" % i)
         ...
         ...     # Write another file
-        ...     with open(os.path.join(d.name, "2.bin"), "w") as f:
+        ...     with open(os.path.join(d, "2.bin"), "w") as f:
         ...         for i in [-1, -2, -10]:
         ...             _ = f.write("%04d" % i)
         ...
-        ...     collected = sorted(sc.binaryRecords(d.name, 4).collect())
+        ...     collected = sorted(sc.binaryRecords(d, 4).collect())
 
         >>> collected
         [b'-001', b'-002', b'-010', b'0000', b'0001', b'0002']
@@ -1181,14 +1175,14 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
+        >>> import tempfile
 
         Set the class of output format
 
         >>> output_format_class = "org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat"
 
-        >>> with TemporaryDirectory() as d:
-        ...     path = os.path.join(d.name, "hadoop_file")
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path = os.path.join(d, "hadoop_file")
         ...
         ...     # Write a temporary Hadoop file
         ...     rdd = sc.parallelize([(1, {3.0: "bb"}), (2, {1.0: "aa"}), (3, {2.0: "dd"})])
@@ -1268,7 +1262,7 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
+        >>> import tempfile
 
         Set the related classes
 
@@ -1277,8 +1271,8 @@ class SparkContext:
         >>> key_class = "org.apache.hadoop.io.IntWritable"
         >>> value_class = "org.apache.hadoop.io.Text"
 
-        >>> with TemporaryDirectory() as d:
-        ...     path = os.path.join(d.name, "new_hadoop_file")
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path = os.path.join(d, "new_hadoop_file")
         ...
         ...     # Write a temporary Hadoop file
         ...     rdd = sc.parallelize([(1, ""), (1, "a"), (3, "x")])
@@ -1353,7 +1347,7 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
+        >>> import tempfile
 
         Set the related classes
 
@@ -1362,8 +1356,8 @@ class SparkContext:
         >>> key_class = "org.apache.hadoop.io.IntWritable"
         >>> value_class = "org.apache.hadoop.io.Text"
 
-        >>> with TemporaryDirectory() as d:
-        ...     path = os.path.join(d.name, "new_hadoop_file")
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path = os.path.join(d, "new_hadoop_file")
         ...
         ...     # Create the conf for writing
         ...     write_conf = {
@@ -1452,7 +1446,7 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
+        >>> import tempfile
 
         Set the related classes
 
@@ -1461,17 +1455,18 @@ class SparkContext:
         >>> key_class = "org.apache.hadoop.io.IntWritable"
         >>> value_class = "org.apache.hadoop.io.Text"
 
-        >>> with TemporaryDirectory() as d:
-        ...     path = os.path.join(d.name, "old_hadoop_file")
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path = os.path.join(d, "old_hadoop_file")
         ...
         ...     # Write a temporary Hadoop file
         ...     rdd = sc.parallelize([(1, ""), (1, "a"), (3, "x")])
         ...     rdd.saveAsHadoopFile(path, output_format_class, key_class, value_class)
         ...
-        ...     collected = sorted(path, input_format_class, key_class, value_class).collect())
+        ...     loaded = sc.hadoopFile(path, input_format_class, key_class, value_class)
+        ...     collected = sorted(loaded.collect())
 
         >>> collected
-        [(0, '1\t'), (0, '1\ta'), (0, '3\tx')]
+        [(0, '1\\t'), (0, '1\\ta'), (0, '3\\tx')]
         """
         jconf = self._dictToJavaMap(conf)
         assert self._jvm is not None
@@ -1534,7 +1529,7 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
+        >>> import tempfile
 
         Set the related classes
 
@@ -1543,8 +1538,8 @@ class SparkContext:
         >>> key_class = "org.apache.hadoop.io.IntWritable"
         >>> value_class = "org.apache.hadoop.io.Text"
 
-        >>> with TemporaryDirectory() as d:
-        ...     path = os.path.join(d.name, "old_hadoop_file")
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path = os.path.join(d, "old_hadoop_file")
         ...
         ...     # Create the conf for writing
         ...     write_conf = {
@@ -1561,11 +1556,11 @@ class SparkContext:
         ...     # Create the conf for reading
         ...     read_conf = {"mapreduce.input.fileinputformat.inputdir": path}
         ...
-        ...     loaded = sc.hadoopRDD(inputFormatClass, keyClass, valueClass, conf=read_conf)
+        ...     loaded = sc.hadoopRDD(input_format_class, key_class, value_class, conf=read_conf)
         ...     collected = sorted(loaded.collect())
 
         >>> collected
-        [(0, '1\t'), (0, '1\ta'), (0, '3\tx')]
+        [(0, '1\\t'), (0, '1\\ta'), (0, '3\\tx')]
         """
         jconf = self._dictToJavaMap(conf)
         assert self._jvm is not None
@@ -1598,12 +1593,12 @@ class SparkContext:
         Examples
         --------
         >>> import os
-        >>> from tempfile import TemporaryDirectory
-        >>> with TemporaryDirectory() as d:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
         ...     # generate a text RDD
-        ...     with open(os.path.join(d.name, "union-text.txt"), "w") as f:
+        ...     with open(os.path.join(d, "union-text.txt"), "w") as f:
         ...         _ = f.write("Hello")
-        ...     text_rdd = sc.textFile(d.name)
+        ...     text_rdd = sc.textFile(d)
         ...
         ...     # generate another RDD
         ...     parallelized = sc.parallelize(["World!"])
@@ -1660,38 +1655,10 @@ class SparkContext:
         >>> mapping = {1: 10001, 2: 10002}
         >>> bc = sc.broadcast(mapping)
 
-        Broadcasted object can be used in RDD operations:
-
         >>> rdd = sc.range(5)
         >>> rdd2 = rdd.map(lambda i: bc.value[i] if i in bc.value else -1)
-        >>> sorted(rdd2.collect())
-        [-1, -1, -1, 10001, 10002]
-
-        Broadcasted object can also be used in UDF:
-
-        >>> df = spark.range(5)
-        >>> df.show()
-        +---+
-        | id|
-        +---+
-        |  0|
-        |  1|
-        |  2|
-        |  3|
-        |  4|
-        +---+
-        >>> spark.udf.register("MYUDF", lambda i: bc.value[i] if i in bc.value else -1)
-        <function ...>
-        >>> df.select(col("id"), expr("MYUDF(id)").alias("mapped")).show()
-        +---+------+
-        | id|mapped|
-        +---+------+
-        |  0|    -1|
-        |  1| 10001|
-        |  2| 10002|
-        |  3|    -1|
-        |  4|    -1|
-        +---+------+
+        >>> rdd2.collect()
+        [-1, 10001, 10002, -1, -1]
 
         >>> bc.destroy()
         """
@@ -1788,33 +1755,43 @@ class SparkContext:
         Examples
         --------
         >>> import os
+        >>> import tempfile
         >>> from pyspark import SparkFiles
-        >>> from tempfile import TemporaryDirectory
 
-        >>> d = TemporaryDirectory()
-        >>> path = os.path.join(d.name, "test.txt")
-        >>> with open(path, "w") as f:
-        ...    _ = f.write("100")
-        >>> sc.addFile(path)
-        >>> def func(iterator):
-        ...    with open(SparkFiles.get("test.txt")) as testFile:
-        ...        fileVal = int(testFile.readline())
-        ...        return [x * fileVal for x in iterator]
-        >>> sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path1 = os.path.join(d, "test1.txt")
+        ...     with open(path1, "w") as f:
+        ...         _ = f.write("100")
+        ...
+        ...     path2 = os.path.join(d, "test2.txt")
+        ...     with open(path2, "w") as f:
+        ...         _ = f.write("200")
+        ...
+        ...     sc.addFile(path1)
+        ...     file_list1 = sorted(sc.listFiles)
+        ...
+        ...     sc.addFile(path2)
+        ...     file_list2 = sorted(sc.listFiles)
+        ...
+        ...     # add path2 twice, this addition will be ignored
+        ...     sc.addFile(path2)
+        ...     file_list3 = sorted(sc.listFiles)
+        ...
+        ...     def func(iterator):
+        ...         with open(SparkFiles.get("test1.txt")) as f:
+        ...             mul = int(f.readline())
+        ...             return [x * mul for x in iterator]
+        ...
+        ...     collected = sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
+
+        >>> file_list1
+        ['file:/.../test1.txt']
+        >>> file_list2
+        ['file:/.../test1.txt', 'file:/.../test2.txt']
+        >>> file_list3
+        ['file:/.../test1.txt', 'file:/.../test2.txt']
+        >>> collected
         [100, 200, 300, 400]
-        >>> sc.listFiles
-        ['file:/.../test.txt']
-
-        Add another file
-
-        >>> path2 = os.path.join(d.name, "test2.txt")
-        >>> with open(path2, "w") as f:
-        ...    _ = f.write("100")
-        >>> sc.addFile(path2)
-        >>> sorted(sc.listFiles)
-        ['file:/.../test.txt', 'file:/.../test2.txt']
-
-        >>> d.cleanup()
         """
         self._jsc.sc().addFile(path, recursive)
 
@@ -1901,42 +1878,48 @@ class SparkContext:
         Creates a zipped file that contains a text file written '100'.
 
         >>> import os
+        >>> import tempfile
         >>> import zipfile
         >>> from pyspark import SparkFiles
-        >>> from tempfile import TemporaryDirectory
 
-        >>> d = TemporaryDirectory()
-        >>> path = os.path.join(d.name, "test.txt")
-        >>> zip_path = os.path.join(d.name, "test.zip")
-        >>> with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipped:
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path = os.path.join(d, "test.txt")
         ...     with open(path, "w") as f:
         ...         _ = f.write("100")
-        ...     zipped.write(path, os.path.basename(path))
-        >>> sc.addArchive(zip_path)
-        >>> sc.listArchives
-        ['file:/.../test.zip']
+        ...
+        ...     zip_path1 = os.path.join(d, "test1.zip")
+        ...     with zipfile.ZipFile(zip_path1, "w", zipfile.ZIP_DEFLATED) as z:
+        ...         z.write(path, os.path.basename(path))
+        ...
+        ...     zip_path2 = os.path.join(d, "test2.zip")
+        ...     with zipfile.ZipFile(zip_path2, "w", zipfile.ZIP_DEFLATED) as z:
+        ...         z.write(path, os.path.basename(path))
+        ...
+        ...     sc.addArchive(zip_path1)
+        ...     arch_list1 = sorted(sc.listArchives)
+        ...
+        ...     sc.addArchive(zip_path2)
+        ...     arch_list2 = sorted(sc.listArchives)
+        ...
+        ...     # add zip_path2 twice, this addition will be ignored
+        ...     sc.addArchive(zip_path2)
+        ...     arch_list3 = sorted(sc.listArchives)
+        ...
+        ...     def func(iterator):
+        ...         with open("%s/test.txt" % SparkFiles.get("test1.zip")) as f:
+        ...             mul = int(f.readline())
+        ...             return [x * mul for x in iterator]
+        ...
+        ...     collected = sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
 
-        Add another zip file.
-
-        >>> zip_path2 = os.path.join(d.name, "test2.zip")
-        >>> with zipfile.ZipFile(zip_path2, "w", zipfile.ZIP_DEFLATED) as zipped:
-        ...     with open(path, "w") as f:
-        ...         _ = f.write("100")
-        ...     zipped.write(path, os.path.basename(path))
-        >>> sc.addArchive(zip_path2)
-        >>> sorted(sc.listArchives)
-        ['file:/.../test.zip', 'file:/.../test2.zip']
-
-        Reads the '100' as an integer in the zipped file, and processes
-        it with the data in the RDD.
-
-        >>> def func(iterator):
-        ...    with open("%s/test.txt" % SparkFiles.get("test.zip")) as f:
-        ...        v = int(f.readline())
-        ...        return [x * int(v) for x in iterator]
-        >>> sc.parallelize([1, 2, 3, 4]).mapPartitions(func).collect()
+        >>> arch_list1
+        ['file:/.../test1.zip']
+        >>> arch_list2
+        ['file:/.../test1.zip', 'file:/.../test2.zip']
+        >>> arch_list3
+        ['file:/.../test1.zip', 'file:/.../test2.zip']
+        >>> collected
         [100, 200, 300, 400]
-        >>> d.cleanup()
         """
         self._jsc.sc().addArchive(path)
 
@@ -2245,7 +2228,7 @@ def _test() -> None:
     import doctest
 
     globs = globals().copy()
-    globs["sc"] = SparkContext("local[4]", "PythonTest")
+    globs["sc"] = SparkContext("local[4]", "context tests")
     (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
     globs["sc"].stop()
     if failure_count:

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -481,7 +481,7 @@ class SparkContext:
 
         Parameters
         ----------
-        conf : :class:`SparkConf`, optional, default None
+        conf : :class:`SparkConf`, optional
             :class:`SparkConf` that will be used for initialization of the :class:`SparkContext`.
 
         Returns
@@ -2082,6 +2082,7 @@ class SparkContext:
         running jobs in this group.
 
         .. versionadded:: 1.0.0
+
         Parameters
         ----------
         groupId : str
@@ -2141,6 +2142,7 @@ class SparkContext:
         Spark fair scheduler pool.
 
         .. versionadded:: 1.0.0
+
         Parameters
         ----------
         key : str
@@ -2177,6 +2179,7 @@ class SparkContext:
         Set a human readable description of the current job.
 
         .. versionadded:: 2.3.0
+
         Parameters
         ----------
         value : str
@@ -2203,6 +2206,7 @@ class SparkContext:
         for more information.
 
         .. versionadded:: 1.1.0
+
         Parameters
         ----------
         groupId : str

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -483,7 +483,7 @@ class SparkContext:
 
         Parameters
         ----------
-        conf : :py:class:`pyspark.SparkConf`, optional
+        conf : :py:class:`pyspark.SparkConf`, optional, default None
             `SparkConf` that will be used for initialisation of the `SparkContext`.
 
         Returns
@@ -1178,18 +1178,18 @@ class SparkContext:
         ----------
         path : str
             path to sequencefile
-        keyClass: str, optional
+        keyClass: str, optional, default None
             fully qualified classname of key Writable class (e.g. "org.apache.hadoop.io.Text")
-        valueClass : str, optional
+        valueClass : str, optional, default None
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional
+        keyConverter : str, optional, default None
             fully qualified name of a function returning key WritableConverter
-        valueConverter : str, optional
+        valueConverter : str, optional, default None
             fully qualifiedname of a function returning value WritableConverter
-        minSplits : int, optional
+        minSplits : int, optional, default None
             minimum splits in dataset (default min(2, sc.defaultParallelism))
-        batchSize : int, optional
+        batchSize : int, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1275,16 +1275,16 @@ class SparkContext:
         valueClass : str
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional
+        keyConverter : str, optional, default None
             fully qualified name of a function returning key WritableConverter
             None by default
-        valueConverter : str, optional
+        valueConverter : str, optional, default None
             fully qualified name of a function returning value WritableConverter
             None by default
-        conf : dict, optional
+        conf : dict, optional, default None
             Hadoop configuration, passed in as a dict
             None by default
-        batchSize : int, optional
+        batchSize : int, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1377,7 +1377,7 @@ class SparkContext:
             (None by default)
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict (None by default)
-        batchSize : int, optional, default 0
+        batchSize : int, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1483,7 +1483,7 @@ class SparkContext:
             fully qualified name of a function returning value WritableConverter
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict
-        batchSize : int, optional
+        batchSize : int, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1574,7 +1574,7 @@ class SparkContext:
             fully qualified name of a function returning value WritableConverter
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict
-        batchSize : int, optional
+        batchSize : int, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1715,7 +1715,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.broadcast.Broadcast`
+        :py:class:`pyspark.Broadcast`
             `Broadcast` object, a read-only variable cached on each machine
 
         Examples

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -99,17 +99,17 @@ class SparkContext:
 
     Parameters
     ----------
-    master : str, optional, default None
+    master : str, optional
         Cluster URL to connect to (e.g. mesos://host:port, spark://host:port, local[4]).
-    appName : str, optional, default None
+    appName : str, optional
         A name for your job, to display on the cluster web UI.
-    sparkHome : str, optional, default None
+    sparkHome : str, optional
         Location where Spark is installed on cluster nodes.
-    pyFiles : list, optional, default None
+    pyFiles : list, optional
         Collection of .zip or .py files to send to the cluster
         and add to PYTHONPATH.  These can be paths on the local file
         system or HDFS, HTTP, HTTPS, or FTP URLs.
-    environment : dict, optional, default None
+    environment : dict, optional
         A dictionary of environment variables to set on
         worker nodes.
     batchSize : int, optional, default 0
@@ -117,18 +117,18 @@ class SparkContext:
         Java object. Set 1 to disable batching, 0 to automatically choose
         the batch size based on object sizes, or -1 to use an unlimited
         batch size
-    serializer : :class:`pyspark.serializers.Serializer`, optional, default `CPickleSerializer`
+    serializer : :class:`Serializer`, optional, default :class:`CPickleSerializer`
         The serializer for RDDs.
-    conf : :py:class:`pyspark.SparkConf`, optional, default None
+    conf : :class:`SparkConf`, optional
         An object setting Spark properties.
-    gateway : :py:class:`py4j.java_gateway.JavaGateway`,  optional, default None
+    gateway : :py:class:`py4j.java_gateway.JavaGateway`,  optional
         Use an existing gateway and JVM, otherwise a new JVM
         will be instantiated. This is only used internally.
-    jsc : :py:class:`py4j.java_gateway.JavaObject`, optional, default None
+    jsc : :py:class:`py4j.java_gateway.JavaObject`, optional
         The JavaSparkContext instance. This is only used internally.
-    profiler_cls : type, optional, default :class:`pyspark.profiler.BasicProfiler`
+    profiler_cls : type, optional, default :class:`BasicProfiler`
         A class of custom Profiler used to do profiling
-    udf_profiler_cls : type, optional, default :class:`pyspark.profiler.UDFBasicProfiler`
+    udf_profiler_cls : type, optional, default :class:`UDFBasicProfiler`
         A class of custom Profiler used to do udf profiling
 
     Notes
@@ -475,23 +475,23 @@ class SparkContext:
     @classmethod
     def getOrCreate(cls, conf: Optional[SparkConf] = None) -> "SparkContext":
         """
-        Get or instantiate a `SparkContext` and register it as a singleton object.
+        Get or instantiate a :class:`SparkContext` and register it as a singleton object.
 
         .. versionadded:: 1.4.0
 
         Parameters
         ----------
-        conf : :py:class:`pyspark.SparkConf`, optional, default None
-            `SparkConf` that will be used for initialisation of the `SparkContext`.
+        conf : :class:`SparkConf`, optional, default None
+            :class:`SparkConf` that will be used for initialization of the :class:`SparkContext`.
 
         Returns
         -------
-        :class:`pyspark.context.SparkContext`
-            current `SparkContext`, or a new one if it wasn't created before the function call.
+        :class:`SparkContext`
+            current :class:`SparkContext`, or a new one if it wasn't created before the function
+            call.
 
         Examples
         --------
-        >>> from pyspark.context import SparkContext
         >>> SparkContext.getOrCreate()
         <SparkContext ...>
         """
@@ -515,7 +515,7 @@ class SparkContext:
 
         Examples
         --------
-        >>> sc.setLogLevel("WARN")
+        >>> sc.setLogLevel("WARN")  # doctest :+SKIP
         """
         self._jsc.setLogLevel(logLevel)
 
@@ -523,9 +523,16 @@ class SparkContext:
     def setSystemProperty(cls, key: str, value: str) -> None:
         """
         Set a Java system property, such as `spark.executor.memory`. This must
-        be invoked before instantiating SparkContext.
+        be invoked before instantiating :class:`SparkContext`.
 
         .. versionadded:: 0.9.0
+        
+        Parameters
+        ----------
+        key : str
+            The key of a new Java system property.
+        value : str
+            The value of a new Java system property.
         """
         SparkContext._ensure_initialized()
         assert SparkContext._jvm is not None
@@ -540,7 +547,7 @@ class SparkContext:
 
         Examples
         --------
-        >>> version = sc.version
+        >>> _ = sc.version
         """
         return self._jsc.version()
 
@@ -564,7 +571,7 @@ class SparkContext:
 
     @property
     def uiWebUrl(self) -> str:
-        """Return the URL of the SparkUI instance started by this `SparkContext`
+        """Return the URL of the SparkUI instance started by this :class:`SparkContext`
 
         .. versionadded:: 2.1.0
         """
@@ -572,13 +579,13 @@ class SparkContext:
 
     @property
     def startTime(self) -> int:
-        """Return the epoch time when the `SparkContext` was started.
+        """Return the epoch time when the :class:`SparkContext` was started.
 
         .. versionadded:: 1.5.0
 
         Examples
         --------
-        >>> start = sc.startTime
+        >>> _ = sc.startTime
         """
         return self._jsc.startTime()
 
@@ -612,7 +619,7 @@ class SparkContext:
 
     def stop(self) -> None:
         """
-        Shut down the `SparkContext`.
+        Shut down the :class:`SparkContext`.
 
         .. versionadded:: 0.7.0
         """
@@ -637,13 +644,13 @@ class SparkContext:
 
     def emptyRDD(self) -> RDD[Any]:
         """
-        Create an `RDD` that has no partitions or elements.
+        Create an :class:`RDD` that has no partitions or elements.
 
         .. versionadded:: 1.5.0
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             An empty RDD
 
         Examples
@@ -670,21 +677,21 @@ class SparkContext:
         ----------
         start : int
             the start value
-        end : int, optional, default None
+        end : int, optional
             the end value (exclusive)
         step : int, optional, default 1
             the incremental step
-        numSlices : int, optional, default None
+        numSlices : int, optional
             the number of partitions of the new RDD
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             An RDD of int
 
         See Also
         --------
-        :meth:`SparkSession.range`
+        :meth:`pyspark.sql.SparkSession.range`
 
         Examples
         --------
@@ -696,12 +703,14 @@ class SparkContext:
         [1, 3, 5]
 
         Generate RDD with a negative step
+
         >>> sc.range(5, 0, -1).collect()
         [5, 4, 3, 2, 1]
         >>> sc.range(0, 5, -1).collect()
         []
 
         Control the number of partitions
+
         >>> sc.range(5, numSlices=1).getNumPartitions()
         1
         >>> sc.range(5, numSlices=10).getNumPartitions()
@@ -722,14 +731,14 @@ class SparkContext:
 
         Parameters
         ----------
-        c : :py:class:`collections.abc.Iterable`
+        c : :class:`collections.abc.Iterable`
             iterable collection to distribute
-        numSlices : int, optional, default None
+        numSlices : int, optional
             the number of partitions of the new RDD
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD representing distributed collection.
 
         Examples
@@ -848,12 +857,12 @@ class SparkContext:
         name : str
             directory to the input data files, the path can be comma separated
             paths as a list of inputs
-        minPartitions : int, optional, default None
+        minPartitions : int, optional
             suggested minimum number of partitions for the resulting RDD
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD representing unpickled data from the file(s).
 
         See Also
@@ -905,17 +914,17 @@ class SparkContext:
         name : str
             directory to the input data files, the path can be comma separated
             paths as a list of inputs
-        minPartitions : int, optional, default None
+        minPartitions : int, optional
             suggested minimum number of partitions for the resulting RDD
         use_unicode : bool, default True
-            If use_unicode is False, the strings will be kept as `str` (encoding
+            If `use_unicode` is False, the strings will be kept as `str` (encoding
             as `utf-8`), which is faster and smaller than unicode.
 
             .. versionadded:: 1.2.0
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD representing text data from the file(s).
 
         See Also
@@ -991,17 +1000,17 @@ class SparkContext:
         path : str
             directory to the input data files, the path can be comma separated
             paths as a list of inputs
-        minPartitions : int, optional, default None
+        minPartitions : int, optional
             suggested minimum number of partitions for the resulting RDD
         use_unicode : bool, default True
-            If use_unicode is False, the strings will be kept as `str` (encoding
+            If `use_unicode` is False, the strings will be kept as `str` (encoding
             as `utf-8`), which is faster and smaller than unicode.
 
             .. versionadded:: 1.2.0
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD representing path-content pairs from the file(s).
 
         Notes
@@ -1027,7 +1036,6 @@ class SparkContext:
         ...         _ = f.write("xyz")
         ...
         ...     collected = sorted(sc.wholeTextFiles(d).collect())
-
         >>> collected
         [('.../1.txt', '123'), ('.../2.txt', 'xyz')]
         """
@@ -1053,12 +1061,12 @@ class SparkContext:
         path : str
             directory to the input data files, the path can be comma separated
             paths as a list of inputs
-        minPartitions : int, optional, default None
+        minPartitions : int, optional
             suggested minimum number of partitions for the resulting RDD
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD representing path-content pairs from the file(s).
 
         Notes
@@ -1111,7 +1119,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD of data with values, represented as byte arrays
 
         See Also
@@ -1176,16 +1184,16 @@ class SparkContext:
         ----------
         path : str
             path to sequencefile
-        keyClass: str, optional, default None
+        keyClass: str, optional
             fully qualified classname of key Writable class (e.g. "org.apache.hadoop.io.Text")
-        valueClass : str, optional, default None
+        valueClass : str, optional
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional, default None
+        keyConverter : str, optional
             fully qualified name of a function returning key WritableConverter
-        valueConverter : str, optional, default None
+        valueConverter : str, optional
             fully qualifiedname of a function returning value WritableConverter
-        minSplits : int, optional, default None
+        minSplits : int, optional
             minimum splits in dataset (default min(2, sc.defaultParallelism))
         batchSize : int, optional, default 0
             The number of Python objects represented as a single
@@ -1193,7 +1201,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD of tuples of key and corresponding value
 
         See Also
@@ -1273,13 +1281,13 @@ class SparkContext:
         valueClass : str
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional, default None
+        keyConverter : str, optional
             fully qualified name of a function returning key WritableConverter
             None by default
-        valueConverter : str, optional, default None
+        valueConverter : str, optional
             fully qualified name of a function returning value WritableConverter
             None by default
-        conf : dict, optional, default None
+        conf : dict, optional
             Hadoop configuration, passed in as a dict
             None by default
         batchSize : int, optional, default 0
@@ -1288,7 +1296,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD of tuples of key and corresponding value
 
         See Also
@@ -1367,13 +1375,13 @@ class SparkContext:
         valueClass : str
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional, default None
+        keyConverter : str, optional
             fully qualified name of a function returning key WritableConverter
             (None by default)
-        valueConverter : str, optional, default None
+        valueConverter : str, optional
             fully qualified name of a function returning value WritableConverter
             (None by default)
-        conf : dict, optional, default None
+        conf : dict, optional
             Hadoop configuration, passed in as a dict (None by default)
         batchSize : int, optional, default 0
             The number of Python objects represented as a single
@@ -1381,7 +1389,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD of tuples of key and corresponding value
 
         See Also
@@ -1475,11 +1483,11 @@ class SparkContext:
         valueClass : str
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional, default None
+        keyConverter : str, optional
             fully qualified name of a function returning key WritableConverter
-        valueConverter : str, optional, default None
+        valueConverter : str, optional
             fully qualified name of a function returning value WritableConverter
-        conf : dict, optional, default None
+        conf : dict, optional
             Hadoop configuration, passed in as a dict
         batchSize : int, optional, default 0
             The number of Python objects represented as a single
@@ -1487,7 +1495,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD of tuples of key and corresponding value
 
         See Also
@@ -1566,11 +1574,11 @@ class SparkContext:
         valueClass : str
             fully qualified classname of value Writable class
             (e.g. "org.apache.hadoop.io.LongWritable")
-        keyConverter : str, optional, default None
+        keyConverter : str, optional
             fully qualified name of a function returning key WritableConverter
-        valueConverter : str, optional, default None
+        valueConverter : str, optional
             fully qualified name of a function returning value WritableConverter
-        conf : dict, optional, default None
+        conf : dict, optional
             Hadoop configuration, passed in as a dict
         batchSize : int, optional, default 0
             The number of Python objects represented as a single
@@ -1578,7 +1586,7 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.RDD`
+        :class:`RDD`
             RDD of tuples of key and corresponding value
 
         See Also
@@ -1713,8 +1721,8 @@ class SparkContext:
 
         Returns
         -------
-        :py:class:`pyspark.Broadcast`
-            `Broadcast` object, a read-only variable cached on each machine
+        :class:`Broadcast`
+            :class:`Broadcast` object, a read-only variable cached on each machine
 
         Examples
         --------
@@ -1746,12 +1754,12 @@ class SparkContext:
         ----------
         value : T
             initialized value
-        accum_param : :py:class:`pyspark.AccumulatorParam`, optional, default None
+        accum_param : :class:`pyspark.AccumulatorParam`, optional
             helper object to define how to add values
 
         Returns
         -------
-        :py:class:`pyspark.Accumulator`
+        :class:`Accumulator`
             `Accumulator` object, a shared variable that can be accumulated
 
         Examples
@@ -2069,6 +2077,14 @@ class SparkContext:
         running jobs in this group.
 
         .. versionadded:: 1.0.0
+        Parameters
+        ----------
+        groupId : str
+            The group ID to assign.
+        description : str
+            The description to set for the job group.
+        interruptOnCancel : bool, optional, default False
+            whether to interrupt jobs on job cancellation.
 
         Notes
         -----
@@ -2120,6 +2136,12 @@ class SparkContext:
         Spark fair scheduler pool.
 
         .. versionadded:: 1.0.0
+        Parameters
+        ----------
+        key : str
+            The key of the local property to set.
+        value : str
+            The value of the local property to set.
 
         See Also
         --------
@@ -2150,6 +2172,10 @@ class SparkContext:
         Set a human readable description of the current job.
 
         .. versionadded:: 2.3.0
+        Parameters
+        ----------
+        value : str
+            The job description to set.
 
         Notes
         -----
@@ -2172,6 +2198,10 @@ class SparkContext:
         for more information.
 
         .. versionadded:: 1.1.0
+        Parameters
+        ----------
+        groupId : str
+            The group ID to cancel the job.
 
         See Also
         --------
@@ -2218,11 +2248,11 @@ class SparkContext:
 
         Parameters
         ----------
-        rdd : :py:class:`pyspark.RDD`
+        rdd : :class:`RDD`
             target RDD to run tasks on
         partitionFunc : function
             a function to run on each partition of the RDD
-        partitions : list, optional, default None
+        partitions : list, optional
             set of partitions to run on; some jobs may not want to compute on all
             partitions of the target RDD, e.g. for operations like `first`
         allowLocal : bool, default False
@@ -2293,7 +2323,7 @@ class SparkContext:
             )
 
     def getConf(self) -> SparkConf:
-        """Return a copy of this SparkContext's configuration :py:class:`pyspark.SparkConf`.
+        """Return a copy of this SparkContext's configuration :class:`SparkConf`.
 
         .. versionadded:: 2.1.0
         """
@@ -2304,7 +2334,7 @@ class SparkContext:
     @property
     def resources(self) -> Dict[str, ResourceInformation]:
         """
-        Return the resource information of this SparkContext.
+        Return the resource information of this :class:`SparkContext`.
         A resource could be a GPU, FPGA, etc.
 
         .. versionadded:: 3.0.0

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -526,7 +526,7 @@ class SparkContext:
         be invoked before instantiating :class:`SparkContext`.
 
         .. versionadded:: 0.9.0
-        
+
         Parameters
         ----------
         key : str

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -99,39 +99,37 @@ class SparkContext:
 
     Parameters
     ----------
-    master : str, optional
+    master : str, optional, default None
         Cluster URL to connect to (e.g. mesos://host:port, spark://host:port, local[4]).
-    appName : str, optional
+    appName : str, optional, default None
         A name for your job, to display on the cluster web UI.
-    sparkHome : str, optional
+    sparkHome : str, optional, default None
         Location where Spark is installed on cluster nodes.
-    pyFiles : list, optional
+    pyFiles : list, optional, default None
         Collection of .zip or .py files to send to the cluster
         and add to PYTHONPATH.  These can be paths on the local file
         system or HDFS, HTTP, HTTPS, or FTP URLs.
-    environment : dict, optional
+    environment : dict, optional, default None
         A dictionary of environment variables to set on
         worker nodes.
-    batchSize : int, optional
+    batchSize : int, optional, default 0
         The number of Python objects represented as a single
         Java object. Set 1 to disable batching, 0 to automatically choose
         the batch size based on object sizes, or -1 to use an unlimited
         batch size
-    serializer : :class:`pyspark.serializers.Serializer`, optional
+    serializer : :class:`pyspark.serializers.Serializer`, optional, default `CPickleSerializer`
         The serializer for RDDs.
-    conf : :py:class:`pyspark.SparkConf`, optional
+    conf : :py:class:`pyspark.SparkConf`, optional, default None
         An object setting Spark properties.
-    gateway : :py:class:`py4j.java_gateway.JavaGateway`,  optional
+    gateway : :py:class:`py4j.java_gateway.JavaGateway`,  optional, default None
         Use an existing gateway and JVM, otherwise a new JVM
         will be instantiated. This is only used internally.
-    jsc : :py:class:`py4j.java_gateway.JavaObject`, optional
+    jsc : :py:class:`py4j.java_gateway.JavaObject`, optional, default None
         The JavaSparkContext instance. This is only used internally.
-    profiler_cls : type, optional
+    profiler_cls : type, optional, default :class:`pyspark.profiler.BasicProfiler`
         A class of custom Profiler used to do profiling
-        (default is :class:`pyspark.profiler.BasicProfiler`).
-    udf_profiler_cls : type, optional
+    udf_profiler_cls : type, optional, default :class:`pyspark.profiler.UDFBasicProfiler`
         A class of custom Profiler used to do udf profiling
-        (default is :class:`pyspark.profiler.UDFBasicProfiler`).
 
     Notes
     -----
@@ -1189,7 +1187,7 @@ class SparkContext:
             fully qualifiedname of a function returning value WritableConverter
         minSplits : int, optional, default None
             minimum splits in dataset (default min(2, sc.defaultParallelism))
-        batchSize : int, default 0
+        batchSize : int, optional, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1284,7 +1282,7 @@ class SparkContext:
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict
             None by default
-        batchSize : int, default 0
+        batchSize : int, optional, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1377,7 +1375,7 @@ class SparkContext:
             (None by default)
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict (None by default)
-        batchSize : int, default 0
+        batchSize : int, optional, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1483,7 +1481,7 @@ class SparkContext:
             fully qualified name of a function returning value WritableConverter
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict
-        batchSize : int, default 0
+        batchSize : int, optional, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 
@@ -1574,7 +1572,7 @@ class SparkContext:
             fully qualified name of a function returning value WritableConverter
         conf : dict, optional, default None
             Hadoop configuration, passed in as a dict
-        batchSize : int, default 0
+        batchSize : int, optional, default 0
             The number of Python objects represented as a single
             Java object. (default 0, choose batchSize automatically)
 

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -684,6 +684,10 @@ class SparkContext:
         :py:class:`pyspark.RDD`
             An RDD of int
 
+        See Also
+        --------
+        :meth:`SparkSession.range`
+
         Examples
         --------
         >>> sc.range(5).collect()
@@ -854,6 +858,10 @@ class SparkContext:
         :py:class:`pyspark.RDD`
             RDD representing unpickled data from the file(s).
 
+        See Also
+        --------
+        :meth:`RDD.saveAsPickleFile`
+
         Examples
         --------
         >>> import os
@@ -911,6 +919,11 @@ class SparkContext:
         -------
         :py:class:`pyspark.RDD`
             RDD representing text data from the file(s).
+
+        See Also
+        --------
+        :meth:`RDD.saveAsTextFile`
+        :meth:`SparkContext.wholeTextFiles`
 
         Examples
         --------
@@ -997,6 +1010,11 @@ class SparkContext:
         -----
         Small files are preferred, as each file will be loaded fully in memory.
 
+        See Also
+        --------
+        :meth:`RDD.saveAsTextFile`
+        :meth:`SparkContext.textFile`
+
         Examples
         --------
         >>> import os
@@ -1049,6 +1067,10 @@ class SparkContext:
         -----
         Small files are preferred, large file is also allowable, but may cause bad performance.
 
+        See Also
+        --------
+        :meth:`SparkContext.binaryRecords`
+
         Examples
         --------
         >>> import os
@@ -1093,6 +1115,10 @@ class SparkContext:
         -------
         :py:class:`pyspark.RDD`
             RDD of data with values, represented as byte arrays
+
+        See Also
+        --------
+        :meth:`SparkContext.binaryFiles`
 
         Examples
         --------
@@ -1171,6 +1197,14 @@ class SparkContext:
         -------
         :py:class:`pyspark.RDD`
             RDD of tuples of key and corresponding value
+
+        See Also
+        --------
+        :meth:`RDD.saveAsSequenceFile`
+        :meth:`RDD.saveAsNewAPIHadoopFile`
+        :meth:`RDD.saveAsHadoopFile`
+        :meth:`SparkContext.newAPIHadoopFile`
+        :meth:`SparkContext.hadoopFile`
 
         Examples
         --------
@@ -1259,6 +1293,14 @@ class SparkContext:
         :py:class:`pyspark.RDD`
             RDD of tuples of key and corresponding value
 
+        See Also
+        --------
+        :meth:`RDD.saveAsSequenceFile`
+        :meth:`RDD.saveAsNewAPIHadoopFile`
+        :meth:`RDD.saveAsHadoopFile`
+        :meth:`SparkContext.sequenceFile`
+        :meth:`SparkContext.hadoopFile`
+
         Examples
         --------
         >>> import os
@@ -1343,6 +1385,13 @@ class SparkContext:
         -------
         :py:class:`pyspark.RDD`
             RDD of tuples of key and corresponding value
+
+        See Also
+        --------
+        :meth:`RDD.saveAsNewAPIHadoopDataset`
+        :meth:`RDD.saveAsHadoopDataset`
+        :meth:`SparkContext.hadoopRDD`
+        :meth:`SparkContext.hadoopFile`
 
         Examples
         --------
@@ -1443,6 +1492,14 @@ class SparkContext:
         :py:class:`pyspark.RDD`
             RDD of tuples of key and corresponding value
 
+        See Also
+        --------
+        :meth:`RDD.saveAsSequenceFile`
+        :meth:`RDD.saveAsNewAPIHadoopFile`
+        :meth:`RDD.saveAsHadoopFile`
+        :meth:`SparkContext.newAPIHadoopFile`
+        :meth:`SparkContext.hadoopRDD`
+
         Examples
         --------
         >>> import os
@@ -1526,6 +1583,13 @@ class SparkContext:
         :py:class:`pyspark.RDD`
             RDD of tuples of key and corresponding value
 
+        See Also
+        --------
+        :meth:`RDD.saveAsNewAPIHadoopDataset`
+        :meth:`RDD.saveAsHadoopDataset`
+        :meth:`SparkContext.newAPIHadoopRDD`
+        :meth:`SparkContext.hadoopFile`
+
         Examples
         --------
         >>> import os
@@ -1589,6 +1653,10 @@ class SparkContext:
         serializer:
 
         .. versionadded:: 0.7.0
+
+        See Also
+        --------
+        :meth:`RDD.union`
 
         Examples
         --------
@@ -1746,6 +1814,7 @@ class SparkContext:
         See Also
         --------
         :meth:`SparkContext.listFiles`
+        :meth:`SparkContext.addPyFile`
         :meth:`SparkFiles.get`
 
         Notes
@@ -1951,6 +2020,10 @@ class SparkContext:
         dirName : str
             path to the directory where checkpoint files will be stored
             (must be HDFS path if running in cluster)
+
+        See Also
+        --------
+        :meth:`SparkContext.getCheckpointDir`
         """
         self._jsc.sc().setCheckpointDir(dirName)
 
@@ -2009,6 +2082,10 @@ class SparkContext:
         If you run jobs in parallel, use :class:`pyspark.InheritableThread` for thread
         local inheritance.
 
+        See Also
+        --------
+        :meth:`SparkContext.cancelJobGroup`
+
         Examples
         --------
         >>> import threading
@@ -2046,6 +2123,10 @@ class SparkContext:
 
         .. versionadded:: 1.0.0
 
+        See Also
+        --------
+        :meth:`SparkContext.getLocalProperty`
+
         Notes
         -----
         If you run jobs in parallel, use :class:`pyspark.InheritableThread` for thread
@@ -2059,6 +2140,10 @@ class SparkContext:
         :meth:`setLocalProperty`.
 
         .. versionadded:: 1.0.0
+
+        See Also
+        --------
+        :meth:`SparkContext.setLocalProperty`
         """
         return self._jsc.getLocalProperty(key)
 
@@ -2089,6 +2174,11 @@ class SparkContext:
         for more information.
 
         .. versionadded:: 1.1.0
+
+        See Also
+        --------
+        :meth:`SparkContext.setJobGroup`
+        :meth:`SparkContext.cancelJobGroup`
         """
         self._jsc.sc().cancelJobGroup(groupId)
 
@@ -2097,6 +2187,11 @@ class SparkContext:
         Cancel all jobs that have been scheduled or are running.
 
         .. versionadded:: 1.1.0
+
+        See Also
+        --------
+        :meth:`SparkContext.cancelJobGroup`
+        :meth:`SparkContext.runJob`
         """
         self._jsc.sc().cancelAllJobs()
 
@@ -2140,6 +2235,10 @@ class SparkContext:
         list
             results of specified partitions
 
+        See Also
+        --------
+        :meth:`SparkContext.cancelAllJobs`
+
         Examples
         --------
         >>> myRDD = sc.parallelize(range(6), 3)
@@ -2165,6 +2264,10 @@ class SparkContext:
         """Print the profile stats to stdout
 
         .. versionadded:: 1.2.0
+
+        See Also
+        --------
+        :meth:`SparkContext.dump_profiles`
         """
         if self.profiler_collector is not None:
             self.profiler_collector.show_profiles()
@@ -2178,6 +2281,10 @@ class SparkContext:
         """Dump the profile stats into directory `path`
 
         .. versionadded:: 1.2.0
+
+        See Also
+        --------
+        :meth:`SparkContext.show_profiles`
         """
         if self.profiler_collector is not None:
             self.profiler_collector.dump_profiles(path)
@@ -2188,7 +2295,7 @@ class SparkContext:
             )
 
     def getConf(self) -> SparkConf:
-        """Return a copy of this SparkContext's configuration.
+        """Return a copy of this SparkContext's configuration :py:class:`pyspark.SparkConf`.
 
         .. versionadded:: 2.1.0
         """


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Make pyspark.context examples self-contained
2, add missing `versionadded` comments
3, add `see-also` sections

### Why are the changes needed?
To make the documentation more readable and able to copy and paste directly in PySpark shell.


### Does this PR introduce _any_ user-facing change?
documents were changed


### How was this patch tested?

- added doctests.
- manually copy-paste test the example in PySpark Shell.
- build the documents and manually checks
