### PR TITLE
[SPARK-40455][CORE]Abort result stage directly when it failed caused by FetchFailedException

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1989,8 +1989,7 @@ private[spark] class DAGScheduler(
                     }
 
                   case resultStage: ResultStage if resultStage.activeJob.isDefined =>
-                    val numMissingPartitions = resultStage.findMissingPartitions().length
-                    if (numMissingPartitions < resultStage.numTasks) {
+                    if (failedStage.isInstanceOf[ResultStage]) {
                       // TODO: support to rollback result tasks.
                       abortStage(resultStage, generateErrorMessage(resultStage), None)
                     }

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -3022,7 +3022,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
-  test("abort the result stage when it failed caused by FetchFailed" +
+  test("SPARK-40455: abort the result stage when it failed caused by FetchFailed" +
     "and its parent map stage is indeterminate") {
     constructIndeterminateStageFetchFailed()
     assert(scheduler.activeJobs.isEmpty && scheduler.failedStages.isEmpty
@@ -3847,43 +3847,38 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     initPushBasedShuffleConfs(conf)
     DAGSchedulerSuite.clearMergerLocs()
     DAGSchedulerSuite.addMergerLocs(Seq("host1", "host2", "host3", "host4", "host5"))
-    val (shuffleId1, shuffleId2) = constructIndeterminateStageFetchFailed()
 
-    // Check status for all failedStages
-    val failedStages = scheduler.failedStages.toSeq
-    assert(failedStages.map(_.id) == Seq(1, 2))
-    // Shuffle blocks of "hostC" is lost, so first task of the `shuffleMapRdd2` needs to retry.
-    assert(failedStages.collect {
-      case stage: ShuffleMapStage if stage.shuffleDep.shuffleId == shuffleId2 => stage
-    }.head.findMissingPartitions() == Seq(0))
-    // The result stage is still waiting for its 2 tasks to complete
-    assert(failedStages.collect {
-      case stage: ResultStage => stage
-    }.head.findMissingPartitions() == Seq(0, 1))
-    // shuffleMergeId for indeterminate stages would start from 1
-    assert(failedStages.collect {
-      case stage: ShuffleMapStage => stage.shuffleDep.shuffleMergeId
-    }.forall(x => x == 1))
-    scheduler.resubmitFailedStages()
+    val shuffleMapRdd1 = new MyRDD(sc, 2, Nil, indeterminate = true)
 
-    // The first task of the `shuffleMapRdd2` failed with fetch failure
+    val shuffleDep1 = new ShuffleDependency(shuffleMapRdd1, new HashPartitioner(2))
+    val shuffleId1 = shuffleDep1.shuffleId
+    val shuffleMapRdd2 = new MyRDD(sc, 2, List(shuffleDep1), tracker = mapOutputTracker)
+
+    val shuffleDep2 = new ShuffleDependency(shuffleMapRdd2, new HashPartitioner(2))
+    val shuffleId2 = shuffleDep2.shuffleId
+    val finalRdd = new MyRDD(sc, 2, List(shuffleDep2), tracker = mapOutputTracker)
+
+    submit(finalRdd, Array(0, 1))
+
+    // Finish the first shuffle map stage.
+    completeShuffleMapStageSuccessfully(0, 0, 2)
+    assert(mapOutputTracker.findMissingPartitions(shuffleId1) === Some(Seq.empty))
+
+    // fail the second shuffle map stage.
     runEvent(makeCompletionEvent(
-      taskSets(3).tasks(0),
+      taskSets(1).tasks(0),
       FetchFailed(makeBlockManagerId("hostA"), shuffleId1, 0L, 0, 0, "ignored"),
       null))
 
     val newFailedStages = scheduler.failedStages.toSeq
     assert(newFailedStages.map(_.id) == Seq(0, 1))
-    // shuffleMergeId for indeterminate failed stages should be 2
-    assert(failedStages.collect {
-      case stage: ShuffleMapStage => stage.shuffleDep.shuffleMergeId
-    }.forall(x => x == 2))
+
     scheduler.resubmitFailedStages()
 
     // First shuffle map stage resubmitted and reran all tasks.
-    assert(taskSets(4).stageId == 0)
-    assert(taskSets(4).stageAttemptId == 1)
-    assert(taskSets(4).tasks.length == 2)
+    assert(taskSets(2).stageId == 0)
+    assert(taskSets(2).stageAttemptId == 1)
+    assert(taskSets(2).tasks.length == 2)
 
     // Finish all stage.
     completeShuffleMapStageSuccessfully(0, 1, 2)
@@ -3893,14 +3888,14 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
       _.mergeStatuses.forall(x => x.shuffleMergeId == 2)))
     assert(mapOutputTracker.getNumAvailableMergeResults(shuffleId1) == 2)
 
-    completeShuffleMapStageSuccessfully(1, 2, 2, Seq("hostC", "hostD"))
+    completeShuffleMapStageSuccessfully(1, 1, 2, Seq("hostC", "hostD"))
     assert(mapOutputTracker.findMissingPartitions(shuffleId2) === Some(Seq.empty))
     // shuffleMergeId should be 2 for the attempt number 2 for stage 1
     assert(mapOutputTracker.shuffleStatuses.get(shuffleId2).forall(
-      _.mergeStatuses.forall(x => x.shuffleMergeId == 3)))
+      _.mergeStatuses.forall(x => x.shuffleMergeId == 2)))
     assert(mapOutputTracker.getNumAvailableMergeResults(shuffleId2) == 2)
 
-    complete(taskSets(6), Seq((Success, 11), (Success, 12)))
+    complete(taskSets(4), Seq((Success, 11), (Success, 12)))
 
     // Job successful ended.
     assert(results === Map(0 -> 11, 1 -> 12))


### PR DESCRIPTION
### What changes were proposed in this pull request?

Abort result stage directly when it failed caused by FetchFailedException.

### Why are the changes needed?

Here's a very serious bug：
`The resultStage with indeterminate parent mapStage resubmit and it led to data inconsistency problems.`

And The reasons for data inconsistency are as follows：
When result stage failed caused by `FetchFailedException`,  spark will determine whether it can be retried.
And the original condition is `numMissingPartitions < resultStage.numTasks`. It is not an exact condition.

If this condition holds on retry, at this time some other running tasks at the current failed result stage might not have been killed yet, when result stage was resubmit, it would got wrong partitions to recalculation.
```
// DAGScheduler#submitMissingTasks
 
// Figure out the indexes of partition ids to compute.
val partitionsToCompute: Seq[Int] = stage.findMissingPartitions() 
```
It is possible that the number of partitions to be recalculated is smaller than the actual number of partitions at result stage and data inconsistency might occur.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing tests and new test
