### PR TITLE
[MINOR][YARN][TESTS] Rename `logConfFile` in `BaseYarnClusterSuite` from `log4j.properties`  to `log4j2.properties` 

### DIFF
--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/BaseYarnClusterSuite.scala
@@ -85,7 +85,7 @@ abstract class BaseYarnClusterSuite extends SparkFunSuite with Matchers {
     logConfDir = new File(tempDir, "log4j")
     logConfDir.mkdir()
 
-    val logConfFile = new File(logConfDir, "log4j.properties")
+    val logConfFile = new File(logConfDir, "log4j2.properties")
     Files.write(LOG4J_CONF, logConfFile, StandardCharsets.UTF_8)
 
     // Disable the disk utilization check to avoid the test hanging when people's disks are


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just rename `logConfFile` in `BaseYarnClusterSuite` from `log4j.properties`  to `log4j2.properties`.


### Why are the changes needed?
Make the log configuration defined in `BaseYarnClusterSuite#LOG4J_CONF` be used during testing.




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass Github Actions
- Manual test

For example, run 

```
mvn clean test -pl resource-managers/yarn -DwildcardSuites=org.apache.spark.deploy.yarn.YarnClusterSuite -Phadoop-3 -Pyarn 
```

The test data will in `resource-managers/yarn/target/test/data/org.apache.spark.deploy.yarn.YarnClusterSuite/yarn-xxxx` as follows:

```
nodeattributes  org.apache.spark.deploy.yarn.YarnClusterSuite-localDir-nm-0_0	org.apache.spark.deploy.yarn.YarnClusterSuite-logDir-nm-0_0
```

**Before**

All `log4j2.properties` content uploaded for UTs as follows:

```
#
# Licensed to the Apache Software Foundation (ASF) under one or more
# contributor license agreements.  See the NOTICE file distributed with
# this work for additional information regarding copyright ownership.
# The ASF licenses this file to You under the Apache License, Version 2.0
# (the "License"); you may not use this file except in compliance with
# the License.  You may obtain a copy of the License at
#
#    http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
#

# Set everything to be logged to the file target/unit-tests.log
rootLogger.level = debug
rootLogger.appenderRef.file.ref = File

appender.file.type = File
appender.file.name = File
appender.file.fileName = target/unit-tests.log
appender.file.append = true
appender.file.layout.type = PatternLayout
appender.file.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex

# Silence verbose logs from 3rd-party libraries.
logger.netty.name = io.netty
logger.netty.level = info
```

This is not defined in `BaseYarnClusterSuite#LOG4J_CONF`, and both `stderr` and `stdout` in the log directory are empty files.

**After**

The `log4j2.properties` content uploaded for UTs as follows:

```
rootLogger.level = debug
rootLogger.appenderRef.stdout.ref = console
appender.console.type = Console
appender.console.name = console
appender.console.target = SYSTEM_ERR
appender.console.layout.type = PatternLayout
appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
logger.jetty.name = org.sparkproject.jetty
logger.jetty.level = warn
logger.eclipse.name = org.eclipse.jetty
logger.eclipse.level = warn
logger.hadoop.name = org.apache.hadoop
logger.hadoop.level = warn
logger.mortbay.name = org.mortbay
logger.mortbay.level = warn
```

The content is consistent with that defined in `BaseYarnClusterSuite#LOG4J_CONF`, and there are Spark job logs in `stderr`