### PR TITLE
[SPARK-40159][SQL] Aggregate should be group only after collapse project to aggregate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1146,7 +1146,8 @@ case class Aggregate(
     groupingExpressions.nonEmpty && aggregateExpressions.map {
       case Alias(child, _) => child
       case e => e
-    }.forall(a => a.deterministic && a.collect { case _: AggregateFunction => true }.isEmpty)
+    }.forall(a => a.deterministic &&
+      a.collect { case _: AggregateFunction | _: PythonUDF => true }.isEmpty)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1146,7 +1146,7 @@ case class Aggregate(
     groupingExpressions.nonEmpty && aggregateExpressions.map {
       case Alias(child, _) => child
       case e => e
-    }.forall(a => a.collect { case _: AggregateFunction => true }.isEmpty)
+    }.forall(a => a.deterministic && a.collect { case _: AggregateFunction => true }.isEmpty)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, MultiInstanceRe
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable.VIEW_STORING_ANALYZED_PLAN
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, TypedImperativeAggregate}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, AggregateFunction, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, RangePartitioning, RoundRobinPartitioning, SinglePartition}
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
@@ -1146,7 +1146,7 @@ case class Aggregate(
     groupingExpressions.nonEmpty && aggregateExpressions.map {
       case Alias(child, _) => child
       case e => e
-    }.forall(a => a.foldable || groupingExpressions.exists(g => a.semanticEquals(g)))
+    }.forall(a => a.collect { case _: AggregateFunction => true }.isEmpty)
   }
 }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/AggregateOptimizeSuite.scala
@@ -217,16 +217,20 @@ class AggregateOptimizeSuite extends AnalysisTest {
       Aggregate(Seq(a + 1), Seq(Alias(a + 1, "a_1")()), relation),
       Aggregate(Seq(a + 1), Seq(Alias((a + 1).cast(StringType), "a_1")()), relation),
       Aggregate(Seq((a + 1).cast(StringType)),
-        Seq(Alias((a + 1).cast(StringType), "a_1")()), relation),
-      Aggregate(Seq(a), Seq(Alias(a + 2, "a_2")()), relation),
-      Aggregate(Seq((a + 1).cast(StringType)), Seq(Alias(a.cast(StringType), "a")()), relation),
-      Aggregate(Seq((a + 1).cast(LongType)),
-        Seq(Alias((a + 1).cast(StringType), "a1")()), relation)
+        Seq(Alias((a + 1).cast(StringType), "a_1")()), relation)
     ).foreach(agg => assert(agg.groupOnly === true))
 
     Seq(
+      // with AggregateFunction
       Aggregate(Seq(a + 1), Seq(Alias(Count(b), "sum_b")()), relation),
-      Aggregate(Seq(a + 1), Seq(Alias(Max(b), "max_b")()), relation)
+      Aggregate(Seq(a + 1), Seq(Alias(Max(b), "max_b")()), relation),
+
+      // without AggregateFunction
+      Aggregate(Seq(a), Seq(Alias(a + 2, "a_2")()), relation),
+      Aggregate(Seq(a), Seq(Alias(a % 2, "a_2")()), relation),
+      Aggregate(Seq((a + 1).cast(StringType)), Seq(Alias(a.cast(StringType), "a")()), relation),
+      Aggregate(Seq((a + 1).cast(LongType)),
+        Seq(Alias((a + 1).cast(StringType), "a1")()), relation)
     ).foreach(agg => assert(agg.groupOnly === false))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1454,7 +1454,7 @@ class DataFrameAggregateSuite extends QueryTest
   }
 
   test("SPARK-40159: Aggregate should be group only after collapse project to aggregate") {
-    val df = testData.distinct().select('key + 1, ('key + 1).cast("long"))
+    val df = testData.distinct().select('key.cast("string"), 'value)
     df.queryExecution.optimizedPlan.collect {
       case a: Aggregate => a
     }.foreach(agg => assert(agg.groupOnly === true))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Aggregates should be group only if all aggregate expressions are the same as grouping expressions , or aliases of grouping expressions. But when we call `dataFrame.show()`, sparkSql will cast non-binaryType column to StringType column, and then CollapseProject rule will push them into the aggregate expressions, so the aggregate should also be group only if the aggregate expressions are cast from grouping expressions.


For example, the optimize plan of `testData.distinct().select('key.cast("string"), 'value)` is
```java
Project [cast(key#3 as string) AS key#10, value#4]
+- Deduplicate [key#3, value#4]
   +- SerializeFromObject [knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).key AS key#3, staticinvoke(class org.apache.spark.unsafe.types.UTF8String, StringType, fromString, knownnotnull(assertnotnull(input[0, org.apache.spark.sql.test.SQLTestData$TestData, true])).value, true, false, true) AS value#4]
      +- ExternalRDD [obj#2]
```
it should be group only.

### Why are the changes needed?

Small improvement,  make the groupOnly method of Aggregate support cast expressions.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added UT
