### PR TITLE
[SPARK-40244][DOCS]Correct the property name of data source option for csv

### DIFF
--- a/docs/sql-data-sources-csv.md
+++ b/docs/sql-data-sources-csv.md
@@ -55,7 +55,7 @@ Data source options of CSV can be set via:
 <table class="table">
   <tr><th><b>Property Name</b></th><th><b>Default</b></th><th><b>Meaning</b></th><th><b>Scope</b></th></tr>
   <tr>
-    <td><code>sep</code></td>
+    <td><code>delimiter</code></td>
     <td>,</td>
     <td>Sets a separator for each field and value. This separator can be one or more characters.</td>
     <td>read/write</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the property name of the separator for each field

### Why are the changes needed?
existing property name was wrong

### Does this PR introduce _any_ user-facing change?
yes, the property name was updated

### How was this patch tested?
Manually check
