### PR TITLE
[SPARK-40508][SQL][3.3] Treat unknown partitioning as UnknownPartitioning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanPartitioning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2ScanPartitioning.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.expressions.V2ExpressionUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -30,7 +31,7 @@ import org.apache.spark.util.collection.Utils.sequenceToOption
  * reported by data sources to their catalyst counterparts. Then, annotates the plan with the
  * result.
  */
-object V2ScanPartitioning extends Rule[LogicalPlan] with SQLConfHelper {
+object V2ScanPartitioning extends Rule[LogicalPlan] with SQLConfHelper with Logging {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     case d @ DataSourceV2ScanRelation(relation, scan: SupportsReportPartitioning, _, None) =>
       val funCatalogOpt = relation.catalog.flatMap {
@@ -52,8 +53,10 @@ object V2ScanPartitioning extends Rule[LogicalPlan] with SQLConfHelper {
             }
           }
         case _: UnknownPartitioning => None
-        case p => throw new IllegalArgumentException("Unsupported data source V2 partitioning " +
-            "type: " + p.getClass.getSimpleName)
+        case p =>
+          logWarning("Spark ignores the partitioning ${p.getClass.getSimpleName}." +
+            " Please use KeyGroupedPartitioning for better performance")
+            None
       }
 
       d.copy(keyGroupedPartitioning = catalystPartitioning)


### PR DESCRIPTION
### What changes were proposed in this pull request?
When running spark application against spark 3.3, I see the following :
```
java.lang.IllegalArgumentException: Unsupported data source V2 partitioning type: CustomPartitioning
    at org.apache.spark.sql.execution.datasources.v2.V2ScanPartitioning$$anonfun$apply$1.applyOrElse(V2ScanPartitioning.scala:46)
    at org.apache.spark.sql.execution.datasources.v2.V2ScanPartitioning$$anonfun$apply$1.applyOrElse(V2ScanPartitioning.scala:34)
    at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:584)
```
The CustomPartitioning works fine with Spark 3.2.1
This PR proposes to relax the code and treat all unknown partitioning the same way as that for UnknownPartitioning.

### Why are the changes needed?
3.3.0 doesn't seem to warrant such behavioral change (from that of 3.2.1 release).

### Does this PR introduce _any_ user-facing change?
This would allow user's custom partitioning to continue to work with 3.3.x releases.

### How was this patch tested?
Existing test suite.
I have run the test using Cassandra Spark connector and modified Spark (with this patch) which passes.