### PR TITLE
[SPARK-40098][SQL][FOLLOWUP] Revert the pretty format of error messages in the Thrift Server

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServerErrors.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServerErrors.scala
@@ -37,9 +37,12 @@ object HiveThriftServerErrors {
   }
 
   def runningQueryError(e: Throwable, format: ErrorMessageFormat.Value): Throwable = e match {
+    case st: SparkThrowable if format == ErrorMessageFormat.PRETTY =>
+      val errorClassPrefix = Option(st.getErrorClass).map(e => s"[$e] ").getOrElse("")
+      new HiveSQLException(
+        s"Error running query: $errorClassPrefix${st.toString}", st.getSqlState, st)
     case st: SparkThrowable with Throwable =>
-      val message = SparkThrowableHelper.getMessage(st, format)
-      new HiveSQLException(s"Error running query: $message", st.getSqlState, st)
+      new HiveSQLException(SparkThrowableHelper.getMessage(st, format), st.getSqlState, st)
     case _ => new HiveSQLException(s"Error running query: ${e.toString}", e)
   }
 

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/ThriftServerWithSparkContextSuite.scala
@@ -162,7 +162,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       val e1 = intercept[HiveSQLException](exec(sql))
       // scalastyle:off line.size.limit
       assert(e1.getMessage ===
-        """Error running query: [DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
+        """Error running query: [DIVIDE_BY_ZERO] org.apache.spark.SparkArithmeticException: [DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
           |== SQL(line 1, position 8) ==
           |select 1 / 0
           |       ^^^^^
@@ -171,7 +171,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       exec(s"set ${SQLConf.ERROR_MESSAGE_FORMAT.key}=${ErrorMessageFormat.MINIMAL}")
       val e2 = intercept[HiveSQLException](exec(sql))
       assert(e2.getMessage ===
-        """Error running query: {
+        """{
           |  "errorClass" : "DIVIDE_BY_ZERO",
           |  "sqlState" : "22012",
           |  "messageParameters" : {
@@ -189,7 +189,7 @@ trait ThriftServerWithSparkContextSuite extends SharedThriftServer {
       exec(s"set ${SQLConf.ERROR_MESSAGE_FORMAT.key}=${ErrorMessageFormat.STANDARD}")
       val e3 = intercept[HiveSQLException](exec(sql))
       assert(e3.getMessage ===
-        """Error running query: {
+        """{
           |  "errorClass" : "DIVIDE_BY_ZERO",
           |  "message" : "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set <config> to \"false\" to bypass this error.",
           |  "sqlState" : "22012",


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose:
1. Output errors in the PRETTY format in the same way as before the PR https://github.com/apache/spark/pull/37520.
2. Do not output non-JSON elements in the MINIMAL and STANDARD formats.

### Why are the changes needed?
1. To not break existing apps that might expect text errors in particular format.
3. Do not output extra text when the Thrift Server outputs errors in an JSON format.

### Does this PR introduce _any_ user-facing change?
Yes.

### How was this patch tested?
By running the modified tests:
```
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *ThriftServerWithSparkContextInBinarySuite"
```