### PR TITLE
[SPARK-40130][PYTHON] Support NumPy scalars in built-in functions

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -972,7 +972,7 @@ class FunctionsTests(ReusedSQLTestCase):
                 df.select(
                     regexp_replace("str", r"(\d+)", "--") == "-----",
                     regexp_replace("str", col("pattern"), col("replacement")) == "-----",
-                    ).first()
+                ).first()
             )
         )
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -989,6 +989,12 @@ class FunctionsTests(ReusedSQLTestCase):
             res = df.select(array_position(df.data, dtype(1)).alias("c")).collect()
             self.assertEqual([Row(c=1), Row(c=0)], res)
 
+        # java.lang.Integer max: 2147483647
+        max_int = 2147483647
+        # Convert int to bigint automatically
+        self.assertEqual(df.select(lit(np.int32(max_int))).dtypes, [("2147483647", "int")])
+        self.assertEqual(df.select(lit(np.int64(max_int + 1))).dtypes, [("2147483648", "bigint")])
+
         df = self.spark.createDataFrame([([1.0, 2.0, 3.0],), ([],)], ["data"])
         for dtype in [np.float32, np.float64]:
             self.assertEqual(df.select(lit(dtype(1))).dtypes, [("1.0", "double")])

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -20,8 +20,7 @@ from inspect import getmembers, isfunction
 from itertools import chain
 import re
 import math
-
-import numpy as np
+import unittest
 
 from py4j.protocol import Py4JJavaError
 from pyspark.sql import Row, Window, types
@@ -57,6 +56,7 @@ from pyspark.sql.functions import (
 )
 from pyspark.sql import functions
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
+from pyspark.testing.utils import have_numpy
 
 
 class FunctionsTests(ReusedSQLTestCase):
@@ -972,11 +972,13 @@ class FunctionsTests(ReusedSQLTestCase):
                 df.select(
                     regexp_replace("str", r"(\d+)", "--") == "-----",
                     regexp_replace("str", col("pattern"), col("replacement")) == "-----",
-                ).first()
+                    ).first()
             )
         )
 
-    def test_np_scalars(self):
+    @unittest.skipIf(not have_numpy, "NumPy not installed")
+    def test_np_scalar_input(self):
+        import numpy as np
         from pyspark.sql.functions import array_contains, array_position
 
         df = self.spark.createDataFrame([([1, 2, 3],), ([],)], ["data"])

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2256,11 +2256,27 @@ class DayTimeIntervalTypeConverter:
         )
 
 
+class NumpyScalarConverter:
+    def can_convert(self, obj: Any) -> bool:
+        try:
+            import numpy as np
+
+            has_numpy = True
+        except Exception:
+            has_numpy = False
+
+        return has_numpy and isinstance(obj, np.generic)
+
+    def convert(self, obj: "np.generic", gateway_client: GatewayClient):
+        return obj.item()
+
+
 # datetime is a subclass of date, we should register DatetimeConverter first
 register_input_converter(DatetimeNTZConverter())
 register_input_converter(DatetimeConverter())
 register_input_converter(DateConverter())
 register_input_converter(DayTimeIntervalTypeConverter())
+register_input_converter(NumpyScalarConverter())
 
 
 def _test() -> None:

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2258,7 +2258,7 @@ class DayTimeIntervalTypeConverter:
 
 class NumpyScalarConverter:
     @property
-    def _has_numpy(self):
+    def _has_numpy(self) -> bool:
         if not hasattr(self, "_has_np"):
             try:
                 global np  # Cache the import of NumPy

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2261,7 +2261,7 @@ class NumpyScalarConverter:
     def _has_numpy(self):
         if not hasattr(self, "_has_np"):
             try:
-                global np
+                global np  # Cache the import of NumPy
                 import numpy as np
 
                 has_np = True

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2271,10 +2271,7 @@ class NumpyScalarConverter:
         return self._has_np
 
     def can_convert(self, obj: Any) -> bool:
-        if self._has_numpy:
-            return isinstance(obj, np.generic)
-        else:
-            return False
+        return self._has_numpy and isinstance(obj, np.generic)
 
     def convert(self, obj: "np.generic", gateway_client: GatewayClient) -> Any:
         return obj.item()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2261,7 +2261,8 @@ class NumpyScalarConverter:
     def _has_numpy(self):
         if not hasattr(self, "_has_np"):
             try:
-                import numpy
+                global np
+                import numpy as np
 
                 has_np = True
             except Exception:
@@ -2271,8 +2272,6 @@ class NumpyScalarConverter:
 
     def can_convert(self, obj: Any) -> bool:
         if self._has_numpy:
-            import numpy as np
-
             return isinstance(obj, np.generic)
         else:
             return False

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2257,15 +2257,25 @@ class DayTimeIntervalTypeConverter:
 
 
 class NumpyScalarConverter:
+    @property
+    def _has_numpy(self):
+        if not hasattr(self, "_has_np"):
+            try:
+                import numpy
+
+                has_np = True
+            except Exception:
+                has_np = False
+            object.__setattr__(self, "_has_np", has_np)
+        return self._has_np
+
     def can_convert(self, obj: Any) -> bool:
-        try:
+        if self._has_numpy:
             import numpy as np
 
-            has_numpy = True
-        except Exception:
-            has_numpy = False
-
-        return has_numpy and isinstance(obj, np.generic)
+            return isinstance(obj, np.generic)
+        else:
+            return False
 
     def convert(self, obj: "np.generic", gateway_client: GatewayClient) -> Any:
         return obj.item()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2261,21 +2261,8 @@ class DayTimeIntervalTypeConverter:
 
 
 class NumpyScalarConverter:
-    @property
-    def _has_numpy(self) -> bool:
-        if not hasattr(self, "_has_np"):
-            try:
-                global np  # Cache the import of NumPy
-                import numpy as np
-
-                has_np = True
-            except Exception:
-                has_np = False
-            object.__setattr__(self, "_has_np", has_np)
-        return self._has_np
-
     def can_convert(self, obj: Any) -> bool:
-        return self._has_numpy and isinstance(obj, np.generic)
+        return has_numpy and isinstance(obj, np.generic)
 
     def convert(self, obj: "np.generic", gateway_client: GatewayClient) -> Any:
         return obj.item()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2267,7 +2267,7 @@ class NumpyScalarConverter:
 
         return has_numpy and isinstance(obj, np.generic)
 
-    def convert(self, obj: "np.generic", gateway_client: GatewayClient):
+    def convert(self, obj: "np.generic", gateway_client: GatewayClient) -> Any:
         return obj.item()
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -49,6 +49,10 @@ from py4j.protocol import register_input_converter
 from py4j.java_gateway import GatewayClient, JavaClass, JavaObject
 
 from pyspark.serializers import CloudPickleSerializer
+from pyspark.sql.utils import has_numpy
+
+if has_numpy:
+    import numpy as np
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -29,6 +29,15 @@ from py4j.protocol import Py4JJavaError
 from pyspark import SparkContext
 from pyspark.find_spark_home import _find_spark_home
 
+has_numpy = False
+try:
+    import numpy as np  # noqa: F401
+
+    has_numpy = True
+except ImportError:
+    pass
+
+
 if TYPE_CHECKING:
     from pyspark.sql.session import SparkSession
     from pyspark.sql.dataframe import DataFrame


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support NumPy scalars in built-in functions by introducing Py4J input converter `NumpyScalarConverter`.

Specifically, 
- `np.int8, np.int16, np.int32, np.int64` are mapped to Spark `int/bigint`.
- `np.float32, np.float64` are mapped to Spark `double`.


Note that 2147483648 is the boundary between Spark `int` and `bigint`:
```py
>>> df.select(lit(np.int64(max_int + 1))).dtypes
[('2147483648', 'bigint')]
>>> df.select(lit(np.int64(max_int))).dtypes
[('2147483647', 'int')]
```


### Why are the changes needed?
As part of [SPARK-39405](https://issues.apache.org/jira/browse/SPARK-39405) for NumPy support in SQL.

### Does this PR introduce _any_ user-facing change?
Yes. NumPy scalars are supported in built-in functions when input parameter accepts scalars;
Influenced functions include `lit`, `when`, `array_contains`, `array_position`, `element_at`, `array_remove`.

Take `lit` for example,
```py
>>> df.select(lit(np.int8(1))).dtypes
[('1', 'int')]
>>> df.select(lit(np.float32(1))).dtypes
[('1.0', 'double')]
```

### How was this patch tested?
Unit tests.
