### PR TITLE
[SPARK-39996][BUILD] Upgrade `postgresql` to 42.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1226,7 +1226,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.3.3</version>
+        <version>42.5.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade `postgresql` 42.3.3 to 42.5.0


### Why are the changes needed?
fix: [CVE-2022-31197](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31197) Fixes SQL generated in PgResultSet.refresh() to escape column identifiers so as to prevent SQL injection.
Previously, the column names for both key and data columns in the table were copied as-is into the generated
SQL. This allowed a malicious table with column names that include statement terminator to be parsed and
executed as multiple separate commands.
Also adds a new test class ResultSetRefreshTest to verify this change.
Reported by [Sho Kato](https://github.com/kato-sho)

[Changelog](https://jdbc.postgresql.org/documentation/changelog.html#version_42.5.0)
### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA