### PR TITLE
[SPARK-40384][INFRA] Also trigger PySpark and SparkR job when changing dockerfile

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -322,7 +322,10 @@ jobs:
   pyspark:
     needs: [precondition, infra-image]
     # always run if pyspark == 'true', even infra-image is skip (such as non-master job)
-    if: always() && fromJson(needs.precondition.outputs.required).pyspark == 'true'
+    if: |
+      always() &&
+      (fromJson(needs.precondition.outputs.required).pyspark == 'true' ||
+      fromJson(needs.precondition.outputs.required).infra-image == 'true')
     name: "Build modules: ${{ matrix.modules }}"
     runs-on: ubuntu-20.04
     container:
@@ -428,7 +431,10 @@ jobs:
   sparkr:
     needs: [precondition, infra-image]
     # always run if sparkr == 'true', even infra-image is skip (such as non-master job)
-    if: always() && fromJson(needs.precondition.outputs.required).sparkr == 'true'
+    if: |
+      always() &&
+      (fromJson(needs.precondition.outputs.required).sparkr == 'true' ||
+      fromJson(needs.precondition.outputs.required).infra-image == 'true')
     name: "Build modules: sparkr"
     runs-on: ubuntu-20.04
     container:
@@ -499,7 +505,10 @@ jobs:
   lint:
     needs: [precondition, infra-image]
     # always run if lint == 'true', even infra-image is skip (such as non-master job)
-    if: always() && fromJson(needs.precondition.outputs.required).lint == 'true'
+    if: |
+      always() &&
+      (fromJson(needs.precondition.outputs.required).lint == 'true' ||
+      fromJson(needs.precondition.outputs.required).infra-image == 'true')
     name: Linters, licenses, dependencies and documentation generation
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should also trigger PySpark and SparkR job when changing dockerfile.

### Why are the changes needed?
We should also trigger PySpark and SparkR job when changing dockerfile as basic test for infra image. For lint job is already set to always true:
https://github.com/apache/spark/blob/3f97cd620a61bc2685bf35215185365e63bedc0a/.github/workflows/build_and_test.yml#L108

but consider we might change this in future, so also added the condition.

Without this patch, only impacts the PR which is changing dockerfile like https://github.com/Yikun/spark/pull/171 (only lint job triggered)



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed.
