### PR TITLE
[SPARK-40257][PYTHON][DOCS] Remove since usage in `pyspark.sql.streaming.query`, and `pyspark.sql.window`

### DIFF
--- a/python/pyspark/sql/streaming/query.py
+++ b/python/pyspark/sql/streaming/query.py
@@ -21,7 +21,6 @@ from typing import Any, Dict, List, Optional
 
 from py4j.java_gateway import JavaObject, java_import
 
-from pyspark import since
 from pyspark.sql.utils import StreamingQueryException
 from pyspark.sql.streaming.listener import StreamingQueryListener
 
@@ -43,8 +42,7 @@ class StreamingQuery:
     def __init__(self, jsq: JavaObject) -> None:
         self._jsq = jsq
 
-    @property  # type: ignore[misc]
-    @since(2.0)
+    @property
     def id(self) -> str:
         """
         Returns the unique id of this query that persists across restarts from checkpoint data.
@@ -52,6 +50,8 @@ class StreamingQuery:
         will be the same every time it is restarted from checkpoint data.
         There can only be one query with the same id active in a Spark cluster.
         Also see, `runId`.
+
+        .. versionadded:: 2.0.0
 
         Returns
         -------
@@ -72,12 +72,13 @@ class StreamingQuery:
         """
         return self._jsq.id().toString()
 
-    @property  # type: ignore[misc]
-    @since(2.1)
+    @property
     def runId(self) -> str:
         """
         Returns the unique id of this query that does not persist across restarts. That is, every
         query that is started (or restarted from checkpoint) will have a different runId.
+
+        .. versionadded:: 2.1.0
 
         Returns
         -------
@@ -98,14 +99,15 @@ class StreamingQuery:
         """
         return self._jsq.runId().toString()
 
-    @property  # type: ignore[misc]
-    @since(2.0)
+    @property
     def name(self) -> str:
         """
         Returns the user-specified name of the query, or null if not specified.
         This name can be specified in the `org.apache.spark.sql.streaming.DataStreamWriter`
         as `dataframe.writeStream.queryName("query").start()`.
         This name, if set, must be unique across all active queries.
+
+        .. versionadded:: 2.0.0
 
         Returns
         -------
@@ -126,11 +128,12 @@ class StreamingQuery:
         """
         return self._jsq.name()
 
-    @property  # type: ignore[misc]
-    @since(2.0)
+    @property
     def isActive(self) -> bool:
         """
         Whether this streaming query is currently active or not.
+
+        .. versionadded:: 2.0.0
 
         Returns
         -------
@@ -148,7 +151,6 @@ class StreamingQuery:
         """
         return self._jsq.isActive()
 
-    @since(2.0)
     def awaitTermination(self, timeout: Optional[int] = None) -> Optional[bool]:
         """
         Waits for the termination of `this` query, either by :func:`query.stop()` or by an
@@ -161,6 +163,8 @@ class StreamingQuery:
         immediately (if the query has terminated with exception).
 
         throws :class:`StreamingQueryException`, if `this` query has terminated with an exception
+
+        .. versionadded:: 2.0.0
 
         Parameters
         ----------
@@ -193,11 +197,12 @@ class StreamingQuery:
         else:
             return self._jsq.awaitTermination()
 
-    @property  # type: ignore[misc]
-    @since(2.1)
+    @property
     def status(self) -> Dict[str, Any]:
         """
         Returns the current status of the query.
+
+        .. versionadded:: 2.1.0
 
         Returns
         -------
@@ -218,13 +223,14 @@ class StreamingQuery:
         """
         return json.loads(self._jsq.status().json())
 
-    @property  # type: ignore[misc]
-    @since(2.1)
+    @property
     def recentProgress(self) -> List[Dict[str, Any]]:
         """
         Returns an array of the most recent [[StreamingQueryProgress]] updates for this query.
         The number of progress updates retained for each stream is configured by Spark session
         configuration `spark.sql.streaming.numRecentProgressUpdates`.
+
+        .. versionadded:: 2.1.0
 
         Returns
         -------
@@ -305,10 +311,11 @@ class StreamingQuery:
         """
         return self._jsq.processAllAvailable()
 
-    @since(2.0)
     def stop(self) -> None:
         """
         Stop this streaming query.
+
+        .. versionadded:: 2.0.0
 
         Examples
         --------
@@ -470,7 +477,6 @@ class StreamingQueryManager:
         """
         return StreamingQuery(self._jsqm.get(id))
 
-    @since(2.0)
     def awaitAnyTermination(self, timeout: Optional[int] = None) -> Optional[bool]:
         """
         Wait until any of the queries on the associated SparkSession has terminated since the
@@ -491,6 +497,8 @@ class StreamingQueryManager:
         then check the `query.exception()` for each query.
 
         throws :class:`StreamingQueryException`, if `this` query has terminated with an exception
+
+        .. versionadded:: 2.0.0
 
         Parameters
         ----------

--- a/python/pyspark/sql/window.py
+++ b/python/pyspark/sql/window.py
@@ -18,7 +18,7 @@
 import sys
 from typing import cast, Iterable, List, Tuple, TYPE_CHECKING, Union
 
-from pyspark import since, SparkContext
+from pyspark import SparkContext
 from pyspark.sql.column import _to_seq, _to_java_column
 
 from py4j.java_gateway import JavaObject
@@ -70,10 +70,11 @@ class Window:
     currentRow: int = 0
 
     @staticmethod
-    @since(1.4)
     def partitionBy(*cols: Union["ColumnOrName", List["ColumnOrName_"]]) -> "WindowSpec":
         """
         Creates a :class:`WindowSpec` with the partitioning defined.
+
+        .. versionadded:: 1.4.0
 
         Parameters
         ----------
@@ -124,10 +125,11 @@ class Window:
         return WindowSpec(jspec)
 
     @staticmethod
-    @since(1.4)
     def orderBy(*cols: Union["ColumnOrName", List["ColumnOrName_"]]) -> "WindowSpec":
         """
         Creates a :class:`WindowSpec` with the ordering defined.
+
+        .. versionadded:: 1.4.0
 
         Parameters
         ----------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `@since` usages in `pyspark.sql.streaming.query`, and `pyspark.sql.window`.


### Why are the changes needed?

NumPy documentation style doesn't play well with our `pyspark.since` (because it just adds `versionadded` directive in the end but NumPy documentation assume to put these in the corresponding section). The output HTML rendering is broken.

### Does this PR introduce _any_ user-facing change?

No, these broken documentations are not released yet.

### How was this patch tested?

I did not test because the format is fully consistent with others.
