### PR TITLE
[SPARK-40210][PYTHON] Fix math atan2, hypot, pow and pmod float argument call

### DIFF
--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -108,14 +108,13 @@ def _invoke_binary_math_function(name: str, col1: Any, col2: Any) -> Column:
     Invokes binary JVM math function identified by name
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
+
     def align_type(c):
         # For legacy reasons, the arguments here can be implicitly converted into column
         return c if isinstance(c, (str, Column)) else lit(c)
 
     return _invoke_function(
-        name,
-        _to_java_column(align_type(col1)),
-        _to_java_column(align_type(col2))
+        name, _to_java_column(align_type(col1)), _to_java_column(align_type(col2))
     )
 
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -108,12 +108,14 @@ def _invoke_binary_math_function(name: str, col1: Any, col2: Any) -> Column:
     Invokes binary JVM math function identified by name
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
+    def align_type(c):
+        # For legacy reasons, the arguments here can be implicitly converted into column
+        return c if isinstance(c, (str, Column)) else lit(c)
+
     return _invoke_function(
         name,
-        # For legacy reasons, the arguments here can be implicitly converted into floats,
-        # if they are not columns or strings.
-        _to_java_column(col1) if isinstance(col1, (str, Column)) else float(col1),
-        _to_java_column(col2) if isinstance(col2, (str, Column)) else float(col2),
+        _to_java_column(align_type(col1)),
+        _to_java_column(align_type(col2))
     )
 
 
@@ -1994,21 +1996,6 @@ def radians(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("radians", col)
 
 
-@overload
-def atan2(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def atan2(col1: float, col2: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def atan2(col1: "ColumnOrName", col2: float) -> Column:
-    ...
-
-
 def atan2(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]) -> Column:
     """
     .. versionadded:: 1.4.0
@@ -2038,21 +2025,6 @@ def atan2(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]
     return _invoke_binary_math_function("atan2", col1, col2)
 
 
-@overload
-def hypot(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def hypot(col1: float, col2: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def hypot(col1: "ColumnOrName", col2: float) -> Column:
-    ...
-
-
 def hypot(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]) -> Column:
     """
     Computes ``sqrt(a^2 + b^2)`` without intermediate overflow or underflow.
@@ -2078,21 +2050,6 @@ def hypot(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]
     Row(HYPOT(1, 2)=2.23606...)
     """
     return _invoke_binary_math_function("hypot", col1, col2)
-
-
-@overload
-def pow(col1: "ColumnOrName", col2: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def pow(col1: float, col2: "ColumnOrName") -> Column:
-    ...
-
-
-@overload
-def pow(col1: "ColumnOrName", col2: float) -> Column:
-    ...
 
 
 def pow(col1: Union["ColumnOrName", float], col2: Union["ColumnOrName", float]) -> Column:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -109,7 +109,7 @@ def _invoke_binary_math_function(name: str, col1: Any, col2: Any) -> Column:
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
 
-    def align_type(c):
+    def align_type(c: Any) -> Union[str, Column]:
         # For legacy reasons, the arguments here can be implicitly converted into column
         return c if isinstance(c, (str, Column)) else lit(c)
 

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -109,13 +109,9 @@ def _invoke_binary_math_function(name: str, col1: Any, col2: Any) -> Column:
     and wraps the result with :class:`~pyspark.sql.Column`.
     """
 
-    def align_type(c: Any) -> Union[str, Column]:
-        # For legacy reasons, the arguments here can be implicitly converted into column
-        return c if isinstance(c, (str, Column)) else lit(c)
-
-    return _invoke_function(
-        name, _to_java_column(align_type(col1)), _to_java_column(align_type(col2))
-    )
+    # For legacy reasons, the arguments here can be implicitly converted into column
+    cols = [_to_java_column(c if isinstance(c, (str, Column)) else lit(c)) for c in (col1, col2)]
+    return _invoke_function(name, *cols)
 
 
 def _options_to_str(options: Optional[Dict[str, Any]] = None) -> Dict[str, Optional[str]]:

--- a/python/pyspark/sql/functions.py
+++ b/python/pyspark/sql/functions.py
@@ -110,7 +110,10 @@ def _invoke_binary_math_function(name: str, col1: Any, col2: Any) -> Column:
     """
 
     # For legacy reasons, the arguments here can be implicitly converted into column
-    cols = [_to_java_column(c if isinstance(c, (str, Column)) else lit(c)) for c in (col1, col2)]
+    cols = [
+        _to_java_column(c) if isinstance(c, (str, Column)) else _create_column_from_literal(c)
+        for c in (col1, col2)
+    ]
     return _invoke_function(name, *cols)
 
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -57,7 +57,7 @@ from pyspark.sql.functions import (
     hypot,
     pow,
     pmod,
-    round
+    round,
 )
 from pyspark.sql import functions
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
@@ -1035,14 +1035,9 @@ class FunctionsTests(ReusedSQLTestCase):
             self.assertEqual([Row(c=1), Row(c=0)], res)
 
     def test_binary_math_function(self):
-        for func, res in [(atan2, 0.13664),
-                          (hypot, 8.07527),
-                          (pow, 2.14359),
-                          (pmod, 1.1)]:
+        for func, res in [(atan2, 0.13664), (hypot, 8.07527), (pow, 2.14359), (pmod, 1.1)]:
             df = self.spark.range(1).select(round(func(1.1, 8), 5).alias("a"))
-            self.assertEqual(
-                Row(a=res), df.first()
-            )
+            self.assertEqual(Row(a=res), df.first())
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -53,6 +53,11 @@ from pyspark.sql.functions import (
     slice,
     least,
     regexp_replace,
+    atan2,
+    hypot,
+    pow,
+    pmod,
+    round
 )
 from pyspark.sql import functions
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
@@ -1028,6 +1033,16 @@ class FunctionsTests(ReusedSQLTestCase):
             self.assertEqual([Row(b=True), Row(b=False)], res)
             res = df.select(array_position(df.data, dtype(1)).alias("c")).collect()
             self.assertEqual([Row(c=1), Row(c=0)], res)
+
+    def test_binary_math_function(self):
+        for func, res in [(atan2, 0.13664),
+                          (hypot, 8.07527),
+                          (pow, 2.14359),
+                          (pmod, 1.1)]:
+            df = self.spark.range(1).select(round(func(1.1, 8), 5).alias("a"))
+            self.assertEqual(
+                Row(a=res), df.first()
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
PySpark atan2, hypot, pow and pmod functions marked as accepting float type as argument but produce error when called together. For example:

```
>>> from pyspark.sql.functions import *
>>> df = spark.range(1)
>>> df.select(atan2(1.1, 2.1)).first()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/functions.py", line 962, in atan2
    return _invoke_binary_math_function("atan2", col1, col2)
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/functions.py", line 111, in _invoke_binary_math_function
    return _invoke_function(
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/functions.py", line 85, in _invoke_function
    return Column(jf(*args))
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/python/lib/py4j-0.10.9.5-src.zip/py4j/java_gateway.py", line 1321, in __call__
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/sql/utils.py", line 190, in deco
    return f(*a, **kw)
  File "/home/khalid/dev/p/SparkTest/spark_venv3.10/lib/python3.10/site-packages/pyspark/python/lib/py4j-0.10.9.5-src.zip/py4j/protocol.py", line 330, in get_return_value
py4j.protocol.Py4JError: An error occurred while calling z:org.apache.spark.sql.functions.atan2. Trace:
py4j.Py4JException: Method atan2([class java.lang.Double, class java.lang.Double]) does not exist
        at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:318)
        at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:339)
        at py4j.Gateway.invoke(Gateway.java:276)
        at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
        at py4j.commands.CallCommand.execute(CallCommand.java:79)
        at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
        at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
        at java.lang.Thread.run(Thread.java:748)

```

Although, this call could be written outside the Spark and supplied as a literal it's still good to be consistent with SQL API and help user to avoid seeing error.

after the fix:

```
>>> from pyspark.sql.functions import *
>>> df = spark.range(1)
>>> df.select(atan2(1.1, 2.1)).first()
Row(ATAN2(1.1, 2.1)=0.4825132950224769)
```


### Why are the changes needed?
Improve user experience. Bug fix


### Does this PR introduce _any_ user-facing change?
Yes, no errors


### How was this patch tested?
```
./python/run-tests
```