### PR TITLE
[SPARK-40366][INFRA] Add `spark` namespace to spark ci image

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -120,7 +120,7 @@ jobs:
         # Convert to lowercase to meet Docker repo name requirement
         REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
         IMG_NAME="apache-spark-ci-image:${{ inputs.branch }}-${{ github.run_id }}"
-        IMG_URL="ghcr.io/$REPO_OWNER/$IMG_NAME"
+        IMG_URL="ghcr.io/$REPO_OWNER/spark/$IMG_NAME"
         echo ::set-output name=image_url::$IMG_URL
 
   # Build: build Spark and run the tests for specified modules.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,8 +119,8 @@ jobs:
       run: |
         # Convert to lowercase to meet Docker repo name requirement
         REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-        IMG_NAME="apache-spark-ci-image:${{ inputs.branch }}-${{ github.run_id }}"
-        IMG_URL="ghcr.io/$REPO_OWNER/spark/$IMG_NAME"
+        IMG_NAME="apache-spark-ci-image-0908:${{ inputs.branch }}-${{ github.run_id }}"
+        IMG_URL="ghcr.io/$REPO_OWNER/$IMG_NAME"
         echo ::set-output name=image_url::$IMG_URL
 
   # Build: build Spark and run the tests for specified modules.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change the spark ci image from `"ghcr.io/$REPO_OWNER/spark/$IMG_NAME"` to `"ghcr.io/$REPO_OWNER/spark/$IMG_NAME"`.

Due to some reasons (https://github.com/docker/build-push-action/issues/687), original base ci image has permission issue, this is a bug of ghcr. Let's frist recover CI first (old image has permission issue but new image not), I will contact github team and take a deep look later.

Related Github incidents: 
- https://downdetector.com.au/status/github/
- https://www.githubstatus.com/incidents/d181frs643d4

### Why are the changes needed?
```
#33 [auth] grundprinzip/apache-spark-ci-image:pull,push token for ghcr.io
#33 DONE 0.0s

#32 exporting to image
#32 exporting manifest sha256:d6a11f99d74b4198a6d35e6341bb94852584dd070f9e7909546ad13490645667 done
#32 exporting config sha256:e227ad580c837e04213fcd11672c618aa5ac7a3523ed454cf99900aff22d3c33 done
#32 pushing layers
#32 pushing layers 0.6s done
#32 ERROR: unexpected status: 403 Forbidden
------
 > exporting to image:
------
ERROR: failed to solve: unexpected status: 403 Forbidden
Error: buildx failed with: ERROR: failed to solve: unexpected status: 403 Forbidden
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
base image ci passed
