### PR TITLE
[SPARK-40382][SQL] Group distinct aggregate expressions by semantically equivalent children in `RewriteDistinctAggregates`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
@@ -405,28 +405,7 @@ object RewriteDistinctAggregates extends Rule[LogicalPlan] {
       }
       Aggregate(groupByAttrs, patchedAggExpressions, firstAggregate)
     } else {
-      // We may have one distinct group only because we grouped using ExpressionSet.
-      // To prevent SparkStrategies from complaining during sanity check, we need to check whether
-      // the original list of aggregate expressions had multiple distinct groups and, if so,
-      // patch that list so we have only one distinct group.
-      val funcChildren = distinctAggs.flatMap { e =>
-        e.aggregateFunction.children.filter(!_.foldable)
-      }
-      val funcChildrenLookup = funcChildren.map { e =>
-        (e, funcChildren.find(fc => e.semanticEquals(fc)).getOrElse(e))
-      }.toMap
-
-      if (funcChildrenLookup.keySet.size > funcChildrenLookup.values.toSet.size) {
-        val patchedAggExpressions = a.aggregateExpressions.map { e =>
-          e.transformDown {
-            case e: Expression =>
-              funcChildrenLookup.getOrElse(e, e)
-          }.asInstanceOf[NamedExpression]
-        }
-        a.copy(aggregateExpressions = patchedAggExpressions)
-      } else {
-        a
-      }
+      a
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregates.scala
@@ -314,7 +314,7 @@ object RewriteDistinctAggregates extends Rule[LogicalPlan] {
                 // only because `distinctAggChildAttrLookup`'s keys have been de-duped
                 // based on semantic equivalence. So we need to translate x to the
                 // semantic equivalent that we are actually using.
-                val x2 = funcChildrenLookup(x)
+                val x2 = funcChildrenLookup.getOrElse(x, x)
                 distinctAggChildAttrLookup.get(x2)
               }
             }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
@@ -78,10 +78,10 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
 
   test("eliminate multiple distinct groups due to superficial differences") {
     val input = testRelation
-      .groupBy('a)(
-        countDistinct('b + 'c).as('agg1),
-        countDistinct('c + 'b).as('agg2),
-        max('c).as('agg3))
+      .groupBy($"a")(
+        countDistinct($"b" + $"c").as("agg1"),
+        countDistinct($"c" + $"b").as("agg2"),
+        max($"c").as("agg3"))
       .analyze
 
     val rewrite = RewriteDistinctAggregates(input)
@@ -93,12 +93,12 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
 
   test("reduce multiple distinct groups due to superficial differences") {
     val input = testRelation
-      .groupBy('a)(
-        countDistinct('b + 'c + 'd).as('agg1),
-        countDistinct('d + 'c + 'b).as('agg2),
-        countDistinct('b + 'c).as('agg4),
-        countDistinct('c + 'b).as('agg4),
-        max('c).as('agg5))
+      .groupBy($"a")(
+        countDistinct($"b" + $"c" + $"d").as("agg1"),
+        countDistinct($"d" + $"c" + $"b").as("agg2"),
+        countDistinct($"b" + $"c").as("agg3"),
+        countDistinct($"c" + $"b").as("agg4"),
+        max($"c").as("agg5"))
       .analyze
 
     val rewrite = RewriteDistinctAggregates(input)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
@@ -76,7 +76,7 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
     checkRewrite(RewriteDistinctAggregates(input))
   }
 
-  test("eliminate multiple distinct groups due to superficial differences") {
+  test("SPARK-40382: eliminate multiple distinct groups due to superficial differences") {
     val input = testRelation
       .groupBy($"a")(
         countDistinct($"b" + $"c").as("agg1"),
@@ -91,7 +91,7 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
     }
   }
 
-  test("reduce multiple distinct groups due to superficial differences") {
+  test("SPARK-40382: reduce multiple distinct groups due to superficial differences") {
     val input = testRelation
       .groupBy($"a")(
         countDistinct($"b" + $"c" + $"d").as("agg1"),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDistinctAggregatesSuite.scala
@@ -84,15 +84,11 @@ class RewriteDistinctAggregatesSuite extends PlanTest {
         max('c).as('agg3))
       .analyze
 
-    val expected = testRelation
-      .groupBy('a)(
-        countDistinct('b + 'c).as('agg1),
-        countDistinct('b + 'c).as('agg2),
-        max('c).as('agg3))
-      .analyze
-
     val rewrite = RewriteDistinctAggregates(input)
-    comparePlans(expected, rewrite)
+    rewrite match {
+      case Aggregate(_, _, LocalRelation(_, _, _)) =>
+      case _ => fail(s"Plan is not as expected:\n$rewrite")
+    }
   }
 
   test("reduce multiple distinct groups due to superficial differences") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -562,8 +562,7 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             // [COUNT(DISTINCT bar), COUNT(DISTINCT foo)] is disallowed because those two distinct
             // aggregates have different column expressions.
             val distinctExpressions =
-            functionsWithDistinct.flatMap(
-              _.aggregateFunction.children.filterNot(_.foldable)).distinct
+              functionsWithDistinct.head.aggregateFunction.children.filterNot(_.foldable)
             val normalizedNamedDistinctExpressions = distinctExpressions.map { e =>
               // Ideally this should be done in `NormalizeFloatingNumbers`, but we do it here
               // because `distinctExpressions` is not extracted during logical phase.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -95,6 +95,10 @@ class PlannerSuite extends SharedSparkSession with AdaptiveSparkPlanHelper {
       // 2 distinct columns with different order
       val query3 = sql("SELECT corr(DISTINCT j, k), count(DISTINCT k, j) FROM v GROUP BY i")
       assertNoExpand(query3.queryExecution.executedPlan)
+
+      // SPARK-40382: 1 distinct expression with cosmetic differences
+      val query4 = sql("SELECT sum(DISTINCT j), max(DISTINCT J) FROM v GROUP BY i")
+      assertNoExpand(query4.queryExecution.executedPlan)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `RewriteDistinctAggregates`, when grouping aggregate expressions by function children, treat children that are semantically equivalent as the same.

### Why are the changes needed?

This PR will reduce the number of projections in the Expand operator when there are multiple distinct aggregations with superficially different children. In some cases, it will eliminate the need for an Expand operator.

Example: In the following query, the Expand operator creates 3\*n rows (where n is the number of incoming rows) because it has a projection for each of function children `b + 1`, `1 + b` and `c`.

```
create or replace temp view v1 as
select * from values
(1, 2, 3.0),
(1, 3, 4.0),
(2, 4, 2.5),
(2, 3, 1.0)
v1(a, b, c);

select
  a,
  count(distinct b + 1),
  avg(distinct 1 + b) filter (where c > 0),
  sum(c)
from
  v1
group by a;
```
The Expand operator has three projections (each producing a row for each incoming row):
```
[a#87, null, null, 0, null, UnscaledValue(c#89)], <== projection #1 (for regular aggregation)
[a#87, (b#88 + 1), null, 1, null, null],          <== projection #2 (for distinct aggregation of b + 1)
[a#87, null, (1 + b#88), 2, (c#89 > 0.0), null]], <== projection #3 (for distinct aggregation of 1 + b)
```
In reality, the Expand only needs one projection for `1 + b` and `b + 1`, because they are semantically equivalent.

With the proposed change, the Expand operator's projections look like this:
```
[a#67, null, 0, null, UnscaledValue(c#69)],  <== projection #1 (for regular aggregations)
[a#67, (b#68 + 1), 1, (c#69 > 0.0), null]],  <== projection #2 (for distinct aggregation on b + 1 and 1 + b)
```
With one less projection, Expand produces 2\*n rows instead of 3\*n rows, but still produces the correct result.

In the case where all distinct aggregates have semantically equivalent children, the Expand operator is not needed at all.

Benchmark code in the JIRA (SPARK-40382).

Before the PR:
```
distinct aggregates:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
all semantically equivalent                       14721          14859         195          5.7         175.5       1.0X
some semantically equivalent                      14569          14572           5          5.8         173.7       1.0X
none semantically equivalent                      14408          14488         113          5.8         171.8       1.0X
```
After the PR:
```
distinct aggregates:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
all semantically equivalent                        3658           3692          49         22.9          43.6       1.0X
some semantically equivalent                       9124           9214         127          9.2         108.8       0.4X
none semantically equivalent                      14601          14777         250          5.7         174.1       0.3X
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit tests.
