### PR TITLE
[SPARK-40180][SQL] Format error messages by `spark-sql`

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -27,6 +27,7 @@ license: |
   - Since Spark 3.4, Number or Number(\*) from Teradata will be treated as Decimal(38,18). In Spark 3.3 or earlier, Number or Number(\*) from Teradata will be treated as Decimal(38, 0), in which case the fractional part will be removed.
   - Since Spark 3.4, v1 database, table, permanent view and function identifier will include 'spark_catalog' as the catalog name if database is defined, e.g. a table identifier will be: `spark_catalog.default.t`. To restore the legacy behavior, set `spark.sql.legacy.v1IdentifierNoCatalog` to `true`.
   - Since Spark 3.4, when ANSI SQL mode(configuration `spark.sql.ansi.enabled`) is on, Spark SQL always returns NULL result on getting a map value with a non-existing key. In Spark 3.3 or earlier, there will be an error.
+  - Since Spark 3.4, the SQL CLI `spark-sql` does not print the prefix `Error in query:` before the error message of `AnalysisException`.
 
 ## Upgrading from Spark SQL 3.2 to 3.3
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3879,7 +3879,7 @@ object SQLConf {
     .doc("When PRETTY, the error message consists of textual representation of error class, " +
       "message and query context. The MINIMAL and STANDARD formats are pretty JSON formats where " +
       "STANDARD includes an additional JSON field `message`. This configuration property " +
-      "influences on error messages of Thrift Server while running queries.")
+      "influences on error messages of Thrift Server and SQL CLI while running queries.")
     .version("3.4.0")
     .stringConf.transform(_.toUpperCase(Locale.ROOT))
     .checkValues(ErrorMessageFormat.values.map(_.toString))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLCLIDriver.scala
@@ -39,7 +39,7 @@ import org.apache.thrift.transport.TSocket
 import org.slf4j.LoggerFactory
 import sun.misc.{Signal, SignalHandler}
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
@@ -394,19 +394,16 @@ private[hive] class SparkSQLCLIDriver extends CliDriver with Logging {
 
           ret = rc.getResponseCode
           if (ret != 0) {
-            rc.getException match {
-              case e: AnalysisException => e.cause match {
-                case Some(_) if !sessionState.getIsSilent =>
-                  err.println(
-                    s"""Error in query: ${e.getMessage}
-                       |${org.apache.hadoop.util.StringUtils.stringifyException(e)}
-                     """.stripMargin)
-                // For analysis exceptions in silent mode or simple ones that only related to the
-                // query itself, such as `NoSuchDatabaseException`, only the error is printed out
-                // to the console.
-                case _ => err.println(s"""Error in query: ${e.getMessage}""")
-              }
-              case _ => err.println(rc.getErrorMessage())
+            val e = rc.getException
+            val msg = e match {
+              case st: SparkThrowable with Throwable =>
+                SparkThrowableHelper.getMessage(st, SparkSQLEnv.sqlContext.conf.errorMessageFormat)
+              case _ => e.getMessage
+            }
+            err.println(msg)
+            if (!sessionState.getIsSilent &&
+                (!e.isInstanceOf[AnalysisException] || e.getCause != null)) {
+              e.printStackTrace(err)
             }
             driver.close()
             return ret

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/CliSuite.scala
@@ -388,8 +388,7 @@ class CliSuite extends SparkFunSuite {
   test("SPARK-11188 Analysis error reporting") {
     runCliWithin(timeout = 2.minute,
       errorResponses = Seq("AnalysisException"))(
-      "select * from nonexistent_table;"
-        -> "Error in query: Table or view not found: nonexistent_table;"
+      "select * from nonexistent_table;" -> "Table or view not found: nonexistent_table;"
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Respect the SQL config `spark.sql.error.messageFormat` introduced by https://github.com/apache/spark/pull/37520, and output error messages in the one of format: `PRETTY` (by default), `MINIMAL` or `STANDARD`.
2. In the `PRETTY` format, output the error message of the `AnalysisException` exception in the same way as for other exceptions, i. e. w/o `Error in query:`.
3. Take into account the `silent` CLI option, and output the call stack only when it is `false`.

In the `MINIMAL` and `STANDARD` formats don't print the call stack independently from the `silent` mode. 

### Why are the changes needed?
To respect the SQL config `spark.sql.error.messageFormat` and to be consistent to error outputs of the Thrift Server. 

### Does this PR introduce _any_ user-facing change?
Yes.

The PR changes the behavior for `AnalysisException`. In that case, `spark-sql` does not output the prefix: `Error in query:` by default (format is PRETTY).

Before:
```sql
spark-sql> DROP TABLE ajhkdha;
Error in query: Table or view not found: ajhkdha; line 1 pos 11;
```

After:
```sql
spark-sql> DROP TABLE ajhkdha;
Table or view not found: ajhkdha; line 1 pos 11;
```

### How was this patch tested?
By running the modified test suites:
```
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly org.apache.spark.sql.hive.thriftserver.CliSuite"
```