### PR TITLE
[SPARK-40165][BUILD] Update test plugins to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1179,7 +1179,7 @@
       <dependency>
         <groupId>org.scalacheck</groupId>
         <artifactId>scalacheck_${scala.binary.version}</artifactId>
-        <version>1.15.4</version>
+        <version>1.16.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -2932,7 +2932,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M7</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -3172,7 +3172,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <id>default-cli</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR test updates plugins to latest versions.

### Why are the changes needed?
This brings improvment & bug fixes like the following:
- 1.scalacheck (from 1.15.4 to 1.16.0)
https://github.com/typelevel/scalacheck/releases
https://github.com/typelevel/scalacheck/compare/1.15.4...v1.16.0
https://github.com/typelevel/scalacheck/commit/2ae1be5c8e5ee1c14abea607d631e334a56796de
https://github.com/typelevel/scalacheck/commit/902121e498e59b5151066a6c1794cdf47a31428f

- 2.maven-surefire-plugin (from 3.0.0-M5 to 3.0.0-M7)
https://github.com/apache/maven-surefire/releases
https://github.com/apache/maven-surefire/compare/surefire-3.0.0-M5...surefire-3.0.0-M7

- 3.maven-dependency-plugin (from 3.1.1 to 3.3.0)
https://github.com/apache/maven-dependency-plugin/compare/maven-dependency-plugin-3.1.1...maven-dependency-plugin-3.3.0
https://github.com/apache/maven-dependency-plugin/commit/9646b0ed76a6d00e468c8eb1b6a27d260b09e944

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA and testing with the existing code.