### PR TITLE
[SPARK-40396][BUILD] Update scalatest and scalatestplus related dependencies to use stable version

### DIFF
--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -200,7 +200,7 @@ public class YarnShuffleService extends AuxiliaryService {
     // because at this point in instantiation there is no Configuration object; it is not passed
     // until `serviceInit` is called, at which point it's too late to adjust the name.
     super("spark_shuffle");
-    logger.info("Initializing YARN shuffle service for Spark", new Throwable());
+    logger.info("Initializing YARN shuffle service for Spark");
     instance = this;
   }
 
@@ -218,7 +218,6 @@ public class YarnShuffleService extends AuxiliaryService {
    */
   @Override
   protected void serviceInit(Configuration externalConf) throws Exception {
-    logger.warn("who call me", new Throwable());
     _conf = new Configuration(externalConf);
     URL confOverlayUrl = Thread.currentThread().getContextClassLoader()
         .getResource(SHUFFLE_SERVICE_CONF_OVERLAY_RESOURCE_NAME);

--- a/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
+++ b/common/network-yarn/src/main/java/org/apache/spark/network/yarn/YarnShuffleService.java
@@ -200,7 +200,7 @@ public class YarnShuffleService extends AuxiliaryService {
     // because at this point in instantiation there is no Configuration object; it is not passed
     // until `serviceInit` is called, at which point it's too late to adjust the name.
     super("spark_shuffle");
-    logger.info("Initializing YARN shuffle service for Spark");
+    logger.info("Initializing YARN shuffle service for Spark", new Throwable());
     instance = this;
   }
 
@@ -218,6 +218,7 @@ public class YarnShuffleService extends AuxiliaryService {
    */
   @Override
   protected void serviceInit(Configuration externalConf) throws Exception {
+    logger.warn("who call me", new Throwable());
     _conf = new Configuration(externalConf);
     URL confOverlayUrl = Thread.currentThread().getContextClassLoader()
         .getResource(SHUFFLE_SERVICE_CONF_OVERLAY_RESOURCE_NAME);

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -241,7 +241,7 @@ scala-compiler/2.12.16//scala-compiler-2.12.16.jar
 scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
-scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
+scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.31//shims-0.9.31.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.31//snakeyaml-1.31.jar

--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -241,7 +241,7 @@ scala-compiler/2.12.16//scala-compiler-2.12.16.jar
 scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
-scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
+scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shims/0.9.31//shims-0.9.31.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.31//snakeyaml-1.31.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -228,7 +228,7 @@ scala-compiler/2.12.16//scala-compiler-2.12.16.jar
 scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
-scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
+scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
 shims/0.9.31//shims-0.9.31.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.31//snakeyaml-1.31.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -228,7 +228,7 @@ scala-compiler/2.12.16//scala-compiler-2.12.16.jar
 scala-library/2.12.16//scala-library-2.12.16.jar
 scala-parser-combinators_2.12/1.1.2//scala-parser-combinators_2.12-1.1.2.jar
 scala-reflect/2.12.16//scala-reflect-2.12.16.jar
-scala-xml_2.12/2.1.0//scala-xml_2.12-2.1.0.jar
+scala-xml_2.12/1.2.0//scala-xml_2.12-1.2.0.jar
 shims/0.9.31//shims-0.9.31.jar
 slf4j-api/1.7.36//slf4j-api-1.7.36.jar
 snakeyaml/1.31//snakeyaml-1.31.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1139,7 +1139,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.3.0-SNAP3</version>
+        <version>3.2.13</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
+      <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1139,19 +1139,19 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.13</version>
+        <version>3.2.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
-        <version>3.2.13.0</version>
+        <version>3.2.12.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
-        <version>3.2.13.0</version>
+        <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
+        <version>3.2.12.0</version>
         <scope>test</scope>
       </dependency>
       <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.2 and upgrade this to 3.2.13.0 -->
@@ -1164,13 +1164,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.6.1</version>
+        <version>4.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>4.6.1</version>
+        <version>4.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1154,6 +1154,7 @@
         <version>3.2.13.0</version>
         <scope>test</scope>
       </dependency>
+      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.2 and upgrade this to 3.2.13.0 -->
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-3-141_${scala.binary.version}</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -398,12 +398,12 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
+      <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
+      <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1145,22 +1145,22 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.11</version>
+        <version>3.2.13</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
-        <version>3.2.11.0</version>
+        <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
+        <version>3.2.13.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
-        <version>3.2.12.0</version>
+        <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
+        <version>3.2.13.0</version>
         <scope>test</scope>
       </dependency>
-      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.1 and upgrade this to 3.2.11.0 -->
+      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.2 and upgrade this to 3.2.13.0 -->
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-3-141_${scala.binary.version}</artifactId>
@@ -1170,13 +1170,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.5.1</version>
+        <version>4.6.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>4.5.1</version>
+        <version>4.6.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1188,7 +1188,7 @@
       <dependency>
         <groupId>org.scalacheck</groupId>
         <artifactId>scalacheck_${scala.binary.version}</artifactId>
-        <version>1.15.4</version>
+        <version>1.16.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
+      <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1139,13 +1139,13 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.2.12</version>
+        <version>3.2.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
-        <version>3.2.12.0</version>
+        <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
+        <version>3.2.11.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1154,7 +1154,7 @@
         <version>3.2.12.0</version>
         <scope>test</scope>
       </dependency>
-      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.1 and upgrade this to 3.2.12.0 -->
+      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.1 and upgrade this to 3.2.11.0 -->
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-3-141_${scala.binary.version}</artifactId>
@@ -1182,7 +1182,7 @@
       <dependency>
         <groupId>org.scalacheck</groupId>
         <artifactId>scalacheck_${scala.binary.version}</artifactId>
-        <version>1.16.0</version>
+        <version>1.15.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
+      <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1144,8 +1144,8 @@
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
-        <version>3.3.0.0-SNAP3</version>
+        <artifactId>scalacheck-1-16_${scala.binary.version}</artifactId>
+        <version>3.2.13.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1181,7 +1181,7 @@
       <dependency>
         <groupId>org.scalacheck</groupId>
         <artifactId>scalacheck_${scala.binary.version}</artifactId>
-        <version>1.15.4</version>
+        <version>1.16.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-xml_${scala.binary.version}</artifactId>
-        <version>1.2.0</version>
+        <version>2.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1109,12 +1109,18 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-xml_${scala.binary.version}</artifactId>
-        <version>1.2.0</version>
+        <version>2.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-compiler</artifactId>
         <version>${scala.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-xml_2.12</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1109,7 +1109,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-xml_${scala.binary.version}</artifactId>
-        <version>2.1.0</version>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatestplus</groupId>
-      <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
+      <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -1150,8 +1150,8 @@
       </dependency>
       <dependency>
         <groupId>org.scalatestplus</groupId>
-        <artifactId>mockito-4-5_${scala.binary.version}</artifactId>
-        <version>3.2.12.0</version>
+        <artifactId>mockito-4-6_${scala.binary.version}</artifactId>
+        <version>3.2.13.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1163,13 +1163,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.5.1</version>
+        <version>4.6.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>4.5.1</version>
+        <version>4.6.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1154,7 +1154,7 @@
         <version>3.2.12.0</version>
         <scope>test</scope>
       </dependency>
-      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.2 and upgrade this to 3.2.13.0 -->
+      <!-- TODO(SPARK-40397): Migrate selenium-java from 3.1 to 4.1 and upgrade this to 3.2.12.0 -->
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-3-141_${scala.binary.version}</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,7 @@
       <dependency>
         <groupId>org.scalatestplus</groupId>
         <artifactId>selenium-3-141_${scala.binary.version}</artifactId>
-        <version>3.3.0.0-SNAP3</version>
+        <version>3.2.10.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr update `scalatest` and `scalatestplus` related dependencies to use stable version as follows:

- Upgrade  `scala-xml` from 1.20 to `2.1.0` to support scalatest 3.2.13

- Update `org.scalatest:scalatest` from 3.3.0-SNAP3 to 3.2.13

- Update `org.scalatestplus:scalacheck-1-15:3.3.0-SNAP3` to `org.scalatestplus:scalacheck-1-16:3.2.13.0` and upgrade `scalacheck` from 1.15.4 to 1.16.0

- Update `org.scalatestplus:selenium-3-141:3.3.0.0-SNAP3` to `org.scalatestplus:selenium-3-141:3.2.10.0` and left TODO of SPARK-40397.


### Why are the changes needed?
Change to use stable version dependencies.

The relevant release notes as follows:
- scala-xml:
   -  https://github.com/scala/scala-xml/releases/tag/v1.3.0
   - https://github.com/scala/scala-xml/releases/tag/v2.0.0
   - https://github.com/scala/scala-xml/releases/tag/v2.0.1
   - https://github.com/scala/scala-xml/releases/tag/v2.1.0
- scalatest : 
   - https://github.com/scalatest/scalatest/releases/tag/release-3.2.10
   - https://github.com/scalatest/scalatest/releases/tag/release-3.2.11
   - https://github.com/scalatest/scalatest/releases/tag/release-3.2.12
   - https://github.com/scalatest/scalatest/releases/tag/release-3.2.13
- org.scalatestplus:scalacheck: 
   - https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.10.0-for-scalacheck-1.15
   - https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.11.0-for-scalacheck-1.15
   - https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.12.0-for-scalacheck-1.16
   - https://github.com/scalatest/scalatestplus-scalacheck/releases/tag/release-3.2.13.0-for-scalacheck-1.16
- org.scalatestplus:mockito:
   - https://github.com/scalatest/scalatestplus-mockito/releases/tag/release-3.2.13.0-for-mockito-4.6 
- org.scalatestplus:selenium:
   - https://github.com/scalatest/scalatestplus-selenium/releases/tag/release-3.2.10.0-for-selenium-3.141

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass GitHub Actions
- Manually check the problems mentioned in https://github.com/apache/spark/pull/35128/files

```
SPARK_GENERATE_GOLDEN_FILES=1 build/sbt clean "sql/testOnly *PlanStability*Suite"
[info] Run completed in 52 seconds, 520 milliseconds.
[info] Total number of tests run: 334
[info] Suites: completed 7, aborted 0
[info] Tests: succeeded 334, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


