### PR TITLE
[SPARK-40293][SQL] Make the V2 table error message more meaningful

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -520,11 +520,6 @@
           "NATURAL CROSS JOIN."
         ]
       },
-      "TABLE_OPERATION" : {
-        "message" : [
-          "Table <tableName> does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog.spark_catalog\"."
-        ]
-      },
       "ORC_TYPE_CAST" : {
         "message" : [
           "Unable to convert <orcType> of Orc to data type <toType>."
@@ -568,6 +563,11 @@
       "SET_TABLE_PROPERTY" : {
         "message" : [
           "<property> is a reserved table property, <msg>."
+        ]
+      },
+      "TABLE_OPERATION" : {
+        "message" : [
+          "Table <tableName> does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog.spark_catalog\"."
         ]
       },
       "TOO_MANY_TYPE_ARGUMENTS_FOR_UDF_CLASS" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -520,6 +520,11 @@
           "NATURAL CROSS JOIN."
         ]
       },
+      "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE" : {
+        "message" : [
+          "Table `spark_catalog`.`default`.`t1` does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by 'spark.sql.catalog.spark_catalog'."
+        ]
+      },
       "ORC_TYPE_CAST" : {
         "message" : [
           "Unable to convert <orcType> of Orc to data type <toType>."

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -567,7 +567,7 @@
       },
       "TABLE_OPERATION" : {
         "message" : [
-          "Table <tableName> does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog.spark_catalog\"."
+          "Table <tableName> does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog\"."
         ]
       },
       "TOO_MANY_TYPE_ARGUMENTS_FOR_UDF_CLASS" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -522,7 +522,7 @@
       },
       "TABLE_OPERATION" : {
         "message" : [
-          "Table '<catalog>'.'<nameSpace>'.'<tableName>' does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog.spark_catalog\"."
+          "Table <tableName> does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog.spark_catalog\"."
         ]
       },
       "ORC_TYPE_CAST" : {

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -520,9 +520,9 @@
           "NATURAL CROSS JOIN."
         ]
       },
-      "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE" : {
+      "TABLE_OPERATION" : {
         "message" : [
-          "Table `spark_catalog`.`default`.`t1` does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by 'spark.sql.catalog.spark_catalog'."
+          "Table '<catalog>'.'<nameSpace>'.'<tableName>' does not support <operation>. Please check the current catalog and namespace to make sure the qualified table name is expected, and also check the catalog implementation which is configured by \"spark.sql.catalog.spark_catalog\"."
         ]
       },
       "ORC_TYPE_CAST" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -541,11 +541,15 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException("ADD COLUMN with v1 tables cannot specify NOT NULL.")
   }
 
-  def operationOnlySupportedWithV2TableError(operation: String): Throwable = {
+  def operationOnlySupportedWithV2TableError(
+      catalog: String,
+      nameSpace: String,
+      tableName: String,
+      operation: String): Throwable = {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE",
-      errorSubClass = "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
-      messageParameters = Array(operation))
+      errorSubClass = "TABLE_OPERATION",
+      messageParameters = Array(catalog, nameSpace, tableName, operation))
   }
 
   def alterColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -547,7 +547,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE",
       errorSubClass = "TABLE_OPERATION",
-      messageParameters = Array(toSQLId(nameParts), toSQLStmt(operation)))
+      messageParameters = Array(toSQLId(nameParts), operation))
   }
 
   def alterColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -547,7 +547,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE",
       errorSubClass = "TABLE_OPERATION",
-      messageParameters = Array(toSQLId(nameParts), operation))
+      messageParameters = Array(toSQLId(nameParts), toSQLStmt(operation)))
   }
 
   def alterColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -542,9 +542,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def operationOnlySupportedWithV2TableError(operation: String): Throwable = {
-    new AnalysisException(s"$operation is only supported with v2 tables. To use" +
-      s" v2 tables, please config the catalog correctly using spark.sql.catalog" +
-      s" and/or add the catalog prefix in the table identifier.")
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_FEATURE",
+      errorSubClass = "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+      messageParameters = Array(operation))
   }
 
   def alterColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -542,14 +542,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def operationOnlySupportedWithV2TableError(
-      catalog: String,
-      nameSpace: String,
-      tableName: String,
+      nameParts: Seq[String],
       operation: String): Throwable = {
     new AnalysisException(
       errorClass = "UNSUPPORTED_FEATURE",
       errorSubClass = "TABLE_OPERATION",
-      messageParameters = Array(catalog, nameSpace, tableName, operation))
+      messageParameters = Array(toSQLId(nameParts), operation))
   }
 
   def alterColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -542,7 +542,9 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   }
 
   def operationOnlySupportedWithV2TableError(operation: String): Throwable = {
-    new AnalysisException(s"$operation is only supported with v2 tables.")
+    new AnalysisException(s"$operation is only supported with v2 tables. To use" +
+      s" v2 tables, please config the catalog correctly using spark.sql.catalog " +
+      s" and/or add the catalog prefix in the table identifier.")
   }
 
   def alterColumnWithV1TableCannotSpecifyNotNullError(): Throwable = {
@@ -842,10 +844,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
   def cannotDeleteTableWhereFiltersError(table: Table, filters: Array[Predicate]): Throwable = {
     new AnalysisException(
       s"Cannot delete from table ${table.name} where ${filters.mkString("[", ", ", "]")}")
-  }
-
-  def deleteOnlySupportedWithV2TablesError(): Throwable = {
-    new AnalysisException("DELETE is only supported with v2 tables.")
   }
 
   def describeDoesNotSupportPartitionForV2TablesError(): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -543,7 +543,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def operationOnlySupportedWithV2TableError(operation: String): Throwable = {
     new AnalysisException(s"$operation is only supported with v2 tables. To use" +
-      s" v2 tables, please config the catalog correctly using spark.sql.catalog " +
+      s" v2 tables, please config the catalog correctly using spark.sql.catalog" +
       s" and/or add the catalog prefix in the table identifier.")
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -52,9 +52,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       cols.foreach { c =>
         if (c.name.length > 1) {
           throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-            ident.catalog.getOrElse(""),
-            ident.database.getOrElse(""),
-            ident.table,
+            Seq(ident.catalog.get, ident.database.get, ident.table),
             "ADD COLUMN with qualified column")
         }
         if (!c.nullable) {
@@ -65,18 +63,14 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     case ReplaceColumns(ResolvedV1TableIdentifier(ident), _) =>
       throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-        ident.catalog.getOrElse(""),
-        ident.database.getOrElse(""),
-        ident.table,
+        Seq(ident.catalog.get, ident.database.get, ident.table),
         "REPLACE COLUMNS")
 
     case a @ AlterColumn(ResolvedTable(catalog, ident, table: V1Table, _), _, _, _, _, _, _)
         if isSessionCatalog(catalog) =>
       if (a.column.name.length > 1) {
         throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-          catalog.name,
-          ident.namespace()(0),
-          ident.name,
+          Seq(catalog.name, ident.namespace()(0), ident.name),
           "ALTER COLUMN with qualified column")
       }
       if (a.nullable.isDefined) {
@@ -84,9 +78,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       }
       if (a.position.isDefined) {
         throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-          catalog.name,
-          ident.namespace()(0),
-          ident.name,
+          Seq(catalog.name, ident.namespace()(0), ident.name),
           "ALTER COLUMN ... FIRST | ALTER")
       }
       val builder = new MetadataBuilder
@@ -112,16 +104,12 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     case RenameColumn(ResolvedV1TableIdentifier(ident), _, _) =>
       throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-        ident.catalog.getOrElse(""),
-        ident.database.getOrElse(""),
-        ident.table,
+        Seq(ident.catalog.get, ident.database.get, ident.table),
         "RENAME COLUMN")
 
     case DropColumns(ResolvedV1TableIdentifier(ident), _, _) =>
       throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-        ident.catalog.getOrElse(""),
-        ident.database.getOrElse(""),
-        ident.table,
+        Seq(ident.catalog.get, ident.database.get, ident.table),
         "DROP COLUMN")
 
     case SetTableProperties(ResolvedV1TableIdentifier(ident), props) =>
@@ -212,9 +200,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       val provider = c.tableSpec.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-          ident.catalog.getOrElse(""),
-          ident.database.getOrElse(""),
-          ident.table,
+          Seq(ident.catalog.get, ident.database.get, ident.table),
           "REPLACE TABLE")
       } else {
         c
@@ -224,9 +210,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       val provider = c.tableSpec.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
         throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-          ident.catalog.getOrElse(""),
-          ident.database.getOrElse(""),
-          ident.table,
+          Seq(ident.catalog.get, ident.database.get, ident.table),
           "REPLACE TABLE AS SELECT")
       } else {
         c

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -51,8 +51,11 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
     case AddColumns(ResolvedV1TableIdentifier(ident), cols) =>
       cols.foreach { c =>
         if (c.name.length > 1) {
-          throw QueryCompilationErrors
-            .operationOnlySupportedWithV2TableError("ADD COLUMN with qualified column")
+          throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+            ident.catalog.getOrElse(""),
+            ident.database.getOrElse(""),
+            ident.table,
+            "ADD COLUMN with qualified column")
         }
         if (!c.nullable) {
           throw QueryCompilationErrors.addColumnWithV1TableCannotSpecifyNotNullError
@@ -60,21 +63,31 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       }
       AlterTableAddColumnsCommand(ident, cols.map(convertToStructField))
 
-    case ReplaceColumns(ResolvedV1TableIdentifier(_), _) =>
-      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError("REPLACE COLUMNS")
+    case ReplaceColumns(ResolvedV1TableIdentifier(ident), _) =>
+      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+        ident.catalog.getOrElse(""),
+        ident.database.getOrElse(""),
+        ident.table,
+        "REPLACE COLUMNS")
 
-    case a @ AlterColumn(ResolvedTable(catalog, _, table: V1Table, _), _, _, _, _, _, _)
+    case a @ AlterColumn(ResolvedTable(catalog, ident, table: V1Table, _), _, _, _, _, _, _)
         if isSessionCatalog(catalog) =>
       if (a.column.name.length > 1) {
-        throw QueryCompilationErrors
-          .operationOnlySupportedWithV2TableError("ALTER COLUMN with qualified column")
+        throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+          catalog.name,
+          ident.namespace()(0),
+          ident.name,
+          "ALTER COLUMN with qualified column")
       }
       if (a.nullable.isDefined) {
         throw QueryCompilationErrors.alterColumnWithV1TableCannotSpecifyNotNullError
       }
       if (a.position.isDefined) {
-        throw QueryCompilationErrors
-          .operationOnlySupportedWithV2TableError("ALTER COLUMN ... FIRST | ALTER")
+        throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+          catalog.name,
+          ident.namespace()(0),
+          ident.name,
+          "ALTER COLUMN ... FIRST | ALTER")
       }
       val builder = new MetadataBuilder
       // Add comment to metadata
@@ -97,11 +110,19 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         builder.build())
       AlterTableChangeColumnCommand(table.catalogTable.identifier, colName, newColumn)
 
-    case RenameColumn(ResolvedV1TableIdentifier(_), _, _) =>
-      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError("RENAME COLUMN")
+    case RenameColumn(ResolvedV1TableIdentifier(ident), _, _) =>
+      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+        ident.catalog.getOrElse(""),
+        ident.database.getOrElse(""),
+        ident.table,
+        "RENAME COLUMN")
 
-    case DropColumns(ResolvedV1TableIdentifier(_), _, _) =>
-      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError("DROP COLUMN")
+    case DropColumns(ResolvedV1TableIdentifier(ident), _, _) =>
+      throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+        ident.catalog.getOrElse(""),
+        ident.database.getOrElse(""),
+        ident.table,
+        "DROP COLUMN")
 
     case SetTableProperties(ResolvedV1TableIdentifier(ident), props) =>
       AlterTableSetPropertiesCommand(ident, props, isView = false)
@@ -187,19 +208,26 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
 
     // For REPLACE TABLE [AS SELECT], we should fail if the catalog is resolved to the
     // session catalog and the table provider is not v2.
-    case c @ ReplaceTable(ResolvedV1Identifier(_), _, _, _, _) =>
+    case c @ ReplaceTable(ResolvedV1Identifier(ident), _, _, _, _) =>
       val provider = c.tableSpec.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
-        throw QueryCompilationErrors.operationOnlySupportedWithV2TableError("REPLACE TABLE")
+        throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+          ident.catalog.getOrElse(""),
+          ident.database.getOrElse(""),
+          ident.table,
+          "REPLACE TABLE")
       } else {
         c
       }
 
-    case c @ ReplaceTableAsSelect(ResolvedV1Identifier(_), _, _, _, _, _) =>
+    case c @ ReplaceTableAsSelect(ResolvedV1Identifier(ident), _, _, _, _, _) =>
       val provider = c.tableSpec.provider.getOrElse(conf.defaultDataSourceName)
       if (!isV2Provider(provider)) {
-        throw QueryCompilationErrors
-          .operationOnlySupportedWithV2TableError("REPLACE TABLE AS SELECT")
+        throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
+          ident.catalog.getOrElse(""),
+          ident.database.getOrElse(""),
+          ident.table,
+          "REPLACE TABLE AS SELECT")
       } else {
         c
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -292,14 +292,13 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
               throw QueryCompilationErrors.tableDoesNotSupportDeletesError(table)
           }
         case LogicalRelation(_, _, catalogTable, _) =>
-          val catalog = catalogTable.get.identifier.catalog.getOrElse("")
-          val nameSpace = catalogTable.get.identifier.database.getOrElse("")
-          val table = catalogTable.get.identifier.table
+          val tableIdentifier = catalogTable.get.identifier
           throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-            catalog, nameSpace, table, "DELETE")
+            Seq(tableIdentifier.catalog.get, tableIdentifier.database.get, tableIdentifier.table),
+            "DELETE")
         case _ =>
           throw QueryCompilationErrors.operationOnlySupportedWithV2TableError(
-            "", "", "", "DELETE")
+            Seq(), "DELETE")
       }
 
     case ReplaceData(_: DataSourceV2Relation, _, query, r: DataSourceV2Relation, Some(write)) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -293,7 +293,7 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
           }
 
         case _ =>
-          throw QueryCompilationErrors.deleteOnlySupportedWithV2TablesError()
+          throw QueryCompilationErrors.operationOnlySupportedWithV2TableError("DELETE")
       }
 
     case ReplaceData(_: DataSourceV2Relation, _, query, r: DataSourceV2Relation, Some(write)) =>

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -47,7 +47,14 @@ ALTER TABLE test_change RENAME COLUMN a TO a1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-RENAME COLUMN is only supported with v2 tables. To use v2 tables, please config the catalog correctly using spark.sql.catalog and/or add the catalog prefix in the table identifier.
+{
+  "errorClass" : "UNSUPPORTED_FEATURE",
+  "errorSubClass" : "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "operation" : "RENAME COLUMN"
+  }
+}
 
 
 -- !query
@@ -85,7 +92,14 @@ ALTER TABLE test_change CHANGE a AFTER b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables. To use v2 tables, please config the catalog correctly using spark.sql.catalog and/or add the catalog prefix in the table identifier.
+{
+  "errorClass" : "UNSUPPORTED_FEATURE",
+  "errorSubClass" : "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "operation" : "ALTER COLUMN ... FIRST | ALTER"
+  }
+}
 
 
 -- !query
@@ -94,7 +108,14 @@ ALTER TABLE test_change CHANGE b FIRST
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables. To use v2 tables, please config the catalog correctly using spark.sql.catalog and/or add the catalog prefix in the table identifier.
+{
+  "errorClass" : "UNSUPPORTED_FEATURE",
+  "errorSubClass" : "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "operation" : "ALTER COLUMN ... FIRST | ALTER"
+  }
+}
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -47,7 +47,7 @@ ALTER TABLE test_change RENAME COLUMN a TO a1
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-RENAME COLUMN is only supported with v2 tables.
+RENAME COLUMN is only supported with v2 tables. To use v2 tables, please config the catalog correctly using spark.sql.catalog and/or add the catalog prefix in the table identifier.
 
 
 -- !query
@@ -85,7 +85,7 @@ ALTER TABLE test_change CHANGE a AFTER b
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables.
+ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables. To use v2 tables, please config the catalog correctly using spark.sql.catalog and/or add the catalog prefix in the table identifier.
 
 
 -- !query
@@ -94,7 +94,7 @@ ALTER TABLE test_change CHANGE b FIRST
 struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
-ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables.
+ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables. To use v2 tables, please config the catalog correctly using spark.sql.catalog and/or add the catalog prefix in the table identifier.
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -52,9 +52,7 @@ org.apache.spark.sql.AnalysisException
   "errorSubClass" : "TABLE_OPERATION",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "catalog" : "spark_catalog",
-    "nameSpace" : "default",
-    "tableName" : "test_change",
+    "tableName" : "`spark_catalog`.`default`.`test_change`",
     "operation" : "RENAME COLUMN"
   }
 }
@@ -100,9 +98,7 @@ org.apache.spark.sql.AnalysisException
   "errorSubClass" : "TABLE_OPERATION",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "catalog" : "spark_catalog",
-    "nameSpace" : "default",
-    "tableName" : "test_change",
+    "tableName" : "`spark_catalog`.`default`.`test_change`",
     "operation" : "ALTER COLUMN ... FIRST | ALTER"
   }
 }
@@ -119,9 +115,7 @@ org.apache.spark.sql.AnalysisException
   "errorSubClass" : "TABLE_OPERATION",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "catalog" : "spark_catalog",
-    "nameSpace" : "default",
-    "tableName" : "test_change",
+    "tableName" : "`spark_catalog`.`default`.`test_change`",
     "operation" : "ALTER COLUMN ... FIRST | ALTER"
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/change-column.sql.out
@@ -49,9 +49,12 @@ struct<>
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
-  "errorSubClass" : "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+  "errorSubClass" : "TABLE_OPERATION",
   "sqlState" : "0A000",
   "messageParameters" : {
+    "catalog" : "spark_catalog",
+    "nameSpace" : "default",
+    "tableName" : "test_change",
     "operation" : "RENAME COLUMN"
   }
 }
@@ -94,9 +97,12 @@ struct<>
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
-  "errorSubClass" : "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+  "errorSubClass" : "TABLE_OPERATION",
   "sqlState" : "0A000",
   "messageParameters" : {
+    "catalog" : "spark_catalog",
+    "nameSpace" : "default",
+    "tableName" : "test_change",
     "operation" : "ALTER COLUMN ... FIRST | ALTER"
   }
 }
@@ -110,9 +116,12 @@ struct<>
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
-  "errorSubClass" : "OPERATION_ONLY_SUPPORTED_WITH_V2_TABLE",
+  "errorSubClass" : "TABLE_OPERATION",
   "sqlState" : "0A000",
   "messageParameters" : {
+    "catalog" : "spark_catalog",
+    "nameSpace" : "default",
+    "tableName" : "test_change",
     "operation" : "ALTER COLUMN ... FIRST | ALTER"
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1535,8 +1535,13 @@ class DataSourceV2SQLSuiteV1Filter extends DataSourceV2SQLSuite with AlterTableT
     val e = intercept[AnalysisException] {
       sql(s"CREATE OR REPLACE TABLE tbl (a int) USING ${classOf[SimpleScanSource].getName}")
     }
-    assert(e.message.contains("Table `spark_catalog`.`default`.`tbl` does not support " +
-      "REPLACE TABLE"))
+    checkError(
+      exception = e,
+      errorClass = "UNSUPPORTED_FEATURE",
+      errorSubClass = "TABLE_OPERATION",
+      sqlState = "0A000",
+      parameters = Map("tableName" -> "`spark_catalog`.`default`.`tbl`",
+        "operation" -> "REPLACE TABLE"))
   }
 
   test("DeleteFrom: - delete with invalid predicate") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1535,7 +1535,8 @@ class DataSourceV2SQLSuiteV1Filter extends DataSourceV2SQLSuite with AlterTableT
     val e = intercept[AnalysisException] {
       sql(s"CREATE OR REPLACE TABLE tbl (a int) USING ${classOf[SimpleScanSource].getName}")
     }
-    assert(e.message.contains("REPLACE TABLE is only supported with v2 tables"))
+    assert(e.message.contains("Table `spark_catalog`.`default`.`t1` does not support " +
+      "REPLACE TABLE"))
   }
 
   test("DeleteFrom: - delete with invalid predicate") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1535,7 +1535,7 @@ class DataSourceV2SQLSuiteV1Filter extends DataSourceV2SQLSuite with AlterTableT
     val e = intercept[AnalysisException] {
       sql(s"CREATE OR REPLACE TABLE tbl (a int) USING ${classOf[SimpleScanSource].getName}")
     }
-    assert(e.message.contains("Table `spark_catalog`.`default`.`t1` does not support " +
+    assert(e.message.contains("Table 'spark_catalog'.'default'.'tbl' does not support " +
       "REPLACE TABLE"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -1535,7 +1535,7 @@ class DataSourceV2SQLSuiteV1Filter extends DataSourceV2SQLSuite with AlterTableT
     val e = intercept[AnalysisException] {
       sql(s"CREATE OR REPLACE TABLE tbl (a int) USING ${classOf[SimpleScanSource].getName}")
     }
-    assert(e.message.contains("Table 'spark_catalog'.'default'.'tbl' does not support " +
+    assert(e.message.contains("Table `spark_catalog`.`default`.`tbl` does not support " +
       "REPLACE TABLE"))
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
@@ -111,8 +111,13 @@ trait DeleteFromTests extends DatasourceV2SQLBase {
         sql(s"DELETE FROM $v1Table WHERE i = 2")
       }
 
-      assert(exc.getMessage.contains("Table `spark_catalog`.`default`.`tbl` does not " +
-        "support DELETE"))
+      checkError(
+        exception = exc,
+        errorClass = "UNSUPPORTED_FEATURE",
+        errorSubClass = "TABLE_OPERATION",
+        sqlState = "0A000",
+        parameters = Map("tableName" -> "`spark_catalog`.`default`.`tbl`",
+          "operation" -> "DELETE"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
@@ -111,7 +111,7 @@ trait DeleteFromTests extends DatasourceV2SQLBase {
         sql(s"DELETE FROM $v1Table WHERE i = 2")
       }
 
-      assert(exc.getMessage.contains("Table `spark_catalog`.`default`.`t1` does not " +
+      assert(exc.getMessage.contains("Table 'spark_catalog'.'default'.'tbl' does not " +
         "support DELETE"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
@@ -111,7 +111,7 @@ trait DeleteFromTests extends DatasourceV2SQLBase {
         sql(s"DELETE FROM $v1Table WHERE i = 2")
       }
 
-      assert(exc.getMessage.contains("Table 'spark_catalog'.'default'.'tbl' does not " +
+      assert(exc.getMessage.contains("Table `spark_catalog`.`default`.`tbl` does not " +
         "support DELETE"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DeleteFromTests.scala
@@ -111,7 +111,8 @@ trait DeleteFromTests extends DatasourceV2SQLBase {
         sql(s"DELETE FROM $v1Table WHERE i = 2")
       }
 
-      assert(exc.getMessage.contains("DELETE is only supported with v2 tables"))
+      assert(exc.getMessage.contains("Table `spark_catalog`.`default`.`t1` does not " +
+        "support DELETE"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -190,7 +190,7 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE t ALTER COLUMN i FIRST")
       }
-      assert(e.message.contains("Table `spark_catalog`.`default`.`t1` does not support " +
+      assert(e.message.contains("Table 'spark_catalog'.'default'.'t' does not support " +
         "ALTER COLUMN ... FIRST | ALTER"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -190,8 +190,13 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE t ALTER COLUMN i FIRST")
       }
-      assert(e.message.contains("Table `spark_catalog`.`default`.`t` does not support " +
-        "ALTER COLUMN ... FIRST | ALTER"))
+      checkError(
+        exception = e,
+        errorClass = "UNSUPPORTED_FEATURE",
+        errorSubClass = "TABLE_OPERATION",
+        sqlState = "0A000",
+        parameters = Map("tableName" -> "`spark_catalog`.`default`.`t`",
+          "operation" -> "ALTER COLUMN ... FIRST | ALTER"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -190,7 +190,8 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE t ALTER COLUMN i FIRST")
       }
-      assert(e.message.contains("ALTER COLUMN ... FIRST | ALTER is only supported with v2 tables"))
+      assert(e.message.contains("Table `spark_catalog`.`default`.`t1` does not support " +
+        "ALTER COLUMN ... FIRST | ALTER"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -190,7 +190,7 @@ class InMemoryCatalogedDDLSuite extends DDLSuite with SharedSparkSession {
       val e = intercept[AnalysisException] {
         sql("ALTER TABLE t ALTER COLUMN i FIRST")
       }
-      assert(e.message.contains("Table 'spark_catalog'.'default'.'t' does not support " +
+      assert(e.message.contains("Table `spark_catalog`.`default`.`t` does not support " +
         "ALTER COLUMN ... FIRST | ALTER"))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1258,7 +1258,7 @@ class PlanResolutionSuite extends AnalysisTest {
             parseAndResolve(sql4)
           }
           assert(e2.getMessage.contains("Table `spark_catalog`.`default`.`v1Table` does not " +
-            "support ALTER COLUMN with qualified column."))
+            "support ALTER COLUMN WITH QUALIFIED COLUMN."))
         } else {
           parsed1 match {
             case AlterColumn(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1258,7 +1258,7 @@ class PlanResolutionSuite extends AnalysisTest {
             parseAndResolve(sql4)
           }
           assert(e2.getMessage.contains("Table `spark_catalog`.`default`.`v1Table` does not " +
-            "support ALTER COLUMN WITH QUALIFIED COLUMN."))
+            "support ALTER COLUMN with qualified column."))
         } else {
           parsed1 match {
             case AlterColumn(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1257,8 +1257,13 @@ class PlanResolutionSuite extends AnalysisTest {
           val e2 = intercept[AnalysisException] {
             parseAndResolve(sql4)
           }
-          assert(e2.getMessage.contains("Table `spark_catalog`.`default`.`v1Table` does not " +
-            "support ALTER COLUMN with qualified column."))
+          checkError(
+            exception = e2,
+            errorClass = "UNSUPPORTED_FEATURE",
+            errorSubClass = "TABLE_OPERATION",
+            sqlState = "0A000",
+            parameters = Map("tableName" -> "`spark_catalog`.`default`.`v1Table`",
+              "operation" -> "ALTER COLUMN with qualified column"))
         } else {
           parsed1 match {
             case AlterColumn(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1257,7 +1257,7 @@ class PlanResolutionSuite extends AnalysisTest {
           val e2 = intercept[AnalysisException] {
             parseAndResolve(sql4)
           }
-          assert(e2.getMessage.contains("Table 'spark_catalog'.'default'.'v1Table' does not " +
+          assert(e2.getMessage.contains("Table `spark_catalog`.`default`.`v1Table` does not " +
             "support ALTER COLUMN with qualified column."))
         } else {
           parsed1 match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/PlanResolutionSuite.scala
@@ -1257,8 +1257,8 @@ class PlanResolutionSuite extends AnalysisTest {
           val e2 = intercept[AnalysisException] {
             parseAndResolve(sql4)
           }
-          assert(e2.getMessage.contains(
-            "ALTER COLUMN with qualified column is only supported with v2 tables"))
+          assert(e2.getMessage.contains("Table 'spark_catalog'.'default'.'v1Table' does not " +
+            "support ALTER COLUMN with qualified column."))
         } else {
           parsed1 match {
             case AlterColumn(


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add more info in the v2 table error message to make it more meaningful.


### Why are the changes needed?
When V2 catalog is not configured, Spark fails to access/create a table using the V2 API and silently falls back to attempting to do the same operation using the V1 Api. This happens frequently among the users. We want to have a better error message so that users can fix the configuration/usage issue by themselves.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing tests
