### PR TITLE
[SPARK-40134][BUILD] Update ORC to 1.7.6

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -218,9 +218,9 @@ objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
 okio/1.14.0//okio-1.14.0.jar
 opencsv/2.3//opencsv-2.3.jar
-orc-core/1.7.5//orc-core-1.7.5.jar
-orc-mapreduce/1.7.5//orc-mapreduce-1.7.5.jar
-orc-shims/1.7.5//orc-shims-1.7.5.jar
+orc-core/1.7.6//orc-core-1.7.6.jar
+orc-mapreduce/1.7.6//orc-mapreduce-1.7.6.jar
+orc-shims/1.7.6//orc-shims-1.7.6.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -205,9 +205,9 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/1.7.5//orc-core-1.7.5.jar
-orc-mapreduce/1.7.5//orc-mapreduce-1.7.5.jar
-orc-shims/1.7.5//orc-shims-1.7.5.jar
+orc-core/1.7.6//orc-core-1.7.6.jar
+orc-mapreduce/1.7.6//orc-mapreduce-1.7.6.jar
+orc-shims/1.7.6//orc-shims-1.7.6.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>
-    <orc.version>1.7.5</orc.version>
+    <orc.version>1.7.6</orc.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>
     <chill.version>0.10.0</chill.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to update ORC to 1.7.6.


### Why are the changes needed?
This will bring the latest changes and bug fixes. 

https://github.com/apache/orc/releases/tag/v1.7.6

- ORC-1204: ORC MapReduce writer to flush when long arrays
- ORC-1205: `nextVector` should invoke `ensureSize` when reusing vectors
- ORC-1215: Remove a wrong `NotNull` annotation on `value` of `setAttribute`
- ORC-1222: Upgrade `tools.hadoop.version` to 2.10.2
- ORC-1227: Use `Constructor.newInstance` instead of `Class.newInstance`
- ORC-1228: Fix `setAttribute` to handle null value



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs. 