### PR TITLE
[SPARK-40228][SQL] Do not simplify multiLike if child is not a cheap expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1147,7 +1147,7 @@ object CollapseProject extends Rule[LogicalPlan] with AliasHelper {
   /**
    * Check if the given expression is cheap that we can inline it.
    */
-  private def isCheap(e: Expression): Boolean = e match {
+  def isCheap(e: Expression): Boolean = e match {
     case _: Attribute | _: OuterReference => true
     case _ if e.foldable => true
     // PythonUDF is handled by the rule ExtractPythonUDFs

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -771,9 +771,6 @@ object LikeSimplification extends Rule[LogicalPlan] {
     }
   }
 
-  private def isSimplifyMultiLike(child: Expression): Boolean =
-    child.isInstanceOf[Attribute] || child.foldable
-
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformAllExpressionsWithPruning(
     _.containsPattern(LIKE_FAMLIY), ruleId) {
     case l @ Like(input, Literal(pattern, StringType), escapeChar) =>
@@ -783,13 +780,13 @@ object LikeSimplification extends Rule[LogicalPlan] {
       } else {
         simplifyLike(input, pattern.toString, escapeChar).getOrElse(l)
       }
-    case l @ LikeAll(child, patterns) if isSimplifyMultiLike(child) =>
+    case l @ LikeAll(child, patterns) if CollapseProject.isCheap(child) =>
       simplifyMultiLike(child, patterns, l)
-    case l @ NotLikeAll(child, patterns) if isSimplifyMultiLike(child) =>
+    case l @ NotLikeAll(child, patterns) if CollapseProject.isCheap(child) =>
       simplifyMultiLike(child, patterns, l)
-    case l @ LikeAny(child, patterns) if isSimplifyMultiLike(child) =>
+    case l @ LikeAny(child, patterns) if CollapseProject.isCheap(child) =>
       simplifyMultiLike(child, patterns, l)
-    case l @ NotLikeAny(child, patterns) if isSimplifyMultiLike(child) =>
+    case l @ NotLikeAny(child, patterns) if CollapseProject.isCheap(child) =>
       simplifyMultiLike(child, patterns, l)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -256,7 +256,7 @@ class LikeSimplificationSuite extends PlanTest {
       testRelation.where(StartsWith("a", "abc") || EqualTo("a", "") || EqualTo("a", "ab")).analyze)
   }
 
-  test("SPARK-40228: Do not simplify multiLike if child is complex expression") {
+  test("SPARK-40228: Do not simplify multiLike if child is not a cheap expression") {
     val originalQuery = testRelation.where($"a".substring(1, 5) likeAny("abc%", "", "ab")).analyze
 
     comparePlans(Optimize.execute(originalQuery), originalQuery)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LikeSimplificationSuite.scala
@@ -250,4 +250,15 @@ class LikeSimplificationSuite extends PlanTest {
       Optimize.execute(testRelation.where($"a" notLikeAny("abc%")).analyze),
       testRelation.where(Not(StartsWith($"a", "abc"))).analyze)
   }
+
+  test("SPARK-40228: Simplify multiLike if child is foldable expression") {
+    comparePlans(Optimize.execute(testRelation.where("a" likeAny("abc%", "", "ab")).analyze),
+      testRelation.where(StartsWith("a", "abc") || EqualTo("a", "") || EqualTo("a", "ab")).analyze)
+  }
+
+  test("SPARK-40228: Do not simplify multiLike if child is complex expression") {
+    val originalQuery = testRelation.where($"a".substring(1, 5) likeAny("abc%", "", "ab")).analyze
+
+    comparePlans(Optimize.execute(originalQuery), originalQuery)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Do not simplify multiLike if child is not a cheap expression.

### Why are the changes needed?

1. Simplifying multiLike in this cases can not benefit the query because it cannot be pushed down.
2. Reduce the number of evaluations for these expressions.

   
For example:
```sql
select * from t1 where substr(name, 1, 5) like any('%a', 'b%', '%c%');
```
```
== Physical Plan ==
*(1) Filter ((EndsWith(substr(name#0, 1, 5), a) OR StartsWith(substr(name#0, 1, 5), b)) OR Contains(substr(name#0, 1, 5), c))
   +- *(1) ColumnarToRow
      +- FileScan parquet default.t1[name#0] Batched: true, DataFilters: [((EndsWith(substr(name#0, 1, 5), a) OR StartsWith(substr(name#0, 1, 5), b)) OR Contains(substr(n..., Format: Parquet, PartitionFilters: [], PushedFilters: [], ReadSchema: struct<name:string>
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.