### PR TITLE
[SPARK-40504][YARN] Make yarn appmaster load config from client

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -899,7 +899,7 @@ object ApplicationMaster extends Logging {
       sys.props(k) = v
     }
 
-    val yarnConf = new YarnConfiguration(SparkHadoopUtil.newConfiguration(sparkConf))
+    val yarnConf = new YarnConfiguration(SparkHadoopUtil.get.newConfiguration(sparkConf))
     master = new ApplicationMaster(amArgs, sparkConf, yarnConf)
 
     val ugi = sparkConf.get(PRINCIPAL) match {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-40504

### What changes were proposed in this pull request?

After apply this, AppMaster will load __spark_hadoop_conf__.xml to override the config. It means appmaster will load config from client, but not from server.

### How was this patch tested?

manual test