### PR TITLE
[SPARK-40172][ML][TESTS] Temporarily disable flaky test cases in ImageFileFormatSuite

### DIFF
--- a/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
@@ -109,7 +109,7 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
 
   // TODO(SPARK-40171): Re-enable the following flaky test case after being fixed.
   // Images with the different number of channels
-  test("readImages pixel values test") {
+  ignore("readImages pixel values test") {
     val images = spark.read.format("image").option("dropInvalid", true)
       .load(imagePath + "/cls=multichannel/").collect()
 

--- a/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/source/image/ImageFileFormatSuite.scala
@@ -49,7 +49,8 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(df.schema("image").dataType == columnSchema, "data do not fit ImageSchema")
   }
 
-  test("image datasource count test") {
+  // TODO(SPARK-40171): Re-enable the following flaky test case after being fixed.
+  ignore("image datasource count test") {
     val df1 = spark.read.format("image").load(imagePath)
     assert(df1.count === 9)
 
@@ -87,7 +88,8 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
     assert(result === invalidImageRow(resultOrigin))
   }
 
-  test("image datasource partition test") {
+  // TODO(SPARK-40171): Re-enable the following flaky test case after being fixed.
+  ignore("image datasource partition test") {
     val result = spark.read.format("image")
       .option("dropInvalid", true).load(imagePath)
       .select(substring_index(col("image.origin"), "/", -1).as("origin"), col("cls"), col("date"))
@@ -105,6 +107,7 @@ class ImageFileFormatSuite extends SparkFunSuite with MLlibTestSparkContext {
     ))
   }
 
+  // TODO(SPARK-40171): Re-enable the following flaky test case after being fixed.
   // Images with the different number of channels
   test("readImages pixel values test") {
     val images = spark.read.format("image").option("dropInvalid", true)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

3 test cases in ImageFileFormatSuite become flaky in the GitHub action tests:

https://github.com/apache/spark/runs/7941765326?check_suite_focus=true
https://github.com/gengliangwang/spark/runs/7928658069

Before they are fixed(https://issues.apache.org/jira/browse/SPARK-40171), I suggest disabling them in OSS.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Disable flaky tests before they are fixed. The test cases keep failing from time to time, while they always pass on local env.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing CI