### PR TITLE
[SPARK-40116][R][INFRA] Remove Arrow in AppVeyor for now

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,10 @@ install:
   # Install SBT and dependencies
   - ps: .\dev\appveyor-install-dependencies.ps1
   # Required package for R unit tests. xml2 is required to use jUnit reporter in testthat.
-  - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"
+  - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'xml2'), repos='https://cloud.r-project.org/')"
+  # TODO(SPARK-40114): support Arrow 9.0.0
+  - cmd: Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+  - cmd: Rscript -e "devtools::install_version('arrow', version='8.0.0', repos='https://cloud.r-project.org')"
   - cmd: Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,10 +42,8 @@ install:
   # Install SBT and dependencies
   - ps: .\dev\appveyor-install-dependencies.ps1
   # Required package for R unit tests. xml2 is required to use jUnit reporter in testthat.
+  # TODO(SPARK-40114): Add 'arrow' back with supporting Arrow 9.0.0
   - cmd: Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'xml2'), repos='https://cloud.r-project.org/')"
-  # TODO(SPARK-40114): support Arrow 9.0.0
-  - cmd: Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
-  - cmd: Rscript -e "devtools::install_version('arrow', version='8.0.0', repos='https://cloud.r-project.org')"
   - cmd: Rscript -e "pkg_list <- as.data.frame(installed.packages()[,c(1, 3:4)]); pkg_list[is.na(pkg_list$Priority), 1:2, drop = FALSE]"
 
 build_script:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remoove the Arrow in AppVeyor for now to recover the build.

### Why are the changes needed?

SparkR does not support Arrow 9.0.0 ([SPARK-40114](https://issues.apache.org/jira/browse/SPARK-40114)) so the tests fail (https://ci.appveyor.com/project/HyukjinKwon/spark/builds/44490387)

Should recover the tests first because it looks it's going to take a while to add the Arrow 9.0.0 support.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should test it out.