### PR TITLE
[SPARK-40135][PS] Support `data` mixed with `index` in DataFrame creation

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -360,7 +360,7 @@ class DataFrame(Frame, Generic[T]):
     Parameters
     ----------
     data : numpy ndarray (structured or homogeneous), dict, pandas DataFrame, Spark DataFrame \
-        \ pandas-on-Spark Series or pandas-on-Spark DataFrame
+        pandas-on-Spark DataFrame or pandas-on-Spark Series
         Dict can contain Series, arrays, constants, or list-like objects
     index : Index or array-like
         Index to use for resulting frame. Will default to RangeIndex if

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -436,19 +436,18 @@ class DataFrame(Frame, Generic[T]):
             assert not copy
             if index is None:
                 internal = InternalFrame(spark_frame=data, index_spark_columns=None)
-        elif isinstance(data, DataFrame):
+        elif isinstance(data, ps.DataFrame):
             assert columns is None
             assert dtype is None
             assert not copy
             if index is None:
-                internal = data._internal
+                internal = data._internal.resolved_copy
         elif isinstance(data, ps.Series):
             assert columns is None
             assert dtype is None
             assert not copy
             if index is None:
-                data = data.to_frame()
-                internal = data._internal
+                internal = data.to_frame()._internal.resolved_copy
         else:
             from pyspark.pandas.indexes.base import Index
 

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -373,9 +373,8 @@ class DataFrame(Frame, Generic[T]):
     copy : boolean, default False
         Copy data from inputs. Only affects DataFrame / 2d ndarray input
 
-    Notes
-    -----
-    Since 3.4.0, it deals with `index` in this way:
+    .. versionchanged:: 3.4.0
+    Since 3.4.0, it deals with `data` and `index` in this approach:
     1, when `data` is a distributed dataset (Internal DataFrame/Spark DataFrame/
     pandas-on-Spark DataFrame/pandas-on-Spark Series), it will first parallize
     the `index` if necessary, and then try to combine the `data` and `index`;

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -351,160 +351,160 @@ rectangle    16.0  2.348543e+108
 
 class DataFrame(Frame, Generic[T]):
     """
-     pandas-on-Spark DataFrame that corresponds to pandas DataFrame logically. This holds Spark
-     DataFrame internally.
+    pandas-on-Spark DataFrame that corresponds to pandas DataFrame logically. This holds Spark
+    DataFrame internally.
 
-     :ivar _internal: an internal immutable Frame to manage metadata.
-     :type _internal: InternalFrame
+    :ivar _internal: an internal immutable Frame to manage metadata.
+    :type _internal: InternalFrame
 
-     Parameters
-     ----------
-     data : numpy ndarray (structured or homogeneous), dict, pandas DataFrame,
-         Spark DataFrame, pandas-on-Spark DataFrame or pandas-on-Spark Series.
-         Dict can contain Series, arrays, constants, or list-like objects
-     index : Index or array-like
-         Index to use for resulting frame. Will default to RangeIndex if
-         no indexing information part of input data and no index provided
-     columns : Index or array-like
-         Column labels to use for resulting frame. Will default to
-         RangeIndex (0, 1, 2, ..., n) if no column labels are provided
-     dtype : dtype, default None
-         Data type to force. Only a single dtype is allowed. If None, infer
-     copy : boolean, default False
-         Copy data from inputs. Only affects DataFrame / 2d ndarray input
+    Parameters
+    ----------
+    data : numpy ndarray (structured or homogeneous), dict, pandas DataFrame,
+        Spark DataFrame, pandas-on-Spark DataFrame or pandas-on-Spark Series.
+        Dict can contain Series, arrays, constants, or list-like objects
+    index : Index or array-like
+        Index to use for resulting frame. Will default to RangeIndex if
+        no indexing information part of input data and no index provided
+    columns : Index or array-like
+        Column labels to use for resulting frame. Will default to
+        RangeIndex (0, 1, 2, ..., n) if no column labels are provided
+    dtype : dtype, default None
+        Data type to force. Only a single dtype is allowed. If None, infer
+    copy : boolean, default False
+        Copy data from inputs. Only affects DataFrame / 2d ndarray input
 
-     Notes
-     -----
-     Since 3.4.0, it support more cases that combine `data` and `index`:
-     1, when `data` is a distributed dataset (Internal DataFrame/Spark DataFrame/
-     pandas-on-Spark DataFrame/pandas-on-Spark Series), it will first parallize
-     the `index` if necessary, and then try to combine the `data` and `index`;
-     Note that in this case `compute.ops_on_diff_frames` should be turned on;
-     2, when `data` is a local dataset (Pandas DataFrame/numpy ndarray/list/etc),
-     it will first collect the `index` to driver if necessary, and then apply
-     the `Pandas.DataFrame(...)` creation internally;
+    Notes
+    -----
+    Since 3.4.0, it support more cases that combine `data` and `index`:
+    1, when `data` is a distributed dataset (Internal DataFrame/Spark DataFrame/
+    pandas-on-Spark DataFrame/pandas-on-Spark Series), it will first parallize
+    the `index` if necessary, and then try to combine the `data` and `index`;
+    Note that in this case `compute.ops_on_diff_frames` should be turned on;
+    2, when `data` is a local dataset (Pandas DataFrame/numpy ndarray/list/etc),
+    it will first collect the `index` to driver if necessary, and then apply
+    the `Pandas.DataFrame(...)` creation internally;
 
-     Examples
-     --------
-     Constructing DataFrame from a dictionary.
+    Examples
+    --------
+    Constructing DataFrame from a dictionary.
 
-     >>> d = {'col1': [1, 2], 'col2': [3, 4]}
-     >>> df = ps.DataFrame(data=d, columns=['col1', 'col2'])
-     >>> df
-        col1  col2
-     0     1     3
-     1     2     4
+    >>> d = {'col1': [1, 2], 'col2': [3, 4]}
+    >>> df = ps.DataFrame(data=d, columns=['col1', 'col2'])
+    >>> df
+       col1  col2
+    0     1     3
+    1     2     4
 
-     Constructing DataFrame from pandas DataFrame
+    Constructing DataFrame from pandas DataFrame
 
-     >>> df = ps.DataFrame(pd.DataFrame(data=d, columns=['col1', 'col2']))
-     >>> df
-        col1  col2
-     0     1     3
-     1     2     4
+    >>> df = ps.DataFrame(pd.DataFrame(data=d, columns=['col1', 'col2']))
+    >>> df
+       col1  col2
+    0     1     3
+    1     2     4
 
-     Notice that the inferred dtype is int64.
+    Notice that the inferred dtype is int64.
 
-     >>> df.dtypes
-     col1    int64
-     col2    int64
-     dtype: object
+    >>> df.dtypes
+    col1    int64
+    col2    int64
+    dtype: object
 
-     To enforce a single dtype:
+    To enforce a single dtype:
 
-     >>> df = ps.DataFrame(data=d, dtype=np.int8)
-     >>> df.dtypes
-     col1    int8
-     col2    int8
-     dtype: object
+    >>> df = ps.DataFrame(data=d, dtype=np.int8)
+    >>> df.dtypes
+    col1    int8
+    col2    int8
+    dtype: object
 
-     Constructing DataFrame from numpy ndarray:
+    Constructing DataFrame from numpy ndarray:
 
-     >>> import numpy as np
-     >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-     ...     columns=['a', 'b', 'c', 'd', 'e'])
-        a  b  c  d  e
-     0  1  2  3  4  5
-     1  6  7  8  9  0
+    >>> import numpy as np
+    >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
+    ...     columns=['a', 'b', 'c', 'd', 'e'])
+       a  b  c  d  e
+    0  1  2  3  4  5
+    1  6  7  8  9  0
 
-     Constructing DataFrame from numpy ndarray with Pandas index:
+    Constructing DataFrame from numpy ndarray with Pandas index:
 
-     >>> import numpy as np
-     >>> import pandas as pd
-     >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-     ...     index=pd.Index([1,4]), columns=['a', 'b', 'c', 'd', 'e'])
-        a  b  c  d  e
-     1  1  2  3  4  5
-     4  6  7  8  9  0
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
+    ...     index=pd.Index([1,4]), columns=['a', 'b', 'c', 'd', 'e'])
+       a  b  c  d  e
+    1  1  2  3  4  5
+    4  6  7  8  9  0
 
-     Constructing DataFrame from numpy ndarray with pandas-on-Spark index:
+    Constructing DataFrame from numpy ndarray with pandas-on-Spark index:
 
-     >>> import numpy as np
-     >>> import pandas as pd
-     >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-     ...     index=ps.Index([1,4]), columns=['a', 'b', 'c', 'd', 'e'])
-        a  b  c  d  e
-     1  1  2  3  4  5
-     4  6  7  8  9  0
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
+    ...     index=ps.Index([1,4]), columns=['a', 'b', 'c', 'd', 'e'])
+       a  b  c  d  e
+    1  1  2  3  4  5
+    4  6  7  8  9  0
 
-     Constructing DataFrame from Pandas DataFrame with Pandas index:
+    Constructing DataFrame from Pandas DataFrame with Pandas index:
 
-     >>> import numpy as np
-     >>> import pandas as pd
-     >>> pdf = pd.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-     ...     columns=['a', 'b', 'c', 'd', 'e'])
-     >>> ps.DataFrame(data=pdf, index=pd.Index([1,4]))
-          a    b    c    d    e
-     1  6.0  7.0  8.0  9.0  0.0
-     4  NaN  NaN  NaN  NaN  NaN
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> pdf = pd.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
+    ...     columns=['a', 'b', 'c', 'd', 'e'])
+    >>> ps.DataFrame(data=pdf, index=pd.Index([1,4]))
+         a    b    c    d    e
+    1  6.0  7.0  8.0  9.0  0.0
+    4  NaN  NaN  NaN  NaN  NaN
 
-     Constructing DataFrame from Pandas DataFrame with pandas-on-Spark index:
+    Constructing DataFrame from Pandas DataFrame with pandas-on-Spark index:
 
-     >>> import numpy as np
-     >>> import pandas as pd
-     >>> pdf = pd.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-     ...     columns=['a', 'b', 'c', 'd', 'e'])
-     >>> ps.DataFrame(data=pdf, index=ps.Index([1,4]))
-          a    b    c    d    e
-     1  6.0  7.0  8.0  9.0  0.0
-     4  NaN  NaN  NaN  NaN  NaN
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> pdf = pd.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
+    ...     columns=['a', 'b', 'c', 'd', 'e'])
+    >>> ps.DataFrame(data=pdf, index=ps.Index([1,4]))
+         a    b    c    d    e
+    1  6.0  7.0  8.0  9.0  0.0
+    4  NaN  NaN  NaN  NaN  NaN
 
-     Constructing DataFrame from SparkDataFrame with Pandas index:
+    Constructing DataFrame from SparkDataFrame with Pandas index:
 
-     >>> import pandas as pd
-     >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
-     >>> ps.DataFrame(data=sdf, index=pd.Index([0, 1, 2]))
-     Traceback (most recent call last):
-       ...
-     ValueError: Cannot combine the series or dataframe...'compute.ops_on_diff_frames' option.
+    >>> import pandas as pd
+    >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
+    >>> ps.DataFrame(data=sdf, index=pd.Index([0, 1, 2]))
+    Traceback (most recent call last):
+      ...
+    ValueError: Cannot combine the series or dataframe...'compute.ops_on_diff_frames' option.
 
-     Need to enable 'compute.ops_on_diff_frames' to combine SparkDataFrame and Pandas index
+    Need to enable 'compute.ops_on_diff_frames' to combine SparkDataFrame and Pandas index
 
-     >>> with ps.option_context("compute.ops_on_diff_frames", True):
-     ...     ps.DataFrame(data=sdf, index=pd.Index([0, 1, 2]))
-             x    y
-     0    Data  1.0
-     1  Bricks  2.0
-     2    None  NaN
+    >>> with ps.option_context("compute.ops_on_diff_frames", True):
+    ...     ps.DataFrame(data=sdf, index=pd.Index([0, 1, 2]))
+            x    y
+    0    Data  1.0
+    1  Bricks  2.0
+    2    None  NaN
 
-     Constructing DataFrame from SparkDataFrame with pandas-on-Spark index:
+    Constructing DataFrame from SparkDataFrame with pandas-on-Spark index:
 
-     >>> import pandas as pd
-     >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
-     >>> ps.DataFrame(data=sdf, index=ps.Index([0, 1, 2]))
-     Traceback (most recent call last):
-       ...
-     ValueError: Cannot combine the series or dataframe...'compute.ops_on_diff_frames' option.
+    >>> import pandas as pd
+    >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
+    >>> ps.DataFrame(data=sdf, index=ps.Index([0, 1, 2]))
+    Traceback (most recent call last):
+      ...
+    ValueError: Cannot combine the series or dataframe...'compute.ops_on_diff_frames' option.
 
-     Need to enable 'compute.ops_on_diff_frames' to combine SparkDataFrame and Pandas index
+    Need to enable 'compute.ops_on_diff_frames' to combine SparkDataFrame and Pandas index
 
-     >>> with ps.option_context("compute.ops_on_diff_frames", True):
-     ...     ps.DataFrame(data=sdf, index=ps.Index([0, 1, 2]))
-             x    y
-     0    Data  1.0
-     1  Bricks  2.0
-     2    None  NaN
-     """
+    >>> with ps.option_context("compute.ops_on_diff_frames", True):
+    ...     ps.DataFrame(data=sdf, index=ps.Index([0, 1, 2]))
+            x    y
+    0    Data  1.0
+    1  Bricks  2.0
+    2    None  NaN
+    """
 
     def __init__(  # type: ignore[no-untyped-def]
         self, data=None, index=None, columns=None, dtype=None, copy=False

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -424,13 +424,7 @@ class DataFrame(Frame, Generic[T]):
         self, data=None, index=None, columns=None, dtype=None, copy=False
     ):
         index_assigned = False
-        if isinstance(data, DataFrame):
-            assert columns is None
-            assert dtype is None
-            assert not copy
-            if index is None:
-                internal = data._internal
-        elif isinstance(data, InternalFrame):
+        if isinstance(data, InternalFrame):
             assert columns is None
             assert dtype is None
             assert not copy
@@ -442,6 +436,12 @@ class DataFrame(Frame, Generic[T]):
             assert not copy
             if index is None:
                 internal = InternalFrame(spark_frame=data, index_spark_columns=None)
+        elif isinstance(data, DataFrame):
+            assert columns is None
+            assert dtype is None
+            assert not copy
+            if index is None:
+                internal = data._internal
         elif isinstance(data, ps.Series):
             assert columns is None
             assert dtype is None

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -454,11 +454,11 @@ class DataFrame(Frame, Generic[T]):
                 internal = InternalFrame.from_pandas(pdf)
         else:
             from pyspark.pandas.indexes.base import Index
-
-            if not isinstance(index, Index):
-                pdf = pd.DataFrame(data=data, index=index, columns=columns, dtype=dtype, copy=copy)
-                internal = InternalFrame.from_pandas(pdf)
-                index_assigned = True
+            if isinstance(index, Index):
+                index = index.to_pandas()
+            pdf = pd.DataFrame(data=data, index=index, columns=columns, dtype=dtype, copy=copy)
+            internal = InternalFrame.from_pandas(pdf)
+            index_assigned = True
 
         if index is not None and not index_assigned:
             data_df = ps.DataFrame(data=data, index=None, columns=columns, dtype=dtype, copy=copy)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -13358,7 +13358,7 @@ def _test() -> None:
     spark = (
         SparkSession.builder.master("local[4]").appName("pyspark.pandas.frame tests").getOrCreate()
     )
-    globs['spark'] = spark
+    globs["spark"] = spark
 
     db_name = "db%s" % str(uuid.uuid4()).replace("-", "")
     spark.sql("CREATE DATABASE %s" % db_name)

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -460,8 +460,8 @@ class DataFrame(Frame, Generic[T]):
             from pyspark.pandas.indexes.base import Index
 
             if isinstance(index, Index):
-                # with local data, collect ps.Index to avoid mismatched results like:
-                # ps.DataFrame([1, 2], index=ps.Index([1, 2])) vs
+                # with local data, collect ps.Index to avoid mismatched results between:
+                # ps.DataFrame([1, 2], index=ps.Index([1, 2])) and
                 # pd.DataFrame([1, 2], index=pd.Index([1, 2]))
                 index = index.to_pandas()
             pdf = pd.DataFrame(data=data, index=index, columns=columns, dtype=dtype, copy=copy)
@@ -473,7 +473,7 @@ class DataFrame(Frame, Generic[T]):
             index_ps = ps.Index(index)
             index_df = index_ps.to_frame()
 
-            # `combine_frames` does not work with a MultiIndex for now
+            # `combine_frames` can not work with a MultiIndex for now
             combined = combine_frames(data_df, index_df, how="right")
             combined_labels = combined._internal.column_labels
             index_labels = [label for label in combined_labels if label[0] == "that"]

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -375,7 +375,7 @@ class DataFrame(Frame, Generic[T]):
 
     Notes
     -----
-    Since 3.4.0, it support more cases that combine `data` and `index`:
+    Since 3.4.0, it deals with `index` in this way:
     1, when `data` is a distributed dataset (Internal DataFrame/Spark DataFrame/
     pandas-on-Spark DataFrame/pandas-on-Spark Series), it will first parallize
     the `index` if necessary, and then try to combine the `data` and `index`;
@@ -431,8 +431,9 @@ class DataFrame(Frame, Generic[T]):
 
     >>> import numpy as np
     >>> import pandas as pd
+
     >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-    ...     index=pd.Index([1,4]), columns=['a', 'b', 'c', 'd', 'e'])
+    ...     index=pd.Index([1, 4]), columns=['a', 'b', 'c', 'd', 'e'])
        a  b  c  d  e
     1  1  2  3  4  5
     4  6  7  8  9  0
@@ -442,7 +443,7 @@ class DataFrame(Frame, Generic[T]):
     >>> import numpy as np
     >>> import pandas as pd
     >>> ps.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
-    ...     index=ps.Index([1,4]), columns=['a', 'b', 'c', 'd', 'e'])
+    ...     index=ps.Index([1, 4]), columns=['a', 'b', 'c', 'd', 'e'])
        a  b  c  d  e
     1  1  2  3  4  5
     4  6  7  8  9  0
@@ -453,7 +454,7 @@ class DataFrame(Frame, Generic[T]):
     >>> import pandas as pd
     >>> pdf = pd.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
     ...     columns=['a', 'b', 'c', 'd', 'e'])
-    >>> ps.DataFrame(data=pdf, index=pd.Index([1,4]))
+    >>> ps.DataFrame(data=pdf, index=pd.Index([1, 4]))
          a    b    c    d    e
     1  6.0  7.0  8.0  9.0  0.0
     4  NaN  NaN  NaN  NaN  NaN
@@ -464,12 +465,12 @@ class DataFrame(Frame, Generic[T]):
     >>> import pandas as pd
     >>> pdf = pd.DataFrame(data=np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 0]]),
     ...     columns=['a', 'b', 'c', 'd', 'e'])
-    >>> ps.DataFrame(data=pdf, index=ps.Index([1,4]))
+    >>> ps.DataFrame(data=pdf, index=ps.Index([1, 4]))
          a    b    c    d    e
     1  6.0  7.0  8.0  9.0  0.0
     4  NaN  NaN  NaN  NaN  NaN
 
-    Constructing DataFrame from SparkDataFrame with Pandas index:
+    Constructing DataFrame from Spark DataFrame with Pandas index:
 
     >>> import pandas as pd
     >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
@@ -487,7 +488,7 @@ class DataFrame(Frame, Generic[T]):
     1  Bricks  2.0
     2    None  NaN
 
-    Constructing DataFrame from SparkDataFrame with pandas-on-Spark index:
+    Constructing DataFrame from Spark DataFrame with pandas-on-Spark index:
 
     >>> import pandas as pd
     >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -109,11 +109,15 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
     def test_creation_index(self):
         err_msg = (
-            "The given index cannot be a pandas-on-Spark index. Try pandas index or array-like."
+            "Cannot combine the series or dataframe because it comes from a different dataframe."
         )
-        with self.assertRaisesRegex(TypeError, err_msg):
+        with self.assertRaisesRegex(ValueError, err_msg):
             ps.DataFrame([1, 2], index=ps.Index([1, 2]))
-        with self.assertRaisesRegex(TypeError, err_msg):
+        with self.assertRaisesRegex(ValueError, err_msg):
+            ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            ps.DataFrame([1, 2], index=ps.Index([1, 2]))
             ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
 
     def _check_extension(self, psdf, pdf):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -146,12 +146,6 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             pd.DataFrame(data=data, index=pd.Index([1, 2, 3, 5, 6])),
         )
 
-        # test local data with ps.MultiIndex
-        self.assert_eq(
-            ps.DataFrame(data=[1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])),
-            pd.DataFrame(data=[1, 2], index=pd.MultiIndex.from_tuples([(1, 3), (2, 4)])),
-        )
-
         err_msg = "Cannot combine the series or dataframe"
         with self.assertRaisesRegex(ValueError, err_msg):
             # test ps.DataFrame with ps.Index
@@ -159,20 +153,6 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         with self.assertRaisesRegex(ValueError, err_msg):
             # test ps.DataFrame with pd.Index
             ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
-
-        # test distributed data with ps.MultiIndex
-        err_msg = "Cannot combine a Distributed Dataset with a MultiIndex"
-        with ps.option_context("compute.ops_on_diff_frames", True):
-            with self.assertRaisesRegex(ValueError, err_msg):
-                # test ps.DataFrame with ps.Index
-                ps.DataFrame(
-                    data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])
-                )
-            with self.assertRaisesRegex(ValueError, err_msg):
-                # test ps.DataFrame with pd.Index
-                ps.DataFrame(
-                    data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])
-                )
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             # test pd.DataFrame with pd.Index
@@ -341,6 +321,27 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                     ),
                 ),
             )
+
+        # test MultiIndex
+        # test local data with ps.MultiIndex
+        self.assert_eq(
+            ps.DataFrame(data=[1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])),
+            pd.DataFrame(data=[1, 2], index=pd.MultiIndex.from_tuples([(1, 3), (2, 4)])),
+        )
+
+        # test distributed data with ps.MultiIndex
+        err_msg = "Cannot combine a Distributed Dataset with a MultiIndex"
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            with self.assertRaisesRegex(ValueError, err_msg):
+                # test ps.DataFrame with ps.Index
+                ps.DataFrame(
+                    data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])
+                )
+            with self.assertRaisesRegex(ValueError, err_msg):
+                # test ps.DataFrame with pd.Index
+                ps.DataFrame(
+                    data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])
+                )
 
     def _check_extension(self, psdf, pdf):
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -108,54 +108,116 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             self.assert_eq(pdf, psdf)
 
     def test_creation_index(self):
+        data = np.random.randn(5, 3)
+
+        # test local data with pd.Index
+        self.assert_eq(
+            ps.DataFrame(data=[1, 2], index=pd.Index([1, 2])),
+            pd.DataFrame(data=[1, 2], index=pd.Index([1, 2])),
+        )
+        self.assert_eq(
+            ps.DataFrame(data=[1, 2], index=pd.Index([2, 3])),
+            pd.DataFrame(data=[1, 2], index=pd.Index([2, 3])),
+        )
+        self.assert_eq(
+            ps.DataFrame(data=[1, 2], index=pd.Index([3, 4])),
+            pd.DataFrame(data=[1, 2], index=pd.Index([3, 4])),
+        )
+        self.assert_eq(
+            ps.DataFrame(data=data, index=pd.Index([1, 2, 3, 5, 6])),
+            pd.DataFrame(data=data, index=pd.Index([1, 2, 3, 5, 6])),
+        )
 
         # test local data with ps.Index
         self.assert_eq(
-            ps.DataFrame([1, 2], index=ps.Index([1, 2])),
-            pd.DataFrame([1, 2], index=pd.Index([1, 2])),
+            ps.DataFrame(data=[1, 2], index=ps.Index([1, 2])),
+            pd.DataFrame(data=[1, 2], index=pd.Index([1, 2])),
         )
         self.assert_eq(
-            ps.DataFrame([1, 2], index=ps.Index([2, 3])),
-            pd.DataFrame([1, 2], index=pd.Index([2, 3])),
+            ps.DataFrame(data=[1, 2], index=ps.Index([2, 3])),
+            pd.DataFrame(data=[1, 2], index=pd.Index([2, 3])),
         )
         self.assert_eq(
-            ps.DataFrame([1, 2], index=ps.Index([3, 4])),
-            pd.DataFrame([1, 2], index=pd.Index([3, 4])),
+            ps.DataFrame(data=[1, 2], index=ps.Index([3, 4])),
+            pd.DataFrame(data=[1, 2], index=pd.Index([3, 4])),
+        )
+        self.assert_eq(
+            ps.DataFrame(data=data, index=ps.Index([1, 2, 3, 5, 6])),
+            pd.DataFrame(data=data, index=pd.Index([1, 2, 3, 5, 6])),
         )
 
         # test local data with ps.MultiIndex
         self.assert_eq(
-            ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])),
-            pd.DataFrame([1, 2], index=pd.MultiIndex.from_tuples([(1, 3), (2, 4)])),
+            ps.DataFrame(data=[1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])),
+            pd.DataFrame(data=[1, 2], index=pd.MultiIndex.from_tuples([(1, 3), (2, 4)])),
         )
 
         err_msg = "Cannot combine the series or dataframe"
         with self.assertRaisesRegex(ValueError, err_msg):
             # test ps.DataFrame with ps.Index
-            ps.DataFrame(ps.DataFrame([1, 2]), index=ps.Index([1, 2]))
+            ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.Index([1, 2]))
         with self.assertRaisesRegex(ValueError, err_msg):
             # test ps.DataFrame with pd.Index
-            ps.DataFrame(ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
+            ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
 
         with ps.option_context("compute.ops_on_diff_frames", True):
-            # test ps.DataFrame with ps.Index
+            # test pd.DataFrame with pd.Index
             self.assert_eq(
-                ps.DataFrame(ps.DataFrame([1, 2]), index=ps.Index([0, 1])),
-                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
+                ps.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
+                pd.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
             )
             self.assert_eq(
-                ps.DataFrame(ps.DataFrame([1, 2]), index=ps.Index([1, 2])),
-                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+                ps.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+                pd.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+            )
+
+            # test ps.DataFrame with ps.Index
+            self.assert_eq(
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.Index([0, 1])),
+                pd.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
+            )
+            self.assert_eq(
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.Index([1, 2])),
+                pd.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
             )
 
             # test ps.DataFrame with pd.Index
             self.assert_eq(
-                ps.DataFrame(ps.DataFrame([1, 2]), index=pd.Index([0, 1])),
-                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([0, 1])),
+                pd.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
             )
             self.assert_eq(
-                ps.DataFrame(ps.DataFrame([1, 2]), index=pd.Index([1, 2])),
-                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([1, 2])),
+                pd.DataFrame(data=pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+            )
+
+        # test with multi data columns
+        pdf = pd.DataFrame(data=data, columns=["A", "B", "C"])
+        psdf = ps.from_pandas(pdf)
+
+        # test with pd.DataFrame and pd.Index
+        self.assert_eq(
+            ps.DataFrame(data=pdf, index=pd.Index([2, 3, 4, 5, 6])),
+            pd.DataFrame(data=pdf, index=pd.Index([2, 3, 4, 5, 6])),
+        )
+
+        # test with pd.DataFrame and ps.Index
+        self.assert_eq(
+            ps.DataFrame(data=pdf, index=ps.Index([2, 3, 4, 5, 6])),
+            pd.DataFrame(data=pdf, index=pd.Index([2, 3, 4, 5, 6])),
+        )
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            # test with ps.DataFrame and pd.Index
+            self.assert_eq(
+                ps.DataFrame(data=psdf, index=pd.Index([2, 3, 4, 5, 6])),
+                pd.DataFrame(data=pdf, index=pd.Index([2, 3, 4, 5, 6])),
+            )
+
+            # test with ps.DataFrame and ps.Index
+            self.assert_eq(
+                ps.DataFrame(data=psdf, index=ps.Index([2, 3, 4, 5, 6])),
+                pd.DataFrame(data=pdf, index=pd.Index([2, 3, 4, 5, 6])),
             )
 
     def _check_extension(self, psdf, pdf):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -160,6 +160,16 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             # test ps.DataFrame with pd.Index
             ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
 
+        # test distributed data with ps.MultiIndex
+        err_msg = "Cannot combine a Distributed Dataset with a MultiIndex"
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            with self.assertRaisesRegex(ValueError, err_msg):
+                # test ps.DataFrame with ps.Index
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+            with self.assertRaisesRegex(ValueError, err_msg):
+                # test ps.DataFrame with pd.Index
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+
         with ps.option_context("compute.ops_on_diff_frames", True):
             # test pd.DataFrame with pd.Index
             self.assert_eq(

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -165,10 +165,14 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
         with ps.option_context("compute.ops_on_diff_frames", True):
             with self.assertRaisesRegex(ValueError, err_msg):
                 # test ps.DataFrame with ps.Index
-                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+                ps.DataFrame(
+                    data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])
+                )
             with self.assertRaisesRegex(ValueError, err_msg):
                 # test ps.DataFrame with pd.Index
-                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+                ps.DataFrame(
+                    data=ps.DataFrame([1, 2]), index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])
+                )
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             # test pd.DataFrame with pd.Index

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -108,18 +108,55 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
             self.assert_eq(pdf, psdf)
 
     def test_creation_index(self):
-        err_msg = (
-            "Cannot combine the series or dataframe because it comes from a different dataframe."
+
+        # test local data with ps.Index
+        self.assert_eq(
+            ps.DataFrame([1, 2], index=ps.Index([1, 2])),
+            pd.DataFrame([1, 2], index=pd.Index([1, 2])),
         )
+        self.assert_eq(
+            ps.DataFrame([1, 2], index=ps.Index([2, 3])),
+            pd.DataFrame([1, 2], index=pd.Index([2, 3])),
+        )
+        self.assert_eq(
+            ps.DataFrame([1, 2], index=ps.Index([3, 4])),
+            pd.DataFrame([1, 2], index=pd.Index([3, 4])),
+        )
+
+        # test local data with ps.MultiIndex
+        self.assert_eq(
+            ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)])),
+            pd.DataFrame([1, 2], index=pd.MultiIndex.from_tuples([(1, 3), (2, 4)])),
+        )
+
+        err_msg = "Cannot combine the series or dataframe"
         with self.assertRaisesRegex(ValueError, err_msg):
-            ps.DataFrame([1, 2], index=ps.Index([1, 2]))
+            # test ps.DataFrame with ps.Index
+            ps.DataFrame(ps.DataFrame([1, 2]), index=ps.Index([1, 2]))
         with self.assertRaisesRegex(ValueError, err_msg):
-            ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+            # test ps.DataFrame with pd.Index
+            ps.DataFrame(ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
 
         with ps.option_context("compute.ops_on_diff_frames", True):
-            ps.DataFrame([1, 2], index=ps.Index([1, 2]))
-            # combine_frames doesn't work with MultiIndex
-            # ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+            # test ps.DataFrame with ps.Index
+            self.assert_eq(
+                ps.DataFrame(ps.DataFrame([1, 2]), index=ps.Index([0, 1])),
+                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
+            )
+            self.assert_eq(
+                ps.DataFrame(ps.DataFrame([1, 2]), index=ps.Index([1, 2])),
+                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+            )
+
+            # test ps.DataFrame with pd.Index
+            self.assert_eq(
+                ps.DataFrame(ps.DataFrame([1, 2]), index=pd.Index([0, 1])),
+                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([0, 1])),
+            )
+            self.assert_eq(
+                ps.DataFrame(ps.DataFrame([1, 2]), index=pd.Index([1, 2])),
+                pd.DataFrame(pd.DataFrame([1, 2]), index=pd.Index([1, 2])),
+            )
 
     def _check_extension(self, psdf, pdf):
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -220,6 +220,114 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
                 pd.DataFrame(data=pdf, index=pd.Index([2, 3, 4, 5, 6])),
             )
 
+        # test String Index
+        pdf = pd.DataFrame(
+            data={
+                "s": ["Hello", "World", "Databricks"],
+                "x": [2002, 2003, 2004],
+            }
+        )
+        pdf = pdf.set_index("s")
+        pdf.index.name = None
+        psdf = ps.from_pandas(pdf)
+
+        # test with pd.DataFrame and pd.Index
+        self.assert_eq(
+            ps.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+            pd.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+        )
+
+        # test with pd.DataFrame and ps.Index
+        self.assert_eq(
+            ps.DataFrame(data=pdf, index=ps.Index(["Hello", "Universe", "Databricks"])),
+            pd.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+        )
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            # test with ps.DataFrame and pd.Index
+            self.assert_eq(
+                ps.DataFrame(data=psdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+                pd.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+            )
+
+            # test with ps.DataFrame and ps.Index
+            self.assert_eq(
+                ps.DataFrame(data=psdf, index=ps.Index(["Hello", "Universe", "Databricks"])),
+                pd.DataFrame(data=pdf, index=pd.Index(["Hello", "Universe", "Databricks"])),
+            )
+
+        # test DatetimeIndex
+        pdf = pd.DataFrame(
+            data={
+                "t": [
+                    datetime(2022, 9, 1, 0, 0, 0, 0),
+                    datetime(2022, 9, 2, 0, 0, 0, 0),
+                    datetime(2022, 9, 3, 0, 0, 0, 0),
+                ],
+                "x": [2002, 2003, 2004],
+            }
+        )
+        pdf = pdf.set_index("t")
+        pdf.index.name = None
+        psdf = ps.from_pandas(pdf)
+
+        # test with pd.DataFrame and pd.DatetimeIndex
+        self.assert_eq(
+            ps.DataFrame(
+                data=pdf,
+                index=pd.DatetimeIndex(["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]),
+            ),
+            pd.DataFrame(
+                data=pdf,
+                index=pd.DatetimeIndex(["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]),
+            ),
+        )
+
+        # test with pd.DataFrame and ps.DatetimeIndex
+        self.assert_eq(
+            ps.DataFrame(
+                data=pdf,
+                index=ps.DatetimeIndex(["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]),
+            ),
+            pd.DataFrame(
+                data=pdf,
+                index=pd.DatetimeIndex(["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]),
+            ),
+        )
+
+        with ps.option_context("compute.ops_on_diff_frames", True):
+            # test with ps.DataFrame and pd.DatetimeIndex
+            self.assert_eq(
+                ps.DataFrame(
+                    data=psdf,
+                    index=pd.DatetimeIndex(
+                        ["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]
+                    ),
+                ),
+                pd.DataFrame(
+                    data=pdf,
+                    index=pd.DatetimeIndex(
+                        ["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]
+                    ),
+                ),
+            )
+
+            # test with ps.DataFrame and ps.DatetimeIndex
+            self.assert_eq(
+                ps.DataFrame(
+                    data=psdf,
+                    index=ps.DatetimeIndex(
+                        ["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]
+                    ),
+                ),
+                pd.DataFrame(
+                    data=pdf,
+                    index=pd.DatetimeIndex(
+                        ["2022-08-31", "2022-09-02", "2022-09-03", "2022-09-05"]
+                    ),
+                ),
+            )
+
     def _check_extension(self, psdf, pdf):
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):
             self.assert_eq(psdf, pdf, check_exact=False)

--- a/python/pyspark/pandas/tests/test_dataframe.py
+++ b/python/pyspark/pandas/tests/test_dataframe.py
@@ -118,7 +118,8 @@ class DataFrameTest(ComparisonTestBase, SQLTestUtils):
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             ps.DataFrame([1, 2], index=ps.Index([1, 2]))
-            ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
+            # combine_frames doesn't work with MultiIndex
+            # ps.DataFrame([1, 2], index=ps.MultiIndex.from_tuples([(1, 3), (2, 4)]))
 
     def _check_extension(self, psdf, pdf):
         if LooseVersion("1.1") <= LooseVersion(pd.__version__) < LooseVersion("1.2.2"):


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. param `data` accepts `ps.DataFrame`, since `pd.DataFrame(...)` also accepts another `pd.DataFrame` as a `data` param;
2. when `data` is distributed (`InternalFrame`/`SparkDataFrame`/`ps.DataFrame`/`ps.Series`), apply `combine_frames` to combine `data` and `index`;
3. when `data` is a local data (`pd.DataFrame`/list/...), directly collect `index`, and apply `pd.DataFrame(...)` internally
- 3.1 `index` should be small, when `data` fits in memory
- 3.2 `combine_frames` can not work with a multi-index for now
- 3.3 most important, to make sure queries like `ps.DataFrame([1, 2], index=ps.Index([1, 2]))` returns same result with `pd.DataFrame([1, 2], index=pd.Index([1, 2]))`, if we apply `combine_frames` in this case, then the results will be different

### Why are the changes needed?
to support `index` in DataFrame creation


### Does this PR introduce _any_ user-facing change?
Yes, `ps.Index` is supported


### How was this patch tested?
added UT