### PR TITLE
[SPARK-40544][SQL][TESTS] Restore the file appender log level threshold of the hive UTs to info

### DIFF
--- a/sql/hive/src/test/resources/log4j2.properties
+++ b/sql/hive/src/test/resources/log4j2.properties
@@ -36,9 +36,9 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
-# Set the logger level of File Appender to WARN
+# Set the logger level of File Appender to INFO
 appender.file.filter.threshold.type = ThresholdFilter
-appender.file.filter.threshold.level = debug
+appender.file.filter.threshold.level = info
 
 # Some packages are noisy for no good reason.
 logger.parquet_recordreader.name = org.apache.parquet.hadoop.ParquetRecordReader


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr restore the file appender log level threshold of the hive UTs from debug to info 


### Why are the changes needed?
Reduce the disk space occupied by `sql/hive/target/unit-tests.log`. After this pr, the file size reduced from 12G to 119M



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions