### PR TITLE
Revert "[SPARK-40049][SQL][TESTS] Add ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite"

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ReplaceNullWithFalseInPredicateEndToEndSuite.scala
@@ -19,18 +19,16 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.{CaseWhen, If, Literal}
 import org.apache.spark.sql.execution.LocalTableScanExec
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, DisableAdaptiveExecutionSuite, EnableAdaptiveExecutionSuite}
 import org.apache.spark.sql.functions.{lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.BooleanType
 
-class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with SharedSparkSession with
-  AdaptiveSparkPlanHelper with DisableAdaptiveExecutionSuite {
+class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
 
   private def checkPlanIsEmptyLocalScan(df: DataFrame): Unit =
-    stripAQEPlan(df.queryExecution.executedPlan) match {
+    df.queryExecution.executedPlan match {
       case s: LocalTableScanExec => assert(s.rows.isEmpty)
       case p => fail(s"$p is not LocalTableScanExec")
     }
@@ -126,6 +124,3 @@ class ReplaceNullWithFalseInPredicateEndToEndSuite extends QueryTest with Shared
     }
   }
 }
-
-class ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite extends
-  ReplaceNullWithFalseInPredicateEndToEndSuite with EnableAdaptiveExecutionSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR reverts commit 1a1e4938f97ecedbb99a440df27d365439a9a621.


### Why are the changes needed?
[Based on the follow up discussion](https://github.com/apache/spark/pull/37500), concluded  `ReplaceNullWithFalseInPredicateWithAQEEndToEndSuite` is not necessary


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
