### PR TITLE
[SPARK-40094][CORE] Send TaskEnd event when task failed with NotSerializableException or TaskOutputFileAlreadyExistException

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -913,6 +913,7 @@ private[spark] class TaskSetManager(
         if (ef.className == classOf[NotSerializableException].getName) {
           // If the task result wasn't serializable, there's no point in trying to re-execute it.
           logError(s"$task had a not serializable result: ${ef.description}; not retrying")
+          sched.dagScheduler.taskEnded(tasks(index), reason, null, accumUpdates, metricPeaks, info)
           abort(s"$task had a not serializable result: ${ef.description}")
           return
         }
@@ -921,6 +922,7 @@ private[spark] class TaskSetManager(
           // re-execute it.
           logError("Task %s in stage %s (TID %d) can not write to output file: %s; not retrying"
             .format(info.id, taskSet.id, tid, ef.description))
+          sched.dagScheduler.taskEnded(tasks(index), reason, null, accumUpdates, metricPeaks, info)
           abort("Task %s in stage %s (TID %d) can not write to output file: %s".format(
             info.id, taskSet.id, tid, ef.description))
           return

--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
@@ -463,7 +463,7 @@ private[spark] class ExecutorMonitor(
   override def checkpointCleaned(rddId: Long): Unit = { }
 
   // Visible for testing.
-  private[dynalloc] def isExecutorIdle(id: String): Boolean = {
+  private[scheduler] def isExecutorIdle(id: String): Boolean = {
     Option(executors.get(id)).map(_.isIdle).getOrElse(throw SparkCoreErrors.noExecutorIdleError(id))
   }
 
@@ -489,7 +489,9 @@ private[spark] class ExecutorMonitor(
    * which the `SparkListenerTaskStart` event is posted before the `SparkListenerBlockManagerAdded`
    * event, which is possible because these events are posted in different threads. (see SPARK-4951)
    */
-  private def ensureExecutorIsTracked(id: String, resourceProfileId: Int): Tracker = {
+  // Visible for testing.
+  private[scheduler] def ensureExecutorIsTracked(
+      id: String, resourceProfileId: Int) : Tracker = {
     val numExecsWithRpId = execResourceProfileCount.computeIfAbsent(resourceProfileId, _ => 0)
     val execTracker = executors.computeIfAbsent(id, _ => {
         val newcount = numExecsWithRpId + 1

--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
@@ -528,7 +528,7 @@ private[spark] class ExecutorMonitor(
     }
   }
 
-  private class Tracker(var resourceProfileId: Int) {
+  private[scheduler] class Tracker(var resourceProfileId: Int) {
     @volatile var timeoutAt: Long = Long.MaxValue
 
     // Tracks whether this executor is thought to be timed out. It's used to detect when the list

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2566,63 +2566,58 @@ class TaskSetManagerSuite
 
   test("SPARK-40094: Send TaskEnd if task failed with " +
     "NotSerializableException or TaskOutputFileAlreadyExistException") {
-    try {
-      sys.props += ("spark.test.home" -> ".")
-      val sparkConf = new SparkConf()
-        .setMaster("local-cluster[1,1,1024]")
-        .setAppName("SPARK-40094")
-        .set(config.DYN_ALLOCATION_TESTING, true)
-        .set(TEST_DYNAMIC_ALLOCATION_SCHEDULE_ENABLED, false)
-        .set(config.DYN_ALLOCATION_ENABLED, true)
-        .set(config.DYN_ALLOCATION_EXECUTOR_IDLE_TIMEOUT, 1L)
+    val sparkConf = new SparkConf()
+      .setMaster("local-cluster[1,1,1024]")
+      .setAppName("SPARK-40094")
+      .set(config.DYN_ALLOCATION_TESTING, true)
+      .set(TEST_DYNAMIC_ALLOCATION_SCHEDULE_ENABLED, false)
+      .set(config.DYN_ALLOCATION_ENABLED, true)
+      .set(config.DYN_ALLOCATION_EXECUTOR_IDLE_TIMEOUT, 1L)
 
-      // setup spark context and init ExecutorAllocationManager
-      sc = new SparkContext(sparkConf)
-      sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
-      // replace dagScheduler to let handleFailedTask send TaskEnd
-      sched.dagScheduler = sc.dagScheduler
+    // setup spark context and init ExecutorAllocationManager
+    sc = new SparkContext(sparkConf)
+    sched = new FakeTaskScheduler(sc, ("exec1", "host1"))
+    // replace dagScheduler to let handleFailedTask send TaskEnd
+    sched.dagScheduler = sc.dagScheduler
 
-      val taskSet = FakeTask.createTaskSet(1)
-      val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
-      assert(sched.taskSetsFailed.isEmpty)
+    val taskSet = FakeTask.createTaskSet(1)
+    val manager = new TaskSetManager(sched, taskSet, MAX_TASK_FAILURES)
+    assert(sched.taskSetsFailed.isEmpty)
 
-      val offerResult = manager.resourceOffer("exec1", "host1", ANY)._1
-      assert(offerResult.isDefined,
-        "Expect resource offer on iteration 0 to return a task")
-      assert(offerResult.get.index === 0)
+    val offerResult = manager.resourceOffer("exec1", "host1", ANY)._1
+    assert(offerResult.isDefined,
+      "Expect resource offer on iteration 0 to return a task")
+    assert(offerResult.get.index === 0)
 
-      val executorMonitor = sc.executorAllocationManager.get.executorMonitor
+    val executorMonitor = sc.executorAllocationManager.get.executorMonitor
 
-      // reflection to mock ExecutorMonitor.onTaskStart
-      val ensureExecutorIsTracked = classOf[ExecutorMonitor]
-        .getDeclaredMethod("ensureExecutorIsTracked",
-          classOf[String], classOf[Int])
-      ensureExecutorIsTracked.setAccessible(true)
-      val executorTracker = ensureExecutorIsTracked.invoke(executorMonitor,
-        "exec1".asInstanceOf[AnyRef],
-        ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID.asInstanceOf[AnyRef])
-      executorTracker.asInstanceOf[executorMonitor.Tracker].updateRunningTasks(1)
+    // reflection to mock ExecutorMonitor.onTaskStart
+    val ensureExecutorIsTracked = classOf[ExecutorMonitor]
+      .getDeclaredMethod("ensureExecutorIsTracked",
+        classOf[String], classOf[Int])
+    ensureExecutorIsTracked.setAccessible(true)
+    val executorTracker = ensureExecutorIsTracked.invoke(executorMonitor,
+      "exec1".asInstanceOf[AnyRef],
+      ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID.asInstanceOf[AnyRef])
+    executorTracker.asInstanceOf[executorMonitor.Tracker].updateRunningTasks(1)
 
-      // assert exec1 is not idle
-      val method = classOf[ExecutorMonitor].getDeclaredMethod("isExecutorIdle",
-        classOf[String])
-      method.setAccessible(true)
-      assert(!method.invoke(executorMonitor, "exec1").asInstanceOf[Boolean])
+    // assert exec1 is not idle
+    val method = classOf[ExecutorMonitor].getDeclaredMethod("isExecutorIdle",
+      classOf[String])
+    method.setAccessible(true)
+    assert(!method.invoke(executorMonitor, "exec1").asInstanceOf[Boolean])
 
-      // handle failed task and send TaskEnd
-      val reason = new ExceptionFailure(
-        new TaskOutputFileAlreadyExistException(
-          new FileAlreadyExistsException("file already exists")),
-        Seq.empty[AccumulableInfo])
-      manager.handleFailedTask(offerResult.get.taskId, TaskState.FAILED, reason)
+    // handle failed task and send TaskEnd
+    val reason = new ExceptionFailure(
+      new TaskOutputFileAlreadyExistException(
+        new FileAlreadyExistsException("file already exists")),
+      Seq.empty[AccumulableInfo])
+    manager.handleFailedTask(offerResult.get.taskId, TaskState.FAILED, reason)
 
-      Thread.sleep(1200)
+    Thread.sleep(1200)
 
-      // executor is idle because task has removed by TaskEnd
-      assert(method.invoke(executorMonitor, "exec1").asInstanceOf[Boolean])
-    } finally {
-      sys.props -= "spark.test.home"
-    }
+    // executor is idle because task has removed by TaskEnd
+    assert(method.invoke(executorMonitor, "exec1").asInstanceOf[Boolean])
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -2599,7 +2599,7 @@ class TaskSetManagerSuite
 
     val executorMonitor = sc.executorAllocationManager.get.executorMonitor
 
-    // reflection to mock ExecutorMonitor.onTaskStart
+    // mock ExecutorMonitor.onTaskStart
     val executorTracker1 = executorMonitor.ensureExecutorIsTracked("exec1",
       ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
     executorTracker1.updateRunningTasks(1)
@@ -2624,7 +2624,7 @@ class TaskSetManagerSuite
 
     Thread.sleep(1200)
 
-    // executor is idle because task has removed by TaskEnd
+    // executor are idle because task has removed by TaskEnd
     assert(executorMonitor.isExecutorIdle("exec1"))
     assert(executorMonitor.isExecutorIdle("exec2"))
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
If task failed with NotSerializableException or TaskOutputFileAlreadyExistException, send TaskEnd event to release executor when dynamic allocation is enable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In dynamic allocation, we depends on TaskEnd to release executor when no task running, if TaskEnd event missed will cause executor not release normally, especially for long running applicaiton.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New UT.