### PR TITLE
[SPARK-40142][PYTHON][SQL][FOLLOW-UP] Make pyspark.sql.functions examples self-contained (part 2, 32 functions)

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -967,12 +967,8 @@ def cos(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(cos(lit(math.pi))).show()
-    +----------------------+
-    |COS(3.141592653589793)|
-    +----------------------+
-    |                  -1.0|
-    +----------------------+
+    >>> df.select(cos(lit(math.pi))).first()  # doctest: +ELLIPSIS
+    Row(COS(3.14159...)=-1.0)
     """
     return _invoke_function_over_columns("cos", col)
 
@@ -996,12 +992,8 @@ def cosh(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(cosh(lit(1))).show()
-    +-----------------+
-    |          COSH(1)|
-    +-----------------+
-    |1.543080634815244|
-    +-----------------+
+    >>> df.select(cosh(lit(1))).first()  # doctest: +ELLIPSIS
+    Row(COSH(1)=1.54308...)
     """
     return _invoke_function_over_columns("cosh", col)
 
@@ -1026,12 +1018,8 @@ def cot(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(cot(lit(math.radians(45)))).show()
-    +-----------------------+
-    |COT(0.7853981633974483)|
-    +-----------------------+
-    |     1.0000000000000002|
-    +-----------------------+
+    >>> df.select(cot(lit(math.radians(45)))).first()  # doctest: +ELLIPSIS
+    Row(COT(0.78539...)=1.00000...)
     """
     return _invoke_function_over_columns("cot", col)
 
@@ -1056,12 +1044,8 @@ def csc(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(csc(lit(math.radians(90)))).show()
-    +-----------------------+
-    |CSC(1.5707963267948966)|
-    +-----------------------+
-    |                    1.0|
-    +-----------------------+
+    >>> df.select(csc(lit(math.radians(90)))).first()  # doctest: +ELLIPSIS
+    Row(CSC(1.57079...)=1.0)
     """
     return _invoke_function_over_columns("csc", col)
 
@@ -1114,12 +1098,8 @@ def expm1(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(expm1(lit(1))).show()
-    +-----------------+
-    |         EXPM1(1)|
-    +-----------------+
-    |1.718281828459045|
-    +-----------------+
+    >>> df.select(expm1(lit(1))).first()  # doctest: +ELLIPSIS
+    Row(EXPM1(1)=1.71828...)
     """
     return _invoke_function_over_columns("expm1", col)
 
@@ -1173,12 +1153,8 @@ def log(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(log(lit(math.e))).show()
-    +---------------------+
-    |ln(2.718281828459045)|
-    +---------------------+
-    |                  1.0|
-    +---------------------+
+    >>> df.select(log(lit(math.e))).first()  # doctest: +ELLIPSIS
+    Row(ln(2.71828...)=1.0)
     """
     return _invoke_function_over_columns("log", col)
 
@@ -1232,20 +1208,12 @@ def log1p(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(log1p(lit(math.e))).show()
-    +------------------------+
-    |LOG1P(2.718281828459045)|
-    +------------------------+
-    |      1.3132616875182228|
-    +------------------------+
+    >>> df.select(log1p(lit(math.e))).first()  # doctest: +ELLIPSIS
+    Row(LOG1P(2.71828...)=1.31326...)
 
     Same as:
-    >>> df.select(log(lit(math.e+1))).show()
-    +---------------------+
-    |ln(3.718281828459045)|
-    +---------------------+
-    |   1.3132616875182228|
-    +---------------------+
+    >>> df.select(log(lit(math.e+1))).first()  # doctest: +ELLIPSIS
+    Row(ln(3.71828...)=1.31326...)
     """
     return _invoke_function_over_columns("log1p", col)
 
@@ -1306,12 +1274,8 @@ def sec(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(sec(lit(1.5))).show()
-    +------------------+
-    |          SEC(1.5)|
-    +------------------+
-    |14.136832902969903|
-    +------------------+
+    >>> df.select(sec(lit(1.5))).first()  # doctest: +ELLIPSIS
+    Row(SEC(1.5)=14.13683...)
     """
     return _invoke_function_over_columns("sec", col)
 
@@ -1372,12 +1336,8 @@ def sin(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(sin(lit(math.radians(90)))).show()
-    +-----------------------+
-    |SIN(1.5707963267948966)|
-    +-----------------------+
-    |                    1.0|
-    +-----------------------+
+    >>> df.select(sin(lit(math.radians(90)))).first()  # doctest: +ELLIPSIS
+    Row(SIN(1.57079...)=1.0)
     """
     return _invoke_function_over_columns("sin", col)
 
@@ -1402,12 +1362,8 @@ def sinh(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(sinh(lit(1.1))).show()
-    +-----------------+
-    |        SINH(1.1)|
-    +-----------------+
-    |1.335647470124177|
-    +-----------------+
+    >>> df.select(sinh(lit(1.1))).first()  # doctest: +ELLIPSIS
+    Row(SINH(1.1)=1.33564...)
     """
     return _invoke_function_over_columns("sinh", col)
 
@@ -1432,12 +1388,8 @@ def tan(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(tan(lit(math.radians(45)))).show()
-    +-----------------------+
-    |TAN(0.7853981633974483)|
-    +-----------------------+
-    |     0.9999999999999999|
-    +-----------------------+
+    >>> df.select(tan(lit(math.radians(45)))).first()  # doctest: +ELLIPSIS
+    Row(TAN(0.78539...)=0.99999...)
     """
     return _invoke_function_over_columns("tan", col)
 
@@ -1463,12 +1415,8 @@ def tanh(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(tanh(lit(math.radians(90)))).show()
-    +------------------------+
-    |TANH(1.5707963267948966)|
-    +------------------------+
-    |      0.9171523356672744|
-    +------------------------+
+    >>> df.select(tanh(lit(math.radians(90)))).first()  # doctest: +ELLIPSIS
+    Row(TANH(1.57079...)=0.91715...)
     """
     return _invoke_function_over_columns("tanh", col)
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -965,6 +965,7 @@ def cos(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(cos(lit(math.pi))).show()
     +----------------------+
@@ -1023,6 +1024,7 @@ def cot(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(cot(lit(math.radians(45)))).show()
     +-----------------------+
@@ -1052,6 +1054,7 @@ def csc(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(csc(lit(math.radians(90)))).show()
     +-----------------------+
@@ -1168,6 +1171,7 @@ def log(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(log(lit(math.e))).show()
     +---------------------+
@@ -1217,7 +1221,7 @@ def log1p(col: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
-        column to calculate natural logarithm for
+        column to calculate natural logarithm for.
 
     Returns
     -------
@@ -1226,6 +1230,7 @@ def log1p(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(log1p(lit(math.e))).show()
     +------------------------+
@@ -1233,6 +1238,7 @@ def log1p(col: "ColumnOrName") -> Column:
     +------------------------+
     |      1.3132616875182228|
     +------------------------+
+
     Same as:
     >>> df.select(log(lit(math.e+1))).show()
     +---------------------+
@@ -1364,6 +1370,7 @@ def sin(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(sin(lit(math.radians(90)))).show()
     +-----------------------+
@@ -1384,7 +1391,7 @@ def sinh(col: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
-        hyperbolic angle in radians
+        hyperbolic angle.
 
     Returns
     -------
@@ -1395,12 +1402,12 @@ def sinh(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(sinh(lit(math.radians(45)))).show()
-    +------------------------+
-    |SINH(0.7853981633974483)|
-    +------------------------+
-    |      0.8686709614860095|
-    +------------------------+
+    >>> df.select(sinh(lit(1.1))).show()
+    +-----------------+
+    |        SINH(1.1)|
+    +-----------------+
+    |1.335647470124177|
+    +-----------------+
     """
     return _invoke_function_over_columns("sinh", col)
 
@@ -1423,6 +1430,7 @@ def tan(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(tan(lit(math.radians(45)))).show()
     +-----------------------+
@@ -1453,6 +1461,7 @@ def tanh(col: "ColumnOrName") -> Column:
 
     Examples
     --------
+    >>> import math
     >>> df = spark.range(1)
     >>> df.select(tanh(lit(math.radians(90)))).show()
     +------------------------+
@@ -1553,18 +1562,10 @@ def asc_nulls_first(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> df = spark.createDataFrame([Row(age=1, name="Bob"),
-    ...                             Row(age=0, name=None),
-    ...                             Row(age=2, name="Alice")])
-    >>> df.show()
-    +---+-----+
-    |age| name|
-    +---+-----+
-    |  1|  Bob|
-    |  0| null|
-    |  2|Alice|
-    +---+-----+
-    >>> df.sort(asc_nulls_first(df.name)).show()
+    >>> df1 = spark.createDataFrame([(1, "Bob"),
+    ...                              (0, None),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(asc_nulls_first(df1.name)).show()
     +---+-----+
     |age| name|
     +---+-----+
@@ -1572,6 +1573,7 @@ def asc_nulls_first(col: "ColumnOrName") -> Column:
     |  2|Alice|
     |  1|  Bob|
     +---+-----+
+
     """
     return (
         col.asc_nulls_first()
@@ -1599,18 +1601,10 @@ def asc_nulls_last(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> df = spark.createDataFrame([Row(age=0, name=None),
-    ...                             Row(age=1, name="Bob"),
-    ...                             Row(age=2, name="Alice")])
-    >>> df.show()
-    +---+-----+
-    |age| name|
-    +---+-----+
-    |  0| null|
-    |  1|  Bob|
-    |  2|Alice|
-    +---+-----+
-    >>> df.sort(asc_nulls_last(df.name)).show()
+    >>> df1 = spark.createDataFrame([(0, None),
+    ...                              (1, "Bob"),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(asc_nulls_last(df1.name)).show()
     +---+-----+
     |age| name|
     +---+-----+
@@ -1618,6 +1612,7 @@ def asc_nulls_last(col: "ColumnOrName") -> Column:
     |  1|  Bob|
     |  0| null|
     +---+-----+
+
     """
     return (
         col.asc_nulls_last() if isinstance(col, Column) else _invoke_function("asc_nulls_last", col)
@@ -1643,18 +1638,10 @@ def desc_nulls_first(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> df = spark.createDataFrame([Row(age=1, name="Bob"),
-    ...                             Row(age=0, name=None),
-    ...                             Row(age=2, name="Alice")])
-    >>> df.show()
-    +---+-----+
-    |age| name|
-    +---+-----+
-    |  1|  Bob|
-    |  0| null|
-    |  2|Alice|
-    +---+-----+
-    >>> df.sort(desc_nulls_first(df.name)).show()
+    >>> df1 = spark.createDataFrame([(0, None),
+    ...                              (1, "Bob"),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(desc_nulls_first(df1.name)).show()
     +---+-----+
     |age| name|
     +---+-----+
@@ -1662,6 +1649,7 @@ def desc_nulls_first(col: "ColumnOrName") -> Column:
     |  1|  Bob|
     |  2|Alice|
     +---+-----+
+
     """
     return (
         col.desc_nulls_first()
@@ -1689,18 +1677,10 @@ def desc_nulls_last(col: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> df = spark.createDataFrame([Row(age=1, name="Bob"),
-    ...                             Row(age=0, name=None),
-    ...                             Row(age=2, name="Alice")])
-    >>> df.show()
-    +---+-----+
-    |age| name|
-    +---+-----+
-    |  1|  Bob|
-    |  0| null|
-    |  2|Alice|
-    +---+-----+
-    >>> df.sort(desc_nulls_last(df.name)).show()
+    >>> df1 = spark.createDataFrame([(0, None),
+    ...                              (1, "Bob"),
+    ...                              (2, "Alice")], ["age", "name"])
+    >>> df1.sort(desc_nulls_last(df1.name)).show()
     +---+-----+
     |age| name|
     +---+-----+
@@ -1708,6 +1688,7 @@ def desc_nulls_last(col: "ColumnOrName") -> Column:
     |  2|Alice|
     |  0| null|
     +---+-----+
+
     """
     return (
         col.desc_nulls_last()
@@ -6764,14 +6745,12 @@ def _test() -> None:
     import doctest
     from pyspark.sql import Row, SparkSession
     import pyspark.sql.functions
-    import math
 
     globs = pyspark.sql.functions.__dict__.copy()
     spark = SparkSession.builder.master("local[4]").appName("sql.functions tests").getOrCreate()
     sc = spark.sparkContext
     globs["sc"] = sc
     globs["spark"] = spark
-    globs["math"] = math
     globs["df"] = spark.createDataFrame([Row(age=2, name="Alice"), Row(age=5, name="Bob")])
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.functions,

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -962,6 +962,16 @@ def cos(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         cosine of the angle, as if computed by `java.lang.Math.cos()`.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(cos(lit(math.pi))).show()
+    +----------------------+
+    |COS(3.141592653589793)|
+    +----------------------+
+    |                  -1.0|
+    +----------------------+
     """
     return _invoke_function_over_columns("cos", col)
 
@@ -981,6 +991,16 @@ def cosh(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         hyperbolic cosine of the angle, as if computed by `java.lang.Math.cosh()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(cosh(lit(1))).show()
+    +-----------------+
+    |          COSH(1)|
+    +-----------------+
+    |1.543080634815244|
+    +-----------------+
     """
     return _invoke_function_over_columns("cosh", col)
 
@@ -994,12 +1014,22 @@ def cot(col: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
-        Angle in radians
+        angle in radians.
 
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        Cotangent of the angle.
+        cotangent of the angle.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(cot(lit(math.radians(45)))).show()
+    +-----------------------+
+    |COT(0.7853981633974483)|
+    +-----------------------+
+    |     1.0000000000000002|
+    +-----------------------+
     """
     return _invoke_function_over_columns("cot", col)
 
@@ -1013,12 +1043,22 @@ def csc(col: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
-        Angle in radians
+        angle in radians.
 
     Returns
     -------
     :class:`~pyspark.sql.Column`
-        Cosecant of the angle.
+        cosecant of the angle.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(csc(lit(math.radians(90)))).show()
+    +-----------------------+
+    |CSC(1.5707963267948966)|
+    +-----------------------+
+    |                    1.0|
+    +-----------------------+
     """
     return _invoke_function_over_columns("csc", col)
 
@@ -1028,6 +1068,26 @@ def exp(col: "ColumnOrName") -> Column:
     Computes the exponential of the given value.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to calculate exponential for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        exponential of the given value.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(exp(lit(0))).show()
+    +------+
+    |EXP(0)|
+    +------+
+    |   1.0|
+    +------+
     """
     return _invoke_function_over_columns("exp", col)
 
@@ -1037,6 +1097,26 @@ def expm1(col: "ColumnOrName") -> Column:
     Computes the exponential of the given value minus one.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to calculate exponential for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        exponential less one.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(expm1(lit(1))).show()
+    +-----------------+
+    |         EXPM1(1)|
+    +-----------------+
+    |1.718281828459045|
+    +-----------------+
     """
     return _invoke_function_over_columns("expm1", col)
 
@@ -1046,6 +1126,26 @@ def floor(col: "ColumnOrName") -> Column:
     Computes the floor of the given value.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to find floor for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        neares integer that is less than or equal to given value.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(floor(lit(2.5))).show()
+    +----------+
+    |FLOOR(2.5)|
+    +----------+
+    |         2|
+    +----------+
     """
     return _invoke_function_over_columns("floor", col)
 
@@ -1055,6 +1155,26 @@ def log(col: "ColumnOrName") -> Column:
     Computes the natural logarithm of the given value.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to calculate natural logarithm for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        natural logarithm of the given value.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(log(lit(math.e))).show()
+    +---------------------+
+    |ln(2.718281828459045)|
+    +---------------------+
+    |                  1.0|
+    +---------------------+
     """
     return _invoke_function_over_columns("log", col)
 
@@ -1064,15 +1184,62 @@ def log10(col: "ColumnOrName") -> Column:
     Computes the logarithm of the given value in Base 10.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to calculate logarithm for.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        logarithm of the given value in Base 10.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(log10(lit(100))).show()
+    +----------+
+    |LOG10(100)|
+    +----------+
+    |       2.0|
+    +----------+
     """
     return _invoke_function_over_columns("log10", col)
 
 
 def log1p(col: "ColumnOrName") -> Column:
     """
-    Computes the natural logarithm of the given value plus one.
+    Computes the natural logarithm of the "given value plus one".
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        column to calculate natural logarithm for
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        natural logarithm of the "given value plus one".
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(log1p(lit(math.e))).show()
+    +------------------------+
+    |LOG1P(2.718281828459045)|
+    +------------------------+
+    |      1.3132616875182228|
+    +------------------------+
+    Same as:
+    >>> df.select(log(lit(math.e+1))).show()
+    +---------------------+
+    |ln(3.718281828459045)|
+    +---------------------+
+    |   1.3132616875182228|
+    +---------------------+
     """
     return _invoke_function_over_columns("log1p", col)
 
@@ -1083,6 +1250,33 @@ def rint(col: "ColumnOrName") -> Column:
     is equal to a mathematical integer.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column for computed results.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(rint(lit(10.6))).show()
+    +----------+
+    |rint(10.6)|
+    +----------+
+    |      11.0|
+    +----------+
+
+    >>> df.select(rint(lit(10.3))).show()
+    +----------+
+    |rint(10.3)|
+    +----------+
+    |      10.0|
+    +----------+
     """
     return _invoke_function_over_columns("rint", col)
 
@@ -1102,6 +1296,16 @@ def sec(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         Secant of the angle.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(sec(lit(1.5))).show()
+    +------------------+
+    |          SEC(1.5)|
+    +------------------+
+    |14.136832902969903|
+    +------------------+
     """
     return _invoke_function_over_columns("sec", col)
 
@@ -1111,6 +1315,33 @@ def signum(col: "ColumnOrName") -> Column:
     Computes the signum of the given value.
 
     .. versionadded:: 1.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column for computed results.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(signum(lit(-5))).show()
+    +----------+
+    |SIGNUM(-5)|
+    +----------+
+    |      -1.0|
+    +----------+
+
+    >>> df.select(signum(lit(6))).show()
+    +---------+
+    |SIGNUM(6)|
+    +---------+
+    |      1.0|
+    +---------+
     """
     return _invoke_function_over_columns("signum", col)
 
@@ -1124,11 +1355,22 @@ def sin(col: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
 
     Returns
     -------
     :class:`~pyspark.sql.Column`
         sine of the angle, as if computed by `java.lang.Math.sin()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(sin(lit(math.radians(90)))).show()
+    +-----------------------+
+    |SIN(1.5707963267948966)|
+    +-----------------------+
+    |                    1.0|
+    +-----------------------+
     """
     return _invoke_function_over_columns("sin", col)
 
@@ -1142,13 +1384,23 @@ def sinh(col: "ColumnOrName") -> Column:
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
-        hyperbolic angle
+        hyperbolic angle in radians
 
     Returns
     -------
     :class:`~pyspark.sql.Column`
         hyperbolic sine of the given value,
         as if computed by `java.lang.Math.sinh()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(sinh(lit(math.radians(45)))).show()
+    +------------------------+
+    |SINH(0.7853981633974483)|
+    +------------------------+
+    |      0.8686709614860095|
+    +------------------------+
     """
     return _invoke_function_over_columns("sinh", col)
 
@@ -1168,6 +1420,16 @@ def tan(col: "ColumnOrName") -> Column:
     -------
     :class:`~pyspark.sql.Column`
         tangent of the given value, as if computed by `java.lang.Math.tan()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(tan(lit(math.radians(45)))).show()
+    +-----------------------+
+    |TAN(0.7853981633974483)|
+    +-----------------------+
+    |     0.9999999999999999|
+    +-----------------------+
     """
     return _invoke_function_over_columns("tan", col)
 
@@ -1188,6 +1450,16 @@ def tanh(col: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         hyperbolic tangent of the given value
         as if computed by `java.lang.Math.tanh()`
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(tanh(lit(math.radians(90)))).show()
+    +------------------------+
+    |TANH(1.5707963267948966)|
+    +------------------------+
+    |      0.9171523356672744|
+    +------------------------+
     """
     return _invoke_function_over_columns("tanh", col)
 
@@ -1232,6 +1504,32 @@ def bitwise_not(col: "ColumnOrName") -> Column:
     Computes bitwise not.
 
     .. versionadded:: 3.2.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column for computed results.
+
+    Examples
+    --------
+    >>> df = spark.range(1)
+    >>> df.select(bitwise_not(lit(0))).show()
+    +---+
+    | ~0|
+    +---+
+    | -1|
+    +---+
+    >>> df.select(bitwise_not(lit(1))).show()
+    +---+
+    | ~1|
+    +---+
+    | -2|
+    +---+
     """
     return _invoke_function_over_columns("bitwise_not", col)
 
@@ -1242,6 +1540,38 @@ def asc_nulls_first(col: "ColumnOrName") -> Column:
     column name, and null values return before non-null values.
 
     .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the ascending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([Row(age=1, name="Bob"),
+    ...                             Row(age=0, name=None),
+    ...                             Row(age=2, name="Alice")])
+    >>> df.show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  1|  Bob|
+    |  0| null|
+    |  2|Alice|
+    +---+-----+
+    >>> df.sort(asc_nulls_first(df.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  0| null|
+    |  2|Alice|
+    |  1|  Bob|
+    +---+-----+
     """
     return (
         col.asc_nulls_first()
@@ -1256,6 +1586,38 @@ def asc_nulls_last(col: "ColumnOrName") -> Column:
     column name, and null values appear after non-null values.
 
     .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the ascending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([Row(age=0, name=None),
+    ...                             Row(age=1, name="Bob"),
+    ...                             Row(age=2, name="Alice")])
+    >>> df.show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  0| null|
+    |  1|  Bob|
+    |  2|Alice|
+    +---+-----+
+    >>> df.sort(asc_nulls_last(df.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  2|Alice|
+    |  1|  Bob|
+    |  0| null|
+    +---+-----+
     """
     return (
         col.asc_nulls_last() if isinstance(col, Column) else _invoke_function("asc_nulls_last", col)
@@ -1268,6 +1630,38 @@ def desc_nulls_first(col: "ColumnOrName") -> Column:
     column name, and null values appear before non-null values.
 
     .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the descending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([Row(age=1, name="Bob"),
+    ...                             Row(age=0, name=None),
+    ...                             Row(age=2, name="Alice")])
+    >>> df.show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  1|  Bob|
+    |  0| null|
+    |  2|Alice|
+    +---+-----+
+    >>> df.sort(desc_nulls_first(df.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  0| null|
+    |  1|  Bob|
+    |  2|Alice|
+    +---+-----+
     """
     return (
         col.desc_nulls_first()
@@ -1282,6 +1676,38 @@ def desc_nulls_last(col: "ColumnOrName") -> Column:
     column name, and null values appear after non-null values.
 
     .. versionadded:: 2.4.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to sort by in the descending order.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the column specifying the order.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([Row(age=1, name="Bob"),
+    ...                             Row(age=0, name=None),
+    ...                             Row(age=2, name="Alice")])
+    >>> df.show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  1|  Bob|
+    |  0| null|
+    |  2|Alice|
+    +---+-----+
+    >>> df.sort(desc_nulls_last(df.name)).show()
+    +---+-----+
+    |age| name|
+    +---+-----+
+    |  1|  Bob|
+    |  2|Alice|
+    |  0| null|
+    +---+-----+
     """
     return (
         col.desc_nulls_last()
@@ -1295,6 +1721,26 @@ def stddev(col: "ColumnOrName") -> Column:
     Aggregate function: alias for stddev_samp.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        standard deviation of given column.
+
+    Examples
+    --------
+    >>> df = spark.range(6)
+    >>> df.select(stddev(df.id)).show()
+    +------------------+
+    |   stddev_samp(id)|
+    +------------------+
+    |1.8708286933869707|
+    +------------------+
     """
     return _invoke_function_over_columns("stddev", col)
 
@@ -1305,6 +1751,26 @@ def stddev_samp(col: "ColumnOrName") -> Column:
     the expression in a group.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        standard deviation of given column.
+
+    Examples
+    --------
+    >>> df = spark.range(6)
+    >>> df.select(stddev_samp(df.id)).show()
+    +------------------+
+    |   stddev_samp(id)|
+    +------------------+
+    |1.8708286933869707|
+    +------------------+
     """
     return _invoke_function_over_columns("stddev_samp", col)
 
@@ -1315,6 +1781,26 @@ def stddev_pop(col: "ColumnOrName") -> Column:
     the expression in a group.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        standard deviation of given column.
+
+    Examples
+    --------
+    >>> df = spark.range(6)
+    >>> df.select(stddev_pop(df.id)).show()
+    +-----------------+
+    |   stddev_pop(id)|
+    +-----------------+
+    |1.707825127659933|
+    +-----------------+
     """
     return _invoke_function_over_columns("stddev_pop", col)
 
@@ -1324,6 +1810,26 @@ def variance(col: "ColumnOrName") -> Column:
     Aggregate function: alias for var_samp
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        variance of given column.
+
+    Examples
+    --------
+    >>> df = spark.range(6)
+    >>> df.select(variance(df.id)).show()
+    +------------+
+    |var_samp(id)|
+    +------------+
+    |         3.5|
+    +------------+
     """
     return _invoke_function_over_columns("variance", col)
 
@@ -1334,6 +1840,26 @@ def var_samp(col: "ColumnOrName") -> Column:
     the values in a group.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        variance of given column.
+
+    Examples
+    --------
+    >>> df = spark.range(6)
+    >>> df.select(var_samp(df.id)).show()
+    +------------+
+    |var_samp(id)|
+    +------------+
+    |         3.5|
+    +------------+
     """
     return _invoke_function_over_columns("var_samp", col)
 
@@ -1343,6 +1869,26 @@ def var_pop(col: "ColumnOrName") -> Column:
     Aggregate function: returns the population variance of the values in a group.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        variance of given column.
+
+    Examples
+    --------
+    >>> df = spark.range(6)
+    >>> df.select(var_pop(df.id)).show()
+    +------------------+
+    |       var_pop(id)|
+    +------------------+
+    |2.9166666666666665|
+    +------------------+
     """
     return _invoke_function_over_columns("var_pop", col)
 
@@ -1352,6 +1898,26 @@ def skewness(col: "ColumnOrName") -> Column:
     Aggregate function: returns the skewness of the values in a group.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        skewness of given column.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([[1],[1],[2]], ["c"])
+    >>> df.select(skewness(df.c)).show()
+    +------------------+
+    |       skewness(c)|
+    +------------------+
+    |0.7071067811865475|
+    +------------------+
     """
     return _invoke_function_over_columns("skewness", col)
 
@@ -1361,6 +1927,26 @@ def kurtosis(col: "ColumnOrName") -> Column:
     Aggregate function: returns the kurtosis of the values in a group.
 
     .. versionadded:: 1.6.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        kurtosis of given column.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([[1],[1],[2]], ["c"])
+    >>> df.select(kurtosis(df.c)).show()
+    +-----------+
+    |kurtosis(c)|
+    +-----------+
+    |       -1.5|
+    +-----------+
     """
     return _invoke_function_over_columns("kurtosis", col)
 
@@ -1375,6 +1961,16 @@ def collect_list(col: "ColumnOrName") -> Column:
     -----
     The function is non-deterministic because the order of collected results depends
     on the order of the rows which may be non-deterministic after a shuffle.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        list of objects with duplicates.
 
     Examples
     --------
@@ -1395,6 +1991,16 @@ def collect_set(col: "ColumnOrName") -> Column:
     -----
     The function is non-deterministic because the order of collected results depends
     on the order of the rows which may be non-deterministic after a shuffle.
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        target column to compute on.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        list of objects with no duplicates.
 
     Examples
     --------
@@ -6158,12 +6764,14 @@ def _test() -> None:
     import doctest
     from pyspark.sql import Row, SparkSession
     import pyspark.sql.functions
+    import math
 
     globs = pyspark.sql.functions.__dict__.copy()
     spark = SparkSession.builder.master("local[4]").appName("sql.functions tests").getOrCreate()
     sc = spark.sparkContext
     globs["sc"] = sc
     globs["spark"] = spark
+    globs["math"] = math
     globs["df"] = spark.createDataFrame([Row(age=2, name="Alice"), Row(age=5, name="Bob")])
     (failure_count, test_count) = doctest.testmod(
         pyspark.sql.functions,

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -967,7 +967,7 @@ def cos(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(cos(lit(math.pi))).first()  # doctest: +ELLIPSIS
+    >>> df.select(cos(lit(math.pi))).first()
     Row(COS(3.14159...)=-1.0)
     """
     return _invoke_function_over_columns("cos", col)
@@ -992,7 +992,7 @@ def cosh(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(cosh(lit(1))).first()  # doctest: +ELLIPSIS
+    >>> df.select(cosh(lit(1))).first()
     Row(COSH(1)=1.54308...)
     """
     return _invoke_function_over_columns("cosh", col)
@@ -1018,7 +1018,7 @@ def cot(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(cot(lit(math.radians(45)))).first()  # doctest: +ELLIPSIS
+    >>> df.select(cot(lit(math.radians(45)))).first()
     Row(COT(0.78539...)=1.00000...)
     """
     return _invoke_function_over_columns("cot", col)
@@ -1044,7 +1044,7 @@ def csc(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(csc(lit(math.radians(90)))).first()  # doctest: +ELLIPSIS
+    >>> df.select(csc(lit(math.radians(90)))).first()
     Row(CSC(1.57079...)=1.0)
     """
     return _invoke_function_over_columns("csc", col)
@@ -1098,7 +1098,7 @@ def expm1(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(expm1(lit(1))).first()  # doctest: +ELLIPSIS
+    >>> df.select(expm1(lit(1))).first()
     Row(EXPM1(1)=1.71828...)
     """
     return _invoke_function_over_columns("expm1", col)
@@ -1153,7 +1153,7 @@ def log(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(log(lit(math.e))).first()  # doctest: +ELLIPSIS
+    >>> df.select(log(lit(math.e))).first()
     Row(ln(2.71828...)=1.0)
     """
     return _invoke_function_over_columns("log", col)
@@ -1208,12 +1208,12 @@ def log1p(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(log1p(lit(math.e))).first()  # doctest: +ELLIPSIS
+    >>> df.select(log1p(lit(math.e))).first()
     Row(LOG1P(2.71828...)=1.31326...)
 
     Same as:
 
-    >>> df.select(log(lit(math.e+1))).first()  # doctest: +ELLIPSIS
+    >>> df.select(log(lit(math.e+1))).first()
     Row(ln(3.71828...)=1.31326...)
     """
     return _invoke_function_over_columns("log1p", col)
@@ -1275,7 +1275,7 @@ def sec(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(sec(lit(1.5))).first()  # doctest: +ELLIPSIS
+    >>> df.select(sec(lit(1.5))).first()
     Row(SEC(1.5)=14.13683...)
     """
     return _invoke_function_over_columns("sec", col)
@@ -1337,7 +1337,7 @@ def sin(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(sin(lit(math.radians(90)))).first()  # doctest: +ELLIPSIS
+    >>> df.select(sin(lit(math.radians(90)))).first()
     Row(SIN(1.57079...)=1.0)
     """
     return _invoke_function_over_columns("sin", col)
@@ -1363,7 +1363,7 @@ def sinh(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(1)
-    >>> df.select(sinh(lit(1.1))).first()  # doctest: +ELLIPSIS
+    >>> df.select(sinh(lit(1.1))).first()
     Row(SINH(1.1)=1.33564...)
     """
     return _invoke_function_over_columns("sinh", col)
@@ -1389,7 +1389,7 @@ def tan(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(tan(lit(math.radians(45)))).first()  # doctest: +ELLIPSIS
+    >>> df.select(tan(lit(math.radians(45)))).first()
     Row(TAN(0.78539...)=0.99999...)
     """
     return _invoke_function_over_columns("tan", col)
@@ -1416,7 +1416,7 @@ def tanh(col: "ColumnOrName") -> Column:
     --------
     >>> import math
     >>> df = spark.range(1)
-    >>> df.select(tanh(lit(math.radians(90)))).first()  # doctest: +ELLIPSIS
+    >>> df.select(tanh(lit(math.radians(90)))).first()
     Row(TANH(1.57079...)=0.91715...)
     """
     return _invoke_function_over_columns("tanh", col)
@@ -1665,7 +1665,7 @@ def stddev(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(stddev(df.id)).first()  # doctest: +ELLIPSIS
+    >>> df.select(stddev(df.id)).first()
     Row(stddev_samp(id)=1.87082...)
     """
     return _invoke_function_over_columns("stddev", col)
@@ -1691,7 +1691,7 @@ def stddev_samp(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(stddev_samp(df.id)).first()  # doctest: +ELLIPSIS
+    >>> df.select(stddev_samp(df.id)).first()
     Row(stddev_samp(id)=1.87082...)
     """
     return _invoke_function_over_columns("stddev_samp", col)
@@ -1717,7 +1717,7 @@ def stddev_pop(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(stddev_pop(df.id)).first()  # doctest: +ELLIPSIS
+    >>> df.select(stddev_pop(df.id)).first()
     Row(stddev_pop(id)=1.70782...)
     """
     return _invoke_function_over_columns("stddev_pop", col)
@@ -1801,7 +1801,7 @@ def var_pop(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(var_pop(df.id)).first()  # doctest: +ELLIPSIS
+    >>> df.select(var_pop(df.id)).first()
     Row(var_pop(id)=2.91666...)
     """
     return _invoke_function_over_columns("var_pop", col)
@@ -1826,7 +1826,7 @@ def skewness(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.createDataFrame([[1],[1],[2]], ["c"])
-    >>> df.select(skewness(df.c)).first()  # doctest: +ELLIPSIS
+    >>> df.select(skewness(df.c)).first()
     Row(skewness(c)=0.70710...)
     """
     return _invoke_function_over_columns("skewness", col)

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -1212,6 +1212,7 @@ def log1p(col: "ColumnOrName") -> Column:
     Row(LOG1P(2.71828...)=1.31326...)
 
     Same as:
+
     >>> df.select(log(lit(math.e+1))).first()  # doctest: +ELLIPSIS
     Row(ln(3.71828...)=1.31326...)
     """
@@ -1664,12 +1665,8 @@ def stddev(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(stddev(df.id)).show()
-    +------------------+
-    |   stddev_samp(id)|
-    +------------------+
-    |1.8708286933869707|
-    +------------------+
+    >>> df.select(stddev(df.id)).first()  # doctest: +ELLIPSIS
+    Row(stddev_samp(id)=1.87082...)
     """
     return _invoke_function_over_columns("stddev", col)
 
@@ -1694,12 +1691,8 @@ def stddev_samp(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(stddev_samp(df.id)).show()
-    +------------------+
-    |   stddev_samp(id)|
-    +------------------+
-    |1.8708286933869707|
-    +------------------+
+    >>> df.select(stddev_samp(df.id)).first()  # doctest: +ELLIPSIS
+    Row(stddev_samp(id)=1.87082...)
     """
     return _invoke_function_over_columns("stddev_samp", col)
 
@@ -1724,12 +1717,8 @@ def stddev_pop(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(stddev_pop(df.id)).show()
-    +-----------------+
-    |   stddev_pop(id)|
-    +-----------------+
-    |1.707825127659933|
-    +-----------------+
+    >>> df.select(stddev_pop(df.id)).first()  # doctest: +ELLIPSIS
+    Row(stddev_pop(id)=1.70782...)
     """
     return _invoke_function_over_columns("stddev_pop", col)
 
@@ -1812,12 +1801,8 @@ def var_pop(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.range(6)
-    >>> df.select(var_pop(df.id)).show()
-    +------------------+
-    |       var_pop(id)|
-    +------------------+
-    |2.9166666666666665|
-    +------------------+
+    >>> df.select(var_pop(df.id)).first()  # doctest: +ELLIPSIS
+    Row(var_pop(id)=2.91666...)
     """
     return _invoke_function_over_columns("var_pop", col)
 
@@ -1841,12 +1826,8 @@ def skewness(col: "ColumnOrName") -> Column:
     Examples
     --------
     >>> df = spark.createDataFrame([[1],[1],[2]], ["c"])
-    >>> df.select(skewness(df.c)).show()
-    +------------------+
-    |       skewness(c)|
-    +------------------+
-    |0.7071067811865475|
-    +------------------+
+    >>> df.select(skewness(df.c)).first()  # doctest: +ELLIPSIS
+    Row(skewness(c)=0.70710...)
     """
     return _invoke_function_over_columns("skewness", col)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Docstring improvements


### Why are the changes needed?
To help users to understand pyspark API


### Does this PR introduce _any_ user-facing change?
Yes, documentation


### How was this patch tested?
`bundle exec jekyll serve --host 0.0.0.0`
