### PR TITLE
[SPARK-40239][CORE] Remove duplicated 'fraction' validation in RDD.sample

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/RDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/RDD.scala
@@ -547,7 +547,6 @@ abstract class RDD[T: ClassTag](
       s"Fraction must be nonnegative, but got ${fraction}")
 
     withScope {
-      require(fraction >= 0.0, "Negative fraction value: " + fraction)
       if (withReplacement) {
         new PartitionwiseSampledRDD[T, T](this, new PoissonSampler[T](fraction), true, seed)
       } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
remove duplicated validation

### Why are the changes needed?
there was already a validation
```
    require(fraction >= 0,
      s"Fraction must be nonnegative, but got ${fraction}")
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing testsuites
