### PR TITLE
[SPARK-40103][R][FEATURE] Support read/write.csv() in SparkR

### DIFF
--- a/R/pkg/NAMESPACE
+++ b/R/pkg/NAMESPACE
@@ -194,6 +194,7 @@ exportMethods("arrange",
               "write.parquet",
               "write.stream",
               "write.text",
+              "write.spark.csv",
               "write.ml")
 
 exportClasses("Column")
@@ -496,6 +497,7 @@ export("as.DataFrame",
        "read.parquet",
        "read.stream",
        "read.text",
+       "read.spark.csv",
        "recoverPartitions",
        "refreshByPath",
        "refreshTable",

--- a/R/pkg/R/DataFrame.R
+++ b/R/pkg/R/DataFrame.R
@@ -1016,6 +1016,40 @@ setMethod("write.text",
             invisible(handledCallJMethod(write, "text", path))
           })
 
+#' Save the content of SparkDataFrame in a csv file at the specified path.
+#'
+#' Files written out with this method can be read back in as a SparkDataFrame
+#' using read.spark.csv().
+#'
+#' @param x A SparkDataFrame
+#' @param path The directory where the file is saved
+#' @param mode one of 'append', 'overwrite', 'error', 'errorifexists', 'ignore'
+#'             save mode (it is 'error' by default)
+#' @param ... additional argument(s) passed to the method.
+#'            You can find the csv-specific options for writing csv files in
+# nolint start
+#'            \url{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{Data Source Option} in the version you use.
+# nolint end
+#' @family SparkDataFrame functions
+#' @aliases write.spark.csv,SparkDataFrame,character-method
+#' @rdname write.spark.csv
+#' @name write.spark.csv
+#' @examples
+#'\dontrun{
+#' sparkR.session()
+#' path <- "path/to/file.csv"
+#' df <- read.spark.csv(path)
+#' write.spark.csv(df, "/tmp/sparkr-tmp/")
+#'}
+#' @note write.spark.csv since 3.3.0
+setMethod("write.spark.csv",
+          signature(x = "SparkDataFrame", path = "character"),
+          function(x, path, mode = "error", ...) {
+            write <- callJMethod(x@sdf, "write")
+            write <- setWriteOptions(write, mode = mode, ...)
+            invisible(handledCallJMethod(write, "csv", path))
+          })
+
 #' Distinct
 #'
 #' Return a new SparkDataFrame containing the distinct rows in this SparkDataFrame.

--- a/R/pkg/R/SQLContext.R
+++ b/R/pkg/R/SQLContext.R
@@ -492,6 +492,37 @@ read.text <- function(path, ...) {
   dataFrame(sdf)
 }
 
+#' Create a SparkDataFrame from a csv file.
+#'
+#' Loads a Parquet file, returning the result as a SparkDataFrame.
+#'
+#' @param path Path of file to read. A vector of multiple paths is allowed.
+#' @param ... additional external data source specific named properties.
+#'            You can find the csv-specific options for reading csv files in
+# nolint start
+#'            \url{https://spark.apache.org/docs/latest/sql-data-sources-csv.html#data-source-option}{Data Source Option} in the version you use.
+# nolint end
+#' @return SparkDataFrame
+#' @rdname read.spark.csv
+#' @examples
+#'\dontrun{
+#' sparkR.session()
+#' path <- "path/to/file.csv"
+#' df <- read.spark.csv(path)
+#' }
+#' @name read.spark.csv
+#' @note read.spark.csv since 3.3.0
+read.spark.csv <- function(path, ...) {
+  sparkSession <- getSparkSession()
+  options <- varargsToStrEnv(...)
+  # Allow the user to have a more flexible definition of the text file path
+  paths <- as.list(suppressWarnings(normalizePath(path)))
+  read <- callJMethod(sparkSession, "read")
+  read <- callJMethod(read, "options", options)
+  sdf <- handledCallJMethod(read, "csv", paths)
+  dataFrame(sdf)
+}
+
 #' SQL Query
 #'
 #' Executes a SQL query using Spark, returning the result as a SparkDataFrame.

--- a/R/pkg/R/generics.R
+++ b/R/pkg/R/generics.R
@@ -603,6 +603,9 @@ setGeneric("write.stream", function(df, source = NULL, outputMode = NULL, ...) {
 #' @rdname write.text
 setGeneric("write.text", function(x, path, ...) { standardGeneric("write.text") })
 
+#' @rdname write.spark.csv
+setGeneric("write.spark.csv", function(x, path, ...) { standardGeneric("write.spark.csv") })
+
 #' @rdname schema
 setGeneric("schema", function(x) { standardGeneric("schema") })
 

--- a/R/pkg/pkgdown/_pkgdown_template.yml
+++ b/R/pkg/pkgdown/_pkgdown_template.yml
@@ -128,12 +128,14 @@ reference:
   - read.orc
   - read.parquet
   - read.text
+  - read.spark.csv
   - write.df
   - write.jdbc
   - write.json
   - write.orc
   - write.parquet
   - write.text
+  - write.spark.csv
 
 - title: "Column functions"
 - contents:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support read csv file in SparkR.

### Why are the changes needed?
Today, almost languages spark supports have the DataFrameReader.csv() API but R. R users usually use read.df() to read the csv file. So we need a more high-level api about it.

Java:
[DataFrameReader.csv()](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/DataFrameReader.html)

Scala:
[DataFrameReader.csv()](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html#csv(paths:String*):org.apache.spark.sql.DataFrame)

Python:
[DataFrameReader.csv()](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameReader.csv.html#pyspark.sql.DataFrameReader.csv)

R base library "utils" has introduced the namespace of "read.csv". So this api has changed the name from "read.csv" to "read.spark.csv" to avoid the conflict.

### Does this PR introduce _any_ user-facing change?
Yes, read.spark.csv and write.spark.csv are introduced.


### How was this patch tested?
UT  (TODO)
