### PR TITLE
[SPARK-40485][SQL] Add partitionColValues to the partitioning options of the JDBC data source

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameReader.scala
@@ -291,6 +291,46 @@ class DataFrameReader private[sql](sparkSession: SparkSession) extends Logging {
     jdbc(url, table, connectionProperties)
   }
 
+  // scalastyle:off line.size.limit
+  /**
+   * Construct a `DataFrame` representing the database table accessible via JDBC URL
+   * url named table. Partitions of the table will be retrieved in parallel based on the parameters
+   * passed to this function.
+   *
+   * Don't create too many partitions in parallel on a large cluster; otherwise Spark might crash
+   * your external database systems.
+   *
+   * You can find the JDBC-specific option and parameter documentation for reading tables via JDBC in
+   * <a href="https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option">
+   * Data Source Option</a> in the version you use.
+   *
+   * @param table                Name of the table in the external database.
+   * @param columnName           Alias of `partitionColumn` option. Refer to `partitionColumn` in
+   *                             <a href="https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html#data-source-option">
+   *                             Data Source Option</a> in the version you use.
+   * @param connectionProperties JDBC database connection arguments, a list of arbitrary string
+   *                             tag/value. Normally at least a "user" and "password" property
+   *                             should be included. "fetchsize" can be used to control the
+   *                             number of rows per fetch and "queryTimeout" can be used to wait
+   *                             for a Statement object to execute to the given number of seconds.
+   * @since 3.4.0
+   */
+  // scalastyle:on line.size.limit
+  def jdbc(
+            url: String,
+            table: String,
+            columnName: String,
+            partitionColValues: String,
+            numPartitions: Int,
+            connectionProperties: Properties): DataFrame = {
+    // partitionColValues overrides settings in extraOptions.
+    this.extraOptions ++= Map(
+      JDBCOptions.JDBC_PARTITION_COLUMN -> columnName,
+      JDBCOptions.JDBC_PARTITION_COL_VALUES -> partitionColValues,
+      JDBCOptions.JDBC_NUM_PARTITIONS -> numPartitions.toString)
+    jdbc(url, table, connectionProperties)
+  }
+
   /**
    * Construct a `DataFrame` representing the database table accessible via JDBC URL
    * url named table using connection properties. The `predicates` parameter gives a list

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -126,13 +126,19 @@ class JDBCOptions(
   val lowerBound = parameters.get(JDBC_LOWER_BOUND)
   // the upper bound of the partition column
   val upperBound = parameters.get(JDBC_UPPER_BOUND)
+  // .........COMMENT HERE.........
+  val partitionColValues = parameters.get(JDBCOptions.JDBC_PARTITION_COL_VALUES)
   // numPartitions is also used for data source writing
-  require((partitionColumn.isEmpty && lowerBound.isEmpty && upperBound.isEmpty) ||
-    (partitionColumn.isDefined && lowerBound.isDefined && upperBound.isDefined &&
-      numPartitions.isDefined),
-    s"When reading JDBC data sources, users need to specify all or none for the following " +
-      s"options: '$JDBC_PARTITION_COLUMN', '$JDBC_LOWER_BOUND', '$JDBC_UPPER_BOUND', " +
-      s"and '$JDBC_NUM_PARTITIONS'")
+  require((partitionColumn.isEmpty && lowerBound.isEmpty && upperBound.isEmpty
+    && partitionColValues.isEmpty) ||
+    ((partitionColumn.isDefined && lowerBound.isDefined && upperBound.isDefined &&
+      numPartitions.isDefined) && partitionColValues.isEmpty) ||
+    (partitionColumn.isDefined && numPartitions.isDefined && partitionColValues.isDefined &&
+      lowerBound.isEmpty && upperBound.isEmpty),
+    s"When reading JDBC data sources and using partitioning features, users need to specify " +
+      s"the options: '$JDBC_PARTITION_COLUMN' and '$JDBC_NUM_PARTITIONS', " +
+      s"in addition users need to specify either '$JDBC_LOWER_BOUND' and '$JDBC_UPPER_BOUND' or" +
+      s" specify a list of values for '$JDBC_PARTITION_COL_VALUES'.")
 
   require(!(parameters.get(JDBC_QUERY_STRING).isDefined && partitionColumn.isDefined),
     s"""
@@ -280,6 +286,7 @@ object JDBCOptions {
   val JDBC_LOWER_BOUND = newOption("lowerBound")
   val JDBC_UPPER_BOUND = newOption("upperBound")
   val JDBC_NUM_PARTITIONS = newOption("numPartitions")
+  val JDBC_PARTITION_COL_VALUES = newOption("partitionColValues")
   val JDBC_QUERY_TIMEOUT = newOption("queryTimeout")
   val JDBC_BATCH_FETCH_SIZE = newOption("fetchsize")
   val JDBC_TRUNCATE = newOption("truncate")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCWriteSuite.scala
@@ -359,9 +359,10 @@ class JDBCWriteSuite extends SharedSparkSession with BeforeAndAfter {
         .option("partitionColumn", "foo")
         .save()
     }.getMessage
-    assert(e.contains("When reading JDBC data sources, users need to specify all or none " +
-      "for the following options: 'partitionColumn', 'lowerBound', 'upperBound', and " +
-      "'numPartitions'"))
+    assert(e.contains("When reading JDBC data sources and using partitioning features, " +
+      "users need to specify the options: 'partitionColumn' and 'numPartitions', in " +
+      "addition users need to specify either 'lowerBound' and 'upperBound' or specify " +
+      "a list of values for 'partitionColValues'."))
   }
 
   test("SPARK-18433: Improve DataSource option keys to be more case-insensitive") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This proposes to extend the available partitioning options for the JDBC data source.

### Why are the changes needed?
Partitioning options allow to read data using multiple workers connected to the target RDBMS. This can improve the performance of data extraction, under the right circumstances.

Currently the only available partitioning and parallelization option for reading from databases is to specify lowerBound, upperBound, together with numPartitions and partitionColumn. The Spark JDBC data source will then use multiple partitions, and thus workers, to read from the RDBMS.   
This proposes to add a similar, however complementary, mechanism for partitioning, where a user-provided list of values is used to compute the target partitions.   
This provides a way to split the data extraction work among workers that could be aligned with the database physical (partitioned and/or indexed) structure, as in the following example:  
```
option("partitionColumn", "region").
option("numPartitions", 3).
option("partitionColValues", "'eastern', 'central', 'western'").  
```

This feature is motivated for performance reasons, to scale and speed up data extraction from:
 - list partitioned tables, available in Oracle and PostgreSQL
 - this is also applicable to tables stored in B*Tree indexes, such as in Oracle's IOTs (Index Organized Tables) and SQL Server's Clustered Indexes.

### Does this PR introduce _any_ user-facing change?
Yes, this adds the option "partitionColValues" to the JDBC data source.

### How was this patch tested?
Added tests to the JDBCSuite and JDBCV2Suite.
Also manually tested against Oracle's list partitioned tables.
