### PR TITLE
[SPARK-40339][SPARK-40342][SPARK-40345][SPARK-40348][PS] Implement quantile in Rolling/RollingGroupby/Expanding/ExpandingGroupby

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -607,7 +607,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
         -------
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also
-        `interpolation` parameters are not supported yet.
+        `interpolation` parameter is not supported yet.
 
         See Also
         --------

--- a/python/pyspark/pandas/missing/window.py
+++ b/python/pyspark/pandas/missing/window.py
@@ -82,7 +82,6 @@ class MissingPandasLikeExpanding:
     corr = _unsupported_function_expanding("corr")
     cov = _unsupported_function_expanding("cov")
     median = _unsupported_function_expanding("median")
-    quantile = _unsupported_function_expanding("quantile")
     validate = _unsupported_function_expanding("validate")
 
     exclusions = _unsupported_property_expanding("exclusions")
@@ -101,7 +100,6 @@ class MissingPandasLikeRolling:
     corr = _unsupported_function_rolling("corr")
     cov = _unsupported_function_rolling("cov")
     median = _unsupported_function_rolling("median")
-    quantile = _unsupported_function_rolling("quantile")
     validate = _unsupported_function_rolling("validate")
 
     exclusions = _unsupported_property_rolling("exclusions")
@@ -120,7 +118,6 @@ class MissingPandasLikeExpandingGroupby:
     corr = _unsupported_function_expanding("corr")
     cov = _unsupported_function_expanding("cov")
     median = _unsupported_function_expanding("median")
-    quantile = _unsupported_function_expanding("quantile")
     validate = _unsupported_function_expanding("validate")
 
     exclusions = _unsupported_property_expanding("exclusions")
@@ -139,7 +136,6 @@ class MissingPandasLikeRollingGroupby:
     corr = _unsupported_function_rolling("corr")
     cov = _unsupported_function_rolling("cov")
     median = _unsupported_function_rolling("median")
-    quantile = _unsupported_function_rolling("quantile")
     validate = _unsupported_function_rolling("validate")
 
     exclusions = _unsupported_property_rolling("exclusions")

--- a/python/pyspark/pandas/tests/test_expanding.py
+++ b/python/pyspark/pandas/tests/test_expanding.py
@@ -82,6 +82,9 @@ class ExpandingTest(PandasOnSparkTestCase, TestUtils):
     def test_expanding_mean(self):
         self._test_expanding_func("mean")
 
+    def test_expanding_quantile(self):
+        self._test_expanding_func(lambda x: x.quantile(0.5), lambda x: x.quantile(0.5, "lower"))
+
     def test_expanding_sum(self):
         self._test_expanding_func("sum")
 
@@ -211,6 +214,11 @@ class ExpandingTest(PandasOnSparkTestCase, TestUtils):
 
     def test_groupby_expanding_mean(self):
         self._test_groupby_expanding_func("mean")
+
+    def test_groupby_expanding_quantile(self):
+        self._test_groupby_expanding_func(
+            lambda x: x.quantile(0.5), lambda x: x.quantile(0.5, "lower")
+        )
 
     def test_groupby_expanding_sum(self):
         self._test_groupby_expanding_func("sum")

--- a/python/pyspark/pandas/tests/test_rolling.py
+++ b/python/pyspark/pandas/tests/test_rolling.py
@@ -79,6 +79,9 @@ class RollingTest(PandasOnSparkTestCase, TestUtils):
     def test_rolling_mean(self):
         self._test_rolling_func("mean")
 
+    def test_rolling_quantile(self):
+        self._test_rolling_func(lambda x: x.quantile(0.5), lambda x: x.quantile(0.5, "lower"))
+
     def test_rolling_sum(self):
         self._test_rolling_func("sum")
 
@@ -211,6 +214,11 @@ class RollingTest(PandasOnSparkTestCase, TestUtils):
 
     def test_groupby_rolling_mean(self):
         self._test_groupby_rolling_func("mean")
+
+    def test_groupby_rolling_quantile(self):
+        self._test_groupby_rolling_func(
+            lambda x: x.quantile(0.5), lambda x: x.quantile(0.5, "lower")
+        )
 
     def test_groupby_rolling_sum(self):
         self._test_groupby_rolling_func("sum")

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -598,7 +598,7 @@ class Rolling(RollingLike[FrameLike]):
         -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also `interpolation`
-        parameters are not supported yet.
+        parameter is not supported yet.
 
         the current implementation of this API uses Spark's Window without
         specifying partition specification. This leads to move all data into
@@ -607,10 +607,10 @@ class Rolling(RollingLike[FrameLike]):
 
         See Also
         --------
-        Series.rolling : Calling object with Series data.
-        DataFrame.rolling : Calling object with DataFrames.
-        Series.quantile : Equivalent method for Series.
-        DataFrame.quantile : Equivalent method for DataFrame.
+        pyspark.pandas.Series.rolling : Calling rolling with Series data.
+        pyspark.pandas.DataFrame.rolling : Calling rolling with DataFrames.
+        pyspark.pandas.Series.quantile : Aggregating quantile for Series.
+        pyspark.pandas.DataFrame.quantile : Aggregating quantile for DataFrame.
 
         Examples
         --------
@@ -1268,14 +1268,14 @@ class RollingGroupby(RollingLike[FrameLike]):
         -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also `interpolation`
-        parameters are not supported yet.
+        parameter is not supported yet.
 
         See Also
         --------
-        Series.rolling : Calling object with Series data.
-        DataFrame.rolling : Calling object with DataFrames.
-        Series.quantile : Equivalent method for Series.
-        DataFrame.quantile : Equivalent method for DataFrame.
+        pyspark.pandas.Series.rolling : Calling rolling with Series data.
+        pyspark.pandas.DataFrame.rolling : Calling rolling with DataFrames.
+        pyspark.pandas.Series.quantile : Aggregating quantile for Series.
+        pyspark.pandas.DataFrame.quantile : Aggregating quantile for DataFrame.
 
         Examples
         --------
@@ -1684,7 +1684,7 @@ class Expanding(ExpandingLike[FrameLike]):
         -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas (the result is
-        similar to the interpolation set to `lower`), also `interpolation` parameters are
+        similar to the interpolation set to `lower`), also `interpolation` parameter is
         not supported yet.
 
         the current implementation of this API uses Spark's Window without
@@ -1694,10 +1694,10 @@ class Expanding(ExpandingLike[FrameLike]):
 
         See Also
         --------
-        Series.expanding : Calling object with Series data.
-        DataFrame.expanding : Calling object with DataFrames.
-        Series.quantile : Equivalent method for Series.
-        DataFrame.quantile : Equivalent method for DataFrame.
+        pyspark.pandas.Series.expanding : Calling expanding with Series data.
+        pyspark.pandas.DataFrame.expanding : Calling expanding with DataFrames.
+        pyspark.pandas.Series.quantile : Aggregating quantile for Series.
+        pyspark.pandas.DataFrame.quantile : Aggregating quantile for DataFrame.
 
         Examples
         --------
@@ -2241,14 +2241,14 @@ class ExpandingGroupby(ExpandingLike[FrameLike]):
         -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also `interpolation`
-        parameters are not supported yet.
+        parameter is not supported yet.
 
         See Also
         --------
-        Series.expanding : Calling object with Series data.
-        DataFrame.expanding : Calling object with DataFrames.
-        Series.quantile : Equivalent method for Series.
-        DataFrame.quantile : Equivalent method for DataFrame.
+        pyspark.pandas.Series.expanding : Calling expanding with Series data.
+        pyspark.pandas.DataFrame.expanding : Calling expanding with DataFrames.
+        pyspark.pandas.Series.quantile : Aggregating quantile for Series.
+        pyspark.pandas.DataFrame.quantile : Aggregating quantile for DataFrame.
 
         Examples
         --------

--- a/python/pyspark/pandas/window.py
+++ b/python/pyspark/pandas/window.py
@@ -595,7 +595,7 @@ class Rolling(RollingLike[FrameLike]):
             calculation.
 
         Notes
-        -------
+        -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also `interpolation`
         parameters are not supported yet.
@@ -1265,7 +1265,7 @@ class RollingGroupby(RollingLike[FrameLike]):
             calculation.
 
         Notes
-        -------
+        -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also `interpolation`
         parameters are not supported yet.
@@ -1681,7 +1681,7 @@ class Expanding(ExpandingLike[FrameLike]):
             This is a panda-on-Spark specific parameter.
 
         Notes
-        -------
+        -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas (the result is
         similar to the interpolation set to `lower`), also `interpolation` parameters are
@@ -2238,7 +2238,7 @@ class ExpandingGroupby(ExpandingLike[FrameLike]):
             calculation.
 
         Notes
-        -------
+        -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also `interpolation`
         parameters are not supported yet.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement quantile in Rolling/RollingGroupby/Expanding/ExpandingGroupby


### Why are the changes needed?

Improve PS api coverage

```python
>>> s = ps.Series([4, 3, 5, 2, 6])
>>> s.rolling(2).quantile(0.5)
0    NaN
1    3.0
2    3.0
3    2.0
4    2.0
dtype: float64

>>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
>>> s.groupby(s).rolling(3).quantile(0.5).sort_index()
2  0     NaN
   1     NaN
3  2     NaN
   3     NaN
   4     3.0
4  5     NaN
   6     NaN
   7     4.0
   8     4.0
5  9     NaN
   10    NaN
dtype: float64

>>> s = ps.Series([1, 2, 3, 4])
>>> s.expanding(2).quantile(0.5)
0    NaN
1    1.0
2    2.0
3    2.0
dtype: float64

>>> s = ps.Series([2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5])
>>> s.groupby(s).expanding(3).quantile(0.5).sort_index()
2  0     NaN
   1     NaN
3  2     NaN
   3     NaN
   4     3.0
4  5     NaN
   6     NaN
   7     4.0
   8     4.0
5  9     NaN
   10    NaN
dtype: float64

```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
