### PR TITLE
[SPARK-39906][INFRA][FOLLOWGUP] Eliminate build warnings - sbt 0.13 hell syntax is deprecated; use slash syntax instead

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -169,7 +169,7 @@ jobs:
     - name: Run benchmarks
       run: |
         dev/change-scala-version.sh ${{ github.event.inputs.scala }}
-        ./build/sbt -Pscala-${{ github.event.inputs.scala }} -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pspark-ganglia-lgpl test:package
+        ./build/sbt -Pscala-${{ github.event.inputs.scala }} -Pyarn -Pmesos -Pkubernetes -Phive -Phive-thriftserver -Phadoop-cloud -Pkinesis-asl -Pspark-ganglia-lgpl Test/package
         # Make less noisy
         cp conf/log4j2.properties.template conf/log4j2.properties
         sed -i 's/rootLogger.level = info/rootLogger.level = warn/g' conf/log4j2.properties


### PR DESCRIPTION
### What changes were proposed in this pull request?
The Pr is following https://github.com/apache/spark/pull/37326
when I run BLASBenchmark on github, found **The following warnings are displayed in github action log:**
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/15246973/187882232-23681d67-930b-4801-bf0b-10185b6d6ae5.png">

### Why are the changes needed?
Use the recommended sbt syntax to eliminate build warnings: _sbt 0.13 shell syntax is deprecated; use slash syntax instead

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.