### PR TITLE
[SPARK-38591][SQL] Add sortWithinGroups to KeyValueGroupedDataset

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/dsl/package.scala
@@ -425,7 +425,9 @@ package object dsl {
           leftGroup: Seq[Attribute],
           rightGroup: Seq[Attribute],
           leftAttr: Seq[Attribute],
-          rightAttr: Seq[Attribute]
+          rightAttr: Seq[Attribute],
+          leftOrder: Seq[SortOrder],
+          rightOrder: Seq[SortOrder]
         ): LogicalPlan = {
         CoGroup.apply[Key, Left, Right, Result](
           func,
@@ -433,6 +435,8 @@ package object dsl {
           rightGroup,
           leftAttr,
           rightAttr,
+          leftOrder,
+          rightOrder,
           logicalPlan,
           otherPlan)
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -395,8 +395,8 @@ object MapGroups {
       UnresolvedDeserializer(encoderFor[K].deserializer, groupingAttributes),
       UnresolvedDeserializer(encoderFor[T].deserializer, dataAttributes),
       groupingAttributes,
-      None,
       dataAttributes,
+      None,
       CatalystSerde.generateObjAttr[U],
       child)
     CatalystSerde.serialize[U](mapped)
@@ -405,16 +405,16 @@ object MapGroups {
   def apply[K : Encoder, T : Encoder, U : Encoder](
     func: (K, Iterator[T]) => TraversableOnce[U],
     groupingAttributes: Seq[Attribute],
-    sortAttributes: Seq[Attribute],
     dataAttributes: Seq[Attribute],
+    dataOrder: Seq[SortOrder],
     child: LogicalPlan): LogicalPlan = {
     val mapped = new MapGroups(
       func.asInstanceOf[(Any, Iterator[Any]) => TraversableOnce[Any]],
       UnresolvedDeserializer(encoderFor[K].deserializer, groupingAttributes),
       UnresolvedDeserializer(encoderFor[T].deserializer, dataAttributes),
       groupingAttributes,
-      Some(sortAttributes),
       dataAttributes,
+      Some(dataOrder),
       CatalystSerde.generateObjAttr[U],
       child)
     CatalystSerde.serialize[U](mapped)
@@ -424,8 +424,8 @@ object MapGroups {
 /**
  * Applies func to each unique group in `child`, based on the evaluation of `groupingAttributes`.
  * Func is invoked with an object representation of the grouping key an iterator containing the
- * object representation of all the rows with that key. Given an optional `sortAttributes` data
- * in the iterator will be sorted accordingly. That sorting does not add computational complexity.
+ * object representation of all the rows with that key. Given an optional `dataOrder`, data in
+ * the iterator will be sorted accordingly. That sorting does not add computational complexity.
  *
  * @param keyDeserializer used to extract the key object for each group.
  * @param valueDeserializer used to extract the items in the iterator from an input row.
@@ -435,8 +435,8 @@ case class MapGroups(
     keyDeserializer: Expression,
     valueDeserializer: Expression,
     groupingAttributes: Seq[Attribute],
-    sortAttributes: Option[Seq[Attribute]],
     dataAttributes: Seq[Attribute],
+    dataOrder: Option[Seq[SortOrder]],
     outputObjAttr: Attribute,
     child: LogicalPlan) extends UnaryNode with ObjectProducer {
   override protected def withNewChildInternal(newChild: LogicalPlan): MapGroups =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -386,18 +386,18 @@ case class AppendColumnsWithObject(
 /** Factory for constructing new `MapGroups` nodes. */
 object MapGroups {
   def apply[K : Encoder, T : Encoder, U : Encoder](
-    func: (K, Iterator[T]) => TraversableOnce[U],
-    groupingAttributes: Seq[Attribute],
-    dataAttributes: Seq[Attribute],
-    dataOrder: Seq[SortOrder],
-    child: LogicalPlan): LogicalPlan = {
+      func: (K, Iterator[T]) => TraversableOnce[U],
+      groupingAttributes: Seq[Attribute],
+      dataAttributes: Seq[Attribute],
+      dataOrder: Seq[SortOrder],
+      child: LogicalPlan): LogicalPlan = {
     val mapped = new MapGroups(
       func.asInstanceOf[(Any, Iterator[Any]) => TraversableOnce[Any]],
       UnresolvedDeserializer(encoderFor[K].deserializer, groupingAttributes),
       UnresolvedDeserializer(encoderFor[T].deserializer, dataAttributes),
       groupingAttributes,
       dataAttributes,
-      Some(dataOrder),
+      dataOrder,
       CatalystSerde.generateObjAttr[U],
       child)
     CatalystSerde.serialize[U](mapped)
@@ -419,7 +419,7 @@ case class MapGroups(
     valueDeserializer: Expression,
     groupingAttributes: Seq[Attribute],
     dataAttributes: Seq[Attribute],
-    dataOrder: Option[Seq[SortOrder]],
+    dataOrder: Seq[SortOrder],
     outputObjAttr: Attribute,
     child: LogicalPlan) extends UnaryNode with ObjectProducer {
   override protected def withNewChildInternal(newChild: LogicalPlan): MapGroups =
@@ -670,8 +670,8 @@ object CoGroup {
       rightGroup,
       leftAttr,
       rightAttr,
-      Some(leftOrder),
-      Some(rightOrder),
+      leftOrder,
+      rightOrder,
       CatalystSerde.generateObjAttr[OUT],
       left,
       right)
@@ -692,8 +692,8 @@ case class CoGroup(
     rightGroup: Seq[Attribute],
     leftAttr: Seq[Attribute],
     rightAttr: Seq[Attribute],
-    leftOrder: Option[Seq[SortOrder]],
-    rightOrder: Option[Seq[SortOrder]],
+    leftOrder: Seq[SortOrder],
+    rightOrder: Seq[SortOrder],
     outputObjAttr: Attribute,
     left: LogicalPlan,
     right: LogicalPlan) extends BinaryNode with ObjectProducer {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/object.scala
@@ -386,23 +386,6 @@ case class AppendColumnsWithObject(
 /** Factory for constructing new `MapGroups` nodes. */
 object MapGroups {
   def apply[K : Encoder, T : Encoder, U : Encoder](
-      func: (K, Iterator[T]) => TraversableOnce[U],
-      groupingAttributes: Seq[Attribute],
-      dataAttributes: Seq[Attribute],
-      child: LogicalPlan): LogicalPlan = {
-    val mapped = new MapGroups(
-      func.asInstanceOf[(Any, Iterator[Any]) => TraversableOnce[Any]],
-      UnresolvedDeserializer(encoderFor[K].deserializer, groupingAttributes),
-      UnresolvedDeserializer(encoderFor[T].deserializer, dataAttributes),
-      groupingAttributes,
-      dataAttributes,
-      None,
-      CatalystSerde.generateObjAttr[U],
-      child)
-    CatalystSerde.serialize[U](mapped)
-  }
-
-  def apply[K : Encoder, T : Encoder, U : Encoder](
     func: (K, Iterator[T]) => TraversableOnce[U],
     groupingAttributes: Seq[Attribute],
     dataAttributes: Seq[Attribute],
@@ -664,35 +647,6 @@ case class FlatMapGroupsInRWithArrow(
 
 /** Factory for constructing new `CoGroup` nodes. */
 object CoGroup {
-  def apply[K : Encoder, L : Encoder, R : Encoder, OUT : Encoder](
-      func: (K, Iterator[L], Iterator[R]) => TraversableOnce[OUT],
-      leftGroup: Seq[Attribute],
-      rightGroup: Seq[Attribute],
-      leftAttr: Seq[Attribute],
-      rightAttr: Seq[Attribute],
-      left: LogicalPlan,
-      right: LogicalPlan): LogicalPlan = {
-    require(StructType.fromAttributes(leftGroup) == StructType.fromAttributes(rightGroup))
-
-    val cogrouped = CoGroup(
-      func.asInstanceOf[(Any, Iterator[Any], Iterator[Any]) => TraversableOnce[Any]],
-      // The `leftGroup` and `rightGroup` are guaranteed te be of same schema, so it's safe to
-      // resolve the `keyDeserializer` based on either of them, here we pick the left one.
-      UnresolvedDeserializer(encoderFor[K].deserializer, leftGroup),
-      UnresolvedDeserializer(encoderFor[L].deserializer, leftAttr),
-      UnresolvedDeserializer(encoderFor[R].deserializer, rightAttr),
-      leftGroup,
-      rightGroup,
-      leftAttr,
-      rightAttr,
-      None,
-      None,
-      CatalystSerde.generateObjAttr[OUT],
-      left,
-      right)
-    CatalystSerde.serialize[OUT](cogrouped)
-  }
-
   def apply[K : Encoder, L : Encoder, R : Encoder, OUT : Encoder](
       func: (K, Iterator[L], Iterator[R]) => TraversableOnce[OUT],
       leftGroup: Seq[Attribute],

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -700,7 +700,9 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
       AppendColumns[Int, Int]((x: Int) => x, left).newColumns,
       AppendColumns[Int, Int]((x: Int) => x, right).newColumns,
       left.output,
-      right.output)
+      right.output,
+      Seq.empty,
+      Seq.empty)
   }
 
   // Union: Mixing between stream and batch not supported

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1890,7 +1890,8 @@ class Dataset[T] private[sql](
       encoderFor[T],
       executed,
       logicalPlan.output,
-      withGroupingKey.newColumns)
+      withGroupingKey.newColumns,
+      Seq.empty)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -174,9 +174,9 @@ class KeyValueGroupedDataset[K, V] private[sql](
   /**
    * (Scala-specific)
    * Applies the given function to each group of data.  For each unique group, the function will
-   * be passed the group key and an iterator that contains all of the elements in the group. The
-   * function can return an iterator containing elements of an arbitrary type which will be returned
-   * as a new [[Dataset]].
+   * be passed the group key and a sorted iterator that contains all of the elements in the group.
+   * The function can return an iterator containing elements of an arbitrary type which will be
+   * returned as a new [[Dataset]].
    *
    * This function does not support partial aggregation, and as a result requires shuffling all
    * the data in the [[Dataset]]. If an application intends to perform an aggregation over each
@@ -207,6 +207,26 @@ class KeyValueGroupedDataset[K, V] private[sql](
     )
   }
 
+
+  /**
+   * (Scala-specific)
+   * Applies the given function to each group of data.  For each unique group, the function will
+   * be passed the group key and a sorted iterator that contains all of the elements in the group.
+   * The function can return an iterator containing elements of an arbitrary type which will be
+   * returned as a new [[Dataset]].
+   *
+   * This function does not support partial aggregation, and as a result requires shuffling all
+   * the data in the [[Dataset]]. If an application intends to perform an aggregation over each
+   * key, it is best to use the reduce function or an
+   * `org.apache.spark.sql.expressions#Aggregator`.
+   *
+   * Internally, the implementation will spill to disk if any given group is too large to fit into
+   * memory.  However, users must take care to avoid materializing the whole iterator for a group
+   * (for example, by calling `toList`) unless they are sure that this is possible given the memory
+   * constraints of their cluster.
+   *
+   * @since 3.3.0
+   */
   def flatMapSortedGroups[U : Encoder]
       (sortExpr: Column, sortExprs: Column*)
       (f: (K, Iterator[V]) => TraversableOnce[U]): Dataset[U] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -188,7 +188,7 @@ class KeyValueGroupedDataset[K, V] private[sql](
    * (for example, by calling `toList`) unless they are sure that this is possible given the memory
    * constraints of their cluster.
    *
-   * @since 3.3.0
+   * @since 3.4.0
    */
   def flatMapSortedGroups[S: Encoder, U : Encoder]
       (s: V => S)(f: (K, Iterator[V]) => TraversableOnce[U]): Dataset[U] = {
@@ -225,7 +225,7 @@ class KeyValueGroupedDataset[K, V] private[sql](
    * (for example, by calling `toList`) unless they are sure that this is possible given the memory
    * constraints of their cluster.
    *
-   * @since 3.3.0
+   * @since 3.4.0
    */
   def flatMapSortedGroups[U : Encoder]
       (sortExpr: Column, sortExprs: Column*)

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -40,7 +40,8 @@ class KeyValueGroupedDataset[K, V] private[sql](
     vEncoder: Encoder[V],
     @transient val queryExecution: QueryExecution,
     private val dataAttributes: Seq[Attribute],
-    private val groupingAttributes: Seq[Attribute]) extends Serializable {
+    private val groupingAttributes: Seq[Attribute],
+    private val dataOrder: Seq[SortOrder]) extends Serializable {
 
   // Similar to [[Dataset]], we turn the passed in encoder to `ExpressionEncoder` explicitly.
   private implicit val kExprEnc = encoderFor(kEncoder)
@@ -62,7 +63,8 @@ class KeyValueGroupedDataset[K, V] private[sql](
       vExprEnc,
       queryExecution,
       dataAttributes,
-      groupingAttributes)
+      groupingAttributes,
+      dataOrder)
 
   /**
    * Returns a new [[KeyValueGroupedDataset]] where the given function `func` has been applied
@@ -85,7 +87,8 @@ class KeyValueGroupedDataset[K, V] private[sql](
       encoderFor[W],
       executed,
       withNewData.newColumns,
-      groupingAttributes)
+      groupingAttributes,
+      dataOrder)
   }
 
   /**
@@ -120,6 +123,37 @@ class KeyValueGroupedDataset[K, V] private[sql](
   }
 
   /**
+   * Not used for streaming.
+   */
+  def sortWithinGroups[S: Encoder](
+      sortBy: V => S, direction: SortDirection = Ascending): KeyValueGroupedDataset[K, V] = {
+    assert(!logicalPlan.isStreaming, "sorted groups not supported for streaming")
+    val withSortKey = AppendColumns(sortBy, dataAttributes, logicalPlan)
+    val sortOrder = withSortKey.newColumns.map(SortOrder(_, direction))
+    val executed = sparkSession.sessionState.executePlan(withSortKey)
+
+    new KeyValueGroupedDataset[K, V](
+      kEncoder, vEncoder, executed, dataAttributes, groupingAttributes, sortOrder)
+  }
+
+  /**
+   * Not used for streaming.
+   */
+  def sortWithinGroups(sortExpr: Column, sortExprs: Column*): KeyValueGroupedDataset[K, V] = {
+    assert(!logicalPlan.isStreaming, "sorted groups not supported for streaming")
+
+    val sortOrder: Seq[SortOrder] = (Seq(sortExpr) ++ sortExprs).map { col =>
+      col.expr match {
+        case expr: SortOrder => expr
+        case expr: Expression => SortOrder(expr, Ascending)
+      }
+    }
+
+    new KeyValueGroupedDataset[K, V](
+      kEncoder, vEncoder, queryExecution, dataAttributes, groupingAttributes, sortOrder)
+  }
+
+  /**
    * (Scala-specific)
    * Applies the given function to each group of data.  For each unique group, the function will
    * be passed the group key and an iterator that contains all of the elements in the group. The
@@ -145,6 +179,7 @@ class KeyValueGroupedDataset[K, V] private[sql](
         f,
         groupingAttributes,
         dataAttributes,
+        dataOrder,
         logicalPlan))
   }
 
@@ -169,85 +204,6 @@ class KeyValueGroupedDataset[K, V] private[sql](
    */
   def flatMapGroups[U](f: FlatMapGroupsFunction[K, V, U], encoder: Encoder[U]): Dataset[U] = {
     flatMapGroups((key, data) => f.call(key, data.asJava).asScala)(encoder)
-  }
-
-  /**
-   * (Scala-specific)
-   * Applies the given function to each group of data.  For each unique group, the function will
-   * be passed the group key and a sorted iterator that contains all of the elements in the group.
-   * The function can return an iterator containing elements of an arbitrary type which will be
-   * returned as a new [[Dataset]].
-   *
-   * This function does not support partial aggregation, and as a result requires shuffling all
-   * the data in the [[Dataset]]. If an application intends to perform an aggregation over each
-   * key, it is best to use the reduce function or an
-   * `org.apache.spark.sql.expressions#Aggregator`.
-   *
-   * Internally, the implementation will spill to disk if any given group is too large to fit into
-   * memory.  However, users must take care to avoid materializing the whole iterator for a group
-   * (for example, by calling `toList`) unless they are sure that this is possible given the memory
-   * constraints of their cluster.
-   *
-   * @since 3.4.0
-   */
-  def flatMapSortedGroups[S: Encoder, U : Encoder]
-      (s: V => S, direction: SortDirection = Ascending)
-      (f: (K, Iterator[V]) => TraversableOnce[U]): Dataset[U] = {
-    val withSortKey = AppendColumns(s, dataAttributes, logicalPlan)
-    val executed = sparkSession.sessionState.executePlan(withSortKey)
-
-    Dataset[U](
-      sparkSession,
-      MapGroups(
-        f,
-        groupingAttributes,
-        dataAttributes,
-        withSortKey.newColumns.map(SortOrder(_, direction)),
-        executed.analyzed
-      )
-    )
-  }
-
-
-  /**
-   * (Scala-specific)
-   * Applies the given function to each group of data.  For each unique group, the function will
-   * be passed the group key and a sorted iterator that contains all of the elements in the group.
-   * The function can return an iterator containing elements of an arbitrary type which will be
-   * returned as a new [[Dataset]].
-   *
-   * This function does not support partial aggregation, and as a result requires shuffling all
-   * the data in the [[Dataset]]. If an application intends to perform an aggregation over each
-   * key, it is best to use the reduce function or an
-   * `org.apache.spark.sql.expressions#Aggregator`.
-   *
-   * Internally, the implementation will spill to disk if any given group is too large to fit into
-   * memory.  However, users must take care to avoid materializing the whole iterator for a group
-   * (for example, by calling `toList`) unless they are sure that this is possible given the memory
-   * constraints of their cluster.
-   *
-   * @since 3.4.0
-   */
-  def flatMapSortedGroups[U : Encoder]
-      (sortExpr: Column, sortExprs: Column*)
-      (f: (K, Iterator[V]) => TraversableOnce[U]): Dataset[U] = {
-    val sortOrder: Seq[SortOrder] = (Seq(sortExpr) ++ sortExprs).map { col =>
-      col.expr match {
-        case expr: SortOrder => expr
-        case expr: Expression => SortOrder(expr, Ascending)
-      }
-    }
-
-    Dataset[U](
-      sparkSession,
-      MapGroups(
-        f,
-        groupingAttributes,
-        dataAttributes,
-        sortOrder,
-        logicalPlan
-      )
-    )
   }
 
   /**
@@ -832,6 +788,8 @@ class KeyValueGroupedDataset[K, V] private[sql](
         other.groupingAttributes,
         this.dataAttributes,
         other.dataAttributes,
+        this.dataOrder,
+        other.dataOrder,
         this.logicalPlan,
         other.logicalPlan))
   }
@@ -850,62 +808,6 @@ class KeyValueGroupedDataset[K, V] private[sql](
       f: CoGroupFunction[K, V, U, R],
       encoder: Encoder[R]): Dataset[R] = {
     cogroup(other)((key, left, right) => f.call(key, left.asJava, right.asJava).asScala)(encoder)
-  }
-
-  /**
-   * (Scala-specific)
-   * Applies the given function to each sorted cogrouped data.  For each unique group, the function
-   * will be passed the grouping key and 2 sorted iterators containing all elements in the group
-   * from [[Dataset]] `this` and `other`.  The function can return an iterator containing elements
-   * of an arbitrary type which will be returned as a new [[Dataset]].
-   *
-   * @since 3.4.0
-   */
-  def cogroupSorted[U, R : Encoder](
-      other: KeyValueGroupedDataset[K, U])(
-      thisSortExprs: Column*)(
-      otherSortExprs: Column*)(
-      f: (K, Iterator[V], Iterator[U]) => TraversableOnce[R]): Dataset[R] = {
-    def toSortOrder(col: Column): SortOrder = col.expr match {
-      case expr: SortOrder => expr
-      case expr: Expression => SortOrder(expr, Ascending)
-    }
-
-    val thisSortOrder: Seq[SortOrder] = thisSortExprs.map(toSortOrder)
-    val otherSortOrder: Seq[SortOrder] = otherSortExprs.map(toSortOrder)
-
-    implicit val uEncoder = other.vExprEnc
-    Dataset[R](
-      sparkSession,
-      CoGroup(
-        f,
-        this.groupingAttributes,
-        other.groupingAttributes,
-        this.dataAttributes,
-        other.dataAttributes,
-        thisSortOrder,
-        otherSortOrder,
-        this.logicalPlan,
-        other.logicalPlan))
-  }
-
-  /**
-   * (Java-specific)
-   * Applies the given function to each sorted cogrouped data.  For each unique group, the function
-   * will be passed the grouping key and 2 sorted iterators containing all elements in the group
-   * from [[Dataset]] `this` and `other`.  The function can return an iterator containing elements
-   * of an arbitrary type which will be returned as a new [[Dataset]].
-   *
-   * @since 3.4.0
-   */
-  def cogroupSorted[U, R](
-      other: KeyValueGroupedDataset[K, U],
-      thisSortExprs: Array[Column],
-      otherSortExprs: Array[Column],
-      f: CoGroupFunction[K, V, U, R],
-      encoder: Encoder[R]): Dataset[R] = {
-    cogroupSorted(other)(thisSortExprs: _*)(otherSortExprs: _*)(
-      (key, left, right) => f.call(key, left.asJava, right.asJava).asScala)(encoder)
   }
 
   override def toString: String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala
@@ -43,6 +43,14 @@ class KeyValueGroupedDataset[K, V] private[sql](
     private val groupingAttributes: Seq[Attribute],
     private val dataOrder: Seq[SortOrder]) extends Serializable {
 
+  // Needed for Spark 3.x binary compatibility
+  def this(kEncoder: Encoder[K],
+           vEncoder: Encoder[V],
+           queryExecution: QueryExecution,
+           dataAttributes: Seq[Attribute],
+           groupingAttributes: Seq[Attribute]) =
+    this(kEncoder, vEncoder, queryExecution, dataAttributes, groupingAttributes, Seq.empty)
+
   // Similar to [[Dataset]], we turn the passed in encoder to `ExpressionEncoder` explicitly.
   private implicit val kExprEnc = encoderFor(kEncoder)
   private implicit val vExprEnc = encoderFor(vEncoder)

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -160,7 +160,8 @@ class RelationalGroupedDataset protected[sql](
       valueEncoder,
       qe,
       df.logicalPlan.output,
-      aliasedGroupings.map(_.toAttribute))
+      aliasedGroupings.map(_.toAttribute),
+      Seq.empty)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -823,9 +823,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         // TODO(SPARK-40443): support applyInPandasWithState in batch query
         throw new UnsupportedOperationException(
           "applyInPandasWithState is unsupported in batch query. Use applyInPandas instead.")
-      case logical.CoGroup(f, key, lObj, rObj, lGroup, rGroup, lAttr, rAttr, oAttr, left, right) =>
+      case logical.CoGroup(
+          f, key, lObj, rObj, lGroup, rGroup, lAttr, rAttr, lOrder, rOrder, oAttr, left, right) =>
         execution.CoGroupExec(
-          f, key, lObj, rObj, lGroup, rGroup, lAttr, rAttr, oAttr,
+          f, key, lObj, rObj, lGroup, rGroup, lAttr, rAttr, lOrder, rOrder, oAttr,
           planLater(left), planLater(right)) :: Nil
 
       case r @ logical.Repartition(numPartitions, shuffle, child) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -806,9 +806,9 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.AppendColumnsExec(f, in, out, planLater(child)) :: Nil
       case logical.AppendColumnsWithObject(f, childSer, newSer, child) =>
         execution.AppendColumnsWithObjectExec(f, childSer, newSer, planLater(child)) :: Nil
-      case logical.MapGroups(f, key, value, grouping, sort, data, objAttr, child) =>
+      case logical.MapGroups(f, key, value, grouping, data, order, objAttr, child) =>
         execution.MapGroupsExec(
-          f, key, value, grouping, sort, data, objAttr, planLater(child)
+          f, key, value, grouping, data, order, objAttr, planLater(child)
         ) :: Nil
       case logical.FlatMapGroupsWithState(
           f, keyDeserializer, valueDeserializer, grouping, data, output, stateEncoder, outputMode,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -806,8 +806,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         execution.AppendColumnsExec(f, in, out, planLater(child)) :: Nil
       case logical.AppendColumnsWithObject(f, childSer, newSer, child) =>
         execution.AppendColumnsWithObjectExec(f, childSer, newSer, planLater(child)) :: Nil
-      case logical.MapGroups(f, key, value, grouping, data, objAttr, child) =>
-        execution.MapGroupsExec(f, key, value, grouping, data, objAttr, planLater(child)) :: Nil
+      case logical.MapGroups(f, key, value, grouping, sort, data, objAttr, child) =>
+        execution.MapGroupsExec(
+          f, key, value, grouping, sort, data, objAttr, planLater(child)
+        ) :: Nil
       case logical.FlatMapGroupsWithState(
           f, keyDeserializer, valueDeserializer, grouping, data, output, stateEncoder, outputMode,
           isFlatMapGroupsWithState, timeout, hasInitialState, initialStateGroupAttrs,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -400,7 +400,7 @@ case class MapGroupsExec(
     valueDeserializer: Expression,
     groupingAttributes: Seq[Attribute],
     dataAttributes: Seq[Attribute],
-    dataOrder: Option[Seq[SortOrder]],
+    dataOrder: Seq[SortOrder],
     outputObjAttr: Attribute,
     child: SparkPlan) extends UnaryExecNode with ObjectProducerExec {
 
@@ -410,7 +410,7 @@ case class MapGroupsExec(
     ClusteredDistribution(groupingAttributes) :: Nil
 
   override def requiredChildOrdering: Seq[Seq[SortOrder]] =
-    Seq(groupingAttributes.map(SortOrder(_, Ascending)) ++ dataOrder.getOrElse(Seq.empty))
+    Seq(groupingAttributes.map(SortOrder(_, Ascending)) ++ dataOrder)
 
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitionsInternal { iter =>
@@ -440,7 +440,7 @@ object MapGroupsExec {
       valueDeserializer: Expression,
       groupingAttributes: Seq[Attribute],
       dataAttributes: Seq[Attribute],
-      dataOrder: Option[Seq[SortOrder]],
+      dataOrder: Seq[SortOrder],
       outputObjAttr: Attribute,
       timeoutConf: GroupStateTimeout,
       child: SparkPlan): MapGroupsExec = {
@@ -626,8 +626,8 @@ case class CoGroupExec(
     rightGroup: Seq[Attribute],
     leftAttr: Seq[Attribute],
     rightAttr: Seq[Attribute],
-    leftOrder: Option[Seq[SortOrder]],
-    rightOrder: Option[Seq[SortOrder]],
+    leftOrder: Seq[SortOrder],
+    rightOrder: Seq[SortOrder],
     outputObjAttr: Attribute,
     left: SparkPlan,
     right: SparkPlan) extends BinaryExecNode with ObjectProducerExec {
@@ -636,8 +636,8 @@ case class CoGroupExec(
     ClusteredDistribution(leftGroup) :: ClusteredDistribution(rightGroup) :: Nil
 
   override def requiredChildOrdering: Seq[Seq[SortOrder]] =
-    (leftGroup.map(SortOrder(_, Ascending)) ++ leftOrder.getOrElse(Seq.empty)) ::
-      (rightGroup.map(SortOrder(_, Ascending)) ++ rightOrder.getOrElse(Seq.empty)) ::
+    (leftGroup.map(SortOrder(_, Ascending)) ++ leftOrder) ::
+      (rightGroup.map(SortOrder(_, Ascending)) ++ rightOrder) ::
       Nil
 
   override protected def doExecute(): RDD[InternalRow] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -510,12 +510,12 @@ object FlatMapGroupsWithStateExec {
       }
       CoGroupExec(
         func, keyDeserializer, valueDeserializer, initialStateDeserializer, groupingAttributes,
-        initialStateGroupAttrs, dataAttributes, initialStateDataAttrs, None, None, outputObjAttr,
-        child, initialState)
+        initialStateGroupAttrs, dataAttributes, initialStateDataAttrs, Seq.empty, Seq.empty,
+        outputObjAttr, child, initialState)
     } else {
       MapGroupsExec(
         userFunc, keyDeserializer, valueDeserializer, groupingAttributes,
-        dataAttributes, None, outputObjAttr, timeoutConf, child)
+        dataAttributes, Seq.empty, outputObjAttr, timeoutConf, child)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -515,7 +515,7 @@ object FlatMapGroupsWithStateExec {
     } else {
       MapGroupsExec(
         userFunc, keyDeserializer, valueDeserializer, groupingAttributes,
-        None, dataAttributes, outputObjAttr, timeoutConf, child)
+        dataAttributes, None, outputObjAttr, timeoutConf, child)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -510,7 +510,7 @@ object FlatMapGroupsWithStateExec {
       }
       CoGroupExec(
         func, keyDeserializer, valueDeserializer, initialStateDeserializer, groupingAttributes,
-        initialStateGroupAttrs, dataAttributes, initialStateDataAttrs, outputObjAttr,
+        initialStateGroupAttrs, dataAttributes, initialStateDataAttrs, None, None, outputObjAttr,
         child, initialState)
     } else {
       MapGroupsExec(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -515,7 +515,7 @@ object FlatMapGroupsWithStateExec {
     } else {
       MapGroupsExec(
         userFunc, keyDeserializer, valueDeserializer, groupingAttributes,
-        dataAttributes, outputObjAttr, timeoutConf, child)
+        None, dataAttributes, outputObjAttr, timeoutConf, child)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -834,16 +834,8 @@ class DatasetSuite extends QueryTest
       ("both desc", leftDescOrder, rightDescOrder, bothDescSortedExpected)
     ).foreach { case (label, leftOrder, rightOrder, expected) =>
       withClue(s"$label sorted") {
-        val Seq(leftSorted, rightSorted) =
-          Seq((leftGrouped, leftOrder), (rightGrouped, rightOrder)).map {
-            case (grouped, order) => if (order.isEmpty) {
-              grouped
-            } else {
-              grouped.sortWithinGroups(order.head, order.tail: _*)
-            }
-          }
-
-        val cogrouped = leftSorted.cogroup(rightSorted) {
+        val cogrouped = leftGrouped.sortWithinGroups(leftOrder: _*)
+          .cogroup(rightGrouped.sortWithinGroups(rightOrder: _*)) {
           case (key, left, right) =>
             Iterator(key -> (left.map(_._2).mkString + "#" + right.map(_._2).mkString))
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -573,6 +573,23 @@ class DatasetSuite extends QueryTest
       "a", "30", "b", "3", "c", "1")
   }
 
+  test("groupBy function, flatMapSorted") {
+    val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1)).toDS()
+    val grouped = ds.groupByKey(v => (v._1, "word"))
+    val aggregated = grouped.flatMapSortedGroups(v => v._2) { (g, iter) =>
+      Iterator(
+        g._1,
+        iter.mkString(", ")
+      )
+    }
+
+    checkDatasetUnorderly(
+      aggregated,
+      "a", "(a,1,10), (a,2,20)",
+      "b", "(b,1,2), (b,2,1)",
+      "c", "(c,1,1)")
+  }
+
   test("groupBy function, mapValues, flatMap") {
     val ds = Seq(("a", 10), ("a", 20), ("b", 1), ("b", 2), ("c", 1)).toDS()
     val keyValue = ds.groupByKey(_._1).mapValues(_._2)

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -575,38 +575,33 @@ class DatasetSuite extends QueryTest
 
   test("groupBy function, flatMapSorted by func") {
     val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1)).toDS()
-    ds.sort($"id".desc)
     val grouped = ds.groupByKey(v => (v._1, "word"))
     val aggregated = grouped.flatMapSortedGroups(v => v._2) { (g, iter) =>
-      Iterator(
-        g._1,
-        iter.mkString(", ")
-      )
+      Iterator(g._1, iter.mkString(", "))
     }
 
     checkDatasetUnorderly(
       aggregated,
       "a", "(a,1,10), (a,2,20)",
       "b", "(b,1,2), (b,2,1)",
-      "c", "(c,1,1)")
+      "c", "(c,1,1)"
+    )
   }
 
   test("groupBy function, flatMapSorted by expr") {
     val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1))
       .toDF("key", "seq", "value")
     val grouped = ds.groupByKey(v => (v.getString(0), "word"))
-    val aggregated = grouped.flatMapSortedGroups($"seq") { (g, iter) =>
-      Iterator(
-        g._1,
-        iter.mkString(", ")
-      )
+    val aggregated = grouped.flatMapSortedGroups($"seq", expr("length(key)")) { (g, iter) =>
+      Iterator(g._1, iter.mkString(", "))
     }
 
     checkDatasetUnorderly(
       aggregated,
-      "a", "(a,1,10), (a,2,20)",
-      "b", "(b,1,2), (b,2,1)",
-      "c", "(c,1,1)")
+      "a", "[a,1,10], [a,2,20]",
+      "b", "[b,1,2], [b,2,1]",
+      "c", "[c,1,1]"
+    )
   }
 
   test("groupBy function, mapValues, flatMap") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -573,10 +573,29 @@ class DatasetSuite extends QueryTest
       "a", "30", "b", "3", "c", "1")
   }
 
-  test("groupBy function, flatMapSorted") {
+  test("groupBy function, flatMapSorted by func") {
     val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1)).toDS()
+    ds.sort($"id".desc)
     val grouped = ds.groupByKey(v => (v._1, "word"))
     val aggregated = grouped.flatMapSortedGroups(v => v._2) { (g, iter) =>
+      Iterator(
+        g._1,
+        iter.mkString(", ")
+      )
+    }
+
+    checkDatasetUnorderly(
+      aggregated,
+      "a", "(a,1,10), (a,2,20)",
+      "b", "(b,1,2), (b,2,1)",
+      "c", "(c,1,1)")
+  }
+
+  test("groupBy function, flatMapSorted by expr") {
+    val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1))
+      .toDF("key", "seq", "value")
+    val grouped = ds.groupByKey(v => (v.getString(0), "word"))
+    val aggregated = grouped.flatMapSortedGroups($"seq") { (g, iter) =>
       Iterator(
         g._1,
         iter.mkString(", ")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.internal.config.MAX_RESULT_SIZE
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.catalyst.{FooClassWithEnum, FooEnum, ScroogeLikeExample}
 import org.apache.spark.sql.catalyst.encoders.{OuterScopes, RowEncoder}
+import org.apache.spark.sql.catalyst.expressions.Descending
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftSemi}
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.execution.{LogicalRDD, RDDScanExec, SQLExecution}
@@ -588,6 +589,21 @@ class DatasetSuite extends QueryTest
     )
   }
 
+  test("groupBy function, flatMapSorted by func desc") {
+    val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1)).toDS()
+    val grouped = ds.groupByKey(v => (v._1, "word"))
+    val aggregated = grouped.flatMapSortedGroups(v => v._2, Descending) { (g, iter) =>
+      Iterator(g._1, iter.mkString(", "))
+    }
+
+    checkDatasetUnorderly(
+      aggregated,
+      "a", "(a,2,20), (a,1,10)",
+      "b", "(b,2,1), (b,1,2)",
+      "c", "(c,1,1)"
+    )
+  }
+
   test("groupBy function, flatMapSorted by expr") {
     val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1))
       .toDF("key", "seq", "value")
@@ -600,6 +616,22 @@ class DatasetSuite extends QueryTest
       aggregated,
       "a", "[a,1,10], [a,2,20]",
       "b", "[b,1,2], [b,2,1]",
+      "c", "[c,1,1]"
+    )
+  }
+
+  test("groupBy function, flatMapSorted by expr desc") {
+    val ds = Seq(("a", 1, 10), ("a", 2, 20), ("b", 2, 1), ("b", 1, 2), ("c", 1, 1))
+      .toDF("key", "seq", "value")
+    val grouped = ds.groupByKey(v => (v.getString(0), "word"))
+    val aggregated = grouped.flatMapSortedGroups($"seq".desc, expr("length(key)")) { (g, iter) =>
+      Iterator(g._1, iter.mkString(", "))
+    }
+
+    checkDatasetUnorderly(
+      aggregated,
+      "a", "[a,2,20], [a,1,10]",
+      "b", "[b,2,1], [b,1,2]",
       "c", "[c,1,1]"
     )
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds `sortWithinGroups` (similar to `Dataset.sortWithinPartitions`) to `KeyValueGroupedDataset` (returned by `Dataset.groupByKey()`).

### Why are the changes needed?
This allows existing methods `flatMapGroups` and `cogroup` to provide a **sorted** iterator of rows for each group key. User code then does not need to sort the groups if their algorithm requires ordered groups (e.g. temporal / as-of joins).

Sorting the entire group inside `flatMapGroups` / `cogroup` requires materialising all rows, which is against the idea of an iterator in the first place. Methods `flatMapGroups` and `cogroup` have the great advantage that they work with groups that are _too large to fit into memory of one executor_. Sorting them in the user function breaks this property.

[org.apache.spark.sql.KeyValueGroupedDataset](https://github.com/apache/spark/blob/47485a3c2df3201c838b939e82d5b26332e2d858/sql/core/src/main/scala/org/apache/spark/sql/KeyValueGroupedDataset.scala#L134-L137):
> Internally, the implementation will spill to disk if any given group is too large to fit into
> memory.  However, users must take care to avoid materializing the whole iterator for a group
> (for example, by calling `toList`) unless they are sure that this is possible given the memory
> constraints of their cluster.

The implementations of `KeyValueGroupedDataset.flatMapGroups` and `KeyValueGroupedDataset.cogroup` already sort each partition according to the group key. By additionally sorting by some data columns, the iterator can be guaranteed to provide some order.

### Does this PR introduce _any_ user-facing change?
This adds `KeyValueGroupedDataset.sortWithinGroups`, which has side effects on existing methods `KeyValueGroupedDataset.flatMapGroups` and `KeyValueGroupedDataset.cogroup`.

### How was this patch tested?
Tests have been added to `DatasetSuite`