### PR TITLE
[SPARK-39915][SQL] Ensure the output partitioning is user-specified in AQE

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
-import org.apache.spark.sql.catalyst.trees.TreePattern.{LOCAL_RELATION, TRUE_OR_FALSE_LITERAL}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{LOCAL_RELATION, REPARTITION_OPERATION, TRUE_OR_FALSE_LITERAL}
 
 /**
  * The base class of two rules in the normal and AQE Optimizer. It simplifies query plans with
@@ -186,13 +186,19 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
    * Add a [[ROOT_REPARTITION]] tag for the root user-specified repartition so this rule can
    * skip optimize it.
    */
-  private def addTagForRootRepartition(plan: LogicalPlan): LogicalPlan = plan match {
-    case p: Project => p.mapChildren(addTagForRootRepartition)
-    case f: Filter => f.mapChildren(addTagForRootRepartition)
-    case r if userSpecifiedRepartition(r) =>
-      r.setTagValue(ROOT_REPARTITION, ())
-      r
-    case _ => plan
+  private def addTagForRootRepartition(plan: LogicalPlan): LogicalPlan = {
+    if (!plan.containsPattern(REPARTITION_OPERATION)) {
+      return plan
+    }
+
+    plan match {
+      case p: Project => p.mapChildren(addTagForRootRepartition)
+      case f: Filter => f.mapChildren(addTagForRootRepartition)
+      case r if userSpecifiedRepartition(r) =>
+        r.setTagValue(ROOT_REPARTITION, ())
+        r
+      case _ => plan
+    }
   }
 
   override def apply(plan: LogicalPlan): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -130,7 +130,8 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
         p
       }
 
-    // the only case can be matched here is that LogicalQueryStage is empty
+    // In AQE, the `Repartition` will be replaced with `LogicalQueryStage`,
+    // so the only case can be matched here is that `LogicalQueryStage` is empty
     case p: LeafNode if !p.isInstanceOf[LocalRelation] && isEmpty(p) => empty(p)
 
     case p: UnaryNode if p.children.nonEmpty && p.children.forall(isEmpty) => p match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -193,6 +193,7 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
     plan match {
       case p: Project => p.mapChildren(addTagForRootRepartition)
       case f: Filter => f.mapChildren(addTagForRootRepartition)
+      case d: DeserializeToObject => d.mapChildren(addTagForRootRepartition)
       case r if userSpecifiedRepartition(r) =>
         r.setTagValue(ROOT_REPARTITION, ())
         r

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -130,8 +130,7 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
         p
       }
 
-    // In AQE, the `Repartition` will be replaced with `LogicalQueryStage`,
-    // so the only case can be matched here is that `LogicalQueryStage` is empty
+    // the only case can be matched here is that LogicalQueryStage is empty
     case p: LeafNode if !p.isInstanceOf[LocalRelation] && isEmpty(p) => empty(p)
 
     case p: UnaryNode if p.children.nonEmpty && p.children.forall(isEmpty) => p match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AQEUtils.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.adaptive
 
 import org.apache.spark.sql.catalyst.plans.physical.{ClusteredDistribution, Distribution, HashPartitioning, UnspecifiedDistribution}
-import org.apache.spark.sql.execution.{CollectMetricsExec, FilterExec, ProjectExec, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.{CollectMetricsExec, DeserializeToObjectExec, FilterExec, ProjectExec, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.exchange.{REPARTITION_BY_COL, REPARTITION_BY_NUM, ShuffleExchangeExec}
 
 object AQEUtils {
@@ -41,6 +41,7 @@ object AQEUtils {
     case f: FilterExec => getRequiredDistribution(f.child)
     case s: SortExec if !s.global => getRequiredDistribution(s.child)
     case c: CollectMetricsExec => getRequiredDistribution(c.child)
+    case d: DeserializeToObjectExec => getRequiredDistribution(d.child)
     case p: ProjectExec =>
       getRequiredDistribution(p.child).flatMap {
         case h: ClusteredDistribution =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -122,7 +122,8 @@ case class AdaptiveSparkPlanExec(
       ReplaceHashWithSortAgg,
       RemoveRedundantSorts,
       DisableUnnecessaryBucketedScan,
-      OptimizeSkewedJoin(ensureRequirements)
+      OptimizeSkewedJoin(ensureRequirements),
+      AdjustShuffleExchangePosition
     ) ++ context.session.sessionState.adaptiveRulesHolder.queryStagePrepRules
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -118,12 +118,12 @@ case class AdaptiveSparkPlanExec(
     Seq(
       RemoveRedundantProjects,
       ensureRequirements,
+      AdjustShuffleExchangePosition,
       ValidateSparkPlan,
       ReplaceHashWithSortAgg,
       RemoveRedundantSorts,
       DisableUnnecessaryBucketedScan,
-      OptimizeSkewedJoin(ensureRequirements),
-      AdjustShuffleExchangePosition
+      OptimizeSkewedJoin(ensureRequirements)
     ) ++ context.session.sessionState.adaptiveRulesHolder.queryStagePrepRules
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdjustShuffleExchangePosition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdjustShuffleExchangePosition.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{DeserializeToObjectExec, SparkPlan}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
+
+/**
+ * This rule is used to adjust the shuffle exchange with special SparkPlan who
+ * does not allow a shuffle on top of it.
+ */
+object AdjustShuffleExchangePosition extends Rule[SparkPlan] {
+  private def shouldAdjust(plan: SparkPlan): Boolean = plan match {
+    // `DeserializeToObjectExec` is used by Spark internally e.g. `Dataset.rdd`.
+    // This conflicts with AQE framework since we may add shuffle back during re-optimize
+    // to preserve the user-specified repartition, so here we adjust the position with shuffle.
+    case _: DeserializeToObjectExec => true
+    case _ => false
+  }
+
+  override def apply(plan: SparkPlan): SparkPlan = plan match {
+    case shuffle: ShuffleExchangeLike if shouldAdjust(shuffle.child) =>
+      shuffle.child.withNewChildren(shuffle.withNewChildren(shuffle.child.children) :: Nil)
+    case _ => plan
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdjustShuffleExchangePosition.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdjustShuffleExchangePosition.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
  */
 object AdjustShuffleExchangePosition extends Rule[SparkPlan] {
   private def shouldAdjust(plan: SparkPlan): Boolean = plan match {
-    // `DeserializeToObjectExec` is used by Spark internally e.g. `Dataset.rdd`.
+    // `DeserializeToObjectExec` is used by Spark internally e.g. `Dataset.rdd`. It produces
+    // safe rows and must be root node because SQL operators only accept unsafe rows as input.
     // This conflicts with AQE framework since we may add shuffle back during re-optimize
     // to preserve the user-specified repartition, so here we adjust the position with shuffle.
     case _: DeserializeToObjectExec => true

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -51,11 +51,6 @@ case class InsertAdaptiveSparkPlan(
     case c: DataWritingCommandExec
         if !c.cmd.isInstanceOf[V1WriteCommand] || !conf.plannedWriteEnabled =>
       c.copy(child = apply(c.child))
-    // `DeserializeToObjectExec` is used by Spark internally e.g. `Dataset.rdd`.
-    // It should always be a root node, and does not allow a shuffle on top of it.
-    // This conflicts with AQE framework since we may add shuffle back during re-optimize
-    // to preserve the user-specified repartition, so here we only apply it's children to AQE.
-    case d: DeserializeToObjectExec => d.withNewChildren(d.children.map(apply))
     case _ if shouldApplyAQE(plan, isSubquery) =>
       if (supportAdaptive(plan)) {
         try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/InsertAdaptiveSparkPlan.scala
@@ -51,6 +51,11 @@ case class InsertAdaptiveSparkPlan(
     case c: DataWritingCommandExec
         if !c.cmd.isInstanceOf[V1WriteCommand] || !conf.plannedWriteEnabled =>
       c.copy(child = apply(c.child))
+    // `DeserializeToObjectExec` is used by Spark internally e.g. `Dataset.rdd`.
+    // It should always be a root node, and does not allow a shuffle on top of it.
+    // This conflicts with AQE framework since we may add shuffle back during re-optimize
+    // to preserve the user-specified repartition, so here we only apply it's children to AQE.
+    case d: DeserializeToObjectExec => d.withNewChildren(d.children.map(apply))
     case _ if shouldApplyAQE(plan, isSubquery) =>
       if (supportAdaptive(plan)) {
         try {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -483,7 +483,7 @@ class DataFrameSuite extends QueryTest
       testData.select("key").coalesce(1).select("key"),
       testData.select("key").collect().toSeq)
 
-    assert(spark.emptyDataFrame.coalesce(1).rdd.partitions.size === 0)
+    assert(spark.emptyDataFrame.coalesce(1).rdd.partitions.size === 1)
   }
 
   test("convert $\"attribute name\" into unresolved attribute") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Support get user-specified root repartition through  `DeserializeToObjectExec`
- Skip optimize empty for the root repartition which is user-specified
- Add a new rule `AdjustShuffleExchangePosition` to adjust the shuffle we add back, so that we can restore shuffle safely.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
AQE can not completely respect the user-specified repartition. The main reasons are:

1. the AQE optimzier will convert empty to local relation which does not reserve the partitioning info
2. the machine of AQE `requiredDistribution` only restore the repartition which does not support through `DeserializeToObjectExec`


After the fix:
The partition number of `spark.range(0).repartition(5).rdd.getNumPartitions` should be 5.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, ensure the user-specified distribution.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add tests