### PR TITLE
[MINOR][PS][DOCS] Fix note in missing pandas

### DIFF
--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -30,7 +30,7 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class _MissingPandasLikeDataFrame:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions

--- a/python/pyspark/pandas/missing/frame.py
+++ b/python/pyspark/pandas/missing/frame.py
@@ -30,8 +30,8 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class _MissingPandasLikeDataFrame:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions
     asfreq = _unsupported_function("asfreq")

--- a/python/pyspark/pandas/missing/general_functions.py
+++ b/python/pyspark/pandas/missing/general_functions.py
@@ -24,7 +24,7 @@ def _unsupported_function(method_name, deprecated=False, reason=""):
 
 
 class _MissingPandasLikeGeneralFunctions:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     pivot = _unsupported_function("pivot")

--- a/python/pyspark/pandas/missing/general_functions.py
+++ b/python/pyspark/pandas/missing/general_functions.py
@@ -24,8 +24,8 @@ def _unsupported_function(method_name, deprecated=False, reason=""):
 
 
 class _MissingPandasLikeGeneralFunctions:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     pivot = _unsupported_function("pivot")
     pivot_table = _unsupported_function("pivot_table")

--- a/python/pyspark/pandas/missing/groupby.py
+++ b/python/pyspark/pandas/missing/groupby.py
@@ -37,7 +37,7 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class MissingPandasLikeDataFrameGroupBy:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
@@ -68,7 +68,7 @@ class MissingPandasLikeDataFrameGroupBy:
 
 
 class MissingPandasLikeSeriesGroupBy:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties

--- a/python/pyspark/pandas/missing/groupby.py
+++ b/python/pyspark/pandas/missing/groupby.py
@@ -37,8 +37,8 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class MissingPandasLikeDataFrameGroupBy:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     corr = _unsupported_property("corr")
@@ -68,8 +68,8 @@ class MissingPandasLikeDataFrameGroupBy:
 
 
 class MissingPandasLikeSeriesGroupBy:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     corr = _unsupported_property("corr")

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -36,7 +36,7 @@ def _unsupported_property(property_name, deprecated=False, reason="", cls="Index
 
 
 class MissingPandasLikeIndex:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
@@ -80,7 +80,7 @@ class MissingPandasLikeIndex:
 
 
 class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
@@ -105,7 +105,7 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
 
 
 class MissingPandasLikeTimedeltaIndex(MissingPandasLikeIndex):
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
@@ -122,7 +122,7 @@ class MissingPandasLikeTimedeltaIndex(MissingPandasLikeIndex):
 
 
 class MissingPandasLikeMultiIndex:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions

--- a/python/pyspark/pandas/missing/indexes.py
+++ b/python/pyspark/pandas/missing/indexes.py
@@ -36,8 +36,8 @@ def _unsupported_property(property_name, deprecated=False, reason="", cls="Index
 
 
 class MissingPandasLikeIndex:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     nbytes = _unsupported_property("nbytes")
@@ -80,8 +80,8 @@ class MissingPandasLikeIndex:
 
 
 class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     nanosecond = _unsupported_property("nanosecond", cls="DatetimeIndex")
@@ -105,8 +105,8 @@ class MissingPandasLikeDatetimeIndex(MissingPandasLikeIndex):
 
 
 class MissingPandasLikeTimedeltaIndex(MissingPandasLikeIndex):
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     nanoseconds = _unsupported_property("nanoseconds", cls="TimedeltaIndex")
@@ -122,8 +122,8 @@ class MissingPandasLikeTimedeltaIndex(MissingPandasLikeIndex):
 
 
 class MissingPandasLikeMultiIndex:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions
     argsort = _unsupported_function("argsort")

--- a/python/pyspark/pandas/missing/resample.py
+++ b/python/pyspark/pandas/missing/resample.py
@@ -38,8 +38,8 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class MissingPandasLikeDataFrameResampler:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     groups = _unsupported_property("groups")
@@ -72,8 +72,8 @@ class MissingPandasLikeDataFrameResampler:
 
 
 class MissingPandasLikeSeriesResampler:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
     groups = _unsupported_property("groups")

--- a/python/pyspark/pandas/missing/resample.py
+++ b/python/pyspark/pandas/missing/resample.py
@@ -38,7 +38,7 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class MissingPandasLikeDataFrameResampler:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties
@@ -72,7 +72,7 @@ class MissingPandasLikeDataFrameResampler:
 
 
 class MissingPandasLikeSeriesResampler:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Properties

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -30,7 +30,7 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class MissingPandasLikeSeries:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions

--- a/python/pyspark/pandas/missing/series.py
+++ b/python/pyspark/pandas/missing/series.py
@@ -30,8 +30,8 @@ def _unsupported_property(property_name, deprecated=False, reason=""):
 
 
 class MissingPandasLikeSeries:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     # Functions
     asfreq = _unsupported_function("asfreq")

--- a/python/pyspark/pandas/missing/window.py
+++ b/python/pyspark/pandas/missing/window.py
@@ -73,8 +73,8 @@ def _unsupported_property_exponential_moving(property_name, deprecated=False, re
 
 
 class MissingPandasLikeExpanding:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_expanding("agg")
     aggregate = _unsupported_function_expanding("aggregate")
@@ -92,8 +92,8 @@ class MissingPandasLikeExpanding:
 
 
 class MissingPandasLikeRolling:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_rolling("agg")
     aggregate = _unsupported_function_rolling("aggregate")
@@ -111,8 +111,8 @@ class MissingPandasLikeRolling:
 
 
 class MissingPandasLikeExpandingGroupby:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_expanding("agg")
     aggregate = _unsupported_function_expanding("aggregate")
@@ -130,8 +130,8 @@ class MissingPandasLikeExpandingGroupby:
 
 
 class MissingPandasLikeRollingGroupby:
-    # NOTE: Please update the document "Supported pandas APIs" when implementing the new API.
-    # Documentation path: `python/docs/source/user_guide/pandas_on_spark/supported_pandas_api.rst`.
+    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_rolling("agg")
     aggregate = _unsupported_function_rolling("aggregate")

--- a/python/pyspark/pandas/missing/window.py
+++ b/python/pyspark/pandas/missing/window.py
@@ -73,7 +73,7 @@ def _unsupported_property_exponential_moving(property_name, deprecated=False, re
 
 
 class MissingPandasLikeExpanding:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_expanding("agg")
@@ -92,7 +92,7 @@ class MissingPandasLikeExpanding:
 
 
 class MissingPandasLikeRolling:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_rolling("agg")
@@ -111,7 +111,7 @@ class MissingPandasLikeRolling:
 
 
 class MissingPandasLikeExpandingGroupby:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_expanding("agg")
@@ -130,7 +130,7 @@ class MissingPandasLikeExpandingGroupby:
 
 
 class MissingPandasLikeRollingGroupby:
-    # NOTE: Please update the pandas-on-Spark reference toc when implementing the new API.
+    # NOTE: Please update the pandas-on-Spark reference document when implementing the new API.
     # Documentation path: `python/docs/source/reference/pyspark.pandas/`.
 
     agg = _unsupported_function_rolling("agg")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix note in missing pandas files.

### Why are the changes needed?
We already add the auto doc gen for `Supported pandas APIs`: https://github.com/apache/spark/pull/36509 , so we can remove this notes. Considering add toc are also easily forgotten, so just add note for toc.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed.