### PR TITLE
[SPARK-40480][SHUFFLE] Remove push-based shuffle data after query finished

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -262,10 +262,11 @@ public abstract class BlockStoreClient implements Closeable {
    * @param host the host of the remote node.
    * @param port the port of the remote node.
    * @param shuffleId shuffle id.
+   * @param shuffleMergeId shuffle merge id.
    *
    * @since 3.4.0
    */
-  public boolean removeShuffleMerge(String host, int port, int shuffleId) {
+  public boolean removeShuffleMerge(String host, int port, int shuffleId, int shuffleMergeId) {
     throw new UnsupportedOperationException();
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -255,4 +255,17 @@ public abstract class BlockStoreClient implements Closeable {
       MergedBlocksMetaListener listener) {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Remove the shuffle merge data in shuffle services
+   *
+   * @param host the host of the remote node.
+   * @param port the port of the remote node.
+   * @param shuffleId shuffle id.
+   *
+   * @since 3.4.0
+   */
+  public boolean removeShuffleMerge(String host, int port, int shuffleId) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -224,6 +224,12 @@ public class ExternalBlockHandler extends RpcHandler
       } finally {
         responseDelayContext.stop();
       }
+    } else if (msgObj instanceof RemoveShuffleMerge) {
+      RemoveShuffleMerge msg = (RemoveShuffleMerge) msgObj;
+      checkAuth(client, msg.appId);
+      logger.info("Remove shuffle merge data for application %s shuffle %d",
+          msg.appId, msg.shuffleId);
+      mergeManager.removeShuffleMerge(msg.appId, msg.shuffleId);
     } else if (msgObj instanceof DiagnoseCorruption) {
       DiagnoseCorruption msg = (DiagnoseCorruption) msgObj;
       checkAuth(client, msg.appId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -229,7 +229,7 @@ public class ExternalBlockHandler extends RpcHandler
       checkAuth(client, msg.appId);
       logger.info("Removing shuffle merge data for application {} shuffle {} shuffleMerge {}",
           msg.appId, msg.shuffleId, msg.shuffleMergeId);
-      mergeManager.removeShuffleMerge(msg.appId, msg.shuffleId, msg.shuffleMergeId);
+      mergeManager.removeShuffleMerge(msg);
     } else if (msgObj instanceof DiagnoseCorruption) {
       DiagnoseCorruption msg = (DiagnoseCorruption) msgObj;
       checkAuth(client, msg.appId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockHandler.java
@@ -227,9 +227,9 @@ public class ExternalBlockHandler extends RpcHandler
     } else if (msgObj instanceof RemoveShuffleMerge) {
       RemoveShuffleMerge msg = (RemoveShuffleMerge) msgObj;
       checkAuth(client, msg.appId);
-      logger.info("Remove shuffle merge data for application %s shuffle %d",
-          msg.appId, msg.shuffleId);
-      mergeManager.removeShuffleMerge(msg.appId, msg.shuffleId);
+      logger.info("Removing shuffle merge data for application {} shuffle {} shuffleMerge {}",
+          msg.appId, msg.shuffleId, msg.shuffleMergeId);
+      mergeManager.removeShuffleMerge(msg.appId, msg.shuffleId, msg.shuffleMergeId);
     } else if (msgObj instanceof DiagnoseCorruption) {
       DiagnoseCorruption msg = (DiagnoseCorruption) msgObj;
       checkAuth(client, msg.appId);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -264,6 +264,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
       client.send(
           new RemoveShuffleMerge(appId, comparableAppAttemptId, shuffleId, shuffleMergeId)
               .toByteBuffer());
+      // TODO(SPARK-42025): Add some error logs for RemoveShuffleMerge RPC.
     } catch (Exception e) {
       logger.error("Exception while sending RemoveShuffleMerge request to {}:{}",
           host, port, e);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -266,7 +266,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
               .toByteBuffer());
       // TODO(SPARK-42025): Add some error logs for RemoveShuffleMerge RPC.
     } catch (Exception e) {
-      logger.error("Exception while sending RemoveShuffleMerge request to {}:{}",
+      logger.debug("Exception while sending RemoveShuffleMerge request to {}:{}",
           host, port, e);
       return false;
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -264,7 +264,7 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
       client.send(
           new RemoveShuffleMerge(appId, comparableAppAttemptId, shuffleId, shuffleMergeId)
               .toByteBuffer());
-      // TODO(SPARK-42025): Add some error logs for RemoveShuffleMerge RPC.
+      // TODO(SPARK-42025): Add some error logs for RemoveShuffleMerge RPC
     } catch (Exception e) {
       logger.debug("Exception while sending RemoveShuffleMerge request to {}:{}",
           host, port, e);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -257,6 +257,20 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
   }
 
   @Override
+  public boolean removeShuffleMerge(String host, int port, int shuffleId) {
+    checkInit();
+    try {
+      TransportClient client = clientFactory.createClient(host, port);
+      client.send(new RemoveShuffleMerge(appId, shuffleId).toByteBuffer());
+    } catch (Exception e) {
+      logger.error("Exception while sending RemoveShuffleMerge request to {}:{}",
+          host, port, e);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
   public MetricSet shuffleMetrics() {
     checkInit();
     return clientFactory.getAllMetrics();

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -257,11 +257,11 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
   }
 
   @Override
-  public boolean removeShuffleMerge(String host, int port, int shuffleId) {
+  public boolean removeShuffleMerge(String host, int port, int shuffleId, int shuffleMergeId) {
     checkInit();
     try {
       TransportClient client = clientFactory.createClient(host, port);
-      client.send(new RemoveShuffleMerge(appId, shuffleId).toByteBuffer());
+      client.send(new RemoveShuffleMerge(appId, shuffleId, shuffleMergeId).toByteBuffer());
     } catch (Exception e) {
       logger.error("Exception while sending RemoveShuffleMerge request to {}:{}",
           host, port, e);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/ExternalBlockStoreClient.java
@@ -261,7 +261,9 @@ public class ExternalBlockStoreClient extends BlockStoreClient {
     checkInit();
     try {
       TransportClient client = clientFactory.createClient(host, port);
-      client.send(new RemoveShuffleMerge(appId, shuffleId, shuffleMergeId).toByteBuffer());
+      client.send(
+          new RemoveShuffleMerge(appId, comparableAppAttemptId, shuffleId, shuffleMergeId)
+              .toByteBuffer());
     } catch (Exception e) {
       logger.error("Exception while sending RemoveShuffleMerge request to {}:{}",
           host, port, e);

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
@@ -122,6 +122,13 @@ public interface MergedShuffleFileManager {
   String[] getMergedBlockDirs(String appId);
 
   /**
+   * Remove shuffle merge data files.
+   *
+   * @param appId application ID
+   */
+  void removeShuffleMerge(String appId, int shuffleId);
+
+  /**
    * Optionally close any resources associated the MergedShuffleFileManager, such as the
    * leveldb for state persistence.
    */

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
@@ -125,7 +125,8 @@ public interface MergedShuffleFileManager {
   /**
    * Remove shuffle merge data files.
    *
-   * @param removeShuffleMerge Remove shuffle merge RPC
+   * @param removeShuffleMerge contains shuffle details (appId, shuffleId, etc) to uniquely
+   * identify a shuffle to be removed
    */
   void removeShuffleMerge(RemoveShuffleMerge removeShuffleMerge);
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
@@ -125,8 +125,10 @@ public interface MergedShuffleFileManager {
    * Remove shuffle merge data files.
    *
    * @param appId application ID
+   * @param shuffleId shuffle ID
+   * @param shuffleMergeId shuffle merge ID, -1 for all shuffle merges.
    */
-  void removeShuffleMerge(String appId, int shuffleId);
+  void removeShuffleMerge(String appId, int shuffleId, int shuffleMergeId);
 
   /**
    * Optionally close any resources associated the MergedShuffleFileManager, such as the

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/MergedShuffleFileManager.java
@@ -26,6 +26,7 @@ import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.FinalizeShuffleMerge;
 import org.apache.spark.network.shuffle.protocol.MergeStatuses;
 import org.apache.spark.network.shuffle.protocol.PushBlockStream;
+import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 
 /**
  * The MergedShuffleFileManager is used to process push based shuffle when enabled. It works
@@ -124,11 +125,9 @@ public interface MergedShuffleFileManager {
   /**
    * Remove shuffle merge data files.
    *
-   * @param appId application ID
-   * @param shuffleId shuffle ID
-   * @param shuffleMergeId shuffle merge ID, -1 for all shuffle merges.
+   * @param removeShuffleMerge Remove shuffle merge RPC
    */
-  void removeShuffleMerge(String appId, int shuffleId, int shuffleMergeId);
+  void removeShuffleMerge(RemoveShuffleMerge removeShuffleMerge);
 
   /**
    * Optionally close any resources associated the MergedShuffleFileManager, such as the

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
@@ -44,12 +44,12 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
 
   @Override
   public StreamCallbackWithID receiveBlockDataAsStream(PushBlockStream msg) {
-    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
   }
 
   @Override
   public MergeStatuses finalizeShuffleMerge(FinalizeShuffleMerge msg) throws IOException {
-    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
   }
 
   @Override
@@ -69,7 +69,7 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
       int shuffleMergeId,
       int reduceId,
       int chunkId) {
-    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
   }
 
   @Override
@@ -78,12 +78,12 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
       int shuffleId,
       int shuffleMergeId,
       int reduceId) {
-    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
   }
 
   @Override
   public String[] getMergedBlockDirs(String appId) {
-    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
@@ -86,7 +86,7 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
   }
 
   @Override
-  public void removeShuffleMerge(String appId, int shuffleId) {
+  public void removeShuffleMerge(String appId, int shuffleId, int shuffleMergeId) {
     throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
@@ -26,6 +26,7 @@ import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.FinalizeShuffleMerge;
 import org.apache.spark.network.shuffle.protocol.MergeStatuses;
 import org.apache.spark.network.shuffle.protocol.PushBlockStream;
+import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 import org.apache.spark.network.util.TransportConf;
 
 /**
@@ -86,7 +87,7 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
   }
 
   @Override
-  public void removeShuffleMerge(String appId, int shuffleId, int shuffleMergeId) {
+  public void removeShuffleMerge(RemoveShuffleMerge removeShuffleMerge) {
     throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
@@ -44,12 +44,12 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
 
   @Override
   public StreamCallbackWithID receiveBlockDataAsStream(PushBlockStream msg) {
-    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
+    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 
   @Override
   public MergeStatuses finalizeShuffleMerge(FinalizeShuffleMerge msg) throws IOException {
-    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
+    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 
   @Override
@@ -69,7 +69,7 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
       int shuffleMergeId,
       int reduceId,
       int chunkId) {
-    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
+    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 
   @Override
@@ -78,12 +78,12 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
       int shuffleId,
       int shuffleMergeId,
       int reduceId) {
-    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
+    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 
   @Override
   public String[] getMergedBlockDirs(String appId) {
-    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
+    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
 
   @Override

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
@@ -88,6 +88,6 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
 
   @Override
   public void removeShuffleMerge(RemoveShuffleMerge removeShuffleMerge) {
-    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+    throw new UnsupportedOperationException("Cannot handle merged shuffle remove");
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/NoOpMergedShuffleFileManager.java
@@ -84,4 +84,9 @@ public class NoOpMergedShuffleFileManager implements MergedShuffleFileManager {
   public String[] getMergedBlockDirs(String appId) {
     throw new UnsupportedOperationException("Cannot handle shuffle block merge");
   }
+
+  @Override
+  public void removeShuffleMerge(String appId, int shuffleId) {
+    throw new UnsupportedOperationException("Cannot handle shuffle block merge");
+  }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -449,7 +449,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
           writeAppAttemptShuffleMergeInfoToDB(appAttemptShuffleMergeId);
         });
       }
-      return mergePartitionsInfo;
+      return new AppShuffleMergePartitionsInfo(msg.shuffleMergeId, true);
     });
   }
 

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -400,6 +400,8 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
   public void removeShuffleMerge(String appId, int shuffleId, int shuffleMergeId) {
     AppShuffleInfo appShuffleInfo = validateAndGetAppShuffleInfo(appId);
     AppShuffleMergePartitionsInfo partitionsInfo = appShuffleInfo.shuffles.remove(shuffleId);
+    logger.info("Start remove shuffle merge: app {} shuffleId {} shuffleMergeId {}",
+        appId, shuffleId, shuffleMergeId);
     if (partitionsInfo != null) {
       AppAttemptShuffleMergeId appAttemptShuffleMergeId =
           new AppAttemptShuffleMergeId(

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -535,7 +535,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       AppShuffleInfo appShuffleInfo,
       int[] reduceIds,
       boolean deleteFromDB) {
-    if(deleteFromDB) {
+    if (deleteFromDB) {
       removeAppShufflePartitionInfoFromDB(appAttemptShuffleMergeId);
     }
     int shuffleId = appAttemptShuffleMergeId.shuffleId;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -435,16 +435,13 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
       if(deleteCurrentMergedShuffle) {
         // request to clean up shuffle we are currently hosting
         if (!mergePartitionsInfo.isFinalized()) {
-          submitCleanupTask(() -> {
+          submitCleanupTask(() ->
             closeAndDeleteOutdatedPartitions(
-                currentAppAttemptShuffleMergeId, mergePartitionsInfo.shuffleMergePartitions);
-            writeAppAttemptShuffleMergeInfoToDB(appAttemptShuffleMergeId);
-          });
+                currentAppAttemptShuffleMergeId, mergePartitionsInfo.shuffleMergePartitions));
         } else {
-          submitCleanupTask(() -> {
+          submitCleanupTask(() ->
             deleteMergedFiles(currentAppAttemptShuffleMergeId, appShuffleInfo,
-                mergePartitionsInfo.getReduceIds(), false);
-          });
+                mergePartitionsInfo.getReduceIds(), false));
         }
       } else if(shuffleMergeId < mergePartitionsInfo.shuffleMergeId) {
         throw new RuntimeException(String.format("Asked to remove old shuffle merged data for " +
@@ -452,12 +449,11 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
             msg.appId, msg.shuffleId, shuffleMergeId, mergePartitionsInfo.shuffleMergeId));
       } else if (shuffleMergeId > mergePartitionsInfo.shuffleMergeId) {
         // cleanup request for newer shuffle - remove the outdated data we have.
-        submitCleanupTask(() -> {
+        submitCleanupTask(() ->
           closeAndDeleteOutdatedPartitions(
-              currentAppAttemptShuffleMergeId, mergePartitionsInfo.shuffleMergePartitions);
-          writeAppAttemptShuffleMergeInfoToDB(appAttemptShuffleMergeId);
-        });
+              currentAppAttemptShuffleMergeId, mergePartitionsInfo.shuffleMergePartitions));
       }
+      writeAppAttemptShuffleMergeInfoToDB(appAttemptShuffleMergeId);
       return new AppShuffleMergePartitionsInfo(shuffleMergeId, true);
     });
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -817,7 +817,8 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
                 "finalizing shuffle partition {}", msg.appId, msg.appAttemptId, msg.shuffleId,
                 msg.shuffleMergeId, partition.reduceId);
           } finally {
-            partition.closeAllFilesAndDeleteIfNeeded(false);
+            Boolean deleteFile = partition.mapTracker.getCardinality() == 0;
+            partition.closeAllFilesAndDeleteIfNeeded(deleteFile);
           }
         }
       }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -57,7 +57,6 @@ import com.google.common.cache.Weigher;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 
-import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +71,7 @@ import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.FinalizeShuffleMerge;
 import org.apache.spark.network.shuffle.protocol.MergeStatuses;
 import org.apache.spark.network.shuffle.protocol.PushBlockStream;
+import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 import org.apache.spark.network.shuffledb.DB;
 import org.apache.spark.network.shuffledb.DBBackend;
 import org.apache.spark.network.shuffledb.DBIterator;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -396,6 +396,20 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     }
   }
 
+  @Override
+  public void removeShuffleMerge(String appId, int shuffleId) {
+    AppShuffleInfo appShuffleInfo = validateAndGetAppShuffleInfo(appId);
+    AppShuffleMergePartitionsInfo partitionsInfo = appShuffleInfo.shuffles.remove(shuffleId);
+    if (partitionsInfo != null) {
+      AppAttemptShuffleMergeId appAttemptShuffleMergeId =
+          new AppAttemptShuffleMergeId(
+              appId, appShuffleInfo.attemptId, shuffleId, partitionsInfo.shuffleMergeId);
+      submitCleanupTask(() ->
+          closeAndDeleteOutdatedPartitions(
+              appAttemptShuffleMergeId, partitionsInfo.shuffleMergePartitions));
+    }
+  }
+
   /**
    * Clean up the AppShufflePartitionInfo for a specific AppShuffleInfo.
    * If cleanupLocalDirs is true, the merged shuffle files will also be deleted.

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/BlockTransferMessage.java
@@ -50,7 +50,7 @@ public abstract class BlockTransferMessage implements Encodable {
     FETCH_SHUFFLE_BLOCKS(9), GET_LOCAL_DIRS_FOR_EXECUTORS(10), LOCAL_DIRS_FOR_EXECUTORS(11),
     PUSH_BLOCK_STREAM(12), FINALIZE_SHUFFLE_MERGE(13), MERGE_STATUSES(14),
     FETCH_SHUFFLE_BLOCK_CHUNKS(15), DIAGNOSE_CORRUPTION(16), CORRUPTION_CAUSE(17),
-    PUSH_BLOCK_RETURN_CODE(18);
+    PUSH_BLOCK_RETURN_CODE(18), REMOVE_SHUFFLE_MERGE(19);
 
     private final byte id;
 
@@ -88,6 +88,7 @@ public abstract class BlockTransferMessage implements Encodable {
         case 16: return DiagnoseCorruption.decode(buf);
         case 17: return CorruptionCause.decode(buf);
         case 18: return BlockPushReturnCode.decode(buf);
+        case 19: return RemoveShuffleMerge.decode(buf);
         default: throw new IllegalArgumentException("Unknown message type: " + type);
       }
     }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
@@ -60,8 +60,7 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof RemoveShuffleMerge) {
       RemoveShuffleMerge o = (RemoveShuffleMerge) other;
-      return Objects.equal(appId, o.appId)
-        && shuffleId == o.shuffleId;
+      return shuffleId == o.shuffleId && Objects.equal(appId, o.appId);
     }
     return false;
   }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
@@ -21,6 +21,7 @@ import com.google.common.base.Objects;
 import io.netty.buffer.ByteBuf;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
 import org.apache.spark.network.protocol.Encoders;
 
 /**

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
@@ -31,11 +31,17 @@ import org.apache.spark.network.protocol.Encoders;
  */
 public class RemoveShuffleMerge extends BlockTransferMessage {
   public final String appId;
+  public final int appAttemptId;
   public final int shuffleId;
   public final int shuffleMergeId;
 
-  public RemoveShuffleMerge(String appId, int shuffleId, int shuffleMergeId) {
+  public RemoveShuffleMerge(
+      String appId,
+      int appAttemptId,
+      int shuffleId,
+      int shuffleMergeId) {
     this.appId = appId;
+    this.appAttemptId = appAttemptId;
     this.shuffleId = shuffleId;
     this.shuffleMergeId = shuffleMergeId;
   }
@@ -47,13 +53,14 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, shuffleId, shuffleMergeId);
+    return Objects.hashCode(appId, appAttemptId, shuffleId, shuffleMergeId);
   }
 
   @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
       .append("appId", appId)
+      .append("attemptId", appAttemptId)
       .append("shuffleId", shuffleId)
       .append("shuffleMergeId", shuffleMergeId)
       .toString();
@@ -64,6 +71,7 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
     if (other != null && other instanceof RemoveShuffleMerge) {
       RemoveShuffleMerge o = (RemoveShuffleMerge) other;
       return Objects.equal(appId, o.appId)
+        && appAttemptId == o.appAttemptId
         && shuffleId == o.shuffleId
         && shuffleMergeId == o.shuffleMergeId;
     }
@@ -72,20 +80,22 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int encodedLength() {
-    return Encoders.Strings.encodedLength(appId) + 4 + 4;
+    return Encoders.Strings.encodedLength(appId) + 4 + 4 + 4;
   }
 
   @Override
   public void encode(ByteBuf buf) {
     Encoders.Strings.encode(buf, appId);
+    buf.writeInt(appAttemptId);
     buf.writeInt(shuffleId);
     buf.writeInt(shuffleMergeId);
   }
 
   public static RemoveShuffleMerge decode(ByteBuf buf) {
     String appId = Encoders.Strings.decode(buf);
+    int attemptId = buf.readInt();
     int shuffleId = buf.readInt();
     int shuffleMergeId = buf.readInt();
-    return new RemoveShuffleMerge(appId, shuffleId, shuffleMergeId);
+    return new RemoveShuffleMerge(appId, attemptId, shuffleId, shuffleMergeId);
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
@@ -32,10 +32,12 @@ import org.apache.spark.network.protocol.Encoders;
 public class RemoveShuffleMerge extends BlockTransferMessage {
   public final String appId;
   public final int shuffleId;
+  public final int shuffleMergeId;
 
-  public RemoveShuffleMerge(String appId, int shuffleId) {
+  public RemoveShuffleMerge(String appId, int shuffleId, int shuffleMergeId) {
     this.appId = appId;
     this.shuffleId = shuffleId;
+    this.shuffleMergeId = shuffleMergeId;
   }
 
   @Override
@@ -45,7 +47,7 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(appId, shuffleId);
+    return Objects.hashCode(appId, shuffleId, shuffleMergeId);
   }
 
   @Override
@@ -53,6 +55,7 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
       .append("appId", appId)
       .append("shuffleId", shuffleId)
+      .append("shuffleMergeId", shuffleMergeId)
       .toString();
   }
 
@@ -60,25 +63,29 @@ public class RemoveShuffleMerge extends BlockTransferMessage {
   public boolean equals(Object other) {
     if (other != null && other instanceof RemoveShuffleMerge) {
       RemoveShuffleMerge o = (RemoveShuffleMerge) other;
-      return shuffleId == o.shuffleId && Objects.equal(appId, o.appId);
+      return Objects.equal(appId, o.appId)
+        && shuffleId == o.shuffleId
+        && shuffleMergeId == o.shuffleMergeId;
     }
     return false;
   }
 
   @Override
   public int encodedLength() {
-    return Encoders.Strings.encodedLength(appId) + 4;
+    return Encoders.Strings.encodedLength(appId) + 4 + 4;
   }
 
   @Override
   public void encode(ByteBuf buf) {
     Encoders.Strings.encode(buf, appId);
     buf.writeInt(shuffleId);
+    buf.writeInt(shuffleMergeId);
   }
 
   public static RemoveShuffleMerge decode(ByteBuf buf) {
     String appId = Encoders.Strings.decode(buf);
     int shuffleId = buf.readInt();
-    return new RemoveShuffleMerge(appId, shuffleId);
+    int shuffleMergeId = buf.readInt();
+    return new RemoveShuffleMerge(appId, shuffleId, shuffleMergeId);
   }
 }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/protocol/RemoveShuffleMerge.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.network.shuffle.protocol;
+
+import com.google.common.base.Objects;
+import io.netty.buffer.ByteBuf;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.spark.network.protocol.Encoders;
+
+/**
+ * Remove the merged data for a given shuffle.
+ * Returns {@link Boolean}
+ *
+ * @since 3.4.0
+ */
+public class RemoveShuffleMerge extends BlockTransferMessage {
+  public final String appId;
+  public final int shuffleId;
+
+  public RemoveShuffleMerge(String appId, int shuffleId) {
+    this.appId = appId;
+    this.shuffleId = shuffleId;
+  }
+
+  @Override
+  protected Type type() {
+    return Type.REMOVE_SHUFFLE_MERGE;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(appId, shuffleId);
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("appId", appId)
+      .append("shuffleId", shuffleId)
+      .toString();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other != null && other instanceof RemoveShuffleMerge) {
+      RemoveShuffleMerge o = (RemoveShuffleMerge) other;
+      return Objects.equal(appId, o.appId)
+        && shuffleId == o.shuffleId;
+    }
+    return false;
+  }
+
+  @Override
+  public int encodedLength() {
+    return Encoders.Strings.encodedLength(appId) + 4;
+  }
+
+  @Override
+  public void encode(ByteBuf buf) {
+    Encoders.Strings.encode(buf, appId);
+    buf.writeInt(shuffleId);
+  }
+
+  public static RemoveShuffleMerge decode(ByteBuf buf) {
+    String appId = Encoders.Strings.decode(buf);
+    int shuffleId = buf.readInt();
+    return new RemoveShuffleMerge(appId, shuffleId);
+  }
+}

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,6 +57,7 @@ import org.apache.spark.network.shuffle.protocol.ExecutorShuffleInfo;
 import org.apache.spark.network.shuffle.protocol.FinalizeShuffleMerge;
 import org.apache.spark.network.shuffle.protocol.MergeStatuses;
 import org.apache.spark.network.shuffle.protocol.PushBlockStream;
+import org.apache.spark.network.shuffle.protocol.RemoveShuffleMerge;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
 

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -267,8 +267,10 @@ public class RemoteBlockPushResolverSuite {
     stream.onData(stream.getID(), ByteBuffer.wrap(new byte[4]));
     stream.onFailure(stream.getID(), new RuntimeException("Forced Failure"));
     pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(TEST_APP, NO_ATTEMPT_ID, 0, 0));
-    MergedBlockMeta blockMeta = pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0);
-    assertEquals("num-chunks", 0, blockMeta.getNumChunks());
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0));
+    assertTrue(e.getMessage().contains("Merged shuffle index file") &&
+        e.getMessage().contains("not found"));
   }
 
   @Test
@@ -281,8 +283,10 @@ public class RemoteBlockPushResolverSuite {
     stream.onData(stream.getID(), ByteBuffer.wrap(new byte[4]));
     stream.onFailure(stream.getID(), new RuntimeException("Forced Failure"));
     pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(TEST_APP, NO_ATTEMPT_ID, 0, 0));
-    MergedBlockMeta blockMeta = pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0);
-    assertEquals("num-chunks", 0, blockMeta.getNumChunks());
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0));
+    assertTrue(e.getMessage().contains("Merged shuffle index file") &&
+        e.getMessage().contains("not found"));
   }
 
   @Test

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -1343,14 +1343,15 @@ public class RemoteBlockPushResolverSuite {
     };
     pushResolver.registerExecutor(testApp, new ExecutorShuffleInfo(
         prepareLocalDirs(localDirs, MERGE_DIRECTORY), 1, MERGE_DIRECTORY_META));
-
-    // 1. Check whether the data is cleaned up when merged shuffle is finalized
     RemoteBlockPushResolver.AppShuffleInfo shuffleInfo =
         pushResolver.validateAndGetAppShuffleInfo(testApp);
-    StreamCallbackWithID streamCallback1 = pushResolver.receiveBlockDataAsStream(
+
+    // 1. Check whether the data is cleaned up when merged shuffle is finalized
+    // 1.1 Cleaned up the merged files when msg.shuffleMergeId is current shuffleMergeId
+    StreamCallbackWithID streamCallback0 = pushResolver.receiveBlockDataAsStream(
         new PushBlockStream(testApp, NO_ATTEMPT_ID, 0, 1, 0, 0, 0));
-    streamCallback1.onData(streamCallback1.getID(), ByteBuffer.wrap(new byte[2]));
-    streamCallback1.onComplete(streamCallback1.getID());
+    streamCallback0.onData(streamCallback0.getID(), ByteBuffer.wrap(new byte[2]));
+    streamCallback0.onComplete(streamCallback0.getID());
     pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, NO_ATTEMPT_ID, 0, 1));
     assertTrue(shuffleInfo.getMergedShuffleMetaFile(0, 1, 0).exists());
     assertTrue(new File(shuffleInfo.getMergedShuffleIndexFilePath(0, 1, 0)).exists());
@@ -1362,26 +1363,74 @@ public class RemoteBlockPushResolverSuite {
     assertFalse(new File(shuffleInfo.getMergedShuffleIndexFilePath(0, 1, 0)).exists());
     assertFalse(shuffleInfo.getMergedShuffleDataFile(0, 1, 0).exists());
 
-    // 2. Check whether the data is cleaned up when merged shuffle is not finalized.
+    // 1.2 Cleaned up the merged files when msg.shuffleMergeId is DELETE_ALL_MERGED_SHUFFLE
+    StreamCallbackWithID streamCallback1 = pushResolver.receiveBlockDataAsStream(
+        new PushBlockStream(testApp, NO_ATTEMPT_ID, 1, 1, 0, 0, 0));
+    streamCallback1.onData(streamCallback1.getID(), ByteBuffer.wrap(new byte[2]));
+    streamCallback1.onComplete(streamCallback1.getID());
+    pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, NO_ATTEMPT_ID, 1, 1));
+    assertTrue(shuffleInfo.getMergedShuffleMetaFile(1, 1, 0).exists());
+    assertTrue(new File(shuffleInfo.getMergedShuffleIndexFilePath(1, 1, 0)).exists());
+    assertTrue(shuffleInfo.getMergedShuffleDataFile(1, 1, 0).exists());
+    pushResolver.removeShuffleMerge(new RemoveShuffleMerge(testApp, NO_ATTEMPT_ID, 1,
+        RemoteBlockPushResolver.DELETE_ALL_MERGED_SHUFFLE));
+    closed.tryAcquire(10, TimeUnit.SECONDS);
+    assertFalse(shuffleInfo.getMergedShuffleMetaFile(1, 1, 0).exists());
+    assertFalse(new File(shuffleInfo.getMergedShuffleIndexFilePath(0, 1, 0)).exists());
+    assertFalse(shuffleInfo.getMergedShuffleDataFile(1, 1, 0).exists());
+
+    // 1.3 Cleaned up the merged files when msg.shuffleMergeId < current shuffleMergeId
     StreamCallbackWithID streamCallback2 = pushResolver.receiveBlockDataAsStream(
         new PushBlockStream(testApp, NO_ATTEMPT_ID, 2, 1, 0, 0, 0));
     streamCallback2.onData(streamCallback2.getID(), ByteBuffer.wrap(new byte[2]));
     streamCallback2.onComplete(streamCallback2.getID());
+    pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, NO_ATTEMPT_ID, 2, 1));
     assertTrue(shuffleInfo.getMergedShuffleMetaFile(2, 1, 0).exists());
-    pushResolver.removeShuffleMerge(
-        new RemoveShuffleMerge(testApp, NO_ATTEMPT_ID, 2, 1));
-    closed.tryAcquire(10, TimeUnit.SECONDS);
-    assertFalse(shuffleInfo.getMergedShuffleMetaFile(2, 1, 0).exists());
+    assertTrue(new File(shuffleInfo.getMergedShuffleIndexFilePath(2, 1, 0)).exists());
+    assertTrue(shuffleInfo.getMergedShuffleDataFile(2, 1, 0).exists());
 
-    // 3. Check whether the data is cleaned up when higher shuffleMergeId finalize request comes
+    RuntimeException e = assertThrows(RuntimeException.class,
+        () -> pushResolver.removeShuffleMerge(
+            new RemoveShuffleMerge(testApp, NO_ATTEMPT_ID, 2, 0)));
+    assertEquals("Asked to remove old shuffle merged data for application " + testApp +
+        " shuffleId 2 shuffleMergeId 0, but current shuffleMergeId 1 ", e.getMessage());
+
+    // 1.4 Cleaned up the merged files when msg.shuffleMergeId > current shuffleMergeId
     StreamCallbackWithID streamCallback3 = pushResolver.receiveBlockDataAsStream(
         new PushBlockStream(testApp, NO_ATTEMPT_ID, 3, 1, 0, 0, 0));
     streamCallback3.onData(streamCallback3.getID(), ByteBuffer.wrap(new byte[2]));
     streamCallback3.onComplete(streamCallback3.getID());
+    pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, NO_ATTEMPT_ID, 3, 1));
     assertTrue(shuffleInfo.getMergedShuffleMetaFile(3, 1, 0).exists());
-    pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, NO_ATTEMPT_ID, 3, 2));
+    assertTrue(new File(shuffleInfo.getMergedShuffleIndexFilePath(3, 1, 0)).exists());
+    assertTrue(shuffleInfo.getMergedShuffleDataFile(3, 1, 0).exists());
+    pushResolver.removeShuffleMerge(
+        new RemoveShuffleMerge(testApp, NO_ATTEMPT_ID, 3, 2));
     closed.tryAcquire(10, TimeUnit.SECONDS);
     assertFalse(shuffleInfo.getMergedShuffleMetaFile(3, 1, 0).exists());
+    assertFalse(new File(shuffleInfo.getMergedShuffleIndexFilePath(3, 1, 0)).exists());
+    assertFalse(shuffleInfo.getMergedShuffleDataFile(3, 1, 0).exists());
+
+    // 2. Check whether the data is cleaned up when merged shuffle is not finalized.
+    StreamCallbackWithID streamCallback4 = pushResolver.receiveBlockDataAsStream(
+        new PushBlockStream(testApp, NO_ATTEMPT_ID, 4, 1, 0, 0, 0));
+    streamCallback4.onData(streamCallback4.getID(), ByteBuffer.wrap(new byte[2]));
+    streamCallback4.onComplete(streamCallback4.getID());
+    assertTrue(shuffleInfo.getMergedShuffleMetaFile(4, 1, 0).exists());
+    pushResolver.removeShuffleMerge(
+        new RemoveShuffleMerge(testApp, NO_ATTEMPT_ID, 4, 1));
+    closed.tryAcquire(10, TimeUnit.SECONDS);
+    assertFalse(shuffleInfo.getMergedShuffleMetaFile(4, 1, 0).exists());
+
+    // 3. Check whether the data is cleaned up when higher shuffleMergeId finalize request comes
+    StreamCallbackWithID streamCallback5 = pushResolver.receiveBlockDataAsStream(
+        new PushBlockStream(testApp, NO_ATTEMPT_ID, 5, 1, 0, 0, 0));
+    streamCallback5.onData(streamCallback5.getID(), ByteBuffer.wrap(new byte[2]));
+    streamCallback5.onComplete(streamCallback5.getID());
+    assertTrue(shuffleInfo.getMergedShuffleMetaFile(5, 1, 0).exists());
+    pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(testApp, NO_ATTEMPT_ID, 5, 2));
+    closed.tryAcquire(10, TimeUnit.SECONDS);
+    assertFalse(shuffleInfo.getMergedShuffleMetaFile(5, 1, 0).exists());
   }
 
   private void useTestFiles(boolean useTestIndexFile, boolean useTestMetaFile) throws IOException {

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -1339,8 +1339,9 @@ public class RemoteBlockPushResolverSuite {
       void deleteMergedFiles(
           AppAttemptShuffleMergeId appAttemptShuffleMergeId,
           AppShuffleInfo appShuffleInfo,
-          int[] reduceIds) {
-        super.deleteMergedFiles(appAttemptShuffleMergeId, appShuffleInfo, reduceIds);
+          int[] reduceIds,
+          boolean deleteFromDB) {
+        super.deleteMergedFiles(appAttemptShuffleMergeId, appShuffleInfo, reduceIds, deleteFromDB);
         closed.release();
       }
     };

--- a/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
+++ b/common/network-shuffle/src/test/java/org/apache/spark/network/shuffle/RemoteBlockPushResolverSuite.java
@@ -269,10 +269,8 @@ public class RemoteBlockPushResolverSuite {
     stream.onData(stream.getID(), ByteBuffer.wrap(new byte[4]));
     stream.onFailure(stream.getID(), new RuntimeException("Forced Failure"));
     pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(TEST_APP, NO_ATTEMPT_ID, 0, 0));
-    RuntimeException e = assertThrows(RuntimeException.class,
-        () -> pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0));
-    assertTrue(e.getMessage().contains("Merged shuffle index file") &&
-        e.getMessage().contains("not found"));
+    MergedBlockMeta blockMeta = pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0);
+    assertEquals("num-chunks", 0, blockMeta.getNumChunks());
   }
 
   @Test
@@ -285,10 +283,8 @@ public class RemoteBlockPushResolverSuite {
     stream.onData(stream.getID(), ByteBuffer.wrap(new byte[4]));
     stream.onFailure(stream.getID(), new RuntimeException("Forced Failure"));
     pushResolver.finalizeShuffleMerge(new FinalizeShuffleMerge(TEST_APP, NO_ATTEMPT_ID, 0, 0));
-    RuntimeException e = assertThrows(RuntimeException.class,
-        () -> pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0));
-    assertTrue(e.getMessage().contains("Merged shuffle index file") &&
-        e.getMessage().contains("not found"));
+    MergedBlockMeta blockMeta = pushResolver.getMergedBlockMeta(TEST_APP, 0, 0, 0);
+    assertEquals("num-chunks", 0, blockMeta.getNumChunks());
   }
 
   @Test

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1207,7 +1207,7 @@ private[spark] class MapOutputTrackerMaster(
 
   // This method is only called in local-mode.
   override def getShufflePushMergerLocations(shuffleId: Int): Seq[BlockManagerId] = {
-    shuffleStatuses(shuffleId).getShufflePushMergerLocations
+    shuffleStatuses.get(shuffleId).map(_.getShufflePushMergerLocations).getOrElse(Seq.empty)
   }
 
   override def stop(): Unit = {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1398,9 +1398,7 @@ private[spark] class DAGScheduler(
    */
   private def prepareShuffleServicesForShuffleMapStage(stage: ShuffleMapStage): Unit = {
     assert(stage.shuffleDep.shuffleMergeAllowed && !stage.shuffleDep.isShuffleMergeFinalizedMarked)
-    if (stage.shuffleDep.getMergerLocs.isEmpty) {
-      getAndSetShufflePushMergerLocations(stage)
-    }
+    getAndSetShufflePushMergerLocations(stage)
 
     val shuffleId = stage.shuffleDep.shuffleId
     val shuffleMergeId = stage.shuffleDep.shuffleMergeId
@@ -1416,16 +1414,24 @@ private[spark] class DAGScheduler(
   }
 
   private def getAndSetShufflePushMergerLocations(stage: ShuffleMapStage): Seq[BlockManagerId] = {
-    val mergerLocs = sc.schedulerBackend.getShufflePushMergerLocations(
-      stage.shuffleDep.partitioner.numPartitions, stage.resourceProfileId)
-    if (mergerLocs.nonEmpty) {
-      stage.shuffleDep.setMergerLocs(mergerLocs)
+    stage.shuffleDep.synchronized {
+      val oldMergeLocs = stage.shuffleDep.getMergerLocs
+      if (oldMergeLocs.isEmpty) {
+        val mergerLocs = sc.schedulerBackend.getShufflePushMergerLocations(
+          stage.shuffleDep.partitioner.numPartitions, stage.resourceProfileId)
+        if (mergerLocs.nonEmpty) {
+          stage.shuffleDep.setMergerLocs(mergerLocs)
+          mapOutputTracker.registerShufflePushMergerLocations(
+            stage.shuffleDep.shuffleId, mergerLocs)
+        }
+        logDebug(s"Shuffle merge locations for shuffle ${stage.shuffleDep.shuffleId} with" +
+          s" shuffle merge ${stage.shuffleDep.shuffleMergeId} is" +
+          s" ${stage.shuffleDep.getMergerLocs.map(_.host).mkString(", ")}")
+        mergerLocs
+      } else {
+        oldMergeLocs
+      }
     }
-
-    logDebug(s"Shuffle merge locations for shuffle ${stage.shuffleDep.shuffleId} with" +
-      s" shuffle merge ${stage.shuffleDep.shuffleMergeId} is" +
-      s" ${stage.shuffleDep.getMergerLocs.map(_.host).mkString(", ")}")
-    mergerLocs
   }
 
   /** Called when stage's parents are available and we can now do its task. */
@@ -2629,16 +2635,13 @@ private[spark] class DAGScheduler(
       shuffleIdToMapStage.filter { case (_, stage) =>
         stage.shuffleDep.shuffleMergeAllowed && stage.shuffleDep.getMergerLocs.isEmpty &&
           runningStages.contains(stage)
-      }.foreach { case(_, stage: ShuffleMapStage) =>
-          if (getAndSetShufflePushMergerLocations(stage).nonEmpty) {
-            logInfo(s"Shuffle merge enabled adaptively for $stage with shuffle" +
-              s" ${stage.shuffleDep.shuffleId} and shuffle merge" +
-              s" ${stage.shuffleDep.shuffleMergeId} with ${stage.shuffleDep.getMergerLocs.size}" +
-              s" merger locations")
-            mapOutputTracker.registerShufflePushMergerLocations(stage.shuffleDep.shuffleId,
-              stage.shuffleDep.getMergerLocs)
-          }
-        }
+      }.foreach { case (_, stage: ShuffleMapStage) =>
+        getAndSetShufflePushMergerLocations(stage)
+        logInfo(s"Shuffle merge enabled adaptively for $stage with shuffle" +
+          s" ${stage.shuffleDep.shuffleId} and shuffle merge" +
+          s" ${stage.shuffleDep.shuffleMergeId} with ${stage.shuffleDep.getMergerLocs.size}" +
+          s" merger locations")
+      }
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2629,10 +2629,12 @@ private[spark] class DAGScheduler(
           runningStages.contains(stage)
       }.foreach { case (_, stage: ShuffleMapStage) =>
         configureShufflePushMergerLocations(stage)
-        logInfo(s"Shuffle merge enabled adaptively for $stage with shuffle" +
-          s" ${stage.shuffleDep.shuffleId} and shuffle merge" +
-          s" ${stage.shuffleDep.shuffleMergeId} with ${stage.shuffleDep.getMergerLocs.size}" +
-          s" merger locations")
+        if (stage.shuffleDep.getMergerLocs.nonEmpty) {
+          logInfo(s"Shuffle merge enabled adaptively for $stage with shuffle" +
+            s" ${stage.shuffleDep.shuffleId} and shuffle merge" +
+            s" ${stage.shuffleDep.shuffleMergeId} with ${stage.shuffleDep.getMergerLocs.size}" +
+            s" merger locations")
+        }
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -57,6 +57,7 @@ class BlockManagerMasterEndpoint(
     isDriver: Boolean)
   extends IsolatedThreadSafeRpcEndpoint with Logging {
 
+  private val testing: Boolean = conf.get(config.Tests.IS_TESTING).getOrElse(false)
   // Mapping from executor id to the block manager's local disk directories.
   private val executorIdToLocalDirs =
     CacheBuilder
@@ -321,20 +322,6 @@ class BlockManagerMasterEndpoint(
   }
 
   private def removeShuffle(shuffleId: Int): Future[Seq[Boolean]] = {
-    val mergerLocations =
-      if (Utils.isPushBasedShuffleEnabled(conf, isDriver)) {
-        mapOutputTracker.getShufflePushMergerLocations(shuffleId)
-      } else {
-        Seq.empty[BlockManagerId]
-      }
-    val removeMsg = RemoveShuffle(shuffleId)
-    val removeShuffleFromExecutorsFutures = blockManagerInfo.values.map { bm =>
-      bm.storageEndpoint.ask[Boolean](removeMsg).recover {
-        // use false as default value means no shuffle data were removed
-        handleBlockRemovalFailure("shuffle", shuffleId.toString, bm.blockManagerId, false)
-      }
-    }.toSeq
-
     // Find all shuffle blocks on executors that are no longer running
     val blocksToDeleteByShuffleService =
       new mutable.HashMap[BlockManagerId, mutable.HashSet[BlockId]]
@@ -374,6 +361,12 @@ class BlockManagerMasterEndpoint(
 
     val removeShuffleMergeFromShuffleServicesFutures =
       externalBlockStoreClient.map { shuffleClient =>
+        val mergerLocations =
+          if (Utils.isPushBasedShuffleEnabled(conf, isDriver)) {
+            mapOutputTracker.getShufflePushMergerLocations(shuffleId)
+          } else {
+            Seq.empty[BlockManagerId]
+          }
         mergerLocations.map { bmId =>
           Future[Boolean] {
             shuffleClient.removeShuffleMerge(bmId.host, bmId.port, shuffleId,
@@ -382,6 +375,16 @@ class BlockManagerMasterEndpoint(
         }
       }.getOrElse(Seq.empty)
 
+    val removeMsg = RemoveShuffle(shuffleId)
+    val removeShuffleFromExecutorsFutures = blockManagerInfo.values.map { bm =>
+      bm.storageEndpoint.ask[Boolean](removeMsg).recover {
+        // use false as default value means no shuffle data were removed
+        handleBlockRemovalFailure("shuffle", shuffleId.toString, bm.blockManagerId, false)
+      }
+    }.toSeq
+    if (testing) {
+      RpcUtils.INFINITE_TIMEOUT.awaitResult(Future.sequence(removeShuffleFromExecutorsFutures))
+    }
     Future.sequence(removeShuffleFromExecutorsFutures ++
       removeShuffleFromShuffleServicesFutures ++
       removeShuffleMergeFromShuffleServicesFutures)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -377,7 +377,7 @@ class BlockManagerMasterEndpoint(
         mergerLocations.map { bmId =>
           Future[Boolean] {
             shuffleClient.removeShuffleMerge(bmId.host, bmId.port, shuffleId,
-              RemoteBlockPushResolver.DELETE_CURRENT_MERGED_SHUFFLE_ID)
+              RemoteBlockPushResolver.DELETE_ALL_MERGED_SHUFFLE)
           }
         }
       }.getOrElse(Seq.empty)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -57,7 +57,6 @@ class BlockManagerMasterEndpoint(
     isDriver: Boolean)
   extends IsolatedThreadSafeRpcEndpoint with Logging {
 
-  private val testing: Boolean = conf.get(config.Tests.IS_TESTING).getOrElse(false)
   // Mapping from executor id to the block manager's local disk directories.
   private val executorIdToLocalDirs =
     CacheBuilder
@@ -382,9 +381,6 @@ class BlockManagerMasterEndpoint(
         handleBlockRemovalFailure("shuffle", shuffleId.toString, bm.blockManagerId, false)
       }
     }.toSeq
-    if (testing) {
-      RpcUtils.INFINITE_TIMEOUT.awaitResult(Future.sequence(removeShuffleFromExecutorsFutures))
-    }
     Future.sequence(removeShuffleFromExecutorsFutures ++
       removeShuffleFromShuffleServicesFutures ++
       removeShuffleMergeFromShuffleServicesFutures)

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -366,8 +366,16 @@ class BlockManagerMasterEndpoint(
         }
       }.getOrElse(Seq.empty)
 
+    val removeShuffleMergeFromShuffleServicesFutures =
+      externalBlockStoreClient.map { shuffleClient =>
+        mapOutputTracker.getShufflePushMergerLocations(shuffleId).map { bmId =>
+          Future[Boolean] { shuffleClient.removeShuffleMerge(bmId.host, bmId.port, shuffleId) }
+        }
+      }.getOrElse(Seq.empty)
+
     Future.sequence(removeShuffleFromExecutorsFutures ++
-      removeShuffleFromShuffleServicesFutures)
+      removeShuffleFromShuffleServicesFutures ++
+      removeShuffleMergeFromShuffleServicesFutures)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -32,7 +32,7 @@ import com.google.common.cache.CacheBuilder
 import org.apache.spark.{MapOutputTrackerMaster, SparkConf}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.{config, Logging}
-import org.apache.spark.network.shuffle.ExternalBlockStoreClient
+import org.apache.spark.network.shuffle.{ExternalBlockStoreClient, RemoteBlockPushResolver}
 import org.apache.spark.rpc.{IsolatedThreadSafeRpcEndpoint, RpcCallContext, RpcEndpointRef, RpcEnv}
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.{CoarseGrainedClusterMessages, CoarseGrainedSchedulerBackend}
@@ -376,7 +376,8 @@ class BlockManagerMasterEndpoint(
       externalBlockStoreClient.map { shuffleClient =>
         mergerLocations.map { bmId =>
           Future[Boolean] {
-            shuffleClient.removeShuffleMerge(bmId.host, bmId.port, shuffleId, -1)
+            shuffleClient.removeShuffleMerge(bmId.host, bmId.port, shuffleId,
+              RemoteBlockPushResolver.DELETE_CURRENT_MERGED_SHUFFLE_ID)
           }
         }
       }.getOrElse(Seq.empty)

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -17,12 +17,16 @@
 
 package org.apache.spark
 
+import java.util.{Collections => JCollections, HashSet => JHashSet}
 import java.util.concurrent.atomic.LongAdder
 
+import scala.collection.JavaConverters._
+import scala.collection.concurrent
 import scala.collection.mutable.ArrayBuffer
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
 import org.roaringbitmap.RoaringBitmap
 
 import org.apache.spark.LocalSparkContext._
@@ -30,10 +34,11 @@ import org.apache.spark.broadcast.BroadcastManager
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.Network.{RPC_ASK_TIMEOUT, RPC_MESSAGE_MAX_SIZE}
 import org.apache.spark.internal.config.Tests.IS_TESTING
+import org.apache.spark.network.shuffle.ExternalBlockStoreClient
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext, RpcEnv}
 import org.apache.spark.scheduler.{CompressedMapStatus, HighlyCompressedMapStatus, MapStatus, MergeStatus}
 import org.apache.spark.shuffle.FetchFailedException
-import org.apache.spark.storage.{BlockManagerId, ShuffleBlockId, ShuffleMergedBlockId}
+import org.apache.spark.storage.{BlockManagerId, BlockManagerInfo, BlockManagerMaster, BlockManagerMasterEndpoint, ShuffleBlockId, ShuffleMergedBlockId}
 
 class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
   private val conf = new SparkConf
@@ -911,6 +916,59 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     slaveTracker.stop()
     rpcEnv.shutdown()
     slaveRpcEnv.shutdown()
+  }
+
+  test("SPARK-40480: shuffle remove should cleanup merged files as well") {
+    val newConf = new SparkConf
+    newConf.set("spark.shuffle.push.enabled", "true")
+    newConf.set("spark.shuffle.service.enabled", "true")
+    newConf.set(SERIALIZER, "org.apache.spark.serializer.KryoSerializer")
+    newConf.set(IS_TESTING, true)
+
+    val SHUFFLE_ID = 10
+    // needs TorrentBroadcast so need a SparkContext
+    withSpark(new SparkContext("local", "MapOutputTrackerSuite", newConf)) { sc =>
+      val rpcEnv = sc.env.rpcEnv
+      val masterTracker = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+
+      val blockStoreClient = mock(classOf[ExternalBlockStoreClient])
+      val blockManagerMasterEndpoint = new BlockManagerMasterEndpoint(
+        rpcEnv,
+        sc.isLocal,
+        sc.conf,
+        sc.listenerBus,
+        Some(blockStoreClient),
+        // We dont care about this ...
+        new concurrent.TrieMap[BlockManagerId, BlockManagerInfo](),
+        masterTracker,
+        sc.env.shuffleManager,
+        true
+      )
+      rpcEnv.stop(sc.env.blockManager.master.driverEndpoint)
+      sc.env.blockManager.master.driverEndpoint =
+        rpcEnv.setupEndpoint(BlockManagerMaster.DRIVER_ENDPOINT_NAME,
+          blockManagerMasterEndpoint)
+
+      masterTracker.registerShuffle(SHUFFLE_ID, 10, 10)
+      val mergerLocs = (1 to 10).map(x => BlockManagerId(s"exec-$x", s"host-$x", x))
+      masterTracker.registerShufflePushMergerLocations(SHUFFLE_ID, mergerLocs)
+
+      assert(masterTracker.getShufflePushMergerLocations(SHUFFLE_ID).map(_.host).toSet ==
+        mergerLocs.map(_.host).toSet)
+
+      val foundHosts = JCollections.synchronizedSet(new JHashSet[String]())
+      when(blockStoreClient.removeShuffleMerge(any(), any(), any(), any())).thenAnswer(
+        (m: InvocationOnMock) => {
+          val host = m.getArgument(0).asInstanceOf[String]
+          val shuffleId = m.getArgument(2).asInstanceOf[Int]
+          assert(shuffleId == SHUFFLE_ID)
+          foundHosts.add(host)
+          true
+        })
+
+      sc.cleaner.get.doCleanupShuffle(SHUFFLE_ID, blocking = true)
+      assert(foundHosts.asScala == mergerLocs.map(_.host).toSet)
+    }
   }
 
   test("SPARK-34826: Adaptive shuffle mergers") {

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -323,7 +323,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     val dataFileReload3Again =
       ShuffleTestAccessor.getMergedShuffleDataFile(mergeManager3, partitionId3, 1)
-    dataFileReload3Again.length() should be ((4 * 5 + 1) * DUMMY_BLOCK_DATA.length)
+    dataFileReload3Again.length() should be (0)
     s3.stop()
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -323,7 +323,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     val dataFileReload3Again =
       ShuffleTestAccessor.getMergedShuffleDataFile(mergeManager3, partitionId3, 1)
-    dataFileReload3Again.length() should be (294)
+    dataFileReload3Again.length() should be ((4 * 5 + 1) * DUMMY_BLOCK_DATA.length)
     s3.stop()
   }
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/network/yarn/YarnShuffleServiceSuite.scala
@@ -323,7 +323,7 @@ abstract class YarnShuffleServiceSuite extends SparkFunSuite with Matchers {
 
     val dataFileReload3Again =
       ShuffleTestAccessor.getMergedShuffleDataFile(mergeManager3, partitionId3, 1)
-    dataFileReload3Again.length() should be (0)
+    dataFileReload3Again.length() should be (294)
     s3.stop()
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Cleanup merged shuffle data files after query finished.

The main changes are:
* After push merge service received FinalizeShuffleMerge RPC from driver, it will mark the MergePartitionsInfo as finilized instead of remove it.
* Delete the shuffle merge files if partition.mapTracker is empty.
* When spark driver begin to cleanup shuffle, if push-based shuffle is enabled, spark driver will send RemoveShuffleMerge RPC to all merger locations to delete all merge data files.

### Why are the changes needed?

There will be too many merged shuffle data files for long running spark applications.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Local cluster test.