### PR TITLE
[SPARK-40271][PYTHON][TESTS][FOLLOW-UP] Make test_lit_list test pass with ANSI mode on

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -978,15 +978,16 @@ class FunctionsTests(ReusedSQLTestCase):
         actual = self.spark.range(1).select(lit(test_list)).first()[0]
         self.assertEqual(actual, expected)
 
-        test_list = ["a", 1, None, 1.0]
-        expected = ["a", "1", None, "1.0"]
-        actual = self.spark.range(1).select(lit(test_list)).first()[0]
-        self.assertEqual(actual, expected)
+        with self.sql_conf({"spark.sql.ansi.enabled": False}):
+            test_list = ["a", 1, None, 1.0]
+            expected = ["a", "1", None, "1.0"]
+            actual = self.spark.range(1).select(lit(test_list)).first()[0]
+            self.assertEqual(actual, expected)
 
-        test_list = [["a", 1, None, 1.0], [1, None, "b"]]
-        expected = [["a", "1", None, "1.0"], ["1", None, "b"]]
-        actual = self.spark.range(1).select(lit(test_list)).first()[0]
-        self.assertEqual(actual, expected)
+            test_list = [["a", 1, None, 1.0], [1, None, "b"]]
+            expected = [["a", "1", None, "1.0"], ["1", None, "b"]]
+            actual = self.spark.range(1).select(lit(test_list)).first()[0]
+            self.assertEqual(actual, expected)
 
         df = self.spark.range(10)
         with self.assertRaisesRegex(ValueError, "lit does not allow a column in a list"):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/37722.
Currently `test_lit_list` fails with the ANSI mode on as below:

```
======================================================================
ERROR: test_lit_list (pyspark.sql.tests.test_functions.FunctionsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/tests/test_functions.py", line 979, in test_lit_list
    actual = self.spark.range(1).select(lit(test_list)).first()[0]
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 2639, in first
    return self.head()
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 2618, in head
    rs = self.head(1)
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 2620, in head
    return self.take(n)
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 1231, in take
    return self.limit(num).collect()
  File "/__w/spark/spark/python/pyspark/sql/dataframe.py", line 1137, in collect
    sock_info = self._jdf.collectToPython()
  File "/__w/spark/spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1323, in __call__
    answer, self.gateway_client, self.target_id, self.name)
  File "/__w/spark/spark/python/pyspark/sql/utils.py", line 205, in deco
    raise converted from None
pyspark.sql.utils.IllegalArgumentException: [CAST_INVALID_INPUT] The value 'a' of the type "STRING" cannot be cast to "DOUBLE" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.

JVM stacktrace:
org.apache.spark.SparkNumberFormatException: [CAST_INVALID_INPUT] The value 'a' of the type "STRING" cannot be cast to "DOUBLE" because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. If necessary set "spark.sql.ansi.enabled" to "false" to bypass this error.
	at org.apache.spark.sql.errors.QueryExecutionErrors$.invalidInputInCastToNumberError(QueryExecutionErrors.scala:168)
	at org.apache.spark.sql.catalyst.expressions.Cast.$anonfun$castToDouble$2(Cast.scala:1132)
	at org.apache.spark.sql.catalyst.expressions.Cast.buildCast(Cast.scala:578)
	at org.apache.spark.sql.catalyst.expressions.Cast.$anonfun$castToDouble$1(Cast.scala:1125)
```
https://github.com/apache/spark/runs/8126104258?check_suite_focus=true

This PR fixes it by explicitly disabling the configuration.

### Why are the changes needed?

To make the tests pass.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

CI in this PR should test it out.