### PR TITLE
[SPARK-40163][SQL][TESTS][FOLLOWUP] Use Junit `Assert` api instead of Java `assert` in `JavaSparkSessionSuite.java`

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaSparkSessionSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaSparkSessionSuite.java
@@ -19,6 +19,7 @@ package test.org.apache.spark.sql;
 
 import org.apache.spark.sql.*;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -50,7 +51,7 @@ public class JavaSparkSessionSuite {
       .getOrCreate();
 
     for (Map.Entry<String, Object> e : map.entrySet()) {
-      assert(spark.conf().get(e.getKey()).equals(e.getValue().toString()));
+      Assert.assertEquals(spark.conf().get(e.getKey()), e.getValue().toString());
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr is a minor fix of https://github.com/apache/spark/pull/37478,  just change to use Junit  api to assert in Java suite.

### Why are the changes needed?
In Java suites, should use JUnit API to make assertions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions