### PR TITLE
[SPARK-40210][PYTHON][CORE] Fix math atan2, hypot, pow and pmod float argument call

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -1734,6 +1734,19 @@ object functions {
   def atan2(yValue: Double, xName: String): Column = atan2(yValue, Column(xName))
 
   /**
+   * @param yValue coordinate on y-axis
+   * @param xValue coordinate on x-axis
+   * @return the <i>theta</i> component of the point
+   *         (<i>r</i>, <i>theta</i>)
+   *         in polar coordinates that corresponds to the point
+   *         (<i>x</i>, <i>y</i>) in Cartesian coordinates,
+   *         as if computed by `java.lang.Math.atan2`
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def atan2(yValue: Double, xValue: Double): Column = atan2(lit(yValue), lit(xValue))
+
+  /**
    * @return inverse hyperbolic tangent of `e`
    *
    * @group math_funcs
@@ -2043,9 +2056,17 @@ object functions {
    * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
    *
    * @group math_funcs
-   * @since 1.4.0
+   * @since 3.4.0
    */
   def hypot(l: Double, rightName: String): Column = hypot(l, Column(rightName))
+
+  /**
+   * Computes `sqrt(a^2^ + b^2^)` without intermediate overflow or underflow.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def hypot(l: Double, r: Double): Column = hypot(lit(l), lit(r))
 
   /**
    * Returns the least value of the list of values, skipping null values.
@@ -2214,6 +2235,14 @@ object functions {
   def pow(l: Double, rightName: String): Column = pow(l, Column(rightName))
 
   /**
+   * Returns the value of the first argument raised to the power of the second argument.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pow(l: Double, r: Double): Column = pow(lit(l), lit(r))
+
+  /**
    * Returns the positive value of dividend mod divisor.
    *
    * @group math_funcs
@@ -2221,6 +2250,86 @@ object functions {
    */
   def pmod(dividend: Column, divisor: Column): Column = withExpr {
     Pmod(dividend.expr, divisor.expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: String, divisor: Column): Column = withExpr {
+    Pmod(Column(dividend).expr, divisor.expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: Column, divisor: String): Column = withExpr {
+    Pmod(dividend.expr, Column(divisor).expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: String, divisor: String): Column = withExpr {
+    Pmod(Column(dividend).expr, Column(divisor).expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: String, divisor: Double): Column = withExpr {
+    Pmod(Column(dividend).expr, lit(divisor).expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: Double, divisor: String): Column = withExpr {
+    Pmod(lit(dividend).expr, Column(divisor).expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: Double, divisor: Column): Column = withExpr {
+    Pmod(lit(dividend).expr, divisor.expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: Column, divisor: Double): Column = withExpr {
+    Pmod(dividend.expr, lit(divisor).expr)
+  }
+
+  /**
+   * Returns the positive value of dividend mod divisor.
+   *
+   * @group math_funcs
+   * @since 3.4.0
+   */
+  def pmod(dividend: Double, divisor: Double): Column = withExpr {
+    Pmod(lit(dividend).expr, lit(divisor).expr)
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MathFunctionsSuite.scala
@@ -83,33 +83,110 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   private def testTwoToOneMathFunction(
-      c: (Column, Column) => Column,
-      d: (Column, Double) => Column,
+      cc: (Column, Column) => Column,
+      cd: (Column, Double) => Column,
+      dc: (Double, Column) => Column,
+      sc: (String, Column) => Column,
+      cs: (Column, String) => Column,
+      ss: (String, String) => Column,
+      sd: (String, Double) => Column,
+      ds: (Double, String) => Column,
+      dd: (Double, Double) => Column,
       f: (Double, Double) => Double): Unit = {
     checkAnswer(
-      nnDoubleData.select(c($"a", $"a")),
+      nnDoubleData.select(cc($"a", $"a")),
       nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(0))))
     )
 
     checkAnswer(
-      nnDoubleData.select(c($"a", $"b")),
+      nnDoubleData.select(cc($"a", $"b")),
       nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(1))))
     )
 
     checkAnswer(
-      nnDoubleData.select(d($"a", 2.0)),
+      nnDoubleData.select(cd($"a", 2.0)),
       nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), 2.0)))
     )
 
     checkAnswer(
-      nnDoubleData.select(d($"a", -0.5)),
+      nnDoubleData.select(cd($"a", -0.5)),
       nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), -0.5)))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(dc(2.0, $"a")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(2.0, r.getDouble(0))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(dc(2.0, $"b")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(2.0, r.getDouble(1))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(sc("a", $"a")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(0))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(sc("a", $"b")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(1))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(cs($"a", "a")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(0))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(cs($"a", "b")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(1))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(ss("a", "a")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(0))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(ss("a", "b")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), r.getDouble(1))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(sd("a", 2.0)),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), 2.0)))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(sd("a", -0.5)),
+      nnDoubleData.collect().toSeq.map(r => Row(f(r.getDouble(0), -0.5)))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(ds(2.0, "a")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(2.0, r.getDouble(0))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(ds(2.0, "b")),
+      nnDoubleData.collect().toSeq.map(r => Row(f(2.0, r.getDouble(1))))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(dd(2.0, 3.0)).limit(1),
+      Seq(Row(f(2.0, 3.0)))
+    )
+
+    checkAnswer(
+      nnDoubleData.select(dd(2.0, -0.5)).limit(1),
+      Seq(Row(f(2.0, -0.5)))
     )
 
     val nonNull = nullDoubles.collect().toSeq.filter(r => r.get(0) != null)
 
     checkAnswer(
-      nullDoubles.select(c($"a", $"a")).orderBy($"a".asc),
+      nullDoubles.select(cc($"a", $"a")).orderBy($"a".asc),
       Row(null) +: nonNull.map(r => Row(f(r.getDouble(0), r.getDouble(0))))
     )
   }
@@ -427,7 +504,8 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("pow / power") {
-    testTwoToOneMathFunction(pow, pow, StrictMath.pow)
+    testTwoToOneMathFunction(pow, pow, pow, pow, pow, pow, pow, pow, pow,
+      StrictMath.pow)
 
     checkAnswer(
       sql("SELECT pow(1, 2), power(2, 1)"),
@@ -459,11 +537,18 @@ class MathFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("hypot") {
-    testTwoToOneMathFunction(hypot, hypot, math.hypot)
+    testTwoToOneMathFunction(hypot, hypot, hypot, hypot, hypot, hypot, hypot, hypot, hypot,
+      math.hypot)
   }
 
   test("atan2") {
-    testTwoToOneMathFunction(atan2, atan2, math.atan2)
+    testTwoToOneMathFunction(atan2, atan2, atan2, atan2, atan2, atan2, atan2, atan2, atan2,
+      math.atan2)
+  }
+
+  test("pmod") {
+    testTwoToOneMathFunction(pmod, pmod, pmod, pmod, pmod, pmod, pmod, pmod, pmod,
+      (a: Double, b: Double) => (a % b).abs)
   }
 
   test("log / ln") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
PySpark atan2, hypot, pow and pmod functions marked as accepting float type as argument but produce error when called together. For example:

```
>>> from pyspark.sql.functions import *
>>> df = spark.range(1)
>>> df.select(atan2(1.1, 2.1)).first()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/functions.py", line 962, in atan2
    return _invoke_binary_math_function("atan2", col1, col2)
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/functions.py", line 111, in _invoke_binary_math_function
    return _invoke_function(
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/functions.py", line 85, in _invoke_function
    return Column(jf(*args))
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/python/lib/py4j-0.10.9.5-src.zip/py4j/java_gateway.py", line 1321, in __call__
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/utils.py", line 190, in deco
    return f(*a, **kw)
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/python/lib/py4j-0.10.9.5-src.zip/py4j/protocol.py", line 330, in get_return_value
py4j.protocol.Py4JError: An error occurred while calling z:org.apache.spark.sql.functions.atan2. Trace:
py4j.Py4JException: Method atan2([class java.lang.Double, class java.lang.Double]) does not exist
        at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:318)
        at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:339)
        at py4j.Gateway.invoke(Gateway.java:276)
        at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
        at py4j.commands.CallCommand.execute(CallCommand.java:79)
        at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
        at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
        at java.lang.Thread.run(Thread.java:748)

```

Although, this call could be written outside the Spark and supplied as a literal it's still good to be consistent with SQL API and help user to avoid seeing error.

after the fix:

```
>>> from pyspark.sql.functions import *
>>> df = spark.range(1)
>>> df.select(atan2(1.1, 2.1)).first()
Row(ATAN2(1.1, 2.1)=0.4825132950224769)
```


### Why are the changes needed?
Improve user experience. Bug fix


### Does this PR introduce _any_ user-facing change?
Yes, no errors


### How was this patch tested?
```
./build/sbt
test
```