### PR TITLE
[SPARK-40324][SQL] Provide a query context of `ParseException`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -363,6 +363,23 @@ abstract class SparkFunSuite
       context: QueryContext): Unit =
     checkError(exception, errorClass, None, None, parameters, false, Array(context))
 
+  protected def checkError(
+      exception: SparkThrowable,
+      errorClass: String,
+      errorSubClass: String,
+      sqlState: String,
+      context: QueryContext): Unit =
+    checkError(exception, errorClass, Some(errorSubClass), None, Map.empty, false, Array(context))
+
+  protected def checkError(
+      exception: SparkThrowable,
+      errorClass: String,
+      errorSubClass: String,
+      sqlState: String,
+      parameters: Map[String, String],
+      context: QueryContext): Unit =
+    checkError(exception, errorClass, Some(errorSubClass), None, parameters, false, Array(context))
+
   class LogAppender(msg: String = "", maxEvents: Int = 1000)
       extends AbstractAppender("logAppender", null, null, true, Property.EMPTY_ARRAY) {
     private val _loggingEvents = new ArrayBuffer[LogEvent]()

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -322,7 +322,8 @@ abstract class SparkFunSuite
       assert(expectedParameters === parameters)
     }
     val actualQueryContext = exception.getQueryContext()
-    assert(actualQueryContext.length === queryContext.length, "Invalid length of the query context")
+    assert(actualQueryContext.length === queryContext.length,
+      s"Invalid length of the query context: ${actualQueryContext.mkString("\n")}")
     actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
       assert(actual.objectType() === expected.objectType(), "Invalid objectType of a query context")
       assert(actual.objectName() === expected.objectName(), "Invalid objectName of a query context")

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -322,8 +322,7 @@ abstract class SparkFunSuite
       assert(expectedParameters === parameters)
     }
     val actualQueryContext = exception.getQueryContext()
-    assert(actualQueryContext.length === queryContext.length,
-      s"Invalid length of the query context: ${actualQueryContext.mkString("\n")}")
+    assert(actualQueryContext.length === queryContext.length, "Invalid length of the query context")
     actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
       assert(actual.objectType() === expected.objectType(), "Invalid objectType of a query context")
       assert(actual.objectName() === expected.objectName(), "Invalid objectName of a query context")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/SQLQueryContext.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/SQLQueryContext.scala
@@ -124,7 +124,7 @@ case class SQLQueryContext(
     }
   }
 
-  private def isValid: Boolean = {
+  def isValid: Boolean = {
     sqlText.isDefined && originStartIndex.isDefined && originStopIndex.isDefined &&
       originStartIndex.get >= 0 && originStopIndex.get < sqlText.get.length &&
       originStartIndex.get <= originStopIndex.get

--- a/sql/core/src/test/resources/sql-tests/results/describe.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/describe.sql.out
@@ -387,7 +387,14 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "42000",
   "messageParameters" : {
     "inputString" : "PARTITION specification is incomplete: `d`"
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 28,
+    "fragment" : "DESC t PARTITION (c='Us', d)"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/join-lateral.sql.out
@@ -152,7 +152,14 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "LATERAL_NATURAL_JOIN",
-  "sqlState" : "0A000"
+  "sqlState" : "0A000",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 18,
+    "stopIndex" : 60,
+    "fragment" : "NATURAL JOIN LATERAL (SELECT c1 + c2 AS c2)"
+  } ]
 }
 
 
@@ -165,7 +172,14 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "LATERAL_JOIN_USING",
-  "sqlState" : "0A000"
+  "sqlState" : "0A000",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 18,
+    "stopIndex" : 63,
+    "fragment" : "JOIN LATERAL (SELECT c1 + c2 AS c2) USING (c2)"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/transform.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/transform.sql.out
@@ -718,7 +718,14 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "TRANSFORM_DISTINCT_ALL",
-  "sqlState" : "0A000"
+  "sqlState" : "0A000",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 92,
+    "fragment" : "SELECT TRANSFORM(DISTINCT b, a, c)\n  USING 'cat' AS (a, b, c)\nFROM script_trans\nWHERE a <= 4"
+  } ]
 }
 
 
@@ -734,7 +741,14 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "UNSUPPORTED_FEATURE",
   "errorSubClass" : "TRANSFORM_DISTINCT_ALL",
-  "sqlState" : "0A000"
+  "sqlState" : "0A000",
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 1,
+    "stopIndex" : 87,
+    "fragment" : "SELECT TRANSFORM(ALL b, a, c)\n  USING 'cat' AS (a, b, c)\nFROM script_trans\nWHERE a <= 4"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -915,7 +915,14 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "42000",
   "messageParameters" : {
     "inputString" : "The definition of window `w` is repetitive."
-  }
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 226,
+    "stopIndex" : 394,
+    "fragment" : "WINDOW\n    w AS (ORDER BY salary DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING),\n    w AS (ORDER BY salary DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)"
+  } ]
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
@@ -54,6 +54,33 @@ trait QueryErrorsSuiteBase extends SharedSparkSession {
       queryContext = Array.empty)
   }
 
+  def validateParsingError(
+      sqlText: String,
+      errorClass: String,
+      sqlState: String,
+      parameters: Map[String, String]): Unit = {
+    checkError(
+      exception = intercept[ParseException](sql(sqlText)),
+      errorClass = errorClass,
+      errorSubClass = None,
+      sqlState = Some(sqlState),
+      parameters = parameters,
+      queryContext = Array.empty)
+  }
+
+  def validateParsingError(
+      sqlText: String,
+      errorClass: String,
+      sqlState: String): Unit = {
+    checkError(
+      exception = intercept[ParseException](sql(sqlText)),
+      errorClass = errorClass,
+      errorSubClass = None,
+      sqlState = Some(sqlState),
+      parameters = Map.empty,
+      queryContext = Array.empty)
+  }
+
   case class ExpectedContext(
       objectType: String,
       objectName: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
@@ -28,13 +28,30 @@ trait QueryErrorsSuiteBase extends SharedSparkSession {
       errorClass: String,
       errorSubClass: Option[String] = None,
       sqlState: String,
-      parameters: Map[String, String] = Map.empty): Unit = {
+      parameters: Map[String, String] = Map.empty,
+      context: QueryContext): Unit = {
     checkError(
       exception = intercept[ParseException](sql(sqlText)),
       errorClass = errorClass,
       errorSubClass = errorSubClass,
       sqlState = Some(sqlState),
-      parameters = parameters)
+      parameters = parameters,
+      queryContext = Array(context))
+  }
+
+  def validateParsingError(
+      sqlText: String,
+      errorClass: String,
+      errorSubClass: Option[String],
+      sqlState: String,
+      parameters: Map[String, String]): Unit = {
+    checkError(
+      exception = intercept[ParseException](sql(sqlText)),
+      errorClass = errorClass,
+      errorSubClass = errorSubClass,
+      sqlState = Some(sqlState),
+      parameters = parameters,
+      queryContext = Array.empty)
   }
 
   case class ExpectedContext(

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryErrorsSuiteBase.scala
@@ -18,68 +18,9 @@
 package org.apache.spark.sql.errors
 
 import org.apache.spark.QueryContext
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSparkSession
 
 trait QueryErrorsSuiteBase extends SharedSparkSession {
-
-  def validateParsingError(
-      sqlText: String,
-      errorClass: String,
-      errorSubClass: Option[String] = None,
-      sqlState: String,
-      parameters: Map[String, String] = Map.empty,
-      context: QueryContext): Unit = {
-    checkError(
-      exception = intercept[ParseException](sql(sqlText)),
-      errorClass = errorClass,
-      errorSubClass = errorSubClass,
-      sqlState = Some(sqlState),
-      parameters = parameters,
-      queryContext = Array(context))
-  }
-
-  def validateParsingError(
-      sqlText: String,
-      errorClass: String,
-      errorSubClass: Option[String],
-      sqlState: String,
-      parameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[ParseException](sql(sqlText)),
-      errorClass = errorClass,
-      errorSubClass = errorSubClass,
-      sqlState = Some(sqlState),
-      parameters = parameters,
-      queryContext = Array.empty)
-  }
-
-  def validateParsingError(
-      sqlText: String,
-      errorClass: String,
-      sqlState: String,
-      parameters: Map[String, String]): Unit = {
-    checkError(
-      exception = intercept[ParseException](sql(sqlText)),
-      errorClass = errorClass,
-      errorSubClass = None,
-      sqlState = Some(sqlState),
-      parameters = parameters,
-      queryContext = Array.empty)
-  }
-
-  def validateParsingError(
-      sqlText: String,
-      errorClass: String,
-      sqlState: String): Unit = {
-    checkError(
-      exception = intercept[ParseException](sql(sqlText)),
-      errorClass = errorClass,
-      errorSubClass = None,
-      sqlState = Some(sqlState),
-      parameters = Map.empty,
-      queryContext = Array.empty)
-  }
 
   case class ExpectedContext(
       objectType: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowPartitionsParserSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.parser.CatalystSqlParser.parsePlan
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.ShowPartitions
 import org.apache.spark.sql.errors.QueryErrorsSuiteBase
-import org.apache.spark.sql.execution.SparkSqlParser
 
 class ShowPartitionsParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
   test("SHOW PARTITIONS") {
@@ -50,10 +49,14 @@ class ShowPartitionsParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
   test("empty values in non-optional partition specs") {
     checkError(
       exception = intercept[ParseException] {
-        new SparkSqlParser().parsePlan("SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)")
+        parsePlan("SHOW PARTITIONS dbx.tab1 PARTITION (a='1', b)")
       },
       errorClass = "INVALID_SQL_SYNTAX",
       sqlState = "42000",
-      parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."))
+      parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."),
+      context = ExpectedContext(
+        fragment = "PARTITION (a='1', b)",
+        start = 25,
+        stop = 44))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/TruncateTableParserSuite.scala
@@ -53,6 +53,10 @@ class TruncateTableParserSuite extends AnalysisTest with QueryErrorsSuiteBase {
       },
       errorClass = "INVALID_SQL_SYNTAX",
       sqlState = "42000",
-      parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."))
+      parameters = Map("inputString" -> "Partition key `b` must set value (can't be empty)."),
+      context = ExpectedContext(
+        fragment = "PARTITION (a='1', b)",
+        start = 24,
+        stop = 43))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to extend `ParseException` and add new field `queryContext` which contains an array of query contexts. By default, the field is initialized by the context of currently processed tree node.

Also I removed the wrapper `validateParsingError()` of `checkError()` to use last one directly.

### Why are the changes needed?
To improve user experience with Spark SQL by providing more context of parsing errors.

### Does this PR introduce _any_ user-facing change?
No, it extends existing functionality.

### How was this patch tested?
By running the affected test suites:
```
$ build/sbt "sql/testOnly *QueryParsingErrorsSuite"
$ build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
$ build/sbt -Phive -Phive-thriftserver "test:testOnly *TruncateTableParserSuite"
$ build/sbt -Phive-2.3 -Phive-thriftserver "test:testOnly *ShowPartitionsParserSuite"
```