### PR TITLE
[SPARK-40131][PYTHON] Support NumPy ndarray in built-in functions

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1050,6 +1050,11 @@ class FunctionsTests(ReusedSQLTestCase):
             self.assertEqual(
                 expected_spark_dtypes, self.spark.range(1).select(lit(arr).alias("b")).dtypes
             )
+        arr = np.array([1, 2]).astype(np.uint)
+        with self.assertRaisesRegex(
+            TypeError, "The type of array scalar '%s' is not supported" % arr.dtype
+        ):
+            self.spark.range(1).select(lit(arr).alias("b"))
 
     def test_binary_math_function(self):
         funcs, expected = zip(*[(atan2, 0.13664), (hypot, 8.07527), (pow, 2.14359), (pmod, 1.1)])

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2270,7 +2270,7 @@ class NumpyScalarConverter:
 
 class NumpyArrayConverter:
     def can_convert(self, obj: Any) -> bool:
-        return has_numpy and isinstance(obj, np.ndarray)
+        return has_numpy and isinstance(obj, np.ndarray) and obj.ndim == 1
 
     def convert(self, obj: "np.ndarray", gateway_client: GatewayClient) -> JavaObject:
         from pyspark import SparkContext

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2286,7 +2286,6 @@ class NumpyArrayConverter:
             float: gateway.jvm.double,
             bool: gateway.jvm.boolean,
             str: gateway.jvm.String,
-            bytes: gateway.jvm.byte,
         }
         jarr = gateway.new_array(tpe_dict[ptpe], len(plist))
         for i in range(len(plist)):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1447,26 +1447,6 @@ def _from_numpy_type(nt: "np.dtype") -> Optional[DataType]:
     return None
 
 
-def _from_numpy_type_to_java_type(nt: "np.dtype", gateway: JavaGateway) -> Optional[JavaClass]:
-    """Convert NumPy type to Py4J Java type."""
-    if nt in [np.dtype("int8"), np.dtype("int16")]:
-        # Mapping int8 to gateway.jvm.byte causes
-        #   TypeError: 'bytes' object does not support item assignment
-        return gateway.jvm.short
-    elif nt == np.dtype("int32"):
-        return gateway.jvm.int
-    elif nt == np.dtype("int64"):
-        return gateway.jvm.long
-    elif nt == np.dtype("float32"):
-        return gateway.jvm.float
-    elif nt == np.dtype("float64"):
-        return gateway.jvm.double
-    elif nt == np.dtype("bool"):
-        return gateway.jvm.boolean
-
-    return None
-
-
 def _infer_type(
     obj: Any,
     infer_dict_as_struct: bool = False,
@@ -2289,6 +2269,27 @@ class NumpyScalarConverter:
 
 
 class NumpyArrayConverter:
+    def _from_numpy_type_to_java_type(
+        self, nt: "np.dtype", gateway: JavaGateway
+    ) -> Optional[JavaClass]:
+        """Convert NumPy type to Py4J Java type."""
+        if nt in [np.dtype("int8"), np.dtype("int16")]:
+            # Mapping int8 to gateway.jvm.byte causes
+            #   TypeError: 'bytes' object does not support item assignment
+            return gateway.jvm.short
+        elif nt == np.dtype("int32"):
+            return gateway.jvm.int
+        elif nt == np.dtype("int64"):
+            return gateway.jvm.long
+        elif nt == np.dtype("float32"):
+            return gateway.jvm.float
+        elif nt == np.dtype("float64"):
+            return gateway.jvm.double
+        elif nt == np.dtype("bool"):
+            return gateway.jvm.boolean
+
+        return None
+
     def can_convert(self, obj: Any) -> bool:
         return has_numpy and isinstance(obj, np.ndarray) and obj.ndim == 1
 
@@ -2302,7 +2303,7 @@ class NumpyArrayConverter:
         if len(obj) > 0 and isinstance(plist[0], str):
             jtpe = gateway.jvm.String
         else:
-            jtpe = _from_numpy_type_to_java_type(obj.dtype, gateway)
+            jtpe = self._from_numpy_type_to_java_type(obj.dtype, gateway)
             if jtpe is None:
                 raise TypeError("The type of array scalar '%s' is not supported" % (obj.dtype))
         jarr = gateway.new_array(jtpe, len(obj))

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2304,7 +2304,7 @@ class NumpyArrayConverter:
         else:
             jtpe = _from_numpy_type_to_java_type(obj.dtype, gateway)
             if jtpe is None:
-                raise TypeError("The type of array scalar is not supported")
+                raise TypeError("The type of array scalar '%s' is not supported" % (obj.dtype))
         jarr = gateway.new_array(jtpe, len(obj))
         for i in range(len(plist)):
             jarr[i] = plist[i]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support NumPy ndarray in built-in functions(`pyspark.sql.functions`) by introducing Py4J input converter `NumpyArrayConverter`. The converter converts a ndarray to a Java array.

The mapping between ndarray dtype with Java primitive type is defined as below:
```py
            np.dtype("int64"): gateway.jvm.long,
            np.dtype("int32"): gateway.jvm.int,
            np.dtype("int16"): gateway.jvm.short,
            # Mapping to gateway.jvm.byte causes
            #   TypeError: 'bytes' object does not support item assignment
            np.dtype("int8"): gateway.jvm.short,
            np.dtype("float32"): gateway.jvm.float,
            np.dtype("float64"): gateway.jvm.double,
            np.dtype("bool"): gateway.jvm.boolean,
```

### Why are the changes needed?
As part of [SPARK-39405](https://issues.apache.org/jira/browse/SPARK-39405) for NumPy support in SQL.

### Does this PR introduce _any_ user-facing change?
Yes. NumPy ndarray is supported in built-in functions.

Take `lit` for example,
```py
>>> spark.range(1).select(lit(np.array([1, 2], dtype='int16'))).dtypes
[('ARRAY(1S, 2S)', 'array<smallint>')]
>>> spark.range(1).select(lit(np.array([1, 2], dtype='int32'))).dtypes
[('ARRAY(1, 2)', 'array<int>')]
>>> spark.range(1).select(lit(np.array([1, 2], dtype='float32'))).dtypes
[("ARRAY(CAST('1.0' AS FLOAT), CAST('2.0' AS FLOAT))", 'array<float>')]
>>> spark.range(1).select(lit(np.array([]))).dtypes
[('ARRAY()', 'array<double>')]
```

### How was this patch tested?
Unit tests.