### PR TITLE
[SPARK-40406][CORE] Change default logging to stderr to consistent with the behavior of log4j1

### DIFF
--- a/core/src/main/resources/org/apache/spark/log4j2-defaults.properties
+++ b/core/src/main/resources/org/apache/spark/log4j2-defaults.properties
@@ -17,11 +17,11 @@
 
 # Set everything to be logged to the console
 rootLogger.level = info
-rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.stdout.ref = console
 
 appender.console.type = Console
-appender.console.name = STDOUT
-appender.console.target = SYSTEM_OUT
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
As @Kimahriman mentioned, the default logging now goes to stdout instead of stderr, so this pr change it back to stderr.


### Why are the changes needed?
Keep consistent with the behavior of log4j1.

Ref to 

https://github.com/apache/spark/blob/78a5825fe266c0884d2dd18cbca9625fa258d7f7/core/src/main/resources/org/apache/spark/log4j-defaults.properties#L18-L23

and the `log4j2.properties.template` also points to `SYSTEM_ERR`.

https://github.com/apache/spark/blob/78d492c1b153240dddc636ec6002e7bfc6b94b3b/conf/log4j2.properties.template#L20-L32




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions