### PR TITLE
[SPARK-40496][SQL] Fix configs to control "enableDateTimeParsingFallback"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -224,7 +224,7 @@ class UnivocityParser(
           case NonFatal(e) =>
             // If fails to parse, then tries the way used in 2.0 and 1.x for backwards
             // compatibility if enabled.
-            if (!enableParsingFallbackForTimestampType) {
+            if (!enableParsingFallbackForDateType) {
               throw e
             }
             val str = DateTimeUtils.cleanLegacyTimestampStr(UTF8String.fromString(datum))
@@ -244,7 +244,7 @@ class UnivocityParser(
             } else {
               // If fails to parse, then tries the way used in 2.0 and 1.x for backwards
               // compatibility if enabled.
-              if (!enableParsingFallbackForDateType) {
+              if (!enableParsingFallbackForTimestampType) {
                 throw e
               }
               val str = DateTimeUtils.cleanLegacyTimestampStr(UTF8String.fromString(datum))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3008,6 +3008,23 @@ abstract class CSVSuite
       }
     }
   }
+
+  test("SPARK-40496: disable parsing fallback when the date/timestamp format is provided") {
+    withTempPath { path =>
+      Seq("2020-01-01").toDF()
+        .repartition(1)
+        .write.text(path.getAbsolutePath)
+
+      var df = spark.read.schema("dt date").option("dateFormat", "yyyy/MM/dd")
+        .csv(path.getAbsolutePath)
+      checkAnswer(df, Seq(Row(null)))
+
+      df = spark.read.schema("ts timestamp").option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
+        .csv(path.getAbsolutePath)
+
+      checkAnswer(df, Seq(Row(null)))
+    }
+  }
 }
 
 class CSVv1Suite extends CSVSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3012,19 +3012,25 @@ abstract class CSVSuite
   test("SPARK-40496: disable parsing fallback when the date/timestamp format is provided") {
     // The test verifies that the fallback can be disabled by providing dateFormat or
     // timestampFormat without any additional configuration.
-    withTempPath { path =>
-      Seq("2020-01-01").toDF()
-        .repartition(1)
-        .write.text(path.getAbsolutePath)
+    //
+    // We also need to disable "legacy" parsing mode that implicitly enables parsing fallback.
+    for (policy <- Seq("exception", "corrected")) {
+      withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> policy) {
+        withTempPath { path =>
+          Seq("2020-01-01").toDF()
+            .repartition(1)
+            .write.text(path.getAbsolutePath)
 
-      var df = spark.read.schema("dt date").option("dateFormat", "yyyy/MM/dd")
-        .csv(path.getAbsolutePath)
-      checkAnswer(df, Seq(Row(null)))
+          var df = spark.read.schema("col date").option("dateFormat", "yyyy/MM/dd")
+            .csv(path.getAbsolutePath)
+          checkAnswer(df, Seq(Row(null)))
 
-      df = spark.read.schema("ts timestamp").option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
-        .csv(path.getAbsolutePath)
+          df = spark.read.schema("col timestamp").option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
+            .csv(path.getAbsolutePath)
 
-      checkAnswer(df, Seq(Row(null)))
+          checkAnswer(df, Seq(Row(null)))
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3010,6 +3010,8 @@ abstract class CSVSuite
   }
 
   test("SPARK-40496: disable parsing fallback when the date/timestamp format is provided") {
+    // The test verifies that the fallback can be disabled by providing dateFormat or
+    // timestampFormat without any additional configuration.
     withTempPath { path =>
       Seq("2020-01-01").toDF()
         .repartition(1)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -3356,6 +3356,23 @@ abstract class JsonSuite
       }
     }
   }
+
+  test("SPARK-40496: disable parsing fallback when the date/timestamp format is provided") {
+    withTempPath { path =>
+      Seq("""{"date": "2020-01-01"}""").toDF()
+        .repartition(1)
+        .write.text(path.getAbsolutePath)
+
+      var df = spark.read.schema("dt date").option("dateFormat", "yyyy/MM/dd")
+        .json(path.getAbsolutePath)
+      checkAnswer(df, Seq(Row(null)))
+
+      df = spark.read.schema("ts timestamp").option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
+        .json(path.getAbsolutePath)
+
+      checkAnswer(df, Seq(Row(null)))
+    }
+  }
 }
 
 class JsonV1Suite extends JsonSuite {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -3360,19 +3360,25 @@ abstract class JsonSuite
   test("SPARK-40496: disable parsing fallback when the date/timestamp format is provided") {
     // The test verifies that the fallback can be disabled by providing dateFormat or
     // timestampFormat without any additional configuration.
-    withTempPath { path =>
-      Seq("""{"date": "2020-01-01"}""").toDF()
-        .repartition(1)
-        .write.text(path.getAbsolutePath)
+    //
+    // We also need to disable "legacy" parsing mode that implicitly enables parsing fallback.
+    for (policy <- Seq("exception", "corrected")) {
+      withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> policy) {
+        withTempPath { path =>
+          Seq("""{"col": "2020-01-01"}""").toDF()
+            .repartition(1)
+            .write.text(path.getAbsolutePath)
 
-      var df = spark.read.schema("dt date").option("dateFormat", "yyyy/MM/dd")
-        .json(path.getAbsolutePath)
-      checkAnswer(df, Seq(Row(null)))
+          var df = spark.read.schema("col date").option("dateFormat", "yyyy/MM/dd")
+            .json(path.getAbsolutePath)
+          checkAnswer(df, Seq(Row(null)))
 
-      df = spark.read.schema("ts timestamp").option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
-        .json(path.getAbsolutePath)
+          df = spark.read.schema("col timestamp").option("timestampFormat", "yyyy/MM/dd HH:mm:ss")
+            .json(path.getAbsolutePath)
 
-      checkAnswer(df, Seq(Row(null)))
+          checkAnswer(df, Seq(Row(null)))
+        }
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -3358,6 +3358,8 @@ abstract class JsonSuite
   }
 
   test("SPARK-40496: disable parsing fallback when the date/timestamp format is provided") {
+    // The test verifies that the fallback can be disabled by providing dateFormat or
+    // timestampFormat without any additional configuration.
     withTempPath { path =>
       Seq("""{"date": "2020-01-01"}""").toDF()
         .repartition(1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

The commit https://github.com/apache/spark/commit/a93044550259fa0ee8897d0576f6eeac8ec73c27 introduced `enableDateTimeParsingFallback` config but the usage was incorrect in CSV/UnivocityParser - DateType and TimestampType configs were swapped.

This PR fixes the issue so `enableParsingFallbackForDateType` controls DateType fallback and `enableParsingFallbackForTimestampType` controls TimestampType.

JSON does not have this problem - the property is correctly used for the corresponding data types in https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala#L305.

Setting parsing fallback via data source option or SQL config will work correctly, the issue would only happen when using `dateFormat` or `timestampFormat` without setting the flag explicitly.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Correctness fix. Without the change, the fallback would not be enabled when using dateFormat and timestampFormat. All other means to set parsing fallback (data source option and SQLConf) will still work correctly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

I added a unit test for CSV and JSON to reproduce the issue and verify it was fixed.