### PR TITLE
[SPARK-40428][CORE] Fix shutdown hook in the CoarseGrainedSchedulerBackend

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2119,7 +2119,9 @@ class SparkContext(config: SparkConf) extends Logging {
     Utils.tryLogNonFatalError {
       _plugins.foreach(_.shutdown())
     }
-    FallbackStorage.cleanUp(_conf, _hadoopConfiguration)
+    Utils.tryLogNonFatalError {
+      FallbackStorage.cleanUp(_conf, _hadoopConfiguration)
+    }
     Utils.tryLogNonFatalError {
       _eventLogger.foreach(_.stop())
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2813,10 +2813,18 @@ private[spark] class DAGScheduler(
   }
 
   def stop(): Unit = {
-    messageScheduler.shutdownNow()
-    shuffleMergeFinalizeScheduler.shutdownNow()
-    eventProcessLoop.stop()
-    taskScheduler.stop()
+    Utils.tryLogNonFatalError {
+      messageScheduler.shutdownNow()
+    }
+    Utils.tryLogNonFatalError {
+      shuffleMergeFinalizeScheduler.shutdownNow()
+    }
+    Utils.tryLogNonFatalError {
+      eventProcessLoop.stop()
+    }
+    Utils.tryLogNonFatalError {
+      taskScheduler.stop()
+    }
   }
 
   eventProcessLoop.start()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -989,12 +989,8 @@ private[spark] class TaskSchedulerImpl(
         barrierCoordinator.stop()
       }
     }
-    Utils.tryLogNonFatalError {
-      starvationTimer.cancel()
-    }
-    Utils.tryLogNonFatalError {
-      abortTimer.cancel()
-    }
+    starvationTimer.cancel()
+    abortTimer.cancel()
   }
 
   override def defaultParallelism(): Int = backend.defaultParallelism()

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -971,18 +971,30 @@ private[spark] class TaskSchedulerImpl(
   }
 
   override def stop(): Unit = {
-    speculationScheduler.shutdown()
+    Utils.tryLogNonFatalError {
+      speculationScheduler.shutdown()
+    }
     if (backend != null) {
-      backend.stop()
+      Utils.tryLogNonFatalError {
+        backend.stop()
+      }
     }
     if (taskResultGetter != null) {
-      taskResultGetter.stop()
+      Utils.tryLogNonFatalError {
+        taskResultGetter.stop()
+      }
     }
     if (barrierCoordinator != null) {
-      barrierCoordinator.stop()
+      Utils.tryLogNonFatalError {
+        barrierCoordinator.stop()
+      }
     }
-    starvationTimer.cancel()
-    abortTimer.cancel()
+    Utils.tryLogNonFatalError {
+      starvationTimer.cancel()
+    }
+    Utils.tryLogNonFatalError {
+      abortTimer.cancel()
+    }
   }
 
   override def defaultParallelism(): Int = backend.defaultParallelism()

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -39,7 +39,7 @@ import org.apache.spark.rpc._
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages._
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend.ENDPOINT_NAME
-import org.apache.spark.util.{RpcUtils, SerializableBuffer, ShutdownHookManager, ThreadUtils, Utils}
+import org.apache.spark.util.{RpcUtils, SerializableBuffer, ThreadUtils, Utils}
 
 /**
  * A scheduler backend that waits for coarse-grained executors to connect.
@@ -126,19 +126,6 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
     conf.get(EXECUTOR_DECOMMISSION_FORCE_KILL_TIMEOUT).map { _ =>
       ThreadUtils.newDaemonSingleThreadScheduledExecutor("cleanup-decommission-execs")
     }
-
-  private var _shutdownHookRef: AnyRef = _
-
-  _shutdownHookRef = ShutdownHookManager.addShutdownHook(
-    ShutdownHookManager.DEFAULT_SHUTDOWN_PRIORITY) { () =>
-    logInfo("Invoking scheduler stop() from shutdown hook")
-    try {
-      stop()
-    } catch {
-      case e: Throwable =>
-        logWarning("Ignoring Exception while stopping scheduler from shutdown hook", e)
-    }
-  }
 
   class DriverEndpoint extends IsolatedRpcEndpoint with Logging {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix the shutdown hook call through to CoarseGrainedSchedulerBackend

### Why are the changes needed?

Sometimes if the driver shuts down abnormally resources may be left dangling.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests.