### PR TITLE
[SPARK-40387][SQL] Improve the implementation of Spark Decimal

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -483,12 +483,10 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def remainder(that: Decimal): Decimal = this % that
 
-  def unary_- : Decimal = {
-    if (decimalVal.eq(null)) {
-      Decimal(-longVal, precision, scale)
-    } else {
-      Decimal(-decimalVal, precision, scale)
-    }
+  def unary_- : Decimal = if (decimalVal.eq(null)) {
+    Decimal(-longVal, precision, scale)
+  } else {
+    Decimal(-decimalVal, precision, scale)
   }
 
   def abs: Decimal = if (this < Decimal.ZERO) this.unary_- else this

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -204,7 +204,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     if (decimalVal.ne(null)) {
       decimalVal.toBigInt
     } else {
-      BigInt(actualLongVal)
+      BigInt(rawLongValue)
     }
   }
 
@@ -212,7 +212,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     if (decimalVal.ne(null)) {
       decimalVal.underlying().toBigInteger()
     } else {
-      java.math.BigInteger.valueOf(actualLongVal)
+      java.math.BigInteger.valueOf(rawLongValue)
     }
   }
 
@@ -240,11 +240,11 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def toFloat: Float = toBigDecimal.floatValue
 
-  private def actualLongVal: Long = longVal / POW_10(_scale)
+  private def rawLongValue: Long = longVal / POW_10(_scale)
 
   def toLong: Long = {
     if (decimalVal.eq(null)) {
-      actualLongVal
+      rawLongValue
     } else {
       decimalVal.longValue
     }
@@ -280,8 +280,8 @@ final class Decimal extends Ordered[Decimal] with Serializable {
   private def roundToNumeric[T <: AnyVal](integralType: IntegralType, maxValue: Int, minValue: Int)
       (f1: Long => T) (f2: Double => T): T = {
     if (decimalVal.eq(null)) {
-      val numericVal = f1(actualLongVal)
-      if (actualLongVal == numericVal) {
+      val numericVal = f1(rawLongValue)
+      if (rawLongValue == numericVal) {
         numericVal
       } else {
         throw QueryExecutionErrors.castingCauseOverflowError(
@@ -304,7 +304,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    */
   private[sql] def roundToLong(): Long = {
     if (decimalVal.eq(null)) {
-      actualLongVal
+      rawLongValue
     } else {
       try {
         // We cannot store Long.MAX_VALUE as a Double without losing precision.
@@ -488,12 +488,12 @@ final class Decimal extends Ordered[Decimal] with Serializable {
       DecimalType.MAX_SCALE, MATH_CONTEXT.getRoundingMode))
 
   def % (that: Decimal): Decimal =
-    if (that.isZero) null else Decimal(toJavaBigDecimal.remainder(that.toJavaBigDecimal,
-      MATH_CONTEXT))
+    if (that.isZero) null
+    else Decimal(toJavaBigDecimal.remainder(that.toJavaBigDecimal, MATH_CONTEXT))
 
   def quot(that: Decimal): Decimal =
-    if (that.isZero) null else Decimal(toJavaBigDecimal.divideToIntegralValue(that.toJavaBigDecimal,
-      MATH_CONTEXT))
+    if (that.isZero) null
+    else Decimal(toJavaBigDecimal.divideToIntegralValue(that.toJavaBigDecimal, MATH_CONTEXT))
 
   def remainder(that: Decimal): Decimal = this % that
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -204,7 +204,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     if (decimalVal.ne(null)) {
       decimalVal.toBigInt
     } else {
-      BigInt(rawLongValue)
+      BigInt(actualLongVal)
     }
   }
 
@@ -212,7 +212,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     if (decimalVal.ne(null)) {
       decimalVal.underlying().toBigInteger()
     } else {
-      java.math.BigInteger.valueOf(rawLongValue)
+      java.math.BigInteger.valueOf(actualLongVal)
     }
   }
 
@@ -240,11 +240,11 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def toFloat: Float = toBigDecimal.floatValue
 
-  private def rawLongValue: Long = longVal / POW_10(_scale)
+  private def actualLongVal: Long = longVal / POW_10(_scale)
 
   def toLong: Long = {
     if (decimalVal.eq(null)) {
-      rawLongValue
+      actualLongVal
     } else {
       decimalVal.longValue
     }
@@ -280,8 +280,8 @@ final class Decimal extends Ordered[Decimal] with Serializable {
   private def roundToNumeric[T <: AnyVal](integralType: IntegralType, maxValue: Int, minValue: Int)
       (f1: Long => T) (f2: Double => T): T = {
     if (decimalVal.eq(null)) {
-      val numericVal = f1(rawLongValue)
-      if (rawLongValue == numericVal) {
+      val numericVal = f1(actualLongVal)
+      if (actualLongVal == numericVal) {
         numericVal
       } else {
         throw QueryExecutionErrors.castingCauseOverflowError(
@@ -304,7 +304,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
    */
   private[sql] def roundToLong(): Long = {
     if (decimalVal.eq(null)) {
-      rawLongValue
+      actualLongVal
     } else {
       try {
         // We cannot store Long.MAX_VALUE as a Double without losing precision.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -184,44 +184,56 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     this
   }
 
-  def toBigDecimal: BigDecimal = if (decimalVal.ne(null)) {
-    decimalVal
-  } else {
-    BigDecimal(longVal, _scale)
+  def toBigDecimal: BigDecimal = {
+    if (decimalVal.ne(null)) {
+      decimalVal
+    } else {
+      BigDecimal(longVal, _scale)
+    }
   }
 
-  def toJavaBigDecimal: java.math.BigDecimal = if (decimalVal.ne(null)) {
-    decimalVal.underlying()
-  } else {
-    java.math.BigDecimal.valueOf(longVal, _scale)
+  def toJavaBigDecimal: java.math.BigDecimal = {
+    if (decimalVal.ne(null)) {
+      decimalVal.underlying()
+    } else {
+      java.math.BigDecimal.valueOf(longVal, _scale)
+    }
   }
 
-  def toScalaBigInt: BigInt = if (decimalVal.ne(null)) {
-    decimalVal.toBigInt
-  } else {
-    BigInt(actualLongVal)
+  def toScalaBigInt: BigInt = {
+    if (decimalVal.ne(null)) {
+      decimalVal.toBigInt
+    } else {
+      BigInt(actualLongVal)
+    }
   }
 
-  def toJavaBigInteger: java.math.BigInteger = if (decimalVal.ne(null)) {
-    decimalVal.underlying().toBigInteger()
-  } else {
-    java.math.BigInteger.valueOf(toLong)
+  def toJavaBigInteger: java.math.BigInteger = {
+    if (decimalVal.ne(null)) {
+      decimalVal.underlying().toBigInteger()
+    } else {
+      java.math.BigInteger.valueOf(actualLongVal)
+    }
   }
 
-  def toUnscaledLong: Long = if (decimalVal.ne(null)) {
-    decimalVal.underlying().unscaledValue().longValueExact()
-  } else {
-    longVal
+  def toUnscaledLong: Long = {
+    if (decimalVal.ne(null)) {
+      decimalVal.underlying().unscaledValue().longValueExact()
+    } else {
+      longVal
+    }
   }
 
   override def toString: String = toBigDecimal.toString()
 
   def toPlainString: String = toJavaBigDecimal.toPlainString
 
-  def toDebugString: String = if (decimalVal.ne(null)) {
-    s"Decimal(expanded, $decimalVal, $precision, $scale)"
-  } else {
-    s"Decimal(compact, $longVal, $precision, $scale)"
+  def toDebugString: String = {
+    if (decimalVal.ne(null)) {
+      s"Decimal(expanded, $decimalVal, $precision, $scale)"
+    } else {
+      s"Decimal(compact, $longVal, $precision, $scale)"
+    }
   }
 
   def toDouble: Double = toBigDecimal.doubleValue
@@ -230,10 +242,12 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   private def actualLongVal: Long = longVal / POW_10(_scale)
 
-  def toLong: Long = if (decimalVal.eq(null)) {
-    actualLongVal
-  } else {
-    decimalVal.longValue
+  def toLong: Long = {
+    if (decimalVal.eq(null)) {
+      actualLongVal
+    } else {
+      decimalVal.longValue
+    }
   }
 
   def toInt: Int = toLong.toInt
@@ -483,10 +497,12 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def remainder(that: Decimal): Decimal = this % that
 
-  def unary_- : Decimal = if (decimalVal.ne(null)) {
-    Decimal(-decimalVal, precision, scale)
-  } else {
-    Decimal(-longVal, precision, scale)
+  def unary_- : Decimal = {
+    if (decimalVal.ne(null)) {
+      Decimal(-decimalVal, precision, scale)
+    } else {
+      Decimal(-longVal, precision, scale)
+    }
   }
 
   def abs: Decimal = if (this < Decimal.ZERO) this.unary_- else this
@@ -548,12 +564,14 @@ object Decimal {
   def apply(value: String): Decimal = new Decimal().set(BigDecimal(value))
 
   // This is used for RowEncoder to handle Decimal inside external row.
-  def fromDecimal(value: Any): Decimal = value match {
-    case j: java.math.BigDecimal => apply(j)
-    case d: BigDecimal => apply(d)
-    case k: scala.math.BigInt => apply(k)
-    case l: java.math.BigInteger => apply(l)
-    case d: Decimal => d
+  def fromDecimal(value: Any): Decimal = {
+    value match {
+      case j: java.math.BigDecimal => apply(j)
+      case d: BigDecimal => apply(d)
+      case k: scala.math.BigInt => apply(k)
+      case l: java.math.BigInteger => apply(l)
+      case d: Decimal => d
+    }
   }
 
   private def numDigitsInIntegralPart(bigDecimal: JavaBigDecimal): Int =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -184,44 +184,44 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     this
   }
 
-  def toBigDecimal: BigDecimal = if (decimalVal.eq(null)) {
-    BigDecimal(longVal, _scale)
-  } else {
+  def toBigDecimal: BigDecimal = if (decimalVal.ne(null)) {
     decimalVal
+  } else {
+    BigDecimal(longVal, _scale)
   }
 
-  def toJavaBigDecimal: java.math.BigDecimal = if (decimalVal.eq(null)) {
-    java.math.BigDecimal.valueOf(longVal, _scale)
-  } else {
+  def toJavaBigDecimal: java.math.BigDecimal = if (decimalVal.ne(null)) {
     decimalVal.underlying()
+  } else {
+    java.math.BigDecimal.valueOf(longVal, _scale)
   }
 
-  def toScalaBigInt: BigInt = if (decimalVal.eq(null)) {
-    BigInt(actualLongVal)
-  } else {
+  def toScalaBigInt: BigInt = if (decimalVal.ne(null)) {
     decimalVal.toBigInt
+  } else {
+    BigInt(actualLongVal)
   }
 
-  def toJavaBigInteger: java.math.BigInteger = if (decimalVal.eq(null)) {
-    java.math.BigInteger.valueOf(actualLongVal)
-  } else {
+  def toJavaBigInteger: java.math.BigInteger = if (decimalVal.ne(null)) {
     decimalVal.underlying().toBigInteger()
+  } else {
+    java.math.BigInteger.valueOf(toLong)
   }
 
-  def toUnscaledLong: Long = if (decimalVal.eq(null)) {
-    longVal
-  } else {
+  def toUnscaledLong: Long = if (decimalVal.ne(null)) {
     decimalVal.underlying().unscaledValue().longValueExact()
+  } else {
+    longVal
   }
 
   override def toString: String = toBigDecimal.toString()
 
   def toPlainString: String = toJavaBigDecimal.toPlainString
 
-  def toDebugString: String = if (decimalVal.eq(null)) {
-    s"Decimal(compact, $longVal, $precision, $scale)"
-  } else {
+  def toDebugString: String = if (decimalVal.ne(null)) {
     s"Decimal(expanded, $decimalVal, $precision, $scale)"
+  } else {
+    s"Decimal(compact, $longVal, $precision, $scale)"
   }
 
   def toDouble: Double = toBigDecimal.doubleValue
@@ -401,18 +401,18 @@ final class Decimal extends Ordered[Decimal] with Serializable {
       // In both cases, we will check whether our precision is okay below
     }
 
-    if (dv.eq(null)) {
-      // We're still using Longs, but we should check whether we match the new precision
-      val p = POW_10(math.min(precision, MAX_LONG_DIGITS))
-      if (lv <= -p || lv >= p) {
-        // Note that we shouldn't have been able to fix this by switching to BigDecimal
-        return false
-      }
-    } else {
+    if (dv.ne(null)) {
       // We get here if either we started with a BigDecimal, or we switched to one because we would
       // have overflowed our Long; in either case we must rescale dv to the new scale.
       dv = dv.setScale(scale, roundMode)
       if (dv.precision > precision) {
+        return false
+      }
+    } else {
+      // We're still using Longs, but we should check whether we match the new precision
+      val p = POW_10(math.min(precision, MAX_LONG_DIGITS))
+      if (lv <= -p || lv >= p) {
+        // Note that we shouldn't have been able to fix this by switching to BigDecimal
         return false
       }
     }
@@ -442,7 +442,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   override def hashCode(): Int = toBigDecimal.hashCode()
 
-  def isZero: Boolean = if (decimalVal.eq(null)) longVal == 0 else decimalVal.signum == 0
+  def isZero: Boolean = if (decimalVal.ne(null)) decimalVal.signum == 0 else longVal == 0
 
   // We should follow DecimalPrecision promote if use longVal for add and subtract:
   // Operation    Result Precision                        Result Scale
@@ -483,10 +483,10 @@ final class Decimal extends Ordered[Decimal] with Serializable {
 
   def remainder(that: Decimal): Decimal = this % that
 
-  def unary_- : Decimal = if (decimalVal.eq(null)) {
-    Decimal(-longVal, precision, scale)
-  } else {
+  def unary_- : Decimal = if (decimalVal.ne(null)) {
     Decimal(-decimalVal, precision, scale)
+  } else {
+    Decimal(-longVal, precision, scale)
   }
 
   def abs: Decimal = if (this < Decimal.ZERO) this.unary_- else this

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/Decimal.scala
@@ -453,7 +453,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
       Decimal(longVal + that.longVal, Math.max(precision, that.precision) + 1, scale)
     } else {
-      Decimal(toBigDecimal.bigDecimal.add(that.toBigDecimal.bigDecimal))
+      Decimal(toJavaBigDecimal.add(that.toJavaBigDecimal))
     }
   }
 
@@ -461,7 +461,7 @@ final class Decimal extends Ordered[Decimal] with Serializable {
     if (decimalVal.eq(null) && that.decimalVal.eq(null) && scale == that.scale) {
       Decimal(longVal - that.longVal, Math.max(precision, that.precision) + 1, scale)
     } else {
-      Decimal(toBigDecimal.bigDecimal.subtract(that.toBigDecimal.bigDecimal))
+      Decimal(toJavaBigDecimal.subtract(that.toJavaBigDecimal))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR used to improve the implementation of Spark `Decimal`. The improvement points are as follows:
1. Use `toJavaBigDecimal` instead of  `toBigDecimal.bigDecimal` 
2. Extract `longVal / POW_10(_scale)` as a new method `def actualLongVal: Long`
3. Remove `BIG_DEC_ZERO` and use `decimalVal.signum` to judge whether or not equals zero.
4. Use `<` instead of `compare`.
5. Correct some code style. 

### Why are the changes needed?
Improve the implementation of Spark Decimal


### Does this PR introduce _any_ user-facing change?
'No'.
Just update the inner implementation.


### How was this patch tested?
N/A
