### PR TITLE
[SPARK-40554][PS] Make `ddof` in `DataFrame.sem` and `Series.sem` accept arbitary integers

### DIFF
--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2127,6 +2127,8 @@ class Frame(object, metaclass=ABCMeta):
         """
         Return unbiased standard error of the mean over requested axis.
 
+        .. versionadded:: 3.3.0
+
         Parameters
         ----------
         axis : {index (0), columns (1)}

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2139,6 +2139,9 @@ class Frame(object, metaclass=ABCMeta):
         ddof : int, default 1
             Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
             where N represents the number of elements.
+
+            .. versionchanged:: 3.4.0
+               Supported including arbitary integers.
         numeric_only : bool, default None
             Include only float, int, boolean columns. False is not supported. This parameter
             is mainly for pandas compatibility.
@@ -2164,6 +2167,11 @@ class Frame(object, metaclass=ABCMeta):
         >>> psdf.sem(ddof=0)
         a    0.471405
         b    0.471405
+        dtype: float64
+
+        >>> psdf.sem(ddof=2)
+        a    0.816497
+        b    0.816497
         dtype: float64
 
         >>> psdf.sem(axis=1)

--- a/python/pyspark/pandas/generic.py
+++ b/python/pyspark/pandas/generic.py
@@ -2187,7 +2187,8 @@ class Frame(object, metaclass=ABCMeta):
         >>> psser.sem(ddof=0)
         0.47140452079103173
         """
-        assert ddof in (0, 1)
+        if not isinstance(ddof, int):
+            raise TypeError("ddof must be integer")
 
         axis = validate_axis(axis)
 
@@ -2205,10 +2206,7 @@ class Frame(object, metaclass=ABCMeta):
                         spark_type_to_pandas_dtype(spark_type), spark_type.simpleString()
                     )
                 )
-            if ddof == 0:
-                return F.stddev_pop(spark_column)
-            else:
-                return F.stddev_samp(spark_column)
+            return SF.stddev(spark_column, ddof)
 
         def sem(psser: "Series") -> Column:
             return std(psser) / F.sqrt(Frame._count_expr(psser))

--- a/python/pyspark/pandas/tests/test_stats.py
+++ b/python/pyspark/pandas/tests/test_stats.py
@@ -454,6 +454,7 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(psser.std(ddof=2), pser.std(ddof=2), almost=True)
         self.assert_eq(psser.sem(), pser.sem(), almost=True)
         self.assert_eq(psser.sem(ddof=0), pser.sem(ddof=0), almost=True)
+        self.assert_eq(psser.sem(ddof=2), pser.sem(ddof=2), almost=True)
 
     def test_stats_on_non_numeric_columns_should_be_discarded_if_numeric_only_is_true(self):
         pdf = pd.DataFrame({"i": [0, 1, 2], "b": [False, False, True], "s": ["x", "y", "z"]})
@@ -504,6 +505,11 @@ class StatsTest(PandasOnSparkTestCase, SQLTestUtils):
         self.assert_eq(
             psdf.sem(ddof=0, numeric_only=True),
             pdf.sem(ddof=0, numeric_only=True),
+            check_exact=False,
+        )
+        self.assert_eq(
+            psdf.sem(ddof=2, numeric_only=True),
+            pdf.sem(ddof=2, numeric_only=True),
             check_exact=False,
         )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `ddof` in `DataFrame.sem` and `Series.sem` accept arbitary integers


### Why are the changes needed?
for API coverage

### Does this PR introduce _any_ user-facing change?
before:
```
In [1]: import pyspark.pandas as ps

In [2]: psdf = ps.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})

In [3]: psdf.sem(ddof=2)
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
Cell In [3], line 1
----> 1 psdf.sem(ddof=2)

File ~/Dev/spark/python/pyspark/pandas/generic.py:2190, in Frame.sem(self, axis, skipna, ddof, numeric_only)
   2120 def sem(
   2121     self,
   2122     axis: Optional[Axis] = None,
   (...)
   2125     numeric_only: bool = None,
   2126 ) -> Union[Scalar, "Series"]:
   2127     """
   2128     Return unbiased standard error of the mean over requested axis.
   2129 
   (...)
   2188     0.47140452079103173
   2189     """
-> 2190     assert ddof in (0, 1)
   2192     axis = validate_axis(axis)
   2194     if numeric_only is None and axis == 0:

AssertionError: 
```

after:
```
In [5]: psdf.sem(ddof=2)
Out[5]: 
a    0.816497
b    0.816497
dtype: float64

In [6]: psdf.to_pandas().sem(ddof=2)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/pandas/utils.py:975: PandasAPIOnSparkAdviceWarning: `to_pandas` loads all data into the driver's memory. It should only be used if the resulting pandas DataFrame is expected to be small.
  warnings.warn(message, PandasAPIOnSparkAdviceWarning)
Out[6]: 
a    0.816497
b    0.816497
dtype: float64
```


### How was this patch tested?
added UT
