### PR TITLE
[SPARK-40339][SPARK-40342][PS][DOCS][FOLLOW-UP] Add Rolling.quantile and Expanding.quantile into PySpark documentation

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/window.rst
+++ b/python/docs/source/reference/pyspark.pandas/window.rst
@@ -36,6 +36,7 @@ Standard moving window functions
    Rolling.min
    Rolling.max
    Rolling.mean
+   Rolling.quantile
 
 Standard expanding window functions
 -----------------------------------
@@ -48,6 +49,7 @@ Standard expanding window functions
    Expanding.min
    Expanding.max
    Expanding.mean
+   Expanding.quantile
 
 Exponential moving window functions
 -----------------------------------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `Rolling.quantile` and `Expanding.quantile` into documentation. 

### Why are the changes needed?

To show the documentation about the new features to end users.

### Does this PR introduce _any_ user-facing change?

No to end users because the original PR is not released yet.

### How was this patch tested?

CI in this PR should test it out.