### PR TITLE
[SPARK-40168][CORE] Handle `SparkException` during shuffle block migration

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -127,7 +127,7 @@ private[storage] class BlockManagerDecommissioner(
               }
               logInfo(s"Migrated $shuffleBlockInfo to $peer")
             } catch {
-              case e: IOException =>
+              case e @ ( _ : IOException | _ : SparkException) =>
                 // If a block got deleted before netty opened the file handle, then trying to
                 // load the blocks now will fail. This is most likely to occur if we start
                 // migrating blocks and then the shuffle TTL cleaner kicks in. However this


### PR DESCRIPTION
### What changes were proposed in this pull request?
Explicitly handle FileNotFoundException wrapped inside SparkException, then mark this block as deleted, further avoid retry of this block and stop of current migration thread

### Why are the changes needed?
FileNotFoundException wrapped inside SparkException is not handled correctly, causing unnecessary retry and stop of current migration thread

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added test in BlockManagerDecommissionUnitSuite
