### PR TITLE
[SPARK-40210][PYTHON][FOLLOW-UP][TEST] Speed up new tests using one action instead of many

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -57,7 +57,6 @@ from pyspark.sql.functions import (
     hypot,
     pow,
     pmod,
-    round,
 )
 from pyspark.sql import functions
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
@@ -1035,9 +1034,10 @@ class FunctionsTests(ReusedSQLTestCase):
             self.assertEqual([Row(c=1), Row(c=0)], res)
 
     def test_binary_math_function(self):
-        for func, res in [(atan2, 0.13664), (hypot, 8.07527), (pow, 2.14359), (pmod, 1.1)]:
-            df = self.spark.range(1).select(round(func(1.1, 8), 5).alias("a"))
-            self.assertEqual(Row(a=res), df.first())
+        funcs, expected = zip(*[(atan2, 0.13664), (hypot, 8.07527), (pow, 2.14359), (pmod, 1.1)])
+        df = self.spark.range(1).select(*(func(1.1, 8) for func in funcs))
+        for a, e in zip(df.first(), expected):
+            self.assertAlmostEqual(a, e, 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### What changes were proposed in this pull request?
This is follow up PR for https://github.com/apache/spark/pull/37748 to improve and speed tests as suggested by @zero323

### Why are the changes needed?

Improve test cases

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing unit tests