### PR TITLE
[SPARK-40483][CONNECT][INFRA] Add `CONNECT` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -151,4 +151,7 @@ WEB UI:
   - "**/*UI.scala"
 DEPLOY:
   - "sbin/**/*"
-
+CONNECT:
+  - "connect/**/*"
+  - "**/sql/sparkconnect/**/*"
+  - "python/pyspark/sql/**/connect/**/*"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `CONNECT` component to our labeler so the PRs related to Spark Connect project have this label.

### Why are the changes needed?

To make the PRs easier to track and search.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor other PRs once this gets merged. The notation is consistent with others.