### PR TITLE
[SPARK-40296] Error class for DISTINCT function not found

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -98,6 +98,11 @@
       "Failed to execute user defined function (<functionName>: (<signature>) => <result>)"
     ]
   },
+  "DISTINCT_FUNCTION_NOT_FOUND": {
+    "message": [
+      "The function `DISTINCT` does not exist in the current schema <current_schema>. To deduplicate columns use SELECT DISTINCT <column_list> … . Otherwise, verify the function name or qualify the function name with its schema."
+    ]
+  },
   "FAILED_RENAME_PATH" : {
     "message" : [
       "Failed to rename <sourcePath> to <targetPath> as destination already exists"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1830,9 +1830,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
     catalogAndNamespace: Seq[String],
     fullName: Option[Seq[String]]): Throwable = {
     if (rawName.length == 1 && rawName.head.toLowerCase(Locale.ROOT) == "distinct") {
+      val argumentsStr = arguments.map(e => s"$e").mkString(",")
       new AnalysisException(
         errorClass = "DISTINCT_FUNCTION_NOT_FOUND",
-        messageParameters = Array(catalogAndNamespace.quoted, s"$arguments")
+        messageParameters = Array(catalogAndNamespace.quoted, argumentsStr)
       )
     } else {
       noSuchFunctionError(rawName, t, fullName)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.errors
 
+import java.util.Locale
+
 import scala.collection.mutable
 
 import org.apache.hadoop.fs.Path
@@ -1819,6 +1821,22 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase {
 
   def tableOrViewNotFoundError(table: String): Throwable = {
     new AnalysisException(s"Table or view not found: $table")
+  }
+
+  def noSuchFunctionError(
+    rawName: Seq[String],
+    t: TreeNode[_],
+    arguments: Seq[Expression],
+    catalogAndNamespace: Seq[String],
+    fullName: Option[Seq[String]]): Throwable = {
+    if (rawName.length == 1 && rawName.head.toLowerCase(Locale.ROOT) == "distinct") {
+      new AnalysisException(
+        errorClass = "DISTINCT_FUNCTION_NOT_FOUND",
+        messageParameters = Array(catalogAndNamespace.quoted, s"$arguments")
+      )
+    } else {
+      noSuchFunctionError(rawName, t, fullName)
+    }
   }
 
   def noSuchFunctionError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4473,6 +4473,16 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       sql("select * from test_temp_view"),
       Row(1, 2, 3, 1, 2, 3, 1, 1))
   }
+
+  test("SPARK-40296: DISTINCT function not found") {
+    val e = intercept[AnalysisException] {
+      sql(
+        """
+          |SELECT SUM(c1), DISTINCT(c1, c2) FROM VALUES(1, 2), (2, 2), (1, 2) AS T(c1, c2);
+          |""".stripMargin)
+    }
+    assert(e.message.contains("The function `DISTINCT` does not exist in the current schema"))
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4473,16 +4473,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       sql("select * from test_temp_view"),
       Row(1, 2, 3, 1, 2, 3, 1, 1))
   }
-
-  test("SPARK-40296: DISTINCT function not found") {
-    val e = intercept[AnalysisException] {
-      sql(
-        """
-          |SELECT SUM(c1), DISTINCT(c1, c2) FROM VALUES(1, 2), (2, 2), (1, 2) AS T(c1, c2);
-          |""".stripMargin)
-    }
-    assert(e.message.contains("The function `DISTINCT` does not exist in the current schema"))
-  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -617,6 +617,21 @@ class QueryCompilationErrorsSuite
         "functionName" -> "`array_contains`",
         "classCanonicalName" -> "org.apache.spark.sql.catalyst.expressions.ArrayContains"))
   }
+
+  test("SPARK-40296: DISTINCT_FUNCTION_NOT_FOUND") {
+    val e = intercept[AnalysisException] {
+      sql(
+        """
+          |SELECT SUM(c1), DISTINCT(c1, c2) FROM VALUES(1, 2), (2, 2), (1, 2) AS T(c1, c2);
+          |""".stripMargin)
+    }
+    checkError(
+      exception = e,
+      errorClass = "DISTINCT_FUNCTION_NOT_FOUND",
+      parameters = Map(
+        "current_schema" -> "spark_catalog.default",
+        "column_list" -> "'c1,'c2"))
+  }
 }
 
 class MyCastToString extends SparkUserDefinedFunction(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

When users have a query like `SELECT SUM(a), DISTINCT(a, b) FROM table`, the DISTINCT is treated as a function but cannot be found with the following message:
```
Undefined function: distinct. This function is neither a built-in/temporary function, nor a persistent function that is qualified as hive_metastore.default.distinct
```

We can standardize this error message for the case of distinct as users might want to use distinct to deduplicate arguments but thought it is an aggregation functions.  The new error message should remind proper actions for fix distinct syntax issue. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve user experience.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

UT