### PR TITLE
[SPARK-40125][INFRA] Add separate infra image for lint job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -300,7 +300,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build and push (Infra)
+      - name: Build and push (main)
         id: docker_build
         uses: docker/build-push-action@v2
         with:
@@ -310,7 +310,7 @@ jobs:
             ${{ needs.precondition.outputs.image_url }}
           # Use the infra image cache to speed up
           cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ inputs.branch }}
-      - name: Build and push (Lint)
+      - name: Build and push (lint)
         id: lint_docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -300,16 +300,27 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build and push
+      - name: Build and push (Infra)
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          context: ./dev/infra/
+          file: ./dev/infra/Dockerfile
           push: true
           tags: |
             ${{ needs.precondition.outputs.image_url }}
           # Use the infra image cache to speed up
           cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ inputs.branch }}
+      - name: Build and push (Lint)
+        id: lint_docker_build
+        uses: docker/build-push-action@v2
+        with:
+          file: ./dev/infra/lint.Dockerfile
+          push: true
+          tags: |
+            ${{ needs.precondition.outputs.image_url }}-lint
+          build-args: BASE_IMG=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ inputs.branch }}-static
+          # Use the lint image cache to speed up
+          cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ inputs.branch }}-lint
 
   pyspark:
     needs: [precondition, infra-image]
@@ -500,7 +511,7 @@ jobs:
       PYSPARK_DRIVER_PYTHON: python3.9
       PYSPARK_PYTHON: python3.9
     container:
-      image: ${{ needs.precondition.outputs.image_url }}
+      image: ${{ needs.precondition.outputs.image_url }}-lint
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v2
@@ -543,53 +554,20 @@ jobs:
         key: docs-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           docs-maven-
-    - name: Install Python linter dependencies
-      run: |
-        # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
-        #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
-        # Jinja2 3.0.0+ causes error when building with Sphinx.
-        #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
-        python3.9 -m pip install 'pandas-stubs==1.2.0.53'
     - name: Install R linter dependencies and SparkR
       run: |
-        apt update
-        apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \
-          libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev \
-          libtiff5-dev libjpeg-dev
-        Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
-        Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')"
         ./R/install-dev.sh
-    - name: Instll JavaScript linter dependencies
-      run: |
-        apt update
-        apt-get install -y nodejs npm
     - name: Install dependencies for documentation generation
       run: |
-        # pandoc is required to generate PySpark APIs as well in nbsphinx.
-        apt-get install -y libcurl4-openssl-dev pandoc
-        # TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
-        #   See also https://github.com/sphinx-doc/sphinx/issues/7551.
-        # Jinja2 3.0.0+ causes error when building with Sphinx.
-        #   See also https://issues.apache.org/jira/browse/SPARK-35375.
-        # Pin the MarkupSafe to 2.0.1 to resolve the CI error.
-        #   See also https://issues.apache.org/jira/browse/SPARK-38279.
-        python3.9 -m pip install 'sphinx<3.1.0' mkdocs pydata_sphinx_theme ipython nbsphinx numpydoc 'jinja2<3.0.0' 'markupsafe==2.0.1'
-        python3.9 -m pip install ipython_genutils # See SPARK-38517
-        python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8' 
-        python3.9 -m pip install 'docutils<0.18.0' # See SPARK-39421
-        apt-get update -y
-        apt-get install -y ruby ruby-dev
-        Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'e1071', 'roxygen2', 'ggplot2', 'mvtnorm', 'statmod'), repos='https://cloud.r-project.org/')"
-        Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
-        Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
-        gem install bundler
         cd docs
         bundle install
     - name: Install Java 8
       uses: actions/setup-java@v1
       with:
         java-version: 8
+    - name: List Python packages (Python 3.9)
+      run: |
+        python3.9 -m pip list
     - name: Scala linter
       run: ./dev/lint-scala
     - name: Java linter

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -25,6 +25,7 @@ on:
     - 'master'
     paths:
     - 'dev/infra/Dockerfile'
+    - 'dev/infra/lint.Dockerfile'
     - '.github/workflows/build_infra_images_cache.yml'
 jobs:
   main:
@@ -52,5 +53,14 @@ jobs:
           tags: ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}-static
           cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}
           cache-to: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }},mode=max
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./dev/infra/
+          push: true
+          tags: ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}-lint-static
+          cache-from: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}-lint
+          cache-to: type=registry,ref=ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}-lint,mode=max
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/dev/infra/lint.Dockerfile
+++ b/dev/infra/lint.Dockerfile
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Use the master static imaghe by default, it will be replaced if build-args is given
+ARG BASE_IMG=ghcr.io/apache/spark/apache-spark-github-action-image-cache:master-static
+FROM $BASE_IMG
+
+## Install Python linter dependencies
+# TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
+#   See also https://github.com/sphinx-doc/sphinx/issues/7551.
+# Jinja2 3.0.0+ causes error when building with Sphinx.
+#   See also https://issues.apache.org/jira/browse/SPARK-35375.
+RUN python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.920' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
+RUN python3.9 -m pip install 'pandas-stubs==1.2.0.53'
+
+## Install R linter dependencies and SparkR
+RUN apt update
+RUN apt-get install -y libcurl4-openssl-dev libgit2-dev libssl-dev libxml2-dev \
+  libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev \
+  libtiff5-dev libjpeg-dev
+RUN Rscript -e "install.packages(c('devtools'), repos='https://cloud.r-project.org/')"
+RUN Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')"
+
+## Instll JavaScript linter dependencies
+RUN apt update
+RUN apt-get install -y nodejs npm
+
+## Install dependencies for documentation generation
+# pandoc is required to generate PySpark APIs as well in nbsphinx.
+RUN apt-get install -y libcurl4-openssl-dev pandoc
+# TODO(SPARK-32407): Sphinx 3.1+ does not correctly index nested classes.
+#   See also https://github.com/sphinx-doc/sphinx/issues/7551.
+# Jinja2 3.0.0+ causes error when building with Sphinx.
+#   See also https://issues.apache.org/jira/browse/SPARK-35375.
+# Pin the MarkupSafe to 2.0.1 to resolve the CI error.
+#   See also https://issues.apache.org/jira/browse/SPARK-38279.
+RUN python3.9 -m pip install 'sphinx<3.1.0' mkdocs pydata_sphinx_theme ipython nbsphinx numpydoc 'jinja2<3.0.0' 'markupsafe==2.0.1'
+RUN python3.9 -m pip install ipython_genutils # See SPARK-38517
+RUN python3.9 -m pip install sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8'
+RUN python3.9 -m pip install 'docutils<0.18.0' # See SPARK-39421
+RUN apt-get update -y
+RUN apt-get install -y ruby ruby-dev
+RUN Rscript -e "install.packages(c('devtools', 'testthat', 'knitr', 'rmarkdown', 'markdown', 'e1071', 'roxygen2', 'ggplot2', 'mvtnorm', 'statmod'), repos='https://cloud.r-project.org/')"
+RUN Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')"
+RUN Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
+RUN gem install bundler


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR:
- Adds `ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ inputs.branch }}-lint` for lint job, it will be used for master/branches/master shedule job.
- Adds `ghcr.io/apache/spark/apache-spark-github-action-image-cache:${{ github.ref_name }}-lint` to speed up lint image build and make lint image as static image.


### Why are the changes needed?

To aovid the issue like https://github.com/apache/spark/pull/37243#issuecomment-1191422150 , we had some initial discussion, we'd better move infra image into lint image to make lint deps static and upgrade manually. And also save about 15 mins for each lint job.

### Does this PR introduce _any_ user-facing change?
No, dev only

### How was this patch tested?
CI passed
