### PR TITLE
[SPARK-40107][SQL] Pull out empty2null conversion from FileFormatWriter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -54,7 +54,8 @@ object V1Writes extends Rule[LogicalPlan] with SQLConfHelper {
           val newQuery = prepareQuery(write, write.query)
           val attrMap = AttributeMap(write.query.output.zip(newQuery.output))
           val newWrite = write.withNewChildren(newQuery :: Nil).transformExpressions {
-            case a: Attribute => attrMap.getOrElse(a, a)
+            case a: Attribute if attrMap.contains(a) =>
+              a.withExprId(attrMap(a).exprId)
           }
           newWrite
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/V1Writes.scala
@@ -19,16 +19,27 @@ package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Ascending, Attribute, AttributeSet, BitwiseAnd, HiveHash, Literal, Pmod, SortOrder}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Sort}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, Attribute, AttributeMap, AttributeSet, BitwiseAnd, Expression, HiveHash, Literal, NamedExpression, Pmod, SortOrder, String2StringExpression, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Sort}
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.DataWritingCommand
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
 
 trait V1WriteCommand extends DataWritingCommand {
-  // Specify the required ordering for the V1 write command. `FileFormatWriter` will
-  // add SortExec if necessary when the requiredOrdering is empty.
+
+  /**
+   * Specify the partition columns of the V1 write command.
+   */
+  def partitionColumns: Seq[Attribute]
+
+  /**
+   * Specify the required ordering for the V1 write command. `FileFormatWriter` will
+   * add SortExec if necessary when the requiredOrdering is empty.
+   */
   def requiredOrdering: Seq[SortOrder]
 }
 
@@ -41,7 +52,11 @@ object V1Writes extends Rule[LogicalPlan] with SQLConfHelper {
       plan.transformDown {
         case write: V1WriteCommand =>
           val newQuery = prepareQuery(write, write.query)
-          write.withNewChildren(newQuery :: Nil)
+          val attrMap = AttributeMap(write.query.output.zip(newQuery.output))
+          val newWrite = write.withNewChildren(newQuery :: Nil).transformExpressions {
+            case a: Attribute => attrMap.getOrElse(a, a)
+          }
+          newWrite
       }
     } else {
       plan
@@ -49,10 +64,21 @@ object V1Writes extends Rule[LogicalPlan] with SQLConfHelper {
   }
 
   private def prepareQuery(write: V1WriteCommand, query: LogicalPlan): LogicalPlan = {
-    val requiredOrdering = write.requiredOrdering
+    val empty2NullPlan = if (hasEmptyToNull(query)) {
+      query
+    } else {
+      val projectList = V1WritesUtils.convertEmptyToNull(query.output, write.partitionColumns)
+      if (projectList.isEmpty) query else Project(projectList, query)
+    }
+    assert(empty2NullPlan.output.length == query.output.length)
+    val attrMap = AttributeMap(query.output.zip(empty2NullPlan.output))
+
+    // Rewrite the attribute references in the required ordering to use the new output.
+    val requiredOrdering = write.requiredOrdering.map(_.transform {
+      case a: Attribute => attrMap.getOrElse(a, a)
+    }.asInstanceOf[SortOrder])
     val outputOrdering = query.outputOrdering
-    // Check if the ordering is already matched. It is needed to ensure the
-    // idempotency of the rule.
+    // Check if the ordering is already matched to ensure the idempotency of the rule.
     val orderingMatched = if (requiredOrdering.length > outputOrdering.length) {
       false
     } else {
@@ -61,14 +87,40 @@ object V1Writes extends Rule[LogicalPlan] with SQLConfHelper {
       }
     }
     if (orderingMatched) {
-      query
+      empty2NullPlan
     } else {
-      Sort(requiredOrdering, global = false, query)
+      Sort(requiredOrdering, global = false, empty2NullPlan)
     }
+  }
+
+  private def hasEmptyToNull(plan: LogicalPlan): Boolean = {
+    plan.find {
+      case p: Project => V1WritesUtils.hasEmptyToNull(p.projectList)
+      case _ => false
+    }.isDefined
   }
 }
 
 object V1WritesUtils {
+
+  /** A function that converts the empty string to null for partition values. */
+  case class Empty2Null(child: Expression) extends UnaryExpression with String2StringExpression {
+    override def convert(v: UTF8String): UTF8String = if (v.numBytes() == 0) null else v
+    override def nullable: Boolean = true
+    override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+      nullSafeCodeGen(ctx, ev, c => {
+        s"""if ($c.numBytes() == 0) {
+           |  ${ev.isNull} = true;
+           |  ${ev.value} = null;
+           |} else {
+           |  ${ev.value} = $c;
+           |}""".stripMargin
+      })
+    }
+
+    override protected def withNewChildInternal(newChild: Expression): Empty2Null =
+      copy(child = newChild)
+  }
 
   def getWriterBucketSpec(
       bucketSpec: Option[BucketSpec],
@@ -134,10 +186,26 @@ object V1WritesUtils {
     } else {
       // We should first sort by dynamic partition columns, then bucket id, and finally sorting
       // columns.
-      // Note we do not need to convert empty string partition columns to null when sorting the
-      // columns since null and empty string values will be next to each other.
       (dynamicPartitionColumns ++ writerBucketSpec.map(_.bucketIdExpression) ++ sortColumns)
         .map(SortOrder(_, Ascending))
     }
+  }
+
+  def convertEmptyToNull(
+      output: Seq[Attribute],
+      partitionColumns: Seq[Attribute]): Seq[NamedExpression] = {
+    val partitionSet = AttributeSet(partitionColumns)
+    var needConvert = false
+    val projectList: Seq[NamedExpression] = output.map {
+      case p if partitionSet.contains(p) && p.dataType == StringType && p.nullable =>
+        needConvert = true
+        Alias(Empty2Null(p), p.name)()
+      case attr => attr
+    }
+    if (needConvert) projectList else Nil
+  }
+
+  def hasEmptyToNull(expressions: Seq[Expression]): Boolean = {
+    expressions.exists(_.exists(_.isInstanceOf[Empty2Null]))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/V1WriteCommandSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.{QueryTest, Row}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, Sort}
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
@@ -51,9 +51,14 @@ abstract class V1WriteCommandSuiteBase extends QueryTest with SQLTestUtils {
     }
   }
 
-  // Execute a write query and check ordering of the plan.
+  /**
+   * Execute a write query and check ordering of the plan. Return the optimized logical write
+   * query plan.
+   */
   protected def executeAndCheckOrdering(
-      hasLogicalSort: Boolean, orderingMatched: Boolean)(query: => Unit): Unit = {
+      hasLogicalSort: Boolean,
+      orderingMatched: Boolean,
+      hasEmpty2Null: Boolean = false)(query: => Unit): Unit = {
     var optimizedPlan: LogicalPlan = null
 
     val listener = new QueryExecutionListener {
@@ -80,6 +85,14 @@ abstract class V1WriteCommandSuiteBase extends QueryTest with SQLTestUtils {
     if (optimizedPlan != null) {
       assert(optimizedPlan.isInstanceOf[Sort] == hasLogicalSort,
         s"Expect hasLogicalSort: $hasLogicalSort, Actual: ${optimizedPlan.isInstanceOf[Sort]}")
+
+      // Check empty2null conversion.
+      val projection = optimizedPlan.collectFirst {
+        case p: Project
+          if p.projectList.exists(_.exists(_.isInstanceOf[V1WritesUtils.Empty2Null])) => p
+      }
+      assert(projection.isDefined == hasEmpty2Null,
+        s"Expect hasEmpty2Null: $hasEmpty2Null, Actual: ${projection.isDefined}")
     }
 
     spark.listenerManager.unregister(listener)
@@ -113,7 +126,8 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
   test("v1 write with string partition columns") {
     withPlannedWrite { enabled =>
       withTable("t") {
-        executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+        executeAndCheckOrdering(
+          hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
           sql("CREATE TABLE t USING PARQUET PARTITIONED BY (k) AS SELECT * FROM t0")
         }
       }
@@ -129,7 +143,8 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
             |PARTITIONED BY (k STRING)
             |CLUSTERED BY (i, j) SORTED BY (j) INTO 2 BUCKETS
             |""".stripMargin)
-        executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+        executeAndCheckOrdering(
+          hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
           sql("INSERT INTO t SELECT * FROM t0")
         }
       }
@@ -164,7 +179,8 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
             |CREATE TABLE t(i INT, j INT) USING PARQUET
             |PARTITIONED BY (k STRING)
             |""".stripMargin)
-        executeAndCheckOrdering(hasLogicalSort = true, orderingMatched = enabled) {
+        executeAndCheckOrdering(
+          hasLogicalSort = true, orderingMatched = enabled, hasEmpty2Null = enabled) {
           sql("INSERT INTO t SELECT * FROM t0 ORDER BY k")
         }
       }
@@ -174,7 +190,8 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
   test("v1 write with null and empty string column values") {
     withPlannedWrite { enabled =>
       withTempPath { path =>
-        executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+        executeAndCheckOrdering(
+          hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
           Seq((0, None), (1, Some("")), (2, None), (3, Some("x")))
             .toDF("id", "p")
             .write
@@ -239,7 +256,8 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
         }
 
         // one static partition column and one dynamic partition column
-        executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+        executeAndCheckOrdering(
+          hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
           sql(
             """
               |INSERT INTO t PARTITION(p1=1, p2)
@@ -248,7 +266,8 @@ class V1WriteCommandSuite extends V1WriteCommandSuiteBase with SharedSparkSessio
         }
 
         // partition columns are dynamic
-        executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+        executeAndCheckOrdering(
+          hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
           sql(
             """
               |INSERT INTO t PARTITION(p1, p2)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -24,7 +24,7 @@ import org.apache.hadoop.hive.ql.plan.TableDesc
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.catalog._
-import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.expressions.{Attribute, SortOrder}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -76,8 +76,11 @@ case class InsertIntoHiveTable(
     outputColumnNames: Seq[String]
   ) extends SaveAsHiveFile with V1WriteCommand with V1WritesHiveUtils {
 
+  override lazy val partitionColumns: Seq[Attribute] = {
+    getDynamicPartitionColumns(table, partition, query)
+  }
+
   override def requiredOrdering: Seq[SortOrder] = {
-    val partitionColumns = getDynamicPartitionColumns(table, partition, query)
     val options = getOptionsWithHiveBucketWrite(table.bucketSpec)
     V1WritesUtils.getSortOrder(outputColumns, partitionColumns, table.bucketSpec, options)
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/V1WriteHiveCommandSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/command/V1WriteHiveCommandSuite.scala
@@ -36,7 +36,8 @@ class V1WriteHiveCommandSuite extends V1WriteCommandSuiteBase with TestHiveSingl
     withPlannedWrite { enabled =>
       withTable("t") {
         withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
-          executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+          executeAndCheckOrdering(
+            hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
             sql(
               """
                 |CREATE TABLE t
@@ -59,7 +60,8 @@ class V1WriteHiveCommandSuite extends V1WriteCommandSuiteBase with TestHiveSingl
             |CLUSTERED BY (i, j) SORTED BY (j) INTO 2 BUCKETS
             |""".stripMargin)
         withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
-          executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+          executeAndCheckOrdering(
+            hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
             sql("INSERT INTO t SELECT * FROM t0")
           }
         }
@@ -77,7 +79,8 @@ class V1WriteHiveCommandSuite extends V1WriteCommandSuiteBase with TestHiveSingl
             |PARTITIONED BY (k)
             |AS SELECT * FROM t0
             |""".stripMargin)
-          executeAndCheckOrdering(hasLogicalSort = enabled, orderingMatched = enabled) {
+          executeAndCheckOrdering(
+            hasLogicalSort = enabled, orderingMatched = enabled, hasEmpty2Null = enabled) {
             sql("INSERT OVERWRITE t SELECT j AS i, i AS j, k FROM t0")
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR is a follow-up for SPARK-37287. It pulls out the physical project that is used to convert empty string partition columns to null in `FileFormatWriter` into the logical planning rule `V1Writes`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To improve the observability of V1 write commands.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.