### PR TITLE
[SPARK-40269][CORE] Randomize the orders of peer in BlockManagerDecommissioner

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -287,7 +287,7 @@ private[storage] class BlockManagerDecommissioner(
     val livePeerSet = bm.getPeers(false).toSet
     val currentPeerSet = migrationPeers.keys.toSet
     val deadPeers = currentPeerSet.diff(livePeerSet)
-    // Randomize the orders of the peers to avoid migrating data to same nodes
+    // Randomize the orders of the peers to avoid hotspot nodes.
     val newPeers = Utils.randomize(livePeerSet.diff(currentPeerSet))
     migrationPeers ++= newPeers.map { peer =>
       logDebug(s"Starting thread to migrate shuffle blocks to ${peer}")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Randomize the orders of peer in BlockManagerDecommissioner

### Why are the changes needed?
Avoid migrating data to same nodes

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually tested
