### PR TITLE
[SPARK-40220][SQL] Don't output the empty map of error message parameters

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/core/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -172,11 +172,14 @@ private[spark] object SparkThrowableHelper {
           }
           val sqlState = e.getSqlState
           if (sqlState != null) g.writeStringField("sqlState", sqlState)
-          g.writeObjectFieldStart("messageParameters")
-          (e.getParameterNames zip e.getMessageParameters).foreach { case (name, value) =>
-            g.writeStringField(name, value)
+          val parameterNames = e.getParameterNames
+          if (!parameterNames.isEmpty) {
+            g.writeObjectFieldStart("messageParameters")
+            (parameterNames zip e.getMessageParameters).foreach { case (name, value) =>
+              g.writeStringField(name, value)
+            }
+            g.writeEndObject()
           }
-          g.writeEndObject()
           val queryContext = e.getQueryContext
           if (!queryContext.isEmpty) {
             g.writeArrayFieldStart("queryContext")

--- a/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/array.sql.out
@@ -213,7 +213,6 @@ struct<>
 org.apache.spark.SparkRuntimeException
 {
   "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -306,7 +306,6 @@ org.apache.spark.SparkArithmeticException
 {
   "errorClass" : "INTERVAL_DIVIDED_BY_ZERO",
   "sqlState" : "22012",
-  "messageParameters" : { },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -350,7 +349,6 @@ org.apache.spark.SparkArithmeticException
 {
   "errorClass" : "INTERVAL_DIVIDED_BY_ZERO",
   "sqlState" : "22012",
-  "messageParameters" : { },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
@@ -202,8 +202,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { }
+  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/try_element_at.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/try_element_at.sql.out
@@ -6,8 +6,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { }
+  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/array.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/array.sql.out
@@ -182,8 +182,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { }
+  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-analytics.sql.out
@@ -497,8 +497,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 
@@ -509,8 +508,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 
@@ -567,8 +565,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 
@@ -579,8 +576,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -204,7 +204,6 @@ org.apache.spark.SparkArithmeticException
 {
   "errorClass" : "INTERVAL_DIVIDED_BY_ZERO",
   "sqlState" : "22012",
-  "messageParameters" : { },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",
@@ -248,7 +247,6 @@ org.apache.spark.SparkArithmeticException
 {
   "errorClass" : "INTERVAL_DIVIDED_BY_ZERO",
   "sqlState" : "22012",
-  "messageParameters" : { },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",

--- a/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
@@ -152,8 +152,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "LATERAL_NATURAL_JOIN",
-  "sqlState" : "0A000",
-  "messageParameters" : { }
+  "sqlState" : "0A000"
 }
 
 
@@ -166,8 +165,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "LATERAL_JOIN_USING",
-  "sqlState" : "0A000",
-  "messageParameters" : { }
+  "sqlState" : "0A000"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
@@ -168,8 +168,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { }
+  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/transform.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/transform.sql.out
@@ -718,8 +718,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "TRANSFORM_DISTINCT_ALL",
-  "sqlState" : "0A000",
-  "messageParameters" : { }
+  "sqlState" : "0A000"
 }
 
 
@@ -735,8 +734,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "TRANSFORM_DISTINCT_ALL",
-  "sqlState" : "0A000",
-  "messageParameters" : { }
+  "sqlState" : "0A000"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/try_element_at.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try_element_at.sql.out
@@ -6,8 +6,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkRuntimeException
 {
-  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO",
-  "messageParameters" : { }
+  "errorClass" : "ELEMENT_AT_BY_INDEX_ZERO"
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-analytics.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-analytics.sql.out
@@ -253,8 +253,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 
@@ -265,8 +264,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 
@@ -323,8 +321,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 
@@ -335,8 +332,7 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 {
-  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION",
-  "messageParameters" : { }
+  "errorClass" : "UNSUPPORTED_GROUPING_EXPRESSION"
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to output the JSON map `messageParameters` of error messages in the MINIMAL and STANDARD formats only when the map is not empty.

### Why are the changes needed?
To be consistent w/ output of other JSON fields of error messages.

### Does this PR introduce _any_ user-facing change?
Yes. The PR can change user-facing error message in the MINIMAL and STANDARD formats of error messages.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
```