### PR TITLE
[SPARK-40187][DOCS] Add `Apache YuniKorn` scheduler docs

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1825,10 +1825,10 @@ Install Apache YuniKorn:
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
 kubectl create namespace yunikorn
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.0.0
 ```
 
-The above steps will install the latest version of YuniKorn on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.0.0 on an existing Kubernetes cluster.
 
 ##### Get started
 
@@ -1843,21 +1843,9 @@ Submit Spark jobs with the following extra options:
 Note that `{{APP_ID}}` is the built-in variable that will be substituted with Spark job ID automatically.
 With the above configuration, the job will be scheduled by YuniKorn scheduler instead of the default Kubernetes scheduler.
 
-##### Work with YuniKorn queues
-
-Apache YuniKorn supports 2 types of resource queues:
-
-- Static
-- Dynamic
-
-The static queues are predefined in YuniKorn configmap, and the dynamic queues are automatically created by the scheduler
-based on [placement rules](https://yunikorn.apache.org/docs/user_guide/placement_rules). Spark supports to run with
-both queue setup. Refer to this [resource quota management](https://yunikorn.apache.org/docs/user_guide/resource_quota_management) for more
-information about how to run Spark with different queue setup.
-
 ##### Limitations
 
-- Apache YuniKorn currently only supports x86 Linux, running Spark on ARM64 with Apache YuniKorn is not supported at present.
+- Apache YuniKorn currently only supports x86 Linux, running Spark on ARM64 (or other platform) with Apache YuniKorn is not supported at present.
 
 ### Stage Level Scheduling Overview
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1815,7 +1815,7 @@ spec:
 
 [Apache YuniKorn](https://yunikorn.apache.org/) is a resource scheduler for Kubernetes that provides advanced batch scheduling
 capabilities, such as job queuing, resource fairness, min/max queue capacity and flexible job ordering policies.
-For available Apache YuniKorn features, please refer to [this doc](https://yunikorn.apache.org/docs/next/get_started/core_features).
+For available Apache YuniKorn features, please refer to [core features](https://yunikorn.apache.org/docs/get_started/core_features).
 
 ##### Prerequisites
 
@@ -1828,7 +1828,7 @@ kubectl create namespace yunikorn
 helm install yunikorn yunikorn/yunikorn --namespace yunikorn
 ```
 
-the above steps will install the latest version of YuniKorn on an existing Kubernetes cluster.
+The above steps will install the latest version of YuniKorn on an existing Kubernetes cluster.
 
 ##### Get started
 
@@ -1840,7 +1840,7 @@ Submit Spark jobs with the following extra options:
 --conf spark.kubernetes.executor.annotation.yunikorn.apache.org/app-id={{APP_ID}}
 ```
 
-Note, `{{APP_ID}}` is the builtin variable that will be substituted with Spark job ID automatically.
+Note that `{{APP_ID}}` is the built-in variable that will be substituted with Spark job ID automatically.
 With the above configuration, the job will be scheduled by YuniKorn scheduler instead of the default Kubernetes scheduler.
 
 ##### Work with YuniKorn queues
@@ -1851,9 +1851,13 @@ Apache YuniKorn supports 2 types of resource queues:
 - Dynamic
 
 The static queues are predefined in YuniKorn configmap, and the dynamic queues are automatically created by the scheduler
-based on [placement rules](https://yunikorn.apache.org/docs/next/user_guide/placement_rules). Spark supports to run with
-both queue setup. Refer to this [doc](https://yunikorn.apache.org/docs/next/user_guide/resource_quota_management) for more
+based on [placement rules](https://yunikorn.apache.org/docs/user_guide/placement_rules). Spark supports to run with
+both queue setup. Refer to this [resource quota management](https://yunikorn.apache.org/docs/user_guide/resource_quota_management) for more
 information about how to run Spark with different queue setup.
+
+##### Limitations
+
+- Apache YuniKorn currently only supports x86 Linux, running Spark on ARM64 with Apache YuniKorn is not supported at present.
 
 ### Stage Level Scheduling Overview
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1853,7 +1853,7 @@ Apache YuniKorn supports 2 types of resource queues:
 The static queues are predefined in YuniKorn configmap, and the dynamic queues are automatically created by the scheduler
 based on [placement rules](https://yunikorn.apache.org/docs/next/user_guide/placement_rules). Spark supports to run with
 both queue setup. Refer to this [doc](https://yunikorn.apache.org/docs/next/user_guide/resource_quota_management) for more
-information how to run Spark with different queue setup.
+information about how to run Spark with different queue setup.
 
 ### Stage Level Scheduling Overview
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1811,6 +1811,50 @@ spec:
   queue: default
 ```
 
+#### Using Apache YuniKorn as Customized Scheduler for Spark on Kubernetes
+
+[Apache YuniKorn](https://yunikorn.apache.org/) is a resource scheduler for Kubernetes that provides advanced batch scheduling
+capabilities, such as job queuing, resource fairness, min/max queue capacity and flexible job ordering policies.
+For available Apache YuniKorn features, please refer to [this doc](https://yunikorn.apache.org/docs/next/get_started/core_features).
+
+##### Prerequisites
+
+Install Apache YuniKorn:
+
+```bash
+helm repo add yunikorn https://apache.github.io/yunikorn-release
+helm repo update
+kubectl create namespace yunikorn
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn
+```
+
+the above steps will install the latest version of YuniKorn on an existing Kubernetes cluster.
+
+##### Get started
+
+Submit Spark jobs with the following extra options:
+
+```bash
+--conf spark.kubernetes.scheduler.name=yunikorn
+--conf spark.kubernetes.driver.annotation.yunikorn.apache.org/app-id={{APP_ID}}
+--conf spark.kubernetes.executor.annotation.yunikorn.apache.org/app-id={{APP_ID}}
+```
+
+Note, `{{APP_ID}}` is the builtin variable that will be substituted with Spark job ID automatically.
+With the above configuration, the job will be scheduled by YuniKorn scheduler instead of the default Kubernetes scheduler.
+
+##### Work with YuniKorn queues
+
+Apache YuniKorn supports 2 types of resource queues:
+
+- Static
+- Dynamic
+
+The static queues are predefined in YuniKorn configmap, and the dynamic queues are automatically created by the scheduler
+based on [placement rules](https://yunikorn.apache.org/docs/next/user_guide/placement_rules). Spark supports to run with
+both queue setup. Refer to this [doc](https://yunikorn.apache.org/docs/next/user_guide/resource_quota_management) for more
+information how to run Spark with different queue setup.
+
 ### Stage Level Scheduling Overview
 
 Stage level scheduling is supported on Kubernetes when dynamic allocation is enabled. This also requires <code>spark.dynamicAllocation.shuffleTracking.enabled</code> to be enabled since Kubernetes doesn't support an external shuffle service at this time. The order in which containers for different profiles is requested from Kubernetes is not guaranteed. Note that since dynamic allocation on Kubernetes requires the shuffle tracking feature, this means that executors from previous stages that used a different ResourceProfile may not idle timeout due to having shuffle data on them. This could result in using more cluster resources and in the worst case if there are no remaining resources on the Kubernetes cluster then Spark could potentially hang. You may consider looking at config <code>spark.dynamicAllocation.shuffleTracking.timeout</code> to set a timeout, but that could result in data having to be recomputed if the shuffle data is really needed.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a section under [customized-kubernetes-schedulers-for-spark-on-kubernetes](https://spark.apache.org/docs/latest/running-on-kubernetes.html#customized-kubernetes-schedulers-for-spark-on-kubernetes) to explain how to run Spark with Apache YuniKorn. This is based on the review comments from #35663.


### Why are the changes needed?
Explain how to run Spark with Apache YuniKorn

### Does this PR introduce _any_ user-facing change?
No
