### PR TITLE
[SPARK-40354][SQL] Support eliminate dynamic partition for datasource v1 writes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -122,6 +122,14 @@ object ExternalCatalogUtils {
     }
   }
 
+  def getPartitionSpecString(value: String): String = {
+    if (value == null || value.isEmpty) {
+      null
+    } else {
+      value
+    }
+  }
+
   def getPartitionValueString(value: String): String = {
     if (value == null || value.isEmpty) {
       DEFAULT_PARTITION_NAME

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -420,6 +420,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val ELIMINATE_DYNAMIC_PARTITION_WRITES =
+    buildConf("spark.sql.optimizer.eliminateDynamicPartitionWrites")
+      .internal()
+      .doc("When set to true, Spark optimizer will infer if the partition column is static and " +
+        "convert it to static partition.")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val COMPRESS_CACHED = buildConf("spark.sql.inMemoryColumnarStorage.compressed")
     .doc("When set to true Spark SQL will automatically select a compression codec for each " +
       "column based on statistics of the data.")
@@ -4683,6 +4692,9 @@ class SQLConf extends Serializable with Logging {
   def maxConcurrentOutputFileWriters: Int = getConf(SQLConf.MAX_CONCURRENT_OUTPUT_FILE_WRITERS)
 
   def plannedWriteEnabled: Boolean = getConf(SQLConf.PLANNED_WRITE_ENABLED)
+
+  def eliminateDynamicPartitionWrites: Boolean =
+    getConf(SQLConf.ELIMINATE_DYNAMIC_PARTITION_WRITES)
 
   def inferDictAsStruct: Boolean = getConf(SQLConf.INFER_NESTED_DICT_AS_STRUCT)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkOptimizer.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.optimizer._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.execution.datasources.{PruneFileSourcePartitions, SchemaPruning, V1Writes}
+import org.apache.spark.sql.execution.datasources.{EliminateV1DynamicPartitionWrites, PruneFileSourcePartitions, SchemaPruning, V1Writes}
 import org.apache.spark.sql.execution.datasources.v2.{GroupBasedRowLevelOperationScanPlanning, OptimizeMetadataOnlyDeleteFromTable, V2ScanPartitioningAndOrdering, V2ScanRelationPushDown, V2Writes}
 import org.apache.spark.sql.execution.dynamicpruning.{CleanupDynamicPruningFilters, PartitionPruning}
 import org.apache.spark.sql.execution.python.{ExtractGroupingPythonUDFFromAggregate, ExtractPythonUDFFromAggregate, ExtractPythonUDFs}
@@ -38,6 +38,7 @@ class SparkOptimizer(
     // TODO: move SchemaPruning into catalyst
     Seq(SchemaPruning) :+
       GroupBasedRowLevelOperationScanPlanning :+
+      EliminateV1DynamicPartitionWrites :+
       V1Writes :+
       V2ScanRelationPushDown :+
       V2ScanPartitioningAndOrdering :+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -179,7 +179,7 @@ case class DataSourceAnalysis(analyzer: Analyzer) extends Rule[LogicalPlan] {
       // Let's say that we have a table "t", which is created by
       // CREATE TABLE t (a INT, b INT, c INT) USING parquet PARTITIONED BY (b, c)
       // The statement of "INSERT INTO TABLE t PARTITION (b=2, c) SELECT 1, 3"
-      // will be converted to "INSERT INTO TABLE t PARTITION (b, c) SELECT 1, 2, 3".
+      // will be converted to "INSERT INTO TABLE t PARTITION (b=2, c) SELECT 1, 2, 3".
       //
       // Basically, we will put those partition columns having a assigned value back
       // to the SELECT clause. The output of the SELECT clause is organized as

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/InsertIntoHadoopFsRelationCommand.scala
@@ -76,7 +76,7 @@ case class InsertIntoHadoopFsRelationCommand(
 
   override def requiredOrdering: Seq[SortOrder] =
     V1WritesUtils.getSortOrder(outputColumns, partitionColumns, bucketSpec, options,
-      staticPartitions.size)
+      numStaticPartitionCols)
 
   override def run(sparkSession: SparkSession, child: SparkPlan): Seq[Row] = {
     // Most formats don't do well with duplicate columns, so lets not allow that
@@ -188,7 +188,7 @@ case class InsertIntoHadoopFsRelationCommand(
           bucketSpec = bucketSpec,
           statsTrackers = Seq(basicWriteJobStatsTracker(hadoopConf)),
           options = options,
-          numStaticPartitionCols = staticPartitions.size)
+          numStaticPartitionCols = numStaticPartitionCols)
 
 
       // update metastore partition metadata
@@ -278,4 +278,7 @@ case class InsertIntoHadoopFsRelationCommand(
 
   override protected def withNewChildInternal(
     newChild: LogicalPlan): InsertIntoHadoopFsRelationCommand = copy(query = newChild)
+
+  override def withNewStaticPartitionSpec(partitionSpec: Map[String, String]): V1WriteCommand =
+    copy(staticPartitions = partitionSpec)
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -1539,7 +1539,7 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
           assert(table.location == makeQualifiedPath(dir.getAbsolutePath))
           assert(spark.sql(s"SHOW PARTITIONS $tableName").count() == 0)
           spark.sql(
-            s"INSERT INTO TABLE $tableName PARTITION(c='c', b) SELECT *, 'b' FROM t WHERE 1 = 0")
+            s"INSERT INTO TABLE $tableName PARTITION(c='c', b) SELECT *, a FROM t WHERE 1 = 0")
           assert(spark.sql(s"SHOW PARTITIONS $tableName").count() == 0)
           assert(!new File(dir, "c=c/b=b").exists())
           checkAnswer(spark.table(tableName), Nil)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/CreateHiveTableAsSelectCommand.scala
@@ -36,6 +36,7 @@ trait CreateHiveTableAsSelectBase extends V1WriteCommand with V1WritesHiveUtils 
   val query: LogicalPlan
   val outputColumnNames: Seq[String]
   val mode: SaveMode
+  override def staticPartitions: Map[String, String] = Map.empty
 
   protected val tableIdentifier = tableDesc.identifier
 
@@ -157,6 +158,8 @@ case class CreateHiveTableAsSelectCommand(
 
   override protected def withNewChildInternal(
     newChild: LogicalPlan): CreateHiveTableAsSelectCommand = copy(query = newChild)
+
+  override def withNewStaticPartitionSpec(partitionSpec: Map[String, String]): V1WriteCommand = this
 }
 
 /**
@@ -207,4 +210,6 @@ case class OptimizedCreateHiveTableAsSelectCommand(
 
   override protected def withNewChildInternal(
     newChild: LogicalPlan): OptimizedCreateHiveTableAsSelectCommand = copy(query = newChild)
+
+  override def withNewStaticPartitionSpec(partitionSpec: Map[String, String]): V1WriteCommand = this
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/InsertIntoHiveTable.scala
@@ -85,6 +85,9 @@ case class InsertIntoHiveTable(
     V1WritesUtils.getSortOrder(outputColumns, partitionColumns, table.bucketSpec, options)
   }
 
+  def staticPartitions: Map[String, String] =
+    partition.filter(_._2.isDefined).map(kv => kv._1 -> kv._2.get)
+
   /**
    * Inserts all the rows in the table into Hive.  Row objects are properly serialized with the
    * `org.apache.hadoop.hive.serde2.SerDe` and the
@@ -293,4 +296,6 @@ case class InsertIntoHiveTable(
 
   override protected def withNewChildInternal(newChild: LogicalPlan): InsertIntoHiveTable =
     copy(query = newChild)
+
+  override def withNewStaticPartitionSpec(partitionSpec: Map[String, String]): V1WriteCommand = this
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Add a new optimizer rule: `EliminateV1DynamicPartitionWrites`. This new rule supports convert dynamic partition writes to statis partition writes if the dynamic column is Literal which has been optimzied by `ConstantFolding` for datasource table.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If the partition column is actually foldable, it's is same with static partition. So there is no needed to do an extra local sort to ensure the same partition values are continuous.

Besides, the dataframe write api does not support specify the static partition spec so users always do dynamic partition writes, e.g.
```java
df.selectExpr("*", "x" as p).write.partitionBy("p").save
``` 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no, improve the performance

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add tests