### PR TITLE
[MINOR][SQL] Remove an unnecessary parameter of the PartitionedFileUtil.splitFiles

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -704,7 +704,6 @@ case class FileSourceScanExec(
             // the fix for PARQUET-2161 is available.
             !RowIndexUtil.isNeededForSchema(requiredSchema)
           PartitionedFileUtil.splitFiles(
-            sparkSession = relation.sparkSession,
             file = file,
             filePath = filePath,
             isSplitable = isSplitable,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionedFileUtil.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/PartitionedFileUtil.scala
@@ -19,13 +19,11 @@ package org.apache.spark.sql.execution
 
 import org.apache.hadoop.fs.{BlockLocation, FileStatus, LocatedFileStatus, Path}
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources._
 
 object PartitionedFileUtil {
   def splitFiles(
-      sparkSession: SparkSession,
       file: FileStatus,
       filePath: Path,
       isSplitable: Boolean,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileScan.scala
@@ -152,7 +152,6 @@ trait FileScan extends Scan
       partition.files.flatMap { file =>
         val filePath = file.getPath
         PartitionedFileUtil.splitFiles(
-          sparkSession = sparkSession,
           file = file,
           filePath = filePath,
           isSplitable = isSplitable(filePath),


### PR DESCRIPTION


### What changes were proposed in this pull request?
Remove an unnecessary parameter of the` PartitionedFileUtil.splitFiles`

### Why are the changes needed?
Make code clearer.

### Does this PR introduce _any_ user-facing change?
'No'

### How was this patch tested?
Pass GitHub Actions
