### PR TITLE
[WIP][SPARK-40100][SQL] Add DataType class for Int128 type

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -90,6 +90,11 @@ public class DataTypes {
   public static final DataType LongType = LongType$.MODULE$;
 
   /**
+   * Gets the Int128Type object.
+   */
+  public static final DataType Int128Type = Int128Type$.MODULE$;
+
+  /**
    * Gets the ShortType object.
    */
   public static final DataType ShortType = ShortType$.MODULE$;

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/types/DataTypes.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/types/DataTypes.java
@@ -90,11 +90,6 @@ public class DataTypes {
   public static final DataType LongType = LongType$.MODULE$;
 
   /**
-   * Gets the Int128Type object.
-   */
-  public static final DataType Int128Type = Int128Type$.MODULE$;
-
-  /**
    * Gets the ShortType object.
    */
   public static final DataType ShortType = ShortType$.MODULE$;
@@ -138,6 +133,17 @@ public class DataTypes {
    */
   public static DecimalType createDecimalType() {
     return DecimalType$.MODULE$.USER_DEFAULT();
+  }
+
+  public static Int128Type createInt128Type() {
+    return Int128Type$.MODULE$;
+  }
+
+  /**
+   * Creates a Decimal128Type with default scale 0.
+   */
+  public static Decimal128Type createDecimal128Type() {
+    return Decimal128Type$.MODULE$.USER_DEFAULT();
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/Int128Holder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/Int128Holder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util;
+
+import org.apache.spark.sql.types.Int128;
+
+public class Int128Holder {
+  private long high;
+  private long low;
+
+  public Int128Holder() {
+  }
+
+  public long high() {
+    return high;
+  }
+
+  public void high(long high) {
+    this.high = high;
+  }
+
+  public long low() {
+    return low;
+  }
+
+  public void low(long low) {
+    this.low = low;
+  }
+
+  public void set(long high, long low) {
+    this.high = high;
+    this.low = low;
+  }
+
+  public void set(Int128 value) {
+    this.high = value.high();
+    this.low = value.low();
+  }
+
+  public Int128 get() {
+    return new Int128().set(high, low);
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/Int128Math.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/Int128Math.java
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util;
+
+import org.apache.spark.sql.types.Int128;
+
+public final class Int128Math {
+  private Int128Math() {}
+
+  public static int compareUnsigned(long aHigh, long aLow, long bHigh, long bLow) {
+    int result = Long.compareUnsigned(aHigh, bHigh);
+
+    if (result == 0) {
+      result = Long.compareUnsigned(aLow, bLow);
+    }
+
+    return result;
+  }
+
+  public static int compare(long aHigh, long aLow, long bHigh, long bLow) {
+    int result = Long.compare(aHigh, bHigh);
+
+    if (result == 0) {
+      result = Long.compareUnsigned(aLow, bLow);
+    }
+
+    return result;
+  }
+
+  public static boolean isZero(long high, long low) {
+    return (high | low) == 0;
+  }
+
+  public static long incrementHigh(long high, long low) {
+    return high + ((low == -1) ? 1 : 0);
+  }
+
+  public static long incrementLow(long high, long low) {
+    return low + 1;
+  }
+
+  public static long decrementHigh(long high, long low) {
+    return high - ((low == 0) ? 1 : 0);
+  }
+
+  public static long decrementLow(long high, long low) {
+    return low - 1;
+  }
+
+  public static long addHigh(long aHigh, long aLow, long bHigh, long bLow) {
+    return aHigh + bHigh + MoreMath.unsignedCarry(aLow, bLow);
+  }
+
+  public static long addLow(long aLow, long bLow) {
+    return aLow + bLow;
+  }
+
+  public static long subtractHigh(long aHigh, long aLow, long bHigh, long bLow) {
+    return aHigh - bHigh - MoreMath.unsignedBorrow(aLow, bLow);
+  }
+
+  public static long subtractLow(long aLow, long bLow) {
+    return aLow - bLow;
+  }
+
+  public static long multiplyHigh(long aHigh, long aLow, long bHigh, long bLow) {
+    return MoreMath.unsignedMultiplyHigh(aLow, bLow) + aLow * bHigh + aHigh * bLow;
+  }
+
+  public static long multiplyLow(long aLow, long bLow)
+    {
+        return aLow * bLow;
+    }
+
+  public static long shiftLeftHigh(long high, long low, int shift) {
+    if (shift < 64) {
+      return (high << shift) | (low >>> 1 >>> (63 - shift));
+    } else {
+      return low << (shift - 64);
+    }
+  }
+
+  public static long shiftLeftLow(long high, long low, int shift) {
+    if (shift < 64) {
+      return low << shift;
+    } else {
+      return 0;
+    }
+  }
+
+  public static long shiftRightUnsignedHigh(long high, long low, int shift) {
+    if (shift < 64) {
+      return high >>> shift;
+    } else {
+      return 0;
+    }
+  }
+
+  public static long shiftRightUnsignedLow(long high, long low, int shift) {
+    if (shift < 64) {
+      return (high << 1 << (63 - shift)) | (low >>> shift);
+    } else {
+      return high >>> (shift - 64);
+    }
+  }
+
+  public static long andHigh(long aHigh, long bHigh) {
+    return aHigh & bHigh;
+  }
+
+  public static long andLow(long aLow, long bLow) {
+    return aLow & bLow;
+  }
+
+  public static int numberOfLeadingZeros(long high, long low) {
+    int count = Long.numberOfLeadingZeros(high);
+    if (count == 64) {
+      count += Long.numberOfLeadingZeros(low);
+    }
+
+    return count;
+  }
+
+  public static int numberOfTrailingZeros(long high, long low) {
+    int count = Long.numberOfTrailingZeros(low);
+    if (count == 64) {
+      count += Long.numberOfTrailingZeros(high);
+    }
+
+    return count;
+  }
+
+  public static int bitCount(long high, long low)
+    {
+        return Long.bitCount(high) + Long.bitCount(low);
+    }
+
+  public static long negateHigh(long high, long low) {
+    return -high - (low != 0 ? 1 : 0);
+  }
+
+  public static long negateLow(long low)
+    {
+        return -low;
+    }
+
+  public static void divide(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+    boolean dividendNegative = dividendHigh < 0;
+    boolean divisorNegative = divisorHigh < 0;
+
+    // for self assignments
+    long tmpHigh;
+    long tmpLow;
+
+    if (dividendNegative) {
+      tmpHigh = negateHigh(dividendHigh, dividendLow);
+      tmpLow = negateLow(dividendLow);
+      dividendHigh = tmpHigh;
+      dividendLow = tmpLow;
+    }
+
+    if (divisorNegative) {
+      tmpHigh = negateHigh(divisorHigh, divisorLow);
+      tmpLow = negateLow(divisorLow);
+      divisorHigh = tmpHigh;
+      divisorLow = tmpLow;
+    }
+
+    dividePositive(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
+
+    boolean resultNegative = dividendNegative ^ divisorNegative;
+    if (resultNegative) {
+      tmpHigh = negateHigh(quotient.high(), quotient.low());
+      tmpLow = negateLow(quotient.low());
+      quotient.set(tmpHigh, tmpLow);
+    }
+
+    if (dividendNegative) {
+      // negate remainder
+      tmpHigh = negateHigh(remainder.high(), remainder.low());
+      tmpLow = negateLow(remainder.low());
+      remainder.set(tmpHigh, tmpLow);
+    }
+  }
+
+  private static void dividePositive(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+    int dividendLeadingZeros = numberOfLeadingZeros(dividendHigh, dividendLow);
+    int divisorLeadingZeros = numberOfLeadingZeros(divisorHigh, divisorLow);
+    int divisorTrailingZeros = numberOfTrailingZeros(divisorHigh, divisorLow);
+
+    int comparison = compareUnsigned(dividendHigh, dividendLow, divisorHigh, divisorLow);
+    if (comparison < 0) {
+      quotient.set(Int128.ZERO());
+      remainder.set(dividendHigh, dividendLow);
+      return;
+    } else if (comparison == 0) {
+      quotient.set(Int128.ONE());
+      remainder.set(Int128.ZERO());
+      return;
+    }
+
+    if (divisorLeadingZeros == 128) {
+      throw new ArithmeticException("Divide by zero");
+    } else if ((dividendHigh | divisorHigh) == 0) {
+      // dividend and divisor fit in an unsigned
+      quotient.set(0, Long.divideUnsigned(dividendLow, divisorLow));
+      remainder.set(0, Long.remainderUnsigned(dividendLow, divisorLow));
+      return;
+    } else if (divisorLeadingZeros == 127) {
+      // divisor is 1
+      quotient.set(dividendHigh, dividendLow);
+      remainder.set(Int128.ZERO());
+      return;
+    } else if ((divisorTrailingZeros + divisorLeadingZeros) == 127) {
+      // only one bit set (i.e., power of 2), so just shift
+
+      //  quotient = dividend >>> divisorTrailingZeros
+      quotient.set(
+        shiftRightUnsignedHigh(dividendHigh, dividendLow, divisorTrailingZeros),
+        shiftRightUnsignedLow(dividendHigh, dividendLow, divisorTrailingZeros));
+
+      //  remainder = dividend & (divisor - 1)
+      long dLow = decrementLow(divisorHigh, divisorLow);
+      long dHigh = decrementHigh(divisorHigh, divisorLow);
+
+      // and
+      remainder.set(
+        andHigh(dividendHigh, dHigh),
+        andLow(dividendLow, dLow));
+      return;
+    }
+
+    if (divisorLeadingZeros - dividendLeadingZeros > 15) { // fastDivide when the values differ by this many orders of magnitude
+      fastDivide(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
+    } else {
+      binaryDivide(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
+    }
+  }
+
+  private static void binaryDivide(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+    int shift = numberOfLeadingZeros(divisorHigh, divisorLow) - numberOfLeadingZeros(dividendHigh, dividendLow);
+
+    // for self assignments
+    long tmpHigh;
+    long tmpLow;
+
+    // divisor = divisor << shift
+    tmpHigh = shiftLeftHigh(divisorHigh, divisorLow, shift);
+    tmpLow = shiftLeftLow(divisorHigh, divisorLow, shift);
+    divisorHigh = tmpHigh;
+    divisorLow = tmpLow;
+
+    long quotientHigh = 0;
+    long quotientLow = 0;
+
+    do {
+      // quotient = quotient << 1
+      tmpHigh = shiftLeftHigh(quotientHigh, quotientLow, 1);
+      tmpLow = shiftLeftLow(quotientHigh, quotientLow, 1);
+      quotientHigh = tmpHigh;
+      quotientLow = tmpLow;
+
+      // if (dividend >= divisor)
+      int comparison = compareUnsigned(dividendHigh, dividendLow, divisorHigh, divisorLow);
+      if (comparison >= 0) {
+        // dividend = dividend - divisor
+        tmpHigh = subtractHigh(dividendHigh, dividendLow, divisorHigh, divisorLow);
+        tmpLow = subtractLow(dividendLow, divisorLow);
+        dividendHigh = tmpHigh;
+        dividendLow = tmpLow;
+
+        // quotient = quotient | 1
+        quotientLow = quotientLow | 1;
+      }
+
+      // divisor = divisor >>> 1
+      tmpHigh = shiftRightUnsignedHigh(divisorHigh, divisorLow, 1);
+      tmpLow = shiftRightUnsignedLow(divisorHigh, divisorLow, 1);
+      divisorHigh = tmpHigh;
+      divisorLow = tmpLow;
+    } while (shift-- != 0);
+
+    quotient.set(quotientHigh, quotientLow);
+    remainder.set(dividendHigh, dividendLow);
+  }
+
+  private static void fastDivide(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+    if (divisorHigh == 0) {
+      if (Long.compareUnsigned(dividendHigh, divisorLow) < 0) {
+        quotient.high(0);
+        remainder.high(0);
+        divide128by64(dividendHigh, dividendLow, divisorLow, quotient, remainder);
+      } else {
+        quotient.high(Long.divideUnsigned(dividendHigh, divisorLow));
+        remainder.high(0);
+        divide128by64(Long.remainderUnsigned(dividendHigh, divisorLow), dividendLow, divisorLow, quotient, remainder);
+      }
+    } else {
+      // used for self assignments
+      long tempHigh;
+      long tempLow;
+
+      int n = Long.numberOfLeadingZeros(divisorHigh);
+
+      // v1 = divisor << n
+      long v1High = shiftLeftHigh(divisorHigh, divisorLow, n);
+
+      // u1 = dividend >>> 1
+      long u1High = shiftRightUnsignedHigh(dividendHigh, dividendLow, 1);
+      long u1Low = shiftRightUnsignedLow(dividendHigh, dividendLow, 1);
+
+      divide128by64(u1High, u1Low, v1High, quotient, remainder);
+
+      long q1High = 0;
+      long q1Low = quotient.low();
+
+      // q1 = q1 >>> (63 - n)
+      tempLow = shiftRightUnsignedLow(q1High, q1Low, 63 - n);
+      tempHigh = shiftRightUnsignedHigh(q1High, q1Low, 63 - n);
+      q1Low = tempLow;
+      q1High = tempHigh;
+
+      // if (q1 != 0)
+      if (!isZero(q1High, q1Low)) {
+        // q1--
+        tempLow = decrementLow(q1High, q1Low);
+        tempHigh = decrementHigh(q1High, q1Low);
+        q1Low = tempLow;
+        q1High = tempHigh;
+      }
+
+      long quotientHigh = q1High;
+      long quotientLow = q1Low;
+
+      // r = dividend - q1 * divisor
+      long productHigh = multiplyHigh(q1High, q1Low, divisorHigh, divisorLow);
+      long productLow = multiplyLow(q1Low, divisorLow);
+
+      long remainderHigh = subtractHigh(dividendHigh, dividendLow, productHigh, productLow);
+      long remainderLow = subtractLow(dividendLow, productLow);
+
+      if (compare(remainderHigh, remainderLow, divisorHigh, divisorLow) >= 0) {
+        // quotient++
+        tempLow = incrementLow(quotientHigh, quotientLow);
+        tempHigh = incrementHigh(quotientHigh, quotientLow);
+        quotientLow = tempLow;
+        quotientHigh = tempHigh;
+
+        tempLow = subtractLow(remainderLow, divisorLow);
+        tempHigh = subtractHigh(remainderHigh, remainderLow, divisorHigh, divisorLow);
+        remainderHigh = tempHigh;
+        remainderLow = tempLow;
+      }
+
+      quotient.set(quotientHigh, quotientLow);
+      remainder.set(remainderHigh, remainderLow);
+    }
+  }
+
+  private static void divide128by64(long high, long low, long divisor, Int128Holder quotient, Int128Holder remainder) {
+    int shift = Long.numberOfLeadingZeros(divisor);
+    if (shift != 0) {
+      divisor <<= shift;
+      high <<= shift;
+      high |= low >>> (64 - shift);
+      low <<= shift;
+    }
+
+    long divisorHigh = divisor >>> 32;
+    long divisorLow = divisor & 0xFFFFFFFFL;
+    long lowHigh = low >>> 32;
+    long lowLow = low & 0xFFFFFFFFL;
+
+    // Compute high quotient digit.
+    long quotientHigh = Long.divideUnsigned(high, divisorHigh);
+    long rhat = Long.remainderUnsigned(high, divisorHigh);
+
+    // qhat >>> 32 == qhat > base
+    while ((quotientHigh >>> 32) != 0 || Long.compareUnsigned(quotientHigh * divisorLow, (rhat << 32) | lowHigh) > 0) {
+      quotientHigh -= 1;
+      rhat += divisorHigh;
+      if ((rhat >>> 32) != 0) {
+        break;
+      }
+    }
+
+    long uhat = ((high << 32) | lowHigh) - quotientHigh * divisor;
+
+    // Compute low quotient digit.
+    long quotientLow = Long.divideUnsigned(uhat, divisorHigh);
+    rhat = Long.remainderUnsigned(uhat, divisorHigh);
+
+    while ((quotientLow >>> 32) != 0 || Long.compareUnsigned(quotientLow * divisorLow, ((rhat << 32) | lowLow)) > 0) {
+      quotientLow -= 1;
+      rhat += divisorHigh;
+      if ((rhat >>> 32) != 0) {
+        break;
+      }
+    }
+
+    quotient.low(quotientHigh << 32 | quotientLow);
+    remainder.low((uhat << 32 | lowLow) - quotientLow * divisor >>> shift);
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/Int128Math.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/Int128Math.java
@@ -19,8 +19,67 @@ package org.apache.spark.sql.util;
 
 import org.apache.spark.sql.types.Int128;
 
+import java.math.BigInteger;
+
+import static java.lang.Math.pow;
+import static java.lang.Math.round;
+
 public final class Int128Math {
-  private Int128Math() {}
+
+  // 1..10^38 (largest value < Int128.MAX_VALUE)
+  private static final Int128[] POWERS_OF_TEN = new Int128[39];
+  private static final int LONG_POWERS_OF_TEN_TABLE_LENGTH = 19;
+  private static final long[] LONG_POWERS_OF_TEN = new long[LONG_POWERS_OF_TEN_TABLE_LENGTH];
+
+  // Lowest 32 bits of a long
+  private static final long LOW_32_BITS = 0xFFFFFFFFL;
+
+  /**
+   * 5^13 fits in 2^31.
+   */
+  private static final int MAX_POWER_OF_FIVE_INT = 13;
+
+  /**
+   * 5^x. All unsigned values.
+   */
+  private static final int[] POWERS_OF_FIVES_INT = new int[MAX_POWER_OF_FIVE_INT + 1];
+
+  /**
+   * 10^9 fits in 2^31.
+   */
+  private static final int MAX_POWER_OF_TEN_INT = 9;
+
+  /**
+   * 10^18 fits in 2^63.
+   */
+  private static final int MAX_POWER_OF_TEN_LONG = 18;
+
+  /**
+   * 10^x. All unsigned values.
+   */
+  private static final int[] POWERS_OF_TEN_INT = new int[MAX_POWER_OF_TEN_INT + 1];
+
+  static {
+    for (int i = 0; i < POWERS_OF_TEN.length; ++i) {
+      POWERS_OF_TEN[i] = Int128.apply(BigInteger.TEN.pow(i));
+    }
+
+    POWERS_OF_FIVES_INT[0] = 1;
+    for (int i = 1; i < POWERS_OF_FIVES_INT.length; ++i) {
+      POWERS_OF_FIVES_INT[i] = POWERS_OF_FIVES_INT[i - 1] * 5;
+    }
+
+    for (int i = 0; i < LONG_POWERS_OF_TEN.length; ++i) {
+      // Although this computes using doubles, incidentally,
+      // this is exact for all powers of 10 that fit in a long.
+      LONG_POWERS_OF_TEN[i] = round(pow(10, i));
+    }
+
+    POWERS_OF_TEN_INT[0] = 1;
+    for (int i = 1; i < POWERS_OF_TEN_INT.length; ++i) {
+      POWERS_OF_TEN_INT[i] = POWERS_OF_TEN_INT[i - 1] * 10;
+    }
+  }
 
   public static boolean inLongRange(long high, long low)
   {
@@ -37,11 +96,11 @@ public final class Int128Math {
     return result;
   }
 
-  public static int compare(long aHigh, long aLow, long bHigh, long bLow) {
-    int result = Long.compare(aHigh, bHigh);
+  public static int compare(long leftHigh, long leftLow, long rightHigh, long rightLow) {
+    int result = Long.compare(leftHigh, rightHigh);
 
     if (result == 0) {
-      result = Long.compareUnsigned(aLow, bLow);
+      result = Long.compareUnsigned(leftLow, rightLow);
     }
 
     return result;
@@ -65,6 +124,87 @@ public final class Int128Math {
 
   public static long decrementLow(long high, long low) {
     return low - 1;
+  }
+
+  public static void rescale(long high, long low, int factor, long[] result, int offset) {
+    if (factor == 0) {
+      result[offset] = high;
+      result[offset + 1] = low;
+    } else if (factor > 0) {
+      shiftLeftBy10(high, low, factor, result, offset);
+    } else {
+      scaleDownRoundUp(high, low, -factor, result, offset);
+    }
+  }
+
+  public static Int128 rescale(Int128 int128, int rescaleFactor) {
+    long[] result = new long[2];
+    rescale(int128.high(), int128.low(), rescaleFactor, result, 0);
+    return Int128.apply(result[0], result[1]);
+  }
+
+  // Multiplies by 10^rescaleFactor. Only positive rescaleFactor values are allowed
+  public static void shiftLeftBy10(
+    long high, long low, int rescaleFactor, long[] result, int offset) {
+    if (rescaleFactor >= POWERS_OF_TEN.length) {
+      throw overflowException();
+    }
+
+    boolean negative = high < 0;
+
+    if (negative) {
+      long tmpHigh = negateHighExact(high, low);
+      long tmpLow = negateLow(low);
+
+      high = tmpHigh;
+      low = tmpLow;
+    }
+
+    multiplyPositives(high, low, POWERS_OF_TEN[rescaleFactor].high(),
+      POWERS_OF_TEN[rescaleFactor].low(), result, offset);
+
+    if (negative) {
+      long tmpHigh = negateHighExact(result[offset], result[offset + 1]);
+      long tmpLow = negateLow(result[offset + 1]);
+
+      result[offset] = tmpHigh;
+      result[offset + 1] = tmpLow;
+    }
+  }
+
+  private static long unsignedCarry(long a, long b) {
+    // HD 2-13
+    return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
+  }
+
+  public static void add(
+    long leftHigh, long leftLow, long rightHigh, long rightLow, long[] result) {
+    long carry = unsignedCarry(leftLow, rightLow);
+
+    long resultLow = leftLow + rightLow;
+    long resultHigh = leftHigh + rightHigh + carry;
+
+    result[0] = resultHigh;
+    result[1] = resultLow;
+
+    if (((resultHigh ^ leftHigh) & (resultHigh ^ rightHigh)) < 0) {
+      throw overflowException();
+    }
+  }
+
+  public static void add(
+    long leftHigh, long leftLow, long rightHigh, long rightLow, long[] result, int offset) {
+    long carry = unsignedCarry(leftLow, rightLow);
+
+    long resultLow = leftLow + rightLow;
+    long resultHigh = leftHigh + rightHigh + carry;
+
+    result[offset] = resultHigh;
+    result[offset + 1] = resultLow;
+
+    if (((resultHigh ^ leftHigh) & (resultHigh ^ rightHigh)) < 0) {
+      throw overflowException();
+    }
   }
 
   public static long addHigh(long aHigh, long aLow, long bHigh, long bLow) {
@@ -173,21 +313,229 @@ public final class Int128Math {
     return count;
   }
 
-  public static int bitCount(long high, long low)
-    {
-        return Long.bitCount(high) + Long.bitCount(low);
+  public static int bitCount(long high, long low) {
+    return Long.bitCount(high) + Long.bitCount(low);
+  }
+
+  private static void negate(long[] value, int offset) {
+    long high = value[offset];
+    long low = value[offset + 1];
+
+    value[offset] = negateHigh(high, low);
+    value[offset + 1] = negateLow(low);
+  }
+
+  private static long negateHighExact(long high, long low) {
+    if (high == Int128.MIN_VALUE().high() && low == Int128.MIN_VALUE().low()) {
+      throw overflowException();
     }
+
+    return negateHigh(high, low);
+  }
 
   public static long negateHigh(long high, long low) {
     return -high - (low != 0 ? 1 : 0);
   }
 
-  public static long negateLow(long low)
-    {
-        return -low;
+  public static long negateLow(long low) {
+    return -low;
+  }
+
+  private static void incrementUnsafe(long[] value, int offset) {
+    long high = value[offset];
+    long low = value[offset + 1];
+
+    value[offset] = incrementHigh(high, low);
+    value[offset + 1] = incrementLow(high, low);
+  }
+
+  private static void scaleDownRoundUp(
+      long high, long low, int scaleFactor, long[] result, int offset) {
+    // optimized path for smaller values
+    if (scaleFactor <= MAX_POWER_OF_TEN_LONG && high == 0 && low >= 0) {
+      long divisor = LONG_POWERS_OF_TEN[scaleFactor];
+      long newLow = low / divisor;
+      if (low % divisor >= (divisor >> 1)) {
+        newLow++;
+      }
+      result[offset] = 0;
+      result[offset + 1] = newLow;
+      return;
     }
 
-  public static void divide(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+    scaleDown(high, low, scaleFactor, result, offset, true);
+  }
+
+  private static void scaleDown(
+      long high, long low, int scaleFactor, long[] result, int offset, boolean roundUp) {
+    boolean negative = high < 0;
+    if (negative) {
+      long tmpLow = negateLow(low);
+      long tmpHigh = negateHighExact(high, low);
+
+      low = tmpLow;
+      high = tmpHigh;
+    }
+
+    // Scales down for 10**rescaleFactor.
+    // Because divide by int has limited divisor,
+    // we choose code path with the least amount of divisions
+    if ((scaleFactor - 1) / MAX_POWER_OF_FIVE_INT < (scaleFactor - 1) / MAX_POWER_OF_TEN_INT) {
+      // scale down for 10**rescale is equivalent to scaling down with 5**rescaleFactor first,
+      // then with 2**rescaleFactor
+      scaleDownFive(high, low, scaleFactor, result, offset);
+      shiftRight(result[offset], result[offset + 1], scaleFactor, roundUp, result, offset);
+    }
+    else {
+      scaleDownTen(high, low, scaleFactor, result, offset, roundUp);
+    }
+
+    if (negative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(result, offset);
+    }
+  }
+
+  /**
+   * Scale down the value for 5**fiveScale (result := decimal / 5**fiveScale).
+   */
+  private static void scaleDownFive(
+      long high, long low, int fiveScale, long[] result, int offset) {
+    if (high < 0) {
+      throw new IllegalArgumentException("Value must be positive");
+    }
+
+    while (true) {
+      int powerFive = Math.min(fiveScale, MAX_POWER_OF_FIVE_INT);
+      fiveScale -= powerFive;
+
+      int divisor = POWERS_OF_FIVES_INT[powerFive];
+      dividePositives(high, low, divisor, result, offset);
+
+      if (fiveScale == 0) {
+        return;
+      }
+
+      high = result[offset];
+      low = result[offset + 1];
+    }
+  }
+
+  /**
+   * Scale down the value for 10**tenScale (this := this / 5**tenScale). This
+   * method rounds-up, eg 44/10=4, 44/10=5.
+   */
+  private static void scaleDownTen(
+      long high, long low, int tenScale, long[] result, int offset, boolean roundUp) {
+    if (high < 0) {
+      throw new IllegalArgumentException("Value must be positive");
+    }
+
+    boolean needsRounding;
+    do {
+      int powerTen = Math.min(tenScale, MAX_POWER_OF_TEN_INT);
+      tenScale -= powerTen;
+
+      int divisor = POWERS_OF_TEN_INT[powerTen];
+      needsRounding = divideCheckRound(high, low, divisor, result, offset);
+
+      high = result[offset];
+      low = result[offset + 1];
+    }
+    while (tenScale > 0);
+
+    if (roundUp && needsRounding) {
+      incrementUnsafe(result, offset);
+    }
+  }
+
+  static void shiftRight(
+      long high, long low, int shift, boolean roundUp, long[] result, int offset) {
+    if (high < 0) {
+      throw new IllegalArgumentException("Value must be positive");
+    }
+
+    if (shift == 0) {
+      return;
+    }
+
+    boolean needsRounding;
+    if (shift < 64) {
+      needsRounding = roundUp && (low & (1L << (shift - 1))) != 0;
+
+      low = (high << 1 << (63 - shift)) | (low >>> shift);
+      high = high >> shift;
+    }
+    else {
+      needsRounding = roundUp && (high & (1L << (shift - 64 - 1))) != 0;
+
+      low = high >> (shift - 64);
+      high = 0;
+    }
+
+    if (needsRounding) {
+      long tmpHigh = incrementHigh(high, low);
+      long tmpLow = incrementLow(high, low);
+
+      high = tmpHigh;
+      low = tmpLow;
+    }
+
+    result[offset] = high;
+    result[offset + 1] = low;
+  }
+
+  /**
+   * Given a and b, two 128 bit values composed of 64 bit values (a_H, a_L) and (b_H, b_L),
+   * respectively, computes the product in the following way:
+   *
+   *                                                                      a_H a_L
+   *                                                                    * b_H b_L
+   * -----------------------------------------------------------------------------------
+   *      64 bits    |       64 bits       |       64 bits       |        64 bits
+   *                 |                     |                     |
+   *                 |                     | z1_H= (a_L * b_L)_H | z1_L = (a_L * b_L)_L
+   *                 | z2_H= (a_L * b_H)_H | z2_L= (a_L * b_H)_L |
+   *                 | z3_H= (a_H * b_L)_H | z3_L= (a_H * b_L)_L |
+   *  (a_H * b_H)_H  |       (a_H * b_H)_L |                     |
+   * -----------------------------------------------------------------------------------
+   *                 |                     |      result_H       |      result_L
+   *
+   * The product is performed on positive values. The product overflows
+   * * if any of the terms above 128 bits is non-zero:
+   *    * a_H and b_H are both non-zero
+   *    * z2_H is non-zero
+   *    * z3_H is non-zero
+   * * result_H is negative (high bit of a java long is set) --
+   * since the original numbers are positive, the result cannot be negative
+   * * any of z1_H, z2_L and z3_L are negative --
+   * since the original numbers are positive, these intermediate results cannot be negative
+   */
+  private static void multiplyPositives(
+    long leftHigh, long leftLow, long rightHigh, long rightLow, long[] result, int offset) {
+
+    long z1High = MoreMath.unsignedMultiplyHigh(leftLow, rightLow);
+    long z1Low = leftLow * rightLow;
+    long z2Low = leftLow * rightHigh;
+    long z3Low = leftHigh * rightLow;
+
+    long resultLow = z1Low;
+    long resultHigh = z1High + z2Low + z3Low;
+
+    if ((leftHigh != 0 && rightHigh != 0) ||
+            resultHigh < 0 || z1High < 0 || z2Low < 0 || z3Low < 0 ||
+            MoreMath.unsignedMultiplyHigh(leftLow, rightHigh) != 0 ||
+            MoreMath.unsignedMultiplyHigh(leftHigh, rightLow) != 0) {
+      throw overflowException();
+    }
+
+    result[offset] = resultHigh;
+    result[offset + 1] = resultLow;
+  }
+
+  public static void divide(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
     boolean dividendNegative = dividendHigh < 0;
     boolean divisorNegative = divisorHigh < 0;
 
@@ -226,7 +574,46 @@ public final class Int128Math {
     }
   }
 
-  private static void dividePositive(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+  private static long high(long value)
+  {
+    return value >>> 32;
+  }
+
+  private static long low(long value)
+  {
+    return value & LOW_32_BITS;
+  }
+
+  private static boolean divideCheckRound(
+      long dividendHigh, long dividendLow, int divisor, long[] result, int offset) {
+    int remainder = dividePositives(dividendHigh, dividendLow, divisor, result, offset);
+    return (remainder >= (divisor >> 1));
+  }
+
+  private static int dividePositives(
+      long dividendHigh, long dividendLow, int divisor, long[] result, int offset) {
+    long remainder = dividendHigh;
+    long high = remainder / divisor;
+    remainder %= divisor;
+
+    remainder = high(dividendLow) + (remainder << 32);
+    int z1 = (int) (remainder / divisor);
+    remainder %= divisor;
+
+    remainder = low(dividendLow) + (remainder << 32);
+    int z0 = (int) (remainder / divisor);
+
+    long low = (((long) z1) << 32) | (((long) z0) & 0xFFFFFFFFL);
+
+    result[offset] = high;
+    result[offset + 1] = low;
+
+    return (int) (remainder % divisor);
+  }
+
+  private static void dividePositive(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
     int dividendLeadingZeros = numberOfLeadingZeros(dividendHigh, dividendLow);
     int divisorLeadingZeros = numberOfLeadingZeros(divisorHigh, divisorLow);
     int divisorTrailingZeros = numberOfTrailingZeros(divisorHigh, divisorLow);
@@ -273,15 +660,19 @@ public final class Int128Math {
       return;
     }
 
-    if (divisorLeadingZeros - dividendLeadingZeros > 15) { // fastDivide when the values differ by this many orders of magnitude
+    // fastDivide when the values differ by this many orders of magnitude
+    if (divisorLeadingZeros - dividendLeadingZeros > 15) {
       fastDivide(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
     } else {
       binaryDivide(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
     }
   }
 
-  private static void binaryDivide(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
-    int shift = numberOfLeadingZeros(divisorHigh, divisorLow) - numberOfLeadingZeros(dividendHigh, dividendLow);
+  private static void binaryDivide(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
+    int shift = numberOfLeadingZeros(divisorHigh, divisorLow) -
+      numberOfLeadingZeros(dividendHigh, dividendLow);
 
     // for self assignments
     long tmpHigh;
@@ -327,7 +718,9 @@ public final class Int128Math {
     remainder.set(dividendHigh, dividendLow);
   }
 
-  private static void fastDivide(long dividendHigh, long dividendLow, long divisorHigh, long divisorLow, Int128Holder quotient, Int128Holder remainder) {
+  private static void fastDivide(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
     if (divisorHigh == 0) {
       if (Long.compareUnsigned(dividendHigh, divisorLow) < 0) {
         quotient.high(0);
@@ -336,7 +729,8 @@ public final class Int128Math {
       } else {
         quotient.high(Long.divideUnsigned(dividendHigh, divisorLow));
         remainder.high(0);
-        divide128by64(Long.remainderUnsigned(dividendHigh, divisorLow), dividendLow, divisorLow, quotient, remainder);
+        divide128by64(Long.remainderUnsigned(dividendHigh, divisorLow),
+          dividendLow, divisorLow, quotient, remainder);
       }
     } else {
       // used for self assignments
@@ -400,7 +794,8 @@ public final class Int128Math {
     }
   }
 
-  private static void divide128by64(long high, long low, long divisor, Int128Holder quotient, Int128Holder remainder) {
+  private static void divide128by64(
+    long high, long low, long divisor, Int128Holder quotient, Int128Holder remainder) {
     int shift = Long.numberOfLeadingZeros(divisor);
     if (shift != 0) {
       divisor <<= shift;
@@ -419,7 +814,8 @@ public final class Int128Math {
     long rhat = Long.remainderUnsigned(high, divisorHigh);
 
     // qhat >>> 32 == qhat > base
-    while ((quotientHigh >>> 32) != 0 || Long.compareUnsigned(quotientHigh * divisorLow, (rhat << 32) | lowHigh) > 0) {
+    while ((quotientHigh >>> 32) != 0 ||
+      Long.compareUnsigned(quotientHigh * divisorLow, (rhat << 32) | lowHigh) > 0) {
       quotientHigh -= 1;
       rhat += divisorHigh;
       if ((rhat >>> 32) != 0) {
@@ -433,7 +829,8 @@ public final class Int128Math {
     long quotientLow = Long.divideUnsigned(uhat, divisorHigh);
     rhat = Long.remainderUnsigned(uhat, divisorHigh);
 
-    while ((quotientLow >>> 32) != 0 || Long.compareUnsigned(quotientLow * divisorLow, ((rhat << 32) | lowLow)) > 0) {
+    while ((quotientLow >>> 32) != 0 ||
+      Long.compareUnsigned(quotientLow * divisorLow, ((rhat << 32) | lowLow)) > 0) {
       quotientLow -= 1;
       rhat += divisorHigh;
       if ((rhat >>> 32) != 0) {
@@ -443,5 +840,9 @@ public final class Int128Math {
 
     quotient.low(quotientHigh << 32 | quotientLow);
     remainder.low((uhat << 32 | lowLow) - quotientLow * divisor >>> shift);
+  }
+
+  private static ArithmeticException overflowException() {
+    return new ArithmeticException("Overflow");
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
@@ -39,18 +39,7 @@ public class MoreMath {
     // HD 2-13
     return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
   }
-
-  /**
-   * Branchless form of
-   * <pre>
-   * if (test < 0) {
-   *   return value;
-   * }
-   * else {
-   *   return 0;
-   * }
-   * </pre>
-   */
+  
   public static long ifNegative(long test, long value)
     {
         return value & (test >> 63);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
@@ -39,16 +39,18 @@ public class MoreMath {
     // HD 2-13
     return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
   }
-  
-  public static long ifNegative(long test, long value)
-    {
-        return value & (test >> 63);
-    }
+
+  public static long ifNegative(long test, long value) {
+    return value & (test >> 63);
+  }
 
   // TODO: replace with JDK 18's Math.unsignedMultiplyHigh
   public static long unsignedMultiplyHigh(long x, long y) {
-    // HD 8-3: High-Order Product Signed from/to Unsigned
-    return multiplyHigh(x, y) + ifNegative(x, y) + ifNegative(y, x);
+    // From Hacker's Delight 2nd Ed. 8-3: High-Order Product Signed from/to Unsigned
+    long result = multiplyHigh(x, y);
+    result += (y & (x >> 63)); // equivalent to: if (x < 0) result += y;
+    result += (x & (y >> 63)); // equivalent to: if (y < 0) result += x;
+    return result;
   }
 
   /**
@@ -119,12 +121,16 @@ public class MoreMath {
     long wHigh;
     long wLow;
     if (!aInLongRange) {
-      // correct z3 due to effects of computing the product of values in 2's complement representation
-      wHigh = z3High - ifNegative(aHigh, bLow) - ifNegative(bLow, aHigh + unsignedBorrow(z3Low, aLow));
+      // correct z3 due to effects of computing the product of values
+      // in 2's complement representation
+      wHigh =
+        z3High - ifNegative(aHigh, bLow) - ifNegative(bLow, aHigh + unsignedBorrow(z3Low, aLow));
       wLow = z3Low - ifNegative(bLow, aLow);
     } else { // !bInLongRange
-      // correct z2 due to effects of computing the product of values in 2's complement representation
-      wHigh = z2High - ifNegative(bHigh, aLow) - ifNegative(aLow, bHigh + unsignedBorrow(z2Low, bLow));
+      // correct z2 due to effects of computing the product of values
+      // in 2's complement representation
+      wHigh =
+        z2High - ifNegative(bHigh, aLow) - ifNegative(aLow, bHigh + unsignedBorrow(z2Low, bLow));
       wLow = z2Low - ifNegative(aLow, bLow);
     }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util;
+
+class MoreMath {
+    private MoreMath() {
+
+    }
+
+    /**
+     * Compute carry of addition with carry
+     */
+    public static long unsignedCarry(long a, long b, long c) {
+        // HD 2-13
+        return (a & b) | ((a | b) & ~(a + b + c)) >>> 63; // TODO: verify
+    }
+
+    public static long unsignedCarry(long a, long b) {
+        // HD 2-13
+        return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
+    }
+
+    public static long unsignedBorrow(long a, long b) {
+        // HD 2-13
+        return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
+    }
+
+    /**
+     * Branchless form of
+     * <pre>
+     * if (test < 0) {
+     *   return value;
+     * }
+     * else {
+     *   return 0;
+     * }
+     * </pre>
+     */
+    public static long ifNegative(long test, long value)
+    {
+        return value & (test >> 63);
+    }
+
+    // TODO: replace with JDK 18's Math.unsignedMultiplyHigh
+    public static long unsignedMultiplyHigh(long x, long y) {
+        // HD 8-3: High-Order Product Signed from/to Unsigned
+        return multiplyHigh(x, y) + ifNegative(x, y) + ifNegative(y, x);
+    }
+
+    /**
+     * Returns as a {@code long} the most significant 64 bits of the 128-bit
+     * product of two 64-bit factors.
+     *
+     * @param x the first value
+     * @param y the second value
+     * @return the result
+     * @since 9
+     */
+    public static long multiplyHigh(long x, long y) {
+        if (x < 0 || y < 0) {
+            // Use technique from section 8-2 of Henry S. Warren, Jr.,
+            // Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 173-174.
+            long x1 = x >> 32;
+            long x2 = x & 0xFFFFFFFFL;
+            long y1 = y >> 32;
+            long y2 = y & 0xFFFFFFFFL;
+            long z2 = x2 * y2;
+            long t = x1 * y2 + (z2 >>> 32);
+            long z1 = t & 0xFFFFFFFFL;
+            long z0 = t >> 32;
+            z1 += x2 * y1;
+            return x1 * y1 + z0 + (z1 >> 32);
+        } else {
+            // Use Karatsuba technique with two base 2^32 digits.
+            long x1 = x >>> 32;
+            long y1 = y >>> 32;
+            long x2 = x & 0xFFFFFFFFL;
+            long y2 = y & 0xFFFFFFFFL;
+            long A = x1 * y1;
+            long B = x2 * y2;
+            long C = (x1 + x2) * (y1 + y2);
+            long K = C - A - B;
+            return (((B >>> 32) + K) >>> 32) + A;
+        }
+    }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
@@ -17,85 +17,132 @@
 
 package org.apache.spark.sql.util;
 
-class MoreMath {
-    private MoreMath() {
+public class MoreMath {
+  private MoreMath() {
 
-    }
+  }
 
-    /**
-     * Compute carry of addition with carry
-     */
-    public static long unsignedCarry(long a, long b, long c) {
-        // HD 2-13
-        return (a & b) | ((a | b) & ~(a + b + c)) >>> 63; // TODO: verify
-    }
+  /**
+   * Compute carry of addition with carry
+   */
+  public static long unsignedCarry(long a, long b, long c) {
+    // HD 2-13
+    return (a & b) | ((a | b) & ~(a + b + c)) >>> 63; // TODO: verify
+  }
 
-    public static long unsignedCarry(long a, long b) {
-        // HD 2-13
-        return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
-    }
+  public static long unsignedCarry(long a, long b) {
+    // HD 2-13
+    return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
+  }
 
-    public static long unsignedBorrow(long a, long b) {
-        // HD 2-13
-        return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
-    }
+  public static long unsignedBorrow(long a, long b) {
+    // HD 2-13
+    return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
+  }
 
-    /**
-     * Branchless form of
-     * <pre>
-     * if (test < 0) {
-     *   return value;
-     * }
-     * else {
-     *   return 0;
-     * }
-     * </pre>
-     */
-    public static long ifNegative(long test, long value)
+  /**
+   * Branchless form of
+   * <pre>
+   * if (test < 0) {
+   *   return value;
+   * }
+   * else {
+   *   return 0;
+   * }
+   * </pre>
+   */
+  public static long ifNegative(long test, long value)
     {
         return value & (test >> 63);
     }
 
-    // TODO: replace with JDK 18's Math.unsignedMultiplyHigh
-    public static long unsignedMultiplyHigh(long x, long y) {
-        // HD 8-3: High-Order Product Signed from/to Unsigned
-        return multiplyHigh(x, y) + ifNegative(x, y) + ifNegative(y, x);
+  // TODO: replace with JDK 18's Math.unsignedMultiplyHigh
+  public static long unsignedMultiplyHigh(long x, long y) {
+    // HD 8-3: High-Order Product Signed from/to Unsigned
+    return multiplyHigh(x, y) + ifNegative(x, y) + ifNegative(y, x);
+  }
+
+  /**
+   * Returns as a {@code long} the most significant 64 bits of the 128-bit
+   * product of two 64-bit factors.
+   *
+   * @param x the first value
+   * @param y the second value
+   * @return the result
+   * @since 9
+   */
+  public static long multiplyHigh(long x, long y) {
+    if (x < 0 || y < 0) {
+      // Use technique from section 8-2 of Henry S. Warren, Jr.,
+      // Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 173-174.
+      long x1 = x >> 32;
+      long x2 = x & 0xFFFFFFFFL;
+      long y1 = y >> 32;
+      long y2 = y & 0xFFFFFFFFL;
+      long z2 = x2 * y2;
+      long t = x1 * y2 + (z2 >>> 32);
+      long z1 = t & 0xFFFFFFFFL;
+      long z0 = t >> 32;
+      z1 += x2 * y1;
+      return x1 * y1 + z0 + (z1 >> 32);
+    } else {
+      // Use Karatsuba technique with two base 2^32 digits.
+      long x1 = x >>> 32;
+      long y1 = y >>> 32;
+      long x2 = x & 0xFFFFFFFFL;
+      long y2 = y & 0xFFFFFFFFL;
+      long A = x1 * y1;
+      long B = x2 * y2;
+      long C = (x1 + x2) * (y1 + y2);
+      long K = C - A - B;
+      return (((B >>> 32) + K) >>> 32) + A;
+    }
+  }
+
+  public static boolean productOverflows(
+    long aHigh,
+    long aLow,
+    long bHigh,
+    long bLow,
+    long z1High,
+    long z2High,
+    long z2Low,
+    long z3High,
+    long z3Low,
+    long resultHigh) {
+    boolean aInLongRange = Int128Math.inLongRange(aHigh, aLow);
+    boolean bInLongRange = Int128Math.inLongRange(bHigh, bLow);
+
+    if (aInLongRange && bInLongRange) {
+      return false;
     }
 
-    /**
-     * Returns as a {@code long} the most significant 64 bits of the 128-bit
-     * product of two 64-bit factors.
-     *
-     * @param x the first value
-     * @param y the second value
-     * @return the result
-     * @since 9
-     */
-    public static long multiplyHigh(long x, long y) {
-        if (x < 0 || y < 0) {
-            // Use technique from section 8-2 of Henry S. Warren, Jr.,
-            // Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 173-174.
-            long x1 = x >> 32;
-            long x2 = x & 0xFFFFFFFFL;
-            long y1 = y >> 32;
-            long y2 = y & 0xFFFFFFFFL;
-            long z2 = x2 * y2;
-            long t = x1 * y2 + (z2 >>> 32);
-            long z1 = t & 0xFFFFFFFFL;
-            long z0 = t >> 32;
-            z1 += x2 * y1;
-            return x1 * y1 + z0 + (z1 >> 32);
-        } else {
-            // Use Karatsuba technique with two base 2^32 digits.
-            long x1 = x >>> 32;
-            long y1 = y >>> 32;
-            long x2 = x & 0xFFFFFFFFL;
-            long y2 = y & 0xFFFFFFFFL;
-            long A = x1 * y1;
-            long B = x2 * y2;
-            long C = (x1 + x2) * (y1 + y2);
-            long K = C - A - B;
-            return (((B >>> 32) + K) >>> 32) + A;
-        }
+    if (!aInLongRange && !bInLongRange) {
+      return aHigh == bHigh && resultHigh <= 0 ||
+        aHigh != bHigh && resultHigh >= 0 ||
+        aHigh != 0 && aHigh != -1 ||
+        bHigh != 0 && bHigh != -1;
     }
+
+    // If a fits in a long, z3High is effectively "0", so we only care about z2 for
+    // checking whether z2 + z3 + z1High overflows.
+    // Similarly, if b fits in a long, we only care about z3.
+    long wHigh;
+    long wLow;
+    if (!aInLongRange) {
+      // correct z3 due to effects of computing the product of values in 2's complement representation
+      wHigh = z3High - ifNegative(aHigh, bLow) - ifNegative(bLow, aHigh + unsignedBorrow(z3Low, aLow));
+      wLow = z3Low - ifNegative(bLow, aLow);
+    } else { // !bInLongRange
+      // correct z2 due to effects of computing the product of values in 2's complement representation
+      wHigh = z2High - ifNegative(bHigh, aLow) - ifNegative(aLow, bHigh + unsignedBorrow(z2Low, bLow));
+      wLow = z2Low - ifNegative(aLow, bLow);
+    }
+
+    // t = w + z1High
+    long tLow = wLow + z1High;
+    long tHigh = wHigh + unsignedCarry(wLow, z1High);
+
+    return !Int128Math.inLongRange(tHigh, tLow);
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import scala.util.Try
+
+import org.apache.spark.annotation.Unstable
+
+@Unstable
+final class Decimal128 extends Ordered[Decimal128] with Serializable {
+  import org.apache.spark.sql.types.Decimal128._
+
+  private var _scale: Int = 0
+  private var int128: Int128 = null
+
+  def scale: Int = _scale
+  def high: Long = int128.high
+  def low: Long = int128.low
+
+  def set(intVal: Int): Decimal128 = {
+    set(Int128(0, intVal.toLong), 0)
+  }
+
+  def set(str: String): Decimal128 = {
+    set(Int128(str), 0)
+  }
+
+  def set(high: Long, low: Long, scale: Int): Decimal128 = {
+    assert(scale >= 0)
+    this.int128 = Int128(high, low)
+    this._scale = scale
+    this
+  }
+
+  def set(int128: Int128, scale: Int): Decimal128 = {
+    assert(scale >= 0)
+    this.int128 = int128
+    this._scale = scale
+    this
+  }
+
+  def isPositive(): Boolean = int128.isPositive()
+
+  def isNegative(): Boolean = int128.isNegative()
+
+  def isZero(): Boolean = int128.isZero()
+
+  def toDouble: Double = int128.toDouble
+
+  def toFloat: Float = int128.toFloat
+
+  def toLong(): Long = int128.toLong()
+
+  def toInt: Int = int128.toInt
+
+  def + (that: Decimal128): Decimal128 = {
+    if (this._scale == that._scale) {
+      Decimal128(this.int128 + that.int128, this._scale)
+    } else if (this._scale > that._scale) {
+      val upScaleN = checkScale(that.int128, this._scale - that._scale)
+      Decimal128(this.int128 + that.int128.scaleUpTen(upScaleN), this._scale)
+    } else {
+      val upScaleN = checkScale(this.int128, that._scale - this._scale)
+      Decimal128(this.int128.scaleUpTen(upScaleN) + that.int128, that._scale)
+    }
+  }
+
+  def - (that: Decimal128): Decimal128 = {
+    if (this._scale == that._scale) {
+      Decimal128(this.int128 - that.int128, this._scale)
+    } else if (this._scale > that._scale) {
+      val upScaleN = checkScale(that.int128, this._scale - that._scale)
+      Decimal128(this.int128 - that.int128.scaleUpTen(upScaleN), this._scale)
+    } else {
+      val upScaleN = checkScale(this.int128, that._scale - this._scale)
+      Decimal128(this.int128.scaleUpTen(upScaleN) - that.int128, that._scale)
+    }
+  }
+
+  def * (that: Decimal128): Decimal128 = {
+    val productScale = this._scale + that._scale
+    val upScaleN1 = checkScale(this.int128, that._scale)
+    val upScaleN2 = checkScale(that.int128, this._scale)
+    Decimal128(this.int128.scaleUpTen(upScaleN1) * that.int128.scaleUpTen(upScaleN2), productScale)
+  }
+
+  def / (that: Decimal128): Decimal128 = {
+    Decimal128(this.int128.scaleUpTen(that._scale) / that.int128.scaleUpTen(this._scale),
+      this._scale + that._scale)
+  }
+
+  def quot (that: Decimal128): Decimal128 = this / that
+
+  def unary_- : Decimal128 = {
+    Decimal128(this.int128.unary_-, this._scale)
+  }
+
+  override def compare(other: Decimal128): Int = {
+    if (this == other) {
+      return 0
+    }
+
+    if (this._scale == other._scale) {
+      this.int128.compare(other.int128)
+    } else if (this._scale > other._scale) {
+      val upScaleN = this._scale - other._scale
+      this.int128.compare(other.int128.scaleUpTen(upScaleN))
+    } else {
+      val upScaleN = other._scale - this._scale
+      this.int128.scaleUpTen(upScaleN).compare(other.int128)
+    }
+  }
+}
+
+@Unstable
+object Decimal128 {
+
+  def apply(high: Long, low: Long, scale: Int): Decimal128 = new Decimal128().set(high, low, scale)
+
+  def apply(int128: Int128, scale: Int): Decimal128 = new Decimal128().set(int128, scale)
+
+  def apply(value: String): Decimal128 = new Decimal128().set(value)
+
+  def checkScale(int128: Int128, scale: Long): Int = {
+    var asInt = scale.toInt
+    if (asInt != scale) {
+      asInt = if (scale > Integer.MAX_VALUE) {
+        Integer.MAX_VALUE
+      } else {
+        Integer.MIN_VALUE
+      }
+      if (!int128.isZero()) {
+        val msg = if (asInt > 0) {
+          "Underflow"
+        } else {
+          "Overflow"
+        }
+        throw new ArithmeticException(msg)
+      }
+    }
+    asInt
+  }
+
+  /** Common methods for Decimal128 evidence parameters */
+  private[sql] trait Decimal128IsConflicted extends Numeric[Decimal128] {
+    override def plus(x: Decimal128, y: Decimal128): Decimal128 = x + y
+    override def times(x: Decimal128, y: Decimal128): Decimal128 = x * y
+    override def minus(x: Decimal128, y: Decimal128): Decimal128 = x - y
+    override def negate(x: Decimal128): Decimal128 = -x
+    override def toDouble(x: Decimal128): Double = x.toDouble
+    override def toFloat(x: Decimal128): Float = x.toFloat
+    override def toInt(x: Decimal128): Int = x.toInt
+    override def toLong(x: Decimal128): Long = x.toLong
+    override def fromInt(x: Int): Decimal128 = new Decimal128().set(x)
+    override def compare(x: Decimal128, y: Decimal128): Int = x.compare(y)
+    // Added from Scala 2.13; don't override to work in 2.12
+    // TODO revisit once Scala 2.12 support is dropped
+    def parseString(str: String): Option[Decimal128] = Try(Decimal128(str)).toOption
+  }
+
+  /** A [[scala.math.Fractional]] evidence parameter for Decimal128s. */
+  private[sql] object Decimal128IsFractional
+    extends Decimal128IsConflicted with Fractional[Decimal128] {
+    override def div(x: Decimal128, y: Decimal128): Decimal128 = x / y
+  }
+
+  /** A [[scala.math.Integral]] evidence parameter for Decimals. */
+  private[sql] object Decimal128AsIfIntegral
+    extends Decimal128IsConflicted with Integral[Decimal128] {
+    override def quot(x: Decimal128, y: Decimal128): Decimal128 = x quot y
+    override def rem(x: Decimal128, y: Decimal128): Decimal128 = x % y
+  }
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Type.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Type.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.spark.sql.types
+
+import scala.reflect.runtime.universe.typeTag
+
+import org.apache.spark.annotation.Stable
+
+case class Decimal128Type(scale: Int) extends FractionalType {
+
+  DecimalType.checkNegativeScale(scale)
+
+  private[sql] type InternalType = Decimal128
+  @transient private[sql] lazy val tag = typeTag[InternalType]
+  private[sql] val numeric = Decimal128.Decimal128IsFractional
+  private[sql] val fractional = Decimal128.Decimal128IsFractional
+  private[sql] val ordering = Decimal128.Decimal128IsFractional
+  private[sql] val asIntegral = Decimal128.Decimal128AsIfIntegral
+
+  /**
+   * The default size of a value of the Decimal128Type, used internally for size estimation.
+   */
+  override def defaultSize: Int = 16
+
+  override def simpleString: String = s"decimal128($scale)"
+
+  override private[spark] def asNullable: Decimal128Type = this
+}
+
+@Stable
+object Decimal128Type extends AbstractDataType {
+
+  val DEFAULT_SCALE = 18
+  val SYSTEM_DEFAULT: Decimal128Type = Decimal128Type(DEFAULT_SCALE)
+  val USER_DEFAULT: Decimal128Type = Decimal128Type(0)
+
+  override private[sql] def defaultConcreteType = SYSTEM_DEFAULT
+
+  override private[sql] def acceptsType(other: DataType): Boolean = {
+    other.isInstanceOf[Decimal128Type]
+  }
+
+  override private[sql] def simpleString: String = "decimal128"
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import java.lang.{Long => JLong}
+
+import org.apache.spark.annotation.Unstable
+import org.apache.spark.sql.util.{Int128Holder, Int128Math}
+
+/**
+ * A mutable implementation of Int128 that hold two Long values to represent the high and low bits
+ * of 128 bits respectively.
+ *
+ * The semantics of the fields are as follows:
+ * - _high and _low represent the high and low bits of 128 bits respectively
+ */
+@Unstable
+final class Int128 extends Ordered[Int128] with Serializable {
+  import org.apache.spark.sql.types.Int128._
+
+  private var _high: Long = 0L
+  private var _low: Long = 0L
+
+  def high: Long = _high
+  def low: Long = _low
+
+  def set(high: Long, low: Long): Int128 = {
+    _high = high
+    _low = low
+    this
+  }
+
+  def isZero(): Boolean = (_high | _low) == 0
+
+  def toDouble: Double = toLong.doubleValue
+
+  def toFloat: Float = toLong.floatValue
+
+  def toLong(): Long = low
+
+  def toInt: Int = toLong.toInt
+
+  def + (that: Int128): Int128 = {
+    val newHigh = Int128Math.addHigh(_high, _low, that.high, that.low)
+    val newLow = Int128Math.addLow(_low, that.low)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def - (that: Int128): Int128 = {
+    val newHigh = Int128Math.subtractHigh(_high, _low, that.high, that.low)
+    val newLow = Int128Math.subtractLow(_low, that.low)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def * (that: Int128): Int128 = {
+    val newHigh = Int128Math.multiplyHigh(_high, _low, that.high, that.low)
+    val newLow = Int128Math.multiplyLow(_low, that.low)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def / (that: Int128): Int128 = if (that.isZero) {
+    null
+  } else {
+    val quotient = new Int128Holder()
+    val remainder = new Int128Holder()
+    divide(this, that, quotient, remainder)
+
+    quotient.get()
+  }
+
+  def % (that: Int128): Int128 = if (that.isZero) {
+    null
+  } else {
+    val quotient = new Int128Holder()
+    val remainder = new Int128Holder()
+    divide(this, that, quotient, remainder)
+
+    remainder.get()
+  }
+
+  def unary_- : Int128 = {
+    val newHigh = Int128Math.negateHigh(this.high, this.low)
+    val newLow = Int128Math.negateLow(this.low)
+    new Int128().set(newHigh, newLow)
+  }
+
+  override def compare(other: Int128): Int = {
+    val result = _high.compare(other._high)
+    if (result == 0) {
+      return JLong.compareUnsigned(low, other._low)
+    }
+    result
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case d: Int128 =>
+      compare(d) == 0
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = _high.hashCode ^ _low.hashCode
+}
+
+@Unstable
+object Int128 {
+  def apply(high: Long, low: Long): Int128 = new Int128().set(high, low)
+
+  val ZERO = Int128(0, 0)
+  val ONE = Int128(0, 1)
+
+  def divide(
+      dividend: Int128, divisor: Int128, quotient: Int128Holder, remainder: Int128Holder): Unit = {
+    Int128Math.divide(dividend.high, dividend.low, divisor.high, divisor.low, quotient, remainder)
+  }
+
+  /** Common methods for Int128 evidence parameters */
+  private[sql] trait Int128IsConflicted extends Numeric[Int128] {
+    override def plus(x: Int128, y: Int128): Int128 = x + y
+    override def times(x: Int128, y: Int128): Int128 = x * y
+    override def minus(x: Int128, y: Int128): Int128 = x - y
+    override def negate(x: Int128): Int128 = -x
+    override def toDouble(x: Int128): Double = x.toDouble
+    override def toFloat(x: Int128): Float = x.toFloat
+    override def toInt(x: Int128): Int = x.toInt
+    override def toLong(x: Int128): Long = x.toLong
+    override def fromInt(x: Int): Int128 = new Int128().set(0, x)
+    override def compare(x: Int128, y: Int128): Int = x.compare(y)
+  }
+
+  /** A [[scala.math.Integral]] evidence parameter for Int128s. */
+  private[sql] object Int128IsIntegral extends Int128IsConflicted with Integral[Int128] {
+    override def quot(x: Int128, y: Int128): Int128 = x / y
+    override def rem(x: Int128, y: Int128): Int128 = x % y
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
@@ -125,6 +125,8 @@ final class Int128 extends Ordered[Int128] with Serializable {
     remainder.get()
   }
 
+  def quot (that: Int128): Int128 = this / that
+
   def unary_- : Int128 = {
     val newHigh = Int128Math.negateHigh(this.high, this.low)
     val newLow = Int128Math.negateLow(this.low)
@@ -184,7 +186,7 @@ object Int128 {
 
   /** A [[scala.math.Integral]] evidence parameter for Int128s. */
   private[sql] object Int128IsIntegral extends Int128IsConflicted with Integral[Int128] {
-    override def quot(x: Int128, y: Int128): Int128 = x / y
+    override def quot(x: Int128, y: Int128): Int128 = x quot y
     override def rem(x: Int128, y: Int128): Int128 = x % y
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128Type.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128Type.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import scala.math.Ordering
+import scala.reflect.runtime.universe.typeTag
+
+import org.apache.spark.annotation.Unstable
+
+/**
+ * The data type representing `Int128` values. Please use the singleton `DataTypes.Int128Type`.
+ *
+ * @since 3.4.0
+ */
+@Unstable
+class Int128Type private() extends IntegralType {
+  private[sql] type InternalType = Int128
+  @transient private[sql] lazy val tag = typeTag[InternalType]
+  private[sql] val numeric = Int128.Int128IsIntegral
+  private[sql] val integral = Int128.Int128IsIntegral
+  private[sql] val ordering = implicitly[Ordering[InternalType]]
+
+  /**
+   * The default size of a value of the Int128Type is 16 bytes.
+   */
+  override def defaultSize: Int = 16
+
+  override def simpleString: String = "int128"
+
+  private[spark] override def asNullable: Int128Type = this
+}
+
+@Unstable
+case object Int128Type extends Int128Type

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -316,6 +316,7 @@ class DataTypeSuite extends SparkFunSuite {
   checkDefaultSize(ShortType, 2)
   checkDefaultSize(IntegerType, 4)
   checkDefaultSize(LongType, 8)
+  checkDefaultSize(Int128Type, 16)
   checkDefaultSize(FloatType, 4)
   checkDefaultSize(DoubleType, 8)
   checkDefaultSize(DecimalType(10, 5), 8)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -321,6 +321,8 @@ class DataTypeSuite extends SparkFunSuite {
   checkDefaultSize(DoubleType, 8)
   checkDefaultSize(DecimalType(10, 5), 8)
   checkDefaultSize(DecimalType.SYSTEM_DEFAULT, 16)
+  checkDefaultSize(Decimal128Type.USER_DEFAULT, 16)
+  checkDefaultSize(Decimal128Type.SYSTEM_DEFAULT, 16)
   checkDefaultSize(DateType, 4)
   checkDefaultSize(TimestampType, 8)
   checkDefaultSize(TimestampNTZType, 8)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/Decimal128Suite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/Decimal128Suite.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import org.apache.spark.SparkFunSuite
+
+class Decimal128Suite extends SparkFunSuite {
+
+  /** Check that a Decimal128 has the given string representation and scale */
+  private def checkDecimal128(d: Decimal128, string: String, scale: Int): Unit = {
+    assert(d.toString === string)
+    assert(d.scale === scale)
+  }
+
+  test("creating decimals") {
+    checkDecimal128(new Decimal128(), "0", 0)
+    checkDecimal128(Decimal128(BigDecimal("0.09")), "0.09", 2)
+    checkDecimal128(Decimal128(BigDecimal("0.9")), "0.9", 1)
+    checkDecimal128(Decimal128(BigDecimal("0.90")), "0.90", 2)
+    checkDecimal128(Decimal128(BigDecimal("0.0")), "0.0", 1)
+    checkDecimal128(Decimal128(BigDecimal("0")), "0", 0)
+    checkDecimal128(Decimal128(BigDecimal("1.0")), "1.0", 1)
+    checkDecimal128(Decimal128(BigDecimal("-0.09")), "-0.09", 2)
+    checkDecimal128(Decimal128(BigDecimal("-0.9")), "-0.9", 1)
+    checkDecimal128(Decimal128(BigDecimal("-0.90")), "-0.90", 2)
+    checkDecimal128(Decimal128(BigDecimal("-1.0")), "-1.0", 1)
+    checkDecimal128(Decimal128(BigDecimal("10.030")), "10.030", 3)
+    checkDecimal128(Decimal128(BigDecimal("10.030"), 1), "10.0", 1)
+    checkDecimal128(Decimal128(BigDecimal("-9.95"), 1), "-10.0", 1)
+    checkDecimal128(Decimal128("10.030"), "10.030", 3)
+    checkDecimal128(Decimal128(10.03), "10.03", 2)
+    checkDecimal128(Decimal128(17L), "17", 0)
+    checkDecimal128(Decimal128(17), "17", 0)
+    checkDecimal128(Decimal128(17L, 2, 1), "31359464925306237747.4", 1)
+    checkDecimal128(
+      Decimal128(BigDecimal("31359464925306237747.4"), 1), "31359464925306237747.4", 1)
+    checkDecimal128(Decimal128(170L, 4, 2), "31359464925306237747.24", 2)
+    checkDecimal128(Decimal128(17L, 24, 1), "31359464925306237749.6", 1)
+    checkDecimal128(Decimal128(1e17.toLong, 18, 0), "1844674407370955161600000000000000018", 0)
+    checkDecimal128(Decimal128(1000000000L, 20, 2), "184467440737095516160000000.20", 2)
+    checkDecimal128(Decimal128(Long.MaxValue), Long.MaxValue.toString, 0)
+    checkDecimal128(Decimal128(Long.MinValue), Long.MinValue.toString, 0)
+
+    val reallyBig = BigDecimal("123182312312313232112312312123.1231231231")
+    val e = intercept[ArithmeticException](Decimal128(reallyBig))
+    assert(e.getMessage.contains("BigInteger out of Int128 range"))
+  }
+
+  test("hash code") {
+    assert(Decimal128(123).hashCode() === (-460565894).##)
+    assert(Decimal128(-123).hashCode() === (1655510596).##)
+    assert(Decimal128(Int.MaxValue).hashCode() === (-217723243).##)
+    assert(Decimal128(Long.MaxValue).hashCode() === (-237151917).##)
+    assert(Decimal128(BigDecimal(123)).hashCode() === (-460565894).##)
+  }
+
+  test("equals") {
+    assert(Decimal128(123) === Decimal128(BigDecimal(123)))
+    assert(Decimal128(123) === Decimal128(BigDecimal("123.00")))
+    assert(Decimal128(-123) === Decimal128(BigDecimal(-123)))
+    assert(Decimal128(-123) === Decimal128(BigDecimal("-123.00")))
+    assert(Decimal128(123, 1) === Decimal128(BigDecimal("12.3")))
+    assert(Decimal128(-123, 2) === Decimal128(BigDecimal("-1.23")))
+    assert(Decimal128(17L, 2, 1) === Decimal128(BigDecimal("31359464925306237747.4")))
+    assert(Decimal128(17L, 2, 1) === Decimal128(BigDecimal("31359464925306237747.4"), 1))
+  }
+
+  test("isZero") {
+    assert(Decimal128(0).isZero)
+    assert(Decimal128(0, 0, 2).isZero)
+    assert(Decimal128("0").isZero)
+    assert(Decimal128("0.000").isZero)
+    assert(!Decimal128(1).isZero)
+    assert(!Decimal128(1, 4, 2).isZero)
+    assert(!Decimal128("1").isZero)
+    assert(!Decimal128("0.001").isZero)
+  }
+
+  test("arithmetic") {
+    assert(Decimal128(100) + Decimal128(-100) === Decimal128(0))
+    assert(Decimal128(100, 0) + Decimal128(-100, 0) === Decimal128(0))
+    assert(Decimal128(100, 1) + Decimal128(-100, 1) === Decimal128(0))
+    assert(Decimal128(100, 1) + Decimal128(-100, 2) === Decimal128(900, 2))
+    assert(Decimal128(100, 1) + Decimal128(-100, 2) === Decimal128("9.00"))
+    assert(Decimal128("10.0") + Decimal128("-1.00") === Decimal128(BigDecimal("9.00")))
+//    assert(Decimal(100) * Decimal(-100) === Decimal(-10000))
+//    assert(Decimal(1e13) * Decimal(1e13) === Decimal(1e26))
+//    assert(Decimal(100) / Decimal(-100) === Decimal(-1))
+//    assert(Decimal(100) / Decimal(0) === null)
+//    assert(Decimal(100) % Decimal(-100) === Decimal(0))
+//    assert(Decimal(100) % Decimal(3) === Decimal(1))
+//    assert(Decimal(-100) % Decimal(3) === Decimal(-1))
+//    assert(Decimal(100) % Decimal(0) === null)
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend Catalyst's type system by a new type: `Int128Type` represents the `Int128`.

### Why are the changes needed?
Spark SQL today supports the `Decimal` data type. The implementation of Spark `Decimal` holds a `BigDecimal` or `Long` value. Spark `Decimal` provides some operators like +, -, *, /, % and so on. These operators rely heavily on the computational power of `BigDecimal` or `Long` itself. For ease of understanding, take the + as an example. The implementation shows below.
```
  def + (that: Decimal): Decimal = {
    if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
      Decimal(longVal + that.longVal, Math.max(precision, that.precision) + 1, scale)
    } else {
      Decimal(toBigDecimal.bigDecimal.add(that.toBigDecimal.bigDecimal))
    }
  }
```
We can see the `+` of `Long` will be called if Spark `Decimal` holds a `Long` value. Otherwise, the add of `BigDecimal` will be called if Spark `Decimal` holds a `BigDecimal` value. The other operators of Spark `Decimal` adopt the similar way. Furthermore, the code shown above calls `Decimal.apply` to construct a new instance of Spark `Decimal`. As we know, the add operator of `BigDecimal` constructed a new instance of `BigDecimal`. So, if we call the + operator of Spark `Decimal` who holds a `Long` value, Spark will construct a new instance of `Decimal`. Otherwise, Spark will construct a new instance of `BigDecimal` and a new instance of `Decimal`.
Through rough analysis, we know:
1. The computational power of Spark `Decimal` may depend on `BigDecimal`.
2. The calculation operators of Spark `Decimal` create a lot of new instances of `Decimal` and may create a lot of new instances of `BigDecimal`.
If a large table has a field called `'colA` whose type is Spark `Decimal`, the execution of `SUM('colA)` will involve the creation of a large number of Spark `Decimal` instances and `BigDecimal` instances. These Spark `Decimal` instances and `BigDecimal` instances will lead to garbage collection frequently.

In this new feature, we will introduce Int128 type.
`Int128` is a high-performance data type about 2X~10X more efficient than Spark `Decimal` for typical operations. It uses a finite (128 bit) precision and can handle up to decimal(38, X). The implementation of `Int128` just uses two `Long` values to represent the high and low bits of 128 bits respectively. `Int128` is lighter than Spark `Decimal`, reduces the cost of `new()` and garbage collection.

This is a starting PR. See more details in https://issues.apache.org/jira/browse/SPARK-40097


### Does this PR introduce _any_ user-facing change?
No, a new data type for `Int128`. It is still in development.


### How was this patch tested?
New test cases.
