### PR TITLE
[SPARK-40199][SQL] Provide useful error when projecting a non-null column encounters null value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions.codegen
 
+import org.apache.commons.text.StringEscapeUtils
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
@@ -274,7 +276,8 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
        |try {
        |  ${inputExpr.trim}
        |} catch (NullPointerException npe) {
-       |  throw QueryExecutionErrors.valueCannotBeNullError("${descPath.mkString(".")}");
+       |  throw QueryExecutionErrors.valueCannotBeNullError(
+       |      "${descPath.map(StringEscapeUtils.escapeJava).mkString(".")}");
        |}
     """.stripMargin
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/GenerateUnsafeProjection.scala
@@ -38,9 +38,10 @@ object GenerateUnsafeProjection extends CodeGenerator[Seq[Expression], UnsafePro
   /**
    * @param dataType The data type being projected
    * @param nullable Whether or not it is nullable
-   * @param descPath The "path" to this projection, with all descriptors along the way. For example
-   *                 with a schema like `f1: STRUCT<f2: ARRAY<STRUCT<f3: INT>>>`, when projecting
-   *                 `f3` this path would be like `Seq("<pos 0>", "<array element>", "`f3`")`
+   * @param descPath The "path" to this projection, with all descriptors along the way. For
+   *                 example with a schema like `f1: STRUCT<f2: ARRAY<STRUCT<f3: INT>>>`, when
+   *                 projecting `f3` this path would be like
+   *                 {{{ Seq("<POS_0>", "`f2`", "<ARRAY_ELEMENT>", "`f3`") }}}
    *                 (names aren't available at the top level so a position is used instead).
    */
   case class Schema(dataType: DataType, nullable: Boolean, descPath: Seq[String])

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -474,6 +474,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
     new RuntimeException(fieldCannotBeNullMsg(index, fieldName))
   }
 
+  def valueCannotBeNullError(locationDesc: String): RuntimeException = {
+    new RuntimeException(s"The value at $locationDesc cannot be null, but a NULL was found. " +
+      "This is typically caused by the presence of a NULL value when the schema indicates the " +
+      "value should be non-null. Check that the input data matches the schema and/or that UDFs " +
+      "which can return null have a nullable return schema.")
+  }
+
   def unableToCreateDatabaseAsFailedToCreateDirectoryError(
       dbDefinition: CatalogDatabase, e: IOException): Throwable = {
     new SparkException(s"Unable to create database ${dbDefinition.name} as failed " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratedProjectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratedProjectionSuite.scala
@@ -347,4 +347,12 @@ class GeneratedProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
         "<POS_0>.<MAP_VALUE>.`f`")
     }
   }
+
+  test("SPARK-40199 Unexpected null handling should handle columns with special chars") {
+    val colName = "col_\"'`,.?$!&%@^~+*-\b\t\f\'\r\n+()[]<>{}|\\/_test"
+    testUnexpectedNullHandling(
+      new StructType().add(colName, StringType, nullable = false),
+      InternalRow(null),
+      s"<POS_0>.`$colName`")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratedProjectionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/GeneratedProjectionSuite.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.catalyst.expressions.codegen
 
 import java.nio.charset.StandardCharsets
 
-import org.apache.commons.lang3.exception.ExceptionUtils
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -296,82 +294,57 @@ class GeneratedProjectionSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  /**
-   * Tests handling of a NULL value where the schema indicates non-null (SPARK-XXXXX).
-   *
-   * @param inputType The schema to use for field in question.
-   * @param inputDatum The value to provide; should match `inputType` and contain a null value.
-   * @param expectedNestedDescriptors Expected descriptors to find in the nested exception messages;
-   *                                  does not include the top-level message.
-   */
   private[this] def testUnexpectedNullHandling(
       inputType: DataType,
       inputDatum: Any,
-      expectedNestedDescriptors: String*): Unit = {
+      expectedFieldDescriptor: String): Unit = {
     for (topLevelNullable <- Seq(false, true)) {
       val proj = UnsafeProjection.create(BoundReference(0, inputType, nullable = topLevelNullable))
-      val baseNpe = intercept[NullPointerException](proj(InternalRow(inputDatum)))
+      val e = intercept[RuntimeException](proj(InternalRow(inputDatum)))
 
-      val npes = ExceptionUtils.getThrowables(baseNpe)
-      npes.foreach(e => assert(e.isInstanceOf[NullPointerException]))
-      val actualMsgs = npes.map(_.getMessage)
-
-      // last message is the "real" NPE so it doesn't have a message
-      assert(actualMsgs.last === null)
-      // penultimate message should provide guidance to users on potential causes
-      assert(actualMsgs.dropRight(1).last.contains(
-        "This is typically caused by the presence of a NULL value"))
-      // all other messages should direct users to caused-by exceptions
-      actualMsgs.dropRight(2).foreach(m => assert(m.contains("Check caused-by exceptions")))
-      // top-level message should always refer to the same column
-      assert(actualMsgs.head.contains("top-level column pos 0"))
-
-      assert(actualMsgs.length === expectedNestedDescriptors.length + 2)
-      expectedNestedDescriptors.zip(actualMsgs.drop(1))
-        .foreach { case (expect, actual) => assert(actual.contains(expect)) }
+      assert(e.getMessage.contains(
+        s"The value at $expectedFieldDescriptor cannot be null, but a NULL was found."))
     }
   }
 
-  test("SPARK-XXXXX Projecting NULLs from non-nullable input should throw NPE with helpful msg") {
-    testUnexpectedNullHandling(StringType, null)
-
+  test("SPARK-40199 Projecting NULLs from non-nullable input should throw a helpful msg") {
     testUnexpectedNullHandling(
       new StructType().add("middle", new StructType().add("bottom", StringType, nullable = false)),
       InternalRow(InternalRow(null)),
-      "field 'middle'", "field 'bottom'")
+      "<POS_0>.`middle`.`bottom`")
   }
 
-  test("SPARK-XXXXX Projecting NULLs from non-nullable array should throw NPE with helpful msg") {
+  test("SPARK-40199 Projecting NULLs from non-nullable array should throw a helpful msg") {
     testUnexpectedNullHandling(
       ArrayType(StringType, containsNull = false),
       ArrayData.toArrayData(Array(null)),
-      "array element")
+      "<POS_0>.<ARRAY_ELEMENT>")
 
     Seq(true, false).foreach { containsNull =>
       testUnexpectedNullHandling(
         ArrayType(new StructType().add("f", StringType, nullable = false), containsNull),
         ArrayData.toArrayData(Array(InternalRow(null))),
-        "array element", "field 'f'")
+        "<POS_0>.<ARRAY_ELEMENT>.`f`")
     }
   }
 
-  test("SPARK-XXXXX Projecting NULLs from non-nullable map should throw NPE with helpful msg") {
+  test("SPARK-40199 Projecting NULLs from non-nullable map should throw a helpful msg") {
     val foo = UTF8String.fromString("foo")
+    def map(key: Any, value: Any): ArrayBasedMapData = ArrayBasedMapData(Array(key), Array(value))
+
     val mapType = MapType(StringType, StringType, valueContainsNull = false)
-    testUnexpectedNullHandling(mapType, ArrayBasedMapData(Map(foo -> null)), "map value")
-    testUnexpectedNullHandling(mapType, ArrayBasedMapData(Array(null), Array(foo)), "map key")
+    testUnexpectedNullHandling(mapType, map(null, foo), "<POS_0>.<MAP_KEY>")
+    testUnexpectedNullHandling(mapType, map(foo, null), "<POS_0>.<MAP_VALUE>")
 
     val nestType = new StructType().add("f", StringType, nullable = false)
     testUnexpectedNullHandling(
-      MapType(nestType, StringType),
-      ArrayBasedMapData(Array(InternalRow(null)), Array(foo)),
-      "map key", "field 'f'")
+      MapType(nestType, StringType), map(InternalRow(null), foo), "<POS_0>.<MAP_KEY>.`f`")
 
     Seq(true, false).foreach { containsNull =>
       testUnexpectedNullHandling(
         MapType(StringType, nestType, containsNull),
-        ArrayBasedMapData(Map(foo -> InternalRow(null))),
-        "map value", "field 'f'")
+        map(foo, InternalRow(null)),
+        "<POS_0>.<MAP_VALUE>.`f`")
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -3430,16 +3430,15 @@ class DataFrameSuite extends QueryTest
     }
   }
 
-  test("SPARK-XXXXX Projecting NULLs from non-nullable input should throw NPE with helpful msg") {
+  test("SPARK-40199 Projecting NULLs from non-nullable input should throw NPE with helpful msg") {
     // See more in-depth testing in GeneratedProjectionSuite; this test exists mainly to validate
     // that the column/field identifiers are populated as expected in a "real" plan
     val valueType = new StructType().add("f", StringType, nullable = false)
     for (topLevelNullable <- Seq(false, true)) {
       val df = spark.createDataFrame(List(Row(Row(null))).asJava,
         new StructType().add("nest", valueType, nullable = topLevelNullable))
-      val e = intercept[NullPointerException](df.collect())
-      assert(e.getMessage.contains("top-level column (pos 0)"))
-      assert(e.getCause.asInstanceOf[NullPointerException].getMessage.contains("nested field 'f'"))
+      val e = intercept[RuntimeException](df.collect())
+      assert(e.getMessage.contains("<POS_0>.`f` cannot be null"))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This modifies `GenerateUnsafeProjection` to wrap projections of non-null fields in try-catch blocks which swallow any `NullPointerException` that is thrown, and instead throw a helpful error message indicating that a null value was encountered where the schema indicated non-null. This new error is added in `QueryExecutionErrors`.

Small modifications are made to a few methods in `GenerateUnsafeProjection` to allow for passing down the path to the projection in question, to give the user a helpful indication of what they need to change. Getting the name of the top-level column seems to require substantial changes since the name is thrown away when the `BoundReference` is created (in favor of an ordinal), so for the top-level only an ordinal is given; for nested fields the name is provided. An example error message looks like:

```
java.lang.RuntimeException: The value at <POS_0>.`middle`.`bottom` cannot be null, but a NULL was found. This is typically caused by the presence of a NULL value when the schema indicates the value should be non-null. Check that the input data matches the schema and/or that UDFs which can return null have a nullable return schema.
```

### Why are the changes needed?
This is needed to help users decipher the error message; currently a `NullPointerException` without any message is thrown, which provides the user no guidance on what they've done wrong, and typically leads them to believe there is a bug in Spark. See the Jira for a specific example of how this behavior can be triggered and what the exception looks like currently.

### Does this PR introduce _any_ user-facing change?
Yes, in the case that a user has a data-schema mismatch, they will not get a much more helpful error message. In other cases, no change.

### How was this patch tested?
See tests in `DataFrameSuite` and `GeneratedProjectionSuite`.