### PR TITLE
[SPARK-40251][MLLIB][DOCS][FOLLOWUP] Update doc for mllib linear algebra acceleration

### DIFF
--- a/docs/ml-guide.md
+++ b/docs/ml-guide.md
@@ -62,11 +62,11 @@ The primary Machine Learning API for Spark is now the [DataFrame](sql-programmin
 
 # Dependencies
 
-MLlib uses linear algebra packages [Breeze](http://www.scalanlp.org/), [dev.ludovic.netlib](https://github.com/luhenry/netlib), and [netlib-java](https://github.com/fommil/netlib-java) for optimised numerical processing[^1]. Those packages may call native acceleration libraries such as [Intel MKL](https://software.intel.com/content/www/us/en/develop/tools/math-kernel-library.html) or [OpenBLAS](http://www.openblas.net) if they are available as system libraries or in runtime library paths.
+MLlib uses linear algebra packages [Breeze](http://www.scalanlp.org/) and [dev.ludovic.netlib](https://github.com/luhenry/netlib) for optimised numerical processing[^1]. Those packages may call native acceleration libraries such as [Intel MKL](https://software.intel.com/content/www/us/en/develop/tools/math-kernel-library.html) or [OpenBLAS](http://www.openblas.net) if they are available as system libraries or in runtime library paths.
 
 However, native acceleration libraries can't be distributed with Spark. See [MLlib Linear Algebra Acceleration Guide](ml-linalg-guide.html) for how to enable accelerated linear algebra processing. If accelerated native libraries are not enabled, you will see a warning message like below and a pure JVM implementation will be used instead:
 ```
-WARN BLAS: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS
+WARNING: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS
 ```
 
 To use MLlib in Python, you will need [NumPy](http://www.numpy.org) version 1.4 or newer.

--- a/docs/ml-linalg-guide.md
+++ b/docs/ml-linalg-guide.md
@@ -58,15 +58,17 @@ sudo yum install openblas
 
 To verify native libraries are properly loaded, start `spark-shell` and run the following code:
 ```
-scala> import dev.ludovic.netlib.NativeBLAS
+scala> import dev.ludovic.netlib.blas.NativeBLAS
 scala> NativeBLAS.getInstance()
 ```
 
-If they are correctly loaded, it should print `dev.ludovic.netlib.NativeBLAS = dev.ludovic.netlib.blas.JNIBLAS@...`. Otherwise the warnings should be printed:
+If they are correctly loaded, it should print `dev.ludovic.netlib.blas.NativeBLAS = dev.ludovic.netlib.blas.JNIBLAS@...`. Otherwise the warnings should be printed:
 ```
-WARN NativeBLAS: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS
+WARN InstanceBuilder: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS
+...
 java.lang.RuntimeException: Unable to load native implementation
-  at dev.ludovic.netlib.NativeBLAS.getInstance(NativeBLAS.java:44)
+  at dev.ludovic.netlib.blas.InstanceBuilder.nativeBlas(InstanceBuilder.java:59)
+  at dev.ludovic.netlib.blas.NativeBLAS.getInstance(NativeBLAS.java:31)
   ...
 ```
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update doc for mllib linear algebra acceleration after https://github.com/apache/spark/pull/37002 & https://github.com/apache/spark/pull/37700

### Why are the changes needed?
> A.Dependence on netlib-java has been completely eliminated after https://github.com/apache/spark/pull/37002 & https://github.com/apache/spark/pull/37700.
> B.Some interfaces of dev.ludovic.netlib.blas have changed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A