### PR TITLE
[SPARK-40545][SQL][TESTS] Clean up `metastorePath` after `SparkSQLEnvSuite` execution

### DIFF
--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
@@ -60,6 +60,7 @@ class SparkSQLEnvSuite extends SparkFunSuite {
           .exists(_.isInstanceOf[DummyStreamingQueryListener]))
       } finally {
         SparkSQLEnv.stop()
+        FileUtils.forceDelete(metastorePath)
       }
     }
   }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SparkSQLEnvSuite.scala
@@ -60,7 +60,9 @@ class SparkSQLEnvSuite extends SparkFunSuite {
           .exists(_.isInstanceOf[DummyStreamingQueryListener]))
       } finally {
         SparkSQLEnv.stop()
-        FileUtils.forceDelete(metastorePath)
+        if (metastorePath.exists()) {
+          FileUtils.forceDelete(metastorePath)
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr adds the cleaning operation of ` sql/hive-thriftserver/spark_derby/` directory after `SparkSQLEnvSuite` execution.

### Why are the changes needed?
Clean the test directory after the UT




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

- Pass Github Actions
- Manual test:

```
mvn clean install  -Phive-thriftserver -pl sql/hive-thriftserver -DskipTests -am
mvn clean install  -pl sql/hive-thriftserver -DwildcardSuites=org.apache.spark.sql.hive.thriftserver.SparkSQLEnvSuite -Phive-thriftserver
git status
```

**Before**

Residual `sql/hive-thriftserver/spark_derby/` directory


**After**

No directory residue

