### PR TITLE
[SPARK-40145][INFRA] Create infra image when cutting down branches

### DIFF
--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -20,12 +20,16 @@
 name: Build / Cache base image
 
 on:
+  # Run jobs when all commits is merged
   push:
     branches:
     - 'master'
+    - 'branch-*'
     paths:
     - 'dev/infra/Dockerfile'
     - '.github/workflows/build_infra_images_cache.yml'
+  # Create infra image when cutting down branches/tags
+  create:
 jobs:
   main:
     if: github.repository == 'apache/spark'

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -20,7 +20,7 @@
 name: Build / Cache base image
 
 on:
-  # Run jobs when all commits is merged
+  # Run jobs when a commit is merged
   push:
     branches:
     - 'master'


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR make jobs running when creating branches/tags and merging commits in branches. This job will create cache/static image like: `ghcr.io/apache/spark/apache-spark-github-action-image-cache:branch-3.4`, `ghcr.io/apache/spark/apache-spark-github-action-image-cache:branch-3.4-static`.

- create event: trigger when branches/tags is created. (tags image may help to save a infra snapshot when create release)
- merge in branches: trigger when branches' 'dev/infra/Dockerfile' is changed.

### Why are the changes needed?
To support infra image in branches.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test in https://github.com/Yikun/spark/commit/af5f96dc0cb37d7879e465a0b6d586d6b04a8280: https://github.com/Yikun/spark/runs/7881447137?check_suite_focus=true#step:6:6544

![image](https://user-images.githubusercontent.com/1736354/185564546-562fb7b8-58e2-43e9-800d-68030d4ead69.png)


