### PR TITLE
[SPARK-39887][SQL][FOLLOW-UP] Do not exclude Union's first child attributes when traversing other children in RemoveRedundantAliases

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -559,7 +559,7 @@ object RemoveRedundantAliases extends Rule[LogicalPlan] {
         })
         Join(newLeft, newRight, joinType, newCondition, hint)
 
-      case _: Union =>
+      case u: Union =>
         var first = true
         plan.mapChildren { child =>
           if (first) {
@@ -570,7 +570,8 @@ object RemoveRedundantAliases extends Rule[LogicalPlan] {
             // output attributes could return incorrect result.
             removeRedundantAliases(child, excluded ++ child.outputSet)
           } else {
-            removeRedundantAliases(child, excluded)
+            // We don't need to exclude those attributes that `Union` inherits from its first child.
+            removeRedundantAliases(child, excluded -- u.children.head.outputSet)
           }
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not exclude `Union`'s first child attributes when traversing other children in `RemoveRedundantAliases`.

### Why are the changes needed?
We don't need to exclude those attributes that `Union` inherits from its first child. See discussion here: https://github.com/apache/spark/pull/37496#discussion_r944509115

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing UTs.
