### PR TITLE
[SPARK-40261][CORE]Exclude DirectTaskResult metadata when calculating result size

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskResultGetter.scala
@@ -73,7 +73,7 @@ private[spark] class TaskResultGetter(sparkEnv: SparkEnv, scheduler: TaskSchedul
               // We should call it here, so that when it's called again in
               // "TaskSetManager.handleSuccessfulTask", it does not need to deserialize the value.
               directResult.value(taskResultSerializer.get())
-              (directResult, directResult.valueBytes.limit())
+              (directResult, serializedData.limit())
             case IndirectTaskResult(blockId, size) =>
               if (!taskSetManager.canFetchMoreResults(size)) {
                 // dropped by executor if size is larger than maxResultSize

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -35,6 +35,7 @@ import org.scalatest.concurrent.Eventually._
 import org.apache.spark._
 import org.apache.spark.TaskState.TaskState
 import org.apache.spark.TestUtils.JavaSourceFromString
+import org.apache.spark.internal.config.MAX_RESULT_SIZE
 import org.apache.spark.internal.config.Network.RPC_MESSAGE_MAX_SIZE
 import org.apache.spark.storage.TaskResultBlockId
 import org.apache.spark.util.{MutableURLClassLoader, RpcUtils, ThreadUtils, Utils}
@@ -295,6 +296,18 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
     // Job failed, even though the failure reason is unknown.
     val unknownFailure = """(?s).*Lost task.*: UnknownReason.*""".r
     assert(unknownFailure.findFirstMatchIn(message).isDefined)
+  }
+
+  test("task result metadata should not be counted into result size") {
+    val conf = new SparkConf().set(MAX_RESULT_SIZE.key, "1M")
+    sc = new SparkContext("local", "test", conf)
+    val rdd = sc.parallelize(1 to 10000, 10000)
+    // This will trigger 10k task but return empty result. The total serialized return tasks
+    // size(including accumUpdates metadata) would be ~10M in total in this example, but the result
+    // value itself is pretty small(empty arrays)
+    // Even setting MAX_RESULT_SIZE to a small value(1M here), it should not throw exception
+    // because the actual result is small
+    rdd.filter(_ < 0).collect()
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -307,7 +307,7 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
     // value itself is pretty small(empty arrays)
     // Even setting MAX_RESULT_SIZE to a small value(1M here), it should not throw exception
     // because the actual result is small
-    assert(rdd.filter(_ < 0).collect() === 0)
+    assert(rdd.filter(_ < 0).collect().isEmpty)
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -298,7 +298,7 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
     assert(unknownFailure.findFirstMatchIn(message).isDefined)
   }
 
-  test("task result metadata should not be counted into result size") {
+  test("SPARK-40261 task result metadata should not be counted into result size") {
     val conf = new SparkConf().set(MAX_RESULT_SIZE.key, "1M")
     sc = new SparkContext("local", "test", conf)
     val rdd = sc.parallelize(1 to 10000, 10000)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -298,7 +298,7 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
     assert(unknownFailure.findFirstMatchIn(message).isDefined)
   }
 
-  test("SPARK-40261 task result metadata should not be counted into result size") {
+  test("SPARK-40261: task result metadata should not be counted into result size") {
     val conf = new SparkConf().set(MAX_RESULT_SIZE.key, "1M")
     sc = new SparkContext("local", "test", conf)
     val rdd = sc.parallelize(1 to 10000, 10000)

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskResultGetterSuite.scala
@@ -307,7 +307,7 @@ class TaskResultGetterSuite extends SparkFunSuite with BeforeAndAfter with Local
     // value itself is pretty small(empty arrays)
     // Even setting MAX_RESULT_SIZE to a small value(1M here), it should not throw exception
     // because the actual result is small
-    rdd.filter(_ < 0).collect()
+    assert(rdd.filter(_ < 0).collect() === 0)
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
When calculating driver result size, only counting actual result value while excluding other metadata (e.g., accumUpdates) in the serialized result task object.


### Why are the changes needed?
metadata should not be counted because they will be discarded by the driver immediately after being processed, and will lead to unexpected exception when running jobs with tons of task but actually return small results.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.


### How was this patch tested?
Unit test