### PR TITLE
[WIP][Do not merge] Spark Decimal support Int128 as the underlying implementation.

### DIFF
--- a/sql/catalyst/pom.xml
+++ b/sql/catalyst/pom.xml
@@ -32,6 +32,7 @@
   <url>https://spark.apache.org/</url>
   <properties>
     <sbt.project.name>catalyst</sbt.project.name>
+    <jmh.version>1.23</jmh.version>
   </properties>
 
   <dependencies>
@@ -126,6 +127,21 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-netty</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/util/MoreMath.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util;
+
+public class MoreMath {
+  private MoreMath() {
+
+  }
+
+  /**
+   * Compute carry of addition with carry
+   */
+  public static long unsignedCarry(long a, long b, long c) {
+    // HD 2-13
+    return (a & b) | ((a | b) & ~(a + b + c)) >>> 63; // TODO: verify
+  }
+
+  public static long unsignedCarry(long a, long b) {
+    // HD 2-13
+    return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
+  }
+
+  public static long unsignedBorrow(long a, long b) {
+    // HD 2-13
+    return ((~a & b) | (~(a ^ b) & (a - b))) >>> 63;
+  }
+
+  public static long ifNegative(long test, long value) {
+    return value & (test >> 63);
+  }
+
+  // TODO: replace with JDK 18's Math.unsignedMultiplyHigh
+  public static long unsignedMultiplyHigh(long x, long y) {
+    // From Hacker's Delight 2nd Ed. 8-3: High-Order Product Signed from/to Unsigned
+    long result = multiplyHigh(x, y);
+    result += (y & (x >> 63)); // equivalent to: if (x < 0) result += y;
+    result += (x & (y >> 63)); // equivalent to: if (y < 0) result += x;
+    return result;
+  }
+
+  /**
+   * Returns as a {@code long} the most significant 64 bits of the 128-bit
+   * product of two 64-bit factors.
+   *
+   * @param x the first value
+   * @param y the second value
+   * @return the result
+   * @since 9
+   */
+  public static long multiplyHigh(long x, long y) {
+    if (x < 0 || y < 0) {
+      // Use technique from section 8-2 of Henry S. Warren, Jr.,
+      // Hacker's Delight (2nd ed.) (Addison Wesley, 2013), 173-174.
+      long x1 = x >> 32;
+      long x2 = x & 0xFFFFFFFFL;
+      long y1 = y >> 32;
+      long y2 = y & 0xFFFFFFFFL;
+      long z2 = x2 * y2;
+      long t = x1 * y2 + (z2 >>> 32);
+      long z1 = t & 0xFFFFFFFFL;
+      long z0 = t >> 32;
+      z1 += x2 * y1;
+      return x1 * y1 + z0 + (z1 >> 32);
+    } else {
+      // Use Karatsuba technique with two base 2^32 digits.
+      long x1 = x >>> 32;
+      long y1 = y >>> 32;
+      long x2 = x & 0xFFFFFFFFL;
+      long y2 = y & 0xFFFFFFFFL;
+      long A = x1 * y1;
+      long B = x2 * y2;
+      long C = (x1 + x2) * (y1 + y2);
+      long K = C - A - B;
+      return (((B >>> 32) + K) >>> 32) + A;
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1098,7 +1098,7 @@ case class Cast(
       buildCast[UTF8String](_,
         s => changePrecision(Decimal.fromStringANSI(s, target, getContextOrNull()), target))
     case BooleanType =>
-      if (SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "Int128") {
+      if (SQLConf.get.getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "Int128") {
         buildCast[Boolean](_,
           b => toPrecision(if (b) Decimal.ONE128 else Decimal.ZERO128, target, getContextOrNull()))
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1098,12 +1098,12 @@ case class Cast(
       buildCast[UTF8String](_,
         s => changePrecision(Decimal.fromStringANSI(s, target, getContextOrNull()), target))
     case BooleanType =>
-      if (SQLConf.get.getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "Int128") {
-        buildCast[Boolean](_,
-          b => toPrecision(if (b) Decimal.ONE128 else Decimal.ZERO128, target, getContextOrNull()))
-      } else {
+      if (SQLConf.get.isDefaultDecimalImplementation) {
         buildCast[Boolean](_,
           b => toPrecision(if (b) Decimal.ONE else Decimal.ZERO, target, getContextOrNull()))
+      } else {
+        buildCast[Boolean](_,
+          b => toPrecision(if (b) Decimal.ONE128 else Decimal.ZERO128, target, getContextOrNull()))
       }
     case DateType =>
       buildCast[Int](_, d => null) // date can't cast to decimal in Hive

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1098,8 +1098,13 @@ case class Cast(
       buildCast[UTF8String](_,
         s => changePrecision(Decimal.fromStringANSI(s, target, getContextOrNull()), target))
     case BooleanType =>
-      buildCast[Boolean](_,
-        b => toPrecision(if (b) Decimal.ONE else Decimal.ZERO, target, getContextOrNull()))
+      if (SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "Int128") {
+        buildCast[Boolean](_,
+          b => toPrecision(if (b) Decimal.ONE128 else Decimal.ZERO128, target, getContextOrNull()))
+      } else {
+        buildCast[Boolean](_,
+          b => toPrecision(if (b) Decimal.ONE else Decimal.ZERO, target, getContextOrNull()))
+      }
     case DateType =>
       buildCast[Int](_, d => null) // date can't cast to decimal in Hive
     case TimestampType =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -1166,7 +1166,7 @@ case class Pmod(
 
   private def pmod(a: Decimal, n: Decimal): Decimal = {
     val r = a % n
-    if (r != null && r.compare(Decimal.ZERO) < 0) {(r + n) % n} else r
+    if (r != null && r.lessThanZero) {(r + n) % n} else r
   }
 
   override def sql: String = s"$prettyName(${left.sql}, ${right.sql})"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ToNumberParser.scala
@@ -669,25 +669,25 @@ class ToNumberParser(numberFormat: String, errorOnFail: Boolean) extends Seriali
           result.append(DOLLAR_SIGN)
         case _: OptionalPlusOrMinusSign =>
           stripTrailingLoneDecimalPoint(result)
-          if (input < Decimal.ZERO) {
+          if (input.lessThanZero) {
             addCharacterCheckingTrailingSpaces(result, MINUS_SIGN)
           } else {
             addCharacterCheckingTrailingSpaces(result, PLUS_SIGN)
           }
         case _: OptionalMinusSign =>
-          if (input < Decimal.ZERO) {
+          if (input.lessThanZero) {
             stripTrailingLoneDecimalPoint(result)
             addCharacterCheckingTrailingSpaces(result, MINUS_SIGN)
           } else {
             result.append(SPACE)
           }
         case OpeningAngleBracket() =>
-          if (input < Decimal.ZERO) {
+          if (input.lessThanZero) {
             result.append(ANGLE_BRACKET_OPEN)
           }
         case ClosingAngleBracket() =>
           stripTrailingLoneDecimalPoint(result)
-          if (input < Decimal.ZERO) {
+          if (input.lessThanZero) {
             addCharacterCheckingTrailingSpaces(result, ANGLE_BRACKET_CLOSE)
           } else {
             result.append(SPACE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4629,6 +4629,9 @@ class SQLConf extends Serializable with Logging {
   def allowNegativeScaleOfDecimalEnabled: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED)
 
+  def isDefaultDecimalImplementation: Boolean =
+    getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "JDKBigDecimal"
+
   def legacyStatisticalAggregate: Boolean = getConf(SQLConf.LEGACY_STATISTICAL_AGGREGATE)
 
   def truncateTableIgnorePermissionAcl: Boolean =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2730,6 +2730,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DECIMAL_OPERATION_IMPLEMENTATION = buildConf("spark.sql.decimalOperations.implementation")
+    .internal()
+    .doc("When JDKBigDecimal, using the java.math.BigDecimal as the underlying implementation. " +
+      "Otherwise, using Int128.")
+    .version("3.4.0")
+    .stringConf
+    .checkValues(Set("JDKBigDecimal", "Int128"))
+    .createWithDefault("JDKBigDecimal")
+
   val LITERAL_PICK_MINIMUM_PRECISION =
     buildConf("spark.sql.legacy.literal.pickMinimumPrecision")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2730,7 +2730,7 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val DECIMAL_OPERATION_IMPLEMENTATION = buildConf("spark.sql.decimalOperations.implementation")
+  val DECIMAL_UNDERLYING_IMPLEMENTATION = buildConf("spark.sql.decimal.implementation")
     .internal()
     .doc("When JDKBigDecimal, using the java.math.BigDecimal as the underlying implementation. " +
       "Otherwise, using Int128.")
@@ -4630,7 +4630,7 @@ class SQLConf extends Serializable with Logging {
     getConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED)
 
   def isDefaultDecimalImplementation: Boolean =
-    getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "JDKBigDecimal"
+    getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "JDKBigDecimal"
 
   def legacyStatisticalAggregate: Boolean = getConf(SQLConf.LEGACY_STATISTICAL_AGGREGATE)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -75,6 +75,12 @@ final class Decimal(
     jdkDecimalOperation.scale
   }
 
+  def lessThanZero: Boolean = if (decimal128Enabled) {
+    this < ZERO128
+  } else {
+    this < ZERO
+  }
+
   /**
    * Set this Decimal to the given Long. Will have precision 20 and scale 0.
    */
@@ -449,7 +455,7 @@ final class Decimal(
     decimal
   }
 
-  def abs: Decimal = if (this < Decimal.ZERO) this.unary_- else this
+  def abs: Decimal = if (this.lessThanZero) this.unary_- else this
 
   def floor: Decimal = if (scale == 0) this else {
     val newPrecision = DecimalType.bounded(precision - scale + 1, 0).precision

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -49,12 +49,12 @@ final class Decimal(
 
   def this() = this(SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "Int128")
 
-  if (initEnabled) initDecimalOperation(decimal128Enabled)
-
-  def initDecimalOperation(flag: Boolean): Unit = if (flag) {
-    decimal128Operation = new Decimal128Operation()
-  } else {
-    jdkDecimalOperation = new JDKDecimalOperation()
+  if (initEnabled) {
+    if (decimal128Enabled) {
+      decimal128Operation = new Decimal128Operation()
+    } else {
+      jdkDecimalOperation = new JDKDecimalOperation()
+    }
   }
 
   def decimalOperation: DecimalOperation[_] = if (decimal128Enabled) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -477,8 +477,11 @@ object Decimal {
 
   val POW_10 = Array.tabulate[Long](MAX_LONG_DIGITS + 1)(i => math.pow(10, i).toLong)
 
-  private[sql] val ZERO = Decimal(0)
-  private[sql] val ONE = Decimal(1)
+  private[sql] val ZERO = new Decimal(false).set(0)
+  private[sql] val ONE = new Decimal(false).set(1)
+
+  private[sql] val ZERO128 = new Decimal(true).set(0)
+  private[sql] val ONE128 = new Decimal(true).set(1)
 
   def apply(value: Double): Decimal = new Decimal().set(value)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -247,10 +247,10 @@ final class Decimal(
    */
   private[sql] def roundToByte(): Byte = if (decimal128Enabled) {
     decimal128Operation.roundToNumeric[Byte](
-      ByteType, Byte.MaxValue, Byte.MinValue) (_.toByte) (_.toByte)
+      this, ByteType, Byte.MaxValue, Byte.MinValue) (_.toByte) (_.toByte)
   } else {
     jdkDecimalOperation.roundToNumeric[Byte](
-      ByteType, Byte.MaxValue, Byte.MinValue) (_.toByte) (_.toByte)
+      this, ByteType, Byte.MaxValue, Byte.MinValue) (_.toByte) (_.toByte)
   }
 
   /**
@@ -259,10 +259,10 @@ final class Decimal(
    */
   private[sql] def roundToShort(): Short = if (decimal128Enabled) {
     decimal128Operation.roundToNumeric[Short](
-      ShortType, Short.MaxValue, Short.MinValue) (_.toShort) (_.toShort)
+      this, ShortType, Short.MaxValue, Short.MinValue) (_.toShort) (_.toShort)
   } else {
     jdkDecimalOperation.roundToNumeric[Short](
-      ShortType, Short.MaxValue, Short.MinValue) (_.toShort) (_.toShort)
+      this, ShortType, Short.MaxValue, Short.MinValue) (_.toShort) (_.toShort)
   }
 
   /**
@@ -271,10 +271,10 @@ final class Decimal(
    */
   private[sql] def roundToInt(): Int = if (decimal128Enabled) {
     decimal128Operation.roundToNumeric[Int](
-      IntegerType, Int.MaxValue, Int.MinValue) (_.toInt) (_.toInt)
+      this, IntegerType, Int.MaxValue, Int.MinValue) (_.toInt) (_.toInt)
   } else {
     jdkDecimalOperation.roundToNumeric[Int](
-      IntegerType, Int.MaxValue, Int.MinValue) (_.toInt) (_.toInt)
+      this, IntegerType, Int.MaxValue, Int.MinValue) (_.toInt) (_.toInt)
   }
 
   /**
@@ -282,9 +282,9 @@ final class Decimal(
    * @throws ArithmeticException if the decimal too big to fit in Long type.
    */
   private[sql] def roundToLong(): Long = if (decimal128Enabled) {
-    decimal128Operation.roundToLong()
+    decimal128Operation.roundToLong(this)
   } else {
-    jdkDecimalOperation.roundToLong()
+    jdkDecimalOperation.roundToLong(this)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -34,7 +34,10 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
 
   def newInstance(): Decimal128Operation = new Decimal128Operation()
 
-  private def set(int128: Int128, precision: Int, scale: Int): Decimal128Operation = {
+  def set(high: Long, low: Long, precision: Int, scale: Int): Decimal128Operation =
+    set(Int128(high, low), precision, scale)
+
+  def set(int128: Int128, precision: Int, scale: Int): Decimal128Operation = {
     this.int128 = int128
     this._precision = precision
     this._scale = scale

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -80,8 +80,7 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
     } else {
       try {
         val rescale = scale - _scale
-        val (newLeftHigh, newLeftLow) =
-          Int128Math.rescale(this.int128.high, this.int128.low, rescale)
+        val (newLeftHigh, newLeftLow) = Int128Math.rescale(this.high, this.low, rescale)
         this.int128 = Int128(newLeftHigh, newLeftLow)
       } catch {
         case _: IllegalArgumentException =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import scala.math.max
+
+import org.apache.spark.annotation.Unstable
+import org.apache.spark.sql.util.Int128Math
+
+@Unstable
+class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
+  import org.apache.spark.sql.types.Decimal128Operation._
+
+  private var int128: Int128 = null
+
+  def newInstance(): Decimal128Operation = new Decimal128Operation()
+
+  private def set(int128: Int128, precision: Int, scale: Int): Decimal128Operation = {
+    this.int128 = int128
+    this._precision = precision
+    this._scale = scale
+    this
+  }
+
+  def setLong(longVal: Long): Unit = {
+    this.int128 = Int128(longVal)
+  }
+
+  def setLong(unscaled: Long, scale: Int): Unit = setLong(unscaled)
+
+  def setBigDecimal(decimalVal: BigDecimal): Unit = {
+    this.int128 = Int128(decimalVal.underlying().unscaledValue())
+  }
+
+  def setNull: Unit = {
+    this.int128 = null
+  }
+
+  def isNull(): Boolean = int128.eq(null)
+
+  def isNotNull(): Boolean = int128.ne(null)
+
+  def getAsBigDecimal(): BigDecimal = BigDecimal(this.int128.toBigInteger, this._scale)
+
+  def getAsJavaBigDecimal(): java.math.BigDecimal =
+    new java.math.BigDecimal(int128.toBigInteger, _scale)
+
+  def getAsJavaBigInteger(): java.math.BigInteger = this.int128.toBigInteger
+
+  def rescale(scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+    val diff = scale - _scale
+    val (newLeftHigh, newLeftLow) = Int128Math.rescale(this.int128.high, this.int128.low, diff)
+    this.int128 = Int128(newLeftHigh, newLeftLow)
+    true
+  }
+
+  def doCompare(that: Decimal128Operation): Int =
+    operatorWithRescale(
+      scale,
+      that.scale,
+      this.int128,
+      that.int128) (Int128.compare)
+
+  def isEqualsZero(): Boolean = this.int128.isZero()
+
+  def doAdd(that: Decimal128Operation): Decimal128Operation = {
+    val (newHigh, newLow) = operatorWithRescale(
+      scale,
+      that.scale,
+      this.int128,
+      that.int128) (Int128Math.add)
+
+    checkOverflow(newHigh, newLow, "Decimal128 addition.")
+
+    val resultScale = max(this._scale, that.scale)
+    val resultPrecision = resultScale +
+      max(this._precision - this._scale, that.precision - that.scale) + 1
+
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)
+  }
+
+  def doSubtract(that: Decimal128Operation): Decimal128Operation = {
+    val (newHigh, newLow) = operatorWithRescale(
+      scale,
+      that.scale,
+      this.int128,
+      that.int128) (Int128Math.subtract)
+
+    checkOverflow(newHigh, newLow, "Decimal128 subtract.")
+
+    val resultScale = max(this._scale, that.scale)
+    val resultPrecision = resultScale +
+      max(this._precision - this._scale, that.precision - that.scale) + 1
+
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)
+  }
+
+  def multiply(that: Decimal128Operation): Decimal128Operation = {
+    val (newHigh, newLow) = Int128Math.multiply(this.int128.high, this.int128.low,
+      that.int128.high, that.int128.low)
+
+    checkOverflow(newHigh, newLow, "Decimal128 multiply.")
+
+    val resultScale = this._scale + that.scale
+    val resultPrecision = this._precision + that.precision + 1
+
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)
+  }
+
+  def divide(that: Decimal128Operation): Decimal128Operation = {
+    val resultScale =
+      Math.min(Math.max(6, this._scale + that.precision + 1), DecimalType.MAX_PRECISION)
+    val rescaleFactor = resultScale - this._scale + that.scale
+    val (newHigh, newLow) = try {
+      Int128Math.divideRoundUp(
+        this.int128.high, this.int128.low, that.int128.high, that.int128.low, rescaleFactor, 0)
+    } catch {
+      case _: ArithmeticException =>
+        throw overflowError("Decimal128 division.")
+    }
+
+    checkOverflow(newHigh, newLow, "Decimal128 division.")
+
+    val resultPrecision = this._precision - this._scale + that.scale + resultScale
+
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)
+  }
+
+  def remainder(that: Decimal128Operation): Decimal128Operation = {
+    val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that.scale)
+    val rightRescaleFactor = Int128Math.rescaleFactor(that.scale, this._scale)
+    val (newHigh, newLow) = Int128Math.remainder(this.int128.high, this.int128.low,
+      that.int128.high, that.int128.low, leftRescaleFactor, rightRescaleFactor)
+
+    checkOverflow(newHigh, newLow, "Decimal128 remainder.")
+
+    val resultScale = Math.max(this._scale, that.scale)
+    val resultPrecision =
+      Math.min(this._precision - this._scale, that.precision - that.scale) + resultScale
+
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)
+  }
+
+  def quot(that: Decimal128Operation): Decimal128Operation = {
+    val divided = this.divide(that)
+    val (newHigh, newLow) =
+      Int128Math.rescaleTruncate(divided.int128.high, divided.int128.low, -divided.scale)
+
+    checkOverflow(newHigh, newLow, "Decimal128 quot.")
+
+    val resultScale = 0
+    val resultPrecision = divided.precision
+
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)
+  }
+
+  def doNegative: Decimal128Operation = {
+    val decimal128Operation = newInstance()
+    decimal128Operation.set(-this.int128, precision, scale)
+  }
+
+  def copy(from: Decimal128Operation): Unit = {
+    this.int128 = from.int128
+  }
+}
+
+@Unstable
+object Decimal128Operation {
+
+  def operatorWithRescale[T](
+      leftScale: Int,
+      rightScale: Int,
+      left: Int128,
+      right: Int128) (f: (Long, Long, Long, Long) => T): T = {
+    val (rescale, rescaleLeft) = if (leftScale > rightScale) {
+      (leftScale - rightScale, false)
+    } else if (leftScale < rightScale) {
+      (rightScale - leftScale, true)
+    } else {
+      (0, false)
+    }
+    if (rescale == 0) {
+      f(left.high, left.low, right.high, right.low)
+    } else {
+      if (rescaleLeft) {
+        val (newLeftHigh, newLeftLow) = Int128Math.rescale(left.high, left.low, rescale)
+        f(newLeftHigh, newLeftLow, right.high, right.low)
+      } else {
+        val (newRightHigh, newRightLow) = Int128Math.rescale(right.high, right.low, rescale)
+        f(left.high, left.low, newRightHigh, newRightLow)
+      }
+    }
+  }
+
+  def checkOverflow(high: Long, low: Long, msg: String): Unit = {
+    if (Int128.overflows(high, low)) {
+      throw overflowError(msg)
+    }
+  }
+
+  def overflowError(msg: String): ArithmeticException = {
+    new ArithmeticException(s"Decimal overflow: $msg")
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.util.Int128Math
 @Unstable
 class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
   import org.apache.spark.sql.types.Decimal128Operation._
+  import org.apache.spark.sql.types.Decimal.{ROUND_CEILING, ROUND_FLOOR}
 
   private var int128: Int128 = null
 
@@ -70,9 +71,15 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
     if (newDecimalVal.precision > precision) {
       return false
     }
-    val diff = scale - _scale
-    val (newLeftHigh, newLeftLow) = Int128Math.rescale(this.int128.high, this.int128.low, diff)
-    this.int128 = Int128(newLeftHigh, newLeftLow)
+
+    val rescale = scale - _scale
+    if (roundMode == ROUND_CEILING || roundMode == ROUND_FLOOR) {
+      set(newDecimalVal)
+    } else {
+      val (newLeftHigh, newLeftLow) = Int128Math.rescale(this.int128.high, this.int128.low, rescale)
+      this.int128 = Int128(newLeftHigh, newLeftLow)
+    }
+
     true
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -176,9 +176,9 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
     val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that.scale)
     val rightRescaleFactor = Int128Math.rescaleFactor(that.scale, this._scale)
     val (newHigh, newLow) = Int128Math.remainder(
-      this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor)
+      this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, false)
 
-    checkOverflow(newHigh, newLow, "Decimal128 remainder.")
+    checkOverflow(newHigh, newLow, "Get Decimal128 remainder.")
 
     val resultScale = Math.max(this._scale, that.scale)
     val resultPrecision =
@@ -189,14 +189,15 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
   }
 
   def quot(that: Decimal128Operation): Decimal128Operation = {
-    val divided = this.divide(that)
-    val (newHigh, newLow) =
-      Int128Math.rescaleTruncate(divided.int128.high, divided.int128.low, -divided.scale)
+    val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that.scale)
+    val rightRescaleFactor = Int128Math.rescaleFactor(that.scale, this._scale)
+    val (newHigh, newLow) = Int128Math.remainder(
+      this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, true)
 
-    checkOverflow(newHigh, newLow, "Decimal128 quot.")
+    checkOverflow(newHigh, newLow, "Get Decimal128 quotient.")
 
     val resultScale = 0
-    val resultPrecision = divided.precision
+    val resultPrecision = this._precision - this._scale + that.scale + resultScale
 
     val decimal128Operation = newInstance()
     decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -175,10 +175,13 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
   def remainder(that: Decimal128Operation): Decimal128Operation = {
     val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that.scale)
     val rightRescaleFactor = Int128Math.rescaleFactor(that.scale, this._scale)
-    val (newHigh, newLow) = Int128Math.remainder(
-      this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, false)
-
-    checkOverflow(newHigh, newLow, "Get Decimal128 remainder.")
+    val (newHigh, newLow) = try {
+      Int128Math.remainder(
+        this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, false)
+    } catch {
+      case _: ArithmeticException =>
+        throw overflowError(s"Get remainder of ${this.int128} divide ${that.int128}.")
+    }
 
     val resultScale = Math.max(this._scale, that.scale)
     val resultPrecision =
@@ -191,10 +194,13 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
   def quot(that: Decimal128Operation): Decimal128Operation = {
     val leftRescaleFactor = Int128Math.rescaleFactor(this._scale, that.scale)
     val rightRescaleFactor = Int128Math.rescaleFactor(that.scale, this._scale)
-    val (newHigh, newLow) = Int128Math.remainder(
-      this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, true)
-
-    checkOverflow(newHigh, newLow, "Get Decimal128 quotient.")
+    val (newHigh, newLow) = try {
+      Int128Math.remainder(
+        this.high, this.low, that.high, that.low, leftRescaleFactor, rightRescaleFactor, true)
+    } catch {
+      case _: ArithmeticException =>
+        throw overflowError(s"Get quotient of ${this.int128} divide ${that.int128}.")
+    }
 
     val resultScale = 0
     val resultPrecision = this._precision - this._scale + that.scale + resultScale

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -62,7 +62,7 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
 
   def getAsJavaBigInteger(): java.math.BigInteger = this.int128.toBigInteger
 
-  def rescale(scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+  def rescale(precision: Int, scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
     val diff = scale - _scale
     val (newLeftHigh, newLeftLow) = Int128Math.rescale(this.int128.high, this.int128.low, diff)
     this.int128 = Int128(newLeftHigh, newLeftLow)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal128Operation.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.types
 
-import scala.math.max
+import scala.math.{max, min}
 
 import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql.util.Int128Math
@@ -75,11 +75,11 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
       return false
     }
 
-    val rescale = scale - _scale
     if (roundMode == ROUND_CEILING || roundMode == ROUND_FLOOR) {
       set(newDecimalVal)
     } else {
       try {
+        val rescale = scale - _scale
         val (newLeftHigh, newLeftLow) =
           Int128Math.rescale(this.int128.high, this.int128.low, rescale)
         this.int128 = Int128(newLeftHigh, newLeftLow)
@@ -147,7 +147,7 @@ class Decimal128Operation extends DecimalOperation[Decimal128Operation] {
     checkOverflow(newHigh, newLow, "Decimal128 multiply.")
 
     val resultScale = this._scale + that.scale
-    val resultPrecision = this._precision + that.precision + 1
+    val resultPrecision = min(DecimalType.MAX_PRECISION, this._precision + that.precision + 1)
 
     val decimal128Operation = newInstance()
     decimal128Operation.set(Int128(newHigh, newLow), resultPrecision, resultScale)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -228,8 +228,11 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
     getAsBigDecimal().longValue
   }
 
-  def roundToNumeric[T <: AnyVal](integralType: IntegralType, maxValue: Int, minValue: Int)
-      (f1: Long => T) (f2: Double => T): T = {
+  def roundToNumeric[T <: AnyVal](
+      decimal: Decimal,
+      integralType: IntegralType,
+      maxValue: Int,
+      minValue: Int) (f1: Long => T) (f2: Double => T): T = {
     if (isNull()) {
       val actualLongVal = longVal / POW_10(_scale)
       val numericVal = f1(actualLongVal)
@@ -237,7 +240,7 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
         numericVal
       } else {
         throw QueryExecutionErrors.castingCauseOverflowError(
-          this, DecimalType(this.precision, this.scale), integralType)
+          decimal, DecimalType(this.precision, this.scale), integralType)
       }
     } else {
       val doubleVal = getAsBigDecimal().toDouble
@@ -245,12 +248,12 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
         f2(doubleVal)
       } else {
         throw QueryExecutionErrors.castingCauseOverflowError(
-          this, DecimalType(this.precision, this.scale), integralType)
+          decimal, DecimalType(this.precision, this.scale), integralType)
       }
     }
   }
 
-  def roundToLong(): Long = if (isNull()) {
+  def roundToLong(decimal: Decimal): Long = if (isNull()) {
     longVal / POW_10(_scale)
   } else {
     try {
@@ -261,7 +264,7 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
     } catch {
       case _: ArithmeticException =>
         throw QueryExecutionErrors.castingCauseOverflowError(
-          this, DecimalType(this.precision, this.scale), LongType)
+          decimal, DecimalType(this.precision, this.scale), LongType)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import java.math.BigInteger
+
+import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.internal.SQLConf
+
+trait DecimalOperation[T <: DecimalOperation[T]] {
+  import org.apache.spark.sql.types.Decimal._
+
+  private var longVal: Long = 0L
+  protected var _precision: Int = 1
+  protected var _scale: Int = 0
+
+  def precision: Int = _precision
+  def scale: Int = _scale
+
+  def newInstance(): T
+
+  /**
+   * Set this DecimalOperation to the given Long. Will have precision 20 and scale 0.
+   */
+  def set(longVal: Long): DecimalOperation[T] = {
+    if (longVal <= -POW_10(MAX_LONG_DIGITS) || longVal >= POW_10(MAX_LONG_DIGITS)) {
+      // We can't represent this compactly as a long without risking overflow
+      setLong(longVal)
+      this.longVal = 0L
+    } else {
+      setNull()
+      this.longVal = longVal
+    }
+    this._precision = 20
+    this._scale = 0
+    this
+  }
+
+  protected def setLong(longVal: Long): Unit
+
+  protected def setLong(unscaled: Long, scale: Int): Unit
+
+  protected def setBigDecimal(decimalVal: BigDecimal): Unit
+
+  protected def setNull(): Unit
+
+  protected def isNull(): Boolean
+
+  protected def isNotNull(): Boolean
+
+  /**
+   * Set this DecimalOperation to the given Int. Will have precision 10 and scale 0.
+   */
+  def set(intVal: Int): DecimalOperation[T] = {
+    setNull()
+    this.longVal = intVal
+    this._precision = 10
+    this._scale = 0
+    this
+  }
+
+  /**
+   * Set this DecimalOperation to the given unscaled Long, with a given precision and scale.
+   */
+  def set(unscaled: Long, precision: Int, scale: Int): DecimalOperation[T] = {
+    if (setOrNull(unscaled, precision, scale) == null) {
+      throw QueryExecutionErrors.unscaledValueTooLargeForPrecisionError()
+    }
+    this
+  }
+
+  /**
+   * Set this DecimalOperation to the given unscaled Long, with a given precision and scale,
+   * and return it, or return null if it cannot be set due to overflow.
+   */
+  def setOrNull(unscaled: Long, precision: Int, scale: Int): DecimalOperation[T] = {
+    if (unscaled <= -POW_10(MAX_LONG_DIGITS) || unscaled >= POW_10(MAX_LONG_DIGITS)) {
+      // We can't represent this compactly as a long without risking overflow
+      if (precision < 19) {
+        return null  // Requested precision is too low to represent this value
+      }
+      setLong(unscaled, scale)
+      this.longVal = 0L
+    } else {
+      val p = POW_10(math.min(precision, MAX_LONG_DIGITS))
+      if (unscaled <= -p || unscaled >= p) {
+        return null  // Requested precision is too low to represent this value
+      }
+      setNull()
+      this.longVal = unscaled
+    }
+    this._precision = precision
+    this._scale = scale
+    this
+  }
+
+  /**
+   * Set this DecimalOperation to the given BigDecimal value, with a given precision and scale.
+   */
+  def set(decimal: BigDecimal, precision: Int, scale: Int): DecimalOperation[T] = {
+    val scaledDecimal = decimal.setScale(scale, ROUND_HALF_UP)
+    if (scaledDecimal.precision > precision) {
+      throw QueryExecutionErrors.decimalPrecisionExceedsMaxPrecisionError(
+        scaledDecimal.precision, precision)
+    }
+    setBigDecimal(scaledDecimal)
+    this.longVal = 0L
+    this._precision = precision
+    this._scale = scale
+    this
+  }
+
+  /**
+   * Set this DecimalOperation to the given BigDecimal value, inheriting its precision and scale.
+   */
+  def set(decimal: BigDecimal): DecimalOperation[T] = {
+    setBigDecimal(decimal)
+    this.longVal = 0L
+    if (decimal.precision < decimal.scale) {
+      // For Decimal, we expect the precision is equal to or large than the scale, however,
+      // in BigDecimal, the digit count starts from the leftmost nonzero digit of the exact
+      // result. For example, the precision of 0.01 equals to 1 based on the definition, but
+      // the scale is 2. The expected precision should be 2.
+      this._precision = decimal.scale
+      this._scale = decimal.scale
+    } else if (decimal.scale < 0 && !SQLConf.get.allowNegativeScaleOfDecimalEnabled) {
+      this._precision = decimal.precision - decimal.scale
+      this._scale = 0
+      // set scale to 0 to correct unscaled value
+      setBigDecimal(decimal.setScale(0))
+    } else {
+      this._precision = decimal.precision
+      this._scale = decimal.scale
+    }
+    this
+  }
+
+  /**
+   * If the value is not in the range of long, convert it to BigDecimal and
+   * the precision and scale are based on the converted value.
+   *
+   * This code avoids BigDecimal object allocation as possible to improve runtime efficiency
+   */
+  def set(bigintval: BigInteger): DecimalOperation[T] = {
+    try {
+      setNull()
+      this.longVal = bigintval.longValueExact()
+      this._precision = DecimalType.MAX_PRECISION
+      this._scale = 0
+      this
+    } catch {
+      case _: ArithmeticException =>
+        set(BigDecimal(bigintval))
+    }
+  }
+
+  /**
+   * Set this DecimalOperation to the given DecimalOperation value.
+   */
+  def set(decimalOperation: T): DecimalOperation[T] = {
+    copy(decimalOperation)
+    this.longVal = decimalOperation.longVal
+    this._precision = decimalOperation._precision
+    this._scale = decimalOperation._scale
+    this
+  }
+
+  def toBigDecimal: BigDecimal = if (isNotNull()) {
+    getAsBigDecimal()
+  } else {
+    BigDecimal(longVal, _scale)
+  }
+
+  def getAsBigDecimal(): BigDecimal
+
+  def toJavaBigDecimal: java.math.BigDecimal = if (isNotNull()) {
+    getAsJavaBigDecimal()
+  } else {
+    java.math.BigDecimal.valueOf(longVal, _scale)
+  }
+
+  protected def getAsJavaBigDecimal(): java.math.BigDecimal
+
+  def toScalaBigInt: BigInt = if (isNotNull()) {
+    getAsBigDecimal().toBigInt
+  } else {
+    BigInt(toLong)
+  }
+
+  def toJavaBigInteger: java.math.BigInteger = if (isNotNull()) {
+    getAsJavaBigInteger()
+  } else {
+    java.math.BigInteger.valueOf(toLong)
+  }
+
+  protected def getAsJavaBigInteger(): java.math.BigInteger
+
+  def toUnscaledLong: Long = if (isNotNull()) {
+    getAsJavaBigDecimal().unscaledValue().longValueExact()
+  } else {
+    longVal
+  }
+
+  def toDebugString: String = if (isNotNull()) {
+    s"Decimal(expanded, ${getAsBigDecimal()}, $precision, $scale)"
+  } else {
+    s"Decimal(compact, $longVal, $precision, $scale)"
+  }
+
+  def toLong: Long = if (isNull()) {
+    longVal / POW_10(_scale)
+  } else {
+    getAsBigDecimal().longValue
+  }
+
+  def roundToNumeric[T <: AnyVal](integralType: IntegralType, maxValue: Int, minValue: Int)
+      (f1: Long => T) (f2: Double => T): T = {
+    if (isNull()) {
+      val actualLongVal = longVal / POW_10(_scale)
+      val numericVal = f1(actualLongVal)
+      if (actualLongVal == numericVal) {
+        numericVal
+      } else {
+        throw QueryExecutionErrors.castingCauseOverflowError(
+          this, DecimalType(this.precision, this.scale), integralType)
+      }
+    } else {
+      val doubleVal = getAsBigDecimal().toDouble
+      if (Math.floor(doubleVal) <= maxValue && Math.ceil(doubleVal) >= minValue) {
+        f2(doubleVal)
+      } else {
+        throw QueryExecutionErrors.castingCauseOverflowError(
+          this, DecimalType(this.precision, this.scale), integralType)
+      }
+    }
+  }
+
+  def roundToLong(): Long = if (isNull()) {
+    longVal / POW_10(_scale)
+  } else {
+    try {
+      // We cannot store Long.MAX_VALUE as a Double without losing precision.
+      // Here we simply convert the decimal to `BigInteger` and use the method
+      // `longValueExact` to make sure the range check is accurate.
+      getAsJavaBigDecimal().toBigInteger.longValueExact()
+    } catch {
+      case _: ArithmeticException =>
+        throw QueryExecutionErrors.castingCauseOverflowError(
+          this, DecimalType(this.precision, this.scale), LongType)
+    }
+  }
+
+  /**
+   * Update precision and scale while keeping our value the same, and return true if successful.
+   *
+   * @return true if successful, false if overflow would occur
+   */
+  def changePrecision(
+      precision: Int,
+      scale: Int,
+      roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+    // fast path for UnsafeProjection
+    if (precision == this.precision && scale == this.scale) {
+      return true
+    }
+    DecimalType.checkNegativeScale(scale)
+    var lv = longVal
+    // First, update our lv if we can, or transfer over to using a BigDecimal
+    if (isNull()) {
+      if (scale < _scale) {
+        // Easier case: we just need to divide our scale down
+        val diff = _scale - scale
+        val pow10diff = POW_10(diff)
+        // % and / always round to 0
+        val droppedDigits = lv % pow10diff
+        lv /= pow10diff
+        roundMode match {
+          case ROUND_FLOOR =>
+            if (droppedDigits < 0) {
+              lv += -1L
+            }
+          case ROUND_CEILING =>
+            if (droppedDigits > 0) {
+              lv += 1L
+            }
+          case ROUND_HALF_UP =>
+            if (math.abs(droppedDigits) * 2 >= pow10diff) {
+              lv += (if (droppedDigits < 0) -1L else 1L)
+            }
+          case ROUND_HALF_EVEN =>
+            val doubled = math.abs(droppedDigits) * 2
+            if (doubled > pow10diff || doubled == pow10diff && lv % 2 != 0) {
+              lv += (if (droppedDigits < 0) -1L else 1L)
+            }
+          case _ =>
+            throw QueryExecutionErrors.unsupportedRoundingMode(roundMode)
+        }
+      } else if (scale > _scale) {
+        // We might be able to multiply lv by a power of 10 and not overflow, but if not,
+        // switch to using a BigDecimal
+        val diff = scale - _scale
+        val p = POW_10(math.max(MAX_LONG_DIGITS - diff, 0))
+        if (diff <= MAX_LONG_DIGITS && lv > -p && lv < p) {
+          // Multiplying lv by POW_10(diff) will still keep it below MAX_LONG_DIGITS
+          lv *= POW_10(diff)
+        } else {
+          // Give up on using Longs; switch to BigDecimal, which we'll modify below
+          setLong(lv, _scale)
+        }
+      }
+      // In both cases, we will check whether our precision is okay below
+    }
+
+    if (isNotNull()) {
+      // We get here if either we started with a BigDecimal, or we switched to one because we would
+      // have overflowed our Long; in either case we must rescale dv to the new scale.
+      if (!rescale(scale, roundMode)) {
+        return false
+      }
+    } else {
+      // We're still using Longs, but we should check whether we match the new precision
+      val p = POW_10(math.min(precision, MAX_LONG_DIGITS))
+      if (lv <= -p || lv >= p) {
+        // Note that we shouldn't have been able to fix this by switching to BigDecimal
+        return false
+      }
+    }
+    longVal = lv
+    _precision = precision
+    _scale = scale
+    true
+  }
+
+  protected def rescale(scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean
+
+  def compare(that: T): Int =
+    if (isNull() && that.isNull() && _scale == that._scale) {
+      if (longVal < that.longVal) -1 else if (longVal == that.longVal) 0 else 1
+    } else {
+      doCompare(that)
+    }
+
+  protected def doCompare(other: T): Int
+
+  def isZero: Boolean = if (isNotNull()) isEqualsZero() else longVal == 0
+
+  protected def isEqualsZero(): Boolean
+
+  def add(that: T): T = {
+    if (isNull() && that.isNull() && _scale == that._scale) {
+      val newDecimalOperation = newInstance()
+      newDecimalOperation.set(
+        longVal + that.longVal, Math.max(precision, that.precision) + 1, scale)
+      newDecimalOperation
+    } else {
+      doAdd(that)
+    }
+  }
+
+  protected def doAdd(that: T): T
+
+  def subtract(that: T): T = {
+    if (isNull() && that.isNull() && _scale == that._scale) {
+      val newDecimalOperation = newInstance()
+      newDecimalOperation.set(
+        longVal - that.longVal, Math.max(precision, that.precision) + 1, scale)
+      newDecimalOperation
+    } else {
+      doSubtract(that)
+    }
+  }
+
+  protected def doSubtract(that: T): T
+
+  def multiply(that: T): T
+
+  def divide(that: T): T
+
+  def remainder(that: T): T
+
+  def quot(that: T): T
+
+  def negative: T = if (isNotNull()) {
+    doNegative
+  } else {
+    val newDecimalOperation = newInstance()
+    newDecimalOperation.set(-longVal, precision, scale)
+    newDecimalOperation
+  }
+
+  def doNegative: T
+
+  protected def copy(from: T): Unit
+}
+
+object DecimalOperation {
+
+  def createDecimalOperation[T <: DecimalOperation[T]](): T =
+    if (SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "JDKBigDecimal") {
+      new JDKDecimalOperation().asInstanceOf[T]
+    } else {
+      new Decimal128Operation().asInstanceOf[T]
+    }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -22,7 +22,7 @@ import java.math.BigInteger
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 
-trait DecimalOperation[T <: DecimalOperation[T]] {
+trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
   import org.apache.spark.sql.types.Decimal._
 
   private var longVal: Long = 0L

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -411,13 +411,3 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
 
   protected def copy(from: T): Unit
 }
-
-object DecimalOperation {
-
-  def createDecimalOperation[T <: DecimalOperation[T]](): T =
-    if (SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "JDKBigDecimal") {
-      new JDKDecimalOperation().asInstanceOf[T]
-    } else {
-      new Decimal128Operation().asInstanceOf[T]
-    }
-}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -260,7 +260,7 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
       // We cannot store Long.MAX_VALUE as a Double without losing precision.
       // Here we simply convert the decimal to `BigInteger` and use the method
       // `longValueExact` to make sure the range check is accurate.
-      getAsJavaBigDecimal().toBigInteger.longValueExact()
+      getAsJavaBigInteger().longValueExact()
     } catch {
       case _: ArithmeticException =>
         throw QueryExecutionErrors.castingCauseOverflowError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.internal.SQLConf
 trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
   import org.apache.spark.sql.types.Decimal._
 
-  private var longVal: Long = 0L
+  protected var longVal: Long = 0L
   protected var _precision: Int = 1
   protected var _scale: Int = 0
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -329,7 +329,7 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
     if (isNotNull()) {
       // We get here if either we started with a BigDecimal, or we switched to one because we would
       // have overflowed our Long; in either case we must rescale dv to the new scale.
-      if (!rescale(scale, roundMode)) {
+      if (!rescale(precision, scale, roundMode)) {
         return false
       }
     } else {
@@ -346,7 +346,8 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
     true
   }
 
-  protected def rescale(scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean
+  protected def rescale(
+      precision: Int, scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean
 
   def compare(that: T): Int =
     if (isNull() && that.isNull() && _scale == that._scale) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/DecimalOperation.scala
@@ -196,16 +196,18 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
 
   protected def getAsJavaBigDecimal(): java.math.BigDecimal
 
+  private def actualLongVal: Long = longVal / POW_10(_scale)
+
   def toScalaBigInt: BigInt = if (isNotNull()) {
     getAsBigDecimal().toBigInt
   } else {
-    BigInt(toLong)
+    BigInt(actualLongVal)
   }
 
   def toJavaBigInteger: java.math.BigInteger = if (isNotNull()) {
     getAsJavaBigInteger()
   } else {
-    java.math.BigInteger.valueOf(toLong)
+    java.math.BigInteger.valueOf(actualLongVal)
   }
 
   protected def getAsJavaBigInteger(): java.math.BigInteger
@@ -223,7 +225,7 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
   }
 
   def toLong: Long = if (isNull()) {
-    longVal / POW_10(_scale)
+    actualLongVal
   } else {
     getAsBigDecimal().longValue
   }
@@ -234,7 +236,6 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
       maxValue: Int,
       minValue: Int) (f1: Long => T) (f2: Double => T): T = {
     if (isNull()) {
-      val actualLongVal = longVal / POW_10(_scale)
       val numericVal = f1(actualLongVal)
       if (actualLongVal == numericVal) {
         numericVal
@@ -254,7 +255,7 @@ trait DecimalOperation[T <: DecimalOperation[T]] extends Serializable {
   }
 
   def roundToLong(decimal: Decimal): Long = if (isNull()) {
-    longVal / POW_10(_scale)
+    actualLongVal
   } else {
     try {
       // We cannot store Long.MAX_VALUE as a Double without losing precision.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
@@ -154,7 +154,7 @@ final class Int128 extends Ordered[Int128] with Serializable {
     JLong.hashCode(hash)
   }
 
-  override def toString: String = toBigInteger.toString
+  override def toString: String = s"Int128($high, $low)"
 }
 
 @Unstable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
@@ -121,7 +121,8 @@ final class Int128 extends Ordered[Int128] with Serializable {
   def % (that: Int128): Int128 = if (that.isZero) {
     null
   } else {
-    val (newHigh, newLow) = Int128Math.remainder(this._high, this._low, that.high, that.low, 0, 0)
+    val (newHigh, newLow) =
+      Int128Math.remainder(this._high, this._low, that.high, that.low, 0, 0, false)
 
     Int128(newHigh, newLow)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Int128.scala
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import java.lang.{Long => JLong}
+import java.math.BigInteger
+import java.nio.{ByteBuffer, ByteOrder}
+
+import scala.util.Try
+
+import org.apache.spark.annotation.Unstable
+import org.apache.spark.sql.util.Int128Math
+
+/**
+ * A mutable implementation of Int128 that hold two Long values to represent the high and low bits
+ * of 128 bits respectively.
+ *
+ * The semantics of the fields are as follows:
+ * - _high and _low represent the high and low bits of 128 bits respectively
+ */
+@Unstable
+final class Int128 extends Ordered[Int128] with Serializable {
+
+  private var _high: Long = 0L
+  private var _low: Long = 0L
+
+  def high: Long = _high
+  def low: Long = _low
+
+  def set(high: Long, low: Long): Int128 = {
+    _high = high
+    _low = low
+    this
+  }
+
+  def set(value: Long): Int128 = set(value >> 63, value)
+
+  def set(bigInteger: BigInteger): Int128 = {
+    _low = bigInteger.longValue()
+    try {
+      _high = bigInteger.shiftRight(64).longValueExact()
+    } catch {
+      case _: ArithmeticException =>
+        throw new ArithmeticException("BigInteger out of Int128 range")
+    }
+
+    this
+  }
+
+  def isPositive(): Boolean = _high > 0 || (_high == 0 && _low != 0)
+
+  def isNegative(): Boolean = _high < 0
+
+  def isZero(): Boolean = (_high | _low) == 0
+
+  def toBigInteger: BigInteger = new BigInteger(toBigEndianBytes())
+
+  def toBigEndianBytes(): Array[Byte] = {
+    val bytes = new Array[Byte](16)
+    toBigEndianBytes(bytes, 0)
+    bytes
+  }
+
+  def toBigEndianBytes(bytes: Array[Byte], offset: Int): Unit = {
+    val byteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+    byteBuffer.putLong(offset, high)
+    byteBuffer.putLong(offset + JLong.BYTES, low)
+  }
+
+  def toDouble: Double = toLong.doubleValue
+
+  def toFloat: Float = toLong.floatValue
+
+  def toLong(): Long = low
+
+  def toInt: Int = toLong.toInt
+
+  def scaleUpTen(n: Int): Int128 = {
+    this * Int128(n >> 63, n)
+  }
+
+  def + (that: Int128): Int128 = {
+    val (newHigh, newLow) = Int128Math.add(this, that)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def - (that: Int128): Int128 = {
+    val (newHigh, newLow) = Int128Math.subtract(this, that)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def * (that: Int128): Int128 = {
+    val (newHigh, newLow) = Int128Math.multiply(this, that)
+    new Int128().set(newHigh, newLow)
+  }
+
+  def / (that: Int128): Int128 = if (that.isZero) {
+    null
+  } else {
+    val (newHigh, newLow) =
+      Int128Math.divideRoundUp(this._high, this._low, that.high, that.low, 0, 0)
+
+    Int128(newHigh, newLow)
+  }
+
+  def % (that: Int128): Int128 = if (that.isZero) {
+    null
+  } else {
+    val (newHigh, newLow) = Int128Math.remainder(this._high, this._low, that.high, that.low, 0, 0)
+
+    Int128(newHigh, newLow)
+  }
+
+  def quot (that: Int128): Int128 = this / that
+
+  def unary_- : Int128 = {
+    val newHigh = Int128Math.negateHigh(this.high, this.low)
+    val newLow = Int128Math.negateLow(this.low)
+    new Int128().set(newHigh, newLow)
+  }
+
+  override def compare(other: Int128): Int = {
+    Int128.compare(this.high, this.low, other.high, other.low)
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case d: Int128 =>
+      compare(d) == 0
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = {
+    // FNV-1a style hash
+    var hash = 0x9E3779B185EBCA87L
+    hash = (hash ^ high) * 0xC2B2AE3D27D4EB4FL
+    hash = (hash ^ low) * 0xC2B2AE3D27D4EB4FL
+    JLong.hashCode(hash)
+  }
+
+  override def toString: String = toBigInteger.toString
+}
+
+@Unstable
+object Int128 {
+
+  def apply(high: Long, low: Long): Int128 = new Int128().set(high, low)
+
+  def apply(value: Long): Int128 = new Int128().set(value)
+
+  def apply(bigInteger: BigInteger): Int128 = new Int128().set(bigInteger)
+
+  def apply(value: String): Int128 = new Int128().set(new BigInteger(value))
+
+  val ZERO = Int128(0, 0)
+  val ONE = Int128(0, 1)
+  val MAX_VALUE = Int128(0x7FFFFFFFFFFFFFFFL, 0xFFFFFFFFFFFFFFFFL)
+  val MIN_VALUE = Int128(0x8000000000000000L, 0x0000000000000000L)
+  val MAX_UNSCALED_DECIMAL = Int128("99999999999999999999999999999999999999")
+  val MIN_UNSCALED_DECIMAL = Int128("-99999999999999999999999999999999999999")
+
+  def compare(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): Int = {
+    var comparison = JLong.compare(leftHigh, rightHigh)
+    if (comparison == 0) {
+      comparison = JLong.compareUnsigned(leftLow, rightLow)
+    }
+
+    comparison
+  }
+
+  def overflows(high: Long, low: Long): Boolean = {
+    compare(high, low, MAX_UNSCALED_DECIMAL.high, MAX_UNSCALED_DECIMAL.low) > 0 ||
+      compare(high, low, MIN_UNSCALED_DECIMAL.high, MIN_UNSCALED_DECIMAL.low) < 0
+  }
+
+  /** Common methods for Int128 evidence parameters */
+  private[sql] trait Int128IsConflicted extends Numeric[Int128] {
+    override def plus(x: Int128, y: Int128): Int128 = x + y
+    override def times(x: Int128, y: Int128): Int128 = x * y
+    override def minus(x: Int128, y: Int128): Int128 = x - y
+    override def negate(x: Int128): Int128 = -x
+    override def toDouble(x: Int128): Double = x.toDouble
+    override def toFloat(x: Int128): Float = x.toFloat
+    override def toInt(x: Int128): Int = x.toInt
+    override def toLong(x: Int128): Long = x.toLong
+    override def fromInt(x: Int): Int128 = new Int128().set(0, x)
+    override def compare(x: Int128, y: Int128): Int = x.compare(y)
+
+    def parseString(str: String): Option[Int128] = Try(Int128(str)).toOption
+  }
+
+  /** A [[scala.math.Integral]] evidence parameter for Int128s. */
+  private[sql] object Int128IsIntegral extends Int128IsConflicted with Integral[Int128] {
+    override def quot(x: Int128, y: Int128): Int128 = x quot y
+    override def rem(x: Int128, y: Int128): Int128 = x % y
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
@@ -68,18 +68,12 @@ class JDKDecimalOperation extends DecimalOperation[JDKDecimalOperation] {
 
   def isEqualsZero(): Boolean = this.decimalVal.signum == 0
 
-  def doAdd(that: JDKDecimalOperation): JDKDecimalOperation = {
-    val jDKDecimalOperation = new JDKDecimalOperation()
-    val newBigDecimal = toJavaBigDecimal.add(that.toJavaBigDecimal)
-    jDKDecimalOperation.set(newBigDecimal)
-    jDKDecimalOperation
+  def doAdd(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {
+    (left, right) => left.add(right)
   }
 
-  def doSubtract(that: JDKDecimalOperation): JDKDecimalOperation = {
-    val jDKDecimalOperation = new JDKDecimalOperation()
-    val newBigDecimal = toJavaBigDecimal.subtract(that.toJavaBigDecimal)
-    jDKDecimalOperation.set(newBigDecimal)
-    jDKDecimalOperation
+  def doSubtract(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {
+    (left, right) => left.subtract(right)
   }
 
   def multiply(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types
+
+import java.math.{MathContext, RoundingMode}
+
+import org.apache.spark.annotation.Unstable
+
+@Unstable
+class JDKDecimalOperation extends DecimalOperation[JDKDecimalOperation] {
+  import org.apache.spark.sql.types.JDKDecimalOperation._
+
+  private var decimalVal: BigDecimal = null
+
+  def newInstance(): JDKDecimalOperation = new JDKDecimalOperation()
+
+  def setLong(longVal: Long): Unit = {
+    this.decimalVal = BigDecimal(longVal)
+  }
+
+  def setLong(unscaled: Long, scale: Int): Unit = {
+    this.decimalVal = BigDecimal(unscaled, scale)
+  }
+
+  def setBigDecimal(decimalVal: BigDecimal): Unit = {
+    this.decimalVal = decimalVal
+  }
+
+  def setNull: Unit = {
+    this.decimalVal = null
+  }
+
+  def isNull(): Boolean = decimalVal.eq(null)
+
+  def isNotNull(): Boolean = decimalVal.ne(null)
+
+  def getAsBigDecimal(): BigDecimal = this.decimalVal
+
+  def getAsJavaBigDecimal(): java.math.BigDecimal = this.decimalVal.underlying()
+
+  def getAsJavaBigInteger(): java.math.BigInteger = this.decimalVal.underlying().toBigInteger
+
+  def rescale(scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+    val newDecimalVal = this.decimalVal.setScale(scale, roundMode)
+    if (newDecimalVal.precision > precision) {
+      return false
+    }
+    this.decimalVal = newDecimalVal
+    true
+  }
+
+  def doCompare(other: JDKDecimalOperation): Int = toBigDecimal.compare(other.toBigDecimal)
+
+  def isEqualsZero(): Boolean = this.decimalVal == BIG_DEC_ZERO
+
+  def doAdd(that: JDKDecimalOperation): JDKDecimalOperation = {
+    val jDKDecimalOperation = new JDKDecimalOperation()
+    val newBigDecimal = toBigDecimal.bigDecimal.add(that.toBigDecimal.bigDecimal)
+    jDKDecimalOperation.set(newBigDecimal)
+    jDKDecimalOperation
+  }
+
+  def doSubtract(that: JDKDecimalOperation): JDKDecimalOperation = {
+    val jDKDecimalOperation = new JDKDecimalOperation()
+    val newBigDecimal = toBigDecimal.bigDecimal.subtract(that.toBigDecimal.bigDecimal)
+    jDKDecimalOperation.set(newBigDecimal)
+    jDKDecimalOperation
+  }
+
+  def multiply(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {
+    (left, right) => left.multiply(right, MATH_CONTEXT)
+  }
+
+  def divide(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {
+    (left, right) => left.divide(right, DecimalType.MAX_SCALE, MATH_CONTEXT.getRoundingMode)
+  }
+
+  def remainder(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {
+    (left, right) => left.remainder(right, MATH_CONTEXT)
+  }
+
+  def quot(that: JDKDecimalOperation): JDKDecimalOperation = withNewInstance(this, that) {
+    (left, right) => left.divideToIntegralValue(right, MATH_CONTEXT)
+  }
+
+  def doNegative: JDKDecimalOperation = {
+    val newDecimalOperation = new JDKDecimalOperation()
+    newDecimalOperation.set(-this.decimalVal, precision, scale)
+    newDecimalOperation
+  }
+
+  def copy(from: JDKDecimalOperation): Unit = {
+    this.decimalVal = from.decimalVal
+  }
+}
+
+@Unstable
+object JDKDecimalOperation {
+  private val BIG_DEC_ZERO = BigDecimal(0)
+
+  val MATH_CONTEXT = new MathContext(DecimalType.MAX_PRECISION, RoundingMode.HALF_UP)
+
+  def withNewInstance(
+      left: JDKDecimalOperation,
+      right: JDKDecimalOperation)
+      (f: (java.math.BigDecimal, java.math.BigDecimal) => BigDecimal): JDKDecimalOperation = {
+    val jDKDecimalOperation = new JDKDecimalOperation()
+    val newBigDecimal = f(left.toJavaBigDecimal, right.toJavaBigDecimal)
+    jDKDecimalOperation.set(newBigDecimal)
+    jDKDecimalOperation
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
@@ -55,7 +55,7 @@ class JDKDecimalOperation extends DecimalOperation[JDKDecimalOperation] {
 
   def getAsJavaBigInteger(): java.math.BigInteger = this.decimalVal.underlying().toBigInteger
 
-  def rescale(scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
+  def rescale(precision: Int, scale: Int, roundMode: BigDecimal.RoundingMode.Value): Boolean = {
     val newDecimalVal = this.decimalVal.setScale(scale, roundMode)
     if (newDecimalVal.precision > precision) {
       return false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/JDKDecimalOperation.scala
@@ -66,18 +66,18 @@ class JDKDecimalOperation extends DecimalOperation[JDKDecimalOperation] {
 
   def doCompare(other: JDKDecimalOperation): Int = toBigDecimal.compare(other.toBigDecimal)
 
-  def isEqualsZero(): Boolean = this.decimalVal == BIG_DEC_ZERO
+  def isEqualsZero(): Boolean = this.decimalVal.signum == 0
 
   def doAdd(that: JDKDecimalOperation): JDKDecimalOperation = {
     val jDKDecimalOperation = new JDKDecimalOperation()
-    val newBigDecimal = toBigDecimal.bigDecimal.add(that.toBigDecimal.bigDecimal)
+    val newBigDecimal = toJavaBigDecimal.add(that.toJavaBigDecimal)
     jDKDecimalOperation.set(newBigDecimal)
     jDKDecimalOperation
   }
 
   def doSubtract(that: JDKDecimalOperation): JDKDecimalOperation = {
     val jDKDecimalOperation = new JDKDecimalOperation()
-    val newBigDecimal = toBigDecimal.bigDecimal.subtract(that.toBigDecimal.bigDecimal)
+    val newBigDecimal = toJavaBigDecimal.subtract(that.toJavaBigDecimal)
     jDKDecimalOperation.set(newBigDecimal)
     jDKDecimalOperation
   }
@@ -111,7 +111,6 @@ class JDKDecimalOperation extends DecimalOperation[JDKDecimalOperation] {
 
 @Unstable
 object JDKDecimalOperation {
-  private val BIG_DEC_ZERO = BigDecimal(0)
 
   val MATH_CONTEXT = new MathContext(DecimalType.MAX_PRECISION, RoundingMode.HALF_UP)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/Int128Math.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/Int128Math.scala
@@ -1,0 +1,1097 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.util
+
+import java.lang.{Long => JLong}
+import java.lang.Math.{pow, round}
+import java.math.BigInteger
+import java.util.Arrays
+
+import org.apache.spark.sql.types.Int128
+
+object Int128Math {
+
+  val MAX_PRECISION = 38
+
+  // Lowest 32 bits of a long
+  private val LOW_32_BITS = 0xFFFFFFFFL
+
+  // 1..10^38 (largest value < Int128.MAX_VALUE)
+  private val POWERS_OF_TEN = Array.tabulate[Int128](39)(i => Int128(BigInteger.TEN.pow(i)))
+
+  // 5^54 is the largest value < Int128.MAX_VALUE
+  private val POWERS_OF_FIVE =
+    Array.tabulate[Int128](54)(i => Int128(BigInteger.valueOf(5).pow(i)))
+
+  private val LONG_POWERS_OF_TEN_TABLE_LENGTH = 19
+
+  // Although this computes using doubles, incidentally,
+  // this is exact for all powers of 10 that fit in a long.
+  private val LONG_POWERS_OF_TEN =
+    Array.tabulate[Long](LONG_POWERS_OF_TEN_TABLE_LENGTH)(i => round(pow(10, i)))
+
+  /**
+   * 5^13 fits in 2^31.
+   */
+  private val MAX_POWER_OF_FIVE_INT = 13
+
+  /**
+   * 5^x. All unsigned values.
+   */
+  private val POWERS_OF_FIVES_INT = new Array[Int](MAX_POWER_OF_FIVE_INT + 1)
+  POWERS_OF_FIVES_INT(0) = 1
+  for (i <- 1 until POWERS_OF_FIVES_INT.length) {
+    POWERS_OF_FIVES_INT(i) = POWERS_OF_FIVES_INT(i - 1) * 5
+  }
+
+  /**
+   * 5^27 fits in 2^31.
+   */
+  private val MAX_POWER_OF_FIVE_LONG = 27
+
+  /**
+   * 5^x. All unsigned values.
+   */
+  private val POWERS_OF_FIVE_LONG = new Array[Long](MAX_POWER_OF_FIVE_LONG + 1)
+  POWERS_OF_FIVE_LONG(0) = 1
+  for (i <- 1 until POWERS_OF_FIVE_LONG.length) {
+    POWERS_OF_FIVE_LONG(i) = POWERS_OF_FIVE_LONG(i - 1) * 5
+  }
+
+  /**
+   * 10^9 fits in 2^31.
+   */
+  private val MAX_POWER_OF_TEN_INT = 9
+
+  /**
+   * 10^18 fits in 2^63.
+   */
+  private val MAX_POWER_OF_TEN_LONG = 18
+
+  /**
+   * 10^x. All unsigned values.
+   */
+  private val POWERS_OF_TEN_INT = new Array[Int](MAX_POWER_OF_TEN_INT + 1)
+  POWERS_OF_TEN_INT(0) = 1
+  for (i <- 1 until POWERS_OF_TEN_INT.length) {
+    POWERS_OF_TEN_INT(i) = POWERS_OF_TEN_INT(i - 1) * 10
+  }
+
+  private val NUMBER_OF_LONGS = 2
+  private val NUMBER_OF_INTS = 2 * NUMBER_OF_LONGS
+
+  private val INT_BASE = 1L << 32
+
+  def add(left: Int128, right: Int128): (Long, Long) =
+    add(left.high, left.low, right.high, right.low)
+
+  def add(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val carry = unsignedCarry(leftLow, rightLow)
+
+    val resultHigh = leftHigh + rightHigh + carry
+    val resultLow = leftLow + rightLow
+
+    if (((resultHigh ^ leftHigh) & (resultHigh ^ rightHigh)) < 0) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) add Int128($rightHigh, $rightLow).")
+    }
+
+    (resultHigh, resultLow)
+  }
+
+  def subtract(left: Int128, right: Int128): (Long, Long) =
+    subtract(left.high, left.low, right.high, right.low)
+
+  def subtract(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val borrow = unsignedBorrow(leftLow, rightLow)
+
+    val resultHigh = leftHigh - rightHigh - borrow
+    val resultLow = leftLow - rightLow
+
+    if (((leftHigh ^ rightHigh) & (leftHigh ^ resultHigh)) < 0) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) subtract Int128($rightHigh, $rightLow).")
+    }
+
+    (resultHigh, resultLow)
+  }
+
+  def multiply(left: Int128, right: Int128): (Long, Long) =
+    multiply(left.high, left.low, right.high, right.low)
+
+  def multiply(leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val leftNegative = leftHigh < 0
+    val rightNegative = rightHigh < 0
+
+    var tmpLeftLow = leftLow
+    var tmpLeftHigh = leftHigh
+    if (leftNegative) {
+      tmpLeftLow = negateLow(tmpLeftLow)
+      tmpLeftHigh = negateHighExact(tmpLeftHigh, tmpLeftLow)
+    }
+
+    var tmpRightLow = rightLow
+    var tmpRightHigh = rightHigh
+    if (rightNegative) {
+      tmpRightLow = negateLow(tmpRightLow)
+      tmpRightHigh = negateHighExact(tmpRightHigh, tmpRightLow)
+    }
+
+    val result = multiplyPositives(tmpLeftHigh, tmpLeftLow, tmpRightHigh, tmpRightLow)
+
+    if (leftNegative == rightNegative) {
+      result
+    } else {
+      (negateHighExact(result._1, result._2), negateLow(result._2))
+    }
+  }
+
+  def divideRoundUp(
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      leftScale: Int,
+      rightScale: Int): (Long, Long) = {
+    if (leftScale > MAX_PRECISION) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) with scale $leftScale exceeding the max precision.")
+    }
+
+    if (rightScale > MAX_PRECISION) {
+      throw int128OverflowException(
+        s"Int128($rightHigh, $rightLow) with scale $rightScale exceeding the max precision.")
+    }
+
+    val dividendIsNegative = leftHigh < 0
+    val divisorIsNegative = rightHigh < 0
+    val quotientIsNegative = dividendIsNegative != divisorIsNegative
+
+    var tmpLeftLow = leftLow
+    var tmpLeftHigh = leftHigh
+    if (dividendIsNegative) {
+      tmpLeftLow = negateLow(tmpLeftHigh)
+      tmpLeftHigh = negateHighExact(tmpLeftLow, tmpLeftHigh)
+    }
+
+    var tmpRightLow = rightLow
+    var tmpRightHigh = rightHigh
+    if (divisorIsNegative) {
+      tmpRightLow = negateLow(tmpRightLow)
+      tmpRightHigh = negateHighExact(tmpRightHigh, tmpRightLow)
+    }
+
+    val (quotient, remainder) =
+      dividePositives(tmpLeftHigh, tmpLeftLow, tmpRightHigh, tmpRightLow, leftScale, rightScale)
+
+    // if (2 * remainder >= divisor) - increment quotient by one
+    val (remainderHigh, remainderLow) = shiftLeft(remainder._1, remainder._2, 1)
+
+    val (quotientHigh, quotientLow) =
+      if (compareUnsigned(remainderHigh, remainderLow, tmpRightHigh, tmpRightLow) >= 0) {
+        incrementUnsafe(quotient._1, quotient._2)
+      } else {
+        (quotient._1, quotient._2)
+      }
+
+    if (quotientIsNegative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(quotientHigh, quotientLow)
+    } else {
+      (quotientHigh, quotientLow)
+    }
+  }
+
+  def remainder(
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      leftScale: Int,
+      rightScale: Int): (Long, Long) = {
+    val dividendIsNegative = leftHigh < 0
+    val divisorIsNegative = rightHigh < 0
+
+    var tmpLeftLow = leftLow
+    var tmpLeftHigh = leftHigh
+    if (dividendIsNegative) {
+      tmpLeftLow = negateLow(tmpLeftLow)
+      tmpLeftHigh = negateHighExact(tmpLeftHigh, tmpLeftLow)
+    }
+
+    var tmpRightLow = rightLow
+    var tmpRightHigh = rightHigh
+    if (divisorIsNegative) {
+      tmpRightLow = negateLow(tmpRightLow)
+      tmpRightHigh = negateHighExact(tmpRightHigh, tmpRightLow)
+    }
+
+    val (_, remainder) =
+      dividePositives(tmpLeftHigh, tmpLeftLow, tmpRightHigh, tmpRightLow, leftScale, rightScale)
+
+    if (dividendIsNegative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(remainder._1, remainder._2)
+    } else {
+      (remainder._1, remainder._2)
+    }
+  }
+
+  def rescaleFactor(fromScale: Long, toScale: Long): Int =
+    Integer.max(0, toScale.toInt - fromScale.toInt)
+
+  def shiftLeft(high: Long, low: Long, shift: Int): (Long, Long) = {
+    var tmpHigh = high
+    var tmpLow = low
+
+    if (shift < 64) {
+      tmpHigh = (tmpHigh << shift) | (low >>> 1 >>> (63 - shift))
+      tmpLow = tmpLow << shift
+    }
+    else {
+      tmpHigh = tmpLow << (shift - 64)
+      tmpLow = 0
+    }
+
+    (tmpHigh, tmpLow)
+  }
+
+  def rescale(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (rescale == 0) {
+      (high, low)
+    } else if (rescale > 0) {
+      shiftLeftBy10(high, low, rescale)
+    } else {
+      scaleDownRoundUp(high, low, -rescale)
+    }
+  }
+
+  def rescaleTruncate(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (rescale == 0) {
+      (high, low)
+    } else if (rescale > 0) {
+      shiftLeftBy10(high, low, rescale)
+    } else {
+      scaleDownTruncate(high, low, -rescale)
+    }
+  }
+
+  /**
+   * Multiplies by 10^rescaleFactor. Only positive rescaleFactor values are allowed.
+   */
+  def shiftLeftBy10(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (rescale >= POWERS_OF_TEN.length) {
+      throw int128OverflowException(s"Rescale Int128($high, $low) with $rescale.")
+    }
+
+    val negative = high < 0
+
+    var tmpHigh = high
+    var tmpLow = low
+    if (negative) {
+      tmpHigh = negateHighExact(tmpHigh, tmpLow)
+      tmpLow = negateLow(tmpLow)
+    }
+
+    val result =
+      multiplyPositives(tmpHigh, tmpLow, POWERS_OF_TEN(rescale).high, POWERS_OF_TEN(rescale).low)
+
+    if (negative) {
+      (negateHighExact(result._1, result._2), negateLow(result._2))
+    } else {
+      result
+    }
+  }
+
+  private def negate(high: Long, low: Long): (Long, Long) = (negateHigh(high, low), negateLow(low))
+
+  def negateHighExact(high: Long, low: Long): Long = {
+    if (high == Int128.MIN_VALUE.high && low == Int128.MIN_VALUE.low) {
+      throw int128OverflowException(s"Cannot negate high exact for Int128($high, $low).")
+    }
+
+    negateHigh(high, low)
+  }
+
+  def negateHigh(high: Long, low: Long): Long = -high - (if (low == 0) 0 else 1)
+
+  def negateLow(low: Long): Long = -low
+
+  private def multiplyPositives(
+      leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): (Long, Long) = {
+    val z1High = MoreMath.unsignedMultiplyHigh(leftLow, rightLow)
+    val z1Low = leftLow * rightLow
+    val z2Low = leftLow * rightHigh
+    val z3Low = leftHigh * rightLow
+
+    val resultHigh = z1High + z2Low + z3Low
+    val resultLow = z1Low
+
+    if ((leftHigh != 0 && rightHigh != 0) ||
+      resultHigh < 0 || z1High < 0 || z2Low < 0 || z3Low < 0 ||
+      MoreMath.unsignedMultiplyHigh(leftLow, rightHigh) != 0 ||
+      MoreMath.unsignedMultiplyHigh(leftHigh, rightLow) != 0) {
+      throw int128OverflowException(
+        s"Int128($leftHigh, $leftLow) and Int128($rightHigh, $rightLow) in multiple positives.")
+    }
+
+    (resultHigh, resultLow)
+  }
+
+  private def dividePositives(
+      dividendHigh: Long, dividendLow: Long, divisor: Int): (Long, Long, Int) = {
+    var remainder = dividendHigh
+    val high = remainder / divisor
+    remainder %= divisor
+
+    remainder = highValue(dividendLow) + (remainder << 32)
+    val z1 = remainder / divisor
+    remainder %= divisor
+
+    remainder = lowValue(dividendLow) + (remainder << 32)
+    val z0 = remainder / divisor
+
+    val low = (z1 << 32) | (z0 & 0xFFFFFFFFL)
+
+    (high, low, (remainder % divisor).toInt)
+  }
+
+  private def dividePositives(
+      leftHigh: Long,
+      leftLow: Long,
+      rightHigh: Long,
+      rightLow: Long,
+      leftScale: Int,
+      rightScale: Int): ((Long, Long), (Long, Long)) = {
+    if (rightHigh == 0 && rightLow == 0) {
+      throw divisionByZeroException()
+    }
+
+    // to fit 128b * 128b * 32b unsigned multiplication
+    val dividend = new Array[Int](NUMBER_OF_INTS * 2 + 1)
+    dividend(0) = lowInt(leftLow)
+    dividend(1) = highInt(leftLow)
+    dividend(2) = lowInt(leftHigh)
+    dividend(3) = highInt(leftHigh)
+
+    if (leftScale > 0) {
+      shiftLeftBy5Destructive(dividend, leftScale)
+      shiftLeftMultiPrecision(dividend, NUMBER_OF_INTS * 2, leftScale)
+    }
+
+    val divisor = new Array[Int](NUMBER_OF_INTS * 2)
+    divisor(0) = lowInt(rightLow)
+    divisor(1) = highInt(rightLow)
+    divisor(2) = lowInt(rightHigh)
+    divisor(3) = highInt(rightHigh)
+
+    if (rightScale > 0) {
+      shiftLeftBy5Destructive(divisor, rightScale)
+      shiftLeftMultiPrecision(divisor, NUMBER_OF_INTS * 2, rightScale)
+    }
+
+    val multiPrecisionQuotient = new Array[Int](NUMBER_OF_INTS * 2)
+    divideUnsignedMultiPrecision(dividend, divisor, multiPrecisionQuotient)
+
+    val quotient = pack(multiPrecisionQuotient)
+    val remainder = pack(dividend)
+    (quotient, remainder)
+  }
+
+  private def scaleDownRoundUp(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    // optimized path for smaller values
+    if (rescale <= MAX_POWER_OF_TEN_LONG && high == 0 && low >= 0) {
+      val divisor = LONG_POWERS_OF_TEN(rescale)
+      var newLow = low / divisor
+      if (low % divisor >= (divisor >> 1)) {
+        newLow += 1
+      }
+      return (0, newLow)
+    }
+
+    scaleDown(high, low, rescale, true)
+  }
+
+  private def scaleDownTruncate(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    // optimized path for smaller values
+    if (rescale <= MAX_POWER_OF_TEN_LONG && high == 0 && low >= 0) {
+      val divisor = LONG_POWERS_OF_TEN(rescale)
+      val newLow = low / divisor
+
+      return (0, newLow)
+    }
+
+    scaleDown(high, low, rescale, false)
+  }
+
+  private def scaleDown(high: Long, low: Long, rescale: Int, roundUp: Boolean): (Long, Long) = {
+    val negative = high < 0
+    var tmpHigh = high
+    var tmpLow = low
+    if (negative) {
+      tmpHigh = negateHighExact(tmpHigh, tmpLow)
+      tmpLow = negateLow(tmpLow)
+    }
+
+    // Scales down for 10**rescaleFactor.
+    // Because divide by int has limited divisor,
+    // we choose code path with the least amount of divisions
+    val result = if ((rescale - 1) / MAX_POWER_OF_FIVE_INT < (rescale - 1) / MAX_POWER_OF_TEN_INT) {
+      // scale down for 10**rescale is equivalent to scaling down with 5**rescaleFactor first,
+      // then with 2**rescaleFactor
+      val result = scaleDownFive(high, low, rescale)
+      shiftRight(result._1, result._2, rescale, roundUp)
+    }
+    else {
+      scaleDownTen(high, low, rescale, roundUp)
+    }
+
+    if (negative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(result._1, result._2)
+    } else {
+      result
+    }
+  }
+
+  /**
+   * Scale down the value for 5**fiveScale (result := decimal / 5**fiveScale).
+   */
+  private def scaleDownFive(high: Long, low: Long, rescale: Int): (Long, Long) = {
+    if (high < 0) {
+      throw negativeInt128Error()
+    }
+
+    var tmpHigh = high
+    var tmpLow = low
+    var fiveScale = rescale
+    while (true) {
+      val powerFive = Math.min(fiveScale, MAX_POWER_OF_FIVE_INT)
+      fiveScale -= powerFive
+
+      val divisor = POWERS_OF_FIVES_INT(powerFive)
+      val result = dividePositives(tmpHigh, tmpLow, divisor)
+
+      if (fiveScale == 0) {
+        return (result._1, result._2)
+      }
+
+      tmpHigh = result._1
+      tmpLow = result._2
+    }
+
+    (tmpHigh, tmpLow)
+  }
+
+  /**
+   * Scale down the value for 10**tenScale (this := this / 5**tenScale). This
+   * method rounds-up, eg 44/10=4, 44/10=5.
+   */
+  private def scaleDownTen(high: Long, low: Long, rescale: Int, roundUp: Boolean): (Long, Long) = {
+    if (high < 0) {
+      throw negativeInt128Error()
+    }
+
+    var needsRounding: Boolean = false
+    var tenScale = rescale
+    var tmpHigh = high
+    var tmpLow = low
+    do {
+      val powerTen = Math.min(tenScale, MAX_POWER_OF_TEN_INT)
+      tenScale -= powerTen
+
+      val divisor = POWERS_OF_TEN_INT(powerTen)
+      val result = divideCheckRound(tmpHigh, tmpLow, divisor)
+
+      tmpHigh = result._1
+      tmpLow = result._2
+      needsRounding = result._3
+    } while (tenScale > 0)
+
+    if (roundUp && needsRounding) {
+      incrementUnsafe(tmpHigh, tmpLow)
+    } else {
+      (tmpHigh, tmpLow)
+    }
+  }
+
+  def shiftRight(high: Long, low: Long, shift: Int, roundUp: Boolean): (Long, Long) = {
+    if (high < 0) {
+      throw negativeInt128Error()
+    }
+
+    if (shift == 0) {
+      return (high, low)
+    }
+
+    var needsRounding: Boolean = false
+    val (newHigh, newLow) = if (shift < 64) {
+      needsRounding = roundUp && (low & (1L << (shift - 1))) != 0
+      (high >> shift, (high << 1 << (63 - shift)) | (low >>> shift))
+    } else {
+      needsRounding = roundUp && (high & (1L << (shift - 64 - 1))) != 0
+      (0L, high >> (shift - 64))
+    }
+
+    if (needsRounding) {
+      (incrementHigh(newHigh, newLow), incrementLow(newLow))
+    } else {
+      (newHigh, newLow)
+    }
+  }
+
+  private def divideCheckRound(
+    dividendHigh: Long, dividendLow: Long, divisor: Int): (Long, Long, Boolean) = {
+    val (high, low, remainder) = dividePositives(dividendHigh, dividendLow, divisor)
+    (high, low, remainder >= (divisor >> 1))
+  }
+
+  /**
+   * Value must have a length of 8
+   */
+  private def shiftLeftBy5Destructive(value: Array[Int], shift: Int): Unit = {
+    if (shift <= MAX_POWER_OF_FIVE_INT) {
+      multiply256Destructive(value, POWERS_OF_FIVES_INT(shift))
+    } else if (shift < MAX_POWER_OF_TEN_LONG) {
+      multiply256Destructive(value, POWERS_OF_FIVE_LONG(shift))
+    } else {
+      multiply256Destructive(value, POWERS_OF_FIVE(shift))
+    }
+  }
+
+  /**
+   * This an unsigned operation. Supplying negative arguments will yield wrong results.
+   * Assumes left array length to be >= 5. However only first 4 int values are multiplied
+   */
+  private def multiply256Destructive(left: Array[Int], r0: Int): Unit = {
+    val l0 = Integer.toUnsignedLong(left(0))
+    val l1 = Integer.toUnsignedLong(left(1))
+    val l2 = Integer.toUnsignedLong(left(2))
+    val l3 = Integer.toUnsignedLong(left(3))
+
+    var accumulator = r0 * l0
+    val z0 = lowValue(accumulator)
+    var z1 = highValue(accumulator)
+
+    accumulator = r0 * l1 + z1
+    z1 = lowValue(accumulator)
+    var z2 = highValue(accumulator)
+
+    accumulator = r0 * l2 + z2
+    z2 = lowValue(accumulator)
+    var z3 = highValue(accumulator)
+
+    accumulator = r0 * l3 + z3
+    z3 = lowValue(accumulator)
+    val z4 = highValue(accumulator)
+
+    left(0) = z0.toInt
+    left(1) = z1.toInt
+    left(2) = z2.toInt
+    left(3) = z3.toInt
+    left(4) = z4.toInt
+  }
+
+  /**
+   * This an unsigned operation. Supplying negative arguments will yield wrong results.
+   * Assumes left array length to be >= 6. However only first 4 int values are multiplied
+   */
+  private def multiply256Destructive(left: Array[Int], right: Long): Unit = {
+    val l0 = Integer.toUnsignedLong(left(0))
+    val l1 = Integer.toUnsignedLong(left(1))
+    val l2 = Integer.toUnsignedLong(left(2))
+    val l3 = Integer.toUnsignedLong(left(3))
+
+    val r0 = lowValue(right)
+    val r1 = highValue(right)
+
+    var z0 = 0L
+    var z1 = 0L
+    var z2 = 0L
+    var z3 = 0L
+    var z4 = 0L
+    var z5 = 0L
+
+    if (l0 != 0) {
+      var accumulator = r0 * l0
+      z0 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l0
+
+      z1 = lowValue(accumulator)
+      z2 = highValue(accumulator)
+    }
+
+    if (l1 != 0) {
+      var accumulator = r0 * l1 + z1
+      z1 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l1 + z2
+
+      z2 = lowValue(accumulator)
+      z3 = highValue(accumulator)
+    }
+
+    if (l2 != 0) {
+      var accumulator = r0 * l2 + z2
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l2 + z3
+
+      z3 = lowValue(accumulator)
+      z4 = highValue(accumulator)
+    }
+
+    if (l3 != 0) {
+      var accumulator = r0 * l3 + z3
+      z3 = lowValue(accumulator);
+      accumulator = highValue(accumulator) + r1 * l3 + z4
+
+      z4 = lowValue(accumulator)
+      z5 = highValue(accumulator)
+    }
+
+    left(0) = z0.toInt
+    left(1) = z1.toInt
+    left(2) = z2.toInt
+    left(3) = z3.toInt
+    left(4) = z4.toInt
+    left(5) = z5.toInt
+  }
+
+  /**
+   * This an unsigned operation. Supplying negative arguments will yield wrong results.
+   * Assumes left array length to be >= 8. However only first 4 int values are multiplied
+   */
+  private def multiply256Destructive(left: Array[Int], right: Int128): Unit = {
+    val l0 = Integer.toUnsignedLong(left(0))
+    val l1 = Integer.toUnsignedLong(left(1))
+    val l2 = Integer.toUnsignedLong(left(2))
+    val l3 = Integer.toUnsignedLong(left(3))
+
+    val r0 = lowValue(right.low)
+    val r1 = highValue(right.low)
+    val r2 = lowValue(right.high)
+    val r3 = highValue(right.high)
+
+    var z0 = 0L
+    var z1 = 0L
+    var z2 = 0L
+    var z3 = 0L
+    var z4 = 0L
+    var z5 = 0L
+    var z6 = 0L
+    var z7 = 0L
+
+    if (l0 != 0) {
+      var accumulator = r0 * l0
+      z0 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l0
+
+      z1 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l0
+
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l0
+
+      z3 = lowValue(accumulator)
+      z4 = highValue(accumulator)
+    }
+
+    if (l1 != 0) {
+      var accumulator = r0 * l1 + z1
+      z1 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l1 + z2
+
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l1 + z3
+
+      z3 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l1 + z4
+
+      z4 = lowValue(accumulator)
+      z5 = highValue(accumulator)
+    }
+
+    if (l2 != 0) {
+      var accumulator = r0 * l2 + z2
+      z2 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l2 + z3
+
+      z3 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l2 + z4
+
+      z4 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l2 + z5
+
+      z5 = lowValue(accumulator)
+      z6 = highValue(accumulator)
+    }
+
+    if (l3 != 0) {
+      var accumulator = r0 * l3 + z3
+      z3 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r1 * l3 + z4
+
+      z4 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r2 * l3 + z5
+
+      z5 = lowValue(accumulator)
+      accumulator = highValue(accumulator) + r3 * l3 + z6
+
+      z6 = lowValue(accumulator)
+      z7 = highValue(accumulator)
+    }
+
+    left(0) = z0.toInt
+    left(1) = z1.toInt
+    left(2) = z2.toInt
+    left(3) = z3.toInt
+    left(4) = z4.toInt
+    left(5) = z5.toInt
+    left(6) = z6.toInt
+    left(7) = z7.toInt
+  }
+
+  def shiftLeftMultiPrecision(number: Array[Int], length: Int, shifts: Int): Unit = {
+    if (shifts == 0) {
+      return
+    }
+    // wordShifts = shifts / 32
+    val wordShifts = shifts >>> 5
+    // we don't wan't to loose any leading bits
+    for (i <- 0 until wordShifts) {
+      checkState(number(length - i - 1) == 0)
+    }
+
+    if (wordShifts > 0) {
+      System.arraycopy(number, 0, number, wordShifts, length - wordShifts)
+      Arrays.fill(number, 0, wordShifts, 0)
+    }
+    val bitShifts = shifts & 31
+    if (bitShifts > 0) {
+      // we don't wan't to loose any leading bits
+      checkState(number(length - 1) >>> (Integer.SIZE - bitShifts) == 0)
+      for (position <- length - 1 until 0 by -1) {
+        number(position) =
+          (number(position) << bitShifts) | (number(position - 1) >>> (Integer.SIZE - bitShifts))
+      }
+      number(0) = number(0) << bitShifts
+    }
+  }
+
+  /**
+   * Divides mutableDividend / mutable divisor
+   * Places remainder in first argument and quotient in the last argument
+   */
+  private def divideUnsignedMultiPrecision(
+      dividend: Array[Int], divisor: Array[Int], quotient: Array[Int]): Unit = {
+    checkArgument(dividend.length == NUMBER_OF_INTS * 2 + 1)
+    checkArgument(divisor.length == NUMBER_OF_INTS * 2)
+    checkArgument(quotient.length == NUMBER_OF_INTS * 2)
+
+    val divisorLength = digitsInIntegerBase(divisor)
+    val dividendLength = digitsInIntegerBase(dividend)
+
+    if (dividendLength < divisorLength) {
+      return
+    }
+
+    if (divisorLength == 1) {
+      val remainder = divideUnsignedMultiPrecision(dividend, dividendLength, divisor(0))
+      checkState(dividend(dividend.length - 1) == 0)
+      System.arraycopy(dividend, 0, quotient, 0, quotient.length)
+      Arrays.fill(dividend, 0)
+      dividend(0) = remainder
+      return
+    }
+
+    // normalize divisor. Most significant divisor word must be > BASE/2
+    // effectively it can be achieved by shifting divisor left until the leftmost bit is 1
+    val nlz = Integer.numberOfLeadingZeros(divisor(divisorLength - 1))
+    shiftLeftMultiPrecision(divisor, divisorLength, nlz)
+    val normalizedDividendLength = Math.min(dividend.length, dividendLength + 1)
+    shiftLeftMultiPrecision(dividend, normalizedDividendLength, nlz)
+
+    divideKnuthNormalized(dividend, normalizedDividendLength, divisor, divisorLength, quotient)
+
+    // un-normalize remainder which is stored in dividend
+    shiftRightMultiPrecision(dividend, normalizedDividendLength, nlz)
+  }
+
+  private def digitsInIntegerBase(digits: Array[Int]): Int = {
+    var length = digits.length
+    while (length > 0 && digits(length - 1) == 0) {
+      length -= 1
+    }
+    length
+  }
+
+  private def divideUnsignedMultiPrecision(
+      dividend: Array[Int], dividendLength: Int, divisor: Int): Int = {
+    if (divisor == 0) {
+      throw divisionByZeroException()
+    }
+
+    if (dividendLength == 1) {
+      val dividendUnsigned = Integer.toUnsignedLong(dividend(0))
+      val divisorUnsigned = Integer.toUnsignedLong(divisor)
+      val quotient = dividendUnsigned / divisorUnsigned
+      val remainder = dividendUnsigned - (divisorUnsigned * quotient)
+      dividend(0) = quotient.toInt
+      return remainder.toInt
+    }
+
+    val divisorUnsigned = Integer.toUnsignedLong(divisor)
+    var remainder = 0L
+    for (dividendIndex <- dividendLength - 1 to 0 by -1) {
+      remainder = (remainder << 32) + Integer.toUnsignedLong(dividend(dividendIndex))
+      val quotient = divideUnsignedLong(remainder, divisor)
+      dividend(dividendIndex) = quotient.toInt
+      remainder = remainder - (quotient * divisorUnsigned)
+    }
+    remainder.toInt
+  }
+
+  private def divideUnsignedLong(dividend: Long, divisor: Int): Long = {
+    val unsignedDivisor = Integer.toUnsignedLong(divisor)
+
+    if (dividend > 0) {
+      return dividend / unsignedDivisor
+    }
+
+    // HD 9-3, 4) q = divideUnsigned(n, 2) / d * 2
+    var quotient = ((dividend >>> 1) / unsignedDivisor) * 2
+    val remainder = dividend - quotient * unsignedDivisor
+
+    if (JLong.compareUnsigned(remainder, unsignedDivisor) >= 0) {
+      quotient += 1
+    }
+
+    quotient
+  }
+
+  private def divideKnuthNormalized(
+      remainder: Array[Int],
+      dividendLength: Int,
+      divisor: Array[Int],
+      divisorLength: Int,
+      quotient: Array[Int]): Unit = {
+    val v1 = divisor(divisorLength - 1)
+    val v0 = divisor(divisorLength - 2)
+    for (reminderIndex <- dividendLength - 1 to divisorLength by -1) {
+      var qHat = estimateQuotient(remainder(reminderIndex), remainder(reminderIndex - 1),
+        remainder(reminderIndex - 2), v1, v0)
+      if (qHat != 0) {
+        val overflow = multiplyAndSubtractUnsignedMultiPrecision(
+          remainder, reminderIndex, divisor, divisorLength, qHat)
+        // Add back - probability is 2**(-31). R += D. Q[digit] -= 1
+        if (overflow) {
+          qHat -= 1
+          addUnsignedMultiPrecision(remainder, reminderIndex, divisor, divisorLength)
+        }
+      }
+      quotient(reminderIndex - divisorLength) = qHat
+    }
+  }
+
+  /**
+   * Use the Knuth notation
+   * <p>
+   * u{x} - dividend
+   * v{v} - divisor
+   */
+  private def estimateQuotient(u2: Int, u1: Int, u0: Int, v1: Int, v0: Int): Int = {
+    // estimate qhat based on the first 2 digits of divisor divided by the first digit of a dividend
+    val u21 = combineInts(u2, u1)
+    var qhat = 0L
+    if (u2 == v1) {
+      qhat = INT_BASE - 1
+    } else if (u21 >= 0) {
+      qhat = u21 / Integer.toUnsignedLong(v1)
+    } else {
+      qhat = divideUnsignedLong(u21, v1)
+    }
+
+    if (qhat == 0) {
+      return 0
+    }
+
+    // Check if qhat is greater than expected considering only first 3 digits of a dividend
+    // This step help to eliminate all the cases when the estimation is greater than q by 2
+    // and eliminates most of the cases when qhat is greater than q by 1
+    //
+    // u2 * b * b + u1 * b + u0 >= (v1 * b + v0) * qhat
+    // u2 * b * b + u1 * b + u0 >= v1 * b * qhat + v0 * qhat
+    // u2 * b * b + u1 * b - v1 * b * qhat >=  v0 * qhat - u0
+    // (u21 - v1 * qhat) * b >=  v0 * qhat - u0
+    // (u21 - v1 * qhat) * b + u0 >=  v0 * qhat
+    // When ((u21 - v1 * qhat) * b + u0) is less than (v0 * qhat) decrease qhat by one
+
+    var iterations = 0
+    var rhat = u21 - Integer.toUnsignedLong(v1) * qhat
+    while (JLong.compareUnsigned(rhat, INT_BASE) < 0 &&
+      JLong.compareUnsigned(Integer.toUnsignedLong(v0) * qhat, combineInts(lowInt(rhat), u0)) > 0) {
+      iterations += 1
+      qhat -= 1
+      rhat += Integer.toUnsignedLong(v1)
+    }
+
+    if (iterations > 2) {
+      throw new IllegalStateException("qhat is greater than q by more than 2: " + iterations)
+    }
+
+    qhat.toInt
+  }
+
+  /**
+   * Calculate multi-precision [left - right * multiplier] with given left offset and length.
+   * Return true when overflow occurred
+   */
+  private def multiplyAndSubtractUnsignedMultiPrecision(
+      left: Array[Int],
+      leftOffset: Int,
+      right: Array[Int],
+      length: Int,
+      multiplier: Int): Boolean = {
+    val unsignedMultiplier = Integer.toUnsignedLong(multiplier)
+    var leftIndex = leftOffset - length
+    var multiplyAccumulator = 0L
+    var subtractAccumulator = INT_BASE
+
+    for (rightIndex <- 0 until length) {
+      multiplyAccumulator =
+        Integer.toUnsignedLong(right(rightIndex)) * unsignedMultiplier + multiplyAccumulator
+      subtractAccumulator = (subtractAccumulator + Integer.toUnsignedLong(left(leftIndex))) -
+        Integer.toUnsignedLong(lowInt(multiplyAccumulator))
+      multiplyAccumulator = highValue(multiplyAccumulator)
+      left(leftIndex) = lowInt(subtractAccumulator)
+      subtractAccumulator = highValue(subtractAccumulator) + INT_BASE - 1
+      leftIndex += 1
+    }
+    subtractAccumulator += Integer.toUnsignedLong(left(leftIndex)) - multiplyAccumulator
+    left(leftIndex) = lowInt(subtractAccumulator)
+    highInt(subtractAccumulator) == 0
+  }
+
+  private def addUnsignedMultiPrecision(
+      left: Array[Int], leftOffset: Int, right: Array[Int], length: Int): Unit = {
+    var leftIndex = leftOffset - length
+    var carry = 0
+    for (rightIndex <- 0 until length) {
+    val accumulator = Integer.toUnsignedLong(left(leftIndex)) +
+      Integer.toUnsignedLong(right(rightIndex)) + Integer.toUnsignedLong(carry)
+    left(leftIndex) = lowInt(accumulator)
+    carry = highInt(accumulator)
+    leftIndex += 1
+  }
+    left(leftIndex) += carry
+  }
+
+  private def shiftRightMultiPrecision(
+      number: Array[Int], length: Int, shifts: Int): Array[Int] = {
+    if (shifts == 0) {
+      return number
+    }
+    // wordShifts = shifts / 32
+    val wordShifts = shifts >>> 5
+    // we don't wan't to loose any trailing bits
+    for (i <- 0 until wordShifts) {
+      checkState(number(i) == 0)
+    }
+    if (wordShifts > 0) {
+      System.arraycopy(number, wordShifts, number, 0, length - wordShifts)
+      Arrays.fill(number, length - wordShifts, length, 0)
+    }
+    val bitShifts = shifts & 31
+    if (bitShifts > 0) {
+      // we don't wan't to loose any trailing bits
+      checkState(number(0) << (Integer.SIZE - bitShifts) == 0)
+      for (position <- 0 until length - 1) {
+        number(position) =
+          (number(position) >>> bitShifts) | (number(position + 1) << (Integer.SIZE - bitShifts))
+      }
+      number(length - 1) = number(length - 1) >>> bitShifts
+    }
+    number;
+  }
+
+  private def pack(parts: Array[Int]): (Long, Long) = {
+    val high = parts(3).toLong << 32 | (parts(2) & 0xFFFFFFFFL)
+    val low = (parts(1).toLong << 32) | (parts(0) & 0xFFFFFFFFL)
+
+    if (parts(4) != 0 || parts(5) != 0 || parts(6) != 0 || parts(7) != 0) {
+      throw new ArithmeticException("Overflow");
+    }
+
+    (high, low)
+  }
+
+  private def compareUnsigned(
+      leftHigh: Long, leftLow: Long, rightHigh: Long, rightLow: Long): Int = {
+    var comparison = JLong.compareUnsigned(leftHigh, rightHigh)
+    if (comparison == 0) {
+      comparison = JLong.compareUnsigned(leftLow, rightLow)
+    }
+
+    comparison
+  }
+
+  private def incrementUnsafe(high: Long, low: Long): (Long, Long) =
+    (incrementHigh(high, low), incrementLow(low))
+
+  def incrementHigh(high: Long, low: Long): Long = high + (if (low == -1) 1 else 0)
+
+  def incrementLow(low: Long): Long = low + 1
+
+  private def combineInts(high: Int, low: Int): Long =
+    (high.toLong << 32) | Integer.toUnsignedLong(low)
+
+  private def highValue(value: Long): Long = value >>> 32
+
+  private def lowValue(value: Long): Long = value & LOW_32_BITS
+
+  private def highInt(value: Long): Int = highValue(value).toInt
+
+  private def lowInt(value: Long): Int = value.toInt
+
+  private def unsignedCarry(left: Long, right: Long): Long =
+    ((left >>> 1) + (right >>> 1) + ((left & right) & 1)) >>> 63 // HD 2-13
+
+  private def unsignedBorrow(left: Long, right: Long): Long =
+    ((~left & right) | (~(left ^ right) & (left - right))) >>> 63 // HD 2-13
+
+  private def checkState(condition: Boolean): Unit = {
+    if (!condition) {
+      throw new IllegalStateException();
+    }
+  }
+
+  private def checkArgument(condition: Boolean): Unit = {
+    if (!condition) {
+      throw new IllegalArgumentException()
+    }
+  }
+
+  def divisionByZeroException(): ArithmeticException =
+    new ArithmeticException("Division by zero")
+
+  private def int128OverflowException(message: String): ArithmeticException =
+    new ArithmeticException(s"Int128 Overflow. $message")
+
+  private def negativeInt128Error(): IllegalArgumentException =
+    new IllegalArgumentException("Value must be positive")
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/util/Int128Math.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/util/Int128Math.scala
@@ -456,9 +456,8 @@ object Int128Math {
       // then with 2**rescaleFactor
       val result = scaleDownFive(high, low, rescale)
       shiftRight(result._1, result._2, rescale, roundUp)
-    }
-    else {
-      scaleDownTen(high, low, rescale, roundUp)
+    } else {
+      scaleDownTen(tmpHigh, tmpLow, rescale, roundUp)
     }
 
     if (negative) {

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkAdd.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkAdd.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+
+@BenchmarkMode({Mode.Throughput, Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions"})
+@Warmup(iterations = 10, time = 20, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 20, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkAdd {
+
+  //  @Benchmark
+  //  @OperationsPerInvocation(BenchmarkData.COUNT)
+  //  public void addBigint(BenchmarkData data) {
+  //    for (int i = 0; i < BenchmarkData.COUNT; i++) {
+  //      sink(data.bigintDividends[i].add(data.bigintDivisors[i]));
+  //    }
+  //  }
+
+  //  @Benchmark
+  //  @OperationsPerInvocation(BenchmarkData.COUNT)
+  //  public void addBigDecimal(BenchmarkData data) {
+  //    for (int i = 0; i < BenchmarkData.COUNT; i++) {
+  //      sink(data.bigDecimalDividends[i].add(data.bigDecimalDivisors[i]));
+  //    }
+  //  }
+
+  @Benchmark
+  @OperationsPerInvocation(BenchmarkData.COUNT)
+  public void addDecimal(BenchmarkData data) {
+    for (int i = 0; i < BenchmarkData.COUNT; i++) {
+      sink(data.decimalDividends[i].$plus(data.decimalDivisors[i]));
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(BenchmarkData.COUNT)
+  public void addDecimal128(BenchmarkData data) {
+    for (int i = 0; i < BenchmarkData.COUNT; i++) {
+      sink(data.decimal128Dividends[i].$plus(data.decimal128Divisors[i]));
+    }
+  }
+
+  //  @Benchmark
+  //  @OperationsPerInvocation(BenchmarkData.COUNT)
+  //  public void addInt128(BenchmarkData data) {
+  //    for (int i = 0; i < BenchmarkData.COUNT; i++) {
+  //      sink(data.dividends[i].$plus(data.divisors[i]));
+  //    }
+  //  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void sink(BigInteger value) {
+
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void sink(BigDecimal value) {
+
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void sink(Decimal value) {
+
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void sink(Int128 value) {
+
+  }
+
+  @State(Scope.Thread)
+  public static class BenchmarkData {
+    private static final int COUNT = 1000;
+
+    private static final Random RANDOM = new Random();
+
+    private final Int128[] dividends = new Int128[COUNT];
+    private final Int128[] divisors = new Int128[COUNT];
+
+    private final BigInteger[] bigintDividends = new BigInteger[COUNT];
+    private final BigInteger[] bigintDivisors = new BigInteger[COUNT];
+
+    private final BigDecimal[] bigDecimalDividends = new BigDecimal[COUNT];
+    private final BigDecimal[] bigDecimalDivisors = new BigDecimal[COUNT];
+
+    private final Decimal[] decimalDividends = new Decimal[COUNT];
+    private final Decimal[] decimalDivisors = new Decimal[COUNT];
+
+    private final Decimal[] decimal128Dividends = new Decimal[COUNT];
+    private final Decimal[] decimal128Divisors = new Decimal[COUNT];
+
+    @Param(value = {"126", "90", "65", "64", "63", "32", "10", "1", "0"})
+    private int dividendMagnitude = 126;
+
+    @Param(value = {"126", "90", "65", "64", "63", "32", "10", "1"})
+    private int divisorMagnitude = 90;
+
+    @Setup
+    public void setup() {
+      int count = 0;
+      while (count < COUNT) {
+        Int128 dividend = Int128MathTest.random(dividendMagnitude);
+        Int128 divisor = Int128MathTest.random(divisorMagnitude);
+
+         int dividendScale = RANDOM.nextInt(10);
+        // int divisorScale = RANDOM.nextInt(10);
+
+        if (ThreadLocalRandom.current().nextBoolean()) {
+          dividend = dividend.unary_$minus();
+        }
+
+        if (ThreadLocalRandom.current().nextBoolean()) {
+          divisor = divisor.unary_$minus();
+        }
+
+        if (!divisor.isZero()) {
+          dividends[count] = dividend;
+          divisors[count] = divisor;
+
+          bigintDividends[count] = dividends[count].toBigInteger();
+          bigintDivisors[count] = divisors[count].toBigInteger();
+
+          bigDecimalDividends[count] = new BigDecimal(bigintDividends[count], dividendScale);
+          bigDecimalDivisors[count] = new BigDecimal(bigintDivisors[count], dividendScale);
+
+          decimalDividends[count] = newJDKDecimal(bigDecimalDividends[count]);
+          decimalDivisors[count] = newJDKDecimal(bigDecimalDivisors[count]);
+
+          decimal128Dividends[count] = newDecimal128(bigDecimalDividends[count]);
+          decimal128Divisors[count] = newDecimal128(bigDecimalDivisors[count]);
+
+          count++;
+        }
+      }
+    }
+  }
+
+  private static Decimal newJDKDecimal(BigDecimal bigDecimal) {
+    Decimal decimal = new Decimal(false);
+    return decimal.set(new scala.math.BigDecimal(bigDecimal));
+  }
+
+  private static Decimal newDecimal128(BigDecimal bigDecimal) {
+    Decimal decimal = new Decimal(true);
+    return decimal.set(new scala.math.BigDecimal(bigDecimal));
+  }
+
+  @Test
+  public void test() {
+    BenchmarkData data = new BenchmarkData();
+    data.setup();
+//    addDecimal2(data);
+    addDecimal128(data);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    BenchmarkRunner.benchmark(BenchmarkAdd.class);
+  }
+}

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkAdd.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkAdd.java
@@ -175,7 +175,7 @@ public class BenchmarkAdd {
   public void test() {
     BenchmarkData data = new BenchmarkData();
     data.setup();
-//    addDecimal2(data);
+    // addDecimal2(data);
     addDecimal128(data);
   }
 

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkAdd.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkAdd.java
@@ -162,12 +162,12 @@ public class BenchmarkAdd {
   }
 
   private static Decimal newJDKDecimal(BigDecimal bigDecimal) {
-    Decimal decimal = new Decimal(false);
+    Decimal decimal = new Decimal(true, true);
     return decimal.set(new scala.math.BigDecimal(bigDecimal));
   }
 
   private static Decimal newDecimal128(BigDecimal bigDecimal) {
-    Decimal decimal = new Decimal(true);
+    Decimal decimal = new Decimal(false, true);
     return decimal.set(new scala.math.BigDecimal(bigDecimal));
   }
 

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkRunner.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/types/BenchmarkRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.apache.curator.shaded.com.google.common.base.StandardSystemProperty;
+import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+public class BenchmarkRunner {
+  private BenchmarkRunner() {}
+
+  public static void benchmark(Class<?> clazz) throws RunnerException {
+    ChainedOptionsBuilder optionsBuilder = new OptionsBuilder()
+      .verbosity(VerboseMode.NORMAL)
+      .include(".*\\." + clazz.getSimpleName() + "\\..*")
+      .resultFormat(ResultFormatType.JSON)
+      .result(String.format("%s/%s-result-%s.json", System.getProperty("java.io.tmpdir"),
+        clazz.getSimpleName(), DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now())));
+
+    if (StandardSystemProperty.OS_NAME.value().equals("Linux")) {
+      optionsBuilder.addProfiler(LinuxPerfAsmProfiler.class);
+    }
+
+    new Runner(optionsBuilder.build()).run();
+  }
+}

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/types/Int128Holder.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/types/Int128Holder.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+public class Int128Holder {
+  private long high;
+  private long low;
+
+  public Int128Holder() {
+  }
+
+  public long high() {
+    return high;
+  }
+
+  public void high(long high) {
+    this.high = high;
+  }
+
+  public long low() {
+    return low;
+  }
+
+  public void low(long low) {
+    this.low = low;
+  }
+
+  public void set(long high, long low) {
+    this.high = high;
+    this.low = low;
+  }
+
+  public void set(Int128 value) {
+    this.high = value.high();
+    this.low = value.low();
+  }
+
+  public Int128 get() {
+    return new Int128().set(high, low);
+  }
+}

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/types/Int128MathTest.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/types/Int128MathTest.java
@@ -1,0 +1,1006 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.types;
+
+import org.apache.spark.sql.util.MoreMath;
+
+import java.math.BigInteger;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.lang.Math.pow;
+import static java.lang.Math.round;
+
+public final class Int128MathTest {
+
+  // 1..10^38 (largest value < Int128.MAX_VALUE)
+  private static final Int128[] POWERS_OF_TEN = new Int128[39];
+  private static final int LONG_POWERS_OF_TEN_TABLE_LENGTH = 19;
+  private static final long[] LONG_POWERS_OF_TEN = new long[LONG_POWERS_OF_TEN_TABLE_LENGTH];
+
+  // Lowest 32 bits of a long
+  private static final long LOW_32_BITS = 0xFFFFFFFFL;
+
+  /**
+   * 5^13 fits in 2^31.
+   */
+  private static final int MAX_POWER_OF_FIVE_INT = 13;
+
+  /**
+   * 5^x. All unsigned values.
+   */
+  private static final int[] POWERS_OF_FIVES_INT = new int[MAX_POWER_OF_FIVE_INT + 1];
+
+  /**
+   * 10^9 fits in 2^31.
+   */
+  private static final int MAX_POWER_OF_TEN_INT = 9;
+
+  /**
+   * 10^18 fits in 2^63.
+   */
+  private static final int MAX_POWER_OF_TEN_LONG = 18;
+
+  /**
+   * 10^x. All unsigned values.
+   */
+  private static final int[] POWERS_OF_TEN_INT = new int[MAX_POWER_OF_TEN_INT + 1];
+
+  static {
+    for (int i = 0; i < POWERS_OF_TEN.length; ++i) {
+      POWERS_OF_TEN[i] = Int128.apply(BigInteger.TEN.pow(i));
+    }
+
+    POWERS_OF_FIVES_INT[0] = 1;
+    for (int i = 1; i < POWERS_OF_FIVES_INT.length; ++i) {
+      POWERS_OF_FIVES_INT[i] = POWERS_OF_FIVES_INT[i - 1] * 5;
+    }
+
+    for (int i = 0; i < LONG_POWERS_OF_TEN.length; ++i) {
+      // Although this computes using doubles, incidentally,
+      // this is exact for all powers of 10 that fit in a long.
+      LONG_POWERS_OF_TEN[i] = round(pow(10, i));
+    }
+
+    POWERS_OF_TEN_INT[0] = 1;
+    for (int i = 1; i < POWERS_OF_TEN_INT.length; ++i) {
+      POWERS_OF_TEN_INT[i] = POWERS_OF_TEN_INT[i - 1] * 10;
+    }
+  }
+
+  public static boolean inLongRange(long high, long low)
+  {
+    return high == (low >> 63);
+  }
+
+  public static int compareUnsigned(long aHigh, long aLow, long bHigh, long bLow) {
+    int result = Long.compareUnsigned(aHigh, bHigh);
+
+    if (result == 0) {
+      result = Long.compareUnsigned(aLow, bLow);
+    }
+
+    return result;
+  }
+
+  public static int compare(long leftHigh, long leftLow, long rightHigh, long rightLow) {
+    int result = Long.compare(leftHigh, rightHigh);
+
+    if (result == 0) {
+      result = Long.compareUnsigned(leftLow, rightLow);
+    }
+
+    return result;
+  }
+
+  public static boolean isZero(long high, long low) {
+    return (high | low) == 0;
+  }
+
+  public static long incrementHigh(long high, long low) {
+    return high + ((low == -1) ? 1 : 0);
+  }
+
+  public static long incrementLow(long high, long low) {
+    return low + 1;
+  }
+
+  public static long decrementHigh(long high, long low) {
+    return high - ((low == 0) ? 1 : 0);
+  }
+
+  public static long decrementLow(long high, long low) {
+    return low - 1;
+  }
+
+  public static Int128 and(Int128 a, Int128 b) {
+    return Int128.apply(andHigh(a.high(), b.high()), andLow(a.low(), b.low()));
+  }
+
+  public static void rescale(long high, long low, int factor, long[] result, int offset) {
+    if (factor == 0) {
+      result[offset] = high;
+      result[offset + 1] = low;
+    } else if (factor > 0) {
+      shiftLeftBy10(high, low, factor, result, offset);
+    } else {
+      scaleDownRoundUp(high, low, -factor, result, offset);
+    }
+  }
+
+  public static Int128 rescale(Int128 int128, int rescaleFactor) {
+    long[] result = new long[2];
+    rescale(int128.high(), int128.low(), rescaleFactor, result, 0);
+    return Int128.apply(result[0], result[1]);
+  }
+
+  // Multiplies by 10^rescaleFactor. Only positive rescaleFactor values are allowed
+  public static void shiftLeftBy10(
+    long high, long low, int rescaleFactor, long[] result, int offset) {
+    if (rescaleFactor >= POWERS_OF_TEN.length) {
+      throw overflowException();
+    }
+
+    boolean negative = high < 0;
+
+    if (negative) {
+      long tmpHigh = negateHighExact(high, low);
+      long tmpLow = negateLow(low);
+
+      high = tmpHigh;
+      low = tmpLow;
+    }
+
+    multiplyPositives(high, low, POWERS_OF_TEN[rescaleFactor].high(),
+      POWERS_OF_TEN[rescaleFactor].low(), result, offset);
+
+    if (negative) {
+      long tmpHigh = negateHighExact(result[offset], result[offset + 1]);
+      long tmpLow = negateLow(result[offset + 1]);
+
+      result[offset] = tmpHigh;
+      result[offset + 1] = tmpLow;
+    }
+  }
+
+  private static long unsignedCarry(long a, long b) {
+    // HD 2-13
+    return ((a >>> 1) + (b >>> 1) + ((a & b) & 1)) >>> 63;
+  }
+
+  public static long[] add(Int128 left, Int128 right) {
+    return add(left.high(), left.low(), right.high(), right.low());
+  }
+
+  public static long[] add(long left, long right) {
+    return add(left >> 63, left, right >> 63, right);
+  }
+
+  public static long[] add(long left, Int128 right) {
+    return add(right, left);
+  }
+
+  public static long[] add(Int128 left, long right) {
+    return add(left.high(), left.low(), right >> 63, right);
+  }
+
+  public static long[] add(long left, long right, int rescale, boolean rescaleLeft) {
+    return add(left >> 63, left, right >> 63, right, rescale, rescaleLeft);
+  }
+
+  public static long[] add(Int128 left, Int128 right, int rescale, boolean rescaleLeft) {
+    return add(left.high(), left.low(), right.high(), right.low(), rescale, rescaleLeft);
+  }
+
+  public static long[] add(long left, Int128 right, int rescale, boolean rescaleLeft) {
+    return add(right, left, rescale, !rescaleLeft);
+  }
+
+  public static long[] add(Int128 left, long right, int rescale, boolean rescaleLeft) {
+    return add(left.high(), left.low(), right >> 63, right, rescale, rescaleLeft);
+  }
+
+  private static long[] add(
+    long leftHigh, long leftLow, long rightHigh, long rightLow, int rescale, boolean rescaleLeft) {
+    long[] result = new long[2];
+    if (rescaleLeft) {
+      rescale(leftHigh, leftLow, rescale, result, 0);
+      return add(result[0], result[1], rightHigh, rightLow);
+    } else {
+      rescale(rightHigh, rightLow, rescale, result, 0);
+      return add(leftHigh, leftLow, result[0], result[1]);
+    }
+  }
+
+  public static long[] add(
+    long leftHigh, long leftLow, long rightHigh, long rightLow) {
+    long[] result = new long[2];
+    long carry = unsignedCarry(leftLow, rightLow);
+
+    long resultLow = leftLow + rightLow;
+    long resultHigh = leftHigh + rightHigh + carry;
+
+    result[0] = resultHigh;
+    result[1] = resultLow;
+
+    if (((resultHigh ^ leftHigh) & (resultHigh ^ rightHigh)) < 0) {
+      throw overflowException();
+    }
+
+    return result;
+  }
+
+  public static void add(
+    long leftHigh, long leftLow, long rightHigh, long rightLow, long[] result, int offset) {
+    long carry = unsignedCarry(leftLow, rightLow);
+
+    long resultLow = leftLow + rightLow;
+    long resultHigh = leftHigh + rightHigh + carry;
+
+    result[offset] = resultHigh;
+    result[offset + 1] = resultLow;
+
+    if (((resultHigh ^ leftHigh) & (resultHigh ^ rightHigh)) < 0) {
+      throw overflowException();
+    }
+  }
+
+  public static long addHigh(long aHigh, long aLow, long bHigh, long bLow) {
+    return aHigh + bHigh + MoreMath.unsignedCarry(aLow, bLow);
+  }
+
+  public static long addHighExact(long aHigh, long aLow, long bHigh, long bLow) {
+    long result = addHigh(aHigh, aLow, bHigh, bLow);
+
+    // HD 2-13 Overflow iff both arguments have the opposite sign of the result
+    if (((result ^ aHigh) & (result ^ bHigh)) < 0) {
+      throw new ArithmeticException("Integer overflow");
+    }
+
+    return result;
+  }
+
+  public static long addLow(long aLow, long bLow) {
+    return aLow + bLow;
+  }
+
+  public static long subtractHigh(long aHigh, long aLow, long bHigh, long bLow) {
+    return aHigh - bHigh - MoreMath.unsignedBorrow(aLow, bLow);
+  }
+
+  public static long subtractHighExact(long aHigh, long aLow, long bHigh, long bLow) {
+    long result = subtractHigh(aHigh, aLow, bHigh, bLow);
+
+    // HD 2-13 Overflow iff the arguments have different signs and
+    // the sign of the result is different from the sign of x
+    if (((aHigh ^ bHigh) & (aHigh ^ result)) < 0) {
+      throw new ArithmeticException("Integer overflow");
+    }
+
+    return result;
+  }
+
+  public static long subtractLow(long aLow, long bLow) {
+    return aLow - bLow;
+  }
+
+  public static Int128 subtract(Int128 a, Int128 b) {
+    return Int128.apply(subtractHigh(a.high(), a.low(), b.high(), b.low()),
+      subtractLow(a.low(), b.low()));
+  }
+
+  public static long multiplyHigh(long aHigh, long aLow, long bHigh, long bLow) {
+    return MoreMath.unsignedMultiplyHigh(aLow, bLow) + aLow * bHigh + aHigh * bLow;
+  }
+
+  public static long multiplyLow(long aLow, long bLow)
+    {
+        return aLow * bLow;
+    }
+
+  public static long shiftLeftHigh(long high, long low, int shift) {
+    if (shift < 64) {
+      return (high << shift) | (low >>> 1 >>> (63 - shift));
+    } else {
+      return low << (shift - 64);
+    }
+  }
+
+  public static long shiftLeftLow(long high, long low, int shift) {
+    if (shift < 64) {
+      return low << shift;
+    } else {
+      return 0;
+    }
+  }
+
+  public static Int128 shiftLeft(Int128 value, int shift)
+  {
+    return Int128.apply(shiftLeftHigh(value.high(), value.low(), shift),
+      shiftLeftLow(value.high(), value.low(), shift));
+  }
+
+  public static long shiftRightUnsignedHigh(long high, long low, int shift) {
+    if (shift < 64) {
+      return high >>> shift;
+    } else {
+      return 0;
+    }
+  }
+
+  public static long shiftRightUnsignedLow(long high, long low, int shift) {
+    if (shift < 64) {
+      return (high << 1 << (63 - shift)) | (low >>> shift);
+    } else {
+      return high >>> (shift - 64);
+    }
+  }
+
+  public static Int128 shiftRightUnsigned(Int128 value, int shift) {
+    return Int128.apply(shiftRightUnsignedHigh(value.high(), value.low(), shift),
+      shiftRightUnsignedLow(value.high(), value.low(), shift));
+  }
+
+  public static long andHigh(long aHigh, long bHigh) {
+    return aHigh & bHigh;
+  }
+
+  public static long andLow(long aLow, long bLow) {
+    return aLow & bLow;
+  }
+
+  public static Int128 add2(Int128 a, Int128 b) {
+    return Int128.apply(addHigh(a.high(), a.low(), b.high(), b.low()),
+      addLow(a.low(), b.low()));
+  }
+
+  public static int numberOfLeadingZeros(long high, long low) {
+    int count = Long.numberOfLeadingZeros(high);
+    if (count == 64) {
+      count += Long.numberOfLeadingZeros(low);
+    }
+
+    return count;
+  }
+
+  public static int numberOfTrailingZeros(long high, long low) {
+    int count = Long.numberOfTrailingZeros(low);
+    if (count == 64) {
+      count += Long.numberOfTrailingZeros(high);
+    }
+
+    return count;
+  }
+
+  public static int bitCount(long high, long low) {
+    return Long.bitCount(high) + Long.bitCount(low);
+  }
+
+  public static int bitCount(Int128 value) {
+    return bitCount(value.high(), value.low());
+  }
+
+  private static void negate(long[] value, int offset) {
+    long high = value[offset];
+    long low = value[offset + 1];
+
+    value[offset] = negateHigh(high, low);
+    value[offset + 1] = negateLow(low);
+  }
+
+  private static long negateHighExact(long high, long low) {
+    if (high == Int128.MIN_VALUE().high() && low == Int128.MIN_VALUE().low()) {
+      throw overflowException();
+    }
+
+    return negateHigh(high, low);
+  }
+
+  public static long negateHigh(long high, long low) {
+    return -high - (low != 0 ? 1 : 0);
+  }
+
+  public static long negateLow(long low) {
+    return -low;
+  }
+
+  public static Int128 decrement(Int128 value) {
+    return Int128.apply(decrementHigh(value.high(), value.low()),
+      decrementLow(value.high(), value.low()));
+  }
+
+  private static void incrementUnsafe(long[] value, int offset) {
+    long high = value[offset];
+    long low = value[offset + 1];
+
+    value[offset] = incrementHigh(high, low);
+    value[offset + 1] = incrementLow(high, low);
+  }
+
+  private static void scaleDownRoundUp(
+      long high, long low, int scaleFactor, long[] result, int offset) {
+    // optimized path for smaller values
+    if (scaleFactor <= MAX_POWER_OF_TEN_LONG && high == 0 && low >= 0) {
+      long divisor = LONG_POWERS_OF_TEN[scaleFactor];
+      long newLow = low / divisor;
+      if (low % divisor >= (divisor >> 1)) {
+        newLow++;
+      }
+      result[offset] = 0;
+      result[offset + 1] = newLow;
+      return;
+    }
+
+    scaleDown(high, low, scaleFactor, result, offset, true);
+  }
+
+  private static void scaleDown(
+      long high, long low, int scaleFactor, long[] result, int offset, boolean roundUp) {
+    boolean negative = high < 0;
+    if (negative) {
+      long tmpLow = negateLow(low);
+      long tmpHigh = negateHighExact(high, low);
+
+      low = tmpLow;
+      high = tmpHigh;
+    }
+
+    // Scales down for 10**rescaleFactor.
+    // Because divide by int has limited divisor,
+    // we choose code path with the least amount of divisions
+    if ((scaleFactor - 1) / MAX_POWER_OF_FIVE_INT < (scaleFactor - 1) / MAX_POWER_OF_TEN_INT) {
+      // scale down for 10**rescale is equivalent to scaling down with 5**rescaleFactor first,
+      // then with 2**rescaleFactor
+      scaleDownFive(high, low, scaleFactor, result, offset);
+      shiftRight(result[offset], result[offset + 1], scaleFactor, roundUp, result, offset);
+    }
+    else {
+      scaleDownTen(high, low, scaleFactor, result, offset, roundUp);
+    }
+
+    if (negative) {
+      // negateExact not needed since all positive values can be negated without overflow
+      negate(result, offset);
+    }
+  }
+
+  /**
+   * Scale down the value for 5**fiveScale (result := decimal / 5**fiveScale).
+   */
+  private static void scaleDownFive(
+      long high, long low, int fiveScale, long[] result, int offset) {
+    if (high < 0) {
+      throw new IllegalArgumentException("Value must be positive");
+    }
+
+    while (true) {
+      int powerFive = Math.min(fiveScale, MAX_POWER_OF_FIVE_INT);
+      fiveScale -= powerFive;
+
+      int divisor = POWERS_OF_FIVES_INT[powerFive];
+      dividePositives(high, low, divisor, result, offset);
+
+      if (fiveScale == 0) {
+        return;
+      }
+
+      high = result[offset];
+      low = result[offset + 1];
+    }
+  }
+
+  /**
+   * Scale down the value for 10**tenScale (this := this / 5**tenScale). This
+   * method rounds-up, eg 44/10=4, 44/10=5.
+   */
+  private static void scaleDownTen(
+      long high, long low, int tenScale, long[] result, int offset, boolean roundUp) {
+    if (high < 0) {
+      throw new IllegalArgumentException("Value must be positive");
+    }
+
+    boolean needsRounding;
+    do {
+      int powerTen = Math.min(tenScale, MAX_POWER_OF_TEN_INT);
+      tenScale -= powerTen;
+
+      int divisor = POWERS_OF_TEN_INT[powerTen];
+      needsRounding = divideCheckRound(high, low, divisor, result, offset);
+
+      high = result[offset];
+      low = result[offset + 1];
+    }
+    while (tenScale > 0);
+
+    if (roundUp && needsRounding) {
+      incrementUnsafe(result, offset);
+    }
+  }
+
+  static void shiftRight(
+      long high, long low, int shift, boolean roundUp, long[] result, int offset) {
+    if (high < 0) {
+      throw new IllegalArgumentException("Value must be positive");
+    }
+
+    if (shift == 0) {
+      return;
+    }
+
+    boolean needsRounding;
+    if (shift < 64) {
+      needsRounding = roundUp && (low & (1L << (shift - 1))) != 0;
+
+      low = (high << 1 << (63 - shift)) | (low >>> shift);
+      high = high >> shift;
+    }
+    else {
+      needsRounding = roundUp && (high & (1L << (shift - 64 - 1))) != 0;
+
+      low = high >> (shift - 64);
+      high = 0;
+    }
+
+    if (needsRounding) {
+      long tmpHigh = incrementHigh(high, low);
+      long tmpLow = incrementLow(high, low);
+
+      high = tmpHigh;
+      low = tmpLow;
+    }
+
+    result[offset] = high;
+    result[offset + 1] = low;
+  }
+
+  /**
+   * Given a and b, two 128 bit values composed of 64 bit values (a_H, a_L) and (b_H, b_L),
+   * respectively, computes the product in the following way:
+   *
+   *                                                                      a_H a_L
+   *                                                                    * b_H b_L
+   * -----------------------------------------------------------------------------------
+   *      64 bits    |       64 bits       |       64 bits       |        64 bits
+   *                 |                     |                     |
+   *                 |                     | z1_H= (a_L * b_L)_H | z1_L = (a_L * b_L)_L
+   *                 | z2_H= (a_L * b_H)_H | z2_L= (a_L * b_H)_L |
+   *                 | z3_H= (a_H * b_L)_H | z3_L= (a_H * b_L)_L |
+   *  (a_H * b_H)_H  |       (a_H * b_H)_L |                     |
+   * -----------------------------------------------------------------------------------
+   *                 |                     |      result_H       |      result_L
+   *
+   * The product is performed on positive values. The product overflows
+   * * if any of the terms above 128 bits is non-zero:
+   *    * a_H and b_H are both non-zero
+   *    * z2_H is non-zero
+   *    * z3_H is non-zero
+   * * result_H is negative (high bit of a java long is set) --
+   * since the original numbers are positive, the result cannot be negative
+   * * any of z1_H, z2_L and z3_L are negative --
+   * since the original numbers are positive, these intermediate results cannot be negative
+   */
+  private static void multiplyPositives(
+    long leftHigh, long leftLow, long rightHigh, long rightLow, long[] result, int offset) {
+
+    long z1High = MoreMath.unsignedMultiplyHigh(leftLow, rightLow);
+    long z1Low = leftLow * rightLow;
+    long z2Low = leftLow * rightHigh;
+    long z3Low = leftHigh * rightLow;
+
+    long resultLow = z1Low;
+    long resultHigh = z1High + z2Low + z3Low;
+
+    if ((leftHigh != 0 && rightHigh != 0) ||
+      resultHigh < 0 || z1High < 0 || z2Low < 0 || z3Low < 0 ||
+      MoreMath.unsignedMultiplyHigh(leftLow, rightHigh) != 0 ||
+      MoreMath.unsignedMultiplyHigh(leftHigh, rightLow) != 0) {
+      throw overflowException();
+    }
+
+    result[offset] = resultHigh;
+    result[offset + 1] = resultLow;
+  }
+
+  public static void divide(
+      long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+      Int128Holder quotient, Int128Holder remainder) {
+    boolean dividendNegative = dividendHigh < 0;
+    boolean divisorNegative = divisorHigh < 0;
+
+    // for self assignments
+    long tmpHigh;
+    long tmpLow;
+
+    if (dividendNegative) {
+      tmpHigh = negateHigh(dividendHigh, dividendLow);
+      tmpLow = negateLow(dividendLow);
+      dividendHigh = tmpHigh;
+      dividendLow = tmpLow;
+    }
+
+    if (divisorNegative) {
+      tmpHigh = negateHigh(divisorHigh, divisorLow);
+      tmpLow = negateLow(divisorLow);
+      divisorHigh = tmpHigh;
+      divisorLow = tmpLow;
+    }
+
+    dividePositive(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
+
+    boolean resultNegative = dividendNegative ^ divisorNegative;
+    if (resultNegative) {
+      tmpHigh = negateHigh(quotient.high(), quotient.low());
+      tmpLow = negateLow(quotient.low());
+      quotient.set(tmpHigh, tmpLow);
+    }
+
+    if (dividendNegative) {
+      // negate remainder
+      tmpHigh = negateHigh(remainder.high(), remainder.low());
+      tmpLow = negateLow(remainder.low());
+      remainder.set(tmpHigh, tmpLow);
+    }
+  }
+
+  private static long high(long value)
+  {
+    return value >>> 32;
+  }
+
+  private static long low(long value)
+  {
+    return value & LOW_32_BITS;
+  }
+
+  private static boolean divideCheckRound(
+      long dividendHigh, long dividendLow, int divisor, long[] result, int offset) {
+    int remainder = dividePositives(dividendHigh, dividendLow, divisor, result, offset);
+    return (remainder >= (divisor >> 1));
+  }
+
+  private static int dividePositives(
+      long dividendHigh, long dividendLow, int divisor, long[] result, int offset) {
+    long remainder = dividendHigh;
+    long high = remainder / divisor;
+    remainder %= divisor;
+
+    remainder = high(dividendLow) + (remainder << 32);
+    int z1 = (int) (remainder / divisor);
+    remainder %= divisor;
+
+    remainder = low(dividendLow) + (remainder << 32);
+    int z0 = (int) (remainder / divisor);
+
+    long low = (((long) z1) << 32) | (((long) z0) & 0xFFFFFFFFL);
+
+    result[offset] = high;
+    result[offset + 1] = low;
+
+    return (int) (remainder % divisor);
+  }
+
+  private static void dividePositive(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
+    int dividendLeadingZeros = numberOfLeadingZeros(dividendHigh, dividendLow);
+    int divisorLeadingZeros = numberOfLeadingZeros(divisorHigh, divisorLow);
+    int divisorTrailingZeros = numberOfTrailingZeros(divisorHigh, divisorLow);
+
+    int comparison = compareUnsigned(dividendHigh, dividendLow, divisorHigh, divisorLow);
+    if (comparison < 0) {
+      quotient.set(Int128.ZERO());
+      remainder.set(dividendHigh, dividendLow);
+      return;
+    } else if (comparison == 0) {
+      quotient.set(Int128.ONE());
+      remainder.set(Int128.ZERO());
+      return;
+    }
+
+    if (divisorLeadingZeros == 128) {
+      throw new ArithmeticException("Divide by zero");
+    } else if ((dividendHigh | divisorHigh) == 0) {
+      // dividend and divisor fit in an unsigned
+      quotient.set(0, Long.divideUnsigned(dividendLow, divisorLow));
+      remainder.set(0, Long.remainderUnsigned(dividendLow, divisorLow));
+      return;
+    } else if (divisorLeadingZeros == 127) {
+      // divisor is 1
+      quotient.set(dividendHigh, dividendLow);
+      remainder.set(Int128.ZERO());
+      return;
+    } else if ((divisorTrailingZeros + divisorLeadingZeros) == 127) {
+      // only one bit set (i.e., power of 2), so just shift
+
+      //  quotient = dividend >>> divisorTrailingZeros
+      quotient.set(
+        shiftRightUnsignedHigh(dividendHigh, dividendLow, divisorTrailingZeros),
+        shiftRightUnsignedLow(dividendHigh, dividendLow, divisorTrailingZeros));
+
+      //  remainder = dividend & (divisor - 1)
+      long dLow = decrementLow(divisorHigh, divisorLow);
+      long dHigh = decrementHigh(divisorHigh, divisorLow);
+
+      // and
+      remainder.set(
+        andHigh(dividendHigh, dHigh),
+        andLow(dividendLow, dLow));
+      return;
+    }
+
+    // fastDivide when the values differ by this many orders of magnitude
+    if (divisorLeadingZeros - dividendLeadingZeros > 15) {
+      fastDivide(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
+    } else {
+      binaryDivide(dividendHigh, dividendLow, divisorHigh, divisorLow, quotient, remainder);
+    }
+  }
+
+  private static void binaryDivide(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
+    int shift = numberOfLeadingZeros(divisorHigh, divisorLow) -
+      numberOfLeadingZeros(dividendHigh, dividendLow);
+
+    // for self assignments
+    long tmpHigh;
+    long tmpLow;
+
+    // divisor = divisor << shift
+    tmpHigh = shiftLeftHigh(divisorHigh, divisorLow, shift);
+    tmpLow = shiftLeftLow(divisorHigh, divisorLow, shift);
+    divisorHigh = tmpHigh;
+    divisorLow = tmpLow;
+
+    long quotientHigh = 0;
+    long quotientLow = 0;
+
+    do {
+      // quotient = quotient << 1
+      tmpHigh = shiftLeftHigh(quotientHigh, quotientLow, 1);
+      tmpLow = shiftLeftLow(quotientHigh, quotientLow, 1);
+      quotientHigh = tmpHigh;
+      quotientLow = tmpLow;
+
+      // if (dividend >= divisor)
+      int comparison = compareUnsigned(dividendHigh, dividendLow, divisorHigh, divisorLow);
+      if (comparison >= 0) {
+        // dividend = dividend - divisor
+        tmpHigh = subtractHigh(dividendHigh, dividendLow, divisorHigh, divisorLow);
+        tmpLow = subtractLow(dividendLow, divisorLow);
+        dividendHigh = tmpHigh;
+        dividendLow = tmpLow;
+
+        // quotient = quotient | 1
+        quotientLow = quotientLow | 1;
+      }
+
+      // divisor = divisor >>> 1
+      tmpHigh = shiftRightUnsignedHigh(divisorHigh, divisorLow, 1);
+      tmpLow = shiftRightUnsignedLow(divisorHigh, divisorLow, 1);
+      divisorHigh = tmpHigh;
+      divisorLow = tmpLow;
+    } while (shift-- != 0);
+
+    quotient.set(quotientHigh, quotientLow);
+    remainder.set(dividendHigh, dividendLow);
+  }
+
+  private static void fastDivide(
+    long dividendHigh, long dividendLow, long divisorHigh, long divisorLow,
+    Int128Holder quotient, Int128Holder remainder) {
+    if (divisorHigh == 0) {
+      if (Long.compareUnsigned(dividendHigh, divisorLow) < 0) {
+        quotient.high(0);
+        remainder.high(0);
+        divide128by64(dividendHigh, dividendLow, divisorLow, quotient, remainder);
+      } else {
+        quotient.high(Long.divideUnsigned(dividendHigh, divisorLow));
+        remainder.high(0);
+        divide128by64(Long.remainderUnsigned(dividendHigh, divisorLow),
+          dividendLow, divisorLow, quotient, remainder);
+      }
+    } else {
+      // used for self assignments
+      long tempHigh;
+      long tempLow;
+
+      int n = Long.numberOfLeadingZeros(divisorHigh);
+
+      // v1 = divisor << n
+      long v1High = shiftLeftHigh(divisorHigh, divisorLow, n);
+
+      // u1 = dividend >>> 1
+      long u1High = shiftRightUnsignedHigh(dividendHigh, dividendLow, 1);
+      long u1Low = shiftRightUnsignedLow(dividendHigh, dividendLow, 1);
+
+      divide128by64(u1High, u1Low, v1High, quotient, remainder);
+
+      long q1High = 0;
+      long q1Low = quotient.low();
+
+      // q1 = q1 >>> (63 - n)
+      tempLow = shiftRightUnsignedLow(q1High, q1Low, 63 - n);
+      tempHigh = shiftRightUnsignedHigh(q1High, q1Low, 63 - n);
+      q1Low = tempLow;
+      q1High = tempHigh;
+
+      // if (q1 != 0)
+      if (!isZero(q1High, q1Low)) {
+        // q1--
+        tempLow = decrementLow(q1High, q1Low);
+        tempHigh = decrementHigh(q1High, q1Low);
+        q1Low = tempLow;
+        q1High = tempHigh;
+      }
+
+      long quotientHigh = q1High;
+      long quotientLow = q1Low;
+
+      // r = dividend - q1 * divisor
+      long productHigh = multiplyHigh(q1High, q1Low, divisorHigh, divisorLow);
+      long productLow = multiplyLow(q1Low, divisorLow);
+
+      long remainderHigh = subtractHigh(dividendHigh, dividendLow, productHigh, productLow);
+      long remainderLow = subtractLow(dividendLow, productLow);
+
+      if (compare(remainderHigh, remainderLow, divisorHigh, divisorLow) >= 0) {
+        // quotient++
+        tempLow = incrementLow(quotientHigh, quotientLow);
+        tempHigh = incrementHigh(quotientHigh, quotientLow);
+        quotientLow = tempLow;
+        quotientHigh = tempHigh;
+
+        tempLow = subtractLow(remainderLow, divisorLow);
+        tempHigh = subtractHigh(remainderHigh, remainderLow, divisorHigh, divisorLow);
+        remainderHigh = tempHigh;
+        remainderLow = tempLow;
+      }
+
+      quotient.set(quotientHigh, quotientLow);
+      remainder.set(remainderHigh, remainderLow);
+    }
+  }
+
+  private static void divide128by64(
+    long high, long low, long divisor, Int128Holder quotient, Int128Holder remainder) {
+    int shift = Long.numberOfLeadingZeros(divisor);
+    if (shift != 0) {
+      divisor <<= shift;
+      high <<= shift;
+      high |= low >>> (64 - shift);
+      low <<= shift;
+    }
+
+    long divisorHigh = divisor >>> 32;
+    long divisorLow = divisor & 0xFFFFFFFFL;
+    long lowHigh = low >>> 32;
+    long lowLow = low & 0xFFFFFFFFL;
+
+    // Compute high quotient digit.
+    long quotientHigh = Long.divideUnsigned(high, divisorHigh);
+    long rhat = Long.remainderUnsigned(high, divisorHigh);
+
+    // qhat >>> 32 == qhat > base
+    while ((quotientHigh >>> 32) != 0 ||
+      Long.compareUnsigned(quotientHigh * divisorLow, (rhat << 32) | lowHigh) > 0) {
+      quotientHigh -= 1;
+      rhat += divisorHigh;
+      if ((rhat >>> 32) != 0) {
+        break;
+      }
+    }
+
+    long uhat = ((high << 32) | lowHigh) - quotientHigh * divisor;
+
+    // Compute low quotient digit.
+    long quotientLow = Long.divideUnsigned(uhat, divisorHigh);
+    rhat = Long.remainderUnsigned(uhat, divisorHigh);
+
+    while ((quotientLow >>> 32) != 0 ||
+      Long.compareUnsigned(quotientLow * divisorLow, ((rhat << 32) | lowLow)) > 0) {
+      quotientLow -= 1;
+      rhat += divisorHigh;
+      if ((rhat >>> 32) != 0) {
+        break;
+      }
+    }
+
+    quotient.low(quotientHigh << 32 | quotientLow);
+    remainder.low((uhat << 32 | lowLow) - quotientLow * divisor >>> shift);
+  }
+
+  public static void divide(
+    Int128 dividend, Int128 divisor, Int128Holder quotient, Int128Holder remainder) {
+    divide(dividend.high(), dividend.low(), divisor.high(), divisor.low(), quotient, remainder);
+  }
+
+  public static Int128 remainder(Int128 dividend, Int128 divisor) {
+    Int128Holder quotient = new Int128Holder();
+    Int128Holder remainder = new Int128Holder();
+    divide(dividend, divisor, quotient, remainder);
+
+    return remainder.get();
+  }
+
+  private static ArithmeticException overflowException() {
+    return new ArithmeticException("Overflow");
+  }
+
+  /**
+   * A random value between 2^(magnitude - 1) (inclusive) and 2^magnitude (exclusive).
+   * Returns 0 if magnitude is 0.
+   */
+  public static Int128 random(int magnitude) {
+    if (magnitude > 126 || magnitude < 0) {
+      throw new IllegalArgumentException("Magnitude must be in [0, 126] range");
+    }
+
+    if (magnitude == 0) {
+      return Int128.ZERO();
+    }
+
+    if (magnitude == 1) {
+      return Int128.ONE();
+    }
+
+    // TODO: optimize
+    Int128 base = shiftLeft(Int128.apply(1), magnitude - 1);
+    Int128 value = random(base);
+    return add2(base, value);
+  }
+
+  /**
+   * @return a random value between {@link Int128#MIN_VALUE()} (inclusive) and
+   * {@link Int128#MAX_VALUE()} (inclusive)
+   */
+  public static Int128 random() {
+    return Int128.apply(ThreadLocalRandom.current().nextLong(),
+      ThreadLocalRandom.current().nextLong());
+  }
+
+  /**
+   * @return a random value between 0 (inclusive) and given bound (exclusive)
+   */
+  public static Int128 random(Int128 bound) {
+    // Based on Random.nextLong(bound)
+
+    // TODO optimize
+    if (!bound.isPositive()) {
+      throw new IllegalArgumentException("bound must be positive: " + bound);
+    }
+
+    Int128 m = decrement(bound);
+    Int128 result = random();
+    if (bitCount(bound) == 1) {
+      // power of two
+      result = and(result, m);
+    }
+    else {
+      Int128 value = shiftRightUnsigned(result, 1);
+      while (true) {
+        result = remainder(value, bound);
+        if (!subtract(add2(value, m), result).isNegative()) {
+          break;
+        }
+        value = shiftRightUnsigned(random(), 1);
+      }
+    }
+
+    return result;
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoderSuite.scala
@@ -718,7 +718,7 @@ class ExpressionEncoderSuite extends CodegenInterpretedPlanTest with AnalysisTes
       useFallback: Boolean = false): Unit = {
     testAndVerifyNotLeakingReflectionObjects(s"encode/decode for $testName: $input", useFallback) {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           val newInput = Decimal(input)
           doEncodeDecodeTest(newInput)
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -203,7 +203,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
           assert(e.getMessage.contains("cannot be represented as Decimal"))
         case e: RuntimeException =>
           assert(e.getCause.isInstanceOf[ArithmeticException])
-          if (SQLConf.get.getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "JDKBigDecimal") {
+          if (SQLConf.get.isDefaultDecimalImplementation) {
             assert(e.getCause.getMessage.contains("cannot be represented as Decimal"))
           } else {
             assert(e.getCause.getMessage.contains("BigInteger out of Int128 range"))
@@ -213,7 +213,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       val encoder = RowEncoder(schema).resolveAndBind()
-      if (SQLConf.get.getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "JDKBigDecimal") {
+      if (SQLConf.get.isDefaultDecimalImplementation) {
         assert(roundTrip(encoder, row).get(0) == null)
       } else {
         intercept[Exception] {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -144,7 +144,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
   test("encode/decode decimal type") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val schema = new StructType()
           .add("int", IntegerType)
           .add("string", StringType)
@@ -171,7 +171,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
   test("RowEncoder should preserve decimal precision and scale") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val schema = new StructType().add("decimal", DecimalType(10, 5), false)
         val encoder = RowEncoder(schema).resolveAndBind()
         val decimal = Decimal("67123.45")
@@ -185,7 +185,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
   test("SPARK-23179: RowEncoder should respect nullOnOverflow for decimals") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val schema = new StructType().add("decimal", DecimalType.SYSTEM_DEFAULT)
         testDecimalOverflow(schema, Row(BigDecimal("9" * 100)))
         testDecimalOverflow(schema, Row(new java.math.BigDecimal("9" * 100)))
@@ -203,7 +203,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
           assert(e.getMessage.contains("cannot be represented as Decimal"))
         case e: RuntimeException =>
           assert(e.getCause.isInstanceOf[ArithmeticException])
-          if (SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "JDKBigDecimal") {
+          if (SQLConf.get.getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "JDKBigDecimal") {
             assert(e.getCause.getMessage.contains("cannot be represented as Decimal"))
           } else {
             assert(e.getCause.getMessage.contains("BigInteger out of Int128 range"))
@@ -213,7 +213,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       val encoder = RowEncoder(schema).resolveAndBind()
-      if (SQLConf.get.getConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION) == "JDKBigDecimal") {
+      if (SQLConf.get.getConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION) == "JDKBigDecimal") {
         assert(roundTrip(encoder, row).get(0) == null)
       } else {
         intercept[Exception] {
@@ -470,7 +470,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
   private def encodeDecodeTestForDecimal(schema: StructType): Unit = {
     test(s"encode/decode: ${schema.simpleString}") {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           doEncodeDecodeTest(schema)
         }
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -49,7 +49,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     testFunc(_.toFloat)
     testFunc(_.toDouble)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         testFunc(Decimal(_))
       }
     }
@@ -232,7 +232,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
   private def testDecimalAndDoubleType(testFunc: (Int => Any) => Unit): Unit = {
     testFunc(_.toDouble)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         testFunc(Decimal(_))
       }
     }
@@ -280,7 +280,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
   private def testDecimalAndLongType(testFunc: (Int => Any) => Unit): Unit = {
     testFunc(_.toLong)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         testFunc(Decimal(_))
       }
     }
@@ -460,7 +460,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Pmod(Literal(-7), Literal(3)), 2)
     checkEvaluation(Pmod(Literal(7.2D), Literal(4.1D)), 3.1000000000000005)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(Pmod(Literal(Decimal(0.7)), Literal(Decimal(0.2))), Decimal(0.1))
       }
     }
@@ -505,7 +505,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Least(Seq(Literal("abc"), Literal("aaaa"))), "aaaa", InternalRow.empty)
     checkEvaluation(Least(Seq(Literal(true), Literal(false))), false, InternalRow.empty)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(
           Least(Seq(
             Literal(BigDecimal("1234567890987654321123456")),
@@ -567,7 +567,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
     checkEvaluation(Greatest(Seq(Literal("abc"), Literal("aaaa"))), "abc", InternalRow.empty)
     checkEvaluation(Greatest(Seq(Literal(true), Literal(false))), true, InternalRow.empty)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(
           Greatest(Seq(
             Literal(BigDecimal("1234567890987654321123456")),
@@ -622,7 +622,7 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
 
   test("SPARK-28322: IntegralDivide supports decimal type") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(IntegralDivide(Literal(Decimal(1)), Literal(Decimal(2))), 0L)
         checkEvaluation(IntegralDivide(Literal(Decimal(2.4)), Literal(Decimal(1.1))), 2L)
         checkEvaluation(IntegralDivide(Literal(Decimal(1.2)), Literal(Decimal(1.1))), 1L)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ArithmeticExpressionSuite.scala
@@ -634,17 +634,10 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
           checkExceptionInExpression[ArithmeticException](
             IntegralDivide(Literal(Decimal(0.2)), Literal(Decimal(0.0))), "Division by zero")
         }
-        if (implementation.equals("JDKBigDecimal")) {
-          // overflows long and so returns a wrong result
-          checkEvaluation(IntegralDivide(
-            Literal(Decimal("99999999999999999999999999999999999")), Literal(Decimal(0.001))),
-            687399551400672280L)
-        } else {
-          checkExceptionInExpression[ArithmeticException](
-            IntegralDivide(
-              Literal(Decimal("99999999999999999999999999999999999")), Literal(Decimal(0.001))),
-            "Decimal overflow: Decimal128 division.")
-        }
+        // overflows long and so returns a wrong result
+        checkEvaluation(IntegralDivide(
+          Literal(Decimal("99999999999999999999999999999999999")), Literal(Decimal(0.001))),
+          687399551400672280L)
         // overflow during promote precision
         withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
           if (implementation.equals("JDKBigDecimal")) {
@@ -655,7 +648,9 @@ class ArithmeticExpressionSuite extends SparkFunSuite with ExpressionEvalHelper 
             checkExceptionInExpression[ArithmeticException](
               IntegralDivide(
                 Literal(Decimal("99999999999999999999999999999999999999")),
-                Literal(Decimal(0.00001))), "Decimal overflow: Decimal128 division.")
+                Literal(Decimal(0.00001))),
+              "Decimal overflow: Get quotient of " +
+                "Int128(5421010862427522170, 687399551400673279) divide Int128(0, 10).")
           }
         }
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -53,7 +53,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   test("cast from long #2") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(cast(123L, DecimalType(3, 1)), null)
         checkEvaluation(cast(123L, DecimalType(2, 0)), null)
       }
@@ -65,7 +65,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     checkEvaluation(cast(cast(-1200, TimestampType), LongType), -1200.toLong)
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(cast(123, DecimalType(3, 1)), null)
         checkEvaluation(cast(123, DecimalType(2, 0)), null)
       }
@@ -82,7 +82,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   test("casting to fixed-precision decimals") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(cast(123, DecimalType.USER_DEFAULT).nullable === false)
         assert(cast(10.03f, DecimalType.SYSTEM_DEFAULT).nullable)
         assert(cast(10.03, DecimalType.SYSTEM_DEFAULT).nullable)
@@ -185,7 +185,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   test("SPARK-28470: Cast should honor nullOnOverflow property") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(Cast(Literal("134.12"), DecimalType(3, 2)), null)
           checkEvaluation(
             Cast(Literal(Timestamp.valueOf("2019-07-25 22:04:36")), DecimalType(3, 2)), null)
@@ -386,7 +386,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   test("Cast should output null for invalid strings when ANSI is not enabled.") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(cast("abdef", DecimalType.USER_DEFAULT), null)
         }
       }
@@ -514,7 +514,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     checkEvaluation(cast(d, FloatType), null)
     checkEvaluation(cast(d, DoubleType), null)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(cast(d, DecimalType.SYSTEM_DEFAULT), null)
         checkEvaluation(cast(d, DecimalType(10, 2)), null)
       }
@@ -552,7 +552,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   test("Fast fail for cast string type to decimal type") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(cast("12345678901234567890123456789012345678", DecimalType(38, 0)),
           Decimal("12345678901234567890123456789012345678"))
         checkEvaluation(cast("123456789012345678901234567890123456789", DecimalType(38, 0)), null)
@@ -579,7 +579,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   test("data type casting II") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(
           cast(cast(cast(cast(cast(cast("5", ByteType), TimestampType),
             DecimalType.SYSTEM_DEFAULT), LongType), StringType), ShortType),
@@ -637,7 +637,7 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   test("SPARK-39749: cast Decimal to string") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val input = Literal.create(Decimal(0.000000123), DecimalType(9, 9))
         checkEvaluation(cast(input, StringType), "1.23E-7")
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala
@@ -52,16 +52,24 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   }
 
   test("cast from long #2") {
-    checkEvaluation(cast(123L, DecimalType(3, 1)), null)
-    checkEvaluation(cast(123L, DecimalType(2, 0)), null)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(cast(123L, DecimalType(3, 1)), null)
+        checkEvaluation(cast(123L, DecimalType(2, 0)), null)
+      }
+    }
   }
 
   test("cast from int #2") {
     checkEvaluation(cast(cast(1000, TimestampType), LongType), 1000.toLong)
     checkEvaluation(cast(cast(-1200, TimestampType), LongType), -1200.toLong)
 
-    checkEvaluation(cast(123, DecimalType(3, 1)), null)
-    checkEvaluation(cast(123, DecimalType(2, 0)), null)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(cast(123, DecimalType(3, 1)), null)
+        checkEvaluation(cast(123, DecimalType(2, 0)), null)
+      }
+    }
   }
 
   test("cast string to date #2") {
@@ -73,110 +81,118 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   }
 
   test("casting to fixed-precision decimals") {
-    assert(cast(123, DecimalType.USER_DEFAULT).nullable === false)
-    assert(cast(10.03f, DecimalType.SYSTEM_DEFAULT).nullable)
-    assert(cast(10.03, DecimalType.SYSTEM_DEFAULT).nullable)
-    assert(cast(Decimal(10.03), DecimalType.SYSTEM_DEFAULT).nullable === false)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(cast(123, DecimalType.USER_DEFAULT).nullable === false)
+        assert(cast(10.03f, DecimalType.SYSTEM_DEFAULT).nullable)
+        assert(cast(10.03, DecimalType.SYSTEM_DEFAULT).nullable)
+        assert(cast(Decimal(10.03), DecimalType.SYSTEM_DEFAULT).nullable === false)
 
-    assert(cast(123, DecimalType(2, 1)).nullable)
-    assert(cast(10.03f, DecimalType(2, 1)).nullable)
-    assert(cast(10.03, DecimalType(2, 1)).nullable)
-    assert(cast(Decimal(10.03), DecimalType(2, 1)).nullable)
+        assert(cast(123, DecimalType(2, 1)).nullable)
+        assert(cast(10.03f, DecimalType(2, 1)).nullable)
+        assert(cast(10.03, DecimalType(2, 1)).nullable)
+        assert(cast(Decimal(10.03), DecimalType(2, 1)).nullable)
 
-    assert(cast(123, DecimalType.IntDecimal).nullable === false)
-    assert(cast(10.03f, DecimalType.FloatDecimal).nullable)
-    assert(cast(10.03, DecimalType.DoubleDecimal).nullable)
-    assert(cast(Decimal(10.03), DecimalType(4, 2)).nullable === false)
-    assert(cast(Decimal(10.03), DecimalType(5, 3)).nullable === false)
+        assert(cast(123, DecimalType.IntDecimal).nullable === false)
+        assert(cast(10.03f, DecimalType.FloatDecimal).nullable)
+        assert(cast(10.03, DecimalType.DoubleDecimal).nullable)
+        assert(cast(Decimal(10.03), DecimalType(4, 2)).nullable === false)
+        assert(cast(Decimal(10.03), DecimalType(5, 3)).nullable === false)
 
-    assert(cast(Decimal(10.03), DecimalType(3, 1)).nullable)
-    assert(cast(Decimal(10.03), DecimalType(4, 1)).nullable === false)
-    assert(cast(Decimal(9.95), DecimalType(2, 1)).nullable)
-    assert(cast(Decimal(9.95), DecimalType(3, 1)).nullable === false)
+        assert(cast(Decimal(10.03), DecimalType(3, 1)).nullable)
+        assert(cast(Decimal(10.03), DecimalType(4, 1)).nullable === false)
+        assert(cast(Decimal(9.95), DecimalType(2, 1)).nullable)
+        assert(cast(Decimal(9.95), DecimalType(3, 1)).nullable === false)
 
-    assert(cast(true, DecimalType.SYSTEM_DEFAULT).nullable === false)
-    assert(cast(true, DecimalType(1, 1)).nullable)
+        assert(cast(true, DecimalType.SYSTEM_DEFAULT).nullable === false)
+        assert(cast(true, DecimalType(1, 1)).nullable)
 
-    checkEvaluation(cast(10.03, DecimalType.SYSTEM_DEFAULT), Decimal(10.03))
-    checkEvaluation(cast(10.03, DecimalType(4, 2)), Decimal(10.03))
-    checkEvaluation(cast(10.03, DecimalType(3, 1)), Decimal(10.0))
-    checkEvaluation(cast(10.03, DecimalType(2, 0)), Decimal(10))
-    checkEvaluation(cast(10.03, DecimalType(1, 0)), null)
-    checkEvaluation(cast(10.03, DecimalType(2, 1)), null)
-    checkEvaluation(cast(10.03, DecimalType(3, 2)), null)
-    checkEvaluation(cast(Decimal(10.03), DecimalType(3, 1)), Decimal(10.0))
-    checkEvaluation(cast(Decimal(10.03), DecimalType(3, 2)), null)
+        checkEvaluation(cast(10.03, DecimalType.SYSTEM_DEFAULT), Decimal(10.03))
+        checkEvaluation(cast(10.03, DecimalType(4, 2)), Decimal(10.03))
+        checkEvaluation(cast(10.03, DecimalType(3, 1)), Decimal(10.0))
+        checkEvaluation(cast(10.03, DecimalType(2, 0)), Decimal(10))
+        checkEvaluation(cast(10.03, DecimalType(1, 0)), null)
+        checkEvaluation(cast(10.03, DecimalType(2, 1)), null)
+        checkEvaluation(cast(10.03, DecimalType(3, 2)), null)
+        checkEvaluation(cast(Decimal(10.03), DecimalType(3, 1)), Decimal(10.0))
+        checkEvaluation(cast(Decimal(10.03), DecimalType(3, 2)), null)
 
-    checkEvaluation(cast(10.05, DecimalType.SYSTEM_DEFAULT), Decimal(10.05))
-    checkEvaluation(cast(10.05, DecimalType(4, 2)), Decimal(10.05))
-    checkEvaluation(cast(10.05, DecimalType(3, 1)), Decimal(10.1))
-    checkEvaluation(cast(10.05, DecimalType(2, 0)), Decimal(10))
-    checkEvaluation(cast(10.05, DecimalType(1, 0)), null)
-    checkEvaluation(cast(10.05, DecimalType(2, 1)), null)
-    checkEvaluation(cast(10.05, DecimalType(3, 2)), null)
-    checkEvaluation(cast(Decimal(10.05), DecimalType(3, 1)), Decimal(10.1))
-    checkEvaluation(cast(Decimal(10.05), DecimalType(3, 2)), null)
+        checkEvaluation(cast(10.05, DecimalType.SYSTEM_DEFAULT), Decimal(10.05))
+        checkEvaluation(cast(10.05, DecimalType(4, 2)), Decimal(10.05))
+        checkEvaluation(cast(10.05, DecimalType(3, 1)), Decimal(10.1))
+        checkEvaluation(cast(10.05, DecimalType(2, 0)), Decimal(10))
+        checkEvaluation(cast(10.05, DecimalType(1, 0)), null)
+        checkEvaluation(cast(10.05, DecimalType(2, 1)), null)
+        checkEvaluation(cast(10.05, DecimalType(3, 2)), null)
+        checkEvaluation(cast(Decimal(10.05), DecimalType(3, 1)), Decimal(10.1))
+        checkEvaluation(cast(Decimal(10.05), DecimalType(3, 2)), null)
 
-    checkEvaluation(cast(9.95, DecimalType(3, 2)), Decimal(9.95))
-    checkEvaluation(cast(9.95, DecimalType(3, 1)), Decimal(10.0))
-    checkEvaluation(cast(9.95, DecimalType(2, 0)), Decimal(10))
-    checkEvaluation(cast(9.95, DecimalType(2, 1)), null)
-    checkEvaluation(cast(9.95, DecimalType(1, 0)), null)
-    checkEvaluation(cast(Decimal(9.95), DecimalType(3, 1)), Decimal(10.0))
-    checkEvaluation(cast(Decimal(9.95), DecimalType(1, 0)), null)
+        checkEvaluation(cast(9.95, DecimalType(3, 2)), Decimal(9.95))
+        checkEvaluation(cast(9.95, DecimalType(3, 1)), Decimal(10.0))
+        checkEvaluation(cast(9.95, DecimalType(2, 0)), Decimal(10))
+        checkEvaluation(cast(9.95, DecimalType(2, 1)), null)
+        checkEvaluation(cast(9.95, DecimalType(1, 0)), null)
+        checkEvaluation(cast(Decimal(9.95), DecimalType(3, 1)), Decimal(10.0))
+        checkEvaluation(cast(Decimal(9.95), DecimalType(1, 0)), null)
 
-    checkEvaluation(cast(-9.95, DecimalType(3, 2)), Decimal(-9.95))
-    checkEvaluation(cast(-9.95, DecimalType(3, 1)), Decimal(-10.0))
-    checkEvaluation(cast(-9.95, DecimalType(2, 0)), Decimal(-10))
-    checkEvaluation(cast(-9.95, DecimalType(2, 1)), null)
-    checkEvaluation(cast(-9.95, DecimalType(1, 0)), null)
-    checkEvaluation(cast(Decimal(-9.95), DecimalType(3, 1)), Decimal(-10.0))
-    checkEvaluation(cast(Decimal(-9.95), DecimalType(1, 0)), null)
+        checkEvaluation(cast(-9.95, DecimalType(3, 2)), Decimal(-9.95))
+        checkEvaluation(cast(-9.95, DecimalType(3, 1)), Decimal(-10.0))
+        checkEvaluation(cast(-9.95, DecimalType(2, 0)), Decimal(-10))
+        checkEvaluation(cast(-9.95, DecimalType(2, 1)), null)
+        checkEvaluation(cast(-9.95, DecimalType(1, 0)), null)
+        checkEvaluation(cast(Decimal(-9.95), DecimalType(3, 1)), Decimal(-10.0))
+        checkEvaluation(cast(Decimal(-9.95), DecimalType(1, 0)), null)
 
-    checkEvaluation(cast(Decimal("1003"), DecimalType.SYSTEM_DEFAULT), Decimal(1003))
-    checkEvaluation(cast(Decimal("1003"), DecimalType(4, 0)), Decimal(1003))
-    checkEvaluation(cast(Decimal("1003"), DecimalType(3, 0)), null)
+        checkEvaluation(cast(Decimal("1003"), DecimalType.SYSTEM_DEFAULT), Decimal(1003))
+        checkEvaluation(cast(Decimal("1003"), DecimalType(4, 0)), Decimal(1003))
+        checkEvaluation(cast(Decimal("1003"), DecimalType(3, 0)), null)
 
-    checkEvaluation(cast(Decimal("995"), DecimalType(3, 0)), Decimal(995))
+        checkEvaluation(cast(Decimal("995"), DecimalType(3, 0)), Decimal(995))
 
-    checkEvaluation(cast(Double.NaN, DecimalType.SYSTEM_DEFAULT), null)
-    checkEvaluation(cast(1.0 / 0.0, DecimalType.SYSTEM_DEFAULT), null)
-    checkEvaluation(cast(Float.NaN, DecimalType.SYSTEM_DEFAULT), null)
-    checkEvaluation(cast(1.0f / 0.0f, DecimalType.SYSTEM_DEFAULT), null)
+        checkEvaluation(cast(Double.NaN, DecimalType.SYSTEM_DEFAULT), null)
+        checkEvaluation(cast(1.0 / 0.0, DecimalType.SYSTEM_DEFAULT), null)
+        checkEvaluation(cast(Float.NaN, DecimalType.SYSTEM_DEFAULT), null)
+        checkEvaluation(cast(1.0f / 0.0f, DecimalType.SYSTEM_DEFAULT), null)
 
-    checkEvaluation(cast(Double.NaN, DecimalType(2, 1)), null)
-    checkEvaluation(cast(1.0 / 0.0, DecimalType(2, 1)), null)
-    checkEvaluation(cast(Float.NaN, DecimalType(2, 1)), null)
-    checkEvaluation(cast(1.0f / 0.0f, DecimalType(2, 1)), null)
+        checkEvaluation(cast(Double.NaN, DecimalType(2, 1)), null)
+        checkEvaluation(cast(1.0 / 0.0, DecimalType(2, 1)), null)
+        checkEvaluation(cast(Float.NaN, DecimalType(2, 1)), null)
+        checkEvaluation(cast(1.0f / 0.0f, DecimalType(2, 1)), null)
 
-    checkEvaluation(cast(true, DecimalType(2, 1)), Decimal(1))
-    checkEvaluation(cast(true, DecimalType(1, 1)), null)
+        checkEvaluation(cast(true, DecimalType(2, 1)), Decimal(1))
+        checkEvaluation(cast(true, DecimalType(1, 1)), null)
 
-    withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
-      assert(cast(Decimal("1003"), DecimalType(3, -1)).nullable)
-      assert(cast(Decimal("1003"), DecimalType(4, -1)).nullable === false)
-      assert(cast(Decimal("995"), DecimalType(2, -1)).nullable)
-      assert(cast(Decimal("995"), DecimalType(3, -1)).nullable === false)
+        withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
+          assert(cast(Decimal("1003"), DecimalType(3, -1)).nullable)
+          assert(cast(Decimal("1003"), DecimalType(4, -1)).nullable === false)
+          assert(cast(Decimal("995"), DecimalType(2, -1)).nullable)
+          assert(cast(Decimal("995"), DecimalType(3, -1)).nullable === false)
 
-      checkEvaluation(cast(Decimal("1003"), DecimalType(3, -1)), Decimal(1000))
-      checkEvaluation(cast(Decimal("1003"), DecimalType(2, -2)), Decimal(1000))
-      checkEvaluation(cast(Decimal("1003"), DecimalType(1, -2)), null)
-      checkEvaluation(cast(Decimal("1003"), DecimalType(2, -1)), null)
+          checkEvaluation(cast(Decimal("1003"), DecimalType(3, -1)), Decimal(1000))
+          checkEvaluation(cast(Decimal("1003"), DecimalType(2, -2)), Decimal(1000))
+          checkEvaluation(cast(Decimal("1003"), DecimalType(1, -2)), null)
+          checkEvaluation(cast(Decimal("1003"), DecimalType(2, -1)), null)
 
-      checkEvaluation(cast(Decimal("995"), DecimalType(3, -1)), Decimal(1000))
-      checkEvaluation(cast(Decimal("995"), DecimalType(2, -2)), Decimal(1000))
-      checkEvaluation(cast(Decimal("995"), DecimalType(2, -1)), null)
-      checkEvaluation(cast(Decimal("995"), DecimalType(1, -2)), null)
+          checkEvaluation(cast(Decimal("995"), DecimalType(3, -1)), Decimal(1000))
+          checkEvaluation(cast(Decimal("995"), DecimalType(2, -2)), Decimal(1000))
+          checkEvaluation(cast(Decimal("995"), DecimalType(2, -1)), null)
+          checkEvaluation(cast(Decimal("995"), DecimalType(1, -2)), null)
+        }
+      }
     }
   }
 
   test("SPARK-28470: Cast should honor nullOnOverflow property") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
-      checkEvaluation(Cast(Literal("134.12"), DecimalType(3, 2)), null)
-      checkEvaluation(
-        Cast(Literal(Timestamp.valueOf("2019-07-25 22:04:36")), DecimalType(3, 2)), null)
-      checkEvaluation(Cast(Literal(BigDecimal(134.12)), DecimalType(3, 2)), null)
-      checkEvaluation(Cast(Literal(134.12), DecimalType(3, 2)), null)
+      Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          checkEvaluation(Cast(Literal("134.12"), DecimalType(3, 2)), null)
+          checkEvaluation(
+            Cast(Literal(Timestamp.valueOf("2019-07-25 22:04:36")), DecimalType(3, 2)), null)
+          checkEvaluation(Cast(Literal(BigDecimal(134.12)), DecimalType(3, 2)), null)
+          checkEvaluation(Cast(Literal(134.12), DecimalType(3, 2)), null)
+        }
+      }
     }
   }
 
@@ -369,7 +385,11 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
 
   test("Cast should output null for invalid strings when ANSI is not enabled.") {
     withSQLConf(SQLConf.ANSI_ENABLED.key -> "false") {
-      checkEvaluation(cast("abdef", DecimalType.USER_DEFAULT), null)
+      Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          checkEvaluation(cast("abdef", DecimalType.USER_DEFAULT), null)
+        }
+      }
       checkEvaluation(cast("2012-12-11", DoubleType), null)
 
       // cast to array
@@ -493,8 +513,12 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
     checkEvaluation(cast(d, LongType), null)
     checkEvaluation(cast(d, FloatType), null)
     checkEvaluation(cast(d, DoubleType), null)
-    checkEvaluation(cast(d, DecimalType.SYSTEM_DEFAULT), null)
-    checkEvaluation(cast(d, DecimalType(10, 2)), null)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(cast(d, DecimalType.SYSTEM_DEFAULT), null)
+        checkEvaluation(cast(d, DecimalType(10, 2)), null)
+      }
+    }
     checkEvaluation(cast(d, StringType), "1970-01-01")
 
     checkEvaluation(
@@ -527,40 +551,48 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   }
 
   test("Fast fail for cast string type to decimal type") {
-    checkEvaluation(cast("12345678901234567890123456789012345678", DecimalType(38, 0)),
-      Decimal("12345678901234567890123456789012345678"))
-    checkEvaluation(cast("123456789012345678901234567890123456789", DecimalType(38, 0)), null)
-    checkEvaluation(cast("12345678901234567890123456789012345678", DecimalType(38, 1)), null)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(cast("12345678901234567890123456789012345678", DecimalType(38, 0)),
+          Decimal("12345678901234567890123456789012345678"))
+        checkEvaluation(cast("123456789012345678901234567890123456789", DecimalType(38, 0)), null)
+        checkEvaluation(cast("12345678901234567890123456789012345678", DecimalType(38, 1)), null)
 
-    checkEvaluation(cast("0.00000000000000000000000000000000000001", DecimalType(38, 0)),
-      Decimal("0"))
-    checkEvaluation(cast("0.00000000000000000000000000000000000000000001", DecimalType(38, 0)),
-      Decimal("0"))
-    checkEvaluation(cast("0.00000000000000000000000000000000000001", DecimalType(38, 18)),
-      Decimal("0E-18"))
-    checkEvaluation(cast("6E-120", DecimalType(38, 0)),
-      Decimal("0"))
+        checkEvaluation(cast("0.00000000000000000000000000000000000001", DecimalType(38, 0)),
+          Decimal("0"))
+        checkEvaluation(cast("0.00000000000000000000000000000000000000000001", DecimalType(38, 0)),
+          Decimal("0"))
+        checkEvaluation(cast("0.00000000000000000000000000000000000001", DecimalType(38, 18)),
+          Decimal("0E-18"))
+        checkEvaluation(cast("6E-120", DecimalType(38, 0)),
+          Decimal("0"))
 
-    checkEvaluation(cast("6E+37", DecimalType(38, 0)),
-      Decimal("60000000000000000000000000000000000000"))
-    checkEvaluation(cast("6E+38", DecimalType(38, 0)), null)
-    checkEvaluation(cast("6E+37", DecimalType(38, 1)), null)
+        checkEvaluation(cast("6E+37", DecimalType(38, 0)),
+          Decimal("60000000000000000000000000000000000000"))
+        checkEvaluation(cast("6E+38", DecimalType(38, 0)), null)
+        checkEvaluation(cast("6E+37", DecimalType(38, 1)), null)
 
-    checkEvaluation(cast("abcd", DecimalType(38, 1)), null)
+        checkEvaluation(cast("abcd", DecimalType(38, 1)), null)
+      }
+    }
   }
 
   test("data type casting II") {
-    checkEvaluation(
-      cast(cast(cast(cast(cast(cast("5", ByteType), TimestampType),
-        DecimalType.SYSTEM_DEFAULT), LongType), StringType), ShortType),
-        5.toShort)
-      checkEvaluation(
-        cast(cast(cast(cast(cast(cast("5", TimestampType, UTC_OPT), ByteType),
-          DecimalType.SYSTEM_DEFAULT), LongType), StringType), ShortType),
-        null)
-      checkEvaluation(cast(cast(cast(cast(cast(cast("5", DecimalType.SYSTEM_DEFAULT),
-        ByteType), TimestampType), LongType), StringType), ShortType),
-        5.toShort)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(
+          cast(cast(cast(cast(cast(cast("5", ByteType), TimestampType),
+            DecimalType.SYSTEM_DEFAULT), LongType), StringType), ShortType),
+          5.toShort)
+        checkEvaluation(
+          cast(cast(cast(cast(cast(cast("5", TimestampType, UTC_OPT), ByteType),
+            DecimalType.SYSTEM_DEFAULT), LongType), StringType), ShortType),
+          null)
+        checkEvaluation(cast(cast(cast(cast(cast(cast("5", DecimalType.SYSTEM_DEFAULT),
+          ByteType), TimestampType), LongType), StringType), ShortType),
+          5.toShort)
+      }
+    }
   }
 
   test("Cast from double II") {
@@ -604,8 +636,12 @@ class CastWithAnsiOffSuite extends CastSuiteBase {
   }
 
   test("SPARK-39749: cast Decimal to string") {
-    val input = Literal.create(Decimal(0.000000123), DecimalType(9, 9))
-    checkEvaluation(cast(input, StringType), "1.23E-7")
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        val input = Literal.create(Decimal(0.000000123), DecimalType(9, 9))
+        checkEvaluation(cast(input, StringType), "1.23E-7")
+      }
+    }
   }
 
   private def castOverflowErrMsg(targetType: DataType): String = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOnSuite.scala
@@ -46,7 +46,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
     Seq(Int.MaxValue + 1L, Int.MinValue - 1L).foreach { value =>
       checkExceptionInExpression[ArithmeticException](cast(value, dt), "overflow")
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkExceptionInExpression[ArithmeticException](
             cast(Decimal(value.toString), dt), "overflow")
         }
@@ -61,7 +61,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
   private def testLongMaxAndMin(dt: DataType): Unit = {
     assert(Seq(LongType, IntegerType).contains(dt))
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         Seq(
           Decimal(Long.MaxValue) + Decimal(1),
           Decimal(Long.MinValue) - Decimal(1)).foreach { value =>
@@ -90,7 +90,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
       checkEvaluation(cast(value, ByteType), value)
       checkEvaluation(cast(value.toString, ByteType), value)
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(cast(Decimal(value.toString), ByteType), value)
         }
       }
@@ -113,7 +113,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
       checkEvaluation(cast(value, ShortType), value)
       checkEvaluation(cast(value.toString, ShortType), value)
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(cast(Decimal(value.toString), ShortType), value)
         }
       }
@@ -130,7 +130,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
       checkEvaluation(cast(value, IntegerType), value)
       checkEvaluation(cast(value.toString, IntegerType), value)
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(cast(Decimal(value.toString), IntegerType), value)
         }
       }
@@ -147,7 +147,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
       checkEvaluation(cast(value, LongType), value)
       checkEvaluation(cast(value.toString, LongType), value)
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(cast(Decimal(value.toString), LongType), value)
         }
       }
@@ -160,7 +160,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   test("ANSI mode: Throw exception on casting out-of-range value to decimal type") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkExceptionInExpression[ArithmeticException](
           cast(Literal("134.12"), DecimalType(3, 2)), "cannot be represented")
         checkExceptionInExpression[ArithmeticException](
@@ -273,7 +273,7 @@ class CastWithAnsiOnSuite extends CastSuiteBase with QueryErrorsBase {
 
   test("Fast fail for cast string type to decimal type in ansi mode") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(cast("12345678901234567890123456789012345678", DecimalType(38, 0)),
           Decimal("12345678901234567890123456789012345678"))
         checkExceptionInExpression[ArithmeticException](

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HashExpressionsSuite.scala
@@ -558,7 +558,7 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       .add("udt", new ExamplePointUDT))
 
   Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-    withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+    withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
       testHash(
         new StructType()
           .add(s"bigDecimalWith$implementation", DecimalType.SYSTEM_DEFAULT)
@@ -590,7 +590,7 @@ class HashExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
         expected: Long): Unit = {
       val decimalType = DataTypes.createDecimalType(precision, scale)
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           val decimal = {
             val value = Decimal.apply(new java.math.BigDecimal(input))
             if (value.changePrecision(precision, scale)) value else null

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -104,7 +104,7 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("seconds") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(ExtractIntervalSeconds("0 second"), Decimal(0, 8, 6))
         checkEvaluation(ExtractIntervalSeconds("1 second"), Decimal(1.0, 8, 6))
         checkEvaluation(ExtractIntervalSeconds("-1 second"), Decimal(-1.0, 8, 6))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/IntervalExpressionsSuite.scala
@@ -103,18 +103,23 @@ class IntervalExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("seconds") {
-    checkEvaluation(ExtractIntervalSeconds("0 second"), Decimal(0, 8, 6))
-    checkEvaluation(ExtractIntervalSeconds("1 second"), Decimal(1.0, 8, 6))
-    checkEvaluation(ExtractIntervalSeconds("-1 second"), Decimal(-1.0, 8, 6))
-    checkEvaluation(ExtractIntervalSeconds("1 minute 59 second"), Decimal(59.0, 8, 6))
-    checkEvaluation(ExtractIntervalSeconds("-59 minutes -59 seconds"), Decimal(-59.0, 8, 6))
-    // Years and months must not be taken into account
-    checkEvaluation(ExtractIntervalSeconds("100 year 10 months 10 seconds"), Decimal(10.0, 8, 6))
-    checkEvaluation(ExtractIntervalSeconds(largeInterval), Decimal(59.999999, 8, 6))
-    checkEvaluation(
-      ExtractIntervalSeconds("10 seconds 1 milliseconds 1 microseconds"),
-      Decimal(10001001, 8, 6))
-    checkEvaluation(ExtractIntervalSeconds("61 seconds 1 microseconds"), Decimal(1000001, 8, 6))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(ExtractIntervalSeconds("0 second"), Decimal(0, 8, 6))
+        checkEvaluation(ExtractIntervalSeconds("1 second"), Decimal(1.0, 8, 6))
+        checkEvaluation(ExtractIntervalSeconds("-1 second"), Decimal(-1.0, 8, 6))
+        checkEvaluation(ExtractIntervalSeconds("1 minute 59 second"), Decimal(59.0, 8, 6))
+        checkEvaluation(ExtractIntervalSeconds("-59 minutes -59 seconds"), Decimal(-59.0, 8, 6))
+        // Years and months must not be taken into account
+        checkEvaluation(
+          ExtractIntervalSeconds("100 year 10 months 10 seconds"), Decimal(10.0, 8, 6))
+        checkEvaluation(ExtractIntervalSeconds(largeInterval), Decimal(59.999999, 8, 6))
+        checkEvaluation(
+          ExtractIntervalSeconds("10 seconds 1 milliseconds 1 microseconds"),
+          Decimal(10001001, 8, 6))
+        checkEvaluation(ExtractIntervalSeconds("61 seconds 1 microseconds"), Decimal(1000001, 8, 6))
+      }
+    }
   }
 
   test("multiply") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/MathExpressionsSuite.scala
@@ -342,7 +342,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkConsistencyBetweenInterpretedAndCodegen(Ceil, DoubleType)
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         testUnary(Ceil, (d: Decimal) => d.ceil, (-20 to 20).map(x => Decimal(x * 0.1)))
         checkConsistencyBetweenInterpretedAndCodegen(Ceil, DecimalType(25, 3))
         checkConsistencyBetweenInterpretedAndCodegen(Ceil, DecimalType(25, 0))
@@ -376,7 +376,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkConsistencyBetweenInterpretedAndCodegen(Floor, DoubleType)
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         testUnary(Floor, (d: Decimal) => d.floor, (-20 to 20).map(x => Decimal(x * 0.1)))
         checkConsistencyBetweenInterpretedAndCodegen(Floor, DecimalType(25, 3))
         checkConsistencyBetweenInterpretedAndCodegen(Floor, DecimalType(25, 0))
@@ -749,7 +749,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(BRound(longPi, scale), longResults(i), EmptyRow)
       checkEvaluation(BRound(floatPi, scale), floatResults(i), EmptyRow)
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkEvaluation(checkDataTypeAndCast(
             RoundFloor(Literal(doublePi), Literal(scale))), doubleResultsFloor(i), EmptyRow)
           checkEvaluation(checkDataTypeAndCast(
@@ -788,7 +788,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       BigDecimal("3.141593"), BigDecimal("3.1415927"))
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         (0 to 7).foreach { i =>
           checkEvaluation(Round(bdPi, i), bdResults(i), EmptyRow)
           checkEvaluation(BRound(bdPi, i), bdResults(i), EmptyRow)
@@ -824,7 +824,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Round(-0.35, 1), -0.4)
     checkEvaluation(Round(-35, -1), -40)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(Round(BigDecimal("45.00"), -1), BigDecimal(50))
       }
     }
@@ -835,7 +835,7 @@ class MathExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(BRound(-0.35, 1), -0.4)
     checkEvaluation(BRound(-35, -1), -40)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(BRound(BigDecimal("45.00"), -1), BigDecimal(40))
         checkEvaluation(checkDataTypeAndCast(RoundFloor(Literal(2.5), Literal(0))), Decimal(2))
         checkEvaluation(checkDataTypeAndCast(RoundFloor(Literal(3.5), Literal(0))), Decimal(3))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -928,10 +928,14 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(FormatNumber(Literal(12831273.83421d), Literal(0)), "12,831,274")
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal(3)), "123,123,324,123.000")
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal(-1)), null)
-    checkEvaluation(
-      FormatNumber(
-        Literal(Decimal(123123324123L) * Decimal(123123.21234d)), Literal(4)),
-      "15,159,339,180,002,773.2778")
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(
+          FormatNumber(
+            Literal(Decimal(123123324123L) * Decimal(123123.21234d)), Literal(4)),
+          "15,159,339,180,002,773.2778")
+      }
+    }
     checkEvaluation(FormatNumber(Literal.create(null, IntegerType), Literal(3)), null)
     assert(FormatNumber(Literal.create(null, NullType), Literal(3)).resolved === false)
 
@@ -946,9 +950,13 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(FormatNumber(Literal(12831273.83421d), Literal("")), "12,831,274")
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal("###,###,###,###,###.###")),
       "123,123,324,123")
-    checkEvaluation(
-      FormatNumber(Literal(Decimal(123123324123L) * Decimal(123123.21234d)),
-        Literal("###,###,###,###,###.####")), "15,159,339,180,002,773.2778")
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkEvaluation(
+          FormatNumber(Literal(Decimal(123123324123L) * Decimal(123123.21234d)),
+            Literal("###,###,###,###,###.####")), "15,159,339,180,002,773.2778")
+      }
+    }
     checkEvaluation(FormatNumber(Literal.create(null, IntegerType), Literal("##.###")), null)
     assert(FormatNumber(Literal.create(null, NullType), Literal("##.###")).resolved === false)
 
@@ -961,58 +969,62 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("ToNumber: positive tests") {
-    Seq(
-      ("$345", "S$999,099.99") -> Decimal(345),
-      ("-$12,345.67", "S$999,099.99") -> Decimal(-12345.67),
-      ("454,123", "999,099") -> Decimal(454123),
-      ("$045", "S$999,099.99") -> Decimal(45),
-      ("454", "099") -> Decimal(454),
-      ("454.", "099.99") -> Decimal(454.0),
-      ("454.6", "099D99") -> Decimal(454.6),
-      ("454.67", "099.00") -> Decimal(454.67),
-      ("454", "000") -> Decimal(454),
-      ("  454 ", "9099") -> Decimal(454),
-      ("454", "099") -> Decimal(454),
-      ("454.67", "099.99") -> Decimal(454.67),
-      ("$454", "$999") -> Decimal(454),
-      ("  454,123 ", "999G099") -> Decimal(454123),
-      ("$454,123", "$999G099") -> Decimal(454123),
-      ("+$89,1,2,3,45.123", "S$999,0,0,0,999.00000") -> Decimal(8912345.123),
-      ("-454", "S999") -> Decimal(-454),
-      ("+454", "S999") -> Decimal(454),
-      ("454", "999PR") -> Decimal(454),
-      (" 454 ", "999PR") -> Decimal(454),
-      ("454-", "999MI") -> Decimal(-454),
-      ("-$54", "MI$99") -> Decimal(-54),
-      // The input string contains more digits than fit in a long integer.
-      ("123,456,789,123,456,789,123", "999,999,999,999,999,999,999") ->
-        Decimal(new JavaBigDecimal("123456789123456789123"))
-    ).foreach { case ((str: String, format: String), expected: Decimal) =>
-      val toNumberExpr = ToNumber(Literal(str), Literal(format))
-      assert(toNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(toNumberExpr, expected)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        Seq(
+          ("$345", "S$999,099.99") -> Decimal(345),
+          ("-$12,345.67", "S$999,099.99") -> Decimal(-12345.67),
+          ("454,123", "999,099") -> Decimal(454123),
+          ("$045", "S$999,099.99") -> Decimal(45),
+          ("454", "099") -> Decimal(454),
+          ("454.", "099.99") -> Decimal(454.0),
+          ("454.6", "099D99") -> Decimal(454.6),
+          ("454.67", "099.00") -> Decimal(454.67),
+          ("454", "000") -> Decimal(454),
+          ("  454 ", "9099") -> Decimal(454),
+          ("454", "099") -> Decimal(454),
+          ("454.67", "099.99") -> Decimal(454.67),
+          ("$454", "$999") -> Decimal(454),
+          ("  454,123 ", "999G099") -> Decimal(454123),
+          ("$454,123", "$999G099") -> Decimal(454123),
+          ("+$89,1,2,3,45.123", "S$999,0,0,0,999.00000") -> Decimal(8912345.123),
+          ("-454", "S999") -> Decimal(-454),
+          ("+454", "S999") -> Decimal(454),
+          ("454", "999PR") -> Decimal(454),
+          (" 454 ", "999PR") -> Decimal(454),
+          ("454-", "999MI") -> Decimal(-454),
+          ("-$54", "MI$99") -> Decimal(-54),
+          // The input string contains more digits than fit in a long integer.
+          ("123,456,789,123,456,789,123", "999,999,999,999,999,999,999") ->
+            Decimal(new JavaBigDecimal("123456789123456789123"))
+        ).foreach { case ((str: String, format: String), expected: Decimal) =>
+          val toNumberExpr = ToNumber(Literal(str), Literal(format))
+          assert(toNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(toNumberExpr, expected)
 
-      val tryToNumberExpr = TryToNumber(Literal(str), Literal(format))
-      assert(tryToNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(tryToNumberExpr, expected)
-    }
+          val tryToNumberExpr = TryToNumber(Literal(str), Literal(format))
+          assert(tryToNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(tryToNumberExpr, expected)
+        }
 
-    for (i <- 0 to 2) {
-      for (j <- 3 to 5) {
-        for (k <- 6 to 9) {
-          Seq(
-            (s"$i$j$k", "999") -> Decimal(s"$i$j$k".toInt),
-            (s"$i$j$k", "S099.") -> Decimal(s"$i$j$k".toInt),
-            (s"$i$j.$k", "99.9") -> Decimal(s"$i$j.$k".toDouble),
-            (s"$i,$j,$k", "999,999,0") -> Decimal(s"$i$j$k".toInt)
-          ).foreach { case ((str: String, format: String), expected: Decimal) =>
-            val toNumberExpr = ToNumber(Literal(str), Literal(format))
-            assert(toNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-            checkEvaluation(toNumberExpr, expected)
+        for (i <- 0 to 2) {
+          for (j <- 3 to 5) {
+            for (k <- 6 to 9) {
+              Seq(
+                (s"$i$j$k", "999") -> Decimal(s"$i$j$k".toInt),
+                (s"$i$j$k", "S099.") -> Decimal(s"$i$j$k".toInt),
+                (s"$i$j.$k", "99.9") -> Decimal(s"$i$j.$k".toDouble),
+                (s"$i,$j,$k", "999,999,0") -> Decimal(s"$i$j$k".toInt)
+              ).foreach { case ((str: String, format: String), expected: Decimal) =>
+                val toNumberExpr = ToNumber(Literal(str), Literal(format))
+                assert(toNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+                checkEvaluation(toNumberExpr, expected)
 
-            val tryToNumberExpr = TryToNumber(Literal(str), Literal(format))
-            assert(tryToNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-            checkEvaluation(tryToNumberExpr, expected)
+                val tryToNumberExpr = TryToNumber(Literal(str), Literal(format))
+                assert(tryToNumberExpr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+                checkEvaluation(tryToNumberExpr, expected)
+              }
+            }
           }
         }
       }
@@ -1080,12 +1092,16 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
           assert(message.contains(expectedErrMsg))
       }
 
-      val toCharResult = ToCharacter(Decimal(456), Literal(format)).checkInputDataTypes()
-      assert(toCharResult != TypeCheckResult.TypeCheckSuccess,
-        s"The format string should have been invalid: $format")
-      toCharResult match {
-        case TypeCheckResult.TypeCheckFailure(message) =>
-          assert(message.contains(expectedErrMsg))
+      Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          val toCharResult = ToCharacter(Decimal(456), Literal(format)).checkInputDataTypes()
+          assert(toCharResult != TypeCheckResult.TypeCheckSuccess,
+            s"The format string should have been invalid: $format")
+          toCharResult match {
+            case TypeCheckResult.TypeCheckFailure(message) =>
+              assert(message.contains(expectedErrMsg))
+          }
+        }
       }
     }
   }
@@ -1132,314 +1148,318 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("ToCharacter: positive tests") {
-    // Test '0' and '9'
-    Seq(
-      (Decimal(454),
-        "9999") ->
-        " 454",
-      (Decimal(454),
-        "99999") ->
-        "  454",
-      (Decimal(4),
-        "0") ->
-        "4",
-      (Decimal(45),
-        "00") ->
-        "45",
-      (Decimal(454),
-        "000") ->
-        "454",
-      (Decimal(454),
-        "0000") ->
-        "0454",
-      (Decimal(454),
-        "00000") ->
-        "00454"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        // Test '0' and '9'
+        Seq(
+          (Decimal(454),
+            "9999") ->
+            " 454",
+          (Decimal(454),
+            "99999") ->
+            "  454",
+          (Decimal(4),
+            "0") ->
+            "4",
+          (Decimal(45),
+            "00") ->
+            "45",
+          (Decimal(454),
+            "000") ->
+            "454",
+          (Decimal(454),
+            "0000") ->
+            "0454",
+          (Decimal(454),
+            "00000") ->
+            "00454"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test '.' and 'D'
-    Seq(
-      (Decimal(0.4542),
-        ".00000") ->
-        ".45420",
-      (Decimal(454.2),
-        "000.0") ->
-        "454.2",
-      (Decimal(454),
-        "000.0") ->
-        "454.0",
-      (Decimal(454.2),
-        "000.00") ->
-        "454.20",
-      (Decimal(454),
-        "000.00") ->
-        "454.00",
-      (Decimal(0.4542),
-        ".0000") ->
-        ".4542",
-      (Decimal(4542),
-        "0000.") ->
-        "4542 "
-    ).foreach { case ((decimal, format), expected) =>
-      val format2 = format.replace('.', 'D')
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
+        // Test '.' and 'D'
+        Seq(
+          (Decimal(0.4542),
+            ".00000") ->
+            ".45420",
+          (Decimal(454.2),
+            "000.0") ->
+            "454.2",
+          (Decimal(454),
+            "000.0") ->
+            "454.0",
+          (Decimal(454.2),
+            "000.00") ->
+            "454.20",
+          (Decimal(454),
+            "000.00") ->
+            "454.00",
+          (Decimal(0.4542),
+            ".0000") ->
+            ".4542",
+          (Decimal(4542),
+            "0000.") ->
+            "4542 "
+        ).foreach { case ((decimal, format), expected) =>
+          val format2 = format.replace('.', 'D')
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
 
-      expr = ToCharacter(Literal(decimal), Literal(format2))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+          expr = ToCharacter(Literal(decimal), Literal(format2))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    Seq(
-      (Decimal(454.2),
-        "0000.00") ->
-        "0454.20",
-      (Decimal(454),
-        "0000.00") ->
-        "0454.00",
-      (Decimal(4542),
-        "00000.") ->
-        "04542 ",
-      (Decimal(454.2),
-        "9999.99") ->
-        " 454.20",
-      (Decimal(454),
-        "9999.99") ->
-        " 454.00",
-      // There are no digits after the decimal point.
-      (Decimal(4542),
-        "99999.") ->
-        " 4542 "
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+        Seq(
+          (Decimal(454.2),
+            "0000.00") ->
+            "0454.20",
+          (Decimal(454),
+            "0000.00") ->
+            "0454.00",
+          (Decimal(4542),
+            "00000.") ->
+            "04542 ",
+          (Decimal(454.2),
+            "9999.99") ->
+            " 454.20",
+          (Decimal(454),
+            "9999.99") ->
+            " 454.00",
+          // There are no digits after the decimal point.
+          (Decimal(4542),
+            "99999.") ->
+            " 4542 "
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test ',' and 'G'
-    Seq(
-      (Decimal(12454),
-        "0,0000") ->
-        "1,2454",
-      (Decimal(12454),
-        "00,000") ->
-        "12,454",
-      (Decimal(124543),
-        "000,000") ->
-        "124,543",
-      (Decimal(12),
-        "000,000") ->
-        "000,012",
-      (Decimal(1245436),
-        "0,000,000") ->
-        "1,245,436",
-      (Decimal(12454367),
-        "00,000,000") ->
-        "12,454,367"
-    ).foreach { case ((decimal, format), expected) =>
-      val format2 = format.replace(',', 'G')
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
+        // Test ',' and 'G'
+        Seq(
+          (Decimal(12454),
+            "0,0000") ->
+            "1,2454",
+          (Decimal(12454),
+            "00,000") ->
+            "12,454",
+          (Decimal(124543),
+            "000,000") ->
+            "124,543",
+          (Decimal(12),
+            "000,000") ->
+            "000,012",
+          (Decimal(1245436),
+            "0,000,000") ->
+            "1,245,436",
+          (Decimal(12454367),
+            "00,000,000") ->
+            "12,454,367"
+        ).foreach { case ((decimal, format), expected) =>
+          val format2 = format.replace(',', 'G')
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
 
-      expr = ToCharacter(Literal(decimal), Literal(format2))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+          expr = ToCharacter(Literal(decimal), Literal(format2))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    Seq(
-      (Decimal(12454),
-        "000,000") ->
-        "012,454",
-      (Decimal(12454),
-        "00,0000") ->
-        "01,2454",
-      (Decimal(12454),
-        "000,0000") ->
-        "001,2454",
-      (Decimal(12454),
-        "0000,0000") ->
-        "0001,2454",
-      (Decimal(12454),
-        "00,0000") ->
-        "01,2454",
-      (Decimal(12454),
-        "000,0000") ->
-        "001,2454",
-      (Decimal(12454),
-        "0000,0000") ->
-        "0001,2454",
-      (Decimal(12454367),
-        "000,000,000") ->
-        "012,454,367",
-      (Decimal(12454),
-        "999,999") ->
-        " 12,454",
-      (Decimal(12454),
-        "9,9999") ->
-        "1,2454",
-      (Decimal(12454),
-        "99,9999") ->
-        " 1,2454",
-      (Decimal(12454),
-        "999,9999") ->
-        "  1,2454",
-      (Decimal(12454),
-        "9999,9999") ->
-        "   1,2454",
-      (Decimal(12454367),
-        "999,999,999") ->
-        " 12,454,367",
-      (Decimal(12454),
-        "999,999") ->
-        " 12,454"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+        Seq(
+          (Decimal(12454),
+            "000,000") ->
+            "012,454",
+          (Decimal(12454),
+            "00,0000") ->
+            "01,2454",
+          (Decimal(12454),
+            "000,0000") ->
+            "001,2454",
+          (Decimal(12454),
+            "0000,0000") ->
+            "0001,2454",
+          (Decimal(12454),
+            "00,0000") ->
+            "01,2454",
+          (Decimal(12454),
+            "000,0000") ->
+            "001,2454",
+          (Decimal(12454),
+            "0000,0000") ->
+            "0001,2454",
+          (Decimal(12454367),
+            "000,000,000") ->
+            "012,454,367",
+          (Decimal(12454),
+            "999,999") ->
+            " 12,454",
+          (Decimal(12454),
+            "9,9999") ->
+            "1,2454",
+          (Decimal(12454),
+            "99,9999") ->
+            " 1,2454",
+          (Decimal(12454),
+            "999,9999") ->
+            "  1,2454",
+          (Decimal(12454),
+            "9999,9999") ->
+            "   1,2454",
+          (Decimal(12454367),
+            "999,999,999") ->
+            " 12,454,367",
+          (Decimal(12454),
+            "999,999") ->
+            " 12,454"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test '$'
-    Seq(
-      (Decimal(78.12),
-        "$99.99") ->
-        "$78.12",
-      (Decimal(78.12),
-        "$00.00") ->
-        "$78.12"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+        // Test '$'
+        Seq(
+          (Decimal(78.12),
+            "$99.99") ->
+            "$78.12",
+          (Decimal(78.12),
+            "$00.00") ->
+            "$78.12"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test 'S'
-    Seq(
-      (Decimal(83028485),
-        "S99999999999.9999999") ->
-        "   +83028485.0000000",
-      (Decimal(0),
-        "9999999999999999.999999999999999S") ->
-        "               0.000000000000000+",
-      (Decimal(unscaled = 43100000000L, precision = 38, scale = 10),
-        "9999999999999999.999999999999999S") ->
-        "               4.310000000000000+",
-      (Decimal(-454.8),
-        "99G999.9S") ->
-        "   454.8-",
-      (Decimal(-454.8),
-        "00G000.0S") ->
-        "00,454.8-",
-      (Decimal(-454),
-        "S999") ->
-        "-454",
-      (Decimal(-454),
-        "999S") ->
-        "454-",
-      (Decimal(-12454.8),
-        "99G999D9S") ->
-        "12,454.8-",
-      (Decimal(-83028485),
-        "99999999999.9999999S") ->
-        "   83028485.0000000-"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+        // Test 'S'
+        Seq(
+          (Decimal(83028485),
+            "S99999999999.9999999") ->
+            "   +83028485.0000000",
+          (Decimal(0),
+            "9999999999999999.999999999999999S") ->
+            "               0.000000000000000+",
+          (Decimal(unscaled = 43100000000L, precision = 38, scale = 10),
+            "9999999999999999.999999999999999S") ->
+            "               4.310000000000000+",
+          (Decimal(-454.8),
+            "99G999.9S") ->
+            "   454.8-",
+          (Decimal(-454.8),
+            "00G000.0S") ->
+            "00,454.8-",
+          (Decimal(-454),
+            "S999") ->
+            "-454",
+          (Decimal(-454),
+            "999S") ->
+            "454-",
+          (Decimal(-12454.8),
+            "99G999D9S") ->
+            "12,454.8-",
+          (Decimal(-83028485),
+            "99999999999.9999999S") ->
+            "   83028485.0000000-"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test 'MI'
-    Seq(
-      (Decimal(4.31),
-        "9999999999999999.999999999999999MI") ->
-        "               4.310000000000000 ",
-      (Decimal(0),
-        "9999999999999999.999999999999999MI") ->
-        "               0.000000000000000 ",
-      (Decimal(unscaled = 43100000000L, precision = 38, scale = 10),
-        "9999999999999999.999999999999999MI") ->
-        "               4.310000000000000 ",
-      (Decimal(-454.8),
-        "99G999.9MI") ->
-        "   454.8-",
-      (Decimal(-454.8),
-        "00G000.0MI") ->
-        "00,454.8-",
-      (Decimal(-454),
-        "999MI") ->
-        "454-",
-      (Decimal(-12454.8),
-        "99G999D9MI") ->
-        "12,454.8-",
-      (Decimal(-4.31),
-        "MI9999999999999999.999999999999999") ->
-        "               -4.310000000000000"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+        // Test 'MI'
+        Seq(
+          (Decimal(4.31),
+            "9999999999999999.999999999999999MI") ->
+            "               4.310000000000000 ",
+          (Decimal(0),
+            "9999999999999999.999999999999999MI") ->
+            "               0.000000000000000 ",
+          (Decimal(unscaled = 43100000000L, precision = 38, scale = 10),
+            "9999999999999999.999999999999999MI") ->
+            "               4.310000000000000 ",
+          (Decimal(-454.8),
+            "99G999.9MI") ->
+            "   454.8-",
+          (Decimal(-454.8),
+            "00G000.0MI") ->
+            "00,454.8-",
+          (Decimal(-454),
+            "999MI") ->
+            "454-",
+          (Decimal(-12454.8),
+            "99G999D9MI") ->
+            "12,454.8-",
+          (Decimal(-4.31),
+            "MI9999999999999999.999999999999999") ->
+            "               -4.310000000000000"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test 'PR'
-    Seq(
-      (Decimal(4.31),
-        "9999999999999999.999999999999999PR") ->
-        "               4.310000000000000  ",
-      (Decimal(0),
-        "9999999999999999.999999999999999PR") ->
-        "               0.000000000000000  ",
-      (Decimal(unscaled = 43100000000L, precision = 38, scale = 10),
-        "9999999999999999.999999999999999PR") ->
-        "               4.310000000000000  ",
-      (Decimal(-123),
-        "9999999999999999.999PR") ->
-        "             <123.000>",
-      (Decimal(-123.4),
-        "9999999999999999.999PR") ->
-        "             <123.400>",
-      (Decimal(-454.8),
-        "99G999.9PR") ->
-        "   <454.8>",
-      (Decimal(-454.8),
-        "00G000.0PR") ->
-        "<00,454.8>",
-      (Decimal(-454),
-        "999PR") ->
-        "<454>",
-      (Decimal(-12454.8),
-        "99G999D9PR") ->
-        "<12,454.8>"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
-    }
+        // Test 'PR'
+        Seq(
+          (Decimal(4.31),
+            "9999999999999999.999999999999999PR") ->
+            "               4.310000000000000  ",
+          (Decimal(0),
+            "9999999999999999.999999999999999PR") ->
+            "               0.000000000000000  ",
+          (Decimal(unscaled = 43100000000L, precision = 38, scale = 10),
+            "9999999999999999.999999999999999PR") ->
+            "               4.310000000000000  ",
+          (Decimal(-123),
+            "9999999999999999.999PR") ->
+            "             <123.000>",
+          (Decimal(-123.4),
+            "9999999999999999.999PR") ->
+            "             <123.400>",
+          (Decimal(-454.8),
+            "99G999.9PR") ->
+            "   <454.8>",
+          (Decimal(-454.8),
+            "00G000.0PR") ->
+            "<00,454.8>",
+          (Decimal(-454),
+            "999PR") ->
+            "<454>",
+          (Decimal(-12454.8),
+            "99G999D9PR") ->
+            "<12,454.8>"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
 
-    // Test overflows
-    Seq(
-      // If there were more digits in the provided input string (before or after the decimal point)
-      // than specified in the format string, an overflow takes place.
-      (Decimal(454),
-        "0") ->
-        "#",
-      (Decimal(454),
-        "00") ->
-        "##",
-      (Decimal(4.67),
-        "9.9") ->
-        "#.#",
-      (Decimal(4.67),
-        "99.9") ->
-        "##.#"
-    ).foreach { case ((decimal, format), expected) =>
-      var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
-      assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
-      checkEvaluation(expr, expected)
+        // Test overflows
+        Seq(
+          // If there were more digits in the provided input string (before or after the decimal
+          // point) than specified in the format string, an overflow takes place.
+          (Decimal(454),
+            "0") ->
+            "#",
+          (Decimal(454),
+            "00") ->
+            "##",
+          (Decimal(4.67),
+            "9.9") ->
+            "#.#",
+          (Decimal(4.67),
+            "99.9") ->
+            "##.#"
+        ).foreach { case ((decimal, format), expected) =>
+          var expr: Expression = ToCharacter(Literal(decimal), Literal(format))
+          assert(expr.checkInputDataTypes() == TypeCheckResult.TypeCheckSuccess)
+          checkEvaluation(expr, expected)
+        }
+      }
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -929,7 +929,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal(3)), "123,123,324,123.000")
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal(-1)), null)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(
           FormatNumber(
             Literal(Decimal(123123324123L) * Decimal(123123.21234d)), Literal(4)),
@@ -951,7 +951,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(FormatNumber(Literal(123123324123L), Literal("###,###,###,###,###.###")),
       "123,123,324,123")
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkEvaluation(
           FormatNumber(Literal(Decimal(123123324123L) * Decimal(123123.21234d)),
             Literal("###,###,###,###,###.####")), "15,159,339,180,002,773.2778")
@@ -970,7 +970,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("ToNumber: positive tests") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         Seq(
           ("$345", "S$999,099.99") -> Decimal(345),
           ("-$12,345.67", "S$999,099.99") -> Decimal(-12345.67),
@@ -1093,7 +1093,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
       }
 
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           val toCharResult = ToCharacter(Decimal(456), Literal(format)).checkInputDataTypes()
           assert(toCharResult != TypeCheckResult.TypeCheckSuccess,
             s"The format string should have been invalid: $format")
@@ -1149,7 +1149,7 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("ToCharacter: positive tests") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         // Test '0' and '9'
         Seq(
           (Decimal(454),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, LongType, _}
 import org.apache.spark.unsafe.array.ByteArrayMethods
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
@@ -196,8 +197,12 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with PlanTestB
     assert(createdFromNull.getDouble(7) === 0.0d)
     assert(createdFromNull.getUTF8String(8) === null)
     assert(createdFromNull.getBinary(9) === null)
-    assert(createdFromNull.getDecimal(10, 10, 0) === null)
-    assert(createdFromNull.getDecimal(11, 38, 18) === null)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(createdFromNull.getDecimal(10, 10, 0) === null)
+        assert(createdFromNull.getDecimal(11, 38, 18) === null)
+      }
+    }
     // assert(createdFromNull.get(11) === null)
 
     // If we have an UnsafeRow with columns that are initially non-null and we null out those

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -198,7 +198,7 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with PlanTestB
     assert(createdFromNull.getUTF8String(8) === null)
     assert(createdFromNull.getBinary(9) === null)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(createdFromNull.getDecimal(10, 10, 0) === null)
         assert(createdFromNull.getDecimal(11, 38, 18) === null)
       }
@@ -206,7 +206,7 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with PlanTestB
     // assert(createdFromNull.get(11) === null)
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         // If we have an UnsafeRow with columns that are initially non-null and we null out those
         // columns, then the serialized row representation should be identical to what we would get
         // by creating an entirely null row via the converter
@@ -570,7 +570,7 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with PlanTestB
 
     // Simple tests
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val inputRow = InternalRow.fromSeq(Seq(
           false, 3.toByte, 15.toShort, -83, 129L, 1.0f, 8.0, UTF8String.fromString("test"),
           Decimal(255), IntervalUtils.stringToInterval(UTF8String.fromString( "interval 1 day")),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/UnwrapCastInBinaryComparisonSuite.scala
@@ -133,7 +133,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     })
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         Seq(decimal2(100.20), decimal2(-200.50)).foreach(v => {
           assertEquivalent(castDecimal2(f3) > v, f3 > decimal(v))
           assertEquivalent(castDecimal2(f3) >= v, f3 >= decimal(v))
@@ -167,7 +167,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
 
     // Another case: 400.5678 is rounded up to 400.57
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val decimalValue = decimal2(400.5678)
         assertEquivalent(castDecimal2(f3) > decimalValue, f3 >= decimal(decimalValue))
         assertEquivalent(castDecimal2(f3) >= decimalValue, f3 >= decimal(decimalValue))
@@ -215,7 +215,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     Seq("true", "false").foreach { ansiEnabled =>
       withSQLConf(SQLConf.ANSI_ENABLED.key -> ansiEnabled) {
         Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-          withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
             val decimalValue = decimal2(123456.1234)
             assertEquivalent(castDecimal2(f3) === decimalValue, castDecimal2(f3) === decimalValue)
           }
@@ -253,7 +253,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
     assert(doubleMax.asInstanceOf[Double].isNaN)
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(getRange(DecimalType(5, 2)).isEmpty)
       }
     }
@@ -301,7 +301,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
 
   test("SPARK-39896: unwrap cast when the literal of In/InSet downcast failed") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val decimalValue = decimal2(123456.1234)
         val decimalValue2 = decimal2(100.20)
         checkInAndInSet(
@@ -327,7 +327,7 @@ class UnwrapCastInBinaryComparisonSuite extends PlanTest with ExpressionEvalHelp
 
     // Another case: 400.5678 is rounded up to 400.57
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val decimalValue1 = decimal2(400.5678)
         val decimalValue2 = decimal2(1.0)
         checkInAndInSet(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -59,7 +59,7 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLHelper {
 
   test("Handle special case for null variable-length Decimal") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val schema = StructType(StructField("d", DecimalType(19, 0), nullable = true) :: Nil)
         val unsafeRowProjection = UnsafeProjection.create(schema)
         val row = unsafeRowProjection(new SpecificInternalRow(schema))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/UnsafeRowUtilsSuite.scala
@@ -79,7 +79,11 @@ class UnsafeRowUtilsSuite extends SparkFunSuite with SQLHelper {
         // precision=19, scale=0
         val bigDecimalVal2 = Decimal(new JavaBigDecimal("1234567890123456789"))
         row.setDecimal(0, bigDecimalVal2, 19) // should succeed
-        assert(!row.isNullAt(0) && UnsafeRowUtils.getOffsetAndSize(row, 0) == (16, 8))
+        if (implementation == "Int128") {
+          assert(!row.isNullAt(0) && UnsafeRowUtils.getOffsetAndSize(row, 0) == (16, 16))
+        } else {
+          assert(!row.isNullAt(0) && UnsafeRowUtils.getOffsetAndSize(row, 0) == (16, 8))
+        }
         assert(UnsafeRowUtils.validateStructuralIntegrity(row, schema))
 
         // set Decimal field to null explicitly, after which this field no longer supports updating

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -35,46 +35,54 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   }
 
   test("creating decimals") {
-    checkDecimal(new Decimal(), "0", 1, 0)
-    checkDecimal(Decimal(BigDecimal("0.09")), "0.09", 2, 2)
-    checkDecimal(Decimal(BigDecimal("0.9")), "0.9", 1, 1)
-    checkDecimal(Decimal(BigDecimal("0.90")), "0.90", 2, 2)
-    checkDecimal(Decimal(BigDecimal("0.0")), "0.0", 1, 1)
-    checkDecimal(Decimal(BigDecimal("0")), "0", 1, 0)
-    checkDecimal(Decimal(BigDecimal("1.0")), "1.0", 2, 1)
-    checkDecimal(Decimal(BigDecimal("-0.09")), "-0.09", 2, 2)
-    checkDecimal(Decimal(BigDecimal("-0.9")), "-0.9", 1, 1)
-    checkDecimal(Decimal(BigDecimal("-0.90")), "-0.90", 2, 2)
-    checkDecimal(Decimal(BigDecimal("-1.0")), "-1.0", 2, 1)
-    checkDecimal(Decimal(BigDecimal("10.030")), "10.030", 5, 3)
-    checkDecimal(Decimal(BigDecimal("10.030"), 4, 1), "10.0", 4, 1)
-    checkDecimal(Decimal(BigDecimal("-9.95"), 4, 1), "-10.0", 4, 1)
-    checkDecimal(Decimal("10.030"), "10.030", 5, 3)
-    checkDecimal(Decimal(10.03), "10.03", 4, 2)
-    checkDecimal(Decimal(17L), "17", 20, 0)
-    checkDecimal(Decimal(17), "17", 10, 0)
-    checkDecimal(Decimal(17L, 2, 1), "1.7", 2, 1)
-    checkDecimal(Decimal(170L, 4, 2), "1.70", 4, 2)
-    checkDecimal(Decimal(17L, 24, 1), "1.7", 24, 1)
-    checkDecimal(Decimal(1e17.toLong, 18, 0), 1e17.toLong.toString, 18, 0)
-    checkDecimal(Decimal(1000000000000000000L, 20, 2), "10000000000000000.00", 20, 2)
-    checkDecimal(Decimal(Long.MaxValue), Long.MaxValue.toString, 20, 0)
-    checkDecimal(Decimal(Long.MinValue), Long.MinValue.toString, 20, 0)
-    intercept[ArithmeticException](Decimal(170L, 2, 1))
-    intercept[ArithmeticException](Decimal(170L, 2, 0))
-    intercept[ArithmeticException](Decimal(BigDecimal("10.030"), 2, 1))
-    intercept[ArithmeticException](Decimal(BigDecimal("-9.95"), 2, 1))
-    intercept[ArithmeticException](Decimal(1e17.toLong, 17, 0))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkDecimal(new Decimal(), "0", 1, 0)
+        checkDecimal(Decimal(BigDecimal("0.09")), "0.09", 2, 2)
+        checkDecimal(Decimal(BigDecimal("0.9")), "0.9", 1, 1)
+        checkDecimal(Decimal(BigDecimal("0.90")), "0.90", 2, 2)
+        checkDecimal(Decimal(BigDecimal("0.0")), "0.0", 1, 1)
+        checkDecimal(Decimal(BigDecimal("0")), "0", 1, 0)
+        checkDecimal(Decimal(BigDecimal("1.0")), "1.0", 2, 1)
+        checkDecimal(Decimal(BigDecimal("-0.09")), "-0.09", 2, 2)
+        checkDecimal(Decimal(BigDecimal("-0.9")), "-0.9", 1, 1)
+        checkDecimal(Decimal(BigDecimal("-0.90")), "-0.90", 2, 2)
+        checkDecimal(Decimal(BigDecimal("-1.0")), "-1.0", 2, 1)
+        checkDecimal(Decimal(BigDecimal("10.030")), "10.030", 5, 3)
+        checkDecimal(Decimal(BigDecimal("10.030"), 4, 1), "10.0", 4, 1)
+        checkDecimal(Decimal(BigDecimal("-9.95"), 4, 1), "-10.0", 4, 1)
+        checkDecimal(Decimal("10.030"), "10.030", 5, 3)
+        checkDecimal(Decimal(10.03), "10.03", 4, 2)
+        checkDecimal(Decimal(17L), "17", 20, 0)
+        checkDecimal(Decimal(17), "17", 10, 0)
+        checkDecimal(Decimal(17L, 2, 1), "1.7", 2, 1)
+        checkDecimal(Decimal(170L, 4, 2), "1.70", 4, 2)
+        checkDecimal(Decimal(17L, 24, 1), "1.7", 24, 1)
+        checkDecimal(Decimal(1e17.toLong, 18, 0), 1e17.toLong.toString, 18, 0)
+        checkDecimal(Decimal(1000000000000000000L, 20, 2), "10000000000000000.00", 20, 2)
+        checkDecimal(Decimal(Long.MaxValue), Long.MaxValue.toString, 20, 0)
+        checkDecimal(Decimal(Long.MinValue), Long.MinValue.toString, 20, 0)
+        intercept[ArithmeticException](Decimal(170L, 2, 1))
+        intercept[ArithmeticException](Decimal(170L, 2, 0))
+        intercept[ArithmeticException](Decimal(BigDecimal("10.030"), 2, 1))
+        intercept[ArithmeticException](Decimal(BigDecimal("-9.95"), 2, 1))
+        intercept[ArithmeticException](Decimal(1e17.toLong, 17, 0))
+      }
+    }
   }
 
   test("creating decimals with negative scale under legacy mode") {
     withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
-      checkDecimal(Decimal(BigDecimal("98765"), 5, -3), "9.9E+4", 5, -3)
-      checkDecimal(Decimal(BigDecimal("314.159"), 6, -2), "3E+2", 6, -2)
-      checkDecimal(Decimal(BigDecimal(1.579e12), 4, -9), "1.579E+12", 4, -9)
-      checkDecimal(Decimal(BigDecimal(1.579e12), 4, -10), "1.58E+12", 4, -10)
-      checkDecimal(Decimal(103050709L, 9, -10), "1.03050709E+18", 9, -10)
-      checkDecimal(Decimal(1e8.toLong, 10, -10), "1.00000000E+18", 10, -10)
+      Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          checkDecimal(Decimal(BigDecimal("98765"), 5, -3), "9.9E+4", 5, -3)
+          checkDecimal(Decimal(BigDecimal("314.159"), 6, -2), "3E+2", 6, -2)
+          checkDecimal(Decimal(BigDecimal(1.579e12), 4, -9), "1.579E+12", 4, -9)
+          checkDecimal(Decimal(BigDecimal(1.579e12), 4, -10), "1.58E+12", 4, -10)
+          checkDecimal(Decimal(103050709L, 9, -10), "1.03050709E+18", 9, -10)
+          checkDecimal(Decimal(1e8.toLong, 10, -10), "1.00000000E+18", 10, -10)
+        }
+      }
     }
   }
 
@@ -84,10 +92,20 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
         .getMessage
         .contains("Negative scale is not allowed under ansi mode")
     }
-    checkNegativeScaleDecimal(Decimal(BigDecimal("98765"), 5, -3))
-    checkNegativeScaleDecimal(Decimal(BigDecimal("98765").underlying(), 5, -3))
-    checkNegativeScaleDecimal(Decimal(98765L, 5, -3))
-    checkNegativeScaleDecimal(Decimal.createUnsafe(98765L, 5, -3))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkNegativeScaleDecimal(Decimal(BigDecimal("98765"), 5, -3))
+        checkNegativeScaleDecimal(Decimal(BigDecimal("98765").underlying(), 5, -3))
+        checkNegativeScaleDecimal(Decimal(98765L, 5, -3))
+        checkNegativeScaleDecimal(Decimal.createUnsafe(98765L, 5, -3))
+      }
+    }
+  }
+
+  def checkBigIntegerOutInt128Range(d: => Decimal): Unit = {
+    intercept[ArithmeticException](d)
+      .getMessage
+      .contains("BigInteger out of Int128 range")
   }
 
   test("double and long values") {
@@ -97,23 +115,32 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
       assert(d.toLong === longValue)
     }
 
-    checkValues(new Decimal(), 0.0, 0L)
-    checkValues(Decimal(BigDecimal("10.030")), 10.03, 10L)
-    checkValues(Decimal(BigDecimal("10.030"), 4, 1), 10.0, 10L)
-    checkValues(Decimal(BigDecimal("-9.95"), 4, 1), -10.0, -10L)
-    checkValues(Decimal(10.03), 10.03, 10L)
-    checkValues(Decimal(17L), 17.0, 17L)
-    checkValues(Decimal(17), 17.0, 17L)
-    checkValues(Decimal(17L, 2, 1), 1.7, 1L)
-    checkValues(Decimal(170L, 4, 2), 1.7, 1L)
-    checkValues(Decimal(1e16.toLong), 1e16, 1e16.toLong)
-    checkValues(Decimal(1e17.toLong), 1e17, 1e17.toLong)
-    checkValues(Decimal(1e18.toLong), 1e18, 1e18.toLong)
-    checkValues(Decimal(2e18.toLong), 2e18, 2e18.toLong)
-    checkValues(Decimal(Long.MaxValue), Long.MaxValue.toDouble, Long.MaxValue)
-    checkValues(Decimal(Long.MinValue), Long.MinValue.toDouble, Long.MinValue)
-    checkValues(Decimal(Double.MaxValue), Double.MaxValue, 0L)
-    checkValues(Decimal(Double.MinValue), Double.MinValue, 0L)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        checkValues(new Decimal(), 0.0, 0L)
+        checkValues(Decimal(BigDecimal("10.030")), 10.03, 10L)
+        checkValues(Decimal(BigDecimal("10.030"), 4, 1), 10.0, 10L)
+        checkValues(Decimal(BigDecimal("-9.95"), 4, 1), -10.0, -10L)
+        checkValues(Decimal(10.03), 10.03, 10L)
+        checkValues(Decimal(17L), 17.0, 17L)
+        checkValues(Decimal(17), 17.0, 17L)
+        checkValues(Decimal(17L, 2, 1), 1.7, 1L)
+        checkValues(Decimal(170L, 4, 2), 1.7, 1L)
+        checkValues(Decimal(1e16.toLong), 1e16, 1e16.toLong)
+        checkValues(Decimal(1e17.toLong), 1e17, 1e17.toLong)
+        checkValues(Decimal(1e18.toLong), 1e18, 1e18.toLong)
+        checkValues(Decimal(2e18.toLong), 2e18, 2e18.toLong)
+        checkValues(Decimal(Long.MaxValue), Long.MaxValue.toDouble, Long.MaxValue)
+        checkValues(Decimal(Long.MinValue), Long.MinValue.toDouble, Long.MinValue)
+        if (implementation == "JDKBigDecimal") {
+          checkValues(Decimal(Double.MaxValue), Double.MaxValue, 0L)
+          checkValues(Decimal(Double.MinValue), Double.MinValue, 0L)
+        } else {
+          checkBigIntegerOutInt128Range(Decimal(Double.MaxValue))
+          checkBigIntegerOutInt128Range(Decimal(Double.MinValue))
+        }
+      }
+    }
   }
 
   // Accessor for the BigDecimal value of a Decimal, which will be null if it's using Longs
@@ -150,14 +177,22 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   }
 
   test("hash code") {
-    assert(Decimal(123).hashCode() === (123).##)
-    assert(Decimal(-123).hashCode() === (-123).##)
-    assert(Decimal(Int.MaxValue).hashCode() === Int.MaxValue.##)
-    assert(Decimal(Long.MaxValue).hashCode() === Long.MaxValue.##)
-    assert(Decimal(BigDecimal(123)).hashCode() === (123).##)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal(123).hashCode() === (123).##)
+        assert(Decimal(-123).hashCode() === (-123).##)
+        assert(Decimal(Int.MaxValue).hashCode() === Int.MaxValue.##)
+        assert(Decimal(Long.MaxValue).hashCode() === Long.MaxValue.##)
+        assert(Decimal(BigDecimal(123)).hashCode() === (123).##)
 
-    val reallyBig = BigDecimal("123182312312313232112312312123.1231231231")
-    assert(Decimal(reallyBig).hashCode() === reallyBig.hashCode)
+        val reallyBig = BigDecimal("123182312312313232112312312123.1231231231")
+        if (implementation == "JDKBigDecimal") {
+          assert(Decimal(reallyBig).hashCode() === reallyBig.hashCode)
+        } else {
+          checkBigIntegerOutInt128Range(Decimal(reallyBig))
+        }
+      }
+    }
   }
 
   test("equals") {
@@ -165,89 +200,134 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     checkCompact(Decimal(123), true)
     checkCompact(Decimal(BigDecimal(123)), false)
     checkCompact(Decimal("123"), false)
-    assert(Decimal(123) === Decimal(BigDecimal(123)))
-    assert(Decimal(123) === Decimal(BigDecimal("123.00")))
-    assert(Decimal(-123) === Decimal(BigDecimal(-123)))
-    assert(Decimal(-123) === Decimal(BigDecimal("-123.00")))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal(123) === Decimal(BigDecimal(123)))
+        assert(Decimal(123) === Decimal(BigDecimal("123.00")))
+        assert(Decimal(-123) === Decimal(BigDecimal(-123)))
+        assert(Decimal(-123) === Decimal(BigDecimal("-123.00")))
+      }
+    }
   }
 
   test("isZero") {
-    assert(Decimal(0).isZero)
-    assert(Decimal(0, 4, 2).isZero)
-    assert(Decimal("0").isZero)
-    assert(Decimal("0.000").isZero)
-    assert(!Decimal(1).isZero)
-    assert(!Decimal(1, 4, 2).isZero)
-    assert(!Decimal("1").isZero)
-    assert(!Decimal("0.001").isZero)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal(0).isZero)
+        assert(Decimal(0, 4, 2).isZero)
+        assert(Decimal("0").isZero)
+        assert(Decimal("0.000").isZero)
+        assert(!Decimal(1).isZero)
+        assert(!Decimal(1, 4, 2).isZero)
+        assert(!Decimal("1").isZero)
+        assert(!Decimal("0.001").isZero)
+      }
+    }
   }
 
   test("arithmetic") {
-    assert(Decimal(100) + Decimal(-100) === Decimal(0))
-    assert(Decimal(100) + Decimal(-100) === Decimal(0))
-    assert(Decimal(100) * Decimal(-100) === Decimal(-10000))
-    assert(Decimal(1e13) * Decimal(1e13) === Decimal(1e26))
-    assert(Decimal(100) / Decimal(-100) === Decimal(-1))
-    assert(Decimal(100) / Decimal(0) === null)
-    assert(Decimal(100) % Decimal(-100) === Decimal(0))
-    assert(Decimal(100) % Decimal(3) === Decimal(1))
-    assert(Decimal(-100) % Decimal(3) === Decimal(-1))
-    assert(Decimal(100) % Decimal(0) === null)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal(100) + Decimal(-100) === Decimal(0))
+        assert(Decimal(100) + Decimal(-100) === Decimal(0))
+        assert(Decimal(100) * Decimal(-100) === Decimal(-10000))
+        assert(Decimal(1e13) * Decimal(1e13) === Decimal(1e26))
+        assert(Decimal(100) / Decimal(-100) === Decimal(-1))
+        assert(Decimal(100) / Decimal(0) === null)
+        assert(Decimal(100) % Decimal(-100) === Decimal(0))
+        assert(Decimal(100) % Decimal(3) === Decimal(1))
+        assert(Decimal(-100) % Decimal(3) === Decimal(-1))
+        assert(Decimal(100) % Decimal(0) === null)
+      }
+    }
   }
 
   test("longVal arithmetic") {
-    assert(Decimal(10, 2, 0) + Decimal(10, 2, 0) === Decimal(20, 3, 0))
-    assert(Decimal(10, 2, 0) + Decimal(90, 2, 0) === Decimal(100, 3, 0))
-    assert(Decimal(10, 2, 0) - Decimal(-10, 2, 0) === Decimal(20, 3, 0))
-    assert(Decimal(10, 2, 0) - Decimal(-90, 2, 0) === Decimal(100, 3, 0))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal(10, 2, 0) + Decimal(10, 2, 0) === Decimal(20, 3, 0))
+        assert(Decimal(10, 2, 0) + Decimal(90, 2, 0) === Decimal(100, 3, 0))
+        assert(Decimal(10, 2, 0) - Decimal(-10, 2, 0) === Decimal(20, 3, 0))
+        assert(Decimal(10, 2, 0) - Decimal(-90, 2, 0) === Decimal(100, 3, 0))
+      }
+    }
   }
 
   test("quot") {
-    assert(Decimal(100).quot(Decimal(100)) === Decimal(BigDecimal("1")))
-    assert(Decimal(100).quot(Decimal(33)) === Decimal(BigDecimal("3")))
-    assert(Decimal(100).quot(Decimal(-100)) === Decimal(BigDecimal("-1")))
-    assert(Decimal(100).quot(Decimal(-33)) === Decimal(BigDecimal("-3")))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal(100).quot(Decimal(100)) === Decimal(BigDecimal("1")))
+        assert(Decimal(100).quot(Decimal(33)) === Decimal(BigDecimal("3")))
+        assert(Decimal(100).quot(Decimal(-100)) === Decimal(BigDecimal("-1")))
+        assert(Decimal(100).quot(Decimal(-33)) === Decimal(BigDecimal("-3")))
+      }
+    }
   }
 
   test("negate & abs") {
-    assert(-Decimal(100) === Decimal(BigDecimal("-100")))
-    assert(-Decimal(-100) === Decimal(BigDecimal("100")))
-    assert(Decimal(100).abs === Decimal(BigDecimal("100")))
-    assert(Decimal(-100).abs === Decimal(BigDecimal("100")))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(-Decimal(100) === Decimal(BigDecimal("-100")))
+        assert(-Decimal(-100) === Decimal(BigDecimal("100")))
+        assert(Decimal(100).abs === Decimal(BigDecimal("100")))
+        assert(Decimal(-100).abs === Decimal(BigDecimal("100")))
+      }
+    }
   }
 
   test("floor & ceil") {
-    assert(Decimal("10.03").floor === Decimal(BigDecimal("10")))
-    assert(Decimal("10.03").ceil === Decimal(BigDecimal("11")))
-    assert(Decimal("-10.03").floor === Decimal(BigDecimal("-11")))
-    assert(Decimal("-10.03").ceil === Decimal(BigDecimal("-10")))
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(Decimal("10.03").floor === Decimal(BigDecimal("10")))
+        assert(Decimal("10.03").ceil === Decimal(BigDecimal("11")))
+        assert(Decimal("-10.03").floor === Decimal(BigDecimal("-11")))
+        assert(Decimal("-10.03").ceil === Decimal(BigDecimal("-10")))
+      }
+    }
   }
 
   // regression test for SPARK-8359
   test("accurate precision after multiplication") {
-    val decimal = (Decimal(Long.MaxValue, 38, 0) * Decimal(Long.MaxValue, 38, 0)).toJavaBigDecimal
-    assert(decimal.unscaledValue.toString === "85070591730234615847396907784232501249")
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        val decimal =
+          (Decimal(Long.MaxValue, 38, 0) * Decimal(Long.MaxValue, 38, 0)).toJavaBigDecimal
+        assert(decimal.unscaledValue.toString === "85070591730234615847396907784232501249")
+      }
+    }
   }
 
   // regression test for SPARK-8677
   test("fix non-terminating decimal expansion problem") {
-    val decimal = Decimal(1.0, 10, 3) / Decimal(3.0, 10, 3)
-    // The difference between decimal should not be more than 0.001.
-    assert(decimal.toDouble - 0.333 < 0.001)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        val decimal = Decimal(1.0, 10, 3) / Decimal(3.0, 10, 3)
+        // The difference between decimal should not be more than 0.001.
+        assert(decimal.toDouble - 0.333 < 0.001)
+      }
+    }
   }
 
   // regression test for SPARK-8800
   test("fix loss of precision/scale when doing division operation") {
-    val a = Decimal(2) / Decimal(3)
-    assert(a.toDouble < 1.0 && a.toDouble > 0.6)
-    val b = Decimal(1) / Decimal(8)
-    assert(b.toDouble === 0.125)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        val a = Decimal(2) / Decimal(3)
+        assert(a.toDouble < 1.0 && a.toDouble > 0.6)
+        val b = Decimal(1) / Decimal(8)
+        assert(b.toDouble === 0.125)
+      }
+    }
   }
 
   test("set/setOrNull") {
-    assert(new Decimal().set(10L, 10, 0).toUnscaledLong === 10L)
-    assert(new Decimal().set(100L, 10, 0).toUnscaledLong === 100L)
-    assert(Decimal(Long.MaxValue, 100, 0).toUnscaledLong === Long.MaxValue)
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        assert(new Decimal().set(10L, 10, 0).toUnscaledLong === 10L)
+        assert(new Decimal().set(100L, 10, 0).toUnscaledLong === 100L)
+        assert(Decimal(Long.MaxValue, 100, 0).toUnscaledLong === Long.MaxValue)
+      }
+    }
   }
 
   test("changePrecision/toPrecision on compact decimal should respect rounding mode") {
@@ -256,15 +336,20 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
         Seq("", "-").foreach { sign =>
           val bd = BigDecimal(sign + n)
           val unscaled = (bd * 10).toLongExact
-          val d = Decimal(unscaled, 8, 1)
-          assert(d.changePrecision(10, 0, mode))
-          assert(d.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
+          Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+            withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+              val d = Decimal(unscaled, 8, 1)
+              assert(d.changePrecision(10, 0, mode))
+              assert(d.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
 
-          val copy = d.toPrecision(10, 0, mode)
-          assert(copy !== null)
-          assert(d.ne(copy))
-          assert(d === copy)
-          assert(copy.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
+              val copy = d.toPrecision(10, 0, mode)
+              assert(copy !== null)
+              assert(d.ne(copy))
+              assert(d === copy)
+              assert(
+                copy.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
+            }
+          }
         }
       }
     }
@@ -272,8 +357,12 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("SPARK-20341: support BigInt's value does not fit in long value range") {
     val bigInt = scala.math.BigInt("9223372036854775808")
-    val decimal = Decimal.apply(bigInt)
-    assert(decimal.toJavaBigDecimal.unscaledValue.toString === "9223372036854775808")
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        val decimal = Decimal.apply(bigInt)
+        assert(decimal.toJavaBigDecimal.unscaledValue.toString === "9223372036854775808")
+      }
+    }
   }
 
   test("SPARK-26038: toScalaBigInt/toJavaBigInteger") {
@@ -281,22 +370,39 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     val decimal = Decimal("1234568790123456789012348790.1234879012345678901234568790")
     assert(decimal.toScalaBigInt == scala.math.BigInt("1234568790123456789012348790"))
     assert(decimal.toJavaBigInteger == new java.math.BigInteger("1234568790123456789012348790"))
-    // fitting long
-    val decimalLong = Decimal(123456789123456789L, 18, 9)
-    assert(decimalLong.toScalaBigInt == scala.math.BigInt("123456789"))
-    assert(decimalLong.toJavaBigInteger == new java.math.BigInteger("123456789"))
+    withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> "Int128") {
+      checkBigIntegerOutInt128Range(
+        Decimal("1234568790123456789012348790.1234879012345678901234568790"))
+    }
+    Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        // fitting long
+        val decimalLong = Decimal(123456789123456789L, 18, 9)
+        assert(decimalLong.toScalaBigInt == scala.math.BigInt("123456789"))
+        assert(decimalLong.toJavaBigInteger == new java.math.BigInteger("123456789"))
+      }
+    }
   }
 
   test("UTF8String to Decimal") {
     def checkFromString(string: String): Unit = {
-      assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
-      assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
+      Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
+          assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
+        }
+      }
     }
 
     def checkOutOfRangeFromString(string: String): Unit = {
-      assert(Decimal.fromString(UTF8String.fromString(string)) === null)
-      val e = intercept[ArithmeticException](Decimal.fromStringANSI(UTF8String.fromString(string)))
-      assert(e.getMessage.contains("out of decimal type range"))
+      Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          assert(Decimal.fromString(UTF8String.fromString(string)) === null)
+          val e =
+            intercept[ArithmeticException](Decimal.fromStringANSI(UTF8String.fromString(string)))
+          assert(e.getMessage.contains("out of decimal type range"))
+        }
+      }
     }
 
     checkFromString("12345678901234567890123456789012345678")
@@ -328,6 +434,10 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
       assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
       assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
     }
+    withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> "Int128") {
+      checkBigIntegerOutInt128Range(Decimal.fromString(
+        UTF8String.fromString("28.9259999999999983799625624669715762138")))
+    }
   }
 
   test("SPARK-37451: Performance improvement regressed String to Decimal cast") {
@@ -339,8 +449,12 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
     withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
       for (string <- values) {
-        assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
-        assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
+        Seq("JDKBigDecimal", "Int128").foreach { implementation =>
+          withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+            assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
+            assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
+          }
+        }
       }
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -121,7 +121,8 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   /** Check whether a decimal is represented compactly (passing whether we expect it to be) */
   private def checkCompact(d: Decimal, expected: Boolean): Unit = {
-    val isCompact = d.invokePrivate(decimalVal()).eq(null)
+    assert(d.decimalOperation.isInstanceOf[JDKDecimalOperation])
+    val isCompact = d.decimalOperation.invokePrivate(decimalVal()).eq(null)
     assert(isCompact == expected, s"$d ${if (expected) "was not" else "was"} compact")
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DecimalSuite.scala
@@ -36,7 +36,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("creating decimals") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkDecimal(new Decimal(), "0", 1, 0)
         checkDecimal(Decimal(BigDecimal("0.09")), "0.09", 2, 2)
         checkDecimal(Decimal(BigDecimal("0.9")), "0.9", 1, 1)
@@ -74,7 +74,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   test("creating decimals with negative scale under legacy mode") {
     withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           checkDecimal(Decimal(BigDecimal("98765"), 5, -3), "9.9E+4", 5, -3)
           checkDecimal(Decimal(BigDecimal("314.159"), 6, -2), "3E+2", 6, -2)
           checkDecimal(Decimal(BigDecimal(1.579e12), 4, -9), "1.579E+12", 4, -9)
@@ -93,7 +93,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
         .contains("Negative scale is not allowed under ansi mode")
     }
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkNegativeScaleDecimal(Decimal(BigDecimal("98765"), 5, -3))
         checkNegativeScaleDecimal(Decimal(BigDecimal("98765").underlying(), 5, -3))
         checkNegativeScaleDecimal(Decimal(98765L, 5, -3))
@@ -116,7 +116,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     }
 
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         checkValues(new Decimal(), 0.0, 0L)
         checkValues(Decimal(BigDecimal("10.030")), 10.03, 10L)
         checkValues(Decimal(BigDecimal("10.030"), 4, 1), 10.0, 10L)
@@ -178,7 +178,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("hash code") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal(123).hashCode() === (123).##)
         assert(Decimal(-123).hashCode() === (-123).##)
         assert(Decimal(Int.MaxValue).hashCode() === Int.MaxValue.##)
@@ -201,7 +201,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     checkCompact(Decimal(BigDecimal(123)), false)
     checkCompact(Decimal("123"), false)
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal(123) === Decimal(BigDecimal(123)))
         assert(Decimal(123) === Decimal(BigDecimal("123.00")))
         assert(Decimal(-123) === Decimal(BigDecimal(-123)))
@@ -212,7 +212,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("isZero") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal(0).isZero)
         assert(Decimal(0, 4, 2).isZero)
         assert(Decimal("0").isZero)
@@ -227,7 +227,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("arithmetic") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal(100) + Decimal(-100) === Decimal(0))
         assert(Decimal(100) + Decimal(-100) === Decimal(0))
         assert(Decimal(100) * Decimal(-100) === Decimal(-10000))
@@ -244,7 +244,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("longVal arithmetic") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal(10, 2, 0) + Decimal(10, 2, 0) === Decimal(20, 3, 0))
         assert(Decimal(10, 2, 0) + Decimal(90, 2, 0) === Decimal(100, 3, 0))
         assert(Decimal(10, 2, 0) - Decimal(-10, 2, 0) === Decimal(20, 3, 0))
@@ -255,7 +255,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("quot") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal(100).quot(Decimal(100)) === Decimal(BigDecimal("1")))
         assert(Decimal(100).quot(Decimal(33)) === Decimal(BigDecimal("3")))
         assert(Decimal(100).quot(Decimal(-100)) === Decimal(BigDecimal("-1")))
@@ -266,7 +266,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("negate & abs") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(-Decimal(100) === Decimal(BigDecimal("-100")))
         assert(-Decimal(-100) === Decimal(BigDecimal("100")))
         assert(Decimal(100).abs === Decimal(BigDecimal("100")))
@@ -277,7 +277,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("floor & ceil") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(Decimal("10.03").floor === Decimal(BigDecimal("10")))
         assert(Decimal("10.03").ceil === Decimal(BigDecimal("11")))
         assert(Decimal("-10.03").floor === Decimal(BigDecimal("-11")))
@@ -289,7 +289,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   // regression test for SPARK-8359
   test("accurate precision after multiplication") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val decimal =
           (Decimal(Long.MaxValue, 38, 0) * Decimal(Long.MaxValue, 38, 0)).toJavaBigDecimal
         assert(decimal.unscaledValue.toString === "85070591730234615847396907784232501249")
@@ -300,7 +300,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   // regression test for SPARK-8677
   test("fix non-terminating decimal expansion problem") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val decimal = Decimal(1.0, 10, 3) / Decimal(3.0, 10, 3)
         // The difference between decimal should not be more than 0.001.
         assert(decimal.toDouble - 0.333 < 0.001)
@@ -311,7 +311,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   // regression test for SPARK-8800
   test("fix loss of precision/scale when doing division operation") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val a = Decimal(2) / Decimal(3)
         assert(a.toDouble < 1.0 && a.toDouble > 0.6)
         val b = Decimal(1) / Decimal(8)
@@ -322,7 +322,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
   test("set/setOrNull") {
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         assert(new Decimal().set(10L, 10, 0).toUnscaledLong === 10L)
         assert(new Decimal().set(100L, 10, 0).toUnscaledLong === 100L)
         assert(Decimal(Long.MaxValue, 100, 0).toUnscaledLong === Long.MaxValue)
@@ -337,7 +337,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
           val bd = BigDecimal(sign + n)
           val unscaled = (bd * 10).toLongExact
           Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-            withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+            withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
               val d = Decimal(unscaled, 8, 1)
               assert(d.changePrecision(10, 0, mode))
               assert(d.toString === bd.setScale(0, mode).toString(), s"num: $sign$n, mode: $mode")
@@ -358,7 +358,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   test("SPARK-20341: support BigInt's value does not fit in long value range") {
     val bigInt = scala.math.BigInt("9223372036854775808")
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         val decimal = Decimal.apply(bigInt)
         assert(decimal.toJavaBigDecimal.unscaledValue.toString === "9223372036854775808")
       }
@@ -370,12 +370,12 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     val decimal = Decimal("1234568790123456789012348790.1234879012345678901234568790")
     assert(decimal.toScalaBigInt == scala.math.BigInt("1234568790123456789012348790"))
     assert(decimal.toJavaBigInteger == new java.math.BigInteger("1234568790123456789012348790"))
-    withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> "Int128") {
+    withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> "Int128") {
       checkBigIntegerOutInt128Range(
         Decimal("1234568790123456789012348790.1234879012345678901234568790"))
     }
     Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-      withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+      withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
         // fitting long
         val decimalLong = Decimal(123456789123456789L, 18, 9)
         assert(decimalLong.toScalaBigInt == scala.math.BigInt("123456789"))
@@ -387,7 +387,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
   test("UTF8String to Decimal") {
     def checkFromString(string: String): Unit = {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
           assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
         }
@@ -396,7 +396,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
 
     def checkOutOfRangeFromString(string: String): Unit = {
       Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-        withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+        withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
           assert(Decimal.fromString(UTF8String.fromString(string)) === null)
           val e =
             intercept[ArithmeticException](Decimal.fromStringANSI(UTF8String.fromString(string)))
@@ -434,7 +434,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
       assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
       assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
     }
-    withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> "Int128") {
+    withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> "Int128") {
       checkBigIntegerOutInt128Range(Decimal.fromString(
         UTF8String.fromString("28.9259999999999983799625624669715762138")))
     }
@@ -450,7 +450,7 @@ class DecimalSuite extends SparkFunSuite with PrivateMethodTester with SQLHelper
     withSQLConf(SQLConf.LEGACY_ALLOW_NEGATIVE_SCALE_OF_DECIMAL_ENABLED.key -> "true") {
       for (string <- values) {
         Seq("JDKBigDecimal", "Int128").foreach { implementation =>
-          withSQLConf(SQLConf.DECIMAL_OPERATION_IMPLEMENTATION.key -> implementation) {
+          withSQLConf(SQLConf.DECIMAL_UNDERLYING_IMPLEMENTATION.key -> implementation) {
             assert(Decimal.fromString(UTF8String.fromString(string)) === Decimal(string))
             assert(Decimal.fromStringANSI(UTF8String.fromString(string)) === Decimal(string))
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Extend Catalyst's type system by a new decimal type: Decimal128Type with Int128.


### Why are the changes needed?
Spark SQL today supports the Decimal data type. The implementation of Spark Decimal holds a BigDecimal or Long value. Spark Decimal provides some operators like +, -, *, /, % and so on. These operators rely heavily on the computational power of BigDecimal or Long itself. For ease of understanding, take the + as an example. The implementation shows below.
```
  def + (that: Decimal): Decimal = {
    if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
      Decimal(longVal + that.longVal, Math.max(precision, that.precision) + 1, scale)
    } else {
      Decimal(toBigDecimal.bigDecimal.add(that.toBigDecimal.bigDecimal))
    }
  }
```
We can see the + of Long will be called if Spark Decimal holds a Long value. Otherwise,  the add of BigDecimal will be called if Spark Decimal holds a BigDecimal value. The other operators of Spark Decimal adopt the similar way. Furthermore, the code shown above calls Decimal.apply to construct a new instance of Spark Decimal.  As we know, the add operator of BigDecimal constructed a new instance of BigDecimal. So, if we call the + operator of Spark Decimal who holds a Long value, Spark will construct a new instance of Decimal. Otherwise, Spark will construct a new instance of BigDecimal and a new instance of Decimal.
Through rough analysis, we know:
1. The computational power of Spark Decimal may depend on BigDecimal.
2. The calculation operators of Spark Decimal create a lot of new instances of Decimal and may create a lot of new instances of BigDecimal.
If a large table has a field called 'colA whose type is Spark Decimal, the execution of SUM('colA) will involve the creation of a large number of Spark Decimal instances and BigDecimal instances. These Spark Decimal instances and BigDecimal instances will lead to garbage collection frequently.
Int128 is a high-performance data type about 1X~6X more efficient than BigDecimal for typical operations. It uses a finite (128 bit) precision and can handle up to decimal(38, X). The implementation of Int128 just uses two Long values to represent the high and low bits of 128 bits respectively. Int128 is lighter than BigDecimal, reduces the cost of new() and garbage collection.
If Spark could support a new type to represent the decimal type with Int128, it would improve the performance for calculation operators.
Now, let's call the new decimal type Decimal128.


### Does this PR introduce _any_ user-facing change?
No, a new decimal type with Int128. It is still in development.


### How was this patch tested?
New test cases.
