### PR TITLE
[SPARK-40419][SQL][TESTS][FOLLOW-UP] Fix test to skip when package is unavailable

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQueryTestSuite.scala
@@ -249,6 +249,13 @@ class SQLQueryTestSuite extends QueryTest with SharedSparkSession with SQLHelper
           s"pandas and/or pyarrow were not available in [$pythonExec].") {
           /* Do nothing */
         }
+      case udfTestCase: UDFTest
+          if udfTestCase.udf.isInstanceOf[TestGroupedAggPandasUDF] &&
+            !shouldTestGroupedAggPandasUDFs =>
+        ignore(s"${testCase.name} is skipped because pyspark," +
+          s"pandas and/or pyarrow were not available in [$pythonExec].") {
+          /* Do nothing */
+        }
       case _ =>
         // Create a test case to run this case.
         test(testCase.name) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR follow-up for https://github.com/apache/spark/pull/37873.

The UDAF test should be skipped when pyspark, pandas and/or pyarrow is unavailable with proper message.


### Why are the changes needed?

Skip the test properly when it's unavailable.

### Does this PR introduce _any_ user-facing change?

No, it's test only.

### How was this patch tested?

Manually test to be skipped when missing package.

![Screen Shot 2022-09-20 at 6 11 30 PM](https://user-images.githubusercontent.com/44108233/191218078-254605b4-157e-4e22-8015-22399ff5e0b2.png)