### PR TITLE
[SPARK-40137][SQL] Combines limits after projection

### DIFF
--- a/python/pyspark/sql/tests/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/test_pandas_udf_scalar.py
@@ -996,9 +996,10 @@ class ScalarPandasUDFTests(ReusedSQLTestCase):
                         "spark.sql.execution.pandas.udf.buffer.size": 4,
                     }
                 ):
-                    self.spark.range(10).repartition(1).select(test_close(col("id"))).limit(
-                        2
-                    ).collect()
+                    data = self.spark.sparkContext.parallelize([((i,), i) for i in range(10)], 1)
+                    self.spark.createDataFrame(data, "s struct<id: long>, tag: long").select(
+                        test_close(col("s.id"))
+                    ).limit(2).collect()
                     # wait here because python udf worker will take some time to detect
                     # jvm side socket closed and then will trigger `GenerateExit` raised.
                     # wait timeout is 10s.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1994,6 +1994,11 @@ object EliminateLimits extends Rule[LogicalPlan] {
       LocalLimit(Literal(Least(Seq(ne, le)).eval().asInstanceOf[Int]), grandChild)
     case Limit(le, Limit(ne, grandChild)) =>
       Limit(Literal(Least(Seq(ne, le)).eval().asInstanceOf[Int]), grandChild)
+
+    case Project(projectList, GlobalLimit(l, child)) =>
+      GlobalLimit(l, Project(projectList, child));
+    case Project(projectList, LocalLimit(l, child)) =>
+      LocalLimit(l, Project(projectList, child))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1995,12 +1995,12 @@ object EliminateLimits extends Rule[LogicalPlan] {
     case Limit(le, Limit(ne, grandChild)) =>
       Limit(Literal(Least(Seq(ne, le)).eval().asInstanceOf[Int]), grandChild)
 
-    case Project(projectList, Limit(l, child)) =>
-      Limit(l, Project(projectList, child))
-    case Project(projectList, GlobalLimit(l, child)) =>
-      GlobalLimit(l, Project(projectList, child));
-    case Project(projectList, LocalLimit(l, child)) =>
-      LocalLimit(l, Project(projectList, child))
+    case GlobalLimit(l, Project(projectList, child)) =>
+      Project(projectList, GlobalLimit(l, child))
+    case LocalLimit(l, Project(projectList, child)) =>
+      Project(projectList, LocalLimit(l, child))
+    case Limit(l, Project(projectList, child)) =>
+      Project(projectList, Limit(l, child))
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1995,6 +1995,8 @@ object EliminateLimits extends Rule[LogicalPlan] {
     case Limit(le, Limit(ne, grandChild)) =>
       Limit(Literal(Least(Seq(ne, le)).eval().asInstanceOf[Int]), grandChild)
 
+    case Project(projectList, Limit(l, child)) =>
+      Limit(l, Project(projectList, child))
     case Project(projectList, GlobalLimit(l, child)) =>
       GlobalLimit(l, Project(projectList, child));
     case Project(projectList, LocalLimit(l, child)) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -103,6 +103,26 @@ class CombiningLimitsSuite extends PlanTest {
     comparePlans(optimized, correctAnswer)
   }
 
+  test("limits: combines limits after Projection") {
+    val originalQuery =
+      testRelation
+        .select($"a")
+        .limit(2)
+        .select($"a", $"a" + 1)
+        .limit(5)
+        .select($"a" + 2)
+        .limit(7)
+
+    val optimized = Optimize.execute(originalQuery.analyze)
+    val correctAnswer =
+      testRelation
+        .select($"a")
+        .select($"a" + 2)
+        .limit(2).analyze
+
+    comparePlans(optimized, correctAnswer)
+  }
+
   test("SPARK-33442: Change Combine Limit to Eliminate limit using max row") {
     // test child max row <= limit.
     val query1 = testRelation.select().groupBy()(count(1)).limit(1).analyze

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -63,8 +63,8 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .limit(5)
-        .select($"a").analyze
+        .select($"a")
+        .limit(5).analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -80,8 +80,8 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .limit(2)
-        .select($"a").analyze
+        .select($"a")
+        .limit(2).analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -97,28 +97,8 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .limit(2)
-        .select($"a").analyze
-
-    comparePlans(optimized, correctAnswer)
-  }
-
-  test("limits: combines limits after Projection") {
-    val originalQuery =
-      testRelation
         .select($"a")
-        .limit(2)
-        .select($"a", $"a" + 1)
-        .limit(5)
-        .select($"a" + 2)
-        .limit(7)
-
-    val optimized = Optimize.execute(originalQuery.analyze)
-    val correctAnswer =
-      testRelation
-        .limit(2)
-        .select($"a")
-        .select($"a" + 2).analyze
+        .limit(2).analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -136,7 +116,7 @@ class CombiningLimitsSuite extends PlanTest {
     comparePlans(optimized2, query2)
 
     // test child max row is none
-    val query3 = testRelation.limit(1).select($"a").analyze
+    val query3 = testRelation.select($"a").limit(1).analyze
     val optimized3 = Optimize.execute(query3)
     comparePlans(optimized3, query3)
 
@@ -166,7 +146,7 @@ class CombiningLimitsSuite extends PlanTest {
     )
     checkPlanAndMaxRow(
       Range(-1, Long.MaxValue, 1, None).select().limit(1),
-      Range(-1, Long.MaxValue, 1, None).limit(1).select(),
+      Range(-1, Long.MaxValue, 1, None).select().limit(1),
       1
     )
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/CombiningLimitsSuite.scala
@@ -63,8 +63,8 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .select($"a")
-        .limit(5).analyze
+        .limit(5)
+        .select($"a").analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -80,8 +80,8 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .select($"a")
-        .limit(2).analyze
+        .limit(2)
+        .select($"a").analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -97,8 +97,8 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
-        .select($"a")
-        .limit(2).analyze
+        .limit(2)
+        .select($"a").analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -116,9 +116,9 @@ class CombiningLimitsSuite extends PlanTest {
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
       testRelation
+        .limit(2)
         .select($"a")
-        .select($"a" + 2)
-        .limit(2).analyze
+        .select($"a" + 2).analyze
 
     comparePlans(optimized, correctAnswer)
   }
@@ -136,7 +136,7 @@ class CombiningLimitsSuite extends PlanTest {
     comparePlans(optimized2, query2)
 
     // test child max row is none
-    val query3 = testRelation.select($"a").limit(1).analyze
+    val query3 = testRelation.limit(1).select($"a").analyze
     val optimized3 = Optimize.execute(query3)
     comparePlans(optimized3, query3)
 
@@ -166,7 +166,7 @@ class CombiningLimitsSuite extends PlanTest {
     )
     checkPlanAndMaxRow(
       Range(-1, Long.MaxValue, 1, None).select().limit(1),
-      Range(-1, Long.MaxValue, 1, None).select().limit(1),
+      Range(-1, Long.MaxValue, 1, None).limit(1).select(),
       1
     )
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -79,7 +79,7 @@ class LimitPushdownSuite extends PlanTest {
       Union(testRelation.limit(1), testRelation2.select($"d", $"e", $"f").limit(1)).limit(2)
     val unionOptimized = Optimize.execute(unionQuery.analyze)
     val unionCorrectAnswer =
-      Union(testRelation.limit(1), testRelation2.select($"d", $"e", $"f").limit(1)).analyze
+      Union(testRelation.limit(1), testRelation2.limit(1).select($"d", $"e", $"f")).analyze
     comparePlans(unionOptimized, unionCorrectAnswer)
   }
 
@@ -89,7 +89,7 @@ class LimitPushdownSuite extends PlanTest {
     val unionOptimized = Optimize.execute(unionQuery.analyze)
     val unionCorrectAnswer =
       Limit(2, Union(
-        LocalLimit(2, testRelation), LocalLimit(2, testRelation2.select($"d", $"e", $"f")))).analyze
+        LocalLimit(2, testRelation), LocalLimit(2, testRelation2).select($"d", $"e", $"f"))).analyze
     comparePlans(unionOptimized, unionCorrectAnswer)
   }
 
@@ -236,7 +236,7 @@ class LimitPushdownSuite extends PlanTest {
     val originalQuery = x.join(y, LeftOuter, joinCondition).select("x.a".attr).limit(5)
     val optimized = Optimize.execute(originalQuery.analyze)
     val correctAnswer =
-      Limit(5, LocalLimit(5, x).join(y, LeftOuter, joinCondition).select("x.a".attr)).analyze
+      Limit(5, LocalLimit(5, x).join(y, LeftOuter, joinCondition)).select("x.a".attr).analyze
     comparePlans(optimized, correctAnswer)
   }
 
@@ -244,21 +244,21 @@ class LimitPushdownSuite extends PlanTest {
     // Push down when it is group only and limit 1.
     comparePlans(
       Optimize.execute(x.groupBy("x.a".attr)("x.a".attr).limit(1).analyze),
-      Limit(1, x.select("x.a".attr)).analyze)
+      Limit(1, x).select("x.a".attr).analyze)
 
     comparePlans(
       Optimize.execute(x.groupBy("x.a".attr)("x.a".attr).select("x.a".attr).limit(1).analyze),
-      Limit(1, x.select("x.a".attr).select("x.a".attr)).analyze)
+      Limit(1, x).select("x.a".attr).select("x.a".attr).analyze)
 
     comparePlans(
       Optimize.execute(x.union(y).groupBy("x.a".attr)("x.a".attr).limit(1).analyze),
-      LocalLimit(1, x).union(LocalLimit(1, y)).select("x.a".attr).limit(1).analyze)
+      LocalLimit(1, x).union(LocalLimit(1, y)).limit(1).select("x.a".attr).analyze)
 
     comparePlans(
       Optimize.execute(
         x.groupBy("x.a".attr)("x.a".attr)
           .select("x.a".attr.as("a1"), "x.a".attr.as("a2")).limit(1).analyze),
-      x.select("x.a".attr).select("x.a".attr.as("a1"), "x.a".attr.as("a2")).limit(1).analyze)
+      x.limit(1).select("x.a".attr).select("x.a".attr.as("a1"), "x.a".attr.as("a2")).analyze)
 
     // No push down
     comparePlans(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LimitPushdownSuite.scala
@@ -244,22 +244,21 @@ class LimitPushdownSuite extends PlanTest {
     // Push down when it is group only and limit 1.
     comparePlans(
       Optimize.execute(x.groupBy("x.a".attr)("x.a".attr).limit(1).analyze),
-      LocalLimit(1, x).select("x.a".attr).limit(1).analyze)
+      Limit(1, x.select("x.a".attr)).analyze)
 
     comparePlans(
       Optimize.execute(x.groupBy("x.a".attr)("x.a".attr).select("x.a".attr).limit(1).analyze),
-      LocalLimit(1, x).select("x.a".attr).select("x.a".attr).limit(1).analyze)
+      Limit(1, x.select("x.a".attr).select("x.a".attr)).analyze)
 
     comparePlans(
       Optimize.execute(x.union(y).groupBy("x.a".attr)("x.a".attr).limit(1).analyze),
-      LocalLimit(1, LocalLimit(1, x).union(LocalLimit(1, y))).select("x.a".attr).limit(1).analyze)
+      LocalLimit(1, x).union(LocalLimit(1, y)).select("x.a".attr).limit(1).analyze)
 
     comparePlans(
       Optimize.execute(
         x.groupBy("x.a".attr)("x.a".attr)
           .select("x.a".attr.as("a1"), "x.a".attr.as("a2")).limit(1).analyze),
-      LocalLimit(1, x).select("x.a".attr)
-        .select("x.a".attr.as("a1"), "x.a".attr.as("a2")).limit(1).analyze)
+      x.select("x.a".attr).select("x.a".attr.as("a1"), "x.a".attr.as("a2")).limit(1).analyze)
 
     // No push down
     comparePlans(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Combine the limits after projection.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`Dataset.show` will add extra `Limit` and `Projection` on top of the given logical plan. If the `Dataset` is already a limit job, this will introduce an extra shuffle phase. So we should combine the limit after projection.

For example:
```scala
spark.sql("select * from spark.store_sales limit 10").show()
```

Before:
```
== Physical Plan ==
AdaptiveSparkPlan (12)
+- == Final Plan ==
   * Project (7)
   +- * GlobalLimit (6)
      +- ShuffleQueryStage (5), Statistics(sizeInBytes=185.6 KiB, rowCount=990)
         +- Exchange (4)
            +- * LocalLimit (3)
               +- * ColumnarToRow (2)
                  +- Scan parquet spark_catalog.spark.store_sales (1)
+- == Initial Plan ==
   Project (11)
   +- GlobalLimit (10)
      +- Exchange (9)
         +- LocalLimit (8)
            +- Scan parquet spark_catalog.spark.store_sales (1)
```
After:
```
== Physical Plan ==
CollectLimit (4)
+- * Project (3)
   +- * ColumnarToRow (2)
      +- Scan parquet spark_catalog.spark.store_sales (1)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

UT and local test.