### PR TITLE
[SPARK-40132][ML] Restore rawPredictionCol to MultilayerPerceptronClassifier.setParams

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -3230,6 +3230,7 @@ class MultilayerPerceptronClassifier(
         solver: str = "l-bfgs",
         initialWeights: Optional[Vector] = None,
         probabilityCol: str = "probability",
+        rawPredictionCol: str = "rawPrediction",
     ) -> "MultilayerPerceptronClassifier":
         """
         setParams(self, \\*, featuresCol="features", labelCol="label", predictionCol="prediction", \


### PR DESCRIPTION


### What changes were proposed in this pull request?

Restore rawPredictionCol to MultilayerPerceptronClassifier.setParams

### Why are the changes needed?

This param was inadvertently removed in the refactoring in https://github.com/apache/spark/commit/40cdb6d51c2befcfeac8fb5cf5faf178d1a5ee7b#r81473316
Without it, using this param in the constructor fails.

### Does this PR introduce _any_ user-facing change?

Not aside from the bug fix.

### How was this patch tested?

Existing tests.