### PR TITLE
[SPARK-40308][SQL] Allow non-foldable delimiter arguments to `str_to_map` function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -547,10 +547,6 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
 
   override def dataType: DataType = MapType(StringType, StringType)
 
-  override def checkInputDataTypes(): TypeCheckResult = {
-    super.checkInputDataTypes()
-  }
-
   private lazy val mapBuilder = new ArrayBasedMapBuilder(StringType, StringType)
 
   override def nullSafeEval(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -548,11 +548,7 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
   override def dataType: DataType = MapType(StringType, StringType)
 
   override def checkInputDataTypes(): TypeCheckResult = {
-    if (Seq(pairDelim, keyValueDelim).exists(! _.foldable)) {
-      TypeCheckResult.TypeCheckFailure(s"$prettyName's delimiters must be foldable.")
-    } else {
-      super.checkInputDataTypes()
-    }
+    super.checkInputDataTypes()
   }
 
   private lazy val mapBuilder = new ArrayBasedMapBuilder(StringType, StringType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ComplexTypeSuite.scala
@@ -476,6 +476,10 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     val m5 = Map("a" -> null)
     checkEvaluation(new StringToMap(s5), m5)
 
+    val s6 = Literal("a=1&b=2&c=3")
+    val m6 = Map("a" -> "1", "b" -> "2", "c" -> "3")
+    checkEvaluation(new StringToMap(s6, NonFoldableLiteral("&"), NonFoldableLiteral("=")), m6)
+
     checkExceptionInExpression[RuntimeException](
       new StringToMap(Literal("a:1,b:2,a:3")), "Duplicate map key")
     withSQLConf(SQLConf.MAP_KEY_DEDUP_POLICY.key -> SQLConf.MapKeyDedupPolicy.LAST_WIN.toString) {
@@ -492,12 +496,6 @@ class ComplexTypeSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(StringToMap(Literal("a:1,b:2,c:3"), Literal(null), Literal(null))
       .checkInputDataTypes().isFailure)
     assert(new StringToMap(Literal(null), Literal(null)).checkInputDataTypes().isFailure)
-
-    assert(new StringToMap(Literal("a:1_b:2_c:3"), NonFoldableLiteral("_"))
-        .checkInputDataTypes().isFailure)
-    assert(
-      new StringToMap(Literal("a=1_b=2_c=3"), Literal("_"), NonFoldableLiteral("="))
-        .checkInputDataTypes().isFailure)
   }
 
   test("SPARK-22693: CreateNamedStruct should not use global variables") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -624,20 +624,6 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
       )
     )
 
-    val selectExpr =
-      """str_to_map(str,
-        |if(flag = 0, '&', '%'),
-        |if(flag = 0, '=', '#'))
-        |""".stripMargin
-
-    checkAnswer(
-      df3.selectExpr(selectExpr),
-      Seq(
-        Row(Map("a" -> "1", "b" -> "2")),
-        Row(Map("k" -> "2", "v" -> "3"))
-      )
-    )
-
     val df4 = Seq(
       ("a:1&b:2", "&"),
       ("k:2%v:3", "%")

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -606,6 +606,50 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
       Seq(Row(Map("a" -> "1", "b" -> "2", "c" -> "3")))
     )
 
+    checkAnswer(
+      df2.selectExpr("str_to_map(a, ',')"),
+      Seq(Row(Map("a" -> "1", "b" -> "2", "c" -> "3")))
+    )
+
+    val df3 = Seq(
+      ("a=1&b=2", "&", "=", 0),
+      ("k#2%v#3", "%", "#", 1)
+    ).toDF("str", "delim1", "delim2", "flag")
+
+    checkAnswer(
+      df3.selectExpr("str_to_map(str, delim1, delim2)"),
+      Seq(
+        Row(Map("a" -> "1", "b" -> "2")),
+        Row(Map("k" -> "2", "v" -> "3"))
+      )
+    )
+
+    val selectExpr =
+      """str_to_map(str,
+        |if(flag = 0, '&', '%'),
+        |if(flag = 0, '=', '#'))
+        |""".stripMargin
+
+    checkAnswer(
+      df3.selectExpr(selectExpr),
+      Seq(
+        Row(Map("a" -> "1", "b" -> "2")),
+        Row(Map("k" -> "2", "v" -> "3"))
+      )
+    )
+
+    val df4 = Seq(
+      ("a:1&b:2", "&"),
+      ("k:2%v:3", "%")
+    ).toDF("str", "delim1")
+
+    checkAnswer(
+      df4.selectExpr("str_to_map(str, delim1)"),
+      Seq(
+        Row(Map("a" -> "1", "b" -> "2")),
+        Row(Map("k" -> "2", "v" -> "3"))
+      )
+    )
   }
 
   test("SPARK-36148: check input data types of regexp_replace") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -612,9 +612,9 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
     )
 
     val df3 = Seq(
-      ("a=1&b=2", "&", "=", 0),
-      ("k#2%v#3", "%", "#", 1)
-    ).toDF("str", "delim1", "delim2", "flag")
+      ("a=1&b=2", "&", "="),
+      ("k#2%v#3", "%", "#")
+    ).toDF("str", "delim1", "delim2")
 
     checkAnswer(
       df3.selectExpr("str_to_map(str, delim1, delim2)"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove the check for foldable delimiter arguments from `StringToMap#checkInputDataTypes`.

Except for `checkInputDataTypes`, `StringToMap` is already able to handle non-foldable delimiter arguments (no other changes are required).

### Why are the changes needed?

Hive 2.3.9 allows non-foldable delimiter arguments, e.g.:
```
drop table if exists maptbl;
create table maptbl as select ',' as del1, ':' as del2, 'a:1,b:2,c:3' as str;
insert into table maptbl select '%' as del1, '-' as del2, 'a-1%b-2%c-3' as str;
select str, str_to_map(str, del1, del2) from maptbl;
```
This returns
```
+--------------+----------------------------+
|     str      |            _c1             |
+--------------+----------------------------+
| a:1,b:2,c:3  | {"a":"1","b":"2","c":"3"}  |
| a-1%b-2%c-3  | {"a":"1","b":"2","c":"3"}  |
+--------------+----------------------------+
2 rows selected (0.13 seconds)
```
However, Spark returns an error:
```
str_to_map's delimiters must be foldable.; line 1 pos 12;
```

The use-case is more likely to be something like this:
```
select
  str,
  str_to_map(str, ',', if(region = 0, ':', '#')) as m
from
  maptbl2;
```

### Does this PR introduce _any_ user-facing change?

Yes, users can now specify non-foldable delimiter arguments to `str_to_map`.

Literals are still accepted, so the change is backwardly compatible.

### How was this patch tested?

New unit tests.
