### PR TITLE
[SPARK-40355][SQL] Improve pushdown for orc & parquet when cast scenario

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -510,11 +510,11 @@ object DataSourceStrategy
       Some(sources.EqualTo(name, convertToScala(v, t)))
 
     case expressions.EqualTo(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.EqualTo(name, convertToScala(castValue, e.dataType)))
     case expressions.EqualTo(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.EqualTo(name, convertToScala(castValue, e.dataType)))
 
@@ -524,11 +524,11 @@ object DataSourceStrategy
       Some(sources.EqualNullSafe(name, convertToScala(v, t)))
 
     case expressions.EqualNullSafe(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.EqualNullSafe(name, convertToScala(castValue, e.dataType)))
     case expressions.EqualNullSafe(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.EqualNullSafe(name, convertToScala(castValue, e.dataType)))
 
@@ -538,11 +538,11 @@ object DataSourceStrategy
       Some(sources.LessThan(name, convertToScala(v, t)))
 
     case expressions.GreaterThan(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.GreaterThan(name, convertToScala(castValue, e.dataType)))
     case expressions.GreaterThan(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.LessThan(name, convertToScala(castValue, e.dataType)))
 
@@ -552,11 +552,11 @@ object DataSourceStrategy
       Some(sources.GreaterThan(name, convertToScala(v, t)))
 
     case expressions.LessThan(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast (l, e.dataType).eval()
       Some(sources.LessThan(name, convertToScala(castValue, e.dataType)))
     case expressions.LessThan(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
-      if Cast.canCast (t, e.dataType) =>
+      if Cast.canUpCast (t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some (sources.GreaterThan(name, convertToScala(castValue, e.dataType)))
 
@@ -566,11 +566,11 @@ object DataSourceStrategy
       Some(sources.LessThanOrEqual(name, convertToScala(v, t)))
 
     case expressions.GreaterThanOrEqual(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.GreaterThanOrEqual(name, convertToScala(castValue, e.dataType)))
     case expressions.GreaterThanOrEqual(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.LessThanOrEqual(name, convertToScala(castValue, e.dataType)))
 
@@ -580,11 +580,11 @@ object DataSourceStrategy
       Some(sources.GreaterThanOrEqual(name, convertToScala(v, t)))
 
     case expressions.LessThanOrEqual(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.LessThanOrEqual(name, convertToScala(castValue, e.dataType)))
     case expressions.LessThanOrEqual(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
-      if Cast.canCast(t, e.dataType) =>
+      if Cast.canUpCast(t, e.dataType) =>
       val castValue = cast(l, e.dataType).eval()
       Some(sources.GreaterThanOrEqual(name, convertToScala(castValue, e.dataType)))
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -503,35 +503,90 @@ object DataSourceStrategy
   private def translateLeafNodeFilter(
       predicate: Expression,
       pushableColumn: PushableColumnBase): Option[Filter] = predicate match {
+
     case expressions.EqualTo(pushableColumn(name), Literal(v, t)) =>
       Some(sources.EqualTo(name, convertToScala(v, t)))
     case expressions.EqualTo(Literal(v, t), pushableColumn(name)) =>
       Some(sources.EqualTo(name, convertToScala(v, t)))
+
+    case expressions.EqualTo(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.EqualTo(name, convertToScala(castValue, e.dataType)))
+    case expressions.EqualTo(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.EqualTo(name, convertToScala(castValue, e.dataType)))
 
     case expressions.EqualNullSafe(pushableColumn(name), Literal(v, t)) =>
       Some(sources.EqualNullSafe(name, convertToScala(v, t)))
     case expressions.EqualNullSafe(Literal(v, t), pushableColumn(name)) =>
       Some(sources.EqualNullSafe(name, convertToScala(v, t)))
 
+    case expressions.EqualNullSafe(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.EqualNullSafe(name, convertToScala(castValue, e.dataType)))
+    case expressions.EqualNullSafe(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.EqualNullSafe(name, convertToScala(castValue, e.dataType)))
+
     case expressions.GreaterThan(pushableColumn(name), Literal(v, t)) =>
       Some(sources.GreaterThan(name, convertToScala(v, t)))
     case expressions.GreaterThan(Literal(v, t), pushableColumn(name)) =>
       Some(sources.LessThan(name, convertToScala(v, t)))
+
+    case expressions.GreaterThan(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.GreaterThan(name, convertToScala(castValue, e.dataType)))
+    case expressions.GreaterThan(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.LessThan(name, convertToScala(castValue, e.dataType)))
 
     case expressions.LessThan(pushableColumn(name), Literal(v, t)) =>
       Some(sources.LessThan(name, convertToScala(v, t)))
     case expressions.LessThan(Literal(v, t), pushableColumn(name)) =>
       Some(sources.GreaterThan(name, convertToScala(v, t)))
 
+    case expressions.LessThan(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast (l, e.dataType).eval()
+      Some(sources.LessThan(name, convertToScala(castValue, e.dataType)))
+    case expressions.LessThan(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
+      if Cast.canCast (t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some (sources.GreaterThan(name, convertToScala(castValue, e.dataType)))
+
     case expressions.GreaterThanOrEqual(pushableColumn(name), Literal(v, t)) =>
       Some(sources.GreaterThanOrEqual(name, convertToScala(v, t)))
     case expressions.GreaterThanOrEqual(Literal(v, t), pushableColumn(name)) =>
       Some(sources.LessThanOrEqual(name, convertToScala(v, t)))
 
+    case expressions.GreaterThanOrEqual(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.GreaterThanOrEqual(name, convertToScala(castValue, e.dataType)))
+    case expressions.GreaterThanOrEqual(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.LessThanOrEqual(name, convertToScala(castValue, e.dataType)))
+
     case expressions.LessThanOrEqual(pushableColumn(name), Literal(v, t)) =>
       Some(sources.LessThanOrEqual(name, convertToScala(v, t)))
     case expressions.LessThanOrEqual(Literal(v, t), pushableColumn(name)) =>
       Some(sources.GreaterThanOrEqual(name, convertToScala(v, t)))
+
+    case expressions.LessThanOrEqual(Cast(e @ pushableColumn(name), _, _, _), l @ Literal(_, t))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.LessThanOrEqual(name, convertToScala(castValue, e.dataType)))
+    case expressions.LessThanOrEqual(l @ Literal(_, t), Cast(e @ pushableColumn(name), _, _, _))
+      if Cast.canCast(t, e.dataType) =>
+      val castValue = cast(l, e.dataType).eval()
+      Some(sources.GreaterThanOrEqual(name, convertToScala(castValue, e.dataType)))
 
     case expressions.InSet(e @ pushableColumn(name), set) =>
       val toScala = CatalystTypeConverters.createToScalaConverter(e.dataType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1048,8 +1048,10 @@ class FileBasedDataSourceSuite extends QueryTest
     Seq("orc", "parquet").foreach { format =>
       withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
         withTempPath { dir =>
-          (1 to 3).map(i => (i, i.toString)).toDF("a", "b").
-            write.parquet(dir.getCanonicalPath)
+          (1 to 3).map(i => (i, i.toString)).toDF("a", "b")
+            .write
+            .format(format)
+            .save(dir.getCanonicalPath)
 
           val df = spark.read.format(format).load(dir.getCanonicalPath)
           checkPushedFilters(format, df.filter("b = 1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -254,6 +254,29 @@ class FileBasedDataSourceSuite extends QueryTest
     }
   }
 
+  private def checkPushedFilters(
+      format: String,
+      df: DataFrame,
+      filters: Array[sources.Filter],
+      noScan: Boolean = false): Unit = {
+    val scanExec = df.queryExecution.sparkPlan.find(_.isInstanceOf[BatchScanExec])
+    if (noScan) {
+      assert(scanExec.isEmpty)
+      return
+    }
+    val scan = scanExec.get.asInstanceOf[BatchScanExec].scan
+    format match {
+      case "orc" =>
+        assert(scan.isInstanceOf[OrcScan])
+        assert(scan.asInstanceOf[OrcScan].pushedFilters === filters)
+      case "parquet" =>
+        assert(scan.isInstanceOf[ParquetScan])
+        assert(scan.asInstanceOf[ParquetScan].pushedFilters === filters)
+      case _ =>
+        fail(s"unknown format $format")
+    }
+  }
+
   // Text file format only supports string type
   test("SPARK-24691 error handling for unsupported types - text") {
     withTempDir { dir =>
@@ -953,29 +976,6 @@ class FileBasedDataSourceSuite extends QueryTest
   }
 
   test("test casts pushdown on orc/parquet for integral types") {
-    def checkPushedFilters(
-        format: String,
-        df: DataFrame,
-        filters: Array[sources.Filter],
-        noScan: Boolean = false): Unit = {
-      val scanExec = df.queryExecution.sparkPlan.find(_.isInstanceOf[BatchScanExec])
-      if (noScan) {
-        assert(scanExec.isEmpty)
-        return
-      }
-      val scan = scanExec.get.asInstanceOf[BatchScanExec].scan
-      format match {
-        case "orc" =>
-          assert(scan.isInstanceOf[OrcScan])
-          assert(scan.asInstanceOf[OrcScan].pushedFilters === filters)
-        case "parquet" =>
-          assert(scan.isInstanceOf[ParquetScan])
-          assert(scan.asInstanceOf[ParquetScan].pushedFilters === filters)
-        case _ =>
-          fail(s"unknown format $format")
-      }
-    }
-
     Seq("orc", "parquet").foreach { format =>
       withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
         withTempPath { dir =>
@@ -1038,6 +1038,32 @@ class FileBasedDataSourceSuite extends QueryTest
             sources.GreaterThan("id", 30)))
           checkPushedFilters(format, df.where(lit(100) >= $"id"),
             Array(sources.IsNotNull("id"), sources.LessThanOrEqual("id", 100)))
+        }
+      }
+    }
+  }
+
+  test("SPARK-40355: test casts pushdown on orc/parquet for " +
+    "the type of column does not match the type of value") {
+    Seq("orc", "parquet").foreach { format =>
+      withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> "") {
+        withTempPath { dir =>
+          (1 to 3).map(i => (i, i.toString)).toDF("a", "b").
+            write.parquet(dir.getCanonicalPath)
+
+          val df = spark.read.format(format).load(dir.getCanonicalPath)
+          checkPushedFilters(format, df.filter("b = 1"),
+            Array(sources.IsNotNull("b"), sources.EqualTo("b", "1")))
+          checkPushedFilters(format, df.filter("b <=> 1"),
+            Array(sources.EqualNullSafe("b", "1")))
+          checkPushedFilters(format, df.filter("b > 1"),
+            Array(sources.IsNotNull("b"), sources.GreaterThan("b", "1")))
+          checkPushedFilters(format, df.filter("b < 1"),
+            Array(sources.IsNotNull("b"), sources.LessThan("b", "1")))
+          checkPushedFilters(format, df.filter("b >= 1"),
+            Array(sources.IsNotNull("b"), sources.GreaterThanOrEqual("b", "1")))
+          checkPushedFilters(format, df.filter("b <= 1"),
+            Array(sources.IsNotNull("b"), sources.LessThanOrEqual("b", "1")))
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
#### Table Schema:
|  a |  b |  part |
|---|---|---|
|  int | **string**   |  **string** | 

#### SQL:
select * from table where b = 1(integer) and part = 1(integer)

### A.Partition column 'part' has been pushed down, but column 'b' not push down.
<img width="815" alt="image" src="https://user-images.githubusercontent.com/15246973/188630971-4eed59c0-d134-4994-a7aa-0d057a49c5dc.png">

### B.After apply the pr, Partition column 'part' and column 'b' has been pushed down.
<img width="804" alt="image" src="https://user-images.githubusercontent.com/15246973/188631231-d30db19d-1d70-4712-bf75-bccaa2c790f4.png">


### Why are the changes needed?
> A.Improve query performance and reduce IO reads
> B.Keep pushedFilters consistent with partitionFilters

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA & add new UT.
