### PR TITLE
[SPARK-40547][DOCS] Fix dead links in sparkr-vignettes.Rmd

### DIFF
--- a/R/pkg/vignettes/sparkr-vignettes.Rmd
+++ b/R/pkg/vignettes/sparkr-vignettes.Rmd
@@ -170,7 +170,7 @@ sparkR.session(sparkHome = "/HOME/spark")
 ### Spark Session {#SetupSparkSession}
 
 
-In addition to `sparkHome`, many other options can be specified in `sparkR.session`. For a complete list, see [Starting up: SparkSession](https://spark.apache.org/docs/latest/sparkr.html#starting-up-sparksession) and [SparkR API doc](https://spark.apache.org/docs/latest/api/R/sparkR.session.html).
+In addition to `sparkHome`, many other options can be specified in `sparkR.session`. For a complete list, see [Starting up: SparkSession](https://spark.apache.org/docs/latest/sparkr.html#starting-up-sparksession) and [SparkR API doc](https://spark.apache.org/docs/latest/api/R/reference/sparkR.session.html).
 
 In particular, the following Spark driver properties can be set in `sparkConfig`.
 
@@ -231,7 +231,7 @@ The general method for creating `SparkDataFrame` from data sources is `read.df`.
 sparkR.session(sparkPackages = "com.databricks:spark-avro_2.12:3.0.0")
 ```
 
-We can see how to use data sources using an example CSV input file. For more information please refer to SparkR [read.df](https://spark.apache.org/docs/latest/api/R/read.df.html) API documentation.
+We can see how to use data sources using an example CSV input file. For more information please refer to SparkR [read.df](https://spark.apache.org/docs/latest/api/R/reference/read.df.html) API documentation.
 ```{r, eval=FALSE}
 df <- read.df(csvPath, "csv", header = "true", inferSchema = "true", na.strings = "NA")
 ```
@@ -340,7 +340,7 @@ A common flow of grouping and aggregation is
 
 2. Feed the `GroupedData` object to `agg` or `summarize` functions, with some provided aggregation functions to compute a number within each group.
 
-A number of widely used functions are supported to aggregate data after grouping, including `avg`, `count_distinct`, `count`, `first`, `kurtosis`, `last`, `max`, `mean`, `min`, `sd`, `skewness`, `stddev_pop`, `stddev_samp`, `sum_distinct`, `sum`, `var_pop`, `var_samp`, `var`. See the [API doc for aggregate functions](https://spark.apache.org/docs/latest/api/R/column_aggregate_functions.html) linked there.
+A number of widely used functions are supported to aggregate data after grouping, including `avg`, `count_distinct`, `count`, `first`, `kurtosis`, `last`, `max`, `mean`, `min`, `sd`, `skewness`, `stddev_pop`, `stddev_samp`, `sum_distinct`, `sum`, `var_pop`, `var_samp`, `var`. See the [API doc for aggregate functions](https://spark.apache.org/docs/latest/api/R/reference/column_aggregate_functions.html) linked there.
 
 For example we can compute a histogram of the number of cylinders in the `mtcars` dataset as shown below.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fix all dead links in sparkr-vignettes.Rmd.

### Why are the changes needed?

binary-release-hadoop3.log logs:
```
yumwang@LM-SHC-16508156 output % tail -n 30 binary-release-hadoop3.log
* this is package ‘SparkR’ version ‘3.3.1’
* package encoding: UTF-8
* checking CRAN incoming feasibility ... NOTE
Maintainer: ‘The Apache Software Foundation <dev@spark.apache.org>’

New submission

Package was archived on CRAN

CRAN repository db overrides:
  X-CRAN-Comment: Archived on 2021-06-28 as issues were not corrected
    in time.

  Should use tools::R_user_dir().

Found the following (possibly) invalid URLs:
  URL: https://spark.apache.org/docs/latest/api/R/column_aggregate_functions.html
    From: inst/doc/sparkr-vignettes.html
    Status: 404
    Message: Not Found
  URL: https://spark.apache.org/docs/latest/api/R/read.df.html
    From: inst/doc/sparkr-vignettes.html
    Status: 404
    Message: Not Found
  URL: https://spark.apache.org/docs/latest/api/R/sparkR.session.html
    From: inst/doc/sparkr-vignettes.html
    Status: 404
    Message: Not Found
* checking package namespace information ... OK
* checking package dependencies ...%
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

manual test.