### PR TITLE
[SPARK-40212] [SQL] SparkSQL castPartValue does not properly handle byte, short, or float

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -534,7 +534,8 @@ object PartitioningUtils extends SQLConfHelper {
     case ShortType => Integer.parseInt(value).toShort
     case IntegerType => Integer.parseInt(value)
     case LongType => JLong.parseLong(value)
-    case FloatType | DoubleType => JDouble.parseDouble(value)
+    case FloatType => JDouble.parseDouble(value).toFloat
+    case DoubleType => JDouble.parseDouble(value)
     case _: DecimalType => Literal(new JBigDecimal(value)).value
     case DateType =>
       Cast(Literal(value), DateType, Some(zoneId.getId)).eval()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PartitioningUtils.scala
@@ -530,7 +530,9 @@ object PartitioningUtils extends SQLConfHelper {
     case _ if value == DEFAULT_PARTITION_NAME => null
     case NullType => null
     case StringType => UTF8String.fromString(unescapePathName(value))
-    case ByteType | ShortType | IntegerType => Integer.parseInt(value)
+    case ByteType => Integer.parseInt(value).toByte
+    case ShortType => Integer.parseInt(value).toShort
+    case IntegerType => Integer.parseInt(value)
     case LongType => JLong.parseLong(value)
     case FloatType | DoubleType => JDouble.parseDouble(value)
     case _: DecimalType => Literal(new JBigDecimal(value)).value

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4371,6 +4371,23 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
+  test("SPARK-40212: SparkSQL castPartValue does not properly handle byte & short") {
+    withTempDir { dir =>
+      val data = Seq[(Int, Byte, Short)](
+        (1, 2, 3)
+      )
+      data.toDF("a", "b", "c")
+        .write
+        .mode("overwrite")
+        .partitionBy("b", "c")
+        .parquet(dir.getCanonicalPath)
+      val res = spark.read
+        .schema("a INT, b BYTE, c SHORT")
+        .parquet(dir.getCanonicalPath)
+      checkAnswer(res, Seq(Row(1, 2, 3)))
+    }
+  }
+
   test("SPARK-39216: Don't collapse projects in CombineUnions if it hasCorrelatedSubquery") {
     checkAnswer(
       sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4371,23 +4371,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
-  test("SPARK-40212: SparkSQL castPartValue does not properly handle byte & short") {
-    withTempDir { dir =>
-      val data = Seq[(Int, Byte, Short)](
-        (1, 2, 3)
-      )
-      data.toDF("a", "b", "c")
-        .write
-        .mode("overwrite")
-        .partitionBy("b", "c")
-        .parquet(dir.getCanonicalPath)
-      val res = spark.read
-        .schema("a INT, b BYTE, c SHORT")
-        .parquet(dir.getCanonicalPath)
-      checkAnswer(res, Seq(Row(1, 2, 3)))
-    }
-  }
-
   test("SPARK-39216: Don't collapse projects in CombineUnions if it hasCorrelatedSubquery") {
     checkAnswer(
       sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?
The `castPartValueToDesiredType` function now returns byte for ByteType and short for ShortType, rather than ints; also floats for FloatType rather than double.

### Why are the changes needed?
Previously, attempting to read back in a file partitioned on one of these column types would result in a ClassCastException at runtime (for Byte, `java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Byte`). I can't think this is anything but a bug, as returning the correct data type prevents the crash.

### Does this PR introduce _any_ user-facing change?
Yes: it changes the observed behavior when reading in a byte/short/float-partitioned file.

### How was this patch tested?
Added unit test. Without the `castPartValueToDesiredType` updates, the test fails with the stated exception.

===
I'll note that I'm not familiar enough with the spark repo to know if this will have ripple effects elsewhere, but tests pass on my fork and since the very similar https://github.com/apache/spark/pull/36344/files only needed to touch these two files I expect this change is self-contained as well.