### PR TITLE
[SPARK-39150][PS] Enable doctest which was disabled when pandas 1.4 upgrade 

### DIFF
--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -569,7 +569,7 @@ class DataFrame(Frame, Generic[T]):
         >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', None],
         ...                   columns=['max_speed', 'shield'])
-        >>> df  # doctest: +SKIP
+        >>> df
                max_speed  shield
         cobra          1       2
         viper          4       5
@@ -7249,19 +7249,19 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         --------
         >>> df = ps.DataFrame({'A': [2, 1, np.nan]}, index=['b', 'a', np.nan])
 
-        >>> df.sort_index()  # doctest: +SKIP
+        >>> df.sort_index()
                 A
         a     1.0
         b     2.0
         None  NaN
 
-        >>> df.sort_index(ascending=False)  # doctest: +SKIP
+        >>> df.sort_index(ascending=False)
                 A
         b     2.0
         a     1.0
         None  NaN
 
-        >>> df.sort_index(na_position='first')  # doctest: +SKIP
+        >>> df.sort_index(na_position='first')
                 A
         None  NaN
         a     1.0
@@ -7274,7 +7274,7 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         2  NaN
 
         >>> df.sort_index(inplace=True)
-        >>> df  # doctest: +SKIP
+        >>> df
                 A
         a     1.0
         b     2.0

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -2382,7 +2382,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         ...                   ["g", "g3"],
         ...                   ["h", "h0"],
         ...                   ["h", "h1"]], columns=["A", "B"])
-        >>> df.groupby("A").head(-1) # doctest: +SKIP
+        >>> df.groupby("A").head(-1)
            A   B
         0  g  g0
         1  g  g1
@@ -2450,7 +2450,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         ...                   ["g", "g3"],
         ...                   ["h", "h0"],
         ...                   ["h", "h1"]], columns=["A", "B"])
-        >>> df.groupby("A").tail(-1) # doctest: +SKIP
+        >>> df.groupby("A").tail(-1)
            A   B
         3  g  g3
         2  g  g2

--- a/python/pyspark/pandas/indexes/base.py
+++ b/python/pyspark/pandas/indexes/base.py
@@ -1163,7 +1163,7 @@ class Index(IndexOpsMixin):
         >>> df = ps.DataFrame([[1, 2], [4, 5], [7, 8]],
         ...                   index=['cobra', 'viper', None],
         ...                   columns=['max_speed', 'shield'])
-        >>> df  # doctest: +SKIP
+        >>> df
                max_speed  shield
         cobra          1       2
         viper          4       5

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -2969,7 +2969,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         --------
         >>> s = ps.Series([2, 1, np.nan], index=['b', 'a', np.nan])
 
-        >>> s.sort_index()  # doctest: +SKIP
+        >>> s.sort_index()
         a       1.0
         b       2.0
         None    NaN
@@ -2981,20 +2981,20 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         2    NaN
         dtype: float64
 
-        >>> s.sort_index(ascending=False)  # doctest: +SKIP
+        >>> s.sort_index(ascending=False)
         b       2.0
         a       1.0
         None    NaN
         dtype: float64
 
-        >>> s.sort_index(na_position='first')  # doctest: +SKIP
+        >>> s.sort_index(na_position='first')
         None    NaN
         a       1.0
         b       2.0
         dtype: float64
 
         >>> s.sort_index(inplace=True)
-        >>> s  # doctest: +SKIP
+        >>> s
         a       1.0
         b       2.0
         None    NaN


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable doctest which was disabled when pandas 1.4 upgrade

### Why are the changes needed?

Remove `# doctest: +SKIP` of SPARK-38947/SPARK-39326 because infra already dump pandas to 1.4+

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
