### PR TITLE
[SPARK-40415][BUILD][K8S] Add explicit Maven dependency for okio

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -217,7 +217,7 @@ netty-transport-native-unix-common/4.1.80.Final//netty-transport-native-unix-com
 netty-transport/4.1.80.Final//netty-transport-4.1.80.Final.jar
 objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.14.0//okio-1.14.0.jar
+okio/1.15.0//okio-1.15.0.jar
 opencsv/2.3//opencsv-2.3.jar
 orc-core/1.8.0/shaded-protobuf/orc-core-1.8.0-shaded-protobuf.jar
 orc-mapreduce/1.8.0/shaded-protobuf/orc-mapreduce-1.8.0-shaded-protobuf.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -201,7 +201,7 @@ netty-transport-native-unix-common/4.1.80.Final//netty-transport-native-unix-com
 netty-transport/4.1.80.Final//netty-transport-4.1.80.Final.jar
 objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.14.0//okio-1.14.0.jar
+okio/1.15.0//okio-1.15.0.jar
 opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
     <kubernetes-client.version>5.12.3</kubernetes-client.version>
+    <okio.version>1.15.0</okio.version>
 
     <test.java.home>${java.home}</test.java.home>
 

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -95,6 +95,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
+      <version>${okio.version}</version>
+    </dependency>
 
     <!-- Required by kubernetes-client but we exclude it -->
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are two places in Spark that depend on okio

```
[INFO] +- org.seleniumhq.selenium:selenium-java:jar:3.141.59:test
...
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:3.11.0:test
[INFO] |  \- com.squareup.okio:okio:jar:1.14.0:test
```

and 

```
[INFO] +- io.fabric8:kubernetes-client:jar:5.12.3:compile
....
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:3.12.12:compile
[INFO] |  |  \- com.squareup.okio:okio:jar:1.15.0:compile
```

But `Spark Project Assembly` chose `com.squareup.okio:okio:jar:1.14.0` instead of `com.squareup.okio:okio:jar:1.15.0` as compile scope dependency

```
[INFO] +- org.apache.spark:spark-kubernetes_2.12:jar:3.4.0-SNAPSHOT:compile
[INFO] |  +- io.fabric8:kubernetes-client:jar:5.12.3:compile
[INFO] |  |  +- com.squareup.okhttp3:okhttp:jar:3.12.12:compile
...
[INFO] +- org.scalatestplus:selenium-3-141_2.12:jar:3.2.10.0:test
[INFO] |  |  +- org.apache.commons:commons-exec:jar:1.3:test
[INFO] |  |  \- com.squareup.okio:okio:jar:1.14.0:compile
```

and the okio version in spark-deps file is also 1.14.0, this seems to be an incorrect behavior, so this pr explicitly adds the dependency definition of `com.squareup.okio:okio` to clarify that the 1.15.0 used by `kubernetes-client` is the compile scope dependency.



### Why are the changes needed?
Should use okio 1.15.0 in spark-deps files.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions