### PR TITLE
[SPARK-40556][PS][SQL] Unpersist the intermediate datasets cached in `AttachDistributedSequenceExec`

### DIFF
--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -911,6 +911,9 @@ class InternalFrame:
         +--------+---+
         """
         if len(sdf.columns) > 0:
+            if not sdf.is_cached and sdf.rdd.getNumPartitions() > 1:
+                sdf.persist()
+
             return SparkDataFrame(
                 sdf._jdf.toDF().withSequenceColumn(column_name),
                 sdf.sparkSession,

--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -6382,7 +6382,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             raise ValueError("axis can only be 0 or 'index'")
         sdf = self._internal.spark_frame.select(self.spark.column, NATURAL_ORDER_COLUMN_NAME)
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
-        sdf0 = sdf
+
+        cached = sdf.cache()
         sdf = InternalFrame.attach_distributed_sequence_column(
             sdf,
             seq_col_name,
@@ -6395,9 +6396,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             sdf = sdf.orderBy(scol.desc_nulls_first(), NATURAL_ORDER_COLUMN_NAME, seq_col_name)
 
         results = sdf.select(scol, seq_col_name).take(1)
-
-        if sdf0.is_cached:
-            sdf0.unpersist(blocking=False)
+        cached.unpersist(blocking=False)
 
         if len(results) == 0:
             raise ValueError("attempt to get argmax of an empty sequence")
@@ -6446,7 +6445,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             raise ValueError("axis can only be 0 or 'index'")
         sdf = self._internal.spark_frame.select(self.spark.column, NATURAL_ORDER_COLUMN_NAME)
         seq_col_name = verify_temp_column_name(sdf, "__distributed_sequence_column__")
-        sdf0 = sdf
+
+        cached = sdf.cache()
         sdf = InternalFrame.attach_distributed_sequence_column(
             sdf,
             seq_col_name,
@@ -6459,9 +6459,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
             sdf = sdf.orderBy(scol.asc_nulls_first(), NATURAL_ORDER_COLUMN_NAME, seq_col_name)
 
         results = sdf.select(scol, seq_col_name).take(1)
-
-        if sdf0.is_cached:
-            sdf0.unpersist(blocking=False)
+        cached.unpersist(blocking=False)
 
         if len(results) == 0:
             raise ValueError("attempt to get argmin of an empty sequence")
@@ -6673,7 +6671,8 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
         index_col_name = verify_temp_column_name(sdf, "__search_sorted_index_col__")
         value_col_name = verify_temp_column_name(sdf, "__search_sorted_value_col__")
         sdf = sdf.select(self.spark.column.alias(value_col_name))
-        sdf0 = sdf
+
+        cached = sdf.cache()
         sdf = InternalFrame.attach_distributed_sequence_column(sdf, index_col_name)
 
         if side == "left":
@@ -6687,8 +6686,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                 F.count(F.lit(0)),
             ).take(1)
 
-        if sdf0.is_cached:
-            sdf0.unpersist(blocking=False)
+        cached.unpersist(blocking=False)
 
         if len(results) == 0:
             return 0

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/AttachDistributedSequenceExec.scala
@@ -42,13 +42,7 @@ case class AttachDistributedSequenceExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     val childRDD = child.execute().map(_.copy())
-    val checkpointed = if (childRDD.getNumPartitions > 1) {
-      // to avoid execute multiple jobs. zipWithIndex launches a Spark job.
-      childRDD.localCheckpoint()
-    } else {
-      childRDD
-    }
-    checkpointed.zipWithIndex().mapPartitions { iter =>
+    childRDD.zipWithIndex().mapPartitions { iter =>
       val unsafeProj = UnsafeProjection.create(output, output)
       val joinedRow = new JoinedRow
       val unsafeRowWriter =


### PR DESCRIPTION
### What changes were proposed in this pull request?

to clean the intermediate cached datasets created in `AttachDistributedSequenceExec`

1. use `cache` instead of `checkpoint`/`localCheckpoint`: `checkpoint` need the checkpoint directory be specified via `sc.setCheckpointDir`, while `localCheckpoint` is not reliable;
2. do not cache data in `AttachDistributedSequenceExec`, so that callers can `unpsersit` cached data if needed;

### Why are the changes needed?
in `argmax`, `argmin`, `searchsorted`, the intermediate RDDs are still cached after the job completed.

before:
```
In [1]: import pyspark.pandas as ps
   ...: s = ps.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0, 'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
   ...: s.argmin()
   ...: 
   ...: sc._jsc.getPersistentRDDs()
Out[1]: {6: JavaObject id=o87}    

In [2]: s.argmin()
Out[2]: 0

Out[3]: sc._jsc.getPersistentRDDs()
Out[3]: {6: JavaObject id=o160, 25: JavaObject id=o161}
```

after:
```
In [1]: import pyspark.pandas as ps
   ...: s = ps.Series({'Corn Flakes': 100.0, 'Almond Delight': 110.0, 'Cinnamon Toast Crunch': 120.0, 'Cocoa Puff': 110.0})
   ...: s.argmin()
   ...: 
   ...: sc._jsc.getPersistentRDDs()
Out[1]: {}          

In [2]: s.argmin()
Out[2]: 0

Out[3]: sc._jsc.getPersistentRDDs()
Out[3]: {}   
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
existing suites