### PR TITLE
[SPARK-40477][SQL] Support `NullType` in `ColumnarBatchRow`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ColumnarBatchRow.java
@@ -184,6 +184,8 @@ public final class ColumnarBatchRow extends InternalRow {
       return getStruct(ordinal, ((StructType)dataType).fields().length);
     } else if (dataType instanceof MapType) {
       return getMap(ordinal);
+    } else if (dataType instanceof NullType) {
+      return null;
     } else {
       throw new UnsupportedOperationException("Datatype not supported " + dataType);
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1430,11 +1430,12 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
       Seq(1).toDF().repartition(1).write.parquet(dir.getCanonicalPath)
 
       val dataTypes =
-        Seq(StringType, BooleanType, ByteType, BinaryType, ShortType, IntegerType, LongType,
-          FloatType, DoubleType, DecimalType(25, 5), DateType, TimestampType)
+        Seq(NullType, StringType, BooleanType, ByteType, BinaryType, ShortType, IntegerType,
+          LongType, FloatType, DoubleType, DecimalType(25, 5), DateType, TimestampType)
 
       val constantValues =
         Seq(
+          null,
           UTF8String.fromString("a string"),
           true,
           1.toByte,
@@ -1461,10 +1462,7 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
           vectorizedReader.initBatch(schema, partitionValues)
           vectorizedReader.nextKeyValue()
           val row = vectorizedReader.getCurrentValue.asInstanceOf[InternalRow]
-
-          // Use `GenericMutableRow` by explicitly copying rather than `ColumnarBatch`
-          // in order to use get(...) method which is not implemented in `ColumnarBatch`.
-          val actual = row.copy().get(1, dt)
+          val actual = row.get(1, dt)
           val expected = v
           if (dt.isInstanceOf[BinaryType]) {
             assert(actual.asInstanceOf[Array[Byte]] sameElements expected.asInstanceOf[Array[Byte]])

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ConstantColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ConstantColumnVectorSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.vectorized
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.{ColumnarArray, ColumnarMap}
+import org.apache.spark.sql.vectorized.{ColumnarArray, ColumnarBatchRow, ColumnarMap}
 import org.apache.spark.unsafe.types.UTF8String
 
 class ConstantColumnVectorSuite extends SparkFunSuite {
@@ -203,5 +203,11 @@ class ConstantColumnVectorSuite extends SparkFunSuite {
       assert(vector.getChild(1).getInt(i) == 25)
       assert(vector.getChild(2).getLong(i) == 12345L)
     }
+  }
+
+  testVector("SPARK-40477: Support NullType", 1, NullType) { vector =>
+    vector.setNull()
+    val bachRow = new ColumnarBatchRow(Array(vector))
+    assert(bachRow.get(0, NullType) === null)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to support `NullType` in `ColumnarBatchRow`.


### Why are the changes needed?
`ColumnarBatchRow.get()` does not support `NullType` currently.
By supporting `NullType` in `ColumnarBatchRow`, `NullType` can be used for partition columns for example.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test added