### PR TITLE
[SPARK-39791][LAUNCHER] In Spark 3.0 standalone cluster mode, unable to customize driver JVM path

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -17,11 +17,21 @@
 
 package org.apache.spark.launcher;
 
+import static org.apache.spark.launcher.CommandBuilderUtils.DEFAULT_PROPERTIES_FILE;
+import static org.apache.spark.launcher.CommandBuilderUtils.ENV_SPARK_HOME;
+import static org.apache.spark.launcher.CommandBuilderUtils.checkArgument;
+import static org.apache.spark.launcher.CommandBuilderUtils.checkState;
+import static org.apache.spark.launcher.CommandBuilderUtils.findJarsDir;
+import static org.apache.spark.launcher.CommandBuilderUtils.firstNonEmpty;
+import static org.apache.spark.launcher.CommandBuilderUtils.isEmpty;
+import static org.apache.spark.launcher.CommandBuilderUtils.join;
+import static org.apache.spark.launcher.CommandBuilderUtils.parseOptionString;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,8 +42,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import static org.apache.spark.launcher.CommandBuilderUtils.*;
 
 /**
  * Abstract Spark command builder that defines common functionality.
@@ -93,8 +101,8 @@ abstract class AbstractCommandBuilder {
     List<String> cmd = new ArrayList<>();
 
     String firstJavaHome = firstNonEmpty(javaHome,
-      childEnv.get("JAVA_HOME"),
       System.getenv("JAVA_HOME"),
+      childEnv.get("JAVA_HOME"),
       System.getProperty("java.home"));
 
     if (firstJavaHome != null) {

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -17,21 +17,11 @@
 
 package org.apache.spark.launcher;
 
-import static org.apache.spark.launcher.CommandBuilderUtils.DEFAULT_PROPERTIES_FILE;
-import static org.apache.spark.launcher.CommandBuilderUtils.ENV_SPARK_HOME;
-import static org.apache.spark.launcher.CommandBuilderUtils.checkArgument;
-import static org.apache.spark.launcher.CommandBuilderUtils.checkState;
-import static org.apache.spark.launcher.CommandBuilderUtils.findJarsDir;
-import static org.apache.spark.launcher.CommandBuilderUtils.firstNonEmpty;
-import static org.apache.spark.launcher.CommandBuilderUtils.isEmpty;
-import static org.apache.spark.launcher.CommandBuilderUtils.join;
-import static org.apache.spark.launcher.CommandBuilderUtils.parseOptionString;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,6 +32,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import static org.apache.spark.launcher.CommandBuilderUtils.*;
 
 /**
  * Abstract Spark command builder that defines common functionality.
@@ -312,3 +304,4 @@ abstract class AbstractCommandBuilder {
   }
 
 }
+

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -304,3 +304,4 @@ abstract class AbstractCommandBuilder {
   }
 
 }
+

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -304,4 +304,3 @@ abstract class AbstractCommandBuilder {
   }
 
 }
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
JVM path default use JAVA_HOME
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In Spark 3.0 standalone mode, unable to customize driver JVM path, instead the JAVA_HOME of the spark-submit submission machine is used, but the JVM paths of my submission machine and the cluster machine are different.

In standalone mode, javaHome always empty, so always take childEnv.get("JAVA_HOME")

```java
List<String> buildJavaCommand(String extraClassPath) throws IOException {
  List<String> cmd = new ArrayList<>();

  String firstJavaHome = firstNonEmpty(javaHome,
    childEnv.get("JAVA_HOME"),
    System.getenv("JAVA_HOME"),
    System.getProperty("java.home")); 
```
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
