### PR TITLE
[SPARK-40272][CORE]Support service port custom with range

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2430,19 +2430,16 @@ package object config {
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
 
-  private[spark] val CUSTOM_SERVICE_PORT =
-    ConfigBuilder("spark.service.port.custom")
-      .doc("Customize the spark service port range, " +
-        "service like SparkUI.port, SparkDriver.port, NettyService.port etc." +
-        "The starting port number is spark.service.port.custom.origin " +
-        "and the port range is limited by spark.port.maxRetries. " +
-        "e.g. spark.service.port.custom.origin=49152 and spark.port.maxRetries=10, " +
-        "the actual range of the port is greater than or equal to 49152 and less than 49163")
-      .booleanConf
-      .createWithDefault(false)
-
   private[spark] val CUSTOM_SERVICE_PORT_ORIGIN =
     ConfigBuilder("spark.service.port.custom.origin")
+      .doc("Customize the spark service port range, " +
+        "service like SparkUI.port, SparkDriver.port, NettyService.port etc. " +
+        "The starting port number is spark.service.port.custom.origin " +
+        "and the port range is limited by spark.port.maxRetries; " +
+        "the final port range is: spark.service.port.custom.origin <= port.range " +
+        "<= spark.service.port.custom.origin + spark.port.maxRetries" +
+        "e.g. spark.service.port.custom.origin=49152 and spark.port.maxRetries=10, " +
+        "the actual range of the port is greater than or equal to 49152 and less than 49163")
       .intConf
       .checkValue(v => v >= 1024, "The threshold should be greater than or equal to 1024.")
       .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2445,5 +2445,5 @@ package object config {
     ConfigBuilder("spark.service.port.custom.origin")
       .intConf
       .checkValue(v => v >= 1024, "The threshold should be greater than or equal to 1024.")
-      .createWithDefault(49152)
+      .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2429,4 +2429,21 @@ package object config {
       .version("3.4.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createWithDefaultString("5s")
+
+  private[spark] val CUSTOM_SERVICE_PORT =
+    ConfigBuilder("spark.service.port.custom")
+      .doc("Customize the spark service port range, " +
+        "service like SparkUI.port, SparkDriver.port, NettyService.port etc." +
+        "The starting port number is spark.service.port.custom.origin " +
+        "and the port range is limited by spark.port.maxRetries. " +
+        "e.g. spark.service.port.custom.origin=49152 and spark.port.maxRetries=10, " +
+        "the actual range of the port is greater than or equal to 49152 and less than 49163")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val CUSTOM_SERVICE_PORT_ORIGIN =
+    ConfigBuilder("spark.service.port.custom.origin")
+      .intConf
+      .checkValue(v => v >= 1024, "The threshold should be greater than or equal to 1024.")
+      .createWithDefault(49152)
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2372,17 +2372,16 @@ private[spark] object Utils extends Logging {
 
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
     val maxRetries = portMaxRetries(conf)
-    val customPortEnable = conf.get(config.CUSTOM_SERVICE_PORT)
     lazy val originPort = conf.get(config.CUSTOM_SERVICE_PORT_ORIGIN)
     for (offset <- 0 to maxRetries) {
       // Do not increment port if startPort is 0, which is treated as a special port
       val tryPort = if (startPort == 0) {
-        if (customPortEnable) {
-          require(originPort >= 1024 && originPort + offset < 65536,
+        if (originPort.isDefined) {
+          require(originPort.get >= 1024 && originPort.get + offset < 65536,
             "The param spark.port.custom.origin should be >= 1024 and" +
               "the sum with (spark.port.custom.origin + spark.port.maxRetries)" +
               " should be < 65536.")
-          userPort(originPort, offset)
+          userPort(originPort.get, offset)
         } else startPort
       } else {
         userPort(startPort, offset)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2372,10 +2372,18 @@ private[spark] object Utils extends Logging {
 
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
     val maxRetries = portMaxRetries(conf)
+    val customPortEnable = conf.get(config.CUSTOM_SERVICE_PORT)
+    lazy val originPort = conf.get(config.CUSTOM_SERVICE_PORT_ORIGIN)
     for (offset <- 0 to maxRetries) {
       // Do not increment port if startPort is 0, which is treated as a special port
       val tryPort = if (startPort == 0) {
-        startPort
+        if (customPortEnable) {
+          require(originPort >= 1024 && originPort + offset < 65536,
+            "The param spark.port.custom.origin should be >= 1024 and" +
+              "the sum with (spark.port.custom.origin + spark.port.maxRetries)" +
+              " should be < 65536.")
+          userPort(originPort, offset)
+        } else startPort
       } else {
         userPort(startPort, offset)
       }

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1528,6 +1528,19 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     conf.set(SERIALIZER, "org.apache.spark.serializer.JavaSerializer")
     assert(Utils.isPushBasedShuffleEnabled(conf, isDriver = true) === false)
   }
+
+  test("custom service port") {
+    val origin = 65435
+    val offset = 100
+    val incSets = scala.collection.mutable.Set[Int]()
+
+    for (j <- 0 to offset) {
+      val random1 = Utils.userPort(origin, j)
+      incSets.add(random1)
+      assert(origin <= random1 && random1 <= origin + offset && random1 < 65536)
+    }
+    assert(incSets.size == offset + 1)
+  }
 }
 
 private class SimpleExtension


### PR DESCRIPTION
### What changes were proposed in this pull request?
Port range specification is supported by specifying the starting port and configuring the number of port retries.Introduction of a new parameters: spark.service.port.custom.origin

Service like SparkUI.port, SparkDriver.port, NettyService.port etc. The starting port number is spark.service.port.custom.origin and the port range is limited by spark.port.maxRetries.  the final port range is: spark.service.port.custom.origin <= port.range <= spark.service.port.custom.origin + spark.port.maxRetries

e.g. spark.service.port.custom.origin=49152 and spark.port.maxRetries=10,  the actual range of the port is greater than or equal to 49152 and less than 49163

### Why are the changes needed?
In a real production environment, there are some special scenarios where we need to limit the scope of the service port.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
new ut
