### PR TITLE
[SPARK-40413][SQL] Fix  `Column.isin` return null

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Column.scala
@@ -793,7 +793,10 @@ class Column(val expr: Expression) extends Logging {
    * @since 1.5.0
    */
   @scala.annotation.varargs
-  def isin(list: Any*): Column = withExpr { In(expr, list.map(lit(_).expr)) }
+  def isin(list: Any*): Column = {
+    val inExpr = In(expr, list.map(lit(_).expr))
+    withExpr(If(IsNotNull(inExpr), inExpr, lit(false).expr))
+  }
 
   /**
    * A boolean expression that is evaluated to true if the value of this expression is contained

--- a/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ColumnExpressionSuite.scala
@@ -460,6 +460,21 @@ class ColumnExpressionSuite extends QueryTest with SharedSparkSession {
       }
   }
 
+  test("withColumn isin") {
+    val df = Seq(("a"), ("b"), ("c"), (""), (null)).toDF("a")
+    val dfWithCol = df.withColumn("name_isin_list1",
+      col("a").isin("a", "d", ""))
+    assert(dfWithCol.filter($"name_isin_list1" === true).count == 2)
+    assert(dfWithCol.filter($"name_isin_list1" === false).count == 3)
+    assert(dfWithCol.filter($"name_isin_list1".isNull).count == 0)
+
+    val dfWithCol1 = df.withColumn("name_isin_list2",
+      col("a").isin("a", "d", "", null))
+    assert(dfWithCol1.filter($"name_isin_list2" === true).count == 2)
+    assert(dfWithCol1.filter($"name_isin_list2" === false).count == 3)
+    assert(dfWithCol1.filter($"name_isin_list2".isNull).count == 0)
+  }
+
   test("IN/INSET with bytes, shorts, ints, dates") {
     def check(): Unit = {
       val values = Seq(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
```
    val df = Seq(("a"), ("b"), ("c"), (""), (null)).toDF("a")
    val dfWithCol1 = df.withColumn("name_isin_list2",
      col("a").isin("a", "d", "", null))
```
get result
```
scala> dfWithCol.show
+----+---------------+
|   a|name_isin_list2|
+----+---------------+
|   a|           true|
|   b|           null|
|   c|           null|
|    |           true|
|null|           null|
+----+---------------+
```
but expect result :
```
+----+---------------+
|   a|name_isin_list2|
+----+---------------+
|   a|           true|
|   b|           false|
|   c|           false|
|    |           true|
|null|           false|
+----+---------------+
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new UT in `ColumnExpressionSuite.scala`