### PR TITLE
[SPARK-40150][SQL] Merging file partition dynamically

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1644,6 +1644,18 @@ object SQLConf {
     .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional
 
+  val FILES_EXPECTED_PARTITION_NUM = buildConf("spark.sql.files.expectPartitionNum")
+    .doc("The expected number of File partitions. It will automatically merge file splits to " +
+      "provide the best concurrency when the file partitions after split exceed the " +
+      "expected num and the size of file partition is less than maxSplitSize. If not set, " +
+      "the default value is the number of concurrent tasks configured by user. " +
+      "This configuration is effective only when using file-based sources such as " +
+      "Parquet, JSON and ORC.")
+    .version("3.4.0")
+    .intConf
+    .checkValue(v => v > 0, "The expected partition number must be a positive integer.")
+    .createOptional
+
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")
     .doc("Whether to ignore corrupt files. If true, the Spark jobs will continue to run when " +
       "encountering corrupted files and the contents that have been read will still be returned. " +
@@ -4104,6 +4116,8 @@ class SQLConf extends Serializable with Logging {
   def filesOpenCostInBytes: Long = getConf(FILES_OPEN_COST_IN_BYTES)
 
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
+
+  def filesExpectPartitionNum: Option[Int] = getConf(FILES_EXPECTED_PARTITION_NUM)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1644,6 +1644,15 @@ object SQLConf {
     .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional
 
+  val FILES_DYNAMIC_MERGE_ENABLED = buildConf("spark.sql.files.dynamicMergeEnabled")
+    .doc("Whether to merge file partition dynamically. If true, It will use the total size, " +
+      "file count and expectPartitionNum to dynamic merge filePartition. This is better to set " +
+      "true if there are many small files in the read path. This configuration is effective " +
+      "only when using file-based sources such as Parquet, JSON and ORC.")
+    .version("3.4.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val FILES_EXPECTED_PARTITION_NUM = buildConf("spark.sql.files.expectedPartitionNum")
     .doc("The expected number of File partitions. It will automatically merge file splits to " +
       "provide the best concurrency when the file partitions after split exceed the " +
@@ -1654,6 +1663,16 @@ object SQLConf {
     .version("3.4.0")
     .intConf
     .checkValue(v => v > 0, "The expected partition number must be a positive integer.")
+    .createOptional
+
+  val FILES_MAX_NUM_IN_PARTITION = buildConf("spark.sql.files.maxNumInPartition")
+    .doc("The max number of files in one filePartition. If set, it will limit the max file num " +
+      "in FilePartition while merging files. This can avoid too many little io in one task. " +
+      "This configuration is effective only when using file-based sources such as Parquet, " +
+      "JSON and ORC.")
+    .version("3.4.0")
+    .intConf
+    .checkValue(v => v > 0, "The max file number in partition must be a positive integer.")
     .createOptional
 
   val IGNORE_CORRUPT_FILES = buildConf("spark.sql.files.ignoreCorruptFiles")
@@ -4117,7 +4136,11 @@ class SQLConf extends Serializable with Logging {
 
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
 
+  def filesDynamicMergeEnabled: Boolean = getConf(FILES_DYNAMIC_MERGE_ENABLED)
+
   def filesExpectedPartitionNum: Option[Int] = getConf(FILES_EXPECTED_PARTITION_NUM)
+
+  def filesMaxNumInPartition: Option[Int] = getConf(FILES_MAX_NUM_IN_PARTITION)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4117,7 +4117,7 @@ class SQLConf extends Serializable with Logging {
 
   def filesMinPartitionNum: Option[Int] = getConf(FILES_MIN_PARTITION_NUM)
 
-  def filesExpectPartitionNum: Option[Int] = getConf(FILES_EXPECTED_PARTITION_NUM)
+  def filesExpectedPartitionNum: Option[Int] = getConf(FILES_EXPECTED_PARTITION_NUM)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1644,7 +1644,7 @@ object SQLConf {
     .checkValue(v => v > 0, "The min partition number must be a positive integer.")
     .createOptional
 
-  val FILES_EXPECTED_PARTITION_NUM = buildConf("spark.sql.files.expectPartitionNum")
+  val FILES_EXPECTED_PARTITION_NUM = buildConf("spark.sql.files.expectedPartitionNum")
     .doc("The expected number of File partitions. It will automatically merge file splits to " +
       "provide the best concurrency when the file partitions after split exceed the " +
       "expected num and the size of file partition is less than maxSplitSize. If not set, " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -77,7 +77,7 @@ object FilePartition extends Logging {
     }
 
     val expectedFilePartitionNum =
-      sparkSession.sessionState.conf.filesExpectPartitionNum.getOrElse(taskParallelismNum)
+      sparkSession.sessionState.conf.filesExpectedPartitionNum.getOrElse(taskParallelismNum)
     var openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
     var maxPartitionBytes = maxSplitBytes
     if (partitionedFiles.size < expectedFilePartitionNum) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FilePartition.scala
@@ -82,7 +82,7 @@ object FilePartition extends Logging {
       sqlConf.filesExpectedPartitionNum.getOrElse(taskParallelismNum)
     var maxPartitionBytes = sqlConf.filesMaxPartitionBytes
     if (partitionedFiles.size < expectedFilePartitionNum) {
-      openCostInBytes = maxSplitBytes
+      openCostInBytes = maxPartitionBytes
     } else {
       val totalSize = partitionedFiles.foldLeft(0L) {
         (totalSize, file) => totalSize + file.length + openCostInBytes


### PR DESCRIPTION
### What changes were proposed in this pull request?
We use `openCostInBytes` to control file partition merging, and the merged partitionSize is determined by `maxSplitBytes`. In the scenarios with a large number of small files, it is difficult for users to set the appropriate configuration to achieve maximum concurrency and best performance.
This PR is trying to use total file size and `expectedPartitionNum`, which is default as the task concurrenty,  to automatically adjust the `maxPartitionBytes` and `openCostInBytes` . With this we cansolve the concurrency problem in the scenario of a large number of small files.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
unit tests.
