### PR TITLE
[SPARK-40279][DOC] Document spark.yarn.report.interval

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -624,6 +624,14 @@ To use a custom metrics.properties for the application master and executors, upd
   </td>
   <td>2.4.0</td>
 </tr>
+<tr>
+  <td><code>spark.yarn.report.interval</code></td>
+  <td><code>1s</code></td>
+  <td>
+    Interval between reports of the current Spark job status in cluster mode.
+  </td>
+  <td>0.9.0</td>
+</tr>
 </table>
 
 #### Available patterns for SHS custom executor log URL


### PR DESCRIPTION
### What changes were proposed in this pull request?

This proposes to document the configuration paramter spark.yarn.report.interval -> Interval between reports of the current Spark job status in cluster mode.

### Why are the changes needed?
Document a configuration parameter for Spark on Yarn.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Not relevant.