### PR TITLE
[SPARK-35542][ML] Fix: Bucketizer created for multiple columns with parameters splitsArray,  inputCols and outputCols can not be loaded after saving it

### DIFF
--- a/python/pyspark/ml/tests/test_persistence.py
+++ b/python/pyspark/ml/tests/test_persistence.py
@@ -32,7 +32,7 @@ from pyspark.ml.classification import (
     OneVsRestModel,
 )
 from pyspark.ml.clustering import KMeans
-from pyspark.ml.feature import Binarizer, HashingTF, PCA
+from pyspark.ml.feature import Binarizer, Bucketizer, HashingTF, PCA
 from pyspark.ml.linalg import Vectors
 from pyspark.ml.param import Params
 from pyspark.ml.pipeline import Pipeline, PipelineModel
@@ -517,6 +517,24 @@ class PersistenceTest(SparkSessionTestCase):
             metadataStr,
         )
         reader.getAndSetParams(lr, loadedMetadata)
+
+    # Test for SPARK-35542 fix.
+    def test_save_and_load_on_nested_list_params(self):
+        temp_path = tempfile.mkdtemp()
+        df = self.spark.createDataFrame([(0.1,), (0.4,), (1.2,), (1.5,)], ["values"])
+        splitsArray = [
+            [-float("inf"), 0.5, 1.4, float("inf")],
+            [-float("inf"), 0.1, 1.2, float("inf")],
+        ]
+        bucketizer = Bucketizer(
+            splitsArray=splitsArray,
+            inputCols=["values", "values"],
+            outputCols=["b1", "b2"]
+        )
+        savePath = temp_path + "/bk_model"
+        bucketizer.write().overwrite().save(savePath)
+        loadedBucketizer = Bucketizer.load(savePath)
+        assert loadedBucketizer.getSplitsArray() == splitsArray
 
 
 if __name__ == "__main__":

--- a/python/pyspark/ml/tests/test_persistence.py
+++ b/python/pyspark/ml/tests/test_persistence.py
@@ -521,17 +521,14 @@ class PersistenceTest(SparkSessionTestCase):
     # Test for SPARK-35542 fix.
     def test_save_and_load_on_nested_list_params(self):
         temp_path = tempfile.mkdtemp()
-        df = self.spark.createDataFrame([(0.1,), (0.4,), (1.2,), (1.5,)], ["values"])
         splitsArray = [
             [-float("inf"), 0.5, 1.4, float("inf")],
             [-float("inf"), 0.1, 1.2, float("inf")],
         ]
         bucketizer = Bucketizer(
-            splitsArray=splitsArray,
-            inputCols=["values", "values"],
-            outputCols=["b1", "b2"]
+            splitsArray=splitsArray, inputCols=["values", "values"], outputCols=["b1", "b2"]
         )
-        savePath = temp_path + "/bk_model"
+        savePath = temp_path + "/bk"
         bucketizer.write().overwrite().save(savePath)
         loadedBucketizer = Bucketizer.load(savePath)
         assert loadedBucketizer.getSplitsArray() == splitsArray

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -220,7 +220,11 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
                 java_param = self._java_obj.getParam(param.name)
                 # SPARK-14931: Only check set params back to avoid default params mismatch.
                 if self._java_obj.isSet(java_param):
-                    value = _java2py(sc, self._java_obj.getOrDefault(java_param))
+                    java_value = self._java_obj.getOrDefault(java_param)
+                    if param.typeConverter.__name__.startswith("toList"):
+                        value = [_java2py(sc, x) for x in list(java_value)]
+                    else:
+                        value = _java2py(sc, java_value)
                     self._set(**{param.name: value})
                 # SPARK-10931: Temporary fix for params that have a default in Java
                 if self._java_obj.hasDefault(java_param) and not self.isDefined(param):


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix: Bucketizer created for multiple columns with parameters splitsArray,  inputCols and outputCols can not be loaded after saving it


### Why are the changes needed?
Bugfix.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test
