### PR TITLE
Revert "[SPARK-40165][BUILD] Update test plugins to latest versions"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1179,7 +1179,7 @@
       <dependency>
         <groupId>org.scalacheck</groupId>
         <artifactId>scalacheck_${scala.binary.version}</artifactId>
-        <version>1.16.0</version>
+        <version>1.15.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -2932,7 +2932,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0-M5</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -3172,7 +3172,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.1.1</version>
           <executions>
             <execution>
               <id>default-cli</id>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This reverts commit 3ed382f391911ec4a79fb204f4986728017dfa4a. https://github.com/apache/spark/pull/37598


### Why are the changes needed?
This patch cause the error like:
```
[error] /home/runner/work/spark/spark/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HttpAuthUtils.java:36:1:  error: package org.apache.http.protocol does not exist
[error] import org.apache.http.protocol.BasicHttpContext;
[error]                                ^
[error] /home/runner/work/spark/spark/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/HttpAuthUtils.java:156:1:  error: cannot find symbol
[error]     private final HttpContext httpContext;
[error]                   ^  symbol:   class HttpContext
[error]   location: class HttpKerberosClientAction
[error] 3 errors
```

The old cache + new pom passed. Then, cache is outdate, the real error happened.

According investigation, I found that this https://github.com/apache/spark/commit/3ed382f391911ec4a79fb204f4986728017dfa4a should be the real first bad commit.

I just found this job are using cache:
https://github.com/panbingkun/spark/runs/7938361118?check_suite_focus=true

With old cache + new: passed. (that's the reason that the original PR passed)

Without any cache + new pom: failed. (that's reason that CI break)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed, especially, 2.13 passed
