### PR TITLE
[SPARK-40484][BUILD] Upgrade log4j2 to 2.19.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -187,10 +187,10 @@ lapack/3.0.2//lapack-3.0.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.18.0//log4j-1.2-api-2.18.0.jar
-log4j-api/2.18.0//log4j-api-2.18.0.jar
-log4j-core/2.18.0//log4j-core-2.18.0.jar
-log4j-slf4j-impl/2.18.0//log4j-slf4j-impl-2.18.0.jar
+log4j-1.2-api/2.19.0//log4j-1.2-api-2.19.0.jar
+log4j-api/2.19.0//log4j-api-2.19.0.jar
+log4j-core/2.19.0//log4j-core-2.19.0.jar
+log4j-slf4j-impl/2.19.0//log4j-slf4j-impl-2.19.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 mesos/1.4.3/shaded-protobuf/mesos-1.4.3-shaded-protobuf.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -171,10 +171,10 @@ lapack/3.0.2//lapack-3.0.2.jar
 leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.12.0//libthrift-0.12.0.jar
-log4j-1.2-api/2.18.0//log4j-1.2-api-2.18.0.jar
-log4j-api/2.18.0//log4j-api-2.18.0.jar
-log4j-core/2.18.0//log4j-core-2.18.0.jar
-log4j-slf4j-impl/2.18.0//log4j-slf4j-impl-2.18.0.jar
+log4j-1.2-api/2.19.0//log4j-1.2-api-2.19.0.jar
+log4j-api/2.19.0//log4j-api-2.19.0.jar
+log4j-core/2.19.0//log4j-core-2.19.0.jar
+log4j-slf4j-impl/2.19.0//log4j-slf4j-impl-2.19.0.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 mesos/1.4.3/shaded-protobuf/mesos-1.4.3-shaded-protobuf.jar

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <slf4j.version>1.7.36</slf4j.version>
-    <log4j.version>2.18.0</log4j.version>
+    <log4j.version>2.19.0</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.3.4</hadoop.version>
     <protobuf.version>2.5.0</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade log4j2 from 2.18.0 to 2.19.0.

### Why are the changes needed?
Log4j 2.19.0 contains new features and fixes, and this version begin to support for slf4j2:

- https://issues.apache.org/jira/browse/LOG4J2-3583 
- https://issues.apache.org/jira/browse/LOG4J2-2975

all changes can be found in the latest [changes report](https://logging.apache.org/log4j/2.x/changes-report.html#a2.19.0).

### Does this PR introduce _any_ user-facing change?
No, log4j 2.19.0 maintains binary compatibility with previous releases.



### How was this patch tested?
Pass GitHub Actions
