### PR TITLE
[SPARK-40403][SQL] Calculate unsafe array size using longs to avoid negative size in error message

### DIFF
--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -708,5 +708,10 @@
       "Writing job aborted"
     ],
     "sqlState" : "40000"
+  },
+  "TOO_MANY_ARRAY_ELEMENTS" : {
+    "message" : [
+      "Cannot initialize array with <numElements> elements of size <size>"
+    ]
   }
 }

--- a/core/src/main/resources/error/error-classes.json
+++ b/core/src/main/resources/error/error-classes.json
@@ -423,6 +423,11 @@
     ],
     "sqlState" : "22023"
   },
+  "TOO_MANY_ARRAY_ELEMENTS" : {
+    "message" : [
+      "Cannot initialize array with <numElements> elements of size <size>"
+    ]
+  },
   "UNABLE_TO_ACQUIRE_MEMORY" : {
     "message" : [
       "Unable to acquire <requestedBytes> bytes of memory, got <receivedBytes>"
@@ -708,10 +713,5 @@
       "Writing job aborted"
     ],
     "sqlState" : "40000"
-  },
-  "TOO_MANY_ARRAY_ELEMENTS" : {
-    "message" : [
-      "Cannot initialize array with <numElements> elements of size <size>"
-    ]
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -57,17 +57,17 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
 
     long fixedPartInBytesLong =
       ByteArrayMethods.roundNumberOfBytesToNearestWord((long) elementSize * numElements);
-    long totalDesiredSize = headerInBytes + fixedPartInBytesLong;
+    long totalInitialSize = headerInBytes + fixedPartInBytesLong;
 
-    if (totalDesiredSize > Integer.MAX_VALUE) {
+    if (totalInitialSize > Integer.MAX_VALUE) {
       throw new IllegalArgumentException(
-        "Cannot initialize array to size " + totalDesiredSize + " bytes");
+        "Cannot initialize array with size " + totalInitialSize + " bytes");
     }
 
-    // it's now safe to cast fixedPartInBytesLong and totalDesiredSize to int
+    // it's now safe to cast fixedPartInBytesLong and totalInitialSize to int
     int fixedPartInBytes = (int) fixedPartInBytesLong;
     // Grows the global buffer ahead for header and fixed size data.
-    holder.grow((int)totalDesiredSize);
+    holder.grow((int)totalInitialSize);
 
     // Write numElements and clear out null bits to header
     Platform.putLong(getBuffer(), startingOffset, numElements);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -55,10 +55,19 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
 
     this.startingOffset = cursor();
 
+    long fixedPartInBytesLong =
+      ByteArrayMethods.roundNumberOfBytesToNearestWord((long) elementSize * numElements);
+    long totalDesiredSize = headerInBytes + fixedPartInBytesLong;
+
+    if (totalDesiredSize > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+        "Cannot initialize array to size " + totalDesiredSize + " bytes");
+    }
+
+    // it's now safe to cast fixedPartInBytesLong and totalDesiredSize to int
+    int fixedPartInBytes = (int) fixedPartInBytesLong;
     // Grows the global buffer ahead for header and fixed size data.
-    int fixedPartInBytes =
-      ByteArrayMethods.roundNumberOfBytesToNearestWord(elementSize * numElements);
-    holder.grow(headerInBytes + fixedPartInBytes);
+    holder.grow((int)totalDesiredSize);
 
     // Write numElements and clear out null bits to header
     Platform.putLong(getBuffer(), startingOffset, numElements);

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions.codegen;
 
+import org.apache.spark.sql.errors.QueryExecutionErrors;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.array.ByteArrayMethods;
@@ -60,8 +61,7 @@ public final class UnsafeArrayWriter extends UnsafeWriter {
     long totalInitialSize = headerInBytes + fixedPartInBytesLong;
 
     if (totalInitialSize > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-        "Cannot initialize array with size " + totalInitialSize + " bytes");
+      throw QueryExecutionErrors.tooManyArrayElementsError(numElements, elementSize);
     }
 
     // it's now safe to cast fixedPartInBytesLong and totalInitialSize to int

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2122,4 +2122,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
         "functionName" -> toSQLId(funcName),
         "expected" -> pattern))
   }
+
+  def tooManyArrayElementsError(
+      numElements: Int,
+      elementSize: Int): SparkIllegalArgumentException = {
+    new SparkIllegalArgumentException(
+      errorClass = "TOO_MANY_ARRAY_ELEMENTS",
+      messageParameters = Array(
+        numElements.toString,
+        elementSize.toString))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2128,8 +2128,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase {
       elementSize: Int): SparkIllegalArgumentException = {
     new SparkIllegalArgumentException(
       errorClass = "TOO_MANY_ARRAY_ELEMENTS",
-      messageParameters = Array(
-        numElements.toString,
-        elementSize.toString))
+      messageParameters = Map(
+        "numElements" -> numElements.toString,
+        "size" -> elementSize.toString))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.codegen
 import org.apache.spark.SparkFunSuite
 
 class UnsafeArrayWriterSuite extends SparkFunSuite {
-  test("Big array size") {
+  test("SPARK-40403: don't print negative number when array is too big") {
     val rowWriter = new UnsafeRowWriter(1)
     rowWriter.resetRowWriter()
     val arrayWriter = new UnsafeArrayWriter(rowWriter, 8)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.codegen
+
+import org.apache.spark.SparkFunSuite
+
+class UnsafeArrayWriterSuite extends SparkFunSuite {
+  test("Big array size") {
+    val rowWriter = new UnsafeRowWriter(1)
+    rowWriter.resetRowWriter()
+    val arrayWriter = new UnsafeArrayWriter(rowWriter, 8)
+    assert(intercept[IllegalArgumentException] {
+      arrayWriter.initialize(268271216)
+    }.getMessage.contains("Cannot initialize array to size 2179703640 bytes"))
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
@@ -26,6 +26,6 @@ class UnsafeArrayWriterSuite extends SparkFunSuite {
     val arrayWriter = new UnsafeArrayWriter(rowWriter, 8)
     assert(intercept[IllegalArgumentException] {
       arrayWriter.initialize(268271216)
-    }.getMessage.contains("Cannot initialize array to size 2179703640 bytes"))
+    }.getMessage.contains("Cannot initialize array with size 2179703640 bytes"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeArrayWriterSuite.scala
@@ -17,15 +17,15 @@
 
 package org.apache.spark.sql.catalyst.expressions.codegen
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 
 class UnsafeArrayWriterSuite extends SparkFunSuite {
   test("SPARK-40403: don't print negative number when array is too big") {
     val rowWriter = new UnsafeRowWriter(1)
     rowWriter.resetRowWriter()
     val arrayWriter = new UnsafeArrayWriter(rowWriter, 8)
-    assert(intercept[IllegalArgumentException] {
+    assert(intercept[SparkIllegalArgumentException] {
       arrayWriter.initialize(268271216)
-    }.getMessage.contains("Cannot initialize array with size 2179703640 bytes"))
+    }.getMessage.contains("Cannot initialize array with 268271216 elements of size 8"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change `UnsafeArrayWriter#initialize` to use longs rather than ints when calculating the initial size of the array.

### Why are the changes needed?

When calculating the initial size in bytes needed for the array, `UnsafeArrayWriter#initialize` uses an int expression, which can overflow. The initialize method then passes the negative size to `BufferHolder#grow`, which complains about the negative size.

Example (the following will run just fine on a 16GB laptop, despite the large driver size setting):
```
bin/spark-sql --driver-memory 22g --master "local[1]"

create or replace temp view data1 as
select 0 as key, id as val
from range(0, 268271216);

create or replace temp view data2 as
select key as lkey, collect_list(val) as bigarray
from data1
group by key;

-- the below cache forces Spark to create unsafe rows
cache lazy table data2;

select count(*) from data2;
```
After a few minutes, `BufferHolder#grow` will throw the following exception:
```
java.lang.IllegalArgumentException: Cannot grow BufferHolder by size -2115263656 because the size is negative
	at org.apache.spark.sql.catalyst.expressions.codegen.BufferHolder.grow(BufferHolder.java:67)
	at org.apache.spark.sql.catalyst.expressions.codegen.UnsafeArrayWriter.initialize(UnsafeArrayWriter.java:61)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$SpecificUnsafeProjection.apply(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.aggregate.Collect.serialize(collect.scala:73)
	at org.apache.spark.sql.catalyst.expressions.aggregate.Collect.serialize(collect.scala:37)
```
This query was going to fail anyway, but the message makes it looks like a bug in Spark rather than a user problem. `UnsafeArrayWriter#initialize` should calculate using a long expression and fail if the size exceeds `Integer.MAX_VALUE`, showing the actual initial size in the error message.

Note: This issue is not related to SPARK-39608, as far as I can tell, despite having the same symptom

### Does this PR introduce _any_ user-facing change?

Other than a better error message, no.

### How was this patch tested?

New unit test.
