### PR TITLE
[SPARK-40175][SQL]Speed up conversion of Tuple2 to Scala Map

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
@@ -129,20 +129,20 @@ object ArrayBasedMapData {
   def toScalaMap(map: ArrayBasedMapData): Map[Any, Any] = {
     val keys = map.keyArray.asInstanceOf[GenericArrayData].array
     val values = map.valueArray.asInstanceOf[GenericArrayData].array
-    keys.zip(values).toMap
+    keys.zip(values)(collection.breakOut)
   }
 
   def toScalaMap(keys: Array[Any], values: Array[Any]): Map[Any, Any] = {
-    keys.zip(values).toMap
+    keys.zip(values)(collection.breakOut)
   }
 
   def toScalaMap(keys: scala.collection.Seq[Any],
       values: scala.collection.Seq[Any]): Map[Any, Any] = {
-    keys.zip(values).toMap
+    keys.zip(values)(collection.breakOut)
   }
 
   def toJavaMap(keys: Array[Any], values: Array[Any]): java.util.Map[Any, Any] = {
     import scala.collection.JavaConverters._
-    keys.zip(values).toMap.asJava
+    keys.zip(values)(collection.breakOut).asInstanceOf[Map[Any, Any]].asJava
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`Traversable.toMap` changed to `collections.breakOut`, that eliminates intermediate tuple collection creation.
I optimized it with reference to this pr:https://github.com/apache/spark/pull/18693
An introduction to `Collections. BreakOut` can be found at [Stack Overflow article](https://stackoverflow.com/questions/1715681/scala-2-8-breakout).

### Why are the changes needed?
When `DeserializeToObject` is executed, converting Tuple2 to Scala Map via `. ToMap` takes a lot of cpu time.
![image](https://user-images.githubusercontent.com/94670132/185860416-f147ddd7-65b3-4dcb-b9d6-9a872015e003.png)
![image](https://user-images.githubusercontent.com/94670132/185860432-2aec4c48-898a-4d66-8d34-2221ab7e9408.png)


### How was this patch tested?
Unit tests run.
No performance tests performed yet.