### PR TITLE
[SPARK-40259][SQL] Support Parquet DSv2 in subquery plan merge

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsMerge.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/SupportsMerge.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.read;
+
+import java.util.Optional;
+
+import org.apache.spark.annotation.Evolving;
+import org.apache.spark.sql.connector.catalog.SupportsRead;
+
+/**
+ * A mix in interface for {@link Scan}. Data sources can implement this interface to indicate
+ * {@link Scan}s can be merged.
+ *
+ * @since 3.4.0
+ */
+@Evolving
+public interface SupportsMerge extends Scan {
+
+  /**
+   * Returns the merged scan.
+   */
+  Optional<SupportsMerge> mergeWith(SupportsMerge other, SupportsRead table);
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -82,7 +82,7 @@ trait FileScan extends Scan
 
   protected def seqToString(seq: Seq[Any]): String = seq.mkString("[", ", ", "]")
 
-  private lazy val (normalizedPartitionFilters, normalizedDataFilters) = {
+  protected lazy val (normalizedPartitionFilters, normalizedDataFilters) = {
     val partitionFilterAttributes = AttributeSet(partitionFilters).map(a => a.name -> a).toMap
     val normalizedPartitionFilters = ExpressionSet(partitionFilters.map(
       QueryPlan.normalizeExpressions(_, fileIndex.partitionSchema.toAttributes

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2177,6 +2177,46 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
+  test("SPARK-40259: Merge non-correlated scalar subqueries with Parquet DSv2 sources") {
+    withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+      withTempPath { path =>
+        testData
+          .withColumn("partition", $"key" % 10)
+          .write
+          .mode(SaveMode.Overwrite)
+          .partitionBy("partition")
+          .parquet(path.getCanonicalPath)
+        withTempView("td") {
+          spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("td")
+          Seq(false).foreach { enableAQE =>
+            withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
+              val df = sql(
+                """
+                  |SELECT
+                  |  (SELECT sum(key) FROM td WHERE partition < 5),
+                  |  (SELECT sum(key) FROM td WHERE partition >= 5),
+                  |  (SELECT sum(value) FROM td WHERE partition < 5),
+                  |  (SELECT sum(value) FROM td WHERE partition >= 5)
+                """.stripMargin)
+
+              checkAnswer(df, Row(2450, 2600, 2450.0, 2600.0) :: Nil)
+
+              val plan = df.queryExecution.executedPlan
+              val subqueryIds = collectWithSubqueries(plan) { case s: SubqueryExec => s.id }
+              val reusedSubqueryIds = collectWithSubqueries(plan) {
+                case rs: ReusedSubqueryExec => rs.child.id
+              }
+
+              assert(subqueryIds.size == 2, "Missing or unexpected SubqueryExec in the plan")
+              assert(reusedSubqueryIds.size == 2,
+                "Missing or unexpected reused ReusedSubqueryExec in the plan")
+            }
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-39355: Single column uses quoted to construct UnresolvedAttribute") {
     checkAnswer(
       sql("""

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2188,7 +2188,7 @@ class SubquerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
           .parquet(path.getCanonicalPath)
         withTempView("td") {
           spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("td")
-          Seq(false).foreach { enableAQE =>
+          Seq(false, true).foreach { enableAQE =>
             withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> enableAQE.toString) {
               val df = sql(
                 """


### PR DESCRIPTION
### What changes were proposed in this pull request?
After https://github.com/apache/spark/pull/32298 we were able to merge scalar subquery plans, but DSv2 sources couldn't benefit from that improvement.
The reason for DSv2 sources were not supported by default is that `SparkOptimizer.earlyScanPushDownRules` build different `Scan`s in logical plans before `MergeScalarSubqueries` is executed. Those `Scan`s can have different pushed-down filters and aggregates and different column pruning defined, which prevents merging the plans.
I would not alter the order of optimization rules as `MergeScalarSubqueries` works better when logical plans are better optimized (a plan is closer to its final logical form, e.g. `InjectRuntimeFilter` already executed). But instead, I would propose a new interface that a `Scan` can implement to indicate if merge is possible with another `Scan` and do the merge if it make sense depending on the `Scan`'s actual parameters.

This PR:
- adds a new interface `SupportsMerge` that `Scan`s can implement to indicate if 2 `Scan`s can be merged and
- adds implementation of `SupportsMerge` to `ParquetScan` as the first DSv2 source. The merge only happens if pushed-down data and partition filters and pushed-down aggregates match.

### Why are the changes needed?
Scalar subquery merge can bring considerable performance improvement (see the original https://github.com/apache/spark/pull/32298 for the benchmarks) so DSv2 sources should also benefit from that feature.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added new UT.
