### PR TITLE
[SPARK-40315][SQL] Add equals() and hashCode() to ArrayBasedMapData

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapData.scala
@@ -39,17 +39,10 @@ class ArrayBasedMapData(val keyArray: ArrayData, val valueArray: ArrayData) exte
   }
 
   override def equals(obj: Any): Boolean = {
-    if (obj == null && this == null) {
-      return true
+    obj match {
+      case other: ArrayBasedMapData => keyArray == other.keyArray && valueArray == other.valueArray
+      case _ => false
     }
-
-    if (obj == null || !obj.isInstanceOf[ArrayBasedMapData]) {
-      return false
-    }
-
-    val other = obj.asInstanceOf[ArrayBasedMapData]
-
-    keyArray.equals(other.keyArray) && valueArray.equals(other.valueArray)
   }
 
   // Hash this class as a Product of two hashCodes. We don't know the DataType which prevents us

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MapData.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/MapData.scala
@@ -20,9 +20,8 @@ package org.apache.spark.sql.catalyst.util
 import org.apache.spark.sql.types.DataType
 
 /**
- * This is an internal data representation for map type in Spark SQL. This should not implement
- * `equals` and `hashCode` because the type cannot be used as join keys, grouping keys, or
- * in equality tests. See SPARK-9415 and PR#13847 for the discussions.
+ * This is an internal data representation for map type in Spark SQL. This type cannot be used as
+ * join keys, grouping keys, or in equality tests. See SPARK-9415 and PR#13847 for the discussions.
  */
 abstract class MapData extends Serializable {
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -164,13 +164,11 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
 
     // We expect two objects to be equal and to have the same hashCode if they have the same
     // elements.
-    assert(arrayBasedMapData1 == arrayBasedMapData2)
     assert(arrayBasedMapData1.equals(arrayBasedMapData2))
     assert(arrayBasedMapData1.hashCode() == arrayBasedMapData2.hashCode())
 
-    // If two objects have different elements, we expect them to not be equal and their hashCode
+    // If two objects have different elements, we expect them not to be equal and their hashCode
     // to be different.
-    assert(arrayBasedMapData1 != arrayBasedMapData3)
     assert(!arrayBasedMapData1.equals(arrayBasedMapData3))
     assert(arrayBasedMapData1.hashCode() != arrayBasedMapData3.hashCode())
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -143,7 +143,7 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("simple equal() and hashCode() semantics") {
+  test("SPARK-40315: simple equal() and hashCode() semantics") {
     val dataToAdd: Map[Int, Int] = Map(0 -> -7, 1 -> 3, 10 -> 4, 20 -> 5)
     val builder1 = new ArrayBasedMapBuilder(IntegerType, IntegerType)
     val builder2 = new ArrayBasedMapBuilder(IntegerType, IntegerType)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ComplexDataSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ComplexDataSuite.scala
@@ -39,8 +39,6 @@ class ComplexDataSuite extends SparkFunSuite {
     val testArrayMap2 = ArrayBasedMapData(testMap2.toMap)
     val testArrayMap3 = ArrayBasedMapData(testMap3.toMap)
     val testArrayMap4 = ArrayBasedMapData(testMap4.toMap)
-    assert(testArrayMap1 !== testArrayMap3)
-    assert(testArrayMap2 !== testArrayMap4)
 
     // UnsafeMapData
     val unsafeConverter = UnsafeProjection.create(Array[DataType](MapType(StringType, IntegerType)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
There is no explicit `hashCode()` function override for the `ArrayBasedMapData` LogicalPlan. As a result, there is a non-deterministic error where the `hashCode()` computed for `ArrayBasedMapData` can be different for two equal objects (objects with equal keys and values).

In this PR, we override the `hashCode` function so that it works exactly as we expect. We also have an explicit `equals()` function for consistency with how `Literal`s check for equality of `ArrayBasedMapData`.

### Why are the changes needed?
This is a bug fix for a non-deterministic error. It is also more consistent with the rest of Spark if we implement the `hashCode` and `equals` methods instead of relying on defaults.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
A simple unit test was added.