### PR TITLE
[SPARK-40383][INFRA] Pin `mypy==0.920` in dev/requirements.txt

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -18,7 +18,7 @@ unittest-xml-reporting
 coverage
 
 # Linter
-mypy
+mypy==0.920
 pytest-mypy-plugins==1.9.3
 flake8==3.9.0
 # See SPARK-38680.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pin `mypy==0.920` in dev/requirements.txt, the same as that in `.github/workflows/build_and_test.yml`


### Why are the changes needed?
before:
the installed version of mypy is `mypy 0.971` now, then `dev/lint-python ` always fail:
```
(spark_dev) ➜  spark git:(master) ✗ dev/lint-python                             
starting python compilation test...
python compilation succeeded.

starting black test...
black checks passed.

starting flake8 test...
flake8 checks passed.

starting mypy annotations test...
annotations failed mypy checks:
python/pyspark/streaming/context.py:372: error: Unused "type: ignore" comment
python/pyspark/streaming/context.py:378: error: Unused "type: ignore" comment
Found 2 errors in 1 file (checked 339 source files)
1
```

after:
```
(spark_dev) ➜  spark git:(master) ✗ dev/lint-python                    
starting python compilation test...
python compilation succeeded.

starting black test...
black checks passed.

starting flake8 test...
flake8 checks passed.

starting mypy annotations test...
annotations passed mypy checks.

starting mypy examples test...
examples passed mypy checks.

starting mypy data test...
annotations passed data checks.


all lint-python tests passed!
```

### Does this PR introduce _any_ user-facing change?
No, only for spark contributors.


### How was this patch tested?
manually test