### PR TITLE
[SPARK-40421][PS] Make `spearman` correlation in `DataFrame.corr` support missing values and `min_periods`

### DIFF
--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -269,26 +269,68 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
             psdf.corr("kendall")
         with self.assertRaisesRegex(TypeError, "Invalid min_periods type"):
             psdf.corr(min_periods="3")
-        with self.assertRaisesRegex(NotImplementedError, "spearman for now"):
-            psdf.corr(method="spearman", min_periods=3)
 
-        self.assert_eq(psdf.corr(), pdf.corr(), check_exact=False)
-        self.assert_eq(psdf.corr(min_periods=1), pdf.corr(min_periods=1), check_exact=False)
-        self.assert_eq(psdf.corr(min_periods=3), pdf.corr(min_periods=3), check_exact=False)
-        self.assert_eq(
-            (psdf + 1).corr(min_periods=2), (pdf + 1).corr(min_periods=2), check_exact=False
-        )
+        for method in ["pearson", "spearman"]:
+            self.assert_eq(psdf.corr(method=method), pdf.corr(method=method), check_exact=False)
+            self.assert_eq(
+                psdf.corr(method=method, min_periods=1),
+                pdf.corr(method=method, min_periods=1),
+                check_exact=False,
+            )
+            self.assert_eq(
+                psdf.corr(method=method, min_periods=3),
+                pdf.corr(method=method, min_periods=3),
+                check_exact=False,
+            )
+            self.assert_eq(
+                (psdf + 1).corr(method=method, min_periods=2),
+                (pdf + 1).corr(method=method, min_periods=2),
+                check_exact=False,
+            )
 
         # multi-index columns
         columns = pd.MultiIndex.from_tuples([("X", "A"), ("X", "B"), ("Y", "C"), ("Z", "D")])
         pdf.columns = columns
         psdf.columns = columns
 
-        self.assert_eq(psdf.corr(), pdf.corr(), check_exact=False)
-        self.assert_eq(psdf.corr(min_periods=1), pdf.corr(min_periods=1), check_exact=False)
-        self.assert_eq(psdf.corr(min_periods=3), pdf.corr(min_periods=3), check_exact=False)
+        for method in ["pearson", "spearman"]:
+            self.assert_eq(psdf.corr(method=method), pdf.corr(method=method), check_exact=False)
+            self.assert_eq(
+                psdf.corr(method=method, min_periods=1),
+                pdf.corr(method=method, min_periods=1),
+                check_exact=False,
+            )
+            self.assert_eq(
+                psdf.corr(method=method, min_periods=3),
+                pdf.corr(method=method, min_periods=3),
+                check_exact=False,
+            )
+            self.assert_eq(
+                (psdf + 1).corr(method=method, min_periods=2),
+                (pdf + 1).corr(method=method, min_periods=2),
+                check_exact=False,
+            )
+
+        # test spearman with identical values
+        pdf = pd.DataFrame(
+            {
+                "a": [0, 1, 1, 1, 0],
+                "b": [2, 2, -1, 1, np.nan],
+                "c": [3, 3, 3, 3, 3],
+                "d": [np.nan, np.nan, np.nan, np.nan, np.nan],
+            }
+        )
+        psdf = ps.from_pandas(pdf)
+        self.assert_eq(psdf.corr(method="spearman"), pdf.corr(method="spearman"), check_exact=False)
         self.assert_eq(
-            (psdf + 1).corr(min_periods=2), (pdf + 1).corr(min_periods=2), check_exact=False
+            psdf.corr(method="spearman", min_periods=1),
+            pdf.corr(method="spearman", min_periods=1),
+            check_exact=False,
+        )
+        self.assert_eq(
+            psdf.corr(method="spearman", min_periods=3),
+            pdf.corr(method="spearman", min_periods=3),
+            check_exact=False,
         )
 
     def test_corr(self):


### PR DESCRIPTION

### What changes were proposed in this pull request?
refactor `spearman`  correlation in `DataFrame.corr` to:

1. support missing values;
2. add parameter min_periods;
3. enable arrow execution since no longer depend on VectorUDT;
4. support lazy evaluation;


### Why are the changes needed?
to make its behavior same as Pandas


### Does this PR introduce _any_ user-facing change?
yes, API change, new parameter supported



### How was this patch tested?
added UT