### PR TITLE
[SPARK-39989][SQL][FollowUp] Improve foldable expression stats estimate for string and binary

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/EstimationUtils.scala
@@ -107,16 +107,16 @@ object EstimationUtils {
         val value = Option(expr.eval(EmptyRow))
         val length = EstimationUtils.getConstantLen(expr)
         // String and binary data do not get min or max
-        val minMax = if (alias.dataType.isInstanceOf[StringType] ||
-          alias.dataType.isInstanceOf[BinaryType]) {
-          None
-        } else {
-          value
+        val minMax = alias.dataType match {
+          case StringType | BinaryType => None
+          case _ => value
         }
-        val distinctCount = if (value.isDefined) 1 else 0
-        alias.toAttribute ->
-          ColumnStat(
-            Some(distinctCount), minMax, minMax, Some(rowCount), Some(length), Some(length))
+        val columnStat = if (value.isDefined) {
+          ColumnStat(Some(1), minMax, minMax, Some(0), Some(length), Some(length))
+        } else {
+          ColumnStat(Some(0), minMax, minMax, Some(rowCount), Some(length), Some(length))
+        }
+        alias.toAttribute -> columnStat
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/ProjectEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/ProjectEstimationSuite.scala
@@ -161,6 +161,18 @@ class ProjectEstimationSuite extends StatsEstimationTestBase {
       rowCount = Some(2),
       attributeStats = toAttributeMap(expectedColStats2, proj2))
     assert(proj2.stats == expectedStats2)
+
+    // expression with variable length
+    val proj3 = Project(Seq(ar1, Alias(Literal("hello"), "v")()), child)
+    val expectedColStats3 = Seq(
+      "key1" -> colStat1,
+      "v" -> ColumnStat(Some(1), None, None, Some(0), Some(5), Some(5), None, 2))
+    val expectedStats3 = Statistics(
+      // size for string => base + offset + avgLength => 8 + 4 + 5
+      sizeInBytes = 2 * (8 + 4 + 8 + 4 + 5),
+      rowCount = Some(2),
+      attributeStats = toAttributeMap(expectedColStats3, proj3))
+    assert(proj3.stats == expectedStats3)
   }
 
   private def checkProjectStats(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/ProjectEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/ProjectEstimationSuite.scala
@@ -173,6 +173,17 @@ class ProjectEstimationSuite extends StatsEstimationTestBase {
       rowCount = Some(2),
       attributeStats = toAttributeMap(expectedColStats3, proj3))
     assert(proj3.stats == expectedStats3)
+
+    // non-nullable expression with zero row count
+    val proj4 = Project(Seq(ar1, Alias(Literal(10L, LongType), "v")()), child.copy(rowCount = 0))
+    val expectedColStats4 = Seq(
+      "key1" -> colStat1,
+      "v" -> ColumnStat(Some(0), Some(10L), Some(10L), Some(0), Some(8), Some(8), None, 2))
+    val expectedStats4 = Statistics(
+      sizeInBytes = 1, // output size will be 1 for zero row count
+      rowCount = Some(0),
+      attributeStats = toAttributeMap(expectedColStats4, proj4))
+    assert(proj4.stats == expectedStats4)
   }
 
   private def checkProjectStats(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR improves the foldable expression statistics estimation by providing more accurate min, max, and data length for string and binary data types.


### Why are the changes needed?
Improve the accuracy of the statistics.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT
