### PR TITLE
[SPARK-40119][CORE] Add cancel job group reason

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2411,6 +2411,9 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Cancel active jobs for the specified group. See `org.apache.spark.SparkContext.setJobGroup`
    * for more information.
+   *
+   * @param groupId the groupId ID to cancel
+   * @param reason reason for cancellation
    */
   def cancelJobGroup(groupId: String, reason: String): Unit = {
     assertNotStopped()
@@ -2420,6 +2423,8 @@ class SparkContext(config: SparkConf) extends Logging {
   /**
    * Cancel active jobs for the specified group. See `org.apache.spark.SparkContext.setJobGroup`
    * for more information.
+   *
+   * @param groupId the groupId ID to cancel
    */
   def cancelJobGroup(groupId: String): Unit = {
     assertNotStopped()

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2412,9 +2412,18 @@ class SparkContext(config: SparkConf) extends Logging {
    * Cancel active jobs for the specified group. See `org.apache.spark.SparkContext.setJobGroup`
    * for more information.
    */
+  def cancelJobGroup(groupId: String, reason: String): Unit = {
+    assertNotStopped()
+    dagScheduler.cancelJobGroup(groupId, Option(reason))
+  }
+
+  /**
+   * Cancel active jobs for the specified group. See `org.apache.spark.SparkContext.setJobGroup`
+   * for more information.
+   */
   def cancelJobGroup(groupId: String): Unit = {
     assertNotStopped()
-    dagScheduler.cancelJobGroup(groupId)
+    dagScheduler.cancelJobGroup(groupId, None)
   }
 
   /** Cancel all jobs that have been scheduled or are running.  */

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1148,7 +1148,7 @@ private[spark] class DAGScheduler(
     }
     val jobIds = activeInGroup.map(_.jobId)
     val reasonForException = reason match {
-      case Some(value) => s"with reason \"$value\""
+      case Some(value) => s"due to reason: $value"
       case None => ""
     }
     jobIds.foreach(handleJobCancellation(_,

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGSchedulerEvent.scala
@@ -61,7 +61,10 @@ private[scheduler] case class JobCancelled(
     reason: Option[String])
   extends DAGSchedulerEvent
 
-private[scheduler] case class JobGroupCancelled(groupId: String) extends DAGSchedulerEvent
+private[scheduler] case class JobGroupCancelled(
+    groupId: String,
+    reason: Option[String])
+  extends DAGSchedulerEvent
 
 private[scheduler] case object AllJobsCancelled extends DAGSchedulerEvent
 

--- a/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
@@ -145,9 +145,10 @@ class JobCancellationSuite extends SparkFunSuite with Matchers with BeforeAndAft
 
     sc.clearJobGroup()
     val jobB = sc.parallelize(1 to 100, 2).countAsync()
-    sc.cancelJobGroup("jobA")
+    sc.cancelJobGroup("jobA", "dummy")
     val e = intercept[SparkException] { ThreadUtils.awaitResult(jobA, Duration.Inf) }.getCause
     assert(e.getMessage contains "cancel")
+    assert(e.getMessage contains "with reason \"dummmy\"")
 
     // Once A is cancelled, job B should finish fairly quickly.
     assert(jobB.get() === 100)

--- a/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/JobCancellationSuite.scala
@@ -148,7 +148,7 @@ class JobCancellationSuite extends SparkFunSuite with Matchers with BeforeAndAft
     sc.cancelJobGroup("jobA", "dummy")
     val e = intercept[SparkException] { ThreadUtils.awaitResult(jobA, Duration.Inf) }.getCause
     assert(e.getMessage contains "cancel")
-    assert(e.getMessage contains "with reason \"dummmy\"")
+    assert(e.getMessage contains "due to reason: dummy")
 
     // Once A is cancelled, job B should finish fairly quickly.
     assert(jobB.get() === 100)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -209,9 +209,10 @@ case class BroadcastExchangeExec(
       relationFuture.get(timeout, TimeUnit.SECONDS).asInstanceOf[broadcast.Broadcast[T]]
     } catch {
       case ex: TimeoutException =>
-        logError(s"Could not execute broadcast in $timeout secs.", ex)
+        val broadcastTimeoutMessage = s"Could not execute broadcast in $timeout secs."
+        logError(broadcastTimeoutMessage, ex)
         if (!relationFuture.isDone) {
-          sparkContext.cancelJobGroup(runId.toString)
+          sparkContext.cancelJobGroup(runId.toString, broadcastTimeoutMessage)
           relationFuture.cancel(true)
         }
         throw QueryExecutionErrors.executeBroadcastTimeoutError(timeout, Some(ex))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add cancel job group reason so that when we kill job groups we can pass appropriate reason. This reason then can be propagated to the jobs and tasks if required.

### Why are the changes needed?
Ease of reasoning with failure of job in some cases like broadcast timeouts

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test cases