### PR TITLE
[SPARK-40205][SQL] Provide a query context of ELEMENT_AT_BY_INDEX_ZERO

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2228,7 +2228,7 @@ case class ElementAt(
           }
         } else {
           val idx = if (index == 0) {
-            throw QueryExecutionErrors.elementAtByIndexZeroError()
+            throw QueryExecutionErrors.elementAtByIndexZeroError(getContextOrNull())
           } else if (index > 0) {
             index - 1
           } else {
@@ -2259,9 +2259,8 @@ case class ElementAt(
           } else {
             ""
           }
-
+          val errorContext = getContextOrNullCode(ctx)
           val indexOutOfBoundBranch = if (failOnError) {
-            val errorContext = getContextOrNullCode(ctx)
             // scalastyle:off line.size.limit
             s"throw QueryExecutionErrors.invalidElementAtIndexError($index, $eval1.numElements(), $errorContext);"
             // scalastyle:on line.size.limit
@@ -2284,7 +2283,7 @@ case class ElementAt(
              |  $indexOutOfBoundBranch
              |} else {
              |  if ($index == 0) {
-             |    throw QueryExecutionErrors.elementAtByIndexZeroError();
+             |    throw QueryExecutionErrors.elementAtByIndexZeroError($errorContext);
              |  } else if ($index > 0) {
              |    $index--;
              |  } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1246,9 +1246,13 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       "length must be greater than or equal to 0.")
   }
 
-  def elementAtByIndexZeroError(): SparkRuntimeException = {
-    new SparkRuntimeException(errorClass = "ELEMENT_AT_BY_INDEX_ZERO",
-      messageParameters = Array.empty)
+  def elementAtByIndexZeroError(context: SQLQueryContext): RuntimeException = {
+    new SparkRuntimeException(
+      errorClass = "ELEMENT_AT_BY_INDEX_ZERO",
+      cause = null,
+      messageParameters = Array.empty,
+      context = getQueryContext(context),
+      summary = getSummary(context))
   }
 
   def concatArraysWithElementsExceedLimitError(numberOfElements: Long): Throwable = {

--- a/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
@@ -213,7 +213,14 @@ struct<>
 org.apache.spark.SparkRuntimeException
 {
   "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { }
+  "messageParameters" : { },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 36,
+    "fragment" : "element_at(array(1, 2, 3), 0)"
+  } ]
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionAnsiErrorsSuite.scala
@@ -114,6 +114,20 @@ class QueryExecutionAnsiErrorsSuite extends QueryTest with QueryErrorsSuiteBase 
         stop = 41))
   }
 
+  test("ELEMENT_AT_BY_INDEX_ZERO: element_at from array by index zero") {
+    checkError(
+      exception = intercept[SparkRuntimeException](
+        sql("select element_at(array(1, 2, 3, 4, 5), 0)").collect()
+      ),
+      errorClass = "ELEMENT_AT_BY_INDEX_ZERO",
+      parameters = Map.empty,
+      context = ExpectedContext(
+        fragment = "element_at(array(1, 2, 3, 4, 5), 0)",
+        start = 7,
+        stop = 41)
+    )
+  }
+
   test("CAST_INVALID_INPUT: cast string to double") {
     checkError(
       exception = intercept[SparkNumberFormatException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -632,16 +632,6 @@ class QueryExecutionErrorsSuite
       matchPVals = true)
   }
 
-  test("ELEMENT_AT_BY_INDEX_ZERO: element_at from array by index zero") {
-    checkError(
-      exception = intercept[SparkRuntimeException](
-        sql("select element_at(array(1, 2, 3, 4, 5), 0)").collect()
-      ),
-      errorClass = "ELEMENT_AT_BY_INDEX_ZERO",
-      parameters = Map.empty
-    )
-  }
-
   test("ARITHMETIC_OVERFLOW: overflow on adding months") {
     checkError(
       exception = intercept[SparkArithmeticException](


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to pass a query context in the `ElementAt` expression (`element_at` function) when the index is 0. For instance:

```sql
spark-sql> set spark.sql.ansi.enabled=true;
spark.sql.ansi.enabled	true
spark-sql> set spark.sql.error.messageFormat=standard;
spark.sql.error.messageFormat	standard
spark-sql> select element_at(array(1), 0);
{
  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
  "message" : "The index 0 is invalid. An index shall be either < 0 or > 0 (the first element has index 1).",
  "messageParameters" : { },
  "queryContext" : [ {
    "objectType" : "",
    "objectName" : "",
    "startIndex" : 8,
    "stopIndex" : 30,
    "fragment" : "element_at(array(1), 0)"
  } ]
}
```

### Why are the changes needed?
To improve user experience with Spark SQL, and provide additional query contexts when the error happens.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
$ build/sbt "test:testOnly *QueryExecutionErrorsSuite"
$ build/sbt "test:testOnly *QueryExecutionAnsiErrorsSuite"
```