### PR TITLE
[SPARK-40157][PYTHON][DOCS] Make pyspark.files examples self-contained

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -382,6 +382,7 @@ pyspark_core = Module(
         "pyspark.conf",
         "pyspark.broadcast",
         "pyspark.accumulators",
+        "pyspark.files",
         "pyspark.serializers",
         "pyspark.profiler",
         "pyspark.shuffle",

--- a/python/pyspark/files.py
+++ b/python/pyspark/files.py
@@ -136,9 +136,8 @@ class SparkFiles:
         Examples
         --------
         >>> from pyspark.files import SparkFiles
-        >>> SparkFiles.getRootDirectory()  # doctest :+SKIP
-        '/private/var/folders/4q/svxtvbs94sv3w6n9nk_6ws1m0000gp/T/
-        spark-a904728e-08d3-400c-a872-cfd82fd6dcd2/userFiles-648cf6d6-bb2c-4f53-82bd-e658aba0c5de'
+        >>> SparkFiles.getRootDirectory()  # doctest: +SKIP
+        '.../spark-a904728e-08d3-400c-a872-cfd82fd6dcd2/userFiles-648cf6d6-bb2c-4f53-82bd-e658aba0c5de'
         """
         if cls._is_running_on_worker:
             return cast(str, cls._root_directory)
@@ -147,3 +146,20 @@ class SparkFiles:
             assert cls._sc is not None
             assert cls._sc._jvm is not None
             return cls._sc._jvm.org.apache.spark.SparkFiles.getRootDirectory()
+
+
+def _test() -> None:
+    import doctest
+    import sys
+    from pyspark import SparkContext
+
+    globs = globals().copy()
+    globs["sc"] = SparkContext("local[2]", "files tests")
+    (failure_count, test_count) = doctest.testmod(globs=globs, optionflags=doctest.ELLIPSIS)
+    globs["sc"].stop()
+    if failure_count:
+        sys.exit(-1)
+
+
+if __name__ == "__main__":
+    _test()

--- a/python/pyspark/files.py
+++ b/python/pyspark/files.py
@@ -45,7 +45,71 @@ class SparkFiles:
     @classmethod
     def get(cls, filename: str) -> str:
         """
-        Get the absolute path of a file added through :meth:`SparkContext.addFile`.
+        Get the absolute path of a file added through
+        :meth:`SparkContext.addFile` or :meth:`SparkContext.addPyFile`.
+
+        .. versionadded:: 0.7.0
+
+        Parameters
+        ----------
+        filename : str
+            file that are added to resources
+
+        Returns
+        -------
+        str
+            the absolute path of the file
+
+        See Also
+        --------
+        :meth:`SparkFiles.getRootDirectory`
+        :meth:`SparkContext.addFile`
+        :meth:`SparkContext.addPyFile`
+        :meth:`SparkContext.listFiles`
+
+        Examples
+        --------
+        >>> import os
+        >>> import tempfile
+        >>> from pyspark import SparkFiles
+
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     path1 = os.path.join(d, "test.txt")
+        ...     with open(path1, "w") as f:
+        ...         _ = f.write("100")
+        ...
+        ...     sc.addFile(path1)
+        ...     file_list1 = sorted(sc.listFiles)
+        ...
+        ...     def func1(iterator):
+        ...         path = SparkFiles.get("test.txt")
+        ...         assert path.startswith(SparkFiles.getRootDirectory())
+        ...         return [path]
+        ...
+        ...     path_list1 = sc.parallelize([1, 2, 3, 4]).mapPartitions(func1).collect()
+        ...
+        ...     path2 = os.path.join(d, "test.py")
+        ...     with open(path2, "w") as f:
+        ...         _ = f.write("import pyspark")
+        ...
+        ...     # py files
+        ...     sc.addPyFile(path2)
+        ...     file_list2 = sorted(sc.listFiles)
+        ...
+        ...     def func2(iterator):
+        ...         path = SparkFiles.get("test.py")
+        ...         assert path.startswith(SparkFiles.getRootDirectory())
+        ...         return [path]
+        ...
+        ...     path_list2 = sc.parallelize([1, 2, 3, 4]).mapPartitions(func2).collect()
+        >>> file_list1
+        ['file:/.../test.txt']
+        >>> set(path_list1)
+        {'.../test.txt'}
+        >>> file_list2
+        ['file:/.../test.py', 'file:/.../test.txt']
+        >>> set(path_list2)
+        {'.../test.py'}
         """
         path = os.path.join(SparkFiles.getRootDirectory(), filename)
         return os.path.abspath(path)
@@ -54,7 +118,27 @@ class SparkFiles:
     def getRootDirectory(cls) -> str:
         """
         Get the root directory that contains files added through
-        :meth:`SparkContext.addFile`.
+        :meth:`SparkContext.addFile` or :meth:`SparkContext.addPyFile`.
+
+        .. versionadded:: 0.7.0
+
+        Returns
+        -------
+        str
+            the root directory that contains files added to resources
+
+        See Also
+        --------
+        :meth:`SparkFiles.get`
+        :meth:`SparkContext.addFile`
+        :meth:`SparkContext.addPyFile`
+
+        Examples
+        --------
+        >>> from pyspark.files import SparkFiles
+        >>> SparkFiles.getRootDirectory()  # doctest :+SKIP
+        '/private/var/folders/4q/svxtvbs94sv3w6n9nk_6ws1m0000gp/T/
+        spark-a904728e-08d3-400c-a872-cfd82fd6dcd2/userFiles-648cf6d6-bb2c-4f53-82bd-e658aba0c5de'
         """
         if cls._is_running_on_worker:
             return cast(str, cls._root_directory)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make pyspark.files examples self-contained


### Why are the changes needed?
Make pyspark.files examples self-contained


### Does this PR introduce _any_ user-facing change?
yes, new example

### How was this patch tested?
added doctests