### PR TITLE
[SPARK-40543][PS][SQL] Make `ddof` in `DataFrame.var` and `Series.var` accept arbitary integers

### DIFF
--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -32,6 +32,11 @@ def stddev(col: Column, ddof: int) -> Column:
     return Column(sc._jvm.PythonSQLUtils.pandasStddev(col._jc, ddof))
 
 
+def var(col: Column, ddof: int) -> Column:
+    sc = SparkContext._active_spark_context
+    return Column(sc._jvm.PythonSQLUtils.pandasVariance(col._jc, ddof))
+
+
 def skew(col: Column) -> Column:
     sc = SparkContext._active_spark_context
     return Column(sc._jvm.PythonSQLUtils.pandasSkewness(col._jc))

--- a/python/pyspark/pandas/tests/test_generic_functions.py
+++ b/python/pyspark/pandas/tests/test_generic_functions.py
@@ -167,6 +167,8 @@ class GenericFunctionsTest(PandasOnSparkTestCase, TestUtils):
         self._test_stat_functions(lambda x: x.std())
         self._test_stat_functions(lambda x: x.std(skipna=False))
         self._test_stat_functions(lambda x: x.std(ddof=2))
+        self._test_stat_functions(lambda x: x.var())
+        self._test_stat_functions(lambda x: x.var(ddof=2))
         self._test_stat_functions(lambda x: x.sem())
         self._test_stat_functions(lambda x: x.sem(skipna=False))
         # self._test_stat_functions(lambda x: x.skew())
@@ -180,6 +182,11 @@ class GenericFunctionsTest(PandasOnSparkTestCase, TestUtils):
             psdf.std(ddof="ddof")
         with self.assertRaisesRegex(TypeError, "ddof must be integer"):
             psdf.a.std(ddof="ddof")
+
+        with self.assertRaisesRegex(TypeError, "ddof must be integer"):
+            psdf.var(ddof="ddof")
+        with self.assertRaisesRegex(TypeError, "ddof must be integer"):
+            psdf.a.var(ddof="ddof")
 
         self.assert_eq(pdf.a.median(), psdf.a.median())
         self.assert_eq(pdf.a.median(skipna=False), psdf.a.median(skipna=False))

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -448,6 +448,7 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
 
         self.assert_eq(psser.var(), pser.var(), almost=True)
         self.assert_eq(psser.var(ddof=0), pser.var(ddof=0), almost=True)
+        self.assert_eq(psser.var(ddof=2), pser.var(ddof=2), almost=True)
         self.assert_eq(psser.std(), pser.std(), almost=True)
         self.assert_eq(psser.std(ddof=0), pser.std(ddof=0), almost=True)
         self.assert_eq(psser.std(ddof=2), pser.std(ddof=2), almost=True)
@@ -481,6 +482,11 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(
             psdf.var(ddof=0, numeric_only=True),
             pdf.var(ddof=0, numeric_only=True),
+            check_exact=False,
+        )
+        self.assert_eq(
+            psdf.var(ddof=2, numeric_only=True),
+            pdf.var(ddof=2, numeric_only=True),
             check_exact=False,
         )
         self.assert_eq(psdf.std(numeric_only=True), pdf.std(numeric_only=True), check_exact=False)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CentralMomentAgg.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CentralMomentAgg.scala
@@ -363,6 +363,28 @@ case class PandasStddev(
 }
 
 /**
+ * Variance in Pandas' fashion. This expression is dedicated only for Pandas API on Spark.
+ * Refer to pandas.core.nanops.nanvar.
+ */
+case class PandasVariance(
+    child: Expression,
+    ddof: Int)
+  extends CentralMomentAgg(child, true) {
+
+  override protected def momentOrder = 2
+
+  override val evaluateExpression: Expression = {
+    If(n === 0.0, Literal.create(null, DoubleType),
+      If(n === ddof, divideByZeroEvalResult, m2 / (n - ddof)))
+  }
+
+  override def prettyName: String = "pandas_variance"
+
+  override protected def withNewChildInternal(newChild: Expression): PandasVariance =
+    copy(child = newChild)
+}
+
+/**
  * Skewness in Pandas' fashion. This expression is dedicated only for Pandas API on Spark.
  * Refer to pandas.core.nanops.nanskew.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -159,6 +159,10 @@ private[sql] object PythonSQLUtils extends Logging {
     Column(PandasStddev(e.expr, ddof).toAggregateExpression(false))
   }
 
+  def pandasVariance(e: Column, ddof: Int): Column = {
+    Column(PandasVariance(e.expr, ddof).toAggregateExpression(false))
+  }
+
   def pandasSkewness(e: Column): Column = {
     Column(PandasSkewness(e.expr).toAggregateExpression(false))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
add a new `var` expression to support arbitary integeral `ddof`


### Why are the changes needed?
for API coverage

### Does this PR introduce _any_ user-facing change?
yes, it accept `ddof` other than {0, 1}

before
```
In [1]: import pyspark.pandas as ps

In [2]: import numpy as np

In [3]: df = ps.DataFrame({'a': [1, 2, 3, np.nan], 'b': [0.1, 0.2, 0.3, np.nan]}, columns=['a', 'b'])

In [4]: df.var(ddof=2)
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In [4], line 1
----> 1 df.var(ddof=2)

File ~/Dev/spark/python/pyspark/pandas/generic.py:1958, in Frame.var(self, axis, ddof, numeric_only)
   1904 def var(
   1905     self, axis: Optional[Axis] = None, ddof: int = 1, numeric_only: bool = None
   1906 ) -> Union[Scalar, "Series"]:
   1907     """
   1908     Return unbiased variance.
   1909 
   (...)
   1956     0.6666666666666666
   1957     """
-> 1958     assert ddof in (0, 1)
   1960     axis = validate_axis(axis)
   1962     if numeric_only is None and axis == 0:

AssertionError:
```

after
```
In [4]: df.var(ddof=2)
Out[4]:                                                                         
a    2.00
b    0.02
dtype: float64

In [5]: df.to_pandas().var(ddof=2)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:975: PandasAPIOnSparkAdviceWarning: `to_pandas` loads all data into the driver's memory. It should only be used if the resulting pandas DataFrame is expected to be small.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
Out[5]: 
a    2.00
b    0.02
dtype: float64


```

### How was this patch tested?
added UT
