### PR TITLE
[SPARK-40291][SQL] Improve the message for column not in group by clause error

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -65,6 +65,12 @@
     ],
     "sqlState" : "22005"
   },
+  "COLUMN_NOT_IN_GROUP_BY_CLAUSE" : {
+    "message" : [
+      "expression '<expression>' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.",
+    ],
+    "sqlState" : "42000"
+  },
   "CONCURRENT_QUERY" : {
     "message" : [
       "Another instance of this query was just started by a concurrent session."

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -67,7 +67,7 @@
   },
   "COLUMN_NOT_IN_GROUP_BY_CLAUSE" : {
     "message" : [
-      "expression '<expression>' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get."
+      "expression <expression> is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in `first()` (or `first_value()`) if you don't care which value you get."
     ],
     "sqlState" : "42000"
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -67,7 +67,7 @@
   },
   "COLUMN_NOT_IN_GROUP_BY_CLAUSE" : {
     "message" : [
-      "expression <expression> is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in `first()` (or `first_value()`) if you don't care which value you get."
+      "The expression <expression> is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in `first()` (or `first_value()`) if you don't care which value you get."
     ],
     "sqlState" : "42000"
   },

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -67,7 +67,7 @@
   },
   "COLUMN_NOT_IN_GROUP_BY_CLAUSE" : {
     "message" : [
-      "expression '<expression>' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.",
+      "expression '<expression>' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get."
     ],
     "sqlState" : "42000"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -343,11 +343,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog {
                     s"if you don't care which value you get."
                 )
               case e: Attribute if !groupingExprs.exists(_.semanticEquals(e)) =>
-                failAnalysis(
-                  s"expression '${e.sql}' is neither present in the group by, " +
-                    s"nor is it an aggregate function. " +
-                    "Add to group by or wrap in first() (or first_value) if you don't care " +
-                    "which value you get.")
+                throw QueryCompilationErrors.columnNotInGroupByClauseError(e)
               case s: ScalarSubquery
                   if s.children.nonEmpty && !groupingExprs.exists(_.semanticEquals(s)) =>
                 failAnalysis(s"Correlated scalar subquery '${s.sql}' is neither " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2527,4 +2527,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
       errorClass = "INVALID_COLUMN_OR_FIELD_DATA_TYPE",
       messageParameters = Array(toSQLId(name), toSQLType(dt), toSQLType(expected)))
   }
+
+  def columnNotInGroupByClauseError(expression: Expression): Throwable = {
+    new AnalysisException(
+      errorClass = "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+      messageParameters = Array(expression.sql)
+    )
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -2531,7 +2531,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def columnNotInGroupByClauseError(expression: Expression): Throwable = {
     new AnalysisException(
       errorClass = "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
-      messageParameters = Array(expression.sql)
+      messageParameters = Array(toSQLExpr(expression))
     )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -331,7 +331,7 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorTest(
     "missing group by",
     testRelation2.groupBy($"a")($"b"),
-    "'b'" :: "group by" :: Nil
+    "'b'" :: "COLUMN_NOT_IN_GROUP_BY_CLAUSE" :: Nil
   )
 
   errorTest(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -331,7 +331,7 @@ class AnalysisErrorSuite extends AnalysisTest {
   errorTest(
     "missing group by",
     testRelation2.groupBy($"a")($"b"),
-    "'b'" :: "COLUMN_NOT_IN_GROUP_BY_CLAUSE" :: Nil
+    "\"b\"" :: "COLUMN_NOT_IN_GROUP_BY_CLAUSE" :: Nil
   )
 
   errorTest(

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -232,7 +232,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdata.a"
+    "expression" : "\"a\""
   }
 }
 
@@ -718,7 +718,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdata.a"
+    "expression" : "\"a\""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -228,7 +228,13 @@ SELECT a, COUNT(b) FILTER (WHERE a != 2) FROM testData GROUP BY b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdata.a"
+  }
+}
 
 
 -- !query
@@ -708,7 +714,13 @@ SELECT a + 2, COUNT(b) FILTER (WHERE b IN (1, 2)) FROM testData GROUP BY a + 1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdata.a"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by-filter.sql.out
@@ -228,7 +228,7 @@ SELECT a, COUNT(b) FILTER (WHERE a != 2) FROM testData GROUP BY b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdata.a' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query
@@ -708,7 +708,7 @@ SELECT a + 2, COUNT(b) FILTER (WHERE b IN (1, 2)) FROM testData GROUP BY a + 1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdata.a' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -43,7 +43,7 @@ SELECT a, COUNT(b) FROM testData GROUP BY b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdata.a' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query
@@ -107,7 +107,7 @@ SELECT a + 2, COUNT(b) FROM testData GROUP BY a + 1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdata.a' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query
@@ -198,7 +198,7 @@ SELECT k AS a, COUNT(v) FROM testDataHasSameNameWithAlias GROUP BY a
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdatahassamenamewithalias.k' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdatahassamenamewithalias.k) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -47,7 +47,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdata.a"
+    "expression" : "\"a\""
   }
 }
 
@@ -117,7 +117,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdata.a"
+    "expression" : "\"a\""
   }
 }
 
@@ -214,7 +214,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdatahassamenamewithalias.k"
+    "expression" : "\"k\""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/group-by.sql.out
@@ -43,7 +43,13 @@ SELECT a, COUNT(b) FROM testData GROUP BY b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdata.a"
+  }
+}
 
 
 -- !query
@@ -107,7 +113,13 @@ SELECT a + 2, COUNT(b) FROM testData GROUP BY a + 1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdata.a"
+  }
+}
 
 
 -- !query
@@ -198,7 +210,13 @@ SELECT k AS a, COUNT(v) FROM testDataHasSameNameWithAlias GROUP BY a
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdatahassamenamewithalias.k) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdatahassamenamewithalias.k"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
@@ -170,7 +170,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "t.c1"
+    "expression" : "\"c1\""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
@@ -166,7 +166,7 @@ SELECT c1 FROM (values (1,2), (3,2)) t(c1, c2) GROUP BY GROUPING SETS (())
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 't.c1' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (t.c1) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/grouping_set.sql.out
@@ -166,7 +166,13 @@ SELECT c1 FROM (values (1,2), (3,2)) t(c1, c2) GROUP BY GROUPING SETS (())
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (t.c1) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "t.c1"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
@@ -53,7 +53,13 @@ CREATE VIEW key_dependent_view AS
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (spark_catalog.default.view_base_table.data) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "spark_catalog.default.view_base_table.data"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
@@ -57,7 +57,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "spark_catalog.default.view_base_table.data"
+    "expression" : "\"data\""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/create_view.sql.out
@@ -53,7 +53,7 @@ CREATE VIEW key_dependent_view AS
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'spark_catalog.default.view_base_table.data' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (spark_catalog.default.view_base_table.data) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -43,7 +43,7 @@ SELECT udf(a), udf(COUNT(udf(b))) FROM testData GROUP BY b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdata.a' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query
@@ -107,7 +107,7 @@ SELECT udf(a + 2), udf(COUNT(b)) FROM testData GROUP BY a + 1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdata.a' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query
@@ -182,7 +182,7 @@ SELECT k AS a, udf(COUNT(udf(v))) FROM testDataHasSameNameWithAlias GROUP BY udf
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-expression 'testdatahassamenamewithalias.k' is neither present in the group by, nor is it an aggregate function. Add to group by or wrap in first() (or first_value) if you don't care which value you get.
+[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdatahassamenamewithalias.k) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -47,7 +47,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdata.a"
+    "expression" : "\"a\""
   }
 }
 
@@ -117,7 +117,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdata.a"
+    "expression" : "\"a\""
   }
 }
 
@@ -198,7 +198,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
   "sqlState" : "42000",
   "messageParameters" : {
-    "expression" : "testdatahassamenamewithalias.k"
+    "expression" : "\"k\""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udf/udf-group-by.sql.out
@@ -43,7 +43,13 @@ SELECT udf(a), udf(COUNT(udf(b))) FROM testData GROUP BY b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdata.a"
+  }
+}
 
 
 -- !query
@@ -107,7 +113,13 @@ SELECT udf(a + 2), udf(COUNT(b)) FROM testData GROUP BY a + 1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdata.a) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdata.a"
+  }
+}
 
 
 -- !query
@@ -182,7 +194,13 @@ SELECT k AS a, udf(COUNT(udf(v))) FROM testDataHasSameNameWithAlias GROUP BY udf
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-[COLUMN_NOT_IN_GROUP_BY_CLAUSE] column (testdatahassamenamewithalias.k) must appear in the GROUP BY clause or be used in an aggregate function. Add it to GROUP BY clause or wrap in first() if you don't care which value you get.
+{
+  "errorClass" : "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+  "sqlState" : "42000",
+  "messageParameters" : {
+    "expression" : "testdatahassamenamewithalias.k"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -899,7 +899,7 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
             }.getMessage
             assert(
               e.contains("COLUMN_NOT_IN_GROUP_BY_CLAUSE") &&
-                e.contains("spark_catalog.default.t.c1"))
+                e.contains("\"c1\""))
           }
           withSQLConf(GROUP_BY_ALIASES.key -> "false") {
             val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -897,10 +897,9 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
             val e = intercept[AnalysisException] {
               sql("SELECT * FROM v3")
             }.getMessage
-            assert(e.contains(
-              "expression 'spark_catalog.default.t.c1' is neither present " +
-              "in the group by, nor is it an aggregate function. Add to group by or wrap in " +
-              "first() (or first_value) if you don't care which value you get."))
+            assert(
+              e.contains("COLUMN_NOT_IN_GROUP_BY_CLAUSE") &&
+                e.contains("spark_catalog.default.t.c1"))
           }
           withSQLConf(GROUP_BY_ALIASES.key -> "false") {
             val e = intercept[AnalysisException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/SQLViewSuite.scala
@@ -896,10 +896,11 @@ abstract class SQLViewSuite extends QueryTest with SQLTestUtils {
           withSQLConf(GROUP_BY_ORDINAL.key -> "false") {
             val e = intercept[AnalysisException] {
               sql("SELECT * FROM v3")
-            }.getMessage
-            assert(
-              e.contains("COLUMN_NOT_IN_GROUP_BY_CLAUSE") &&
-                e.contains("\"c1\""))
+            }
+            checkError(e,
+              errorClass = "COLUMN_NOT_IN_GROUP_BY_CLAUSE",
+              parameters = Map(
+                "expression" -> "\"c1\""))
           }
           withSQLConf(GROUP_BY_ALIASES.key -> "false") {
             val e = intercept[AnalysisException] {


### PR DESCRIPTION

### What changes were proposed in this pull request?
Improve the message for columns not in group by clause error


### Why are the changes needed?
Use the new error class framework for columns not in group by clause error


### Does this PR introduce _any_ user-facing change?
Yes, adding error class


### How was this patch tested?
UT
