### PR TITLE
[SPARK-40404][DOCS] Add precondition description for `spark.shuffle.service.db.backend` in `running-on-yarn.md`

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -854,7 +854,9 @@ The following extra configuration options are available when the shuffle service
   <td>
     When work-preserving restart is enabled in YARN, this is used to specify the disk-base store used 
     in shuffle service state store, supports `LEVELDB` and `ROCKSDB` with `LEVELDB` as default value. 
-    The original data store in `LevelDB/RocksDB` will not be automatically convert to another kind of storage now.
+    The original data store in `LevelDB/RocksDB` will not be automatically converted to another kind 
+    of storage now. The original data store will be retained and the new type data store will be 
+    created when switching storage types.
   </td>
   <td>3.4.0</td>
 </tr>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -852,8 +852,8 @@ The following extra configuration options are available when the shuffle service
   <td><code>spark.shuffle.service.db.backend</code></td>
   <td>LEVELDB</td>
   <td>
-    To specify the kind of disk-base store used in shuffle service state store, supports `LEVELDB` and `ROCKSDB` now 
-    and `LEVELDB` as default value. 
+    When Yarn NodeManager recovery is enabled, this use to specify the kind of disk-base store used in shuffle 
+    service state store, supports `LEVELDB` and `ROCKSDB` now and `LEVELDB` as default value. 
     The original data store in `LevelDB/RocksDB` will not be automatically convert to another kind of storage now.
   </td>
   <td>3.4.0</td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -852,8 +852,8 @@ The following extra configuration options are available when the shuffle service
   <td><code>spark.shuffle.service.db.backend</code></td>
   <td>LEVELDB</td>
   <td>
-    When Yarn NodeManager recovery is enabled, this use to specify the kind of disk-base store used in shuffle 
-    service state store, supports `LEVELDB` and `ROCKSDB` now and `LEVELDB` as default value. 
+    When work-preserving restart is enabled in YARN, this is used to specify the disk-base store used 
+    in shuffle service state store, supports `LEVELDB` and `ROCKSDB` with `LEVELDB` as default value. 
     The original data store in `LevelDB/RocksDB` will not be automatically convert to another kind of storage now.
   </td>
   <td>3.4.0</td>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -322,9 +322,9 @@ SPARK_WORKER_OPTS supports the following system properties:
   <td>true</td>
   <td>
     Store External Shuffle service state on local disk so that when the external shuffle service is restarted, it will
-    automatically reload info on current executors.  This only affects standalone mode.  You should also enable 
-    <code>spark.worker.cleanup.enabled</code>, to ensure that the state eventually gets cleaned up.  
-    This config may be removed in the future.
+    automatically reload info on current executors.  This only affects standalone mode (yarn always has this behavior
+    enabled).  You should also enable <code>spark.worker.cleanup.enabled</code>, to ensure that the state
+    eventually gets cleaned up.  This config may be removed in the future.
   </td>
   <td>3.0.0</td>
 </tr>

--- a/docs/spark-standalone.md
+++ b/docs/spark-standalone.md
@@ -322,9 +322,9 @@ SPARK_WORKER_OPTS supports the following system properties:
   <td>true</td>
   <td>
     Store External Shuffle service state on local disk so that when the external shuffle service is restarted, it will
-    automatically reload info on current executors.  This only affects standalone mode (yarn always has this behavior
-    enabled).  You should also enable <code>spark.worker.cleanup.enabled</code>, to ensure that the state
-    eventually gets cleaned up.  This config may be removed in the future.
+    automatically reload info on current executors.  This only affects standalone mode.  You should also enable 
+    <code>spark.worker.cleanup.enabled</code>, to ensure that the state eventually gets cleaned up.  
+    This config may be removed in the future.
   </td>
   <td>3.0.0</td>
 </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?
From the context from [pr](https://github.com/apache/spark/pull/19032) of [SPARK-17321](https://issues.apache.org/jira/browse/SPARK-17321), `YarnShuffleService` will persist data into `Level/RocksDB` when Yarn NM recovery is enabled. So this pr adds the precondition description related to `Yarn NM recovery is enabled` for `spark.shuffle.service.db.backend`. in `running-on-yarn.md`

### Why are the changes needed?
Add precondition description for `spark.shuffle.service.db.backend` in `running-on-yarn.md`

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions