### PR TITLE
[SPARK-40320][Core] Executor should exit when initialization failed for fatal error

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
@@ -173,7 +173,7 @@ private class DedicatedMessageLoop(
   (1 to endpoint.threadCount()).foreach { _ =>
     /**
      * We need to be careful not to use [[ExecutorService#submit]].
-     * `submit` api will swallow errors in [[FutureTask#setException]].
+     * `submit` api will swallow uncaught exceptions in [[FutureTask#setException]].
      * */
     threadpool.execute(receiveLoopRunnable)
   }

--- a/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
@@ -171,6 +171,10 @@ private class DedicatedMessageLoop(
   }
 
   (1 to endpoint.threadCount()).foreach { _ =>
+    /**
+     * We need to be careful not to use [[ExecutorService#submit]].
+     * `submit` api will swallow errors in [[FutureTask#setException]].
+     * */
     threadpool.execute(receiveLoopRunnable)
   }
 

--- a/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/netty/MessageLoop.scala
@@ -171,7 +171,7 @@ private class DedicatedMessageLoop(
   }
 
   (1 to endpoint.threadCount()).foreach { _ =>
-    threadpool.submit(receiveLoopRunnable)
+    threadpool.execute(receiveLoopRunnable)
   }
 
   // Mark active to handle the OnStart message.

--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -19,31 +19,34 @@ package org.apache.spark.executor
 
 import java.io.File
 import java.nio.ByteBuffer
-import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.Properties
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.concurrent.duration._
 
-import org.json4s.{DefaultFormats, Extraction}
 import org.json4s.JsonAST.{JArray, JObject}
 import org.json4s.JsonDSL._
+import org.json4s.{DefaultFormats, Extraction}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually.{eventually, timeout}
 import org.scalatestplus.mockito.MockitoSugar
 
-import org.apache.spark._
 import org.apache.spark.TestUtils._
-import org.apache.spark.resource._
+import org.apache.spark._
+import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
+import org.apache.spark.internal.config.PLUGINS
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
+import org.apache.spark.resource._
 import org.apache.spark.rpc.RpcEnv
-import org.apache.spark.scheduler.TaskDescription
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.{KillTask, LaunchTask}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerExecutorAdded, SparkListenerExecutorRemoved, TaskDescription}
 import org.apache.spark.serializer.JavaSerializer
-import org.apache.spark.util.{SerializableBuffer, ThreadUtils, Utils}
+import org.apache.spark.util.{SerializableBuffer, SparkUncaughtExceptionHandler, ThreadUtils, Utils}
 
 class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
     with LocalSparkContext with MockitoSugar {
@@ -535,6 +538,40 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
     }
   }
 
+  /**
+   * A fatal error occurred when [[Executor]] was initialized, this should be caught by
+   * [[SparkUncaughtExceptionHandler]] and [[Executor]] can exit by itself.
+   */
+  test("SPARK-40320 Executor should exit when initialization failed for fatal error") {
+    new SparkUncaughtExceptionHandler
+    val conf = new SparkConf()
+      .setMaster("local-cluster[1, 1, 1024]")
+      .set(PLUGINS, Seq(classOf[FatalErrorPlugin].getName))
+      .setAppName("test")
+    sc = new SparkContext(conf)
+    val executorAddCounter = new AtomicInteger(0)
+    val executorRemovedCounter = new AtomicInteger(0)
+
+    val listener = new SparkListener() {
+      override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
+        executorAddCounter.getAndIncrement()
+      }
+
+      override def onExecutorRemoved(executorRemoved: SparkListenerExecutorRemoved): Unit = {
+        executorRemovedCounter.getAndIncrement()
+      }
+    }
+    try {
+      sc.addSparkListener(listener)
+      eventually(timeout(60.seconds)) {
+        assert(executorAddCounter.get() >= 2)
+        assert(executorRemovedCounter.get() >= 2)
+      }
+    } finally {
+      sc.removeSparkListener(listener)
+    }
+  }
+
   private def createMockEnv(conf: SparkConf, serializer: JavaSerializer,
       rpcEnv: Option[RpcEnv] = None): SparkEnv = {
     val mockEnv = mock[SparkEnv]
@@ -545,5 +582,23 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
     when(mockEnv.rpcEnv).thenReturn(rpcEnv.getOrElse(mockRpcEnv))
     SparkEnv.set(mockEnv)
     mockEnv
+  }
+}
+
+private class FatalErrorPlugin extends SparkPlugin {
+  override def driverPlugin(): DriverPlugin = new TestDriverPlugin()
+
+  override def executorPlugin(): ExecutorPlugin = new TestErrorExecutorPlugin()
+}
+
+private class TestDriverPlugin extends DriverPlugin {
+}
+
+private class TestErrorExecutorPlugin extends ExecutorPlugin {
+  override def init(_ctx: PluginContext, extraConf: java.util.Map[String, String]): Unit = {
+      /**
+       * A fatal error. See nonFatal definition in [[NonFatal]].
+       */
+      throw new UnsatisfiedLinkError("Mock throws fatal error.")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before when the Executor plugin fails to initialize for fatal error, the Executor shows active in sparkUI but does not accept any job. As expected Executor should exit when initialization failed with fatal error. 
The root cause:  The thread pool execution uses the inappropriate API `submit` instead of `execute`. This leads to  `SparkUncaughtExceptionHandler` can't catch the fatal error.

### Why are the changes needed?
As expected Executor should exit when initialization failed with fatal error. Before Executor was active but can't do anything which is confused.

### Does this PR introduce any user-facing change?
No
### How was this patch tested?
new added test

