### PR TITLE
[SPARK-40196][PYTHON][PS][FOLLOWUP] Skip SparkFunctionsTests.test_repeat

### DIFF
--- a/python/pyspark/pandas/tests/test_spark_functions.py
+++ b/python/pyspark/pandas/tests/test_spark_functions.py
@@ -25,7 +25,8 @@ from pyspark.testing.pandasutils import PandasOnSparkTestCase
 
 class SparkFunctionsTests(PandasOnSparkTestCase):
     def test_repeat(self):
-        self.assertTrue(spark_column_equals(SF.repeat(F.lit(1), 2), F.repeat(F.lit(1), 2)))
+        # TODO: Placeholder
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mark `SparkFunctionsTests.test_repeat` as placeholder.


### Why are the changes needed?
```
  test_repeat (pyspark.pandas.tests.test_spark_functions.SparkFunctionsTests) ... FAIL (0.052s)

======================================================================
FAIL [0.052s]: test_repeat (pyspark.pandas.tests.test_spark_functions.SparkFunctionsTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/pandas/tests/test_spark_functions.py", line 28, in test_repeat
    self.assertTrue(spark_column_equals(SF.repeat(F.lit(1), 2), F.repeat(F.lit(1), 2)))
AssertionError: False is not true

----------------------------------------------------------------------
Ran 1 test in 8.471s
```

According to https://github.com/apache/spark/pull/37888#issuecomment-1248987419 we'd better skip it first.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed
