### PR TITLE
[SPARK-40288][SQL] After `RemoveRedundantAggregates`, `PullOutGroupingExpressions` should applied to avoid attribute missing when use complex expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullOutGroupingExpressions.scala
@@ -46,35 +46,37 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.AGGREGATE
  *    +- LocalRelation [c#219]
  */
 object PullOutGroupingExpressions extends Rule[LogicalPlan] {
-  override def apply(plan: LogicalPlan): LogicalPlan = {
-    plan.transformWithPruning(_.containsPattern(AGGREGATE)) {
-      case a: Aggregate if a.resolved =>
-        val complexGroupingExpressionMap = mutable.LinkedHashMap.empty[Expression, NamedExpression]
-        val newGroupingExpressions = a.groupingExpressions.toIndexedSeq.map {
-          case e if !e.foldable && e.children.nonEmpty =>
-            complexGroupingExpressionMap
-              .getOrElseUpdate(e.canonicalized, Alias(e, s"_groupingexpression")())
-              .toAttribute
-          case o => o
-        }
-        if (complexGroupingExpressionMap.nonEmpty) {
-          def replaceComplexGroupingExpressions(e: Expression): Expression = {
-            e match {
-              case _ if AggregateExpression.isAggregate(e) => e
-              case _ if e.foldable => e
-              case _ if complexGroupingExpressionMap.contains(e.canonicalized) =>
-                complexGroupingExpressionMap.get(e.canonicalized).map(_.toAttribute).getOrElse(e)
-              case _ => e.mapChildren(replaceComplexGroupingExpressions)
-            }
-          }
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    plan.transformWithPruning(_.containsPattern(AGGREGATE)) (applyLocally)
 
-          val newAggregateExpressions = a.aggregateExpressions
-            .map(replaceComplexGroupingExpressions(_).asInstanceOf[NamedExpression])
-          val newChild = Project(a.child.output ++ complexGroupingExpressionMap.values, a.child)
-          Aggregate(newGroupingExpressions, newAggregateExpressions, newChild)
-        } else {
-          a
+  val applyLocally: PartialFunction[LogicalPlan, LogicalPlan] = {
+    case a: Aggregate if a.resolved =>
+      val complexGroupingExpressionMap = mutable.LinkedHashMap.empty[Expression, NamedExpression]
+      val newGroupingExpressions = a.groupingExpressions.toIndexedSeq.map {
+        case e if !e.foldable && e.children.nonEmpty =>
+          complexGroupingExpressionMap
+            .getOrElseUpdate(e.canonicalized, Alias(e, s"_groupingexpression")())
+            .toAttribute
+        case o => o
+      }
+      if (complexGroupingExpressionMap.nonEmpty) {
+        def replaceComplexGroupingExpressions(e: Expression): Expression = {
+          e match {
+            case _ if AggregateExpression.isAggregate(e) => e
+            case _ if e.foldable => e
+            case _ if complexGroupingExpressionMap.contains(e.canonicalized) =>
+              complexGroupingExpressionMap.get(e.canonicalized).map(_.toAttribute).getOrElse(e)
+            case _ => e.mapChildren(replaceComplexGroupingExpressions)
+          }
         }
-    }
+
+        val newAggregateExpressions = a.aggregateExpressions
+          .map(replaceComplexGroupingExpressions(_).asInstanceOf[NamedExpression])
+        val newChild = Project(a.child.output ++ complexGroupingExpressionMap.values, a.child)
+        Aggregate(newGroupingExpressions, newAggregateExpressions, newChild)
+      } else {
+        a
+      }
   }
+
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RemoveRedundantAggregatesSuite.scala
@@ -87,20 +87,6 @@ class RemoveRedundantAggregatesSuite extends PlanTest {
     comparePlans(optimized, expected)
   }
 
-  test("Remove redundant aggregate with aliases") {
-    for (agg <- aggregates($"b")) {
-      val query = relation
-        .groupBy($"a" + $"b")(($"a" + $"b") as "c", agg)
-        .groupBy($"c")($"c")
-        .analyze
-      val expected = relation
-        .groupBy($"a" + $"b")(($"a" + $"b") as "c")
-        .analyze
-      val optimized = Optimize.execute(query)
-      comparePlans(optimized, expected)
-    }
-  }
-
   test("Remove redundant aggregate with non-deterministic upper") {
     val query = relation
       .groupBy($"a")($"a")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Atfter RemoveRedundantAggregates rule, we should pull the complex group by expression out.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This will fix the issue SPARK-40288.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
unit test.