### PR TITLE
[SPARK-39546][K8S] Support `ports` definition in executor pod template

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -177,7 +177,7 @@ private[spark] class BasicExecutorFeatureStep(
             .withContainerPort(port)
             .build()
         }
-    } else Nil
+    } else Seq.empty
 
     if (!isDefaultProfile) {
       if (pod.container != null && pod.container.getResources() != null) {
@@ -201,7 +201,7 @@ private[spark] class BasicExecutorFeatureStep(
         .withValue(Utils.getCurrentUserName())
         .endEnv()
       .addAllToEnv(executorEnv.asJava)
-      .withPorts(requiredPorts.asJava)
+      .addAllToPorts(requiredPorts.asJava)
       .addToArgs("executor")
       .build()
     val executorContainerWithConfVolume = if (disableConfigMap) {

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStep.scala
@@ -177,7 +177,7 @@ private[spark] class BasicExecutorFeatureStep(
             .withContainerPort(port)
             .build()
         }
-    } else Seq.empty
+    } else Nil
 
     if (!isDefaultProfile) {
       if (pod.container != null && pod.container.getResources() != null) {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -523,6 +523,7 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     val podConfigured1 = step1.configurePod(baseDriverPod)
     // port-from-template should exist after step1
     assert(podConfigured1.container.getPorts.contains(ports))
+
   }
 
   // There is always exactly one controller reference, and it points to the driver pod.

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -16,8 +16,13 @@
  */
 package org.apache.spark.deploy.k8s.features
 
+import scala.collection.JavaConverters
+import scala.collection.JavaConverters._
+
 import com.google.common.net.InternetDomainName
+import io.fabric8.kubernetes.api.model._
 import org.scalatest.BeforeAndAfter
+
 import org.apache.spark.{SecurityManager, SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, KubernetesTestConf, SecretVolumeUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import scala.collection.JavaConverters
 import scala.collection.JavaConverters._
 
 import com.google.common.net.InternetDomainName
@@ -511,19 +510,18 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(mem === s"${expected}Mi")
   }
 
-  test("SPARK-39546: executor pod template should support port definitions") {
+  test("SPARK-39546: Support ports definition in executor pod template") {
     val baseDriverPod = SparkPod.initialPod()
     val ports = new ContainerPortBuilder()
       .withName("port-from-template")
       .withContainerPort(1000)
       .build()
-    baseDriverPod.container.setPorts(JavaConverters.seqAsJavaListConverter(Seq(ports)).asJava)
+    baseDriverPod.container.setPorts(Seq(ports).asJava)
     val step1 = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
       defaultProfile)
     val podConfigured1 = step1.configurePod(baseDriverPod)
     // port-from-template should exist after step1
     assert(podConfigured1.container.getPorts.contains(ports))
-
   }
 
   // There is always exactly one controller reference, and it points to the driver pod.

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/BasicExecutorFeatureStepSuite.scala
@@ -16,12 +16,8 @@
  */
 package org.apache.spark.deploy.k8s.features
 
-import scala.collection.JavaConverters._
-
 import com.google.common.net.InternetDomainName
-import io.fabric8.kubernetes.api.model._
 import org.scalatest.BeforeAndAfter
-
 import org.apache.spark.{SecurityManager, SparkConf, SparkException, SparkFunSuite}
 import org.apache.spark.deploy.k8s.{KubernetesExecutorConf, KubernetesTestConf, SecretVolumeUtils, SparkPod}
 import org.apache.spark.deploy.k8s.Config._
@@ -510,6 +506,19 @@ class BasicExecutorFeatureStepSuite extends SparkFunSuite with BeforeAndAfter {
     assert(mem === s"${expected}Mi")
   }
 
+  test("SPARK-39546: executor pod template should support port definitions") {
+    val baseDriverPod = SparkPod.initialPod()
+    val ports = new ContainerPortBuilder()
+      .withName("port-from-template")
+      .withContainerPort(1000)
+      .build()
+    baseDriverPod.container.setPorts(JavaConverters.seqAsJavaListConverter(Seq(ports)).asJava)
+    val step1 = new BasicExecutorFeatureStep(newExecutorConf(), new SecurityManager(baseConf),
+      defaultProfile)
+    val podConfigured1 = step1.configurePod(baseDriverPod)
+    // port-from-template should exist after step1
+    assert(podConfigured1.container.getPorts.contains(ports))
+  }
 
   // There is always exactly one controller reference, and it points to the driver pod.
   private def checkOwnerReferences(executor: Pod, driverPodUid: String): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr changes the fabric8 k8s method used in BasicExecutorFeatureStep about setting blockmanager ports. Because It will override port definitions in executor pod template file.


### Why are the changes needed?
We use spark.kubernetes.executor.podTemplateFile to specify executor pod definition. However, we cannot set port definition to pod. For example, this is my executorPodTemplate.yaml 
```
apiversion: v1
kind: Pod
spec:
  containers:
    - name: spark-kubernetes-executor
      ports:
        - containerPort: 8090
          name: jmx-exporter
          protocol: TCP
```
When executors start, the pod definitions only show default blockmanager port.
```
      ports:
        - containerPort: 7079
          name: blockmanager
          protocol: TCP
```
It looks like a bug, because the BasicExecutorFeatureStep uses withPorts to override all port definitions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Add unit test
