### PR TITLE
[SPARK-40332][PS][DOCS][FOLLOWUP] Fix wrong underline length

### DIFF
--- a/python/pyspark/pandas/groupby.py
+++ b/python/pyspark/pandas/groupby.py
@@ -604,7 +604,7 @@ class GroupBy(Generic[FrameLike], metaclass=ABCMeta):
             Return type determined by caller of GroupBy object.
 
         Notes
-        -------
+        -----
         `quantile` in pandas-on-Spark are using distributed percentile approximation
         algorithm unlike pandas, the result might different with pandas, also
         `interpolation` parameter is not supported yet.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix wrong underline length


### Why are the changes needed?
there is a warning in doc build
```
reading sources... [ 68%] reference/pyspark.pandas/groupby
/usr/local/lib/python3.9/dist-packages/numpydoc/docscrape.py:449: UserWarning:

potentially wrong underline length... 
Notes 
------- in 
Return group values at the given quantile.
... in the docstring of quantile in /__w/spark/spark/python/pyspark/pandas/groupby.py.

reading sources... [ 68%] reference/pyspark.pandas/index
reading sources... [ 68%] reference/pyspark.pandas/indexing
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing suites