### PR TITLE
[SPARK-40178][PYTHON][SQL] Fix partitioning hint parameters in PySpark

### DIFF
--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -72,15 +72,7 @@ def _to_java_column(col: "ColumnOrName") -> JavaObject:
 
 
 def _to_java_expr(col: "ColumnOrName") -> JavaObject:
-    if isinstance(col, (Column, str)):
-        return _to_java_column(col).expr()
-    else:
-        raise TypeError(
-            "Invalid argument, not a string or column: "
-            "{0} of type {1}. "
-            "For column literals, use 'lit', 'array', 'struct' or 'create_map' "
-            "function.".format(col, type(col))
-        )
+    return _to_java_column(col).expr()
 
 
 def _to_seq(

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -71,6 +71,18 @@ def _to_java_column(col: "ColumnOrName") -> JavaObject:
     return jcol
 
 
+def _to_java_expr(col: "ColumnOrName") -> JavaObject:
+    if isinstance(col, (Column, str)):
+        return _to_java_column(col).expr()
+    else:
+        raise TypeError(
+            "Invalid argument, not a string or column: "
+            "{0} of type {1}. "
+            "For column literals, use 'lit', 'array', 'struct' or 'create_map' "
+            "function.".format(col, type(col))
+        )
+
+
 def _to_seq(
     sc: SparkContext,
     cols: Iterable["ColumnOrName"],

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -52,7 +52,7 @@ from pyspark.rdd import (
 from pyspark.serializers import BatchedSerializer, CPickleSerializer, UTF8Deserializer
 from pyspark.storagelevel import StorageLevel
 from pyspark.traceback_utils import SCCallSiteSync
-from pyspark.sql.column import Column, _to_seq, _to_list, _to_java_column
+from pyspark.sql.column import Column, _to_seq, _to_list, _to_java_column, _to_java_expr
 from pyspark.sql.readwriter import DataFrameWriter, DataFrameWriterV2
 from pyspark.sql.streaming import DataStreamWriter
 from pyspark.sql.types import (
@@ -977,7 +977,8 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
                     )
                 )
 
-        jdf = self._jdf.hint(name, self._jseq(parameters))
+        jdf = self._jdf.hint(name, self._jseq(parameters,
+                                              converter=lambda x: _to_java_expr(x) if isinstance(x, (Column, str)) else x))
         return DataFrame(jdf, self.sparkSession)
 
     def count(self) -> int:


### PR DESCRIPTION
I added code that converts the column parameters to Java expressions before passing them to the JVM hint method.
Partitioning hint parameters used to raise an error:
```
>>> df = spark.range(1024)
>>> 
>>> df
DataFrame[id: bigint]
>>> df.hint("rebalance", "id")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/maxwellconradt/spark/python/pyspark/sql/dataframe.py", line 980, in hint
    jdf = self._jdf.hint(name, self._jseq(parameters))
  File "/Users/maxwellconradt/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1322, in __call__
  File "/Users/maxwellconradt/spark/python/pyspark/sql/utils.py", line 196, in deco
    raise converted from None
pyspark.sql.utils.AnalysisException: REBALANCE Hint parameter should include columns, but id found
>>> df.hint("repartition", "id")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/maxwellconradt/spark/python/pyspark/sql/dataframe.py", line 980, in hint
    jdf = self._jdf.hint(name, self._jseq(parameters))
  File "/Users/maxwellconradt/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1322, in __call__
  File "/Users/maxwellconradt/spark/python/pyspark/sql/utils.py", line 196, in deco
    raise converted from None
pyspark.sql.utils.AnalysisException: REPARTITION Hint parameter should include columns, but id found
```
This is a bug because there's no other way to specify a column as a hint parameter in PySpark.

After this MR this functionality works:
```
>>> df = spark.range(1024)
>>> df.hint("repartition", 'id')
DataFrame[id: bigint]
>>> df.hint('repartition', 'id').explain()
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Exchange hashpartitioning(id#0L, 200), REPARTITION_BY_COL, [plan_id=6]
   +- Range (0, 1024, step=1, splits=8)


>>> df.hint('rebalance', 'id').explain()
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Exchange hashpartitioning(id#0L, 200), REBALANCE_PARTITIONS_BY_COL, [plan_id=14]
   +- Range (0, 1024, step=1, splits=8)
```

### Does this PR introduce _any_ user-facing change?
It fixes a bug.

### How was this patch tested?
I added a test case `test_partitioning_hints` on `DataFrameTests` to test the partitioning hint functionality in its entirety, not only ensuring it did not raise a spurious exception, but also that the repartitioning does occur.