### PR TITLE
[SPARK-40469][CORE] Avoid creating directory failures

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockManager.scala
@@ -105,7 +105,7 @@ private[spark] class DiskBlockManager(
         val newDir = new File(localDirs(dirId), "%02x".format(subDirId))
         if (!newDir.exists()) {
           val path = newDir.toPath
-          Files.createDirectory(path)
+          Files.createDirectories(path)
           if (permissionChangingRequired) {
             // SPARK-37618: Create dir as group writable so files within can be deleted by the
             // shuffle service in a secure setup. This will remove the setgid bit so files created


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replace `Files.createDirectory` with `Files.createDirectories`.

### Why are the changes needed?

To avoid creating directory failures if the parent directory removed by YARN:
```
java.nio.file.NoSuchFileException: /hadoop/3/yarn/local/usercache/<User Name>/appcache/application_1654776504115_37917/blockmgr-e18b484f-8c49-4c7d-b649-710439b0e4c3/3c
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384)
	at java.nio.file.Files.createDirectory(Files.java:674)
	at org.apache.spark.storage.DiskBlockManager.getFile(DiskBlockManager.scala:123)
	at org.apache.spark.storage.DiskBlockManager.getFile(DiskBlockManager.scala:146)
	at org.apache.spark.storage.DiskStore.contains(DiskStore.scala:147)
	at org.apache.spark.storage.BlockManager.getLocalValues(BlockManager.scala:853)
	at org.apache.spark.broadcast.TorrentBroadcast.$anonfun$readBroadcastBlock$4(TorrentBroadcast.scala:253)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.broadcast.TorrentBroadcast.$anonfun$readBroadcastBlock$2(TorrentBroadcast.scala:250)
	at org.apache.spark.util.KeyLock.withLock(KeyLock.scala:64)
	at org.apache.spark.broadcast.TorrentBroadcast.$anonfun$readBroadcastBlock$1(TorrentBroadcast.scala:245)
	at org.apache.spark.util.Utils$.tryOrIOException(Utils.scala:1383)
	at org.apache.spark.broadcast.TorrentBroadcast.readBroadcastBlock(TorrentBroadcast.scala:245)
	at org.apache.spark.broadcast.TorrentBroadcast.getValue(TorrentBroadcast.scala:109)
	at org.apache.spark.broadcast.Broadcast.value(Broadcast.scala:70)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:86)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:52)
	at org.apache.spark.scheduler.Task.run(Task.scala:132)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:487)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1417)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:490)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test.