### PR TITLE
[WIP][SPARK-40309][PYTHON][PS] Introduce `sql_conf` context manager for `pyspark.sql`

### DIFF
--- a/python/pyspark/pandas/tests/test_utils.py
+++ b/python/pyspark/pandas/tests/test_utils.py
@@ -19,7 +19,9 @@ import pandas as pd
 
 from pyspark.pandas.indexes.base import Index
 from pyspark.pandas.utils import (
+    default_session,
     lazy_property,
+    sql_conf,
     validate_arguments_and_invoke_function,
     validate_bool_kwarg,
     validate_index_loc,
@@ -104,6 +106,20 @@ class UtilsTest(PandasOnSparkTestCase, SQLTestUtils):
         err_msg = "index -4 is out of bounds for axis 0 with size 3"
         with self.assertRaisesRegex(IndexError, err_msg):
             validate_index_loc(psidx, -4)
+
+    def test_sql_conf(self):
+        def conf_str_to_bool(conf_str: str) -> bool:
+            return eval(conf_str.title())
+
+        spark = default_session()
+        k = "spark.sql.execution.arrow.pyspark.enabled"
+        old_conf = conf_str_to_bool(spark.conf.get(k))
+        print(old_conf)
+        new_conf = not old_conf
+        print(new_conf)
+        with sql_conf({k: new_conf}, spark=spark):
+            self.assertEquals(conf_str_to_bool(spark.conf.get(k)), new_conf)
+        self.assertEquals(conf_str_to_bool(spark.conf.get(k)), old_conf)
 
 
 class TestClassForLazyProp:

--- a/python/pyspark/pandas/tests/test_utils.py
+++ b/python/pyspark/pandas/tests/test_utils.py
@@ -114,9 +114,7 @@ class UtilsTest(PandasOnSparkTestCase, SQLTestUtils):
         spark = default_session()
         k = "spark.sql.execution.arrow.pyspark.enabled"
         old_conf = conf_str_to_bool(spark.conf.get(k))
-        print(old_conf)
         new_conf = not old_conf
-        print(new_conf)
         with sql_conf({k: new_conf}, spark=spark):
             self.assertEquals(conf_str_to_bool(spark.conf.get(k)), new_conf)
         self.assertEquals(conf_str_to_bool(spark.conf.get(k)), old_conf)

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -39,6 +39,7 @@ import warnings
 
 from pyspark.sql import functions as F, Column, DataFrame as SparkDataFrame, SparkSession
 from pyspark.sql.types import DoubleType
+from pyspark.sql.utils import sql_conf as sql_sql_conf
 import pandas as pd
 from pandas.api.types import is_list_like  # type: ignore[attr-defined]
 
@@ -497,19 +498,8 @@ def sql_conf(pairs: Dict[str, Any], *, spark: Optional[SparkSession] = None) -> 
     if spark is None:
         spark = default_session()
 
-    keys = pairs.keys()
-    new_values = pairs.values()
-    old_values = [spark.conf.get(key, None) for key in keys]
-    for key, new_value in zip(keys, new_values):
-        spark.conf.set(key, new_value)
-    try:
-        yield
-    finally:
-        for key, old_value in zip(keys, old_values):
-            if old_value is None:
-                spark.conf.unset(key)
-            else:
-                spark.conf.set(key, old_value)
+    with sql_sql_conf(pairs, spark=spark) as c:
+        yield c
 
 
 def validate_arguments_and_invoke_function(

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -493,8 +493,6 @@ def sql_conf(pairs: Dict[str, Any], *, spark: Optional[SparkSession] = None) -> 
     A convenient context manager to set `value` to the Spark SQL configuration `key` and
     then restores it back when it exits.
     """
-    assert isinstance(pairs, dict), "pairs should be a dictionary."
-
     if spark is None:
         spark = default_session()
 

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -80,12 +80,27 @@ class UtilsTests(ReusedSQLTestCase):
         def conf_str_to_bool(conf_str: str) -> bool:
             return eval(conf_str.title())
 
+        # Set one Spark SQL conf
         k = "spark.sql.execution.arrow.pyspark.enabled"
         old_conf = conf_str_to_bool(self.spark.conf.get(k))
         new_conf = not old_conf
         with sql_conf({k: new_conf}):
             self.assertEquals(conf_str_to_bool(self.spark.conf.get(k)), new_conf)
         self.assertEquals(conf_str_to_bool(self.spark.conf.get(k)), old_conf)
+
+        with self.assertRaisesRegex(AssertionError, "pairs should be a dictionary"):
+            with sql_conf(new_conf):
+                pass
+
+        # Set multiple Spark SQL confs
+        k2 = "spark.sql.execution.arrow.pyspark.fallback.enabled"
+        old_conf2 = conf_str_to_bool(self.spark.conf.get(k2))
+        new_conf2 = not old_conf2
+        with sql_conf({k: new_conf, k2: new_conf2}):
+            self.assertEquals(conf_str_to_bool(self.spark.conf.get(k)), new_conf)
+            self.assertEquals(conf_str_to_bool(self.spark.conf.get(k2)), new_conf2)
+        self.assertEquals(conf_str_to_bool(self.spark.conf.get(k)), old_conf)
+        self.assertEquals(conf_str_to_bool(self.spark.conf.get(k2)), old_conf2)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -22,6 +22,7 @@ from pyspark.sql.utils import (
     ParseException,
     IllegalArgumentException,
     SparkUpgradeException,
+    sql_conf,
 )
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.sql.functions import to_date, unix_timestamp, from_unixtime
@@ -74,6 +75,17 @@ class UtilsTests(ReusedSQLTestCase):
         except AnalysisException as e:
             self.assertEquals(e.getErrorClass(), "UNRESOLVED_COLUMN")
             self.assertEquals(e.getSqlState(), "42000")
+
+    def test_sql_conf(self):
+        def conf_str_to_bool(conf_str: str) -> bool:
+            return eval(conf_str.title())
+
+        k = "spark.sql.execution.arrow.pyspark.enabled"
+        old_conf = conf_str_to_bool(self.spark.conf.get(k))
+        new_conf = not old_conf
+        with sql_conf({k: new_conf}):
+            self.assertEquals(conf_str_to_bool(self.spark.conf.get(k)), new_conf)
+        self.assertEquals(conf_str_to_bool(self.spark.conf.get(k)), old_conf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce `sql_conf` context manager for `pyspark.sql`.

### Why are the changes needed?
That simplifies the control of Spark SQL configuration as below

from
```py
original_value = spark.conf.get("key")
spark.conf.set("key", "value")
...
spark.conf.set("key", original_value)
```
to
```py
with sql_conf({"key": "value"}):
    ...
```
[Here](https://github.com/apache/spark/blob/master/python/pyspark/pandas/utils.py#L490) is such a context manager is in Pandas API on Spark.

We should introduce one in `pyspark.sql`, and deduplicate code if possible.

### Does this PR introduce _any_ user-facing change?
Yes. Users may use the context manager to manage the Spark SQL configuration for a code block.

For example,
```py
>>> from pyspark.sql.utils import sql_conf
>>> with sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
...    pdf = sdf.toPandas()


```


### How was this patch tested?
Unit tests.
