### PR TITLE
[SPARK-40481][CORE] Ignore stage fetch failure caused by decommissioned executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2222,7 +2222,7 @@ package object config {
       .createWithDefault(5)
 
   private[spark] val STAGE_IGNORE_DECOMMISSION_FETCH_FAILURE =
-    ConfigBuilder("spark.stage.ignoreOnDecommissionFetchFailure")
+    ConfigBuilder("spark.stage.ignoreDecommissionFetchFailure")
       .doc("Whether ignore stage fetch failure caused by executor decommission when " +
         "count spark.stage.maxConsecutiveAttempts")
       .version("3.4.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2221,6 +2221,14 @@ package object config {
       .checkValue(_ >= 0, "needs to be a non-negative value")
       .createWithDefault(5)
 
+  private[spark] val STAGE_IGNORE_DECOMMISSION_FETCH_FAILURE =
+    ConfigBuilder("spark.stage.attempt.ignoreOnDecommissionFetchFailure")
+      .doc("Whether ignore stage fetch failure caused by executor decommission when " +
+      "count spark.stage.maxConsecutiveAttempts")
+      .version("3.4.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val PUSH_BASED_SHUFFLE_ENABLED =
     ConfigBuilder("spark.shuffle.push.enabled")
       .doc("Set to true to enable push-based shuffle on the client side and this works in " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2222,9 +2222,9 @@ package object config {
       .createWithDefault(5)
 
   private[spark] val STAGE_IGNORE_DECOMMISSION_FETCH_FAILURE =
-    ConfigBuilder("spark.stage.attempt.ignoreOnDecommissionFetchFailure")
+    ConfigBuilder("spark.stage.ignoreOnDecommissionFetchFailure")
       .doc("Whether ignore stage fetch failure caused by executor decommission when " +
-      "count spark.stage.maxConsecutiveAttempts")
+        "count spark.stage.maxConsecutiveAttempts")
       .version("3.4.0")
       .booleanConf
       .createWithDefault(false)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2176,7 +2176,15 @@ private[spark] class DAGScheduler(
     }
   }
 
-  private def isExecutorDecommissioned(taskScheduler: TaskScheduler, bmAddress: BlockManagerId) = {
+  /**
+   * Whether executor is decommissioned. Return true when executors are in below cases:
+   *  1. Waiting fro decommission start
+   *  2. Under decommission process
+   *  3. Stopped or terminated after finishing decommission
+   *  4. Under decommission process, then removed by driver with other reasons
+   */
+  private[scheduler] def isExecutorDecommissioned(
+      taskScheduler: TaskScheduler, bmAddress: BlockManagerId): Boolean = {
     if (bmAddress != null) {
       taskScheduler
         .getExecutorDecommissionState(bmAddress.executorId)

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -2178,7 +2178,7 @@ private[spark] class DAGScheduler(
 
   /**
    * Whether executor is decommissioned. Return true when executors are in below cases:
-   *  1. Waiting fro decommission start
+   *  1. Waiting for decommission start
    *  2. Under decommission process
    *  3. Stopped or terminated after finishing decommission
    *  4. Under decommission process, then removed by driver with other reasons

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1867,7 +1867,7 @@ private[spark] class DAGScheduler(
             s"(attempt ${failedStage.latestInfo.attemptNumber}) running")
         } else {
           val ignoreStageFailure = ignoreDecommissionFetchFailure &&
-            isExecutorDecommissioned(taskScheduler, bmAddress)
+            isExecutorDecommissioningOrDecommissioned(taskScheduler, bmAddress)
           if (ignoreStageFailure) {
             logInfo("Ignoring fetch failure from $task of $failedStage attempt " +
               s"${task.stageAttemptId} when count spark.stage.maxConsecutiveAttempts " +
@@ -2177,13 +2177,15 @@ private[spark] class DAGScheduler(
   }
 
   /**
-   * Whether executor is decommissioned. Return true when executors are in below cases:
+   * Whether executor is decommissioning or decommissioned.
+   * Return true when:
    *  1. Waiting for decommission start
    *  2. Under decommission process
-   *  3. Stopped or terminated after finishing decommission
-   *  4. Under decommission process, then removed by driver with other reasons
+   * Return false when:
+   *  1. Stopped or terminated after finishing decommission
+   *  2. Under decommission process, then removed by driver with other reasons
    */
-  private[scheduler] def isExecutorDecommissioned(
+  private[scheduler] def isExecutorDecommissioningOrDecommissioned(
       taskScheduler: TaskScheduler, bmAddress: BlockManagerId): Boolean = {
     if (bmAddress != null) {
       taskScheduler

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1147,8 +1147,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
-  test("SPARK-40481: Multiple consecutive stage fetch failures from decommissioned executor" +
-    "should not fail job when ignoreOnDecommissionFetchFailure is enabled.") {
+  test("SPARK-40481: Multiple consecutive stage fetch failures from decommissioned executor " +
+    "should not fail job when ignoreDecommissionFetchFailure is enabled.") {
     conf.set(config.STAGE_IGNORE_DECOMMISSION_FETCH_FAILURE.key, "true")
 
     setupStageAbortTest(sc)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1146,8 +1146,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assertDataStructuresEmpty()
   }
 
-  test("SPARK-40481: Multiple consecutive stage fetch failures should not fail job " +
-    "when ignoreOnDecommissionFetchFailure is enabled.") {
+  test("SPARK-40481: Multiple consecutive stage fetch failures from decommissioned executor" +
+    "should not fail job when ignoreOnDecommissionFetchFailure is enabled.") {
     conf.set(config.STAGE_IGNORE_DECOMMISSION_FETCH_FAILURE.key, "true")
 
     setupStageAbortTest(sc)
@@ -1176,8 +1176,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     sc.listenerBus.waitUntilEmpty()
     assert(scheduler.runningStages.nonEmpty)
     assert(!ended)
-
   }
+
   /**
    * In this test we simulate a job failure where the first stage completes successfully and
    * the second stage fails due to a fetch failure. Multiple successive fetch failures of a stage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2606,7 +2606,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>2.2.0</td>
 </tr>
 <tr>
-  <td><code>spark.stage.ignoreOnDecommissionFetchFailure</code></td>
+  <td><code>spark.stage.ignoreDecommissionFetchFailure</code></td>
   <td>false</td>
   <td>
     Whether ignore stage fetch failure caused by executor decommission when

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2606,7 +2606,7 @@ Apart from these, the following properties are also available, and may be useful
   <td>2.2.0</td>
 </tr>
 <tr>
-  <td><code>spark.stage.attempt.ignoreOnDecommissionFetchFailure</code></td>
+  <td><code>spark.stage.ignoreOnDecommissionFetchFailure</code></td>
   <td>false</td>
   <td>
     Whether ignore stage fetch failure caused by executor decommission when

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2605,6 +2605,15 @@ Apart from these, the following properties are also available, and may be useful
   </td>
   <td>2.2.0</td>
 </tr>
+<tr>
+  <td><code>spark.stage.attempt.ignoreOnDecommissionFetchFailure</code></td>
+  <td>false</td>
+  <td>
+    Whether ignore stage fetch failure caused by executor decommission when 
+    count <code>spark.stage.maxConsecutiveAttempts</code>
+  </td>
+  <td>3.4.0</td>
+</tr>
 </table>
 
 ### Barrier Execution Mode

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2609,7 +2609,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.stage.attempt.ignoreOnDecommissionFetchFailure</code></td>
   <td>false</td>
   <td>
-    Whether ignore stage fetch failure caused by executor decommission when 
+    Whether ignore stage fetch failure caused by executor decommission when
     count <code>spark.stage.maxConsecutiveAttempts</code>
   </td>
   <td>3.4.0</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a config `spark.stage.ignoreDecommissionFetchFailure` to control whether ignore stage fetch failure caused by decommissioned executor when count `spark.stage.maxConsecutiveAttempts`

Fetch failure only be ignored when executors are in below condition:
1. Waiting for decommission start
2. Under decommission process

Fetch failure might not be ignored when executors are in below condition, but this is best effort approach based on current mechanism. 
1. Stopped or terminated after finishing decommission
2. Under decommission process, then removed by driver with other reasons

### Why are the changes needed?
When executor decommission is enabled, there would be more stage failure caused by FetchFailed from decommissioned executor, further causing whole job's failure. One reason is decommissioning executor won't wait all FetchData requests to be finished, it will self-exit when no running tasks and migration finished. It would be better not to count such failure in `spark.stage.maxConsecutiveAttempts`. AWS EMR already supported this. Please refer https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-configure.html 

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Added test in `DAGSchedulerSuite`
