### PR TITLE
[SPARK-40522][BUILD] Upgrade `kafka` to 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.2.2</kafka.version>
+    <kafka.version>3.2.3</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <!-- Version used for internal directory structure -->
     <hive.version.short>2.3</hive.version.short>
     <!-- note that this should be compatible with Kafka brokers version 0.10 and up -->
-    <kafka.version>3.2.1</kafka.version>
+    <kafka.version>3.2.2</kafka.version>
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.12.3</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache Kafka from 3.2.1 to 3.2.3

[Release notes](https://downloads.apache.org/kafka/3.2.3/RELEASE_NOTES.html)

### Why are the changes needed?
[Memory Allocation with Excessive Size Value](https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEKAFKA-3027430)
[CVE-2022-34917](https://www.cve.org/CVERecord?id=CVE-2022-34917)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA
