### PR TITLE
[SPARK-40039][SS][FOLLOWUP] Fixes scala style check issue

### DIFF
--- a/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/AbortableStreamBasedCheckpointFileManager.scala
+++ b/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/AbortableStreamBasedCheckpointFileManager.scala
@@ -65,7 +65,8 @@ class AbortableStreamBasedCheckpointFileManager(path: Path, hadoopConf: Configur
         if (!overwriteIfPossible && fc.util().exists(path)) {
           fsDataOutputStream.abort()
           throw new FileAlreadyExistsException(
-            s"Failed to close atomic stream $path (stream: $fsDataOutputStream) as destination already exists")
+            s"Failed to close atomic stream $path (stream: " +
+            s"$fsDataOutputStream) as destination already exists")
         }
         fsDataOutputStream.close()
       } catch {

--- a/hadoop-cloud/src/test/java/org/apache/spark/internal/io/cloud/abortable/AbortableFileSystem.java
+++ b/hadoop-cloud/src/test/java/org/apache/spark/internal/io/cloud/abortable/AbortableFileSystem.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.statistics.BufferedIOStatisticsOutputStream;
 import org.apache.hadoop.util.Progressable;
 
 public class AbortableFileSystem extends RawLocalFileSystem {


### PR DESCRIPTION
### What changes were proposed in this pull request?

The dev/run-tests script indicated a scala style error because the line was too long. This change fixes this issue.

```
$ ./dev/run-tests

...

========================================================================
Running Scala style checks
========================================================================
[info] Checking Scala style using SBT with these profiles:  -Phadoop-3 -Pkinesis-asl -Phive -Pkubernetes -Phive-thriftserver -Phadoop-cloud -Pspark-ganglia-lgpl -Pmesos -Pyarn -Pdocker-integration-tests
Using SPARK_LOCAL_IP=127.0.0.1
[info] [launcher] getting org.scala-sbt sbt 1.7.1  (this may take some time)...
 [info] [launcher] getting Scala 2.12.16 (for sbt)...
Scalastyle checks failed at following occurrences:
[error] /Users/roczei/github/spark/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/AbortableStreamBasedCheckpointFileManager.scala:68: File line length exceeds 100 characters
[error] /Users/roczei/github/spark/hadoop-cloud/src/hadoop-3/main/scala/org/apache/spark/internal/io/cloud/AbortableStreamBasedCheckpointFileManager.scala:68: File line length exceeds 100 characters
[error] Total time: 12 s, completed Aug 26, 2022 12:19:15 PM
[error] running /Users/roczei/github/spark/dev/lint-scala -Phadoop-3 -Pkinesis-asl -Phive -Pkubernetes -Phive-thriftserver -Phadoop-cloud -Pspark-ganglia-lgpl -Pmesos -Pyarn -Pdocker-integration-tests ; received return code 1
```

### Why are the changes needed?

Same as the previous reason.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

I have just validated again with the ./dev/run-tests script which started the scala style checks. Result:

```
========================================================================
Running Scala style checks
========================================================================
[info] Checking Scala style using SBT with these profiles:  -Phadoop-3 -Pyarn -Pkubernetes -Phadoop-cloud -Pspark-ganglia-lgpl -Pdocker-integration-tests -Phive -Phive-thriftserver -Pmesos -Pkinesis-asl
Using SPARK_LOCAL_IP=127.0.0.1
Scalastyle checks passed.
```
