### PR TITLE
[MINOR][SQL][TESTS] Fix scalar-subquery-select.sql

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-select.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-select.sql.out
@@ -425,7 +425,6 @@ struct<>
 org.apache.spark.SparkException
 {
   "errorClass" : "MULTI_VALUE_SUBQUERY_ERROR",
-  "messageParameters" : { },
   "queryContext" : [ {
     "objectType" : "",
     "objectName" : "",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Regenerate scalar-subquery-select.sql.out

### Why are the changes needed?
To fix the test failure.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the test suite:
```
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
```