### PR TITLE
[SPARK-40297][SQL] CTE outer reference nested in CTE main body cannot be resolved

### DIFF
--- a/sql/core/src/test/resources/sql-tests/inputs/cte-nested.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/cte-nested.sql
@@ -147,3 +147,60 @@ WITH
     SELECT * FROM t3
   )
 SELECT * FROM t2;
+
+-- CTE nested in CTE main body FROM clause references outer CTE def
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_outer
+  )
+  SELECT * FROM cte_inner
+);
+
+-- CTE double nested in CTE main body FROM clause references outer CTE def
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM (
+      WITH cte_inner_inner AS (
+        SELECT * FROM cte_outer
+      )
+      SELECT * FROM cte_inner_inner
+    )
+  )
+  SELECT * FROM cte_inner
+);
+
+-- Invalid reference to invisible CTE def nested CTE def
+WITH cte_outer AS (
+  WITH cte_invisible_inner AS (
+    SELECT 1
+  )
+  SELECT * FROM cte_invisible_inner
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+);
+
+-- Invalid reference to invisible CTE def nested CTE def (in FROM)
+WITH cte_outer AS (
+  SELECT * FROM (
+    WITH cte_invisible_inner AS (
+      SELECT 1
+    )
+    SELECT * FROM cte_invisible_inner
+  )
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+);

--- a/sql/core/src/test/resources/sql-tests/results/cte-legacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-legacy.sql.out
@@ -233,3 +233,83 @@ struct<>
 -- !query output
 org.apache.spark.sql.AnalysisException
 Table or view not found: t1; line 5 pos 20
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_outer
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<1:int>
+-- !query output
+1
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM (
+      WITH cte_inner_inner AS (
+        SELECT * FROM cte_outer
+      )
+      SELECT * FROM cte_inner_inner
+    )
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_outer; line 8 pos 22
+
+
+-- !query
+WITH cte_outer AS (
+  WITH cte_invisible_inner AS (
+    SELECT 1
+  )
+  SELECT * FROM cte_invisible_inner
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_invisible_inner; line 9 pos 18
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT * FROM (
+    WITH cte_invisible_inner AS (
+      SELECT 1
+    )
+    SELECT * FROM cte_invisible_inner
+  )
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_invisible_inner; line 11 pos 18

--- a/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nested.sql.out
@@ -240,3 +240,82 @@ SELECT * FROM t2
 struct<1:int>
 -- !query output
 1
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_outer
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<1:int>
+-- !query output
+1
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM (
+      WITH cte_inner_inner AS (
+        SELECT * FROM cte_outer
+      )
+      SELECT * FROM cte_inner_inner
+    )
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<1:int>
+-- !query output
+1
+
+
+-- !query
+WITH cte_outer AS (
+  WITH cte_invisible_inner AS (
+    SELECT 1
+  )
+  SELECT * FROM cte_invisible_inner
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_invisible_inner; line 9 pos 18
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT * FROM (
+    WITH cte_invisible_inner AS (
+      SELECT 1
+    )
+    SELECT * FROM cte_invisible_inner
+  )
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_invisible_inner; line 11 pos 18

--- a/sql/core/src/test/resources/sql-tests/results/cte-nonlegacy.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/cte-nonlegacy.sql.out
@@ -232,3 +232,82 @@ SELECT * FROM t2
 struct<1:int>
 -- !query output
 1
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_outer
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<1:int>
+-- !query output
+1
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT 1
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM (
+      WITH cte_inner_inner AS (
+        SELECT * FROM cte_outer
+      )
+      SELECT * FROM cte_inner_inner
+    )
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<1:int>
+-- !query output
+1
+
+
+-- !query
+WITH cte_outer AS (
+  WITH cte_invisible_inner AS (
+    SELECT 1
+  )
+  SELECT * FROM cte_invisible_inner
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_invisible_inner; line 9 pos 18
+
+
+-- !query
+WITH cte_outer AS (
+  SELECT * FROM (
+    WITH cte_invisible_inner AS (
+      SELECT 1
+    )
+    SELECT * FROM cte_invisible_inner
+  )
+)
+SELECT * FROM (
+  WITH cte_inner AS (
+    SELECT * FROM cte_invisible_inner
+  )
+  SELECT * FROM cte_inner
+)
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+Table or view not found: cte_invisible_inner; line 11 pos 18

--- a/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CTEInlineSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.{And, GreaterThan, LessThan, Literal, Or}
-import org.apache.spark.sql.catalyst.plans.logical.{Filter, Project, RebalancePartitions, RepartitionByExpression, RepartitionOperation, WithCTE}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.adaptive._
 import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
@@ -483,6 +483,164 @@ abstract class CTEInlineSuiteBase
             |SELECT * FROM cte_1
         """.stripMargin)
         checkAnswer(df, Row(1, 100) :: Nil)
+      }
+    }
+  }
+
+  test("Make sure CTESubstitution places WithCTE back in the plan correctly.") {
+    withView("t") {
+      Seq((0, 1), (1, 2)).toDF("c1", "c2").createOrReplaceTempView("t")
+
+      // CTE on both sides of join - WithCTE placed over first common parent, i.e., the join.
+      val df1 = sql(
+        s"""
+           |select count(v1.c3), count(v2.c3) from (
+           |  with
+           |  v1 as (
+           |    select c1, c2, rand() c3 from t
+           |  )
+           |  select * from v1
+           |) v1 join (
+           |  with
+           |  v2 as (
+           |    select c1, c2, rand() c3 from t
+           |  )
+           |  select * from v2
+           |) v2 on v1.c1 = v2.c1
+         """.stripMargin)
+      checkAnswer(df1, Row(2, 2) :: Nil)
+      df1.queryExecution.analyzed match {
+        case Aggregate(_, _, WithCTE(_, cteDefs)) => assert(cteDefs.length == 2)
+        case other => fail(s"Expect pattern Aggregate(WithCTE(_)) but got $other")
+      }
+
+      // CTE on one side of join - WithCTE placed back where it was.
+      val df2 = sql(
+        s"""
+           |select count(v1.c3), count(v2.c3) from (
+           |  select c1, c2, rand() c3 from t
+           |) v1 join (
+           |  with
+           |  v2 as (
+           |    select c1, c2, rand() c3 from t
+           |  )
+           |  select * from v2
+           |) v2 on v1.c1 = v2.c1
+         """.stripMargin)
+      checkAnswer(df2, Row(2, 2) :: Nil)
+      df2.queryExecution.analyzed match {
+        case Aggregate(_, _, Join(_, SubqueryAlias(_, WithCTE(_, cteDefs)), _, _, _)) =>
+          assert(cteDefs.length == 1)
+        case other => fail(s"Expect pattern Aggregate(Join(_, WithCTE(_))) but got $other")
+      }
+
+      // CTE on one side of join and both sides of union - WithCTE placed on first common parent.
+      val df3 = sql(
+        s"""
+           |select count(v1.c3), count(v2.c3) from (
+           |  select c1, c2, rand() c3 from t
+           |) v1 join (
+           |  select * from (
+           |    with
+           |    v1 as (
+           |      select c1, c2, rand() c3 from t
+           |    )
+           |    select * from v1
+           |  )
+           |  union all
+           |  select * from (
+           |    with
+           |    v2 as (
+           |      select c1, c2, rand() c3 from t
+           |    )
+           |    select * from v2
+           |  )
+           |) v2 on v1.c1 = v2.c1
+         """.stripMargin)
+      checkAnswer(df3, Row(4, 4) :: Nil)
+      df3.queryExecution.analyzed match {
+        case Aggregate(_, _, Join(_, SubqueryAlias(_, WithCTE(_: Union, cteDefs)), _, _, _)) =>
+          assert(cteDefs.length == 2)
+        case other => fail(
+          s"Expect pattern Aggregate(Join(_, (WithCTE(Union(_, _))))) but got $other")
+      }
+
+      // CTE on one side of join and one side of union - WithCTE placed back where it was.
+      val df4 = sql(
+        s"""
+           |select count(v1.c3), count(v2.c3) from (
+           |  select c1, c2, rand() c3 from t
+           |) v1 join (
+           |  select * from (
+           |    with
+           |    v1 as (
+           |      select c1, c2, rand() c3 from t
+           |    )
+           |    select * from v1
+           |  )
+           |  union all
+           |  select c1, c2, rand() c3 from t
+           |) v2 on v1.c1 = v2.c1
+         """.stripMargin)
+      checkAnswer(df4, Row(4, 4) :: Nil)
+      df4.queryExecution.analyzed match {
+        case Aggregate(_, _, Join(_, SubqueryAlias(_, Union(children, _, _)), _, _, _))
+          if children.head.find(_.isInstanceOf[WithCTE]).isDefined =>
+          assert(
+            children.head.collect {
+              case w: WithCTE => w
+            }.head.cteDefs.length == 1)
+        case other => fail(
+          s"Expect pattern Aggregate(Join(_, (WithCTE(Union(_, _))))) but got $other")
+      }
+
+      // CTE on both sides of join and one side of union - WithCTE placed on first common parent.
+      val df5 = sql(
+        s"""
+           |select count(v1.c3), count(v2.c3) from (
+           |  with
+           |  v1 as (
+           |    select c1, c2, rand() c3 from t
+           |  )
+           |  select * from v1
+           |) v1 join (
+           |  select c1, c2, rand() c3 from t
+           |  union all
+           |  select * from (
+           |    with
+           |    v2 as (
+           |      select c1, c2, rand() c3 from t
+           |    )
+           |    select * from v2
+           |  )
+           |) v2 on v1.c1 = v2.c1
+         """.stripMargin)
+      checkAnswer(df5, Row(4, 4) :: Nil)
+      df5.queryExecution.analyzed match {
+        case Aggregate(_, _, WithCTE(_, cteDefs)) => assert(cteDefs.length == 2)
+        case other => fail(s"Expect pattern Aggregate(WithCTE(_)) but got $other")
+      }
+
+      // CTE as root node - WithCTE placed back where it was.
+      val df6 = sql(
+        s"""
+           |with
+           |v1 as (
+           |  select c1, c2, rand() c3 from t
+           |)
+           |select count(v1.c3), count(v2.c3) from
+           |v1 join (
+           |  with
+           |  v2 as (
+           |    select c1, c2, rand() c3 from t
+           |  )
+           |  select * from v2
+           |) v2 on v1.c1 = v2.c1
+         """.stripMargin)
+      checkAnswer(df6, Row(2, 2) :: Nil)
+      df6.queryExecution.analyzed match {
+        case WithCTE(_, cteDefs) => assert(cteDefs.length == 2)
+        case other => fail(s"Expect pattern WithCTE(_) but got $other")
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes a bug where a CTE reference cannot be resolved if this reference occurs in an inner CTE definition nested in the outer CTE's main body FROM clause. E.g.,
```
WITH cte_outer AS (
  SELECT 1
)
SELECT * FROM (
  WITH cte_inner AS (
    SELECT * FROM cte_outer
  )
  SELECT * FROM cte_inner
)
```

This fix is to change the `CTESubstitution`'s traverse order from `resolveOperatorsUpWithPruning` to `resolveOperatorsDownWithPruning` and also to recursively call `traverseAndSubstituteCTE` for CTE main body.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix. Without the fix an `AnalysisException` would be thrown for CTE queries mentioned above.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added UTs.