### PR TITLE
[SPARK-40142][PYTHON][SQL][FOLLOWUP] Fix version of asin/mean and add alias note for mean

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -577,8 +577,9 @@ def avg(col: "ColumnOrName") -> Column:
 def mean(col: "ColumnOrName") -> Column:
     """
     Aggregate function: returns the average of the values in a group.
+    An alias of :func:`avg`.
 
-    .. versionadded:: 1.3.0
+    .. versionadded:: 1.4.0
 
     Parameters
     ----------
@@ -775,7 +776,7 @@ def asin(col: "ColumnOrName") -> Column:
     """
     Computes inverse sine of the input column.
 
-    .. versionadded:: 1.3.0
+    .. versionadded:: 1.4.0
 
     Parameters
     ----------


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Fix version of asin/mean and add alias note for mean

### Why are the changes needed?

https://github.com/apache/spark/pull/37575#discussion_r949917079

According to: https://github.com/apache/spark/blob/f98f9f8566243a8a01edcaad3b847bbd2f52305b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L705-L721

https://github.com/apache/spark/blob/a9bb924480e4953457dad680c15ca346f71a26c8/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L1575-L1589

the `asin`/`mean` were introduced in 1.4.0 (history commit: https://github.com/apache/spark/commit/4e6a310f8062102ea6a022fb21171f896c8296ae), so this PR try to fix it to right version.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
