### PR TITLE
[SPARK-40332][PS] Implement `GroupBy.quantile`

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/groupby.rst
+++ b/python/docs/source/reference/pyspark.pandas/groupby.rst
@@ -79,6 +79,7 @@ Computations / Descriptive Stats
    GroupBy.sum
    GroupBy.var
    GroupBy.nunique
+   GroupBy.quantile
    GroupBy.size
    GroupBy.diff
    GroupBy.idxmax

--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -45,7 +45,7 @@ from typing import (
 import warnings
 
 import pandas as pd
-from pandas.api.types import is_hashable, is_list_like  # type: ignore[attr-defined]
+from pandas.api.types import is_number, is_hashable, is_list_like  # type: ignore[attr-defined]
 
 if LooseVersion(pd.__version__) >= LooseVersion("1.3.0"):
     from pandas.core.common import _builtin_table  # type: ignore[attr-defined]
@@ -580,6 +580,56 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         return self._reduce_for_stat_function(
             F.mean, accepted_spark_types=(NumericType,), bool_to_numeric=True
         )
+
+    # TODO: 'q' accepts list like type
+    def quantile(self, q: float = 0.5) -> FrameLike:
+        """
+        Return group values at the given quantile.
+
+        .. note:: `quantile` in pandas-on-Spark are using distributed percentile approximation
+        algorithm unlike pandas, the result might different with pandas in accuracy, also
+        `interpolation` parameters are not supported yet.
+
+        Parameters
+        ----------
+        q : float, default 0.5 (50% quantile)
+            Value between 0 and 1 providing the quantile to compute.
+
+            .. versionadded:: 3.4.0
+
+        Returns
+        -------
+        pyspark.pandas.Series or pyspark.pandas.DataFrame
+
+        See Also
+        --------
+        pyspark.pandas.Series.quantile
+        pyspark.pandas.DataFrame.quantile
+        pyspark.sql.functions.percentile_approx
+
+        Examples
+        --------
+        >>> df = ps.DataFrame([
+        ...     ['a', 1], ['a', 2], ['a', 3],
+        ...     ['b', 1], ['b', 3], ['b', 5]
+        ... ], columns=['key', 'val'])
+
+        Groupby one column and return the quantile of the remaining columns in
+        each group.
+
+        >>> df.groupby('key').quantile()
+             val
+        key
+        a    2
+        b    3
+        """
+        if is_list_like(q):
+            raise NotImplementedError("q doesn't support for list like type for now")
+        if not is_number(q):
+            raise TypeError("must be real number, not %s" % type(q).__name__)
+        if q < 0 or q > 1:
+            raise ValueError("'q' must be between 0 and 1. Got '%s' instead" % q)
+        return self._reduce_for_stat_function(lambda col: F.percentile_approx(col, q))
 
     def min(self, numeric_only: Optional[bool] = False) -> FrameLike:
         """

--- a/python/pyspark/pandas/missing/groupby.py
+++ b/python/pyspark/pandas/missing/groupby.py
@@ -50,7 +50,6 @@ class MissingPandasLikeDataFrameGroupBy:
     indices = _unsupported_property("indices")
     ngroups = _unsupported_property("ngroups")
     plot = _unsupported_property("plot")
-    quantile = _unsupported_property("quantile")
     tshift = _unsupported_property("tshift")
 
     # Deprecated properties
@@ -82,7 +81,6 @@ class MissingPandasLikeSeriesGroupBy:
     is_monotonic_increasing = _unsupported_property("is_monotonic_increasing")
     ngroups = _unsupported_property("ngroups")
     plot = _unsupported_property("plot")
-    quantile = _unsupported_property("quantile")
     tshift = _unsupported_property("tshift")
 
     # Deprecated properties

--- a/python/pyspark/pandas/tests/test_groupby.py
+++ b/python/pyspark/pandas/tests/test_groupby.py
@@ -1358,31 +1358,46 @@ class GroupByTest(PandasOnSparkTestCase, TestUtils):
             psdf.groupby("A")["C"].mean()
 
     def test_quantile(self):
-        df = pd.DataFrame(
-            [["a", 1], ["a", 2], ["a", 3], ["b", 1], ["b", 3], ["b", 5]], columns=["key", "val"]
-        )
-        psdf = ps.from_pandas(df)
-        # accept float and int between 0 and 1
-        for i in [0, 0.1, 0.5, 1]:
-            self.assert_eq(
-                df.groupby("key").quantile(q=i, interpolation="lower"),
-                psdf.groupby("key").quantile(q=i),
-            )
-        # raise ValueError when q not in [0, 1]
-        with self.assertRaises(ValueError):
-            psdf.groupby("key").quantile(q=1.1)
-        with self.assertRaises(ValueError):
-            psdf.groupby("key").quantile(q=-0.1)
-        with self.assertRaises(ValueError):
-            psdf.groupby("key").quantile(q=2)
-        # raise TypeError when q type mismatch
-        with self.assertRaises(TypeError):
-            psdf.groupby("key").quantile(q="0.1")
-        # raise NotImplementedError when q is list like type
-        with self.assertRaises(NotImplementedError):
-            psdf.groupby("key").quantile(q=(0.1, 0.5))
-        with self.assertRaises(NotImplementedError):
-            psdf.groupby("key").quantile(q=[0.1, 0.5])
+        dfs = [
+            pd.DataFrame(
+                [["a", 1], ["a", 2], ["a", 3], ["b", 1], ["b", 3], ["b", 5]], columns=["key", "val"]
+            ),
+            pd.DataFrame(
+                [["a", True], ["a", True], ["a", False], ["b", True], ["b", True], ["b", False]],
+                columns=["key", "val"],
+            ),
+        ]
+        for df in dfs:
+            psdf = ps.from_pandas(df)
+            # q accept float and int between 0 and 1
+            for i in [0, 0.1, 0.5, 1]:
+                self.assert_eq(
+                    df.groupby("key").quantile(q=i, interpolation="lower"),
+                    psdf.groupby("key").quantile(q=i),
+                    almost=True,
+                )
+                self.assert_eq(
+                    df.groupby("key")["val"].quantile(q=i, interpolation="lower"),
+                    psdf.groupby("key")["val"].quantile(q=i),
+                    almost=True,
+                )
+            # raise ValueError when q not in [0, 1]
+            with self.assertRaises(ValueError):
+                psdf.groupby("key").quantile(q=1.1)
+            with self.assertRaises(ValueError):
+                psdf.groupby("key").quantile(q=-0.1)
+            with self.assertRaises(ValueError):
+                psdf.groupby("key").quantile(q=2)
+            with self.assertRaises(ValueError):
+                psdf.groupby("key").quantile(q=np.nan)
+            # raise TypeError when q type mismatch
+            with self.assertRaises(TypeError):
+                psdf.groupby("key").quantile(q="0.1")
+            # raise NotImplementedError when q is list like type
+            with self.assertRaises(NotImplementedError):
+                psdf.groupby("key").quantile(q=(0.1, 0.5))
+            with self.assertRaises(NotImplementedError):
+                psdf.groupby("key").quantile(q=[0.1, 0.5])
 
     def test_min(self):
         self._test_stat_func(lambda groupby_obj: groupby_obj.min())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement `GroupBy.quantile`


### Why are the changes needed?
Improve PS api coverage

### Does this PR introduce _any_ user-facing change?
yes, new API
```python
>>> df = ps.DataFrame([
...     ['a', 1], ['a', 2], ['a', 3],
...     ['b', 1], ['b', 3], ['b', 5]
... ], columns=['key', 'val'])
>>> df.groupby('key').quantile()
     val
key
a    2.0
b    3.0
```

### How was this patch tested?
UT
